### PR TITLE
[processing] Add generic option to show feature count for vector outputs

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -63,6 +63,7 @@ class ProcessingConfig:
     DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'DefaultOutputVectorLayerExt'
     TEMP_PATH = 'TEMP_PATH2'
     RESULTS_GROUP_NAME = 'RESULTS_GROUP_NAME'
+    VECTOR_FEATURE_COUNT = 'VECTOR_FEATURE_COUNT'
 
     settings = {}
     settingIcons = {}
@@ -183,6 +184,11 @@ class ProcessingConfig:
             valuetype=Setting.STRING,
             placeholder=ProcessingConfig.tr("Leave blank to avoid loading results in a predetermined group")
         ))
+
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.VECTOR_FEATURE_COUNT,
+            ProcessingConfig.tr('Show feature count for output vector layers'), False))
 
     @staticmethod
     def setGroupIcon(group, icon):

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -106,6 +106,11 @@ def handleAlgorithmResults(alg, context, feedback=None, showResults=True, parame
                 else:
                     details.project.addMapLayer(mapLayer)
 
+                if (ProcessingConfig.getSetting(ProcessingConfig.VECTOR_FEATURE_COUNT) and
+                        layer.type() == QgsMapLayerType.VectorLayer):
+                    layer_tree_layer = details.project.layerTreeRoot().findLayer(layer.id())
+                    layer_tree_layer.setCustomProperty("showFeatureCount", True)
+
                 if details.postProcessor():
                     details.postProcessor().postProcessLayer(layer, context, feedback)
 


### PR DESCRIPTION
After some discussion in #39522, there is some agreement in that having a `Show feature count for output vector layers` option is a good idea, since it gives users a first glimpse on what they're getting from a Processing algorithm.

I'm here implementing that Processing option and setting it to `False` by default, since in some circumstances it might lead to unwanted long waiting times (which by the way could be mentioned in a followup PR for documentation).

Fix #39522

This is how it looks like:

![image](https://user-images.githubusercontent.com/652785/185598057-bb220235-290e-482f-92c4-51271239b5eb.png)

