### PR TITLE
Prevent dropping a gpkg file over another another one and show nicer message

### DIFF
--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -348,7 +348,12 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
     {
       importResults.append( tr( "You cannot import layer %1 over itself!" ).arg( dropUri.name ) );
       hasError = true;
-
+    }
+    // Neither we should support copying the whole GPKG file
+    else if ( dropUri.providerKey == QString() && dropUri.uri == dropUri.filePath )
+    {
+      importResults.append( tr( "You cannot import a GeoPackage file over another GeoPackage file!" ) );
+      hasError = true;
     }
     else
     {

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -350,7 +350,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
       hasError = true;
     }
     // Neither we should support copying the whole GPKG file
-    else if ( dropUri.providerKey == QString() && dropUri.uri == dropUri.filePath )
+    else if ( dropUri.providerKey.isEmpty() && dropUri.uri == dropUri.filePath )
     {
       importResults.append( tr( "You cannot import a GeoPackage file over another GeoPackage file!" ) );
       hasError = true;


### PR DESCRIPTION
The bug is described in detail in https://github.com/qgis/QGIS/issues/45177 . While I cannot reproduce on my Ubuntu 22.04, I think the "Failed to import rasters error" was not very clear anyways.