### PR TITLE
Fix broken regexps in server which disable the layer/attribute name cleaning

### DIFF
--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -236,7 +236,8 @@ namespace QgsWfs
 
       //xsd:element
       QDomElement attElem = doc.createElement( QStringLiteral( "element" )/*xsd:element*/ );
-      attElem.setAttribute( QStringLiteral( "name" ), attributeName.replace( ' ', '_' ).replace( cleanTagNameRegExp, QString() ) );
+      const thread_local QRegularExpression sCleanTagNameRegExp( QStringLiteral( "[^\\w\\.-_]" ), QRegularExpression::PatternOption::UseUnicodePropertiesOption );
+      attElem.setAttribute( QStringLiteral( "name" ), attributeName.replace( ' ', '_' ).replace( sCleanTagNameRegExp, QString() ) );
       const QVariant::Type attributeType = field.type();
       if ( attributeType == QVariant::Int )
       {

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -39,6 +39,8 @@
 
 #include "qgswfsgetfeature.h"
 
+#include <QRegularExpression>
+
 namespace QgsWfs
 {
 
@@ -272,7 +274,8 @@ namespace QgsWfs
         for ( const QgsField &field : fields )
         {
           fieldnames.append( field.name() );
-          propertynames.append( field.name().replace( ' ', '_' ).replace( cleanTagNameRegExp, QString() ) );
+          const thread_local QRegularExpression sCleanTagNameRegExp( QStringLiteral( "[^\\w\\.-_]" ), QRegularExpression::PatternOption::UseUnicodePropertiesOption );
+          propertynames.append( field.name().replace( ' ', '_' ).replace( sCleanTagNameRegExp, QString() ) );
         }
         QString fieldName;
         for ( plstIt = propertyList.constBegin(); plstIt != propertyList.constEnd(); ++plstIt )
@@ -1547,7 +1550,8 @@ namespace QgsWfs
     QDomElement createFieldElement( const QgsField &field, const QVariant &value, QDomDocument &doc )
     {
       const QgsEditorWidgetSetup setup = field.editorWidgetSetup();
-      const QString attributeName = field.name().replace( ' ', '_' ).replace( cleanTagNameRegExp, QString() );
+      const thread_local QRegularExpression sCleanTagNameRegExp( QStringLiteral( "[^\\w\\.-_]" ), QRegularExpression::PatternOption::UseUnicodePropertiesOption );
+      const QString attributeName = field.name().replace( ' ', '_' ).replace( sCleanTagNameRegExp, QString() );
       QDomElement fieldElem = doc.createElement( QStringLiteral( "qgs:" ) + attributeName );
       if ( QgsVariantUtils::isNull( value ) )
       {

--- a/src/server/services/wfs/qgswfsutils.h
+++ b/src/server/services/wfs/qgswfsutils.h
@@ -74,9 +74,6 @@ namespace QgsWfs
   const QString OGC_NAMESPACE = QStringLiteral( "http://www.opengis.net/ogc" );
   const QString QGS_NAMESPACE = QStringLiteral( "http://www.qgis.org/gml" );
 
-  // Define clean tagName regExp
-  const QRegExp cleanTagNameRegExp( "(?![\\w\\d\\.-])." );
-
 } // namespace QgsWfs
 
 #endif

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -31,6 +31,8 @@
 
 #include "qgsexception.h"
 
+#include <QRegularExpression>
+
 namespace QgsWms
 {
   namespace
@@ -308,7 +310,8 @@ namespace QgsWms
           // layer wms name
           layerElem.setAttribute( QStringLiteral( "name" ), wmsName );
           // define an id based on layer wms name
-          layerElem.setAttribute( QStringLiteral( "id" ), wmsName.replace( QRegExp( "[\\W]" ), QStringLiteral( "_" ) ) );
+          const thread_local QRegularExpression sRegEx( QStringLiteral( "[\\W]" ), QRegularExpression::UseUnicodePropertiesOption );
+          layerElem.setAttribute( QStringLiteral( "id" ), wmsName.replace( sRegEx, QStringLiteral( "_" ) ) );
 
           // layer title
           QDomElement titleElem = doc.createElement( QStringLiteral( "ows:Title" ) );


### PR DESCRIPTION
Looks like this has been broken ever since it was introduced.

The pertinent question is whether we WANT the attribute/layer ids to be cleaned, or whether fixing the broken cleaning will cause regressions in itself....