### PR TITLE
Bring back CP949 codec in QgsDxfExport. Fixes #44756

### DIFF
--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -412,6 +412,7 @@ static const char *DXF_ENCODINGS[][2] =
   { "ANSI_932", "Shift_JIS" },
   { "ANSI_936", "CP936" },
   { "ANSI_949", "CP949" },
+  { "ANSI_949", "ms949" },
   { "ANSI_950", "CP950" },
 //  { "ANSI_1361", "" },
 //  { "ANSI_1200", "" },


### PR DESCRIPTION
After Qt changed the codec name from "CP949" to "ms949" it disappeared from available encodings.

This PR adds the new codec mapped to the same ANSI_949 in order to avoid breaking builds against older Qt versions. Not sure if it's the best way, but I don't want to mess further with the list that is already a bit chaotic....