### PR TITLE
Fix Legend symbol with unit "Meters at scale" #49858

### DIFF
--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -362,7 +362,6 @@ const QgsFeatureFilterProvider *QgsRenderContext::featureFilterProvider() const
 double QgsRenderContext::convertToPainterUnits( double size, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &scale, Qgis::RenderSubcomponentProperty property ) const
 {
   double conversionFactor = 1.0;
-  bool isMapUnitHack = false;
   switch ( unit )
   {
     case QgsUnitTypes::RenderMillimeters:
@@ -403,7 +402,6 @@ double QgsRenderContext::convertToPainterUnits( double size, QgsUnitTypes::Rende
       {
         // invalid map to pixel. A size in map units can't be calculated, so treat the size as points
         // and clamp it to a reasonable range. It's the best we can do in this situation!
-        isMapUnitHack = true;
         conversionFactor = mScaleFactor / POINTS_TO_MM;
       }
       break;
@@ -430,16 +428,8 @@ double QgsRenderContext::convertToPainterUnits( double size, QgsUnitTypes::Rende
       convertedSize = std::min( convertedSize, scale.maxSizeMM * mScaleFactor );
   }
 
-  if ( isMapUnitHack )
-  {
-    // since we are arbitrarily treating map units as mm, we need to clamp to an (arbitrary!) reasonable range.
-    convertedSize = std::clamp( convertedSize, 10.0, 100.0 );
-  }
-  else
-  {
-    const double symbologyReferenceScaleFactor = mSymbologyReferenceScale > 0 ? mSymbologyReferenceScale / mRendererScale : 1;
-    convertedSize *= symbologyReferenceScaleFactor;
-  }
+  const double symbologyReferenceScaleFactor = mSymbologyReferenceScale > 0 ? mSymbologyReferenceScale / mRendererScale : 1;
+  convertedSize *= symbologyReferenceScaleFactor;
 
   if ( mFlags & Qgis::RenderContextFlag::RenderSymbolPreview )
   {


### PR DESCRIPTION
## Description
This is a follow-up to #49858 that Legend symbol with unit "Meters at scale" is not matching rendered symbol.
Existem 2 problemas relacionados:

 0 - Legend symbol with unit "Meters at scale" is not matching rendered symbol #49858
![Screenshot from 2022-08-23 12-18-49](https://user-images.githubusercontent.com/88335017/186134206-cbc6d2e5-90f8-46aa-b285-53f3895b4f2f.png)

1 - When editing a symbol and we change the unit to "Meters at scale" the stroke width and offsets are set to a high value in the preview.

![2](https://user-images.githubusercontent.com/88335017/186135740-64f03e87-e2aa-4988-b272-150f94498cf2.png)

After the change I got the following result:

![Screenshot from 2022-08-23 10-31-44](https://user-images.githubusercontent.com/88335017/186136444-d3d66b04-4ee8-48f7-b7d9-638064db92cd.png)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
