### PR TITLE
Disable shared opengl contexts

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -927,8 +927,14 @@ int main( int argc, char *argv[] )
   // As suggested by Qt documentation at:
   //   - https://doc.qt.io/qt-5/qtwebengine.html
   //   - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
+#if 0
+  // this is disabled, because it breaks Qt 3D. See
+  // https://interest.qt-project.narkive.com/GYwuMDac/qwebengineview-qsurfaceformat-errors-in-console
+  // https://bugreports.qt.io/browse/QTBUG-60614
+  // https://bugreports.qt.io/browse/QTBUG-60605
 #if !defined(QT_NO_OPENGL)
   QCoreApplication::setAttribute( Qt::AA_ShareOpenGLContexts, true );
+#endif
 #endif
 
   // Set up the QgsSettings Global Settings:


### PR DESCRIPTION
Revert https://github.com/qgis/QGIS/pull/47873

While required for Qt Webengine, this breaks Qt 3D. It seems the two are mutually exclusive on current QT/QtWebengine builds.

See

https://interest.qt-project.narkive.com/GYwuMDac/qwebengineview-qsurfaceformat-errors-in-console
https://bugreports.qt.io/browse/QTBUG-60614
https://bugreports.qt.io/browse/QTBUG-60605
