### PR TITLE
[qml] Add QgsProject's Q_PROPERTY for distanceUnits and areaUnits

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1858,6 +1858,24 @@ Emitted whenever the project's selection color has been changed.
 .. versionadded:: 3.10
 %End
 
+    void distanceUnitsChanged();
+%Docstring
+Emitted whenever the project's default distance units has been changed.
+
+.. seealso:: :py:func:`setDistanceUnits`
+
+.. versionadded:: 3.28
+%End
+
+    void areaUnitsChanged();
+%Docstring
+Emitted whenever the project's default area units has been changed.
+
+.. seealso:: :py:func:`setAreaUnits`
+
+.. versionadded:: 3.28
+%End
+
 
     void layersWillBeRemoved( const QStringList &layerIds );
 %Docstring

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3385,7 +3385,12 @@ QgsUnitTypes::DistanceUnit QgsProject::distanceUnits() const
 
 void QgsProject::setDistanceUnits( QgsUnitTypes::DistanceUnit unit )
 {
+  if ( distanceUnits() == unit )
+    return;
+
   writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), QgsUnitTypes::encodeUnit( unit ) );
+
+  emit distanceUnitsChanged();
 }
 
 QgsUnitTypes::AreaUnit QgsProject::areaUnits() const
@@ -3402,7 +3407,12 @@ QgsUnitTypes::AreaUnit QgsProject::areaUnits() const
 
 void QgsProject::setAreaUnits( QgsUnitTypes::AreaUnit unit )
 {
+  if ( areaUnits() == unit )
+    return;
+
   writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), QgsUnitTypes::encodeUnit( unit ) );
+
+  emit areaUnitsChanged();
 }
 
 QString QgsProject::homePath() const

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -118,6 +118,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged )
     Q_PROPERTY( QColor selectionColor READ selectionColor WRITE setSelectionColor NOTIFY selectionColorChanged )
     Q_PROPERTY( bool topologicalEditing READ topologicalEditing WRITE setTopologicalEditing NOTIFY topologicalEditingChanged )
+    Q_PROPERTY( QgsUnitTypes::DistanceUnit distanceUnits READ distanceUnits WRITE setDistanceUnits NOTIFY distanceUnitsChanged )
+    Q_PROPERTY( QgsUnitTypes::AreaUnit distanceUnits READ areaUnits WRITE setAreaUnits NOTIFY areaUnitsChanged )
 
   public:
 
@@ -1850,6 +1852,22 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \since QGIS 3.10
      */
     void selectionColorChanged();
+
+    /**
+     * Emitted whenever the project's default distance units has been changed.
+
+     * \see setDistanceUnits()
+     * \since QGIS 3.28
+     */
+    void distanceUnitsChanged();
+
+    /**
+     * Emitted whenever the project's default area units has been changed.
+
+     * \see setAreaUnits()
+     * \since QGIS 3.28
+     */
+    void areaUnitsChanged();
 
     //
     // signals from QgsMapLayerRegistry


### PR DESCRIPTION
## Description

The PR adds two new Q_PROPERTY for distance and area units settings. Needed in QField to insure measuring tool matches a project's given settings there (https://github.com/opengisch/QField/pull/3276). 

