### PR TITLE
Don't equate unknown location accuracy with invalid locations

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -752,7 +752,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
   FixStatus fixStatus = NoData;
 
   // no fix if any of the three report bad; default values are invalid values and won't be changed if the corresponding NMEA msg is not received
-  if ( info.status == 'V' || info.fixType == NMEA_FIX_BAD || info.qualityIndicator == Qgis::GpsQualityIndicator::Invalid || info.qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( info.status == 'V' || info.fixType == NMEA_FIX_BAD || info.qualityIndicator == Qgis::GpsQualityIndicator::Invalid ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     fixStatus = NoFix;
   }
@@ -761,7 +761,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     fixStatus = Fix2D;
     validFlag = true;
   }
-  else if ( info.status == 'A' || info.fixType == NMEA_FIX_3D || ( info.qualityIndicator != Qgis::GpsQualityIndicator::Invalid && info.qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
+  else if ( info.status == 'A' || info.fixType == NMEA_FIX_3D || ( info.qualityIndicator != Qgis::GpsQualityIndicator::Invalid ) ) // good
   {
     fixStatus = Fix3D;
     validFlag = true;

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -23,15 +23,12 @@
 #include <QStringList>
 #include <QFileInfo>
 
-#include "qgsnmeaconnection.h"
-#include "qgslogger.h"
 #include "info.h"
-
 
 bool QgsGpsInformation::isValid() const
 {
   bool valid = false;
-  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid || qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     valid = false;
   }
@@ -39,7 +36,7 @@ bool QgsGpsInformation::isValid() const
   {
     valid = true;
   }
-  else if ( status == 'A' || fixType == NMEA_FIX_3D || ( qualityIndicator != Qgis::GpsQualityIndicator::Invalid && qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
+  else if ( status == 'A' || fixType == NMEA_FIX_3D || ( qualityIndicator != Qgis::GpsQualityIndicator::Invalid ) ) // good
   {
     valid = true;
   }
@@ -52,7 +49,7 @@ QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
   FixStatus fixStatus = NoData;
 
   // no fix if any of the three report bad; default values are invalid values and won't be changed if the corresponding NMEA msg is not received
-  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid || qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     fixStatus = NoFix;
   }
@@ -60,7 +57,7 @@ QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
   {
     fixStatus = Fix2D;
   }
-  else if ( status == 'A' || fixType == NMEA_FIX_3D || ( qualityIndicator != Qgis::GpsQualityIndicator::Invalid && qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
+  else if ( status == 'A' || fixType == NMEA_FIX_3D || qualityIndicator != Qgis::GpsQualityIndicator::Invalid ) // good
   {
     fixStatus = Fix3D;
   }


### PR DESCRIPTION
Followup 5bbad0280. Locations returned by QQGeoPositionInfo don't have a quality indication, yet should still be treated at
a valid GPS location

Otherwise functionality in the GPS information panel is lost when the Qt Geoposition device is used. 