### PR TITLE
[qt6][themes] Fix drop down arrow position for instant popup tool buttons

### DIFF
--- a/resources/themes/Blend of Gray/icons/arrow-down-disabled.svg
+++ b/resources/themes/Blend of Gray/icons/arrow-down-disabled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 3.704 3.704"><path d="M2.249 1.455h-.794l.397.794z" fill="#b2b2b2" fill-opacity="0.5" stroke="#b2b2b2" stroke-opacity="0.5" stroke-width=".265" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -259,9 +259,31 @@ QToolButton:checked:disabled
 {
     border: 1px solid rgba(240,240,240,100);
 }
-QToolButton::menu-arrow 
+QToolButton::menu-arrow
 {
     image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-arrow:disabled
+{
+    image: url(@theme_path/icons/arrow-down-disabled.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-indicator
+{
+    top: 0.2em;
+    right: -0.2em;
+    image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-indicator:disabled
+{
+    top: 0.2em;
+    right: -0.2em;
+    image: url(@theme_path/icons/arrow-down-disabled.svg);
     width: 0.8em;
     height: 1.2em;
 }

--- a/resources/themes/Night Mapping/icons/arrow-down-disabled.svg
+++ b/resources/themes/Night Mapping/icons/arrow-down-disabled.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 3.704 3.704"><path d="M2.249 1.455h-.794l.397.794z" fill="#b2b2b2" fill-opacity="0.5" stroke="#b2b2b2" stroke-opacity="0.5" stroke-width=".265" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -269,9 +269,31 @@ QToolButton:checked:disabled
 {
     border: 1px solid rgba(215,128,26,100);
 }
-QToolButton::menu-arrow 
+QToolButton::menu-arrow
 {
     image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-arrow:disabled
+{
+    image: url(@theme_path/icons/arrow-down-disabled.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-indicator
+{
+    top: 0.2em;
+    right: -0.2em;
+    image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
+}
+QToolButton::menu-indicator:disabled
+{
+    top: 0.2em;
+    right: -0.2em;
+    image: url(@theme_path/icons/arrow-down-disabled.svg);
     width: 0.8em;
     height: 1.2em;
 }


### PR DESCRIPTION
## Description

Above (broken), below (PR):
![image](https://user-images.githubusercontent.com/1728657/185842455-76defe7d-1d99-4911-8fa4-0722ffc42d7c.png)
