### PR TITLE
Fetch geometries when conditional formatting rule requires it

### DIFF
--- a/python/core/auto_generated/qgsconditionalstyle.sip.in
+++ b/python/core/auto_generated/qgsconditionalstyle.sip.in
@@ -73,11 +73,11 @@ Writes the condition styles state to a DOM node.
 .. seealso:: :py:func:`readXml`
 %End
 
-    bool rulesNeedGeometry( );
+    bool rulesNeedGeometry() const;
 %Docstring
 Returns ``True`` if at least one rule needs geometry.
 
-.. versionadded:: 3.26
+.. versionadded:: 3.26.3
 %End
 
   signals:

--- a/python/core/auto_generated/qgsconditionalstyle.sip.in
+++ b/python/core/auto_generated/qgsconditionalstyle.sip.in
@@ -73,6 +73,13 @@ Writes the condition styles state to a DOM node.
 .. seealso:: :py:func:`readXml`
 %End
 
+    bool rulesNeedGeometry( );
+%Docstring
+Returns ``True`` if at least one rule needs geometry.
+
+.. versionadded:: 3.26
+%End
+
   signals:
 
     void changed();

--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -86,7 +86,7 @@ bool QgsConditionalLayerStyles::writeXml( QDomNode &node, QDomDocument &doc, con
   return true;
 }
 
-bool QgsConditionalLayerStyles::rulesNeedGeometry()
+bool QgsConditionalLayerStyles::rulesNeedGeometry() const
 {
   for ( const QgsConditionalStyle &style : std::as_const( mRowStyles ) )
   {

--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -86,6 +86,18 @@ bool QgsConditionalLayerStyles::writeXml( QDomNode &node, QDomDocument &doc, con
   return true;
 }
 
+bool QgsConditionalLayerStyles::rulesNeedGeometry()
+{
+  for ( const QgsConditionalStyle &style : std::as_const( mRowStyles ) )
+  {
+    if ( QgsExpression( style.rule() ).needsGeometry() )
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool QgsConditionalLayerStyles::readXml( const QDomNode &node, const QgsReadWriteContext &context )
 {
   const QDomElement condel = node.firstChildElement( QStringLiteral( "conditionalstyles" ) );

--- a/src/core/qgsconditionalstyle.h
+++ b/src/core/qgsconditionalstyle.h
@@ -92,6 +92,12 @@ class CORE_EXPORT QgsConditionalLayerStyles : public QObject
      */
     bool writeXml( QDomNode &node, QDomDocument &doc, const QgsReadWriteContext &context ) const;
 
+    /**
+     * Returns TRUE if at least one rule needs geometry.
+     * \since QGIS 3.26
+     */
+    bool rulesNeedGeometry( );
+
   signals:
 
     /**

--- a/src/core/qgsconditionalstyle.h
+++ b/src/core/qgsconditionalstyle.h
@@ -94,9 +94,9 @@ class CORE_EXPORT QgsConditionalLayerStyles : public QObject
 
     /**
      * Returns TRUE if at least one rule needs geometry.
-     * \since QGIS 3.26
+     * \since QGIS 3.26.3
      */
-    bool rulesNeedGeometry( );
+    bool rulesNeedGeometry() const;
 
   signals:
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -140,7 +140,19 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   // create an empty form to find out if it needs geometry or not
   const QgsAttributeForm emptyForm( mLayer, QgsFeature(), mEditorContext );
 
-  const bool needsGeometry = !( request.flags() & QgsFeatureRequest::NoGeometry )
+  bool conditionalFormattingRulesNeedsGeometry { false };
+  const auto cConditionalStyles { mLayer->conditionalStyles()->rowStyles() };
+  for ( const auto &style : std::as_const( cConditionalStyles ) )
+  {
+    if ( QgsExpression( style.rule() ).needsGeometry() )
+    {
+      conditionalFormattingRulesNeedsGeometry = true;
+      break;
+    }
+  }
+
+  const bool needsGeometry = conditionalFormattingRulesNeedsGeometry ||
+                             !( request.flags() & QgsFeatureRequest::NoGeometry )
                              || ( request.spatialFilterType() != Qgis::SpatialFilterType::NoFilter )
                              || emptyForm.needsGeometry();
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -140,18 +140,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   // create an empty form to find out if it needs geometry or not
   const QgsAttributeForm emptyForm( mLayer, QgsFeature(), mEditorContext );
 
-  bool conditionalFormattingRulesNeedsGeometry { false };
-  const auto cConditionalStyles { mLayer->conditionalStyles()->rowStyles() };
-  for ( const auto &style : std::as_const( cConditionalStyles ) )
-  {
-    if ( QgsExpression( style.rule() ).needsGeometry() )
-    {
-      conditionalFormattingRulesNeedsGeometry = true;
-      break;
-    }
-  }
-
-  const bool needsGeometry = conditionalFormattingRulesNeedsGeometry ||
+  const bool needsGeometry = mLayer->conditionalStyles()->rulesNeedGeometry() ||
                              !( request.flags() & QgsFeatureRequest::NoGeometry )
                              || ( request.spatialFilterType() != Qgis::SpatialFilterType::NoFilter )
                              || emptyForm.needsGeometry();

--- a/tests/src/python/test_qgsconditionalstyle.py
+++ b/tests/src/python/test_qgsconditionalstyle.py
@@ -175,6 +175,16 @@ class TestPyQgsConditionalStyle(unittest.TestCase):
         self.assertEqual(styles.fieldStyles('test'), [QgsConditionalStyle("@value > 30"), QgsConditionalStyle("@value > 40")])
         self.assertEqual(styles.fieldStyles('test2'), [QgsConditionalStyle("@value > 50")])
 
+    def testRequiresGeometry(self):
+
+        styles = QgsConditionalLayerStyles()
+        styles.setRowStyles([QgsConditionalStyle("@value > 10")])
+        self.assertFalse(styles.rulesNeedGeometry())
+        styles.setRowStyles([QgsConditionalStyle("@value > 10"), QgsConditionalStyle('$geometry IS NULL')])
+        self.assertTrue(styles.rulesNeedGeometry())
+        styles.setRowStyles([QgsConditionalStyle('$geometry IS NULL'), QgsConditionalStyle("@value > 10")])
+        self.assertTrue(styles.rulesNeedGeometry())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #43252

When a conditional formatting rule style requires geometry we need to fetch them or the rule won't work.