### PR TITLE
fix build

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -317,6 +317,7 @@ Constructor for QgsSymbolLegendNode.
 :param item: the legend symbol item
 :param parent: attach a parent QObject to the legend node.
 %End
+    ~QgsSymbolLegendNode();
 
     virtual Qt::ItemFlags flags() const;
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -324,6 +324,8 @@ QgsSymbolLegendNode::QgsSymbolLegendNode( QgsLayerTreeLayer *nodeLayer, const Qg
   }
 }
 
+QgsSymbolLegendNode::~QgsSymbolLegendNode() = default;
+
 Qt::ItemFlags QgsSymbolLegendNode::flags() const
 {
   if ( mItem.isCheckable() )

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -371,6 +371,7 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
      * \param parent attach a parent QObject to the legend node.
      */
     QgsSymbolLegendNode( QgsLayerTreeLayer *nodeLayer, const QgsLegendSymbolItem &item, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    ~QgsSymbolLegendNode();
 
     Qt::ItemFlags flags() const override;
     QVariant data( int role ) const override;


### PR DESCRIPTION
Without this PR, unable to build with msvc.
Indeed, the unique_ptr of `QgsSymbol `(line 525 in header file) with a forward declaration of `QgsSymbol ` needs the owner's destructor to be in the cpp file.