### PR TITLE
Qt Extras modules have been removed from Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,9 +481,6 @@ if(WITH_CORE)
     find_package(${QT_VERSION_BASE} COMPONENTS 3DCore 3DRender 3DInput 3DLogic 3DExtras REQUIRED)
     set(HAVE_3D TRUE)  # used in qgsconfig.h
   endif()
-  if (APPLE)
-    find_package(${QT_VERSION_BASE} COMPONENTS MacExtras REQUIRED)
-  endif()
 
   # get the Qt plugins directory
   get_target_property(QMAKE_EXECUTABLE ${QT_VERSION_BASE}::qmake LOCATION)
@@ -498,7 +495,7 @@ if(WITH_CORE)
   endif()
   if (WITH_QUICK)
     find_package(${QT_VERSION_BASE} COMPONENTS Qml Quick REQUIRED)
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Android" AND NOT BUILD_WITH_QT6)
       find_package(${QT_VERSION_BASE} COMPONENTS AndroidExtras)
     endif()
 

--- a/mac/cmake/1qt.cmake.in
+++ b/mac/cmake/1qt.cmake.in
@@ -16,8 +16,8 @@ SET (QT_FWVER "5")
 # build list of Qt frameworks to bundle
 
 # core list, includes dependencies and used by extra plugins
-SET (QTLISTQG QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtConcurrent QtPrintSupport QtSerialPort QtPositioning QtTest QtSql QtMacExtras QtDBus)
-SET (PYQTLIST Qt QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtPrintSupport QtPositioning QtSerialPort QtTest QtSql QtMacExtras QtDBus)
+SET (QTLISTQG QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtConcurrent QtPrintSupport QtSerialPort QtPositioning QtTest QtSql QtDBus)
+SET (PYQTLIST Qt QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtPrintSupport QtPositioning QtSerialPort QtTest QtSql QtDBus)
 
 # QtQuickWidgets appears to be implied direct dep, it needs Quick and Qml,
 # whether or not WITH_QUICK specified

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -144,12 +144,6 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
   target_link_libraries(qgis_native ${QT_VERSION_BASE}::DBus)
 endif()
 
-if (APPLE)
-  find_package(${QT_VERSION_BASE}MacExtras)
-
-  target_link_libraries(qgis_native ${QT_VERSION_BASE}::MacExtras)
-endif()
-
 if (MSVC)
   find_package(${QT_VERSION_BASE}WinExtras)
 

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -18,7 +18,6 @@
 #include "qgsmacnative.h"
 
 #include <Cocoa/Cocoa.h>
-#include <QtMacExtras/QtMac>
 
 #include <QString>
 #include <QPixmap>
@@ -60,7 +59,7 @@ QgsMacNative::~QgsMacNative()
 
 void QgsMacNative::setIconPath( const QString &iconPath )
 {
-  mQgsUserNotificationCenter->_qgisIcon = QtMac::toNSImage( QPixmap( iconPath ) );
+  mQgsUserNotificationCenter->_qgisIcon = [[NSImage alloc] initWithCGImage:QPixmap( iconPath ).toImage().toCGImage()];
 }
 
 const char *QgsMacNative::currentAppLocalizedName()
@@ -105,7 +104,7 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
   }
   else
   {
-    image = QtMac::toNSImage( px );
+    image = [[NSImage alloc] initWithCGImage:px.toImage().toCGImage()];
   }
   notification.contentImage = image;
 


### PR DESCRIPTION
https://www.qt.io/blog/qt-extras-modules-in-qt-6

turns out, there's an easy way to accomplish the image conversion which already works on qt5.