### PR TITLE
Follow up b7e31d4: do not include map canvas filter(s)

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -846,12 +846,6 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             QString filterExp = layer->renderer() ? layer->renderer()->legendKeyToExpression( ruleKey, layer, ok ) : QString();
             if ( ok )
             {
-              const QString canvasFilter = QgsMapCanvasUtils::filterForLayer( QgisApp::instance()->mapCanvas(), layer );
-              if ( canvasFilter == QLatin1String( "FALSE" ) )
-                return;
-              else if ( !canvasFilter.isEmpty() )
-                filterExp = QStringLiteral( "(%1) AND (%2)" ).arg( filterExp, canvasFilter );
-
               QgisApp::instance()->attributeTable( QgsAttributeTableFilterModel::ShowFilteredList, filterExp );
             }
           }


### PR DESCRIPTION
## Description

@uclaros , apologies for not answering in the initial PR, I had auto merge set and just didn't catch your comment soon enough.

You raised a fair issue. This commit avoids including map canvas filters (temporal et al) to the new legend symbol's show in attribute table action.