### PR TITLE
Fix long,lat point cloud not being rendered correctly

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -323,7 +323,7 @@ bool QgsCopcPointCloudIndex::hasNode( const IndexedPointCloudNode &n ) const
   mHierarchyMutex.lock();
 
   auto it = mHierarchy.constFind( n );
-  const bool found = it != mHierarchy.constEnd() && *it  > 0;
+  const bool found = it != mHierarchy.constEnd() && ( *it ) >= 0;
   mHierarchyMutex.unlock();
   return found;
 }
@@ -348,7 +348,7 @@ QList<IndexedPointCloudNode> QgsCopcPointCloudIndex::nodeChildren( const Indexed
   {
     int dx = i & 1, dy = !!( i & 2 ), dz = !!( i & 4 );
     const IndexedPointCloudNode n2( d, x + dx, y + dy, z + dz );
-    if ( fetchNodeHierarchy( n2 ) && mHierarchy[n] > 0 )
+    if ( fetchNodeHierarchy( n2 ) && mHierarchy[n] >= 0 )
       lst.append( n2 );
   }
   return lst;

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -516,7 +516,8 @@ QVector<IndexedPointCloudNode> QgsPointCloudLayerRenderer::traverseTree( const Q
   if ( !context.zRange().isInfinite() && !context.zRange().overlaps( adjustedNodeZRange ) )
     return nodes;
 
-  nodes.append( n );
+  if ( pc->nodePointCount( n ) > 0 )
+    nodes.append( n );
 
   double childrenErrorPixels = nodeErrorPixels / 2.0;
   if ( childrenErrorPixels < maxErrorPixels )

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -76,7 +76,7 @@ QList<IndexedPointCloudNode> QgsRemoteCopcPointCloudIndex::nodeChildren( const I
   {
     int dx = i & 1, dy = !!( i & 2 ), dz = !!( i & 4 );
     const IndexedPointCloudNode n2( d, x + dx, y + dy, z + dz );
-    if ( fetchNodeHierarchy( n2 ) && mHierarchy[n] > 0 )
+    if ( fetchNodeHierarchy( n2 ) && mHierarchy[n] >= 0 )
       lst.append( n2 );
   }
   return lst;

--- a/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
@@ -228,7 +228,7 @@ bool QgsRemoteEptPointCloudIndex::loadNodeHierarchy( const IndexedPointCloudNode
       const int nodePointCount = it.value().toInt();
       const IndexedPointCloudNode nodeId = IndexedPointCloudNode::fromString( nodeIdStr );
       mHierarchyMutex.lock();
-      if ( nodePointCount > 0 )
+      if ( nodePointCount >= 0 )
         mHierarchy[nodeId] = nodePointCount;
       else if ( nodePointCount == -1 )
         mHierarchyNodes.insert( nodeId );


### PR DESCRIPTION
## Description
Fixes https://github.com/qgis/QGIS/issues/48311 and potentially rendering of more datasets.
Basically some of the inner nodes of the hierarchy tree could be empty while the leaves are the ones that hold point cloud points data. 