### PR TITLE
[processing][feature] Add option to log fixed errors in FixGeometries alg

### DIFF
--- a/src/analysis/processing/qgsalgorithmfixgeometries.h
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.h
@@ -42,12 +42,19 @@ class QgsFixGeometriesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QgsFixGeometriesAlgorithm *createInstance() const override SIP_FACTORY;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
 
   protected:
+
     QgsProcessingFeatureSource::Flag sourceFlags() const override;
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type type ) const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    bool mLogFixedErrors = false;
 
 };
 


### PR DESCRIPTION
Fix geometries does a great job, but users can't currently know what has been fixed in their data.

This PR adds a new parameter to such algorithm to obtain a log of the fixed errors. By default the new parameter is false.

![image](https://user-images.githubusercontent.com/652785/186239917-d98df054-212c-4fee-b14a-537d50ab9ee4.png)

![image](https://user-images.githubusercontent.com/652785/186239936-85dde6b9-6d87-4692-a520-dc9d6a8e2ee0.png)


