### PR TITLE
Fix #47810 - zoom last and next with rotated map looses scale

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1457,9 +1457,9 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
     mLastExtent.removeAt( i );
   }
 
-  if ( !mLastExtent.isEmpty() && mLastExtent.last() != extent() )
+  if ( !mLastExtent.isEmpty() && mLastExtent.last() != mSettings.extent() )
   {
-    mLastExtent.append( extent() );
+    mLastExtent.append( mSettings.extent() );
   }
 
   // adjust history to no more than 100
@@ -1605,7 +1605,7 @@ void QgsMapCanvas::zoomToNextExtent()
 void QgsMapCanvas::clearExtentHistory()
 {
   mLastExtent.clear(); // clear the zoom history list
-  mLastExtent.append( extent() ) ; // set the current extent in the list
+  mLastExtent.append( mSettings.extent() ) ; // set the current extent in the list
   mLastExtentIndex = mLastExtent.size() - 1;
   // update controls' enabled state
   emit zoomLastStatusChanged( mLastExtentIndex > 0 );

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -80,6 +80,7 @@ class TestQgsMapCanvas : public QObject
     void testZoomResolutions();
     void testTooltipEvent();
     void testMapLayers();
+    void testExtentHistory();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
@@ -585,6 +586,22 @@ void TestQgsMapCanvas::testMapLayers()
   QCOMPARE( canvas->layer( vl1->id() ), vl1 );
   QCOMPARE( canvas->layer( vl2->id() ), vl2.get() );
   QCOMPARE( canvas->layer( QStringLiteral( "xxx" ) ), nullptr );
+}
+
+void TestQgsMapCanvas::testExtentHistory()
+{
+  QgsRectangle initialExtent;
+  const QList<double> rotations = QList<double>() << 0.0 << 30.0;
+  for ( double rotation : rotations )
+  {
+    mCanvas->setRotation( rotation );
+    mCanvas->clearExtentHistory();
+    mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+    initialExtent = mCanvas->extent();
+    mCanvas->setExtent( QgsRectangle( 100, 100, 110, 110 ) );
+    mCanvas->zoomToPreviousExtent();
+    QCOMPARE( mCanvas->extent(), initialExtent );
+  }
 }
 
 QGSTEST_MAIN( TestQgsMapCanvas )


### PR DESCRIPTION
## Description

Fixes #47810

In QgsMapCanvas, for the extents history, use `mSettings.extent()` instead of `extent()` (which is `mSettings.visibleExtent()`).

In the case of a rotated map the visibleExtent ("Extent" in the picture below) is the bounding box of the zone the user sees ("Canvas" in the picture below).

<img src="https://user-images.githubusercontent.com/34267385/185632507-19f4b183-dc3e-45dd-ab7d-2363bb01632c.png" width=400>

In the extents history, using the visibleExtent leads to scale errors when rotation is non-zero.