### PR TITLE
Better size hint for marker symbol buttons

### DIFF
--- a/src/app/decorations/qgsdecorationgriddialog.cpp
+++ b/src/app/decorations/qgsdecorationgriddialog.cpp
@@ -19,17 +19,13 @@
 
 #include "qgsdecorationgrid.h"
 
-#include "qgslogger.h"
 #include "qgshelp.h"
-#include "qgsstyle.h"
 #include "qgssymbol.h"
 #include "qgssymbolselectordialog.h"
 #include "qgisapp.h"
-#include "qgsguiutils.h"
 #include "qgsgui.h"
 #include "qgslinesymbol.h"
 #include "qgsmarkersymbol.h"
-#include "qgsdoublevalidator.h"
 
 QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidget *parent )
   : QDialog( parent )
@@ -188,6 +184,7 @@ void QgsDecorationGridDialog::updateSymbolButtons()
       mLineSymbolButton->setVisible( false );
       mLineSymbolButton->setEnabled( false );
       mLineSymbolLabel->setVisible( false );
+      mMarkerSymbolFrame->setVisible( true );
       break;
     }
     case ( QgsDecorationGrid::Line ):
@@ -198,6 +195,7 @@ void QgsDecorationGridDialog::updateSymbolButtons()
       mMarkerSymbolButton->setVisible( false );
       mMarkerSymbolButton->setEnabled( false );
       mMarkerSymbolLabel->setVisible( false );
+      mMarkerSymbolFrame->setVisible( false );
       break;
     }
   }

--- a/src/gui/layout/qgslayoutmapgridwidget.cpp
+++ b/src/gui/layout/qgslayoutmapgridwidget.cpp
@@ -526,6 +526,7 @@ void QgsLayoutMapGridWidget::setGridItems()
       mGridLineStyleButton->setVisible( false );
       mLineStyleLabel->setVisible( false );
       mGridMarkerStyleButton->setVisible( true );
+      mMarkerStyleFrame->setVisible( true );
       mMarkerStyleLabel->setVisible( true );
       mGridBlendComboBox->setVisible( true );
       mGridBlendLabel->setVisible( true );
@@ -537,6 +538,7 @@ void QgsLayoutMapGridWidget::setGridItems()
       mGridLineStyleButton->setVisible( true );
       mLineStyleLabel->setVisible( true );
       mGridMarkerStyleButton->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
       mMarkerStyleLabel->setVisible( false );
       mGridBlendComboBox->setVisible( true );
       mGridBlendLabel->setVisible( true );
@@ -548,6 +550,7 @@ void QgsLayoutMapGridWidget::setGridItems()
       mGridLineStyleButton->setVisible( false );
       mLineStyleLabel->setVisible( false );
       mGridMarkerStyleButton->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
       mMarkerStyleLabel->setVisible( false );
       mGridBlendComboBox->setVisible( false );
       mGridBlendLabel->setVisible( false );
@@ -1157,6 +1160,8 @@ void QgsLayoutMapGridWidget::mGridTypeComboBox_currentIndexChanged( int )
       mGridLineStyleButton->setVisible( true );
       mLineStyleLabel->setVisible( true );
       mGridMarkerStyleButton->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
       mMarkerStyleLabel->setVisible( false );
       mGridBlendComboBox->setVisible( true );
       mGridBlendLabel->setVisible( true );
@@ -1170,6 +1175,7 @@ void QgsLayoutMapGridWidget::mGridTypeComboBox_currentIndexChanged( int )
       mGridLineStyleButton->setVisible( false );
       mLineStyleLabel->setVisible( false );
       mGridMarkerStyleButton->setVisible( true );
+      mMarkerStyleFrame->setVisible( true );
       mMarkerStyleLabel->setVisible( true );
       mGridBlendComboBox->setVisible( true );
       mGridBlendLabel->setVisible( true );
@@ -1183,6 +1189,7 @@ void QgsLayoutMapGridWidget::mGridTypeComboBox_currentIndexChanged( int )
       mGridLineStyleButton->setVisible( true );
       mLineStyleLabel->setVisible( true );
       mGridMarkerStyleButton->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
       mMarkerStyleLabel->setVisible( false );
       mGridBlendComboBox->setVisible( true );
       mGridBlendLabel->setVisible( true );
@@ -1196,6 +1203,7 @@ void QgsLayoutMapGridWidget::mGridTypeComboBox_currentIndexChanged( int )
       mGridLineStyleButton->setVisible( false );
       mLineStyleLabel->setVisible( false );
       mGridMarkerStyleButton->setVisible( false );
+      mMarkerStyleFrame->setVisible( false );
       mMarkerStyleLabel->setVisible( false );
       mGridBlendComboBox->setVisible( false );
       mGridBlendLabel->setVisible( false );

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -53,17 +53,47 @@ QgsSymbolButton::QgsSymbolButton( QWidget *parent, const QString &dialogTitle )
   setMenu( mMenu );
   setPopupMode( QToolButton::MenuButtonPopup );
 
+  updateSizeHint();
+}
+
+void QgsSymbolButton::updateSizeHint()
+{
   //make sure height of button looks good under different platforms
   const QSize size = QToolButton::minimumSizeHint();
   const int fontHeight = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 1.4 );
-  mSizeHint = QSize( size.width(), std::max( size.height(), fontHeight ) );
+  switch ( mType )
+  {
+    case Qgis::SymbolType::Marker:
+      if ( mSymbol )
+      {
+        mSizeHint = QSize( size.width(), std::max( size.height(), fontHeight * 3 ) );
+        setMaximumWidth( mSizeHint.height() * 1.5 );
+        setMinimumWidth( maximumWidth() );
+      }
+      else
+      {
+        mSizeHint = QSize( size.width(), fontHeight );
+        setMaximumWidth( 999999 );
+        mSizeHint.setWidth( QToolButton::sizeHint().width() );
+      }
+      break;
+
+    case Qgis::SymbolType::Line:
+    case Qgis::SymbolType::Fill:
+    case Qgis::SymbolType::Hybrid:
+      mSizeHint = QSize( size.width(), std::max( size.height(), fontHeight ) );
+      break;
+  }
+
+  setMinimumHeight( mSizeHint.height( ) );
+
+  updateGeometry();
 }
 
 QgsSymbolButton::~QgsSymbolButton() = default;
 
 QSize QgsSymbolButton::minimumSizeHint() const
 {
-
   return mSizeHint;
 }
 
@@ -94,8 +124,9 @@ void QgsSymbolButton::setSymbolType( Qgis::SymbolType type )
         break;
     }
   }
-  updatePreview();
   mType = type;
+  updateSizeHint();
+  updatePreview();
 }
 
 void QgsSymbolButton::showSettingsDialog()
@@ -218,6 +249,7 @@ void QgsSymbolButton::registerExpressionContextGenerator( QgsExpressionContextGe
 void QgsSymbolButton::setSymbol( QgsSymbol *symbol )
 {
   mSymbol.reset( symbol );
+  updateSizeHint();
   updatePreview();
   emit changed();
 }

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -346,6 +346,8 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
 
     void showColorDialog();
 
+    void updateSizeHint();
+
 };
 
 #endif // QGSSYMBOLBUTTON_H

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -224,6 +224,156 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
+     <item row="5" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinSize">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QgsSymbolButton" name="btnChangeSymbol">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="labelAltClamping">
+       <property name="text">
+        <string>Altitude clamping</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelRadius">
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="Qgs3DModelSourceLineEdit" name="lineEditModel" native="true"/>
+       </item>
+      </layout>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelBillboardSymbol">
+       <property name="text">
+        <string>Billboard symbol</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelBillboardHeight">
+       <property name="text">
+        <string>Billboard Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinLength">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cboShape"/>
+     </item>
+     <item row="8" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinBillboardHeight">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelBottomRadius">
+       <property name="text">
+        <string>Bottom radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelModel">
+       <property name="text">
+        <string>Model</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelLength">
+       <property name="text">
+        <string>Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelMinorRadius">
+       <property name="text">
+        <string>Minor radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelTopRadius">
+       <property name="text">
+        <string>Top radius</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinRadius">
        <property name="maximum">
@@ -253,79 +403,10 @@
        </item>
       </widget>
      </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="Qgs3DModelSourceLineEdit" name="lineEditModel" native="true"/>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelRadius">
-       <property name="text">
-        <string>Radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="labelBottomRadius">
-       <property name="text">
-        <string>Bottom radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinSize">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelModel">
-       <property name="text">
-        <string>Model</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="QgsDoubleSpinBox" name="spinTopRadius">
        <property name="maximum">
         <double>99999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinBillboardHeight">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="labelBillboardSymbol">
-       <property name="text">
-        <string>Billboard symbol</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>5.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="labelBillboardHeight">
-       <property name="text">
-        <string>Billboard Height</string>
        </property>
       </widget>
      </item>
@@ -336,74 +417,10 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
-      <widget class="QgsSymbolButton" name="btnChangeSymbol">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelMinorRadius">
-       <property name="text">
-        <string>Minor radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cboShape"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="labelTopRadius">
-       <property name="text">
-        <string>Top radius</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Shape</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinLength">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="labelAltClamping">
-       <property name="text">
-        <string>Altitude clamping</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="labelLength">
-       <property name="text">
-        <string>Length</string>
        </property>
       </widget>
      </item>
@@ -449,7 +466,6 @@
   <tabstop>spinBottomRadius</tabstop>
   <tabstop>spinSize</tabstop>
   <tabstop>spinLength</tabstop>
-  <tabstop>lineEditModel</tabstop>
   <tabstop>spinBillboardHeight</tabstop>
   <tabstop>btnChangeSymbol</tabstop>
   <tabstop>cboAltClamping</tabstop>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>493</width>
-        <height>1620</height>
+        <height>1675</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -108,74 +108,7 @@
           <string>Appearance</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,0,0">
-          <item row="7" column="0">
-           <widget class="QLabel" name="mCrossWidthLabel">
-            <property name="text">
-             <string>Cross width</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mGridTypeComboBox"/>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="mGridBlendLabel">
-            <property name="text">
-             <string>Blend mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="mMapGridCRSLabel">
-            <property name="text">
-             <string>CRS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QgsDoubleSpinBox" name="mCrossWidthSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="decimals">
-             <number>2</number>
-            </property>
-            <property name="showClearButton" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QgsProjectionSelectionWidget" name="mMapGridCrsSelector" native="true">
-            <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="mLineStyleLabel">
-            <property name="text">
-             <string>Line style</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mIntervalXLabel_2">
-            <property name="text">
-             <string>Interval</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1" colspan="2">
+          <item row="6" column="1" colspan="2">
            <widget class="QgsSymbolButton" name="mGridLineStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -188,17 +121,48 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mGridTypeLabel_2">
+          <item row="6" column="0">
+           <widget class="QLabel" name="mLineStyleLabel">
             <property name="text">
-             <string>Grid type</string>
+             <string>Line style</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="1" column="1" colspan="2">
+           <widget class="QgsProjectionSelectionWidget" name="mMapGridCrsSelector" native="true">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mCrossWidthDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mIntervalXLabel_2">
+            <property name="text">
+             <string>Interval</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mMapGridCRSLabel">
+            <property name="text">
+             <string>CRS</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
            <widget class="QStackedWidget" name="mIntervalStackedWidget">
             <property name="currentIndex">
              <number>0</number>
@@ -334,20 +298,24 @@
             </widget>
            </widget>
           </item>
-          <item row="10" column="1" colspan="2">
-           <widget class="QgsBlendModeComboBox" name="mGridBlendComboBox"/>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="mMarkerStyleLabel">
+          <item row="0" column="0">
+           <widget class="QLabel" name="mGridTypeLabel_2">
             <property name="text">
-             <string>Marker style</string>
+             <string>Grid type</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="10" column="0">
+           <widget class="QLabel" name="mGridBlendLabel">
+            <property name="text">
+             <string>Blend mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="mOffsetXLabel_2">
             <property name="text">
              <string>Offset</string>
@@ -357,30 +325,13 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="1" colspan="2">
-           <widget class="QgsSymbolButton" name="mGridMarkerStyleButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
+          <item row="7" column="1">
+           <widget class="QWidget" name="widget" native="true"/>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="2" column="1" colspan="2">
            <widget class="QComboBox" name="mMapGridUnitComboBox"/>
           </item>
-          <item row="7" column="2">
-           <widget class="QgsPropertyOverrideButton" name="mCrossWidthDDBtn">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1" colspan="2">
+          <item row="4" column="1" colspan="2">
            <layout class="QGridLayout" name="gridLayout_5">
             <item row="2" column="1">
              <widget class="QgsPropertyOverrideButton" name="mOffsetYDDBtn">
@@ -429,6 +380,89 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="mGridTypeComboBox"/>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="mCrossWidthLabel">
+            <property name="text">
+             <string>Cross width</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QgsDoubleSpinBox" name="mCrossWidthSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="showClearButton" stdset="0">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1" colspan="2">
+           <widget class="QgsBlendModeComboBox" name="mGridBlendComboBox"/>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="mMarkerStyleLabel">
+            <property name="text">
+             <string>Marker style</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1" colspan="2">
+           <widget class="QWidget" name="mMarkerStyleFrame" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_11">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QgsSymbolButton" name="mGridMarkerStyleButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Change…</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1114,14 +1148,35 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -1136,30 +1191,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
@@ -1246,6 +1280,7 @@
   <tabstop>mRotatedAnnotationsMarginToCornerSpinBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/layout/qgslayoutmarkerwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmarkerwidgetbase.ui
@@ -56,7 +56,7 @@
         <x>0</x>
         <y>0</y>
         <width>306</width>
-        <height>249</height>
+        <height>248</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -75,13 +75,6 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Symbol</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QgsSymbolButton" name="mShapeStyleButton">
             <property name="sizePolicy">
@@ -94,6 +87,26 @@
              <string>Change…</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Symbol</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -172,15 +185,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>

--- a/src/ui/qgsannotationwidgetbase.ui
+++ b/src/ui/qgsannotationwidgetbase.ui
@@ -14,37 +14,7 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="1">
-    <widget class="QgsSymbolButton" name="mFrameStyleButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mMapMarkerLabel_3">
-     <property name="text">
-      <string>Frame style</string>
-     </property>
-     <property name="buddy">
-      <cstring>mMapMarkerButton</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="mMapPositionFixedCheckBox">
-     <property name="text">
-      <string>Fixed map position</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mMarginsGroupBox">
      <property name="title">
       <string>Contents Margins</string>
@@ -181,38 +151,15 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
-     <property name="toolTip">
-      <string>Allows the annotation to be associated with a map layer. If set, the annotation will only be visible when the layer is visible.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="mMapMarkerLabel">
+   <item row="0" column="0" colspan="2">
+    <widget class="QCheckBox" name="mMapPositionFixedCheckBox">
      <property name="text">
-      <string>Map marker</string>
-     </property>
-     <property name="buddy">
-      <cstring>mMapMarkerButton</cstring>
+      <string>Fixed map position</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QgsSymbolButton" name="mMapMarkerButton">
+   <item row="4" column="1">
+    <widget class="QgsSymbolButton" name="mFrameStyleButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -234,18 +181,91 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mMapMarkerLabel_3">
+     <property name="text">
+      <string>Frame style</string>
+     </property>
+     <property name="buddy">
+      <cstring>mMapMarkerButton</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
+     <property name="toolTip">
+      <string>Allows the annotation to be associated with a map layer. If set, the annotation will only be visible when the layer is visible.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsSymbolButton" name="mMapMarkerButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mMapMarkerLabel">
+     <property name="text">
+      <string>Map marker</string>
+     </property>
+     <property name="buddy">
+      <cstring>mMapMarkerButton</cstring>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">qgsmaplayercombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
@@ -254,15 +274,20 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mMapPositionFixedCheckBox</tabstop>
   <tabstop>mLayerComboBox</tabstop>
   <tabstop>mMapMarkerButton</tabstop>
+  <tabstop>mFrameStyleButton</tabstop>
+  <tabstop>mSpinTopMargin</tabstop>
+  <tabstop>mSpinLeftMargin</tabstop>
+  <tabstop>mSpinRightMargin</tabstop>
+  <tabstop>mSpinBottomMargin</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>390</width>
-    <height>548</height>
+    <height>559</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,8 +29,24 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="7" column="1">
-       <widget class="QLabel" name="mOffsetYLabel">
+      <item row="7" column="2">
+       <widget class="QgsDoubleSpinBox" name="mOffsetXEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <double>-10000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="mIntervalYLabel">
         <property name="text">
          <string>Y</string>
         </property>
@@ -42,71 +58,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0" rowspan="2">
-       <widget class="QLabel" name="mOffsetLabel">
-        <property name="text">
-         <string>Offset</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="2">
-       <widget class="QgsDoubleSpinBox" name="mOffsetYEdit">
-        <property name="minimum">
-         <double>-10000000000000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000000000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QgsSymbolButton" name="mMarkerSymbolButton">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QgsSymbolButton" name="mLineSymbolButton">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0" colspan="3">
+      <item row="10" column="0" colspan="3">
        <layout class="QGridLayout" name="gridLayout_4">
         <property name="leftMargin">
          <number>9</number>
@@ -136,14 +88,7 @@
         </item>
        </layout>
       </item>
-      <item row="5" column="2">
-       <widget class="QgsDoubleSpinBox" name="mIntervalYEdit">
-        <property name="maximum">
-         <double>10000000000000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="22" column="0" colspan="3">
+      <item row="23" column="0" colspan="3">
        <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
         <property name="title">
          <string>Draw Annotation</string>
@@ -226,80 +171,7 @@
         </layout>
        </widget>
       </item>
-      <item row="6" column="2">
-       <widget class="QgsDoubleSpinBox" name="mOffsetXEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimum">
-         <double>-10000000000000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000000000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0" colspan="3">
-       <widget class="QLabel" name="mUpdateIntervalOffsetLabel">
-        <property name="text">
-         <string>Update Interval / Offset from</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QLabel" name="mLineSymbolLabel">
-        <property name="text">
-         <string>Line symbol</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="mGridTypeLabel">
-        <property name="text">
-         <string>Grid type</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QgsDoubleSpinBox" name="mIntervalXEdit">
-        <property name="maximum">
-         <double>10000000000000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" rowspan="2">
-       <widget class="QLabel" name="mIntervalLabel">
-        <property name="text">
-         <string>Interval</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QLabel" name="mIntervalYLabel">
-        <property name="text">
-         <string>Y</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="23" column="0" colspan="3">
+      <item row="24" column="0" colspan="3">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -328,17 +200,57 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="mMarkerSymbolLabel">
+      <item row="8" column="1">
+       <widget class="QLabel" name="mOffsetYLabel">
         <property name="text">
-         <string>Marker symbol</string>
+         <string>Y</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="8" column="2">
+       <widget class="QgsDoubleSpinBox" name="mOffsetYEdit">
+        <property name="minimum">
+         <double>-10000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" rowspan="2">
+       <widget class="QLabel" name="mIntervalLabel">
+        <property name="text">
+         <string>Interval</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QgsDoubleSpinBox" name="mIntervalYEdit">
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="mGridTypeLabel">
+        <property name="text">
+         <string>Grid type</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
        <widget class="QLabel" name="mOffsetXLabel">
         <property name="text">
          <string>X</string>
@@ -348,13 +260,132 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="2">
+       <widget class="QgsDoubleSpinBox" name="mIntervalXEdit">
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" rowspan="2">
+       <widget class="QLabel" name="mOffsetLabel">
+        <property name="text">
+         <string>Offset</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QgsSymbolButton" name="mLineSymbolButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="mLineSymbolLabel">
+        <property name="text">
+         <string>Line symbol</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="3">
+       <widget class="QLabel" name="mUpdateIntervalOffsetLabel">
+        <property name="text">
+         <string>Update Interval / Offset from</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
        <widget class="QLabel" name="mIntervalXLabel">
         <property name="text">
          <string>X</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QWidget" name="mMarkerSymbolFrame" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QgsSymbolButton" name="mMarkerSymbolButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QLabel" name="mMarkerSymbolLabel">
+        <property name="text">
+         <string>Marker symbol</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -375,24 +406,24 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsFontButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsfontbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgseditconditionalformatrulewidget.ui
+++ b/src/ui/qgseditconditionalformatrulewidget.ui
@@ -23,6 +23,71 @@
    <item row="5" column="0" colspan="2">
     <widget class="QComboBox" name="mPresetsList"/>
    </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLineEdit" name="mNameEdit">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="mSaveRule">
+       <property name="text">
+        <string>Done</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mCancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mDeleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -30,12 +95,56 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLineEdit" name="mNameEdit">
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLineEdit" name="mRuleEdit">
+       <property name="text">
+        <string>@value</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnBuildExpression">
+       <property name="text">
+        <string>…</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string/>
+      <string>Condition</string>
      </property>
     </widget>
+   </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>43</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="6" column="0" colspan="2">
     <widget class="QFrame" name="horizontalFrame_2">
@@ -53,21 +162,11 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Background</string>
-          </property>
-         </widget>
-        </item>
-        <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="1">
          <widget class="QgsColorButton" name="btnBackgroundColor">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -92,20 +191,7 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLabel" name="label_6">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Text</string>
-          </property>
-         </widget>
-        </item>
-        <item>
+        <item row="0" column="3">
          <widget class="QgsColorButton" name="btnTextColor">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -130,11 +216,33 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_6">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Background</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
          <widget class="QCheckBox" name="checkIcon">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -147,33 +255,50 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QgsSymbolButton" name="btnChangeIcon">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>10</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
+        <item row="1" column="1" colspan="3">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QgsSymbolButton" name="btnChangeIcon">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>10</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -324,128 +449,19 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="mSaveRule">
-       <property name="text">
-        <string>Done</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mCancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mDeleteButton">
-       <property name="text">
-        <string>Delete</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Condition</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>43</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLineEdit" name="mRuleEdit">
-       <property name="text">
-        <string>@value</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnBuildExpression">
-       <property name="text">
-        <string>…</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -245,40 +245,7 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="1" column="1">
-           <widget class="QgsSymbolButton" name="mMarkerStyleButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="1">
-           <widget class="QgsSymbolButton" name="mFillStyleButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Marker style</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
            <widget class="QgsSymbolButton" name="mLineStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -291,10 +258,23 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_6">
             <property name="text">
              <string>Fill style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QgsSymbolButton" name="mFillStyleButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
@@ -308,10 +288,50 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Line style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QgsSymbolButton" name="mMarkerStyleButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Marker style</string>
             </property>
            </widget>
           </item>
@@ -331,43 +351,6 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Marker style</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="mStyleComboBox"/>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="mCheckBoxShowMarkersAtSampledPoints">
-            <property name="text">
-             <string>Show markers at sampled points</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QgsSymbolButton" name="mSurfaceMarkerStyleButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Style</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0" colspan="2">
            <widget class="QStackedWidget" name="mSymbologyStackedWidget">
             <property name="sizePolicy">
@@ -453,6 +436,63 @@
             </widget>
            </widget>
           </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="mCheckBoxShowMarkersAtSampledPoints">
+            <property name="text">
+             <string>Show markers at sampled points</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="mStyleComboBox"/>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QgsSymbolButton" name="mSurfaceMarkerStyleButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Marker style</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </widget>
@@ -509,11 +549,9 @@
   <tabstop>mLineStyleButton</tabstop>
   <tabstop>mFillStyleButton</tabstop>
   <tabstop>mStyleComboBox</tabstop>
-  <tabstop>mSymbologyStackedWidget</tabstop>
   <tabstop>mSurfaceLineStyleButton</tabstop>
   <tabstop>mSurfaceFillStyleButton</tabstop>
   <tabstop>mCheckBoxShowMarkersAtSampledPoints</tabstop>
-  <tabstop>mSurfaceMarkerStyleButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/qgspointclusterrendererwidgetbase.ui
+++ b/src/ui/symbollayer/qgspointclusterrendererwidgetbase.ui
@@ -84,23 +84,43 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsSymbolButton" name="mCenterSymbolToolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
     <widget class="QLabel" name="mCenterSymbolLabel">
      <property name="text">
       <string>Cluster symbol</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsSymbolButton" name="mCenterSymbolToolButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The default approach of showing these with the same size hint
as regular buttons/combo boxes doesn't work well -- we end
up with a long, short widget which usually ends up with
a clipped marker symbol + a lot of wasted horizontal space.

Revise this so that marker symbol buttons instead use a more
appropriate squarish size which is much less likely to show
clipped marker symbols.


Eg before:

![image](https://user-images.githubusercontent.com/1829991/186793275-858449a6-24ac-4238-b6f0-e9213363079d.png)

after:

![image](https://user-images.githubusercontent.com/1829991/186793309-a506df2a-5903-4da2-9f63-179a26d8d691.png)

