### PR TITLE
[3D] qgs3dmapcanvaswidget: Update state of the correct button on change

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -436,7 +436,7 @@ void Qgs3DMapCanvasWidget::configure()
 
   connect( w, &Qgs3DMapConfigWidget::isValidChanged, this, [ = ]( bool valid )
   {
-    buttons->button( QDialogButtonBox::Ok )->setEnabled( valid );
+    buttons->button( QDialogButtonBox::Apply )->setEnabled( valid );
   } );
 
   QVBoxLayout *layout = new QVBoxLayout( dlg );


### PR DESCRIPTION
This is fix for a regression introduced by commit
9e0074c5b4fea78bab72469f35a672045acf9423.

With the configuration window being non modal, the `OK` and `Cancel`
buttons were removed to keep only the `Apply` button. However, the
state of the removed `Ok` button was still updated on every change,
hence creating a crash.

This issue is fixed by changing the state of the `Apply` button
instead.

cc @nyalldawson 