### PR TITLE
Stablise svg cache test

### DIFF
--- a/tests/src/core/testqgssvgcache.cpp
+++ b/tests/src/core/testqgssvgcache.cpp
@@ -25,7 +25,6 @@
 #include <QtConcurrent>
 #include <QElapsedTimer>
 #include "qgssvgcache.h"
-#include "qgsmultirenderchecker.h"
 #include "qgsapplication.h"
 
 /**
@@ -330,18 +329,69 @@ void TestQgsSvgCache::dynamicSvg()
   const QString dynamicImage = TEST_DATA_DIR + QStringLiteral( "/svg/test_dynamic_svg.svg" );
   const QString svg = cache.svgContent( dynamicImage, 200, QColor( 0, 0, 0 ), QColor( 0, 0, 0 ), 1.0,
   1.0, 0, false, {{"text1", "green?"}, {"text2", "supergreen"}, {"align",  "middle" }} );
-  const QString controlImage = TEST_DATA_DIR + QStringLiteral( "/svg/test_dynamic_svg_control.svg" );
-  const QString controlSvg = cache.svgContent( controlImage, 200, QColor( 0, 0, 0 ), QColor( 0, 0, 0 ), 1.0,
-                             1.0, 0, false, {} );
-  if ( controlSvg != svg )
-  {
-    QString reportString;
-    reportString.append( QStringLiteral( "<h3>Expected SVG content</h3><p><code>%1</code></p>" ).arg( controlSvg.toHtmlEscaped() ) );
-    reportString.append( QStringLiteral( "<h3>Actual SVG content</h3><p><code>%1</code></p>" ).arg( svg.toHtmlEscaped() ) );
-    appendToReport( QStringLiteral( "Dynamic SVG content" ), reportString );
-  }
 
-  QCOMPARE( svg, controlSvg );
+  QDomDocument doc;
+  QVERIFY( doc.setContent( svg ) );
+
+  // because Qt ordering of QDomElement attributes are random, we can't directly compare the XML string
+  // and instead have to check manually element by element...
+  const QDomElement svgElement = doc.firstChildElement( QStringLiteral( "svg" ) );
+  QVERIFY( !svgElement.isNull() );
+  QCOMPARE( svgElement.attribute( QStringLiteral( "width" ) ), QStringLiteral( "30mm" ) );
+  QCOMPARE( svgElement.attribute( QStringLiteral( "height" ) ), QStringLiteral( "30mm" ) );
+  QCOMPARE( svgElement.attribute( QStringLiteral( "version" ) ), QStringLiteral( "1.1" ) );
+  QCOMPARE( svgElement.attribute( QStringLiteral( "viewBox" ) ), QStringLiteral( "0 0 32.75 32.75" ) );
+  QCOMPARE( svgElement.attribute( QStringLiteral( "xmlns" ) ), QStringLiteral( "http://www.w3.org/2000/svg" ) );
+
+  const QDomElement gElement = svgElement.firstChildElement( QStringLiteral( "g" ) );
+  QVERIFY( !gElement.isNull() );
+  QCOMPARE( gElement.attribute( QStringLiteral( "transform" ) ), QStringLiteral( "translate(-81.521 -137.75)" ) );
+
+  const QDomElement g2Element = gElement.firstChildElement( QStringLiteral( "g" ) );
+  QVERIFY( !g2Element.isNull() );
+  QCOMPARE( g2Element.attribute( QStringLiteral( "fill" ) ), QStringLiteral( "#FFFFFF" ) );
+  QCOMPARE( g2Element.attribute( QStringLiteral( "fill-opacity" ) ), QStringLiteral( "0.7" ) );
+  QCOMPARE( g2Element.attribute( QStringLiteral( "stroke" ) ), QStringLiteral( "#000000" ) );
+
+  const QDomElement circleElement = g2Element.firstChildElement( QStringLiteral( "circle" ) );
+  QVERIFY( !circleElement.isNull() );
+  QCOMPARE( circleElement.attribute( QStringLiteral( "cx" ) ), QStringLiteral( "97.896" ) );
+  QCOMPARE( circleElement.attribute( QStringLiteral( "cy" ) ), QStringLiteral( "154.12" ) );
+  QCOMPARE( circleElement.attribute( QStringLiteral( "r" ) ), QStringLiteral( "15.875" ) );
+
+  const QDomElement path1Element = g2Element.firstChildElement( QStringLiteral( "path" ) );
+  QVERIFY( !path1Element.isNull() );
+  QCOMPARE( path1Element.attribute( QStringLiteral( "d" ) ), QStringLiteral( "m82.815 148.83h30.162" ) );
+  QCOMPARE( path1Element.attribute( QStringLiteral( "stroke-width" ) ), QStringLiteral( ".26458px" ) );
+
+  const QDomElement path2Element = path1Element.nextSiblingElement( QStringLiteral( "path" ) );
+  QVERIFY( !path2Element.isNull() );
+  QCOMPARE( path2Element.attribute( QStringLiteral( "d" ) ), QStringLiteral( "m82.815 159.42h30.162" ) );
+  QCOMPARE( path2Element.attribute( QStringLiteral( "stroke-width" ) ), QStringLiteral( ".25px" ) );
+
+  const QDomElement g3Element = g2Element.nextSiblingElement( QStringLiteral( "g" ) );
+  QVERIFY( !g3Element.isNull() );
+  QCOMPARE( g3Element.attribute( QStringLiteral( "stroke-width" ) ), QStringLiteral( ".265" ) );
+  QCOMPARE( g3Element.attribute( QStringLiteral( "text-anchor" ) ), QStringLiteral( "middle" ) );
+  QCOMPARE( g3Element.attribute( QStringLiteral( "alignment-baseline" ) ), QStringLiteral( "middle" ) );
+
+  const QDomElement text1Element = g3Element.firstChildElement( QStringLiteral( "text" ) );
+  QVERIFY( !text1Element.isNull() );
+  QCOMPARE( text1Element.attribute( QStringLiteral( "x" ) ), QStringLiteral( "98" ) );
+  QCOMPARE( text1Element.attribute( QStringLiteral( "y" ) ), QStringLiteral( "147.5" ) );
+  QCOMPARE( text1Element.attribute( QStringLiteral( "font-size" ) ), QStringLiteral( "6px" ) );
+  QCOMPARE( text1Element.attribute( QStringLiteral( "font-family" ) ), QStringLiteral( "QGIS Vera Sans" ) );
+  QCOMPARE( text1Element.attribute( QStringLiteral( "font-weight" ) ), QStringLiteral( "bold" ) );
+  QCOMPARE( text1Element.text(), QStringLiteral( "green?" ) );
+
+  const QDomElement text2Element = text1Element.nextSiblingElement( QStringLiteral( "text" ) );
+  QVERIFY( !text2Element.isNull() );
+  QCOMPARE( text2Element.attribute( QStringLiteral( "x" ) ), QStringLiteral( "98" ) );
+  QCOMPARE( text2Element.attribute( QStringLiteral( "y" ) ), QStringLiteral( "156.3" ) );
+  QCOMPARE( text2Element.attribute( QStringLiteral( "font-size" ) ), QStringLiteral( "4.5px" ) );
+  QCOMPARE( text2Element.attribute( QStringLiteral( "font-family" ) ), QStringLiteral( "QGIS Vera Sans" ) );
+  QCOMPARE( text2Element.attribute( QStringLiteral( "font-weight" ) ), QStringLiteral( "bold" ) );
+  QCOMPARE( text2Element.text(), QStringLiteral( "supergreen" ) );
 }
 
 void TestQgsSvgCache::aspectRatio()


### PR DESCRIPTION
Because QDomDocument.toString returns element attributes in a non-deterministic order, we can't directly compare two XML documents. Instead resort to element/attribute by element comparison.
