### PR TITLE
Fix missing encodings for the dxf exporter

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2193,7 +2193,7 @@ QStringList QgsDxfExport::encodings()
   for ( const QByteArray &codec : codecs )
   {
     int i;
-    for ( i = 0; i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) && strcmp( codec.data(), DXF_ENCODINGS[i][1] ) != 0; ++i )
+    for ( i = 0; i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) && strcasecmp( codec.data(), DXF_ENCODINGS[i][1] ) != 0; ++i )
       ;
 
     if ( i < static_cast< int >( sizeof( DXF_ENCODINGS ) / sizeof( *DXF_ENCODINGS ) ) )


### PR DESCRIPTION

The list of encodings available in QgsDxfExport is incomplete on present Qt versions (including 5.15 in windows .msi installers of 3.16+).

It's because codecs returned by QTextCodec.availableCodecs() are compared with a whitelist: https://github.com/qgis/QGIS/blob/master/src/core/dxf/qgsdxfexport_p.h#L402-L418

while Qt apparently changed most "CPxxxx" codepages to lowercase "cpxxxx". It's easily visible by comparing Windows' 3.16.16 .msi installer (Qt 5.15) with the old .exe one (Qt 5.11).

This PR simply makes that comparision case insensitive.
