### PR TITLE
Use "MS SQL Server" for user facing texts

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -397,7 +397,7 @@ QString createFilters( const QString &type )
       }
       else if ( driverName.startsWith( QLatin1String( "MSSQL" ) ) )
       {
-        sDatabaseDrivers += QObject::tr( "MSSQL" ) + ",MSSQL;";
+        sDatabaseDrivers += QObject::tr( "MS SQL Server" ) + ",MSSQL;";
       }
       else if ( driverName.startsWith( QLatin1String( "OCI" ) ) )
       {

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -361,7 +361,7 @@ bool QgsManageConnectionsDialog::populateConnections()
         if ( root.tagName() != QLatin1String( "qgsMssqlConnections" ) )
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
-                                    tr( "The file is not a MSSQL connections exchange file." ) );
+                                    tr( "The file is not a MS SQL Server connections exchange file." ) );
           return false;
         }
         break;
@@ -1105,7 +1105,7 @@ void QgsManageConnectionsDialog::loadMssqlConnections( const QDomDocument &doc, 
   {
     QMessageBox::information( this,
                               tr( "Loading Connections" ),
-                              tr( "The file is not a MSSQL connections exchange file." ) );
+                              tr( "The file is not a MS SQL Server connections exchange file." ) );
     return;
   }
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -433,7 +433,7 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
       connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this, [ = ]()
       {
         // this is gross - TODO - find a way to get access to messageBar from data items
-        QMessageBox::information( nullptr, tr( "Import to MSSQL database" ), tr( "Import was successful." ) );
+        QMessageBox::information( nullptr, tr( "Import to MS SQL Server database" ), tr( "Import was successful." ) );
         if ( state() == Qgis::BrowserItemState::Populated )
           refresh();
         else
@@ -446,7 +446,7 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
         if ( error != Qgis::VectorExportResult::UserCanceled )
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-          output->setTitle( tr( "Import to MSSQL database" ) );
+          output->setTitle( tr( "Import to MS SQL Server database" ) );
           output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
           output->showMessage();
         }
@@ -468,7 +468,7 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
   if ( hasError )
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
-    output->setTitle( tr( "Import to MSSQL database" ) );
+    output->setTitle( tr( "Import to MS SQL Server database" ) );
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
     output->showMessage();
   }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -172,7 +172,7 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
       primaryKeyFromGeometryColumnsTable = getPrimaryKeyFromGeometryColumns( cols );
       if ( !primaryKeyFromGeometryColumnsTable )
         QgsMessageLog::logMessage( tr( "Invalid primary key from geometry_columns table for layer '%1', get primary key from the layer." )
-                                   .arg( anUri.table() ), tr( "MSSQL" ) );
+                                   .arg( anUri.table() ), tr( "MS SQL Server" ) );
     }
 
     if ( !primaryKeyFromGeometryColumnsTable )

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -146,7 +146,7 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
   }
   else
   {
-    setWindowTitle( tr( "Add MSSQL Table(s)" ) );
+    setWindowTitle( tr( "Add MS SQL Server Table(s)" ) );
   }
 
   populateConnectionList();
@@ -387,7 +387,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
   {
     // Let user know we couldn't initialize the MSSQL provider
     QMessageBox::warning( this,
-                          tr( "MSSQL Provider" ), db->errorText() );
+                          tr( "MS SQL Server Provider" ), db->errorText() );
     return;
   }
 
@@ -477,7 +477,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
     QApplication::restoreOverrideCursor();
     // Let user know we couldn't retrieve tables from the MSSQL provider
     QMessageBox::warning( this,
-                          tr( "MSSQL Provider" ), q.lastError().text() );
+                          tr( "MS SQL Server Provider" ), q.lastError().text() );
     return;
   }
 

--- a/src/providers/mssql/qgsmssqltransaction.cpp
+++ b/src/providers/mssql/qgsmssqltransaction.cpp
@@ -57,7 +57,7 @@ bool QgsMssqlTransaction::executeSql( const QString &sql, QString &error, bool i
     if ( isDirty )
       rollbackToSavepoint( savePoints().last(), error );
 
-    QString msg = tr( "MSSQL query failed: %1" ).arg( query.lastError().text() );
+    QString msg = tr( "MS SQL Server query failed: %1" ).arg( query.lastError().text() );
     if ( error.isEmpty() )
       error = msg;
     else

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1627,7 +1627,7 @@ Shift+R to enable range selection.</string>
      <normaloff>:/images/themes/default/mActionAddMssqlLayer.svg</normaloff>:/images/themes/default/mActionAddMssqlLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add MSSQL Spatial Layer…</string>
+    <string>Add MS SQL Server Layer…</string>
    </property>
   </action>
   <action name="mActionAddOracleLayer">

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Create a New MSSQL Connection</string>
+   <string>Create a New MS SQL Server Connection</string>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>


### PR DESCRIPTION
This is a follow-up to #47238 that replace MSSQL with MS SQL Server in the GUI
In few other places the old name was still shown so let's try to harmonize (I assumed that if the string is translatable, then it's shown to the user and is modifiable)