### PR TITLE
feature(postgres): Define session role for connection

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -75,6 +75,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     }
     txtPort->setText( port );
     txtDatabase->setText( settings.value( key + "/database" ).toString() );
+    txtSessionRole->setText( settings.value( key + "/session_role" ).toString() );
     cb_publicSchemaOnly->setChecked( settings.value( key + "/publicOnly", false ).toBool() );
     cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
     cb_dontResolveType->setChecked( settings.value( key + "/dontResolveType", false ).toBool() );
@@ -162,6 +163,7 @@ void QgsPgNewConnection::accept()
   settings.setValue( baseKey + "/host", txtHost->text() );
   settings.setValue( baseKey + "/port", txtPort->text() );
   settings.setValue( baseKey + "/database", txtDatabase->text() );
+  settings.setValue( baseKey + "/session_role", txtSessionRole->text() );
   settings.setValue( baseKey + "/username", mAuthSettings->storeUsernameIsChecked( ) ? mAuthSettings->username() : QString() );
   settings.setValue( baseKey + "/password", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? mAuthSettings->password() : QString() );
   settings.setValue( baseKey + "/authcfg", mAuthSettings->configId() );
@@ -236,7 +238,12 @@ void QgsPgNewConnection::testConnection()
                        mAuthSettings->configId() );
   }
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), true );
+  if ( !txtSessionRole->text().isEmpty() )
+  {
+    uri.setParam( QStringLiteral( "session_role" ), txtSessionRole->text() );
+  }
+
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri, true );
 
   if ( conn )
   {

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -258,6 +258,42 @@ QgsPostgresConn *QgsPostgresConn::connectDb( const QString &conninfo, bool reado
   return conn;
 }
 
+QgsPostgresConn *QgsPostgresConn::connectDb( const QgsDataSourceUri &uri, bool readonly, bool shared, bool transaction )
+{
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), readonly, shared, transaction );
+  if ( !conn )
+  {
+    return conn;
+  }
+
+  const QString sessionRoleKey = QStringLiteral( "session_role" );
+  if ( uri.hasParam( sessionRoleKey ) )
+  {
+    const QString sessionRole = uri.param( sessionRoleKey );
+    if ( !sessionRole.isEmpty() )
+    {
+      if ( !conn->setSessionRole( sessionRole ) )
+      {
+        QgsDebugMsgLevel(
+          QStringLiteral(
+            "Set session role failed for ROLE %1"
+          )
+          .arg( quotedValue( sessionRole ) )
+          ,
+          2
+        );
+        conn->unref();
+        return nullptr;
+      }
+    }
+  }
+  else
+  {
+    conn->resetSessionRole();
+  }
+  return conn;
+}
+
 static void noticeProcessor( void *arg, const char *message )
 {
   Q_UNUSED( arg )
@@ -1217,6 +1253,19 @@ QString QgsPostgresConn::postgisVersion() const
   }
 
   return mPostgisVersionInfo;
+}
+
+/* Functions for determining available features in postGIS */
+bool QgsPostgresConn::setSessionRole( const QString &sessionRole )
+{
+  if ( !sessionRole.isEmpty() )
+    return LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "SET ROLE %1" ).arg( quotedValue( sessionRole ) ) );
+  else
+    return resetSessionRole();
+}
+bool QgsPostgresConn::resetSessionRole()
+{
+  return LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "RESET ROLE" ) );
 }
 
 QString QgsPostgresConn::quotedIdentifier( const QString &ident )

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -211,12 +211,34 @@ class QgsPostgresConn : public QObject
     Q_OBJECT
 
   public:
-    /*
+
+    /**
+     * Get a new PostgreSQL connection
+     *
+     * \param connInfo the QgsDataSourceUri connection info with username / password
+     * \param readOnly is the connection read only ?
      * \param shared allow using a shared connection. Should never be
      *        called from a thread other than the main one.
      *        An assertion guards against such programmatic error.
+     * \param transaction is the connection a transaction ?
+     *
+     * \returns the PostgreSQL connection
      */
     static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false );
+
+    /**
+     * Get a new PostgreSQL connection
+     *
+     * \param uri the QgsDataSourceUri with username / password
+     * \param readOnly is the connection read only ?
+     * \param shared allow using a shared connection. Should never be
+     *        called from a thread other than the main one.
+     *        An assertion guards against such programmatic error.
+     * \param transaction is the connection a transaction ?
+     *
+     * \returns the PostgreSQL connection
+     */
+    static QgsPostgresConn *connectDb( const QgsDataSourceUri &uri, bool readOnly, bool shared = true, bool transaction = false );
 
 
     QgsPostgresConn( const QString &conninfo, bool readOnly, bool shared, bool transaction );
@@ -251,6 +273,27 @@ class QgsPostgresConn : public QObject
 
     //! PostgreSQL version
     int pgVersion() const { return mPostgresqlVersion; }
+
+    /**
+     * Sets the current user identifier of the current PostgreSQL session
+     *
+     * \param sessionRole the PostgreSQL ROLE for the session, it must be a role that the current session user is a member of.
+     *
+     * \returns TRUE if successful
+     *
+     * \since QGIS 3.28.0
+     */
+    bool setSessionRole( const QString &sessionRole );
+
+    /**
+     * Resets the current user identifier of the current PostgreSQL session
+     * to the current session user identifier (user used to log in)
+     *
+     * \returns TRUE if successful
+     *
+     * \since QGIS 3.28.0
+     */
+    bool resetSessionRole();
 
     //! run a query and free result buffer
     bool PQexecNR( const QString &query, const QString &originatorClass = QString(), const QString &queryOrigin = QString() );

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -242,7 +242,7 @@ void QgsPostgresDataItemGuiProvider::createSchema( QgsDataItem *item, QgsDataIte
     return;
 
   const QgsDataSourceUri uri = QgsPostgresConn::connUri( item->name() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri, false );
   if ( !conn )
   {
     notify( tr( "New Schema" ), tr( "Unable to create schema." ), context, Qgis::MessageLevel::Warning );
@@ -276,7 +276,7 @@ void QgsPostgresDataItemGuiProvider::deleteSchema( QgsPGSchemaItem *schemaItem, 
 {
   // check if schema contains tables/views
   const QgsDataSourceUri uri = QgsPostgresConn::connUri( schemaItem->connectionName() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri, false );
   if ( !conn )
   {
     notify( tr( "Delete Schema" ), tr( "Unable to delete schema." ), context, Qgis::MessageLevel::Warning );
@@ -349,7 +349,7 @@ void QgsPostgresDataItemGuiProvider::renameSchema( QgsPGSchemaItem *schemaItem, 
 
   const QString schemaName = QgsPostgresConn::quotedIdentifier( schemaItem->name() );
   const QgsDataSourceUri uri = QgsPostgresConn::connUri( schemaItem->connectionName() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri, false );
   if ( !conn )
   {
     notify( tr( "Rename Schema" ), tr( "Unable to rename schema." ), context, Qgis::MessageLevel::Warning );
@@ -399,7 +399,7 @@ void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem, Qgs
   const QString newName = QgsPostgresConn::quotedIdentifier( dlg.name() );
 
   const QgsDataSourceUri dsUri( layerItem->uri() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to rename '%1'." ).arg( lowerTypeName ), context, Qgis::MessageLevel::Warning );
@@ -445,7 +445,7 @@ void QgsPostgresDataItemGuiProvider::truncateTable( QgsPGLayerItem *layerItem, Q
     return;
 
   const QgsDataSourceUri dsUri( layerItem->uri() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     notify( tr( "Truncate Table" ), tr( "Unable to truncate table." ), context, Qgis::MessageLevel::Warning );
@@ -485,7 +485,7 @@ void QgsPostgresDataItemGuiProvider::refreshMaterializedView( QgsPGLayerItem *la
     return;
 
   const QgsDataSourceUri dsUri( layerItem->uri() );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     notify( tr( "Refresh View" ), tr( "Unable to refresh the view." ), context, Qgis::MessageLevel::Warning );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -50,7 +50,7 @@ bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
   }
   schemaTableName += QgsPostgresConn::quotedIdentifier( tableName );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -138,7 +138,7 @@ bool QgsPostgresUtils::deleteSchema( const QString &schema, const QgsDataSourceU
 
   QString schemaName = QgsPostgresConn::quotedIdentifier( schema );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri, false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -177,7 +177,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
     return;
   }
 
-  mConnectionRO = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), true );
+  mConnectionRO = QgsPostgresConn::connectDb( mUri, true );
   if ( !mConnectionRO )
   {
     return;
@@ -373,7 +373,7 @@ QgsPostgresConn *QgsPostgresProvider::connectionRW()
   }
   else if ( !mConnectionRW )
   {
-    mConnectionRW = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), false );
+    mConnectionRW = QgsPostgresConn::connectDb( mUri, false );
   }
   return mConnectionRW;
 }
@@ -392,6 +392,26 @@ void QgsPostgresProvider::setTransaction( QgsTransaction *transaction )
 {
   // static_cast since layers cannot be added to a transaction of a non-matching provider
   mTransaction = static_cast<QgsPostgresTransaction *>( transaction );
+
+  const QString sessionRoleKey = QStringLiteral( "session_role" );
+  if ( mUri.hasParam( sessionRoleKey ) )
+  {
+    const QString sessionRole = mUri.param( sessionRoleKey );
+    if ( !sessionRole.isEmpty() )
+    {
+      if ( !mTransaction->connection()->setSessionRole( sessionRole ) )
+      {
+        QgsDebugMsgLevel(
+          QStringLiteral(
+            "Set session role failed for ROLE %1"
+          )
+          .arg( quotedValue( sessionRole ) )
+          ,
+          2
+        );
+      }
+    }
+  }
 }
 
 QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPostgresConn *conn )
@@ -4551,7 +4571,7 @@ Qgis::VectorExportResult QgsPostgresProvider::createEmptyLayer( const QString &u
   QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( tableName ), 2 );
 
   // create the table
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     if ( errorMessage )
@@ -5366,7 +5386,7 @@ bool QgsPostgresProviderMetadata::styleExists( const QString &uri, const QString
   errorCause.clear();
 
   QgsDataSourceUri dsUri( uri );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), true );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, true );
   if ( !conn )
   {
     errorCause = QObject::tr( "Connection to database failed" );
@@ -5430,7 +5450,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
   QString sldStyle { sldStyleIn };
   QgsPostgresUtils::replaceInvalidXmlChars( sldStyle );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -5597,7 +5617,7 @@ QString QgsPostgresProviderMetadata::loadStyle( const QString &uri, QString &err
   QgsDataSourceUri dsUri( uri );
   QString selectQmlQuery;
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), true );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, true );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -5677,7 +5697,7 @@ int QgsPostgresProviderMetadata::listStyles( const QString &uri, QStringList &id
   errCause.clear();
   QgsDataSourceUri dsUri( uri );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), true );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, true );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
@@ -5766,7 +5786,7 @@ bool QgsPostgresProviderMetadata::deleteStyleById( const QString &uri, const QSt
   QgsDataSourceUri dsUri( uri );
   bool deleted;
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
@@ -5799,7 +5819,7 @@ QString QgsPostgresProviderMetadata::getStyleById( const QString &uri, const QSt
 {
   QgsDataSourceUri dsUri( uri );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), true );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, true );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );

--- a/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
+++ b/src/providers/postgres/qgspostgresprovidermetadatautils.cpp
@@ -25,7 +25,7 @@ QList<QgsLayerMetadataProviderResult> QgsPostgresProviderMetadataUtils::searchLa
   QList<QgsLayerMetadataProviderResult> results;
   QgsDataSourceUri dsUri( uri );
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( conn && ( ! feedback || ! feedback->isCanceled() ) )
   {
 
@@ -152,7 +152,7 @@ bool QgsPostgresProviderMetadataUtils::saveLayerMetadata( const QgsMapLayerType 
     return false;
   }
 
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri, false );
   if ( !conn )
   {
     errorMessage = QObject::tr( "Connection to database failed" );
@@ -347,4 +347,3 @@ bool QgsPostgresProviderMetadataUtils::saveLayerMetadata( const QgsMapLayerType 
 
   return saved;
 }
-

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -90,7 +90,7 @@ QgsPostgresRasterProvider::QgsPostgresRasterProvider( const QString &uri, const 
     return;
   }
 
-  mConnectionRO = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), true );
+  mConnectionRO = QgsPostgresConn::connectDb( mUri, true );
   if ( !mConnectionRO )
   {
     return;
@@ -865,7 +865,7 @@ QgsPostgresConn *QgsPostgresRasterProvider::connectionRW()
 {
   if ( !mConnectionRW )
   {
-    mConnectionRW = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), false );
+    mConnectionRW = QgsPostgresConn::connectDb( mUri, false );
   }
   return mConnectionRW;
 }

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -37,58 +37,8 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="TextLabel1_2">
-          <property name="text">
-           <string>&amp;Name</string>
-          </property>
-          <property name="buddy">
-           <cstring>txtName</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="txtName">
-          <property name="toolTip">
-           <string>Name of the new connection</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Service</string>
-          </property>
-          <property name="buddy">
-           <cstring>txtService</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1">
          <widget class="QLineEdit" name="txtService"/>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="TextLabel1">
-          <property name="text">
-           <string>Hos&amp;t</string>
-          </property>
-          <property name="buddy">
-           <cstring>txtHost</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="txtHost"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="TextLabel2_2">
-          <property name="text">
-           <string>Port</string>
-          </property>
-          <property name="buddy">
-           <cstring>txtPort</cstring>
-          </property>
-         </widget>
         </item>
         <item row="3" column="1">
          <widget class="QLineEdit" name="txtPort">
@@ -96,19 +46,6 @@
            <string>5432</string>
           </property>
          </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="TextLabel2">
-          <property name="text">
-           <string>&amp;Database</string>
-          </property>
-          <property name="buddy">
-           <cstring>txtDatabase</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLineEdit" name="txtDatabase"/>
         </item>
         <item row="5" column="0">
          <widget class="QLabel" name="TextLabel3_3">
@@ -120,8 +57,81 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="txtName">
+          <property name="toolTip">
+           <string>Name of the new connection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="txtHost"/>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLineEdit" name="txtDatabase"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="TextLabel2">
+          <property name="text">
+           <string>&amp;Database</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtDatabase</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="TextLabel1_2">
+          <property name="text">
+           <string>&amp;Name</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtName</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="TextLabel1">
+          <property name="text">
+           <string>Hos&amp;t</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtHost</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="5" column="1">
          <widget class="QComboBox" name="cbxSSLmode"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Service</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtService</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="TextLabel2_2">
+          <property name="text">
+           <string>Port</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtPort</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QLineEdit" name="txtSessionRole"/>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Session ROLE</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -31,6 +31,8 @@ class TestQgsDataSourceUri: public QObject
     void checkSetConnection_data();
     void checkSetConnectionService();
     void checkSetConnectionService_data();
+    void checkConnectionInfo();
+    void checkConnectionInfo_data();
     void checkAuthParams();
     void checkParameterKeys();
 };
@@ -348,6 +350,64 @@ void TestQgsDataSourceUri::checkSetConnectionService()
   QCOMPARE( uri.password(), password );
   QCOMPARE( uri.sslMode(), sslmode );
   QCOMPARE( uri.authConfigId(), authcfg );
+}
+
+void TestQgsDataSourceUri::checkConnectionInfo_data()
+{
+  QTest::addColumn<QString>( "uri" );
+  QTest::addColumn<QString>( "conninfo" );
+
+
+  QTest::newRow( "service" )
+      << "service='qgis_test'"
+      << "service='qgis_test'" // conninfo
+      ;
+
+  QTest::newRow( "db_host_port_user_pw" )
+      << "dbname='qgis_test' host=postgres port=5432 user='qgis_test_user' password='qgis_test_user_password'"
+      << "dbname='qgis_test' host=postgres port=5432 user='qgis_test_user' password='qgis_test_user_password'" // conninfo
+      ;
+
+  QTest::newRow( "oci" )
+      << "host=myhost port=1234 user='myname' password='mypasswd' estimatedmetadata=true srid=1000003007 table=\"myschema\".\"mytable\" (GEOM) myparam='myvalue' sql="
+      << "host=myhost port=1234 user='myname' password='mypasswd'" // conninfo
+      ;
+
+  QTest::newRow( "pgrast" )
+      << R"(PG: dbname='qgis_tests' host=localhost port=5432 user='myname' sslmode=disable estimatedmetadata=true srid=3067 table="public"."basic_map_tiled" (rast))"
+      << "dbname='qgis_tests' host=localhost port=5432 user='myname' sslmode=disable" // conninfo
+      ;
+
+  QTest::newRow( "pg_notable" )
+      << "PG: dbname=mydb host=myhost user=myname password=mypasswd port=5432 mode=2 schema=myschema "
+      << "dbname='mydb' host=myhost port=5432 user='myname' password='mypasswd'" // conninfo
+      ;
+
+  QTest::newRow( "pg_notable_quoted" )
+      << "dbname='mydb' host='myhost' user='myname' password='mypasswd' port='5432' mode='2' schema=myschema"
+      << "dbname='mydb' host=myhost port=5432 user='myname' password='mypasswd'" // conninfo
+      ;
+
+  QTest::newRow( "pgmlsz" )
+      << "PG: dbname=mydb host=myhost user=myname password=mypasswd port=5432 mode=2 schema=public column=geom table=mytable type=MultiLineStringZ"
+      << "dbname='mydb' host=myhost port=5432 user='myname' password='mypasswd'" // conninfo
+      ;
+}
+
+void TestQgsDataSourceUri::checkConnectionInfo()
+{
+  QFETCH( QString, uri );
+  QFETCH( QString, conninfo );
+
+  QgsDataSourceUri ds( uri );
+  QCOMPARE( ds.connectionInfo(), conninfo );
+  QCOMPARE( ds.connectionInfo( true ), conninfo );
+  QCOMPARE( ds.connectionInfo( false ), conninfo );
+
+  ds.setParam( QStringLiteral( "extraparam" ), QStringLiteral( "extravalue" ) );
+  QCOMPARE( ds.connectionInfo(), conninfo );
+  QCOMPARE( ds.connectionInfo( true ), conninfo );
+  QCOMPARE( ds.connectionInfo( false ), conninfo );
 }
 
 void TestQgsDataSourceUri::checkAuthParams()

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -27,6 +27,10 @@ class TestQgsDataSourceUri: public QObject
   private slots:
     void checkparser();
     void checkparser_data();
+    void checkSetConnection();
+    void checkSetConnection_data();
+    void checkSetConnectionService();
+    void checkSetConnectionService_data();
     void checkAuthParams();
     void checkParameterKeys();
 };
@@ -237,6 +241,113 @@ void TestQgsDataSourceUri::checkparser()
   QCOMPARE( ds.sslMode(), sslmode );
   QCOMPARE( ds.sql(), sql );
   QCOMPARE( ds.param( "myparam" ), myparam );
+}
+
+void TestQgsDataSourceUri::checkSetConnection_data()
+{
+  QTest::addColumn<QString>( "host" );
+  QTest::addColumn<QString>( "port" );
+  QTest::addColumn<QString>( "dbname" );
+  QTest::addColumn<QString>( "user" );
+  QTest::addColumn<QString>( "password" );
+  QTest::addColumn<QgsDataSourceUri::SslMode>( "sslmode" );
+  QTest::addColumn<QString>( "authcfg" );
+
+  QTest::newRow( "simple" )
+      << "myhost" // host
+      << "5432" // port
+      << "mydb" // dbname
+      << "myname" // user
+      << "mypasswd" // password
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "" // authcfg
+      ;
+
+  QTest::newRow( "authcfg" )
+      << "myhost" // host
+      << "5432" // port
+      << "" // dbname
+      << "" // user
+      << "mypasswd" // password
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "myauthcfg" // authcfg
+      ;
+}
+
+void TestQgsDataSourceUri::checkSetConnection()
+{
+  QFETCH( QString, host );
+  QFETCH( QString, port );
+  QFETCH( QString, dbname );
+  QFETCH( QString, user );
+  QFETCH( QString, password );
+  QFETCH( QgsDataSourceUri::SslMode, sslmode );
+  QFETCH( QString, authcfg );
+
+  QgsDataSourceUri uri;
+  if ( authcfg.isEmpty() )
+    uri.setConnection( host, port, dbname, user, password, sslmode );
+  else
+    uri.setConnection( host, port, dbname, user, password, sslmode, authcfg );
+
+  QCOMPARE( uri.host(), host );
+  QCOMPARE( uri.port(), port );
+  QCOMPARE( uri.database(), dbname );
+  QCOMPARE( uri.username(), user );
+  QCOMPARE( uri.password(), password );
+  QCOMPARE( uri.sslMode(), sslmode );
+  QCOMPARE( uri.authConfigId(), authcfg );
+}
+
+void TestQgsDataSourceUri::checkSetConnectionService_data()
+{
+  QTest::addColumn<QString>( "service" );
+  QTest::addColumn<QString>( "dbname" );
+  QTest::addColumn<QString>( "user" );
+  QTest::addColumn<QString>( "password" );
+  QTest::addColumn<QgsDataSourceUri::SslMode>( "sslmode" );
+  QTest::addColumn<QString>( "authcfg" );
+
+  QTest::newRow( "simple" )
+      << "myservice" // service
+      << "mydb" // dbname
+      << "myname" // user
+      << "mypasswd" // password
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "" // authcfg
+      ;
+
+  QTest::newRow( "authcfg" )
+      << "myservice" // service
+      << "" // dbname
+      << "" // user
+      << "mypasswd" // password
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "myauthcfg" // authcfg
+      ;
+}
+
+void TestQgsDataSourceUri::checkSetConnectionService()
+{
+  QFETCH( QString, service );
+  QFETCH( QString, dbname );
+  QFETCH( QString, user );
+  QFETCH( QString, password );
+  QFETCH( QgsDataSourceUri::SslMode, sslmode );
+  QFETCH( QString, authcfg );
+
+  QgsDataSourceUri uri;
+  if ( authcfg.isEmpty() )
+    uri.setConnection( service, dbname, user, password, sslmode );
+  else
+    uri.setConnection( service, dbname, user, password, sslmode, authcfg );
+
+  QCOMPARE( uri.service(), service );
+  QCOMPARE( uri.database(), dbname );
+  QCOMPARE( uri.username(), user );
+  QCOMPARE( uri.password(), password );
+  QCOMPARE( uri.sslMode(), sslmode );
+  QCOMPARE( uri.authConfigId(), authcfg );
 }
 
 void TestQgsDataSourceUri::checkAuthParams()

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -44,6 +44,7 @@ void TestQgsDataSourceUri::checkparser_data()
   QTest::addColumn<QString>( "service" );
   QTest::addColumn<QString>( "user" );
   QTest::addColumn<QString>( "password" );
+  QTest::addColumn<QString>( "authcfg" );
   QTest::addColumn<QString>( "dbname" );
   QTest::addColumn<QString>( "host" );
   QTest::addColumn<QString>( "port" );
@@ -66,6 +67,7 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // service
       << "myname" // user
       << "mypasswd" // password
+      << "" // authcfg
       << "" // dbname
       << "myhost" // host
       << "1234" // port
@@ -88,6 +90,7 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // service
       << "myname" // user
       << "" // password
+      << "" // authcfg
       << "qgis_tests" // dbname
       << "localhost" // host
       << "5432" // port
@@ -110,6 +113,7 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // service
       << "myname" // user
       << "mypasswd" // password
+      << "" // authcfg
       << "mydb" // dbname
       << "myhost" // host
       << "5432" // port
@@ -132,6 +136,30 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // service
       << "myname" // user
       << "mypasswd" // password
+      << "" // authcfg
+      << "mydb" // dbname
+      << "myhost" // host
+      << "5432" // port
+      << "" // driver
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "" // sql
+      << "" // myparam
+      << "public" // schema
+      ;
+
+  QTest::newRow( "pg_notable_authcfg" )
+      << "PG: dbname=mydb host=myhost authcfg=myauthcfg port=5432 mode=2 schema=myschema "
+      << "" // table
+      << "" // geometrycolumn
+      << "" // key
+      << false // estimatedmetadata
+      << "" // srid
+      << QgsWkbTypes::Unknown // type
+      << false // selectatid
+      << "" // service
+      << "" // user
+      << "" // password
+      << "myauthcfg" // authcfg
       << "mydb" // dbname
       << "myhost" // host
       << "5432" // port
@@ -156,6 +184,7 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // service
       << "myname" // user
       << "mypasswd" // password
+      << "" // authcfg
       << "mydb" // dbname
       << "myhost" // host
       << "5432" // port
@@ -180,6 +209,7 @@ void TestQgsDataSourceUri::checkparser()
   QFETCH( QString, service );
   QFETCH( QString, user );
   QFETCH( QString, password );
+  QFETCH( QString, authcfg );
   QFETCH( QString, dbname );
   QFETCH( QString, host );
   QFETCH( QString, port );
@@ -199,6 +229,7 @@ void TestQgsDataSourceUri::checkparser()
   QCOMPARE( ds.service(), service );
   QCOMPARE( ds.username(), user );
   QCOMPARE( ds.password(), password );
+  QCOMPARE( ds.authConfigId(), authcfg );
   QCOMPARE( ds.database(), dbname );
   QCOMPARE( ds.host(), host );
   QCOMPARE( ds.port(), port );

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -67,7 +67,7 @@ class TestQgsPostgresConn: public QObject
       if ( ! _connection )
       {
         const char *connstring = getenv( "QGIS_PGTEST_DB" );
-        if ( NULL == connstring ) connstring = "service=qgis_test";
+        if ( !connstring ) connstring = "service=qgis_test";
         _connection = QgsPostgresConn::connectDb( connstring, true );
         assert( _connection );
       }

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -19,6 +19,7 @@
 #include <qgspostgresconn.h>
 #include <qgsfields.h>
 #include <qgspostgresprovider.h>
+#include <qgsdatasourceuri.h>
 
 // Helper function for QCOMPARE
 char *toString( const QgsPostgresGeometryColumnType &t )
@@ -202,6 +203,65 @@ class TestQgsPostgresConn: public QObject
       QCOMPARE( lit->geometryColType, SctTopoGeometry );
       // TODO: add more tests
 
+    }
+
+    void connectDb()
+    {
+      QgsPostgresConn *conn = getConnection();
+      QVERIFY( conn != 0 );
+
+      const QString sql = QStringLiteral( "SELECT SESSION_USER, CURRENT_USER;" );
+
+      QgsPostgresResult result( conn->PQexec( sql ) );
+      // current_user is the same as session_user
+      QCOMPARE( result.PQgetvalue( 0, 0 ), result.PQgetvalue( 0, 1 ) );
+
+      const char *connstring = getenv( "QGIS_PGTEST_DB" );
+      if ( !connstring ) connstring = "service=qgis_test";
+      const QString conninfo( connstring );
+      QgsDataSourceUri uri( conninfo );
+
+      // Update postgres uri to use qgis_test_user which is member of qgis_test_group
+      uri.setUsername( QStringLiteral( "qgis_test_user" ) );
+      uri.setPassword( QStringLiteral( "qgis_test_user_password" ) );
+
+      // Connection with qgis_test_user without session_role
+      conn = QgsPostgresConn::connectDb( uri, true );
+      QVERIFY( conn );
+      result = conn->PQexec( sql );
+      const QString session_user = result.PQgetvalue( 0, 0 );
+      QCOMPARE( session_user, "qgis_test_user" );
+      // current_user is the same as session_user
+      QCOMPARE( result.PQgetvalue( 0, 1 ), session_user );
+      conn->unref();
+
+      // Add known session_role parameter to postgres uri
+      uri.setParam( QStringLiteral( "session_role" ),  QStringLiteral( "qgis_test_group" ) );
+      conn = QgsPostgresConn::connectDb( uri, true );
+      QVERIFY( conn );
+      result = conn->PQexec( sql );
+      // session_user does not change
+      QCOMPARE( result.PQgetvalue( 0, 0 ), session_user );
+      // current_user has changed
+      QCOMPARE( result.PQgetvalue( 0, 1 ), "qgis_test_group" );
+      conn->unref();
+
+      // Add unknown session_role parameter to postgres uri
+      // uri.setParam( QStringLiteral( "session_role" ),  QStringLiteral( "qgis_test_unknown_group" ) );
+      // conn = QgsPostgresConn::connectDb( uri.connectionInfo( true ), true );
+      // QVERIFY( !conn );
+      // conn->unref();
+
+      // Remove session_role parameter from postgre uri
+      uri.removeParam( QStringLiteral( "session_role" ) );
+      conn = QgsPostgresConn::connectDb( uri, true );
+      QVERIFY( conn );
+      result = conn->PQexec( sql );
+      // session_user does not change
+      QCOMPARE( result.PQgetvalue( 0, 0 ), session_user );
+      // current_user back to session_user
+      QCOMPARE( result.PQgetvalue( 0, 1 ), session_user );
+      conn->unref();
     }
 #endif
 };

--- a/tests/testdata/provider/testdata_pg_role.sql
+++ b/tests/testdata/provider/testdata_pg_role.sql
@@ -1,3 +1,5 @@
+DROP GROUP IF EXISTS qgis_test_group;
 DROP USER IF EXISTS qgis_test_user;
 CREATE USER qgis_test_user PASSWORD 'qgis_test_user_password' LOGIN;
-
+CREATE USER qgis_test_group NOLOGIN;
+ALTER GROUP qgis_test_group ADD USER qgis_test_user;


### PR DESCRIPTION
# Description

Be able to define a session role for postgres connection.

Documentation: https://www.postgresql.org/docs/current/sql-set-role.html

The `session_role` setting will be used to set the current user identifier
of the current SQL session to be `session_role`. Permissions checking for
SQL commands is carried out as though the named role were the one that had
logged in originally.

This is useful to automatically give the ownership of a new object (Table, View, Function) to
the `session_role` group and thus share ownership and associated rights with all members 
of the `session_role` group.

The specified `session_role` must be a role that the current session user
is a member of. (If the session user is a superuser, any role can be selected.)

Funded by 3liz https://3liz.com/