### PR TITLE
fix normals in border of no data values

### DIFF
--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -659,6 +659,11 @@ QVector<QVector3D> QgsMeshLayerUtils::calculateNormals( const QgsTriangularMesh 
       const int index1( face.at( ( i + 1 ) % 3 ) );
       const int index2( face.at( ( i + 2 ) % 3 ) );
 
+      if ( std::isnan( verticalMagnitude[index] ) ||
+           std::isnan( verticalMagnitude[index1] ) ||
+           std::isnan( verticalMagnitude[index2] ) )
+        continue;
+
       const QgsMeshVertex &vert( triangularMesh.vertices().at( index ) );
       const QgsMeshVertex &otherVert1( triangularMesh.vertices().at( index1 ) );
       const QgsMeshVertex &otherVert2( triangularMesh.vertices().at( index2 ) );


### PR DESCRIPTION
For mesh in 3D, if the dataset on which is based the vertical position has some no data values (NaN), the faces next this values are rendered black due to the normals caclulation that takes account of this no data value (when smooth triangle is activated).

This PR fixes this issue by ignoring no data values.

**Before**
![image](https://user-images.githubusercontent.com/7416892/187679205-2216875c-982e-4a0d-a206-8ce4eea6e67f.png)

**After**
![image](https://user-images.githubusercontent.com/7416892/187679317-959b61f5-cc55-49a7-92e5-4f3aee69d3be.png)

