### PR TITLE
[ui] Ask for confirmation (which can be turned off) when deleting features

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8431,9 +8431,13 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesV
     if ( !allFeaturesInView )
     {
       // for extra safety to make sure we are not removing geometries by accident
-      int res = QMessageBox::warning( mMapCanvas, tr( "Delete %n feature(s) from layer \"%1\"", nullptr, numberOfSelectedFeatures ).arg( vlayer->name() ),
-                                      tr( "Some of the <b>%n</b> selected feature(s) about to be deleted <b>are outside of the current map view</b>. Would you still like to continue?", nullptr, numberOfSelectedFeatures ),
-                                      QMessageBox::Yes | QMessageBox::No );
+      QMessageBox warning( QMessageBox::Warning,
+                           tr( "Delete %n feature(s) from layer \"%1\"", nullptr, numberOfSelectedFeatures ).arg( vlayer->name() ),
+                           tr( "Some of the <b>%n</b> selected feature(s) about to be deleted <b>are outside of the current map view</b>. Would you still like to continue?", nullptr, numberOfSelectedFeatures ),
+                           QMessageBox::Yes | QMessageBox::Cancel,
+                           mMapCanvas );
+      warning.button( QMessageBox::Yes )->setText( tr( "Delete %n Feature(s)", nullptr, numberOfSelectedFeatures ) );
+      int res = warning.exec();
       if ( res != QMessageBox::Yes )
         return;
       confirmationServed = true;
@@ -8453,9 +8457,13 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesV
     }
 
     // for extra safety to make sure we know that the delete can have impact on children and joins
-    int res = QMessageBox::question( mMapCanvas, tr( "Delete at least %1 feature(s) on other layer(s)" ).arg( childrenCount ),
-                                     tr( "Delete %1 feature(s) on layer \"%2\", %3 as well\nand all of its other descendants.\nDelete these features?" ).arg( numberOfSelectedFeatures ).arg( vlayer->name(), childrenInfo ),
-                                     QMessageBox::Yes | QMessageBox::No );
+    QMessageBox question( QMessageBox::Question,
+                          tr( "Delete at least %1 feature(s) on other layer(s)" ).arg( childrenCount ),
+                          tr( "Delete %1 feature(s) on layer \"%2\", %3 as well\nand all of its other descendants.\nDelete these features?" ).arg( numberOfSelectedFeatures ).arg( vlayer->name(), childrenInfo ),
+                          QMessageBox::Yes | QMessageBox::Cancel,
+                          mMapCanvas );
+    question.button( QMessageBox::Yes )->setText( tr( "Delete %n Feature(s)", nullptr, numberOfSelectedFeatures ) );
+    int res = question.exec();
     if ( res != QMessageBox::Yes )
       return;
     confirmationServed = true;
@@ -8464,23 +8472,24 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesV
   if ( !confirmationServed )
   {
     QgsSettings settings;
-    const bool showConfirmation = settings.value( QStringLiteral( "showDeletionConfirmation" ), true, QgsSettings::App ).toBool();
+    const bool showConfirmation = settings.value( QStringLiteral( "askToDeleteFeatures" ), true, QgsSettings::App ).toBool();
     if ( showConfirmation )
     {
       QMessageBox confirmMessage( QMessageBox::Question,
                                   tr( "Delete %n feature(s) from layer \"%1\"", nullptr, numberOfSelectedFeatures ).arg( vlayer->name() ),
                                   tr( "<b>%n</b> selected feature(s) is/are about to be deleted. Would you like to continue?", nullptr, numberOfSelectedFeatures ),
-                                  QMessageBox::Yes | QMessageBox::No,
+                                  QMessageBox::Yes | QMessageBox::Cancel,
                                   mMapCanvas );
-      confirmMessage.setCheckBox( new QCheckBox( tr( "Show this again next time" ) ) );
-      confirmMessage.checkBox()->setChecked( true );
+      confirmMessage.button( QMessageBox::Yes )->setText( tr( "Delete %n Feature(s)", nullptr, numberOfSelectedFeatures ) );
+      confirmMessage.setCheckBox( new QCheckBox( tr( "Don't show this message again" ) ) );
+      confirmMessage.checkBox()->setChecked( false );
       int res = confirmMessage.exec();
       if ( res != QMessageBox::Yes )
         return;
 
-      if ( !confirmMessage.checkBox()->isChecked() )
+      if ( confirmMessage.checkBox()->isChecked() )
       {
-        settings.setValue( QStringLiteral( "showDeletionConfirmation" ), false, QgsSettings::App );
+        settings.setValue( QStringLiteral( "askToDeleteFeatures" ), false, QgsSettings::App );
       }
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8400,7 +8400,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesV
     return;
   }
 
-  //validate selection
+  // validate selection
   const int numberOfSelectedFeatures = vlayer->selectedFeatureCount();
   if ( numberOfSelectedFeatures == 0 )
   {
@@ -8410,7 +8410,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesV
     return;
   }
 
-  //display an "ooutside of view" warning
+  // display an "outside of view" warning
   bool confirmationServed = false;
   if ( checkFeaturesVisible )
   {


### PR DESCRIPTION
## Description

This PR implements a deletion confirmation dialog when a user trigger the delete selected action (either via the DEL key or toolbar action in the main window or attribute table). It looks like this:
![image](https://user-images.githubusercontent.com/1728657/187064180-7c9098a8-8802-478c-b1cb-315740d81ffb.png)

Until now, a warning / confirmation dialog was thrown at users _only_ when some features felt out of the map canvas extent or triggered child relation feature(s) deletion. 

If neither of these are shown, users are now shown a new confirmation dialog asking whether they really want to delete the selected features. This added UI/UX insures that we further reduce the risks of accidental feature deletion where users might have unknowingly triggered the action and hit save not knowing features have been deleted.

The confirmation dialog also allows for users who would be irritated by this new safeguard to disable the confirmation altogether by unchecking "show this again next time" checkbox.

Lastly, the selected feature count is now also shown in the dialog message itself (on top of being displayed in the title bar). Quite a few users are actually missing this crucial detail when placed in the title bar.

_Funded by the [QGIS user group Switzerland](https://www.qgis.ch/)._