### PR TITLE
Support longlong variant types when converting mapbox gl styles

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -299,6 +299,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
     switch ( jsonFillOpacity.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         fillOpacity = jsonFillOpacity.toDouble();
         rasterOpacity = fillOpacity;
@@ -529,6 +530,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
     switch ( jsonLineWidth.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         lineWidth = jsonLineWidth.toDouble() * context.pixelSizeConversionFactor();
         break;
@@ -558,6 +560,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
     switch ( jsonLineOffset.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         lineOffset = -jsonLineOffset.toDouble() * context.pixelSizeConversionFactor();
         break;
@@ -585,6 +588,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
     switch ( jsonLineOpacity.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         lineOpacity = jsonLineOpacity.toDouble();
         break;
@@ -828,6 +832,7 @@ bool QgsMapBoxGlStyleConverter::parseCircleLayer( const QVariantMap &jsonLayer, 
     switch ( jsonCircleRadius.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         circleDiameter = jsonCircleRadius.toDouble() * context.pixelSizeConversionFactor() * 2;
         break;
@@ -855,6 +860,7 @@ bool QgsMapBoxGlStyleConverter::parseCircleLayer( const QVariantMap &jsonLayer, 
     switch ( jsonCircleOpacity.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         circleOpacity = jsonCircleOpacity.toDouble();
         break;
@@ -912,6 +918,7 @@ bool QgsMapBoxGlStyleConverter::parseCircleLayer( const QVariantMap &jsonLayer, 
     switch ( circleStrokeWidthJson.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         circleStrokeWidth = circleStrokeWidthJson.toDouble() * context.pixelSizeConversionFactor();
         break;
@@ -939,6 +946,7 @@ bool QgsMapBoxGlStyleConverter::parseCircleLayer( const QVariantMap &jsonLayer, 
     switch ( jsonCircleStrokeOpacity.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         circleStrokeOpacity = jsonCircleStrokeOpacity.toDouble();
         break;
@@ -1053,6 +1061,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     switch ( jsonTextSize.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         textSize = jsonTextSize.toDouble() * context.pixelSizeConversionFactor();
         break;
@@ -1090,6 +1099,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     switch ( jsonTextMaxWidth.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         textMaxWidth = jsonTextMaxWidth.toDouble() * EM_TO_CHARS;
         break;
@@ -1121,6 +1131,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     switch ( jsonTextLetterSpacing.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         textLetterSpacing = jsonTextLetterSpacing.toDouble();
         break;
@@ -1400,6 +1411,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     switch ( jsonHaloWidth.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
         bufferSize = jsonHaloWidth.toDouble() * context.pixelSizeConversionFactor() * BUFFER_SIZE_SCALE;
         break;
@@ -1428,6 +1440,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     switch ( jsonTextHaloBlur.type() )
     {
       case QVariant::Int:
+      case QVariant::LongLong:
       case QVariant::Double:
       {
         haloBlurSize = jsonTextHaloBlur.toDouble() * context.pixelSizeConversionFactor();
@@ -1862,6 +1875,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
       switch ( jsonSpacing.type() )
       {
         case QVariant::Int:
+        case QVariant::LongLong:
         case QVariant::Double:
           spacing = jsonSpacing.toDouble() * context.pixelSizeConversionFactor();
           break;
@@ -1908,6 +1922,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
       switch ( jsonIconRotate.type() )
       {
         case QVariant::Int:
+        case QVariant::LongLong:
         case QVariant::Double:
           rotation = jsonIconRotate.toDouble();
           break;
@@ -1961,6 +1976,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
       switch ( jsonIconSize.type() )
       {
         case QVariant::Int:
+        case QVariant::LongLong:
         case QVariant::Double:
         {
           size = jsonIconSize.toDouble();
@@ -2041,6 +2057,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
         switch ( jsonIconSize.type() )
         {
           case QVariant::Int:
+          case QVariant::LongLong:
           case QVariant::Double:
           {
             size = jsonIconSize.toDouble();
@@ -2085,6 +2102,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
         switch ( jsonIconRotate.type() )
         {
           case QVariant::Int:
+          case QVariant::LongLong:
           case QVariant::Double:
             rotation = jsonIconRotate.toDouble();
             break;
@@ -2111,6 +2129,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
         switch ( jsonIconOpacity.type() )
         {
           case QVariant::Int:
+          case QVariant::LongLong:
           case QVariant::Double:
             iconOpacity = jsonIconOpacity.toDouble();
             break;
@@ -3009,7 +3028,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
           return QgsExpression::createFieldEqualityExpression( attribute, expression.at( 2 ).toList().value( 0 ) );
       }
       else if ( expression.at( 2 ).type() == QVariant::String || expression.at( 2 ).type() == QVariant::Int
-                || expression.at( 2 ).type() == QVariant::Double )
+                || expression.at( 2 ).type() == QVariant::Double || expression.at( 2 ).type() == QVariant::LongLong )
       {
         return QgsExpression::createFieldEqualityExpression( attribute, expression.at( 2 ) );
       }
@@ -3038,7 +3057,7 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
             caseString += QStringLiteral( "WHEN %1 " ).arg( QgsExpression::createFieldEqualityExpression( attribute, expression.at( i ).toList().value( 0 ) ) );
         }
         else if ( expression.at( i ).type() == QVariant::String || expression.at( i ).type() == QVariant::Int
-                  || expression.at( i ).type() == QVariant::Double )
+                  || expression.at( i ).type() == QVariant::Double || expression.at( i ).type() == QVariant::LongLong )
         {
           caseString += QStringLiteral( "WHEN (%1) " ).arg( QgsExpression::createFieldEqualityExpression( attribute, expression.at( i ) ) );
         }
@@ -3298,6 +3317,7 @@ QString QgsMapBoxGlStyleConverter::parseValue( const QVariant &value, QgsMapBoxG
       return QgsExpression::quotedValue( value );
 
     case QVariant::Int:
+    case QVariant::LongLong:
     case QVariant::Double:
       return value.toString();
 


### PR DESCRIPTION
Depending on which method is used to convert json to a variantmap,we may end up with longlong values instead of ints. Make the converter tolerant to these too.
