### PR TITLE
Added missing size parameter to native MacOS code for initWithCGImage…

### DIFF
--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -59,7 +59,7 @@ QgsMacNative::~QgsMacNative()
 
 void QgsMacNative::setIconPath( const QString &iconPath )
 {
-  mQgsUserNotificationCenter->_qgisIcon = [[NSImage alloc] initWithCGImage:QPixmap( iconPath ).toImage().toCGImage()];
+  mQgsUserNotificationCenter->_qgisIcon = [[NSImage alloc] initWithCGImage:QPixmap( iconPath ).toImage().toCGImage() size:NSZeroSize];
 }
 
 const char *QgsMacNative::currentAppLocalizedName()
@@ -104,7 +104,7 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
   }
   else
   {
-    image = [[NSImage alloc] initWithCGImage:px.toImage().toCGImage()];
+    image = [[NSImage alloc] initWithCGImage:px.toImage().toCGImage() size:NSZeroSize];
   }
   notification.contentImage = image;
 


### PR DESCRIPTION
…function return type NSImage

## Description

References to Apple Developer Documentation:

[[NSImage] initWithCGImage](https://developer.apple.com/documentation/appkit/nsimage/1519939-initwithcgimage)

Previous code possibly used [[NSBitmapImageRep] initWithCGImage](https://developer.apple.com/documentation/appkit/nsbitmapimagerep/1395423-initwithcgimage) documentation as it is missing the size parameter.

The code previously compiled, but QGIS crashed after the splash screen. Possible update to Xcode 13.2.1 was the issue, but failed code is only 2 days old. It now compiles and runs as before without the compiler warning.

Compiler output for failed code:

```
/Users/sam/Documents/GitHub/QGIS/src/native/mac/qgsmacnative.mm:62:60: warning: 'NSImage' may not respond to 'initWithCGImage:'
  mQgsUserNotificationCenter->_qgisIcon = [[NSImage alloc] initWithCGImage:QPixmap( iconPath ).toImage().toCGImage()];
                                           ~~~~~~~~~~~~~~~ ^
```

Edit: clarified submitted code was compiled and runs.