### PR TITLE
[processing] Harmonize tags in algs related to error finding and fixing

### DIFF
--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -74,7 +74,7 @@ class CheckValidity(QgisAlgorithm):
         return 'vectorgeometry'
 
     def tags(self):
-        return self.tr('valid,invalid,detect').split(',')
+        return self.tr('valid,invalid,detect,error').split(',')
 
     def __init__(self):
         super().__init__()

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -32,7 +32,7 @@ QString QgsFixGeometriesAlgorithm::displayName() const
 
 QStringList QgsFixGeometriesAlgorithm::tags() const
 {
-  return QObject::tr( "repair,invalid,geometry,make,valid" ).split( ',' );
+  return QObject::tr( "repair,invalid,geometry,make,valid,error" ).split( ',' );
 }
 
 QString QgsFixGeometriesAlgorithm::group() const

--- a/src/analysis/processing/qgsalgorithmremoveduplicatevertices.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatevertices.cpp
@@ -31,7 +31,7 @@ QString QgsAlgorithmRemoveDuplicateVertices::displayName() const
 
 QStringList QgsAlgorithmRemoveDuplicateVertices::tags() const
 {
-  return QObject::tr( "points,valid,overlapping,vertex,nodes" ).split( ',' );
+  return QObject::tr( "points,valid,overlapping,vertex,nodes,invalid,error,repair" ).split( ',' );
 }
 
 QString QgsAlgorithmRemoveDuplicateVertices::group() const


### PR DESCRIPTION
Because it's nice to see them while searching using keywords like: `invalid`, `repair` or `error`.

![image](https://user-images.githubusercontent.com/652785/185659431-d8a1b6aa-3732-4ee0-bbd2-ea800206c7b0.png)
