### PR TITLE
[processing][feature]  Add a row_index and col_index field to the output of the "Create Grid" algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmgrid.cpp
+++ b/src/analysis/processing/qgsalgorithmgrid.cpp
@@ -119,6 +119,18 @@ QVariantMap QgsGridAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
   fields.append( QgsField( QStringLiteral( "top" ), QVariant::Double ) );
   fields.append( QgsField( QStringLiteral( "right" ), QVariant::Double ) );
   fields.append( QgsField( QStringLiteral( "bottom" ), QVariant::Double ) );
+  
+  switch (mIdx)
+  {
+  case 0: //point
+  case 2: //rectangle
+  case 4: //hexagon
+    fields.append( QgsField( QStringLiteral( "row_index" ), QVariant::LongLong ) );
+    fields.append( QgsField( QStringLiteral( "col_index" ), QVariant::LongLong ) );
+    break;  
+  }
+  
+
 
   QgsWkbTypes::Type outputWkb = QgsWkbTypes::Polygon;
   switch ( mIdx )
@@ -186,7 +198,7 @@ void QgsGridAlgorithm::createPointGrid( std::unique_ptr< QgsFeatureSink > &sink,
       const double y = mGridExtent.yMaximum() - ( row * mVSpacing - row * mVOverlay );
 
       f.setGeometry( QgsGeometry( new QgsPoint( x, y ) ) );
-      f.setAttributes( QgsAttributes() << id << x << y << x + mHSpacing << y + mVSpacing );
+      f.setAttributes( QgsAttributes() << id << x << y << x + mHSpacing << y + mVSpacing << row << col);
       if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
         throw QgsProcessingException( writeFeatureError( sink.get(), QVariantMap(), QStringLiteral( "OUTPUT" ) ) );
 
@@ -346,7 +358,7 @@ void QgsGridAlgorithm::createRectangleGrid( std::unique_ptr< QgsFeatureSink > &s
       std::unique_ptr< QgsPolygon > poly = std::make_unique< QgsPolygon >();
       poly->setExteriorRing( new QgsLineString( ringX, ringY ) );
       f.setGeometry( std::move( poly ) );
-      f.setAttributes( QgsAttributes() << id << x1 << y1 << x2 << y2 );
+      f.setAttributes( QgsAttributes() << id << x1 << y1 << x2 << y2 << row << col);
       if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
         throw QgsProcessingException( writeFeatureError( sink.get(), QVariantMap(), QStringLiteral( "OUTPUT" ) ) );
 
@@ -513,7 +525,7 @@ void QgsGridAlgorithm::createHexagonGrid( std::unique_ptr<QgsFeatureSink> &sink,
       std::unique_ptr< QgsPolygon > poly = std::make_unique< QgsPolygon >();
       poly->setExteriorRing( new QgsLineString( ringX, ringY ) );
       f.setGeometry( std::move( poly ) );
-      f.setAttributes( QgsAttributes() << id << x1 << y1 << x4 << y3 );
+      f.setAttributes( QgsAttributes() << id << x1 << y1 << x4 << y3 << row << col);
       if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
         throw QgsProcessingException( writeFeatureError( sink.get(), QVariantMap(), QStringLiteral( "OUTPUT" ) ) );
 


### PR DESCRIPTION
## Description

This pull request add a row_index and col_index as field to the output of the "Create Grid" algorithm, for the output of type point, rectangle and hexagon

preview :
![screenshot_grid_qgis](https://user-images.githubusercontent.com/30632058/186527911-d2be89d3-b709-44cb-a64e-3ada83fa0743.png)

row and col variable where already used for generating the grid, this commit just expose them into new fields

Motivation for this change: In my use case I had a grid with data associated to each polygons and I needed to calculate the moving average to smooth de data.

PS: This is my first contribution, any feedback  is welcome :smiley: 