### PR TITLE
Improvements to line_interpolate_point() docs

### DIFF
--- a/resources/function_help/json/line_interpolate_point
+++ b/resources/function_help/json/line_interpolate_point
@@ -11,8 +11,14 @@
     "description": "distance along line to interpolate"
   }],
   "examples": [{
-    "expression": "geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),distance:=5))",
+    "expression": "geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 8 0)'), distance:=5))",
     "returns": "'Point (5 0)'"
+  }, {
+    "expression": "geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 1 1, 2 0)'), distance:=2.1))",
+    "returns": "'Point (1.48492424 0.51507576)'"
+  }, {
+    "expression": "geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 1 0)'), distance:=2))",
+    "returns": "NULL"
   }],
   "tags": ["distance", "interpolated", "linestring", "point", "specified", "along"]
 }


### PR DESCRIPTION
## Description
- Make it more obvious that the distance is in CRS units, not a percentage, on the first example
- Add example that ends up with floating point coordinates
- Add example that returns NULL

I built QGIS with this and tested that:
- [x] I did not break the JSON
- [x] The examples and their return values match