### PR TITLE
[ui] Ask user before closing expression dialog if expression was edited

### DIFF
--- a/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
@@ -118,6 +118,7 @@ Used to save geometry
 
     virtual void accept();
 
+    virtual void reject();
 
 };
 

--- a/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
@@ -120,6 +120,7 @@ Used to save geometry
 
     virtual void reject();
 
+
 };
 
 

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -98,7 +98,7 @@ void QgsExpressionBuilderDialog::reject()
     if ( askToDiscardEditedExpression )
     {
       QMessageBox confirmMessage( QMessageBox::Question,
-                                  tr( "Expression was edited" ),
+                                  tr( "Expression was Edited" ),
                                   tr( "Closing the dialog now will discard the changes to the expression. Proceed?" ),
                                   QMessageBox::Yes | QMessageBox::No,
                                   this );

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -88,14 +88,15 @@ void QgsExpressionBuilderDialog::accept()
 
 void QgsExpressionBuilderDialog::reject()
 {
-	if (builder->expressionText() != mInitialText)
-	{
-		const int res = QMessageBox::warning( this, tr( "Expression was edited" ),
-											  tr( "Closing the dialog will discard the changes to the expression. Proceed?" ),
-											  QMessageBox::Yes | QMessageBox::No );
-		if ( res != QMessageBox::Yes )
-		  return;
-	}
+  if ( builder->expressionText() != mInitialText )
+  {
+    const int res = QMessageBox::warning( this, tr( "Expression was edited" ),
+                                          tr( "Closing the dialog will discard the changes to the expression. Proceed?" ),
+                                          QMessageBox::Yes | QMessageBox::No
+                                          QMessageBox::Yes );
+    if ( res != QMessageBox::Yes )
+      return;
+  }
   QDialog::reject();
 }
 

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -99,11 +99,12 @@ void QgsExpressionBuilderDialog::reject()
     {
       QMessageBox confirmMessage( QMessageBox::Question,
                                   tr( "Expression was Edited" ),
-                                  tr( "Closing the dialog now will discard the changes to the expression. Proceed?" ),
+                                  tr( "The changes to the expression will be discarded. Would you like to continue?" ),
                                   QMessageBox::Yes | QMessageBox::No,
                                   this );
       confirmMessage.setCheckBox( new QCheckBox( tr( "Don't show this message again" ) ) );
       confirmMessage.checkBox()->setChecked( false );
+      confirmMessage.button( QMessageBox::Yes )->setText( tr( "Discard changes" ) );
 
       int res = confirmMessage.exec();
 

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -17,6 +17,7 @@
 #include "qgssettings.h"
 #include "qgsguiutils.h"
 #include "qgsgui.h"
+#include <QMessageBox>
 
 QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, const QString &startText, QWidget *parent, const QString &key, const QgsExpressionContext &context )
   : QDialog( parent )
@@ -33,6 +34,8 @@ QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, c
   builder->setExpressionText( startText );
   builder->expressionTree()->loadRecent( mRecentKey );
   builder->expressionTree()->loadUserExpressions( );
+
+  mInitialText = startText;
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsExpressionBuilderDialog::showHelp );
 }
@@ -81,6 +84,19 @@ void QgsExpressionBuilderDialog::accept()
 {
   builder->expressionTree()->saveToRecent( builder->expressionText(), mRecentKey );
   QDialog::accept();
+}
+
+void QgsExpressionBuilderDialog::reject()
+{
+	if (builder->expressionText() != mInitialText)
+	{
+		const int res = QMessageBox::warning( this, tr( "Expression was edited" ),
+											  tr( "Closing the dialog will discard the changes to the expression. Proceed?" ),
+											  QMessageBox::Yes | QMessageBox::No );
+		if ( res != QMessageBox::Yes )
+		  return;
+	}
+  QDialog::reject();
 }
 
 void QgsExpressionBuilderDialog::setGeomCalculator( const QgsDistanceArea &da )

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -21,6 +21,7 @@
 
 QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, const QString &startText, QWidget *parent, const QString &key, const QgsExpressionContext &context )
   : QDialog( parent )
+  , mInitialText( startText )
   , mRecentKey( key )
 {
   setupUi( this );
@@ -35,7 +36,6 @@ QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, c
   builder->expressionTree()->loadRecent( mRecentKey );
   builder->expressionTree()->loadUserExpressions( );
 
-  mInitialText = startText;
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsExpressionBuilderDialog::showHelp );
 }

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -88,15 +88,35 @@ void QgsExpressionBuilderDialog::accept()
 
 void QgsExpressionBuilderDialog::reject()
 {
+
   if ( builder->expressionText() != mInitialText )
   {
-    const int res = QMessageBox::warning( this, tr( "Expression was edited" ),
-                                          tr( "Closing the dialog will discard the changes to the expression. Proceed?" ),
-                                          QMessageBox::Yes | QMessageBox::No
-                                          QMessageBox::Yes );
-    if ( res != QMessageBox::Yes )
-      return;
+
+    QgsSettings settings;
+    const bool askToDiscardEditedExpression = settings.value( QStringLiteral( "askToDiscardEditedExpression" ), true, QgsSettings::Gui ).toBool();
+
+    if ( askToDiscardEditedExpression )
+    {
+      QMessageBox confirmMessage( QMessageBox::Question,
+                                  tr( "Expression was edited" ),
+                                  tr( "Closing the dialog now will discard the changes to the expression. Proceed?" ),
+                                  QMessageBox::Yes | QMessageBox::No,
+                                  this );
+      confirmMessage.setCheckBox( new QCheckBox( tr( "Don't show this message again" ) ) );
+      confirmMessage.checkBox()->setChecked( false );
+
+      int res = confirmMessage.exec();
+
+      if ( confirmMessage.checkBox()->isChecked() )
+      {
+        settings.setValue( QStringLiteral( "askToDiscardEditedExpression" ), false, QgsSettings::Gui );
+      }
+
+      if ( res != QMessageBox::Yes )
+        return;
+    }
   }
+
   QDialog::reject();
 }
 

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -119,8 +119,10 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
     void done( int r ) override;
 
     void accept() override;
+    void reject() override;
 
   private:
+    QString mInitialText;
     QString mRecentKey;
     bool mAllowEvalErrors = false;
 

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -122,7 +122,7 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
     void reject() override;
 
   private:
-    QString mInitialText;
+    const QString mInitialText;
     QString mRecentKey;
     bool mAllowEvalErrors = false;
 


### PR DESCRIPTION
## Description
The expression dialog makes it easy to lose one's work if the user hits the Esc key and closes the dialog. Any edits since the last press on OK will be lost.

I added a simple check in the dialog that compares the text that was in it when opened and the text that is in it when it is supposed to be closed without applying (rejecting with Cancel/Esc/X, not accepting the dialog with OK). If there is a different, a QMessageBox will ask the user if they really want to throw their changes away.

The user can choose to not get this warning again by ticking a checkbox, similar to other dialogs. The choice is saved as settings option `gui/askToDiscardEditedExpression`.

![grafik](https://user-images.githubusercontent.com/7661092/187282261-702495c1-1c2c-4353-92ba-54e8cd9b374b.png)

With this change it affects the "Expression String Builder" (Override icon -> edit), "Expression Dialog (Epsilon icon, e. g. for Geometry Generator or for Pre-calculated Value in the model builder), "Expression Based Filter" (Attribute Table -> Advanced filter expression). I am not sure if there are any other Epsilon button dialogs that are different and not affected by the change.

It does not affect "Select by Expression", "Raster Calculator", "Mesh Calculator" and other potential uses of the dialog. If wanted I could add the same checks to those dialogs.

My original motivation to add a safe-guard was when discarding a autocomplete suggestion with Esc did close the dialog. I could not reproduce that anymore though. Still I think this would be a nice feature to have.

I [posted it on Twitter](https://twitter.com/cartocalypse/status/1561361521887903745) and got some mixed feedback. A frequent feedback was to have an option to disable it. Several people stated that they lost expressions due to this in the past and would really like a safeguard like this.

I like [Matthias' suggestion](https://twitter.com/mprove/status/1561374771195019265) to have an Apply button and automatically saving edit state but that would be way beyond my non-existent C++ skills. Another feedback IRL was that a undo that survive closing the dialog would be great. And another idea was to have a list of stored expressions available similar to the functions editor for the Python functions.

# TODO
## Add to other dialogs?
Should this be added to "Select by Expression", "Raster Calculator", "Mesh Calculator" and potentially other dialogs as well?

## BadWindow warnings!
Each time the QMessageBox is triggered, I get a BadWindow warning in the terminal. Here are some from earlier:

```
Warning: QXcbConnection: XCB error: 3 (BadWindow), sequence: 3320, resource id: 21713376, major code: 40 (TranslateCoords), minor code: 0
Warning: QXcbConnection: XCB error: 3 (BadWindow), sequence: 4674, resource id: 21717126, major code: 40 (TranslateCoords), minor code: 0
Warning: QXcbConnection: XCB error: 3 (BadWindow), sequence: 5052, resource id: 21720427, major code: 40 (TranslateCoords), minor code: 0
Warning: QXcbConnection: XCB error: 3 (BadWindow), sequence: 5263, resource id: 21722496, major code: 40 (TranslateCoords), minor code: 0
```

How can I avoid them? 

# Warning or Question as QMessageBox type?
Not sure. I think Question fits better.

# Which options directory to put the option in?
`QgsSettings::App`? `QgsSettings::Gui`?


## Documentation?
Seems not needed to me.

## Tests?
I would need some help if tests are needed for this.

# Tested
- [x] I compiled and ran QGIS with this change and it worked fine for me.

-----


Greetings from the contributor's meeting in Firenze and thanks to the lovely people around for their help!