### PR TITLE
Handle expression variables visibility

### DIFF
--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -421,7 +421,8 @@ Returns the list of variables hidden within the scope.
     void setHiddenVariables( const QStringList &hiddenVariables );
 %Docstring
 
-Sets the list of variables intended to be hidden.
+Sets the list of variables intended to be hidden in the
+expression builder dialog and widget.
 
 .. seealso:: :py:func:`hiddenVariables`
 
@@ -436,7 +437,8 @@ Sets the list of variables intended to be hidden.
     void addHiddenVariable( const QString &hiddenVariable );
 %Docstring
 
-Adds the passed variable to a list of hidden variables.
+Adds the passed variable to a list of hidden variables that
+won't be visible in the expression builder dialog and widget.
 
 .. seealso:: :py:func:`hiddenVariables`
 

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -404,6 +404,63 @@ Writes scope variables to an XML ``element``.
 .. versionadded:: 3.6
 %End
 
+
+    QStringList hiddenVariables() const;
+%Docstring
+Returns the list of variables hidden within the scope.
+
+.. seealso:: :py:func:`setHiddenVariables`
+
+.. seealso:: :py:func:`addHiddenVariable`
+
+.. seealso:: :py:func:`removeHiddenVariable`
+
+.. versionadded:: 3.28
+%End
+
+    void setHiddenVariables( const QStringList &hiddenVariables );
+%Docstring
+
+Sets the list of variables intended to be hidden.
+
+.. seealso:: :py:func:`hiddenVariables`
+
+.. seealso:: :py:func:`addHiddenVariable`
+
+.. seealso:: :py:func:`removeHiddenVariable`
+
+.. versionadded:: 3.28
+%End
+
+
+    void addHiddenVariable( const QString &hiddenVariable );
+%Docstring
+
+Adds the passed variable to a list of hidden variables.
+
+.. seealso:: :py:func:`hiddenVariables`
+
+.. seealso:: :py:func:`setHiddenVariables`
+
+.. seealso:: :py:func:`removeHiddenVariable`
+
+.. versionadded:: 3.28
+%End
+
+    void removeHiddenVariable( const QString &hiddenVariable );
+%Docstring
+
+Removes the passed variable from a list of hidden variables.
+
+.. seealso:: :py:func:`hiddenVariables`
+
+.. seealso:: :py:func:`setHiddenVariables`
+
+.. seealso:: :py:func:`addHiddenVariable`
+
+.. versionadded:: 3.28
+%End
+
 };
 
 class QgsExpressionContext

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -47,6 +47,7 @@ QgsExpressionContextScope::QgsExpressionContextScope( const QgsExpressionContext
   , mFeature( other.mFeature )
   , mHasGeometry( other.mHasGeometry )
   , mGeometry( other.mGeometry )
+  , mHiddenVariables( other.mHiddenVariables )
 {
   QHash<QString, QgsScopedExpressionFunction * >::const_iterator it = other.mFunctions.constBegin();
   for ( ; it != other.mFunctions.constEnd(); ++it )
@@ -63,6 +64,7 @@ QgsExpressionContextScope &QgsExpressionContextScope::operator=( const QgsExpres
   mFeature = other.mFeature;
   mHasGeometry = other.mHasGeometry;
   mGeometry = other.mGeometry;
+  mHiddenVariables = other.mHiddenVariables;
 
   qDeleteAll( mFunctions );
   mFunctions.clear();
@@ -119,6 +121,29 @@ QStringList QgsExpressionContextScope::variableNames() const
   QStringList names = mVariables.keys();
   return names;
 }
+
+QStringList QgsExpressionContextScope::hiddenVariables() const
+{
+  return mHiddenVariables;
+}
+
+void QgsExpressionContextScope::setHiddenVariables( const QStringList &hiddenVariables )
+{
+  mHiddenVariables = hiddenVariables;
+}
+
+void QgsExpressionContextScope::addHiddenVariable( const QString &hiddenVariable )
+{
+  if ( !mHiddenVariables.contains( hiddenVariable ) )
+    mHiddenVariables << hiddenVariable;
+}
+
+void QgsExpressionContextScope::removeHiddenVariable( const QString &hiddenVariable )
+{
+  if ( mHiddenVariables.contains( hiddenVariable ) )
+    mHiddenVariables.removeAt( mHiddenVariables.indexOf( hiddenVariable ) );
+}
+
 
 /// @cond PRIVATE
 class QgsExpressionContextVariableCompare
@@ -208,8 +233,14 @@ void QgsExpressionContextScope::readXml( const QDomElement &element, const QgsRe
   {
     const QDomElement variableElement = variablesNodeList.at( i ).toElement();
     const QString key = variableElement.attribute( QStringLiteral( "name" ) );
-    const QVariant value = QgsXmlUtils::readVariant( variableElement.firstChildElement( QStringLiteral( "Option" ) ) );
-    setVariable( key, value );
+    if ( variableElement.tagName() == QStringLiteral( "Variable" ) )
+    {
+      const QVariant value = QgsXmlUtils::readVariant( variableElement.firstChildElement( QStringLiteral( "Option" ) ) );
+      setVariable( key, value );
+    }
+    else
+      addHiddenVariable( key );
+
   }
 }
 
@@ -221,6 +252,13 @@ bool QgsExpressionContextScope::writeXml( QDomElement &element, QDomDocument &do
     varElem.setAttribute( QStringLiteral( "name" ), it.key() );
     QDomElement valueElem = QgsXmlUtils::writeVariant( it.value().value, document );
     varElem.appendChild( valueElem );
+    element.appendChild( varElem );
+  }
+
+  for ( QString hiddenVariable : mHiddenVariables )
+  {
+    QDomElement varElem = document.createElement( QStringLiteral( "HiddenVariable" ) );
+    varElem.setAttribute( QStringLiteral( "name" ), hiddenVariable );
     element.appendChild( varElem );
   }
   return true;
@@ -421,10 +459,20 @@ QStringList QgsExpressionContext::filteredVariableNames() const
   QStringList allVariables = variableNames();
   QStringList filtered;
   const auto constAllVariables = allVariables;
+
+  QStringList hiddenVariables;
+
+  for ( const QgsExpressionContextScope *scope : mStack )
+  {
+    const QStringList scopeHiddenVariables = scope->hiddenVariables();
+    for ( const QString &name : scopeHiddenVariables )
+      hiddenVariables << name ;
+  }
+
   for ( const QString &variable : constAllVariables )
   {
     if ( variable.startsWith( '_' ) ||
-         variable.compare( QStringLiteral( "frame_timestep_unit" ) ) == 0 )
+         hiddenVariables.contains( variable ) )
       continue;
 
     filtered << variable;

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -393,7 +393,8 @@ class CORE_EXPORT QgsExpressionContextScope
 
     /**
      *
-     * Sets the list of variables intended to be hidden.
+     * Sets the list of variables intended to be hidden in the
+     * expression builder dialog and widget.
      *
      * \see hiddenVariables()
      * \see addHiddenVariable()
@@ -405,7 +406,8 @@ class CORE_EXPORT QgsExpressionContextScope
 
     /**
      *
-     * Adds the passed variable to a list of hidden variables.
+     * Adds the passed variable to a list of hidden variables that
+     * won't be visible in the expression builder dialog and widget.
      *
      * \see hiddenVariables()
      * \see setHiddenVariables()

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -380,6 +380,51 @@ class CORE_EXPORT QgsExpressionContextScope
      */
     bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;
 
+
+    /**
+     * Returns the list of variables hidden within the scope.
+     *
+     * \see setHiddenVariables()
+     * \see addHiddenVariable()
+     * \see removeHiddenVariable()
+     * \since QGIS 3.28
+     */
+    QStringList hiddenVariables() const;
+
+    /**
+     *
+     * Sets the list of variables intended to be hidden.
+     *
+     * \see hiddenVariables()
+     * \see addHiddenVariable()
+     * \see removeHiddenVariable()
+     * \since QGIS 3.28
+     */
+    void setHiddenVariables( const QStringList &hiddenVariables );
+
+
+    /**
+     *
+     * Adds the passed variable to a list of hidden variables.
+     *
+     * \see hiddenVariables()
+     * \see setHiddenVariables()
+     * \see removeHiddenVariable()
+     * \since QGIS 3.28
+     */
+    void addHiddenVariable( const QString &hiddenVariable );
+
+    /**
+     *
+     * Removes the passed variable from a list of hidden variables.
+     *
+     * \see hiddenVariables()
+     * \see setHiddenVariables()
+     * \see addHiddenVariable()
+     * \since QGIS 3.28
+     */
+    void removeHiddenVariable( const QString &hiddenVariable );
+
   private:
     QString mName;
     QHash<QString, StaticVariable> mVariables;
@@ -388,6 +433,7 @@ class CORE_EXPORT QgsExpressionContextScope
     QgsFeature mFeature;
     bool mHasGeometry = false;
     QgsGeometry mGeometry;
+    QStringList mHiddenVariables;
 };
 
 /**

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -82,6 +82,9 @@ QgsExpressionContextScope *QgsTemporalNavigationObject::createExpressionContextS
   scope->setVariable( QStringLiteral( "animation_start_time" ), mTemporalExtents.begin(), true );
   scope->setVariable( QStringLiteral( "animation_end_time" ), mTemporalExtents.end(), true );
   scope->setVariable( QStringLiteral( "animation_interval" ), mTemporalExtents.end() - mTemporalExtents.begin(), true );
+
+  scope->addHiddenVariable( QStringLiteral( "frame_timestep_unit" ) );
+
   return scope.release();
 }
 

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -203,6 +203,26 @@ void TestQgsExpressionContext::contextScope()
   QVERIFY( !scope.removeVariable( "missing" ) );
   QVERIFY( scope.removeVariable( "toremove" ) );
   QVERIFY( !scope.hasVariable( "toremove" ) );
+
+  // checks for variables visibility updates
+  QCOMPARE( scope.hiddenVariables().length(), 0 );
+
+  scope.addHiddenVariable( QStringLiteral( "visibilitytest" ) );
+  QCOMPARE( scope.hiddenVariables().length(), 1 );
+  QCOMPARE( scope.hiddenVariables().at( 0 ), QStringLiteral( "visibilitytest" ) );
+
+  scope.removeHiddenVariable( QStringLiteral( "visibilitytest" ) );
+  QCOMPARE( scope.hiddenVariables().length(), 0 );
+
+  QStringList hiddenVariables;
+  hiddenVariables << QStringLiteral( "visibilitytest1" );
+  hiddenVariables << QStringLiteral( "visibilitytest2" );
+  hiddenVariables << QStringLiteral( "visibilitytest3" );
+
+  scope.setHiddenVariables( hiddenVariables );
+
+  QCOMPARE( scope.hiddenVariables().length(), 3 );
+
 }
 
 void TestQgsExpressionContext::contextScopeCopy()


### PR DESCRIPTION
Follow up changes from https://github.com/qgis/QGIS/pull/49869

Adds functions inside the QgsExpressionContextScope that handles showing and hiding of the expression variables.
This provides a robust way for handling expression variables visibility.