### PR TITLE
Fix unreported issue with default field values exp context

### DIFF
--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -321,13 +321,7 @@ QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
       << QgsExpressionContextUtils::globalScope()
       << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
       << QgsExpressionContextUtils::layerScope( mLayer )
-      << QgsExpressionContextUtils::formScope( QgsFeature( mLayer->fields() ) )
       << QgsExpressionContextUtils::mapToolCaptureScope( QList<QgsPointLocator::Match>() );
-
-  context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) );
-  context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
-                                   << QStringLiteral( "current_feature" )
-                                   << QStringLiteral( "form_mode" ) );
 
   return context;
 }


### PR DESCRIPTION
The form context is not needed/relevant here, the "Apply default
values on update" already accesses the current form values.
