### PR TITLE
Pass stepWidth/stepHeight parameter to external WMS layer

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -2044,6 +2044,14 @@ namespace QgsWms
       {
         wmsUri.setParam( QStringLiteral( "dpiMode" ), paramIt.value() );
       }
+      else if ( paramName == QLatin1String( "stepwidth" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "stepWidth" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "stepheight" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "stepHeight" ), paramIt.value() );
+      }
       else
       {
         wmsUri.setParam( paramName, paramIt.value() );


### PR DESCRIPTION
Sometimes it is necessary to set the stepWidth/stepHeight of a WMS layer to a higher value (e.g. to avoid tiling problems with labels in large print layouts). This PR adds a change such that these parameters can be used for external WMS layers in GetMap and GetPrint. 
Usage: ...&layers=EXTERNAL_WMS:testlayer&testlayer:stepWidth=10000&testlayer:stepHeight=10000