### PR TITLE
Don't use QVariant::canConvert to test for variant user types

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -5,7 +5,6 @@ test_core_compositionconverter
 test_core_dxfexport
 test_core_expression
 test_core_field
-test_core_geometry
 test_core_labelingengine
 test_core_layoutpicture
 test_core_maprendererjob
@@ -13,7 +12,6 @@ test_core_networkaccessmanager
 test_core_ogcutils
 test_core_tiledownloadmanager
 test_core_vectortilelayer
-test_core_geometry_pointxy
 test_gui_datetimeedit
 test_gui_processinggui
 test_gui_querybuilder

--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -145,7 +145,7 @@ QgsFeatureList QgsGeometryByExpressionAlgorithm::processFeature( const QgsFeatur
   }
   else
   {
-    if ( value.canConvert< QgsGeometry >() )
+    if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
     {
       const QgsGeometry geom = value.value<QgsGeometry>();
       feature.setGeometry( geom );

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -832,7 +832,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedPosition( double &x, bool &xSuccess
            && !attributes.at( pointCol ).isNull() )
       {
         QVariant pointAsVariant = attributes.at( pointCol );
-        if ( pointAsVariant.canConvert<QgsGeometry>() )
+        if ( pointAsVariant.userType() == QMetaType::type( "QgsGeometry" ) )
         {
           const  QgsGeometry geometry = pointAsVariant.value<QgsGeometry>();
           if ( const QgsPoint *point  = ( geometry.constGet() ? qgsgeometry_cast<const QgsPoint *>( geometry.constGet()->simplifiedTypeRef() ) : nullptr ) )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -982,7 +982,7 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   const QString startToken = htmlOutput ? QStringLiteral( "<i>&lt;" ) : QStringLiteral( "<" );
   const QString endToken = htmlOutput ? QStringLiteral( "&gt;</i>" ) : QStringLiteral( ">" );
 
-  if ( value.canConvert<QgsGeometry>() )
+  if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     //result is a geometry
     QgsGeometry geom = value.value<QgsGeometry>();
@@ -1000,13 +1000,13 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   {
     return htmlOutput ? tr( "<i>NULL</i>" ) : QString();
   }
-  else if ( value.canConvert< QgsFeature >() )
+  else if ( value.userType() == QMetaType::type( "QgsFeature" ) )
   {
     //result is a feature
     QgsFeature feat = value.value<QgsFeature>();
     return startToken + tr( "feature: %1" ).arg( feat.id() ) + endToken;
   }
-  else if ( value.canConvert< QgsInterval >() )
+  else if ( value.userType() == QMetaType::type( "QgsInterval" ) )
   {
     QgsInterval interval = value.value<QgsInterval>();
     if ( interval.days() > 1 )
@@ -1026,7 +1026,7 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
       return startToken + tr( "interval: %1 seconds" ).arg( interval.seconds() ) + endToken;
     }
   }
-  else if ( value.canConvert< QgsGradientColorRamp >() )
+  else if ( value.userType() == QMetaType::type( "QgsGradientColorRamp" ) )
   {
     return startToken + tr( "gradient ramp" ) + endToken;
   }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1369,7 +1369,7 @@ static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionCont
 static QVariant fcnLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // two variants, one for geometry, one for string
-  if ( values.at( 0 ).canConvert<QgsGeometry>() )
+  if ( values.at( 0 ).userType() == QMetaType::type( "QgsGeometry" ) )
   {
     //geometry variant
     QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
@@ -3182,7 +3182,7 @@ static QVariant fcnCollectGeometries( const QVariantList &values, const QgsExpre
   parts.reserve( list.size() );
   for ( const QVariant &value : std::as_const( list ) )
   {
-    if ( value.canConvert<QgsGeometry>() )
+    if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
     {
       parts << value.value<QgsGeometry>();
     }
@@ -5206,7 +5206,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *,
 {
   QgsGradientColorRamp expRamp;
   const QgsColorRamp *ramp = nullptr;
-  if ( values.at( 0 ).canConvert<QgsGradientColorRamp>() )
+  if ( values.at( 0 ).userType() == QMetaType::type( "QgsGradientColorRamp" ) )
   {
     expRamp = QgsExpressionUtils::getRamp( values.at( 0 ), parent );
     ramp = &expRamp;

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -468,7 +468,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         return compare( fL - fR ) ? TVL_True : TVL_False;
       }
       // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here
-      else if ( vL.canConvert< QgsInterval >() && vR.canConvert< QgsInterval >() )
+      else if ( vL.userType() == QMetaType::type( "QgsInterval" ) && vR.userType() == QMetaType::type( "QgsInterval" ) )
       {
         double fL = QgsExpressionUtils::getInterval( vL, parent ).seconds();
         ENSURE_NO_EVAL_ERROR

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -40,7 +40,7 @@ QgsExpressionUtils::TVL QgsExpressionUtils::NOT[3] = { True, False, Unknown };
 
 QgsGradientColorRamp QgsExpressionUtils::getRamp( const QVariant &value, QgsExpression *parent, bool report_error )
 {
-  if ( value.canConvert<QgsGradientColorRamp>() )
+  if ( value.userType() == QMetaType::type( "QgsGradientColorRamp" ) )
     return value.value<QgsGradientColorRamp>();
 
   // If we get here then we can't convert so we just error and return invalid.

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -92,13 +92,13 @@ class CORE_EXPORT QgsExpressionUtils
         return Unknown;
 
       //handle some special cases
-      if ( value.canConvert<QgsGeometry>() )
+      if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
       {
         //geom is false if empty
         const QgsGeometry geom = value.value<QgsGeometry>();
         return geom.isNull() ? False : True;
       }
-      else if ( value.canConvert<QgsFeature>() )
+      else if ( value.userType() == QMetaType::type( "QgsFeature" ) )
       {
         //feat is false if non-valid
         const QgsFeature feat = value.value<QgsFeature>();
@@ -171,7 +171,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static inline bool isIntervalSafe( const QVariant &v )
     {
-      if ( v.canConvert<QgsInterval>() )
+      if ( v.userType() == QMetaType::type( "QgsInterval" ) )
       {
         return true;
       }
@@ -308,7 +308,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsInterval getInterval( const QVariant &value, QgsExpression *parent, bool report_error = false )
     {
-      if ( value.canConvert<QgsInterval>() )
+      if ( value.userType() == QMetaType::type( "QgsInterval" ) )
         return value.value<QgsInterval>();
 
       QgsInterval inter = QgsInterval::fromString( value.toString() );
@@ -327,7 +327,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsGeometry getGeometry( const QVariant &value, QgsExpression *parent )
     {
-      if ( value.canConvert<QgsGeometry>() )
+      if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
         return value.value<QgsGeometry>();
 
       parent->setEvalErrorString( QStringLiteral( "Cannot convert to geometry" ) );
@@ -336,7 +336,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static QgsFeature getFeature( const QVariant &value, QgsExpression *parent )
     {
-      if ( value.canConvert<QgsFeature>() )
+      if ( value.userType() == QMetaType::type( "QgsFeature" ) )
         return value.value<QgsFeature>();
 
       parent->setEvalErrorString( QStringLiteral( "Cannot convert to feature" ) );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2446,7 +2446,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
         ddPosition = true;
 
         QgsPoint point;
-        if ( pointPosProperty.canConvert<QgsReferencedGeometry>() )
+        if ( pointPosProperty.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
         {
           QgsReferencedGeometry referencedGeometryPoint = pointPosProperty.value<QgsReferencedGeometry>();
           point = QgsPoint( referencedGeometryPoint.asPoint() );
@@ -2455,7 +2455,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
                && ct.sourceCrs() != referencedGeometryPoint.crs() )
             QgsMessageLog::logMessage( QObject::tr( "Label position geometry is not in layer coordinates reference system. Layer CRS: '%1', Geometry CRS: '%2'" ).arg( ct.sourceCrs().userFriendlyIdentifier(), referencedGeometryPoint.crs().userFriendlyIdentifier() ), QObject::tr( "Labeling" ), Qgis::Warning );
         }
-        else if ( pointPosProperty.canConvert<QgsGeometry>() )
+        else if ( pointPosProperty.userType() == QMetaType::type( "QgsGeometry" ) )
         {
           point = QgsPoint( pointPosProperty.value<QgsGeometry>().asPoint() );
         }

--- a/src/core/layout/qgslayoutitemmanualtable.cpp
+++ b/src/core/layout/qgslayoutitemmanualtable.cpp
@@ -77,7 +77,7 @@ bool QgsLayoutItemManualTable::getTableContents( QgsLayoutTableContents &content
       {
         QVariant cellContent = row.at( columnNumber ).content();
 
-        if ( cellContent.canConvert< QgsProperty >() )
+        if ( cellContent.userType() == QMetaType::type( "QgsProperty" ) )
         {
           // expression based cell content, evaluate now
           QgsExpressionContextScopePopper popper( context, scopeForCell( rowNumber, columnNumber ) );

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -202,7 +202,7 @@ QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const QgsP
 
           if ( foundParam )
           {
-            if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+            if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
             {
               // make sure layer output name is correctly set
               QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
@@ -1074,11 +1074,11 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
 
     }
 
-    if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+    if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
       value = fromVar.sink;
-      if ( value.canConvert<QgsProperty>() )
+      if ( value.userType() == QMetaType::type( "QgsProperty" ) )
       {
         value = value.value< QgsProperty >().valueAsString( context.expressionContext() );
       }
@@ -1134,16 +1134,16 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
     }
 
     QgsFeatureSource *featureSource = nullptr;
-    if ( value.canConvert<QgsProcessingFeatureSourceDefinition>() )
+    if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
     {
       QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
       value = fromVar.source;
     }
-    else if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+    else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
       value = fromVar.sink;
-      if ( value.canConvert<QgsProperty>() )
+      if ( value.userType() == QMetaType::type( "QgsProperty" ) )
       {
         value = value.value< QgsProperty >().valueAsString( context.expressionContext() );
       }
@@ -1828,7 +1828,7 @@ void QgsProcessingModelAlgorithm::changeParameterName( const QString &oldName, c
 
           case QgsProcessingModelChildParameterSource::StaticValue:
           {
-            if ( valueIt->staticValue().canConvert< QgsProperty >() )
+            if ( valueIt->staticValue().userType() == QMetaType::type( "QgsProperty" ) )
             {
               QgsProperty property = valueIt->staticValue().value< QgsProperty >();
               if ( property.propertyType() == QgsProperty::ExpressionBasedProperty )

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -34,7 +34,7 @@ QVariant QgsProcessingModelOutput::toVariant() const
   QVariantMap map;
   map.insert( QStringLiteral( "name" ), mName );
 
-  if ( mDefaultValue.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( mDefaultValue.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     QVariantMap defaultMap = mDefaultValue.value<QgsProcessingOutputLayerDefinition>().toVariant().toMap();
     defaultMap.insert( QStringLiteral( "class" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -890,17 +890,17 @@ QString QgsProcessingAlgorithm::invalidSourceError( const QVariantMap &parameter
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.canConvert<QgsProcessingFeatureSourceDefinition>() )
+    if ( var.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
     {
       QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( var );
       var = fromVar.source;
     }
-    else if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+    else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       var = fromVar.sink;
     }
-    if ( var.canConvert<QgsProperty>() )
+    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -922,7 +922,7 @@ QString QgsProcessingAlgorithm::invalidRasterError( const QVariantMap &parameter
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.canConvert<QgsProperty>() )
+    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -944,12 +944,12 @@ QString QgsProcessingAlgorithm::invalidSinkError( const QVariantMap &parameters,
   else
   {
     QVariant var = parameters.value( name );
-    if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+    if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       var = fromVar.sink;
     }
-    if ( var.canConvert<QgsProperty>() )
+    if ( var.userType() == QMetaType::type( "QgsProperty" ) )
     {
       QgsProperty p = var.value< QgsProperty >();
       if ( p.propertyType() == QgsProperty::StaticProperty )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -114,7 +114,7 @@ bool QgsProcessingOutputLayerDefinition::operator!=( const QgsProcessingOutputLa
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )
 {
   const QVariant val = parameters.value( name );
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().propertyType() != QgsProperty::StaticProperty;
   else
     return false;
@@ -134,7 +134,7 @@ QString QgsProcessingParameters::parameterAsString( const QgsProcessingParameter
     return QString();
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
 
   if ( !val.isValid() )
@@ -166,7 +166,7 @@ QString QgsProcessingParameters::parameterAsExpression( const QgsProcessingParam
     return QString();
 
   const QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
 
   if ( val.isValid() && !val.toString().isEmpty() )
@@ -194,7 +194,7 @@ double QgsProcessingParameters::parameterAsDouble( const QgsProcessingParameterD
     return 0;
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsDouble( context.expressionContext(), definition->defaultValue().toDouble() );
 
   bool ok = false;
@@ -221,7 +221,7 @@ int QgsProcessingParameters::parameterAsInt( const QgsProcessingParameterDefinit
     return 0;
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsInt( context.expressionContext(), definition->defaultValue().toInt() );
 
   bool ok = false;
@@ -266,7 +266,7 @@ QList< int > QgsProcessingParameters::parameterAsInts( const QgsProcessingParame
   const QVariant val = value;
   if ( val.isValid() )
   {
-    if ( val.canConvert<QgsProperty>() )
+    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
       resultList << val.value< QgsProperty >().valueAsInt( context.expressionContext(), definition->defaultValue().toInt() );
     else if ( val.type() == QVariant::List )
     {
@@ -319,7 +319,7 @@ QDateTime QgsProcessingParameters::parameterAsDateTime( const QgsProcessingParam
     return QDateTime();
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QDateTime d = val.toDateTime();
@@ -356,7 +356,7 @@ QDate QgsProcessingParameters::parameterAsDate( const QgsProcessingParameterDefi
     return QDate();
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QDate d = val.toDate();
@@ -393,7 +393,7 @@ QTime QgsProcessingParameters::parameterAsTime( const QgsProcessingParameterDefi
     return QTime();
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
 
   QTime d;
@@ -459,7 +459,7 @@ QList<int> QgsProcessingParameters::parameterAsEnums( const QgsProcessingParamet
 
   QVariantList resultList;
   const QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     resultList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.type() == QVariant::List )
   {
@@ -570,7 +570,7 @@ QStringList QgsProcessingParameters::parameterAsEnumStrings( const QgsProcessing
         processVariant( s );
       }
     }
-    else if ( var.canConvert<QgsProperty>() )
+    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
     else
     {
@@ -628,7 +628,7 @@ bool QgsProcessingParameters::parameterAsBool( const QgsProcessingParameterDefin
   const QVariant def = definition->defaultValue();
 
   const QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsBool( context.expressionContext(), def.toBool() );
   else if ( val.isValid() )
     return val.toBool();
@@ -644,7 +644,7 @@ bool QgsProcessingParameters::parameterAsBoolean( const QgsProcessingParameterDe
   const QVariant def = definition->defaultValue();
 
   const QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return val.value< QgsProperty >().valueAsBool( context.expressionContext(), def.toBool() );
   else if ( val.isValid() )
     return val.toBool();
@@ -675,7 +675,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   QString destName;
   QgsRemappingSinkDefinition remapDefinition;
   bool useRemapDefinition = false;
-  if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -692,7 +692,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   }
 
   QString dest;
-  if ( definition && val.canConvert<QgsProperty>() )
+  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -766,7 +766,7 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
 
   bool selectedFeaturesOnly = false;
   long long featureLimit = -1;
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -774,14 +774,14 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
     featureLimit = fromVar.featureLimit;
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -792,7 +792,7 @@ QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParamet
   if ( !vl )
   {
     QString layerRef;
-    if ( val.canConvert<QgsProperty>() )
+    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     {
       layerRef = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
     }
@@ -862,7 +862,7 @@ QgsMapLayer *QgsProcessingParameters::parameterAsLayer( const QgsProcessingParam
     return nullptr;
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -872,14 +872,14 @@ QgsMapLayer *QgsProcessingParameters::parameterAsLayer( const QgsProcessingParam
     return layer;
   }
 
-  if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -941,7 +941,7 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
 
   QgsProject *destinationProject = nullptr;
   QString destName;
-  if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -951,7 +951,7 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
   }
 
   QString dest;
-  if ( definition && val.canConvert<QgsProperty>() )
+  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -1008,7 +1008,7 @@ QString QgsProcessingParameters::parameterAsFileOutput( const QgsProcessingParam
 {
   QVariant val = value;
 
-  if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -1016,7 +1016,7 @@ QString QgsProcessingParameters::parameterAsFileOutput( const QgsProcessingParam
   }
 
   QString dest;
-  if ( definition && val.canConvert<QgsProperty>() )
+  if ( definition && val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     dest = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   }
@@ -1079,17 +1079,17 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
 
   QVariant val = value;
 
-  if ( val.canConvert< QgsRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     return val.value<QgsRectangle>();
   }
-  if ( val.canConvert< QgsGeometry >() )
+  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     const QgsGeometry geom = val.value<QgsGeometry>();
     if ( !geom.isNull() )
       return geom.boundingBox();
   }
-  if ( val.canConvert< QgsReferencedRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     if ( crs.isValid() && rr.crs().isValid() && crs != rr.crs() )
@@ -1108,20 +1108,20 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
     return rr;
   }
 
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -1130,7 +1130,7 @@ QgsRectangle QgsProcessingParameters::parameterAsExtent( const QgsProcessingPara
   QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( qvariant_cast<QObject *>( val ) );
 
   QString rectText;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     rectText = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     rectText = val.toString();
@@ -1203,7 +1203,7 @@ QgsGeometry QgsProcessingParameters::parameterAsExtentGeometry( const QgsProcess
 
   QVariant val = parameters.value( definition->name() );
 
-  if ( val.canConvert< QgsReferencedRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     QgsGeometry g = QgsGeometry::fromRect( rr );
@@ -1223,26 +1223,26 @@ QgsGeometry QgsProcessingParameters::parameterAsExtentGeometry( const QgsProcess
     }
   }
 
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
 
   QString rectText;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     rectText = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     rectText = val.toString();
@@ -1323,7 +1323,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
   QVariant val = value;
-  if ( val.canConvert< QgsReferencedRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     if ( rr.crs().isValid() )
@@ -1332,26 +1332,26 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
     }
   }
 
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
 
   QString valueAsString;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     valueAsString = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else
     valueAsString = val.toString();
@@ -1366,20 +1366,20 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsExtentCrs( cons
       return crs;
   }
 
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -1410,17 +1410,17 @@ QgsPointXY QgsProcessingParameters::parameterAsPoint( const QgsProcessingParamet
     return QgsPointXY();
 
   const QVariant val = value;
-  if ( val.canConvert< QgsPointXY >() )
+  if ( val.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     return val.value<QgsPointXY>();
   }
-  if ( val.canConvert< QgsGeometry >() )
+  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     const QgsGeometry geom = val.value<QgsGeometry>();
     if ( !geom.isNull() )
       return geom.centroid().asPoint();
   }
-  if ( val.canConvert< QgsReferencedPointXY >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedPointXY rp = val.value<QgsReferencedPointXY>();
     if ( crs.isValid() && rp.crs().isValid() && crs != rp.crs() )
@@ -1488,7 +1488,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsPointCrs( const
 
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsPointCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
-  if ( value.canConvert< QgsReferencedPointXY >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedPointXY rr = value.value<QgsReferencedPointXY>();
     if ( rr.crs().isValid() )
@@ -1528,22 +1528,22 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return QgsGeometry();
 
   const QVariant val = value;
-  if ( val.canConvert< QgsGeometry >() )
+  if ( val.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     return val.value<QgsGeometry>();
   }
 
-  if ( val.canConvert< QgsPointXY >() )
+  if ( val.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     return QgsGeometry::fromPointXY( val.value<QgsPointXY>() );
   }
 
-  if ( val.canConvert< QgsRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     return QgsGeometry::fromRect( val.value<QgsRectangle>() );
   }
 
-  if ( val.canConvert< QgsReferencedPointXY >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedPointXY rp = val.value<QgsReferencedPointXY>();
     if ( crs.isValid() && rp.crs().isValid() && crs != rp.crs() )
@@ -1561,7 +1561,7 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return QgsGeometry::fromPointXY( rp );
   }
 
-  if ( val.canConvert< QgsReferencedRectangle >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle rr = val.value<QgsReferencedRectangle>();
     QgsGeometry g = QgsGeometry::fromRect( rr );
@@ -1581,7 +1581,7 @@ QgsGeometry QgsProcessingParameters::parameterAsGeometry( const QgsProcessingPar
     return g;
   }
 
-  if ( val.canConvert< QgsReferencedGeometry >() )
+  if ( val.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
     QgsReferencedGeometry rg = val.value<QgsReferencedGeometry>();
     if ( crs.isValid() && rg.crs().isValid() && crs != rg.crs() )
@@ -1642,7 +1642,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
 
 QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
 {
-  if ( value.canConvert< QgsReferencedGeometry >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
     const QgsReferencedGeometry rg = value.value<QgsReferencedGeometry>();
     if ( rg.crs().isValid() )
@@ -1651,7 +1651,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
     }
   }
 
-  if ( value.canConvert< QgsReferencedPointXY >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedPointXY rp = value.value<QgsReferencedPointXY>();
     if ( rp.crs().isValid() )
@@ -1660,7 +1660,7 @@ QgsCoordinateReferenceSystem QgsProcessingParameters::parameterAsGeometryCrs( co
     }
   }
 
-  if ( value.canConvert< QgsReferencedRectangle >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle rr = value.value<QgsReferencedRectangle>();
     if ( rr.crs().isValid() )
@@ -1724,7 +1724,7 @@ QVariantList QgsProcessingParameters::parameterAsMatrix( const QgsProcessingPara
 
   QString resultString;
   const QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     resultString = val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.type() == QVariant::List )
     return val.toList();
@@ -1793,14 +1793,14 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
         processVariant( s );
       }
     }
-    else if ( var.canConvert<QgsProperty>() )
+    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
-    else if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+    else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
       const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
       const QVariant sink = fromVar.sink;
-      if ( sink.canConvert<QgsProperty>() )
+      if ( sink.userType() == QMetaType::type( "QgsProperty" ) )
       {
         processVariant( sink.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
       }
@@ -1876,7 +1876,7 @@ QStringList QgsProcessingParameters::parameterAsFileList( const QgsProcessingPar
         processVariant( s );
       }
     }
-    else if ( var.canConvert<QgsProperty>() )
+    else if ( var.userType() == QMetaType::type( "QgsProperty" ) )
       processVariant( var.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() ) );
     else
     {
@@ -1918,7 +1918,7 @@ QList<double> QgsProcessingParameters::parameterAsRange( const QgsProcessingPara
   QStringList resultStringList;
   const QVariant val = value;
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     resultStringList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
   else if ( val.type() == QVariant::List )
   {
@@ -1986,7 +1986,7 @@ QStringList QgsProcessingParameters::parameterAsFields( const QgsProcessingParam
   const QVariant val = value;
   if ( val.isValid() )
   {
-    if ( val.canConvert<QgsProperty>() )
+    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
       resultStringList << val.value< QgsProperty >().valueAsString( context.expressionContext(), definition->defaultValue().toString() );
     else if ( val.type() == QVariant::List )
     {
@@ -2090,7 +2090,7 @@ QColor QgsProcessingParameters::parameterAsColor( const QgsProcessingParameterDe
     return QColor();
 
   QVariant val = value;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     val = val.value< QgsProperty >().value( context.expressionContext(), definition->defaultValue() );
   }
@@ -2446,7 +2446,7 @@ QString QgsProcessingParameterDefinition::valueAsPythonString( const QVariant &v
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -2953,7 +2953,7 @@ QString QgsProcessingParameterBoolean::valueAsPythonString( const QVariant &val,
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
   return val.toBool() ? QStringLiteral( "True" ) : QStringLiteral( "False" );
 }
@@ -2989,20 +2989,20 @@ bool QgsProcessingParameterCrs::checkValueIsAcceptable( const QVariant &input, Q
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsCoordinateReferenceSystem>() )
+  if ( input.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
   {
     return true;
   }
-  else if ( input.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  else if ( input.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     return true;
   }
-  else if ( input.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     return true;
   }
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -3022,7 +3022,7 @@ QString QgsProcessingParameterCrs::valueAsPythonString( const QVariant &value, Q
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsCoordinateReferenceSystem>() )
+  if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
@@ -3030,7 +3030,7 @@ QString QgsProcessingParameterCrs::valueAsPythonString( const QVariant &value, Q
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -3064,7 +3064,7 @@ bool QgsProcessingParameterMapLayer::checkValueIsAcceptable( const QVariant &inp
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -3095,7 +3095,7 @@ QString QgsProcessingParameterMapLayer::valueAsPythonString( const QVariant &val
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -3329,30 +3329,30 @@ bool QgsProcessingParameterExtent::checkValueIsAcceptable( const QVariant &input
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( input.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     return true;
   }
-  else if ( input.canConvert<QgsProcessingOutputLayerDefinition>() )
-  {
-    return true;
-  }
-
-  if ( input.canConvert<QgsProperty>() )
+  else if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     return true;
   }
 
-  if ( input.canConvert< QgsRectangle >() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
+  {
+    return true;
+  }
+
+  if ( input.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     const QgsRectangle r = input.value<QgsRectangle>();
     return !r.isNull();
   }
-  if ( input.canConvert< QgsGeometry >() )
+  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     return true;
   }
-  if ( input.canConvert< QgsReferencedRectangle >() )
+  if ( input.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle r = input.value<QgsReferencedRectangle>();
     return !r.isNull();
@@ -3396,10 +3396,10 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert< QgsRectangle >() )
+  if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     const QgsRectangle r = value.value<QgsRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -3407,7 +3407,7 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ) );
   }
-  else if ( value.canConvert< QgsReferencedRectangle >() )
+  else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4 [%5]'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -3415,7 +3415,7 @@ QString QgsProcessingParameterExtent::valueAsPythonString( const QVariant &value
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ),                                                                                                                             r.crs().authid() );
   }
-  else if ( value.canConvert< QgsGeometry >() )
+  else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
@@ -3455,20 +3455,20 @@ bool QgsProcessingParameterPoint::checkValueIsAcceptable( const QVariant &input,
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
 
-  if ( input.canConvert< QgsPointXY >() )
+  if ( input.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     return true;
   }
-  if ( input.canConvert< QgsReferencedPointXY >() )
+  if ( input.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     return true;
   }
-  if ( input.canConvert< QgsGeometry >() )
+  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     return true;
   }
@@ -3499,23 +3499,23 @@ QString QgsProcessingParameterPoint::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert< QgsPointXY >() )
+  if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     const QgsPointXY r = value.value<QgsPointXY>();
     return QStringLiteral( "'%1,%2'" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
   }
-  else if ( value.canConvert< QgsReferencedPointXY >() )
+  else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "'%1,%2 [%3]'" ).arg( qgsDoubleToString( r.x() ),
            qgsDoubleToString( r.y() ),
            r.crs().authid() );
   }
-  else if ( value.canConvert< QgsGeometry >() )
+  else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
@@ -3552,41 +3552,41 @@ bool QgsProcessingParameterGeometry::checkValueIsAcceptable( const QVariant &inp
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
 
   const bool anyTypeAllowed = mGeomTypes.isEmpty() || mGeomTypes.contains( QgsWkbTypes::UnknownGeometry );
 
-  if ( input.canConvert< QgsGeometry >() )
+  if ( input.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     return ( anyTypeAllowed || mGeomTypes.contains( input.value<QgsGeometry>().type() ) ) &&
            ( mAllowMultipart || !input.value<QgsGeometry>().isMultipart() );
   }
 
-  if ( input.canConvert< QgsReferencedGeometry >() )
+  if ( input.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
     return ( anyTypeAllowed || mGeomTypes.contains( input.value<QgsReferencedGeometry>().type() ) ) &&
            ( mAllowMultipart || !input.value<QgsReferencedGeometry>().isMultipart() );
   }
 
-  if ( input.canConvert< QgsPointXY >() )
+  if ( input.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     return anyTypeAllowed || mGeomTypes.contains( QgsWkbTypes::PointGeometry );
   }
 
-  if ( input.canConvert< QgsRectangle >() )
+  if ( input.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     return anyTypeAllowed || mGeomTypes.contains( QgsWkbTypes::PolygonGeometry );
   }
 
-  if ( input.canConvert< QgsReferencedPointXY >() )
+  if ( input.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     return anyTypeAllowed || mGeomTypes.contains( QgsWkbTypes::PointGeometry );
   }
 
-  if ( input.canConvert< QgsReferencedRectangle >() )
+  if ( input.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     return anyTypeAllowed || mGeomTypes.contains( QgsWkbTypes::PolygonGeometry );
   }
@@ -3629,45 +3629,45 @@ QString QgsProcessingParameterGeometry::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression(%1)" ).arg( QgsProcessingUtils::stringToPythonLiteral( value.value< QgsProperty >().asExpression() ) );
 
-  if ( value.canConvert< QgsGeometry >() )
+  if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
   {
     const QgsGeometry g = value.value<QgsGeometry>();
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.canConvert< QgsReferencedGeometry >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
     const QgsReferencedGeometry g = value.value<QgsReferencedGeometry>();
     if ( !g.isNull() )
       return asPythonString( g, g.crs() );
   }
 
-  if ( value.canConvert< QgsPointXY >() )
+  if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     const QgsGeometry g = QgsGeometry::fromPointXY( value.value<QgsPointXY>() );
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.canConvert< QgsReferencedPointXY >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     const QgsReferencedGeometry g = QgsReferencedGeometry::fromReferencedPointXY( value.value<QgsReferencedPointXY>() );
     if ( !g.isNull() )
       return asPythonString( g, g.crs() );
   }
 
-  if ( value.canConvert< QgsRectangle >() )
+  if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     const QgsGeometry g = QgsGeometry::fromRect( value.value<QgsRectangle>() );
     if ( !g.isNull() )
       return asPythonString( g );
   }
 
-  if ( value.canConvert< QgsReferencedRectangle >() )
+  if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     const QgsReferencedGeometry g = QgsReferencedGeometry::fromReferencedRect( value.value<QgsReferencedRectangle>() );
     if ( !g.isNull() )
@@ -3817,7 +3817,7 @@ bool QgsProcessingParameterFile::checkValueIsAcceptable( const QVariant &input, 
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -3989,7 +3989,7 @@ QString QgsProcessingParameterMatrix::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4175,7 +4175,7 @@ QString QgsProcessingParameterMultipleLayers::valueAsPythonString( const QVarian
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( mLayerType == QgsProcessing::TypeFile )
@@ -4399,7 +4399,7 @@ bool QgsProcessingParameterNumber::checkValueIsAcceptable( const QVariant &value
     input = defaultValue();
   }
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -4417,7 +4417,7 @@ QString QgsProcessingParameterNumber::valueAsPythonString( const QVariant &value
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return value.toString();
@@ -4535,7 +4535,7 @@ bool QgsProcessingParameterRange::checkValueIsAcceptable( const QVariant &input,
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -4575,7 +4575,7 @@ QString QgsProcessingParameterRange::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4658,7 +4658,7 @@ bool QgsProcessingParameterRasterLayer::checkValueIsAcceptable( const QVariant &
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -4687,7 +4687,7 @@ QString QgsProcessingParameterRasterLayer::valueAsPythonString( const QVariant &
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -4732,7 +4732,7 @@ bool QgsProcessingParameterEnum::checkValueIsAcceptable( const QVariant &value, 
     input = defaultValue();
   }
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -4851,7 +4851,7 @@ QString QgsProcessingParameterEnum::valueAsPythonString( const QVariant &value, 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( mUsesStaticStrings )
@@ -4912,7 +4912,7 @@ QString QgsProcessingParameterEnum::valueAsPythonComment( const QVariant &value,
   if ( !value.isValid() )
     return QString();
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QString();
 
   if ( mUsesStaticStrings )
@@ -5098,7 +5098,7 @@ QString QgsProcessingParameterString::valueAsPythonString( const QVariant &value
   if ( !value.isValid() || value.isNull() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -5258,7 +5258,7 @@ QString QgsProcessingParameterExpression::valueAsPythonString( const QVariant &v
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -5342,7 +5342,7 @@ bool QgsProcessingParameterVectorLayer::checkValueIsAcceptable( const QVariant &
 
   QVariant var = v;
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -5379,7 +5379,7 @@ QString QgsProcessingParameterVectorLayer::valueAsPythonString( const QVariant &
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -5479,7 +5479,7 @@ bool QgsProcessingParameterMeshLayer::checkValueIsAcceptable( const QVariant &v,
 
   QVariant var = v;
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -5516,7 +5516,7 @@ QString QgsProcessingParameterMeshLayer::valueAsPythonString( const QVariant &va
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -5557,7 +5557,7 @@ bool QgsProcessingParameterField::checkValueIsAcceptable( const QVariant &input,
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -5592,7 +5592,7 @@ QString QgsProcessingParameterField::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.type() == QVariant::List )
@@ -5842,19 +5842,19 @@ bool QgsProcessingParameterFeatureSource::checkValueIsAcceptable( const QVariant
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( var );
     var = fromVar.source;
   }
-  else if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -5892,10 +5892,10 @@ QString QgsProcessingParameterFeatureSource::valueAsPythonString( const QVariant
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression(%1)" ).arg( QgsProcessingUtils::stringToPythonLiteral( value.value< QgsProperty >().asExpression() ) );
 
-  if ( value.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( value );
     QString geometryCheckString;
@@ -6115,13 +6115,13 @@ bool QgsProcessingParameterFeatureSink::checkValueIsAcceptable( const QVariant &
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -6148,10 +6148,10 @@ QString QgsProcessingParameterFeatureSink::valueAsPythonString( const QVariant &
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == QgsProperty::StaticProperty )
@@ -6398,13 +6398,13 @@ bool QgsProcessingParameterRasterDestination::checkValueIsAcceptable( const QVar
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -6431,10 +6431,10 @@ QString QgsProcessingParameterRasterDestination::valueAsPythonString( const QVar
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == QgsProperty::StaticProperty )
@@ -6522,13 +6522,13 @@ bool QgsProcessingParameterFileDestination::checkValueIsAcceptable( const QVaria
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -6557,10 +6557,10 @@ QString QgsProcessingParameterFileDestination::valueAsPythonString( const QVaria
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == QgsProperty::StaticProperty )
@@ -6675,7 +6675,7 @@ bool QgsProcessingParameterFolderDestination::checkValueIsAcceptable( const QVar
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -6823,13 +6823,13 @@ bool QgsProcessingParameterVectorDestination::checkValueIsAcceptable( const QVar
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -6856,10 +6856,10 @@ QString QgsProcessingParameterVectorDestination::valueAsPythonString( const QVar
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == QgsProperty::StaticProperty )
@@ -7076,7 +7076,7 @@ bool QgsProcessingParameterBand::checkValueIsAcceptable( const QVariant &input, 
   if ( !input.isValid() )
     return mFlags & FlagOptional;
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -7115,7 +7115,7 @@ QString QgsProcessingParameterBand::valueAsPythonString( const QVariant &value, 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.type() == QVariant::List )
@@ -7443,7 +7443,7 @@ QString QgsProcessingParameterLayout::valueAsPythonString( const QVariant &value
   if ( !value.isValid() || value.isNull() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -7518,7 +7518,7 @@ QString QgsProcessingParameterLayoutItem::valueAsPythonString( const QVariant &v
   if ( !value.isValid() || value.isNull() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   const QString s = value.toString();
@@ -7651,7 +7651,7 @@ QString QgsProcessingParameterColor::valueAsPythonString( const QVariant &value,
   if ( !value.isValid() || value.isNull() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.canConvert< QColor >() && !value.value< QColor >().isValid() )
@@ -7717,7 +7717,7 @@ bool QgsProcessingParameterColor::checkValueIsAcceptable( const QVariant &input,
   {
     return true;
   }
-  else if ( input.canConvert<QgsProperty>() )
+  else if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -7799,7 +7799,7 @@ QString QgsProcessingParameterCoordinateOperation::valueAsPythonString( const QV
   if ( !value.isValid() || value.isNull() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsCoordinateReferenceSystem>() )
+  if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
@@ -7807,7 +7807,7 @@ QString QgsProcessingParameterCoordinateOperation::valueAsPythonString( const QV
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -7939,7 +7939,7 @@ QString QgsProcessingParameterMapTheme::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8037,7 +8037,7 @@ bool QgsProcessingParameterDateTime::checkValueIsAcceptable( const QVariant &val
     input = defaultValue();
   }
 
-  if ( input.canConvert<QgsProperty>() )
+  if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     return true;
   }
@@ -8081,7 +8081,7 @@ QString QgsProcessingParameterDateTime::valueAsPythonString( const QVariant &val
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   if ( value.type() == QVariant::DateTime )
@@ -8255,7 +8255,7 @@ QString QgsProcessingParameterProviderConnection::valueAsPythonString( const QVa
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8370,7 +8370,7 @@ QString QgsProcessingParameterDatabaseSchema::valueAsPythonString( const QVarian
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8504,7 +8504,7 @@ QString QgsProcessingParameterDatabaseTable::valueAsPythonString( const QVariant
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
   return QgsProcessingUtils::stringToPythonLiteral( value.toString() );
@@ -8653,7 +8653,7 @@ bool QgsProcessingParameterPointCloudLayer::checkValueIsAcceptable( const QVaria
 
   QVariant var = v;
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -8690,7 +8690,7 @@ QString QgsProcessingParameterPointCloudLayer::valueAsPythonString( const QVaria
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -8732,7 +8732,7 @@ bool QgsProcessingParameterAnnotationLayer::checkValueIsAcceptable( const QVaria
 
   QVariant var = v;
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -8769,7 +8769,7 @@ QString QgsProcessingParameterAnnotationLayer::valueAsPythonString( const QVaria
   if ( !val.isValid() )
     return QStringLiteral( "None" );
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( val.value< QgsProperty >().asExpression() );
 
   QVariantMap p;
@@ -8800,13 +8800,13 @@ bool QgsProcessingParameterPointCloudDestination::checkValueIsAcceptable( const 
   if ( !var.isValid() )
     return mFlags & FlagOptional;
 
-  if ( var.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( var.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( var );
     var = fromVar.sink;
   }
 
-  if ( var.canConvert<QgsProperty>() )
+  if ( var.userType() == QMetaType::type( "QgsProperty" ) )
   {
     const QgsProperty p = var.value< QgsProperty >();
     if ( p.propertyType() == QgsProperty::StaticProperty )
@@ -8833,10 +8833,10 @@ QString QgsProcessingParameterPointCloudDestination::valueAsPythonString( const 
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
 
-  if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
     if ( fromVar.sink.propertyType() == QgsProperty::StaticProperty )

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -416,7 +416,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
   long long featureLimit = -1;
   bool overrideGeometryCheck = false;
   QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -426,7 +426,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
     overrideGeometryCheck = fromVar.flags & QgsProcessingFeatureSourceDefinition::Flag::FlagOverrideDefaultGeometryCheck;
     geometryCheck = fromVar.geometryCheck;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition (e.g. an output from earlier in a model) - get extra properties from it
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
@@ -442,7 +442,7 @@ QgsProcessingFeatureSource *QgsProcessingUtils::variantToSource( const QVariant 
   }
 
   QString layerRef;
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     layerRef = val.value< QgsProperty >().valueAsString( context.expressionContext(), fallbackValue.toString() );
   }
@@ -490,25 +490,25 @@ QgsCoordinateReferenceSystem QgsProcessingUtils::variantToCrs( const QVariant &v
 {
   QVariant val = value;
 
-  if ( val.canConvert<QgsCoordinateReferenceSystem>() )
+  if ( val.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
   {
     // input is a QgsCoordinateReferenceSystem - done!
     return val.value< QgsCoordinateReferenceSystem >();
   }
-  else if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
   }
-  else if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
+  else if ( val.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     val = fromVar.sink;
   }
 
-  if ( val.canConvert<QgsProperty>() && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) && val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
   {
     val = val.value< QgsProperty >().staticValue();
   }
@@ -517,7 +517,7 @@ QgsCoordinateReferenceSystem QgsProcessingUtils::variantToCrs( const QVariant &v
   if ( QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( qvariant_cast<QObject *>( val ) ) )
     return layer->crs();
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     val = val.value< QgsProperty >().valueAsString( context.expressionContext(), fallbackValue.toString() );
 
   if ( !val.isValid() )
@@ -601,16 +601,16 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
   if ( !value.isValid() )
     return QStringLiteral( "None" );
 
-  if ( value.canConvert<QgsProperty>() )
+  if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     return QStringLiteral( "QgsProperty.fromExpression('%1')" ).arg( value.value< QgsProperty >().asExpression() );
-  else if ( value.canConvert<QgsCoordinateReferenceSystem>() )
+  else if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
   {
     if ( !value.value< QgsCoordinateReferenceSystem >().isValid() )
       return QStringLiteral( "QgsCoordinateReferenceSystem()" );
     else
       return QStringLiteral( "QgsCoordinateReferenceSystem('%1')" ).arg( value.value< QgsCoordinateReferenceSystem >().authid() );
   }
-  else if ( value.canConvert< QgsRectangle >() )
+  else if ( value.userType() == QMetaType::type( "QgsRectangle" ) )
   {
     QgsRectangle r = value.value<QgsRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -618,7 +618,7 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ) );
   }
-  else if ( value.canConvert< QgsReferencedRectangle >() )
+  else if ( value.userType() == QMetaType::type( "QgsReferencedRectangle" ) )
   {
     QgsReferencedRectangle r = value.value<QgsReferencedRectangle>();
     return QStringLiteral( "'%1, %3, %2, %4 [%5]'" ).arg( qgsDoubleToString( r.xMinimum() ),
@@ -626,13 +626,13 @@ QString QgsProcessingUtils::variantToPythonLiteral( const QVariant &value )
            qgsDoubleToString( r.xMaximum() ),
            qgsDoubleToString( r.yMaximum() ),                                                                                                                             r.crs().authid() );
   }
-  else if ( value.canConvert< QgsPointXY >() )
+  else if ( value.userType() == QMetaType::type( "QgsPointXY" ) )
   {
     QgsPointXY r = value.value<QgsPointXY>();
     return QStringLiteral( "'%1,%2'" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
   }
-  else if ( value.canConvert< QgsReferencedPointXY >() )
+  else if ( value.userType() == QMetaType::type( "QgsReferencedPointXY" ) )
   {
     QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "'%1,%2 [%3]'" ).arg( qgsDoubleToString( r.x() ),
@@ -992,14 +992,14 @@ QVariant QgsProcessingUtils::generateIteratingDestination( const QVariant &input
   if ( !input.isValid() )
     return QStringLiteral( "memory:%1" ).arg( id.toString() );
 
-  if ( input.canConvert<QgsProcessingOutputLayerDefinition>() )
+  if ( input.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
   {
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( input );
     QVariant newSink = generateIteratingDestination( fromVar.sink, id, context );
     fromVar.sink = QgsProperty::fromValue( newSink );
     return fromVar;
   }
-  else if ( input.canConvert<QgsProperty>() )
+  else if ( input.userType() == QMetaType::type( "QgsProperty" ) )
   {
     QString res = input.value< QgsProperty>().valueAsString( context.expressionContext() );
     return generateIteratingDestination( res, id, context );

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -860,7 +860,7 @@ QVariant QgsAggregateCalculator::calculateGeometryAggregate( QgsFeatureIterator 
     Q_ASSERT( context );
     context->setFeature( f );
     const QVariant v = expression->evaluate( context );
-    if ( v.canConvert<QgsGeometry>() )
+    if ( v.userType() == QMetaType::type( "QgsGeometry" ) )
     {
       geometries << v.value<QgsGeometry>();
     }

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -80,6 +80,8 @@
 #include "qgsdbquerylog.h"
 #include "qgsfontmanager.h"
 #include "qgsunsetattributevalue.h"
+#include "qgscolorrampimpl.h"
+#include "qgsinterval.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -289,12 +291,17 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QgsAuthManager::MessageLevel>( "QgsAuthManager::MessageLevel" );
     qRegisterMetaType<QgsNetworkRequestParameters>( "QgsNetworkRequestParameters" );
     qRegisterMetaType<QgsNetworkReplyContent>( "QgsNetworkReplyContent" );
+    qRegisterMetaType<QgsFeature>( "QgsFeature" );
     qRegisterMetaType<QgsGeometry>( "QgsGeometry" );
+    qRegisterMetaType<QgsInterval>( "QgsInterval" );
+    qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
+    qRegisterMetaType<QgsPointXY>( "QgsPointXY" );
     qRegisterMetaType<QgsDatumTransform::GridDetails>( "QgsDatumTransform::GridDetails" );
     qRegisterMetaType<QgsDatumTransform::TransformDetails>( "QgsDatumTransform::TransformDetails" );
     qRegisterMetaType<QgsNewsFeedParser::Entry>( "QgsNewsFeedParser::Entry" );
     qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
     qRegisterMetaType<QgsLocatorResult>( "QgsLocatorResult" );
+    qRegisterMetaType<QgsGradientColorRamp>( "QgsGradientColorRamp" );
     qRegisterMetaType<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // Qt6 documentation says these are not needed anymore (https://www.qt.io/blog/whats-new-in-qmetatype-qvariant) #spellok

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -194,42 +194,42 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
 
     case QVariant::UserType:
     {
-      if ( value.canConvert< QgsProperty >() )
+      if ( value.userType() == QMetaType::type( "QgsProperty" ) )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProperty" ) );
         const QDomElement propertyElem = QgsXmlUtils::writeVariant( value.value< QgsProperty >().toVariant(), doc );
         element.appendChild( propertyElem );
         break;
       }
-      else if ( value.canConvert< QgsCoordinateReferenceSystem >() )
+      else if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsCoordinateReferenceSystem" ) );
         const QgsCoordinateReferenceSystem crs = value.value< QgsCoordinateReferenceSystem >();
         crs.writeXml( element, doc );
         break;
       }
-      else if ( value.canConvert< QgsGeometry >() )
+      else if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
       {
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsGeometry" ) );
         const QgsGeometry geom = value.value< QgsGeometry >();
         element.setAttribute( QStringLiteral( "value" ), geom.asWkt() );
         break;
       }
-      else if ( value.canConvert< QgsProcessingOutputLayerDefinition >() )
+      else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsProcessingOutputLayerDefinition >().toVariant(), doc );
         element.appendChild( valueElement );
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );
         break;
       }
-      else if ( value.canConvert< QgsProcessingFeatureSourceDefinition >() )
+      else if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsProcessingFeatureSourceDefinition >().toVariant(), doc );
         element.appendChild( valueElement );
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingFeatureSourceDefinition" ) );
         break;
       }
-      else if ( value.canConvert< QgsRemappingSinkDefinition >() )
+      else if ( value.userType() == QMetaType::type( "QgsRemappingSinkDefinition" ) )
       {
         const QDomElement valueElement = writeVariant( value.value< QgsRemappingSinkDefinition >().toVariant(), doc );
         element.appendChild( valueElement );

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -394,7 +394,7 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
     for ( const QString &v : list )
       res.append( linkSourcesForParameterValue( model, v, childId, context ) );
   }
-  else if ( value.canConvert< QgsProcessingModelChildParameterSource >() )
+  else if ( value.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
   {
     const QgsProcessingModelChildParameterSource source = value.value< QgsProcessingModelChildParameterSource >();
     switch ( source.source() )

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -233,7 +233,7 @@ void QgsProcessingMapLayerComboBox::setValue( const QVariant &value, QgsProcessi
   bool found = false;
   bool selectedOnly = false;
   bool iterate = false;
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
     val = fromVar.source;
@@ -250,7 +250,7 @@ void QgsProcessingMapLayerComboBox::setValue( const QVariant &value, QgsProcessi
     mGeometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;
   }
 
-  if ( val.canConvert<QgsProperty>() )
+  if ( val.userType() == QMetaType::type( "QgsProperty" ) )
   {
     if ( val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
     {

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -212,7 +212,7 @@ QVariant QgsProcessingModelerParameterWidget::value() const
         const QVariantList vList = v.toList();
         if ( std::all_of( vList.begin(), vList.end(), []( const QVariant & val )
       {
-        return val.canConvert< QgsProcessingModelChildParameterSource >();
+        return val.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" );
         } ) )
         {
           return v;

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -41,7 +41,7 @@ QgsProcessingMultipleSelectionPanelWidget::QgsProcessingMultipleSelectionPanelWi
   : QgsPanelWidget( parent )
   , mValueFormatter( []( const QVariant & v )->QString
 {
-  if ( v.canConvert< QgsProcessingModelChildParameterSource >() )
+  if ( v.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
     return v.value< QgsProcessingModelChildParameterSource >().staticValue().toString();
   else
     return v.toString();
@@ -105,7 +105,7 @@ QVariantList QgsProcessingMultipleSelectionPanelWidget::selectedOptions() const
     {
       const QVariant option = item->data( Qt::UserRole );
 
-      if ( option.canConvert< QgsProcessingModelChildParameterSource >() )
+      if ( option.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
         hasModelSources = true;
 
       options << option;
@@ -119,7 +119,7 @@ QVariantList QgsProcessingMultipleSelectionPanelWidget::selectedOptions() const
     options.clear();
     for ( const QVariant &option : originalOptions )
     {
-      if ( option.canConvert< QgsProcessingModelChildParameterSource >() )
+      if ( option.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
         options << option;
       else
         options << QVariant::fromValue( QgsProcessingModelChildParameterSource::fromStaticValue( option ) );
@@ -203,8 +203,8 @@ void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value
   for ( int i = 0; i < mModel->rowCount(); ++i )
   {
     if ( mModel->item( i )->data( Qt::UserRole ) == value ||
-         ( mModel->item( i )->data( Qt::UserRole ).canConvert< QgsProcessingModelChildParameterSource >() &&
-           value.canConvert< QgsProcessingModelChildParameterSource >() &&
+         ( mModel->item( i )->data( Qt::UserRole ).userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) &&
+           value.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) &&
            mModel->item( i )->data( Qt::UserRole ).value< QgsProcessingModelChildParameterSource >() ==
            value.value< QgsProcessingModelChildParameterSource >() )
        )

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -97,7 +97,7 @@ void QgsProcessingLayerOutputDestinationWidget::setValue( const QVariant &value 
     {
       saveToTemporary();
     }
-    else if ( value.canConvert< QgsProcessingOutputLayerDefinition >() )
+    else if ( value.userType() == QMetaType::type( "QgsProcessingOutputLayerDefinition" ) )
     {
       const QgsProcessingOutputLayerDefinition def = value.value< QgsProcessingOutputLayerDefinition >();
       if ( def.sink.staticValue().toString() == QLatin1String( "memory:" ) || def.sink.staticValue().toString() == QgsProcessing::TEMPORARY_OUTPUT || def.sink.staticValue().toString().isEmpty() )
@@ -133,7 +133,7 @@ void QgsProcessingLayerOutputDestinationWidget::setValue( const QVariant &value 
       }
       else
       {
-        if ( !prev.canConvert<QgsProcessingOutputLayerDefinition>() ||
+        if ( prev.userType() != QMetaType::type( "QgsProcessingOutputLayerDefinition" ) ||
              !( prev.value< QgsProcessingOutputLayerDefinition >() == QgsProcessingLayerOutputDestinationWidget::value().value< QgsProcessingOutputLayerDefinition >() ) )
           emit destinationChanged();
       }

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -185,7 +185,7 @@ const QgsProcessingParameterDefinition *QgsAbstractProcessingParameterWidgetWrap
 
 void QgsAbstractProcessingParameterWidgetWrapper::setParameterValue( const QVariant &value, QgsProcessingContext &context )
 {
-  if ( mPropertyButton && value.canConvert< QgsProperty >() )
+  if ( mPropertyButton && value.userType() == QMetaType::type( "QgsProperty" ) )
   {
     mPropertyButton->setToProperty( value.value< QgsProperty >() );
   }
@@ -332,7 +332,7 @@ void QgsAbstractProcessingParameterWidgetWrapper::setDynamicParentLayerParameter
     }
 
     QVariant val = parentWrapper->parameterValue();
-    if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+    if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
     {
       // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
       const QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2280,7 +2280,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
   }
 
   QVariant val = parentWrapper->parameterValue();
-  if ( val.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - get extra properties from it
     QgsProcessingFeatureSourceDefinition fromVar = qvariant_cast<QgsProcessingFeatureSourceDefinition>( val );
@@ -4431,7 +4431,7 @@ void QgsProcessingFieldWidgetWrapper::setParentLayerWrapperValue( const QgsAbstr
 
   QVariant value = parentWrapper->parameterValue();
 
-  if ( value.canConvert<QgsProcessingFeatureSourceDefinition>() )
+  if ( value.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
   {
     // input is a QgsProcessingFeatureSourceDefinition - source from it.
     // this is normally discouraged, and algorithms should NEVER do this -- but in this case we can make
@@ -7130,7 +7130,7 @@ void QgsProcessingMultipleLayerWidgetWrapper::setWidgetValue( const QVariant &va
 
     for ( const QVariant &v : value.toList() )
     {
-      if ( v.canConvert< QgsProcessingModelChildParameterSource >() )
+      if ( v.userType() == QMetaType::type( "QgsProcessingModelChildParameterSource" ) )
       {
         const QgsProcessingModelChildParameterSource source = v.value< QgsProcessingModelChildParameterSource >();
         opts << QVariant::fromValue( source );
@@ -7357,7 +7357,7 @@ void QgsProcessingAnnotationLayerWidgetWrapper::setWidgetValue( const QVariant &
     }
 
     QVariant val = value;
-    if ( val.canConvert<QgsProperty>() )
+    if ( val.userType() == QMetaType::type( "QgsProperty" ) )
     {
       if ( val.value< QgsProperty >().propertyType() == QgsProperty::StaticProperty )
       {

--- a/src/gui/qgsdetaileditemdelegate.cpp
+++ b/src/gui/qgsdetaileditemdelegate.cpp
@@ -50,7 +50,7 @@ void QgsDetailedItemDelegate::paint( QPainter *thepPainter,
 {
   // After painting we need to restore the painter to its original state
   const QgsScopedQPainterState painterState( thepPainter );
-  if ( index.data( Qt::UserRole ).canConvert<QgsDetailedItemData>() )
+  if ( index.data( Qt::UserRole ).userType() == QMetaType::type( "QgsDetailedItemData" ) )
   {
     const QgsDetailedItemData myData =
       index.data( Qt::UserRole ).value<QgsDetailedItemData>();
@@ -71,7 +71,7 @@ QSize QgsDetailedItemDelegate::sizeHint(
   const QStyleOptionViewItem &option,
   const QModelIndex &index ) const
 {
-  if ( index.data( Qt::UserRole ).canConvert<QgsDetailedItemData>() )
+  if ( index.data( Qt::UserRole ).userType() == QMetaType::type( "QgsDetailedItemData" ) )
   {
     const QgsDetailedItemData myData =
       index.data( Qt::UserRole ).value<QgsDetailedItemData>();

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -315,7 +315,7 @@ void QgsFieldCalculator::accept()
       }
       else if ( updatingGeom )
       {
-        if ( value.canConvert< QgsGeometry >() )
+        if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
         {
           QgsGeometry geom = value.value< QgsGeometry >();
           mVectorLayer->changeGeometry( feature.id(), geom );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -767,7 +767,7 @@ QString QgsAfsProviderMetadata::encodeUri( const QVariantMap &parts ) const
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "url" ), parts.value( QStringLiteral( "url" ) ).toString() );
 
-  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).canConvert< QgsRectangle >() )
+  if ( parts.contains( QStringLiteral( "bounds" ) ) && parts.value( QStringLiteral( "bounds" ) ).userType() == QMetaType::type( "QgsRectangle" ) )
   {
     const QgsRectangle bBox = parts.value( QStringLiteral( "bounds" ) ).value< QgsRectangle >();
     dsUri.setParam( QStringLiteral( "bbox" ), QStringLiteral( "%1,%2,%3,%4" ).arg( bBox.xMinimum() ).arg( bBox.yMinimum() ).arg( bBox.xMaximum() ).arg( bBox.yMaximum() ) );

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -45,7 +45,7 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
       return value.toString();
 
     case QVariant::UserType:
-      if ( value.canConvert<QgsGeometry>() )
+      if ( value.userType() == QMetaType::type( "QgsGeometry" ) )
       {
         const QgsGeometry geom = value.value<QgsGeometry>();
         return QString( "ST_GeomFromText('%1',%2)" ).arg( geom.asWkt() ).arg( mRequestedSrid.isEmpty() ? mDetectedSrid : mRequestedSrid );

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -833,14 +833,14 @@ void qgisFunctionWrapper( sqlite3_context *ctxt, int nArgs, sqlite3_value **args
     }
     case QVariant::UserType:
     {
-      if ( ret.canConvert<QgsGeometry>() )
+      if ( ret.userType() == QMetaType::type( "QgsGeometry" ) )
       {
         char *blob = nullptr;
         int size = 0;
         qgsGeometryToSpatialiteBlob( ret.value<QgsGeometry>(), /*srid*/0, blob, size );
         sqlite3_result_blob( ctxt, blob, size, deleteGeometryBlob );
       }
-      else if ( ret.canConvert<QgsInterval>() )
+      else if ( ret.userType() == QMetaType::type( "QgsInterval" ) )
       {
         sqlite3_result_double( ctxt, ret.value<QgsInterval>().seconds() );
       }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -10947,14 +10947,14 @@ void TestQgsProcessing::generateIteratingDestination()
   def.sink = QgsProperty::fromValue( "ape.shp" );
   def.destinationProject = &p;
   QVariant res = QgsProcessingUtils::generateIteratingDestination( def, 2, context );
-  QVERIFY( res.canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QStringLiteral( "ape_2.shp" ) );
   QCOMPARE( fromVar.destinationProject, &p );
 
   def.sink = QgsProperty::fromExpression( "'ape' || '.shp'" );
   res = QgsProcessingUtils::generateIteratingDestination( def, 2, context );
-  QVERIFY( res.canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QStringLiteral( "ape_2.shp" ) );
   QCOMPARE( fromVar.destinationProject, &p );
@@ -10963,7 +10963,7 @@ void TestQgsProcessing::generateIteratingDestination()
   def2.sink = QgsProperty::fromValue( QgsProcessing::TEMPORARY_OUTPUT );
   def2.destinationProject = &p;
   res = QgsProcessingUtils::generateIteratingDestination( def2, 2, context );
-  QVERIFY( res.canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( res.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( res );
   QCOMPARE( fromVar.sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QCOMPARE( fromVar.destinationProject, &p );

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -452,7 +452,7 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   QCOMPARE( map["default_value"].toMap()["create_options"].toMap()[QStringLiteral( "fileEncoding" )].toString(), QStringLiteral( "my_encoding" ) );
   QgsProcessingModelOutput out;
   out.loadVariant( map );
-  QVERIFY( out.defaultValue().canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( out.defaultValue().userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   layerDef = out.defaultValue().value<QgsProcessingOutputLayerDefinition>();
   QCOMPARE( layerDef.sink.staticValue().toString(), QStringLiteral( "my_path" ) );
   QCOMPARE( layerDef.createOptions[QStringLiteral( "fileEncoding" )].toString(), QStringLiteral( "my_encoding" ) );
@@ -990,7 +990,7 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).source(), QgsProcessingModelChildParameterSource::Expression );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).expression(), QStringLiteral( "1+2" ) );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).source(), QgsProcessingModelChildParameterSource::StaticValue );
-  QVERIFY( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().canConvert< QgsProperty >() );
+  QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().userType(), QMetaType::type( "QgsProperty" ) );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().value< QgsProperty >().expressionString(), QStringLiteral( "1+8" ) );
 
   QCOMPARE( alg6c1.modelOutputs().count(), 1 );
@@ -1282,7 +1282,7 @@ void TestQgsProcessingModelAlgorithm::modelExecution()
   QVERIFY( error.isEmpty() );
   QCOMPARE( params.value( "INPUT" ).toString(), QStringLiteral( "dest.shp" ) );
   QCOMPARE( params.value( "EXPRESSION" ).toString(), QStringLiteral( "true" ) );
-  QVERIFY( params.value( "OUTPUT" ).canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( params.value( "OUTPUT" ).userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   const QgsProcessingOutputLayerDefinition outDef = qvariant_cast<QgsProcessingOutputLayerDefinition>( params.value( "OUTPUT" ) );
   QCOMPARE( outDef.destinationName, QStringLiteral( "MY_OUT" ) );
   QCOMPARE( outDef.sink.staticValue().toString(), QStringLiteral( "memory:" ) );
@@ -1295,7 +1295,7 @@ void TestQgsProcessingModelAlgorithm::modelExecution()
   QVERIFY( error.isEmpty() );
   QCOMPARE( params.value( "INPUT" ).toString(), QStringLiteral( "dest.shp" ) );
   QCOMPARE( params.value( "EXPRESSION" ).toString(), QStringLiteral( "true" ) );
-  QVERIFY( params.value( "OUTPUT" ).canConvert<QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( params.value( "OUTPUT" ).userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   const QgsProcessingOutputLayerDefinition outDef2 = qvariant_cast<QgsProcessingOutputLayerDefinition>( params.value( "OUTPUT" ) );
   QCOMPARE( outDef2.destinationName, QStringLiteral( "MY_OUT" ) );
   QCOMPARE( outDef2.sink.staticValue().toString(), QStringLiteral( "memory:" ) );

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -393,7 +393,7 @@ void TestQgsGeometry::asVariant()
   //convert to and from a QVariant
   QVariant var = QVariant::fromValue( original );
   QVERIFY( var.isValid() );
-  QVERIFY( !var.canConvert< QgsReferencedGeometry >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsGeometry" ) );
 
   QgsGeometry fromVar = qvariant_cast<QgsGeometry>( var );
   QCOMPARE( fromVar.constGet()->vertexAt( QgsVertexId( 0, 0, 0 ) ).x(), 1.0 );
@@ -425,7 +425,7 @@ void TestQgsGeometry::referenced()
   QVariant var = QVariant::fromValue( geom1 );
   QVERIFY( var.isValid() );
 
-  QVERIFY( var.canConvert< QgsReferencedGeometry >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedGeometry" ) );
 
   QgsReferencedGeometry geom2 = qvariant_cast<QgsReferencedGeometry>( var );
   QCOMPARE( geom2.asWkt(), geom1.asWkt() );

--- a/tests/src/core/geometry/testqgspointxy.cpp
+++ b/tests/src/core/geometry/testqgspointxy.cpp
@@ -325,8 +325,7 @@ void TestQgsPointXY::asVariant()
   //convert to and from a QVariant
   const QVariant var = QVariant::fromValue( p1 );
   QVERIFY( var.isValid() );
-  QVERIFY( var.canConvert< QgsPointXY >() );
-  QVERIFY( !var.canConvert< QgsReferencedPointXY >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsPointXY" ) );
 
   const QgsPointXY p2 = qvariant_cast<QgsPointXY>( var );
   QCOMPARE( p2.x(), p1.x() );
@@ -347,7 +346,7 @@ void TestQgsPointXY::referenced()
   // not great - we'd ideally like this to pass, but it doesn't:
   // QVERIFY( !var.canConvert< QgsPointXY >() );
 
-  QVERIFY( var.canConvert< QgsReferencedPointXY >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedPointXY" ) );
 
   const QgsReferencedPointXY p2 = qvariant_cast<QgsReferencedPointXY>( var );
   QCOMPARE( p2.x(), p1.x() );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -279,7 +279,7 @@ void TestQgsRectangle::asVariant()
   //convert to and from a QVariant
   const QVariant var = QVariant::fromValue( rect1 );
   QVERIFY( var.isValid() );
-  QVERIFY( var.canConvert< QgsRectangle >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsRectangle" ) );
   QVERIFY( !var.canConvert< QgsReferencedRectangle >() );
 
   const QgsRectangle rect2 = qvariant_cast<QgsRectangle>( var );
@@ -303,7 +303,7 @@ void TestQgsRectangle::referenced()
   // not great - we'd ideally like this to pass, but it doesn't:
   // QVERIFY( !var.canConvert< QgsRectangle >() );
 
-  QVERIFY( var.canConvert< QgsReferencedRectangle >() );
+  QCOMPARE( var.userType(), QMetaType::type( "QgsReferencedRectangle" ) );
 
   const QgsReferencedRectangle rect2 = qvariant_cast<QgsReferencedRectangle>( var );
   QCOMPARE( rect2.xMinimum(), rect1.xMinimum() );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2408,7 +2408,7 @@ class TestQgsExpression: public QObject
         qDebug() << exp.evalErrorString();
 
       QCOMPARE( exp.hasEvalError(), false );
-      QCOMPARE( res.canConvert<QgsFeature>(), featureMatched );
+      QCOMPARE( res.userType() == QMetaType::type( "QgsFeature" ), featureMatched );
       if ( featureMatched )
       {
         QgsFeature feat = res.value<QgsFeature>();
@@ -3500,7 +3500,7 @@ class TestQgsExpression: public QObject
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
 
-      QCOMPARE( out.canConvert<QgsGeometry>(), true );
+      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QCOMPARE( geom.equals( outGeom ), true );
     }
@@ -3561,7 +3561,7 @@ class TestQgsExpression: public QObject
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
-      QCOMPARE( out.canConvert<QgsGeometry>(), true );
+      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QCOMPARE( geom.equals( outGeom ), true );
     }
@@ -3704,7 +3704,7 @@ class TestQgsExpression: public QObject
       QVariant out = exp.evaluate( &context );
       QCOMPARE( exp.hasEvalError(), evalError );
 
-      QCOMPARE( out.canConvert<QgsGeometry>(), true );
+      QCOMPARE( out.userType() == QMetaType::type( "QgsGeometry" ), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       outGeom.normalize();
       result.normalize();

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -5988,7 +5988,7 @@ void TestProcessingGui::mapLayerComboBox()
   // now make a selection in the layer, and repeat
   vl2->selectAll();
   combo->setValue( sourceDef, context );
-  QVERIFY( combo->value().canConvert< QgsProcessingFeatureSourceDefinition >() );
+  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
   QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().source.staticValue().toString(), vl2->id() );
   QVERIFY( combo->value().value< QgsProcessingFeatureSourceDefinition >().selectedFeaturesOnly );
   QVERIFY( combo->currentText().startsWith( vl2->name() ) );
@@ -6003,7 +6003,7 @@ void TestProcessingGui::mapLayerComboBox()
   // phew, nearly there. Let's check another variation
   vl2->selectAll();
   combo->setValue( sourceDef, context );
-  QVERIFY( combo->value().canConvert< QgsProcessingFeatureSourceDefinition >() );
+  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
   QCOMPARE( spy.count(), 10 );
   combo->setValue( QVariant::fromValue( vl ), context );
   QCOMPARE( combo->value().toString(), vl->id() );
@@ -6018,7 +6018,7 @@ void TestProcessingGui::mapLayerComboBox()
   sourceDef = QgsProcessingFeatureSourceDefinition( vl->id(), true );
   combo->setValue( sourceDef, context );
   // expect "selected only" state to remain
-  QVERIFY( combo->value().canConvert< QgsProcessingFeatureSourceDefinition >() );
+  QCOMPARE( combo->value().userType(), QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) );
   QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().source.staticValue().toString(), vl->id() );
   QVERIFY( combo->value().value< QgsProcessingFeatureSourceDefinition >().selectedFeaturesOnly );
   QVERIFY( combo->currentText().startsWith( vl->name() ) );
@@ -8587,13 +8587,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8610,13 +8610,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
 
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8631,7 +8631,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
 
@@ -8639,7 +8639,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8649,7 +8649,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8661,7 +8661,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8678,7 +8678,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.shp" ) ) );
 
@@ -8691,13 +8691,13 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -8729,7 +8729,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -8760,7 +8760,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( def );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QVERIFY( v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().size(), 2 );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().value( QStringLiteral( "field1" ) ), QgsProperty::fromField( QStringLiteral( "source1" ) ) );
@@ -8768,7 +8768,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
 
   panel3.setValue( QStringLiteral( "other.shp" ) );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QVERIFY( !v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
 }
 
@@ -8781,13 +8781,13 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8799,7 +8799,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8814,7 +8814,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8824,7 +8824,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8836,7 +8836,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8853,7 +8853,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.shp" ) ) );
 
@@ -8866,13 +8866,13 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -8904,7 +8904,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -8934,13 +8934,13 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8954,7 +8954,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.tif" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -8966,7 +8966,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.tif" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.tif" ) ) );
 
@@ -8979,13 +8979,13 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -9017,7 +9017,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
@@ -9047,13 +9047,13 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QSignalSpy changedSpy( &panel, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   QVariant v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
 
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9067,7 +9067,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.las" ) );
   QVERIFY( !panel.outputIsSkipped() );
@@ -9079,7 +9079,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   settings.setValue( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), TEST_DATA_DIR );
   panel.setValue( QStringLiteral( "test.las" ) );
   v = panel.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.las" ) ) );
 
@@ -9092,13 +9092,13 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QSignalSpy changedSpy2( &panel2, &QgsProcessingLayerOutputDestinationWidget::destinationChanged );
 
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
 
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
@@ -9130,7 +9130,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
 
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
-  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );

--- a/tests/src/gui/testqgstableeditor.cpp
+++ b/tests/src/gui/testqgstableeditor.cpp
@@ -963,20 +963,20 @@ void TestQgsTableEditor::properties()
   QCOMPARE( w.tableContents().size(), 1 );
   QCOMPARE( w.tableContents().at( 0 ).size(), 4 );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().toString(), QStringLiteral( "Jet" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).content().canConvert< QgsProperty >() );
-  QVERIFY( w.tableContents().at( 0 ).at( 1 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != QMetaType::type( "QgsProperty" ) );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), QMetaType::type( "QgsProperty" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "1+2" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != QMetaType::type( "QgsProperty" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != QMetaType::type( "QgsProperty" ) );
 
   w.selectionModel()->clearSelection();
   w.setSelectionCellProperty( QgsProperty::fromExpression( QStringLiteral( "2+3" ) ) );
   QCOMPARE( spy.count(), 1 );
 
   w.selectionModel()->select( w.model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect );
-  QVERIFY( !w.tableContents().at( 0 ).at( 0 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().userType() != QMetaType::type( "QgsProperty" ) );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::Select );
   QVERIFY( !w.selectionCellProperty().isActive() );
   w.selectionModel()->select( w.model()->index( 0, 1 ), QItemSelectionModel::ClearAndSelect );
@@ -988,14 +988,14 @@ void TestQgsTableEditor::properties()
   QCOMPARE( spy.count(), 2 );
   QVERIFY( w.selectionCellProperty().isActive() );
   QCOMPARE( w.selectionCellProperty().asExpression(), QStringLiteral( "3+4" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 0 ).content().canConvert< QgsProperty >() );
+  QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().userType(), QMetaType::type( "QgsProperty" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 0 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "3+4" ) );
-  QVERIFY( w.tableContents().at( 0 ).at( 1 ).content().canConvert< QgsProperty >() );
+  QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().userType(), QMetaType::type( "QgsProperty" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 1 ).content().value< QgsProperty >().asExpression(), QStringLiteral( "3+4" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 2 ).content().toString(), QStringLiteral( "87" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 2 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 2 ).content().userType() != QMetaType::type( "QgsProperty" ) );
   QCOMPARE( w.tableContents().at( 0 ).at( 3 ).content().toString(), QStringLiteral( "Jet3" ) );
-  QVERIFY( !w.tableContents().at( 0 ).at( 3 ).content().canConvert< QgsProperty >() );
+  QVERIFY( w.tableContents().at( 0 ).at( 3 ).content().userType() != QMetaType::type( "QgsProperty" ) );
   w.selectionModel()->select( w.model()->index( 0, 3 ), QItemSelectionModel::Select );
   QVERIFY( !w.selectionCellProperty().isActive() );
 }


### PR DESCRIPTION
This doesn't have the same logic in qt 6 as in previous versions, where in qt 6 canConvert may return true even if the variant
value isn't of the specified type