### PR TITLE
[vectortiles] Support vector tiles URLs which point directly to a ESRI vector tile service resources/styles/root.json endpoint

### DIFF
--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -301,6 +301,7 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     bool mTileBorderRendering = false;
 
     QVariantMap mArcgisLayerConfiguration;
+    QVariantMap mArcgisStyleConfiguration;
 
     QgsCoordinateTransformContext mTransformContext;
 


### PR DESCRIPTION
This endpoint should also be supported -- it's often used as the public URL for these services