### PR TITLE
Allow hiding empty layers in sublayers dialog

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
@@ -259,6 +259,24 @@ Sets whether system and internal tables will be shown in the model.
 .. seealso:: :py:func:`includeSystemTables`
 %End
 
+    bool includeEmptyLayers() const;
+%Docstring
+Returns ``True`` if empty tables will be shown in the model.
+
+.. seealso:: :py:func:`setIncludeEmptyLayers`
+
+.. versionadded:: 3.28
+%End
+
+    void setIncludeEmptyLayers( bool include );
+%Docstring
+Sets whether empty tables will be shown in the model.
+
+.. seealso:: :py:func:`includeEmptyLayers`
+
+.. versionadded:: 3.28
+%End
+
   protected:
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const;
 

--- a/src/app/qgsprovidersublayersdialog.cpp
+++ b/src/app/qgsprovidersublayersdialog.cpp
@@ -190,6 +190,7 @@ QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, cons
   connect( mLayersTree->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsProviderSublayersDialog::treeSelectionChanged );
   connect( mSearchLineEdit, &QgsFilterLineEdit::textChanged, mProxyModel, &QgsProviderSublayerProxyModel::setFilterString );
   connect( mCheckShowSystem, &QCheckBox::toggled, mProxyModel, &QgsProviderSublayerProxyModel::setIncludeSystemTables );
+  connect( mCheckShowEmpty, &QCheckBox::toggled, mProxyModel, &QgsProviderSublayerProxyModel::setIncludeEmptyLayers );
   connect( mLayersTree, &QTreeView::doubleClicked, this, [ = ]( const QModelIndex & index )
   {
     const QModelIndex left = mLayersTree->model()->index( index.row(), 0, index.parent() );

--- a/src/core/providers/qgsprovidersublayermodel.cpp
+++ b/src/core/providers/qgsprovidersublayermodel.cpp
@@ -665,8 +665,9 @@ bool QgsProviderSublayerProxyModel::filterAcceptsRow( int source_row, const QMod
   if ( sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::Name ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
     return true;
 
-  // check against the Description column's edit role so that Feature count is searchable
-  if ( sourceModel()->data( sourceModel()->index( source_row, 1, source_parent ), static_cast< int >( Qt::EditRole ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
+  // check against the Description column's display role as it might be different from QgsProviderSublayerModel::Role::Description
+  const QModelIndex descriptionColumnIndex = sourceModel()->index( source_row, 1, source_parent );
+  if ( sourceModel()->data( descriptionColumnIndex, static_cast< int >( Qt::DisplayRole ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
     return true;
 
   const QVariant wkbTypeVariant =  sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::WkbType ) );

--- a/src/core/providers/qgsprovidersublayermodel.cpp
+++ b/src/core/providers/qgsprovidersublayermodel.cpp
@@ -656,13 +656,17 @@ bool QgsProviderSublayerProxyModel::filterAcceptsRow( int source_row, const QMod
   if ( !mIncludeSystemTables && static_cast< Qgis::SublayerFlags >( sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::Flags ) ).toInt() ) & Qgis::SublayerFlag::SystemTable )
     return false;
 
+  if ( !mIncludeEmptyLayers && sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::FeatureCount ) ) == 0 )
+    return false;
+
   if ( mFilterString.trimmed().isEmpty() )
     return true;
 
   if ( sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::Name ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
     return true;
 
-  if ( sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::Description ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
+  // check against the Description column's edit role so that Feature count is searchable
+  if ( sourceModel()->data( sourceModel()->index( source_row, 1, source_parent ), static_cast< int >( Qt::EditRole ) ).toString().contains( mFilterString, Qt::CaseInsensitive ) )
     return true;
 
   const QVariant wkbTypeVariant =  sourceModel()->data( sourceIndex, static_cast< int >( QgsProviderSublayerModel::Role::WkbType ) );
@@ -700,6 +704,17 @@ bool QgsProviderSublayerProxyModel::includeSystemTables() const
 void QgsProviderSublayerProxyModel::setIncludeSystemTables( bool include )
 {
   mIncludeSystemTables = include;
+  invalidateFilter();
+}
+
+bool QgsProviderSublayerProxyModel::includeEmptyLayers() const
+{
+  return mIncludeEmptyLayers;
+}
+
+void QgsProviderSublayerProxyModel::setIncludeEmptyLayers( bool include )
+{
+  mIncludeEmptyLayers = include;
   invalidateFilter();
 }
 

--- a/src/core/providers/qgsprovidersublayermodel.h
+++ b/src/core/providers/qgsprovidersublayermodel.h
@@ -415,6 +415,22 @@ class CORE_EXPORT QgsProviderSublayerProxyModel: public QSortFilterProxyModel
      */
     void setIncludeSystemTables( bool include );
 
+    /**
+     * Returns TRUE if empty tables will be shown in the model.
+     *
+     * \see setIncludeEmptyLayers()
+     * \since QGIS 3.28
+     */
+    bool includeEmptyLayers() const;
+
+    /**
+     * Sets whether empty tables will be shown in the model.
+     *
+     * \see includeEmptyLayers()
+     * \since QGIS 3.28
+     */
+    void setIncludeEmptyLayers( bool include );
+
   protected:
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
     bool lessThan( const QModelIndex &source_left, const QModelIndex &source_right ) const override;
@@ -423,6 +439,7 @@ class CORE_EXPORT QgsProviderSublayerProxyModel: public QSortFilterProxyModel
 
     QString mFilterString;
     bool mIncludeSystemTables = false;
+    bool mIncludeEmptyLayers = true;
 
 };
 

--- a/src/ui/qgsprovidersublayersdialogbase.ui
+++ b/src/ui/qgsprovidersublayersdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>584</width>
-    <height>236</height>
+    <height>311</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="7" column="0">
+   <item row="6" column="0">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -83,11 +83,40 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QCheckBox" name="mCheckShowSystem">
-     <property name="text">
-      <string>Show system and internal tables</string>
+   <item row="5" column="0">
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="title">
+      <string>Options</string>
      </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="mCbxAddToGroup">
+        <property name="text">
+         <string>Add layers to a group</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mCheckShowSystem">
+        <property name="text">
+         <string>Show system and internal tables</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mCheckShowEmpty">
+        <property name="text">
+         <string>Show empty vector layers</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="2" column="0">
@@ -120,17 +149,16 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
-    <widget class="QCheckBox" name="mCbxAddToGroup">
-     <property name="text">
-      <string>Add layers to a group</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
@@ -142,8 +170,6 @@
   <tabstop>mLayersTree</tabstop>
   <tabstop>mBtnSelectAll</tabstop>
   <tabstop>mBtnDeselectAll</tabstop>
-  <tabstop>mCbxAddToGroup</tabstop>
-  <tabstop>mCheckShowSystem</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/src/python/test_qgsprovidersublayermodel.py
+++ b/tests/src/python/test_qgsprovidersublayermodel.py
@@ -502,7 +502,16 @@ class TestQgsProviderSublayerModel(unittest.TestCase):
         layer2.setFeatureCount(-1)
         layer2.setWkbType(QgsWkbTypes.LineString)
 
-        model.setSublayerDetails([layer1, layer2])
+        layer3 = QgsProviderSublayerDetails()
+        layer3.setType(QgsMapLayerType.VectorLayer)
+        layer3.setName('yet another layer 3')
+        layer3.setDescription('an empty layer')
+        layer3.setProviderKey('ogr')
+        layer3.setUri('uri 3')
+        layer3.setFeatureCount(0)
+        layer3.setWkbType(QgsWkbTypes.Polygon)
+
+        model.setSublayerDetails([layer1, layer2, layer3])
 
         item1 = QgsProviderSublayerModel.NonLayerItem()
         item1.setUri('item uri 1')
@@ -512,7 +521,7 @@ class TestQgsProviderSublayerModel(unittest.TestCase):
 
         model.addNonLayerItem(item1)
 
-        self.assertEqual(proxy.rowCount(QModelIndex()), 3)
+        self.assertEqual(proxy.rowCount(QModelIndex()), 4)
 
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
         self.assertEqual(proxy.data(proxy.index(0, 1), Qt.DisplayRole), 'item desc 1')
@@ -539,6 +548,15 @@ class TestQgsProviderSublayerModel(unittest.TestCase):
         self.assertEqual(proxy.data(proxy.index(2, 0), QgsProviderSublayerModel.Role.Description), 'description 1')
         self.assertEqual(proxy.data(proxy.index(2, 0), QgsProviderSublayerModel.Role.IsNonLayerItem), False)
 
+        self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'yet another layer 3')
+        self.assertEqual(proxy.data(proxy.index(3, 1), Qt.DisplayRole), 'an empty layer - Polygon (0)')
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.ProviderKey), 'ogr')
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.LayerType), QgsMapLayerType.VectorLayer)
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.Uri), 'uri 3')
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.Name), 'yet another layer 3')
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.Description), 'an empty layer')
+        self.assertEqual(proxy.data(proxy.index(3, 0), QgsProviderSublayerModel.Role.IsNonLayerItem), False)
+
         proxy.setFilterString(' 1')
         self.assertEqual(proxy.rowCount(QModelIndex()), 2)
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
@@ -557,32 +575,47 @@ class TestQgsProviderSublayerModel(unittest.TestCase):
         self.assertEqual(proxy.rowCount(QModelIndex()), 1)
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'another layer 2')
 
+        # should also allow filtering by the feature count as it appears in the description too but it's not in the description role
+        proxy.setFilterString('0')
+        self.assertEqual(proxy.rowCount(QModelIndex()), 1)
+        self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'yet another layer 3')
+
         proxy.setFilterString('')
-        self.assertEqual(proxy.rowCount(QModelIndex()), 3)
+        self.assertEqual(proxy.rowCount(QModelIndex()), 4)
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
         self.assertEqual(proxy.data(proxy.index(1, 0), Qt.DisplayRole), 'another layer 2')
         self.assertEqual(proxy.data(proxy.index(2, 0), Qt.DisplayRole), 'layer 1')
+        self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'yet another layer 3')
 
         # add a system table
-        layer3 = QgsProviderSublayerDetails()
-        layer3.setType(QgsMapLayerType.VectorLayer)
-        layer3.setName('system table')
-        layer3.setFlags(Qgis.SublayerFlags(Qgis.SublayerFlag.SystemTable))
+        layer_system = QgsProviderSublayerDetails()
+        layer_system.setType(QgsMapLayerType.VectorLayer)
+        layer_system.setName('system table')
+        layer_system.setFlags(Qgis.SublayerFlags(Qgis.SublayerFlag.SystemTable))
 
-        model.setSublayerDetails([layer1, layer2, layer3])
+        model.setSublayerDetails([layer1, layer2, layer3, layer_system])
         # system tables should be hidden by default
-        self.assertEqual(proxy.rowCount(QModelIndex()), 3)
+        self.assertEqual(proxy.rowCount(QModelIndex()), 4)
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
         self.assertEqual(proxy.data(proxy.index(1, 0), Qt.DisplayRole), 'another layer 2')
         self.assertEqual(proxy.data(proxy.index(2, 0), Qt.DisplayRole), 'layer 1')
+        self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'yet another layer 3')
 
         proxy.setIncludeSystemTables(True)
+        self.assertEqual(proxy.rowCount(QModelIndex()), 5)
+        self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
+        self.assertEqual(proxy.data(proxy.index(1, 0), Qt.DisplayRole), 'another layer 2')
+        self.assertEqual(proxy.data(proxy.index(2, 0), Qt.DisplayRole), 'layer 1')
+        self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'system table')
+        self.assertEqual(proxy.data(proxy.index(4, 0), Qt.DisplayRole), 'yet another layer 3')
+
+        # hide empty vector layers
+        proxy.setIncludeEmptyLayers(False)
         self.assertEqual(proxy.rowCount(QModelIndex()), 4)
         self.assertEqual(proxy.data(proxy.index(0, 0), Qt.DisplayRole), 'item name 1')
         self.assertEqual(proxy.data(proxy.index(1, 0), Qt.DisplayRole), 'another layer 2')
         self.assertEqual(proxy.data(proxy.index(2, 0), Qt.DisplayRole), 'layer 1')
         self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'system table')
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsprovidersublayermodel.py
+++ b/tests/src/python/test_qgsprovidersublayermodel.py
@@ -617,5 +617,6 @@ class TestQgsProviderSublayerModel(unittest.TestCase):
         self.assertEqual(proxy.data(proxy.index(2, 0), Qt.DisplayRole), 'layer 1')
         self.assertEqual(proxy.data(proxy.index(3, 0), Qt.DisplayRole), 'system table')
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
When adding layers from a large container file like a Geopackage, the updated sublayers handling dialog makes it easier to locate the desired layers. However, it has become harder to load layers based on their feature count, since the count column has been integrated in the generic *Description* column.
When dealing with tens of layers in a single container the issue is more apparent.
This PR caters for the common use case of skipping loading layers that are empty by adding a checkbox that allows the user to hide empty vector layers (or tables)

![image](https://user-images.githubusercontent.com/11358178/185757597-6f347f99-be95-45d2-bd40-8e2bde88db21.png)

![image](https://user-images.githubusercontent.com/11358178/185757612-425b3890-3ae7-4112-b117-177351ae9d47.png)

Furthermore, the available checkboxes are  grouped in a collapsible groupbox to keep things tidy.

Lastly, the *search* functionality now checks against the table's  *Description* column instead of `QgsProviderSublayerModel::Role::Description` so that the feature count can also be searched for.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
