### PR TITLE
[feature] Add project's default coordinate display type settings (Map Units, Geographic, and Custom CRS Units)

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1917,8 +1917,9 @@ Qgis.RelationshipCardinality.__doc__ = 'Relationship cardinality.\n\n.. versiona
 # --
 Qgis.RelationshipCardinality.baseClass = Qgis
 # monkey patching scoped based enum
-Qgis.CoordinateDisplayType.Geographic.__doc__ = "Geographic"
-Qgis.CoordinateDisplayType.MapUnits.__doc__ = "Map units"
-Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. versionadded:: 3.28\n\n' + '* ``Geographic``: ' + Qgis.CoordinateDisplayType.Geographic.__doc__ + '\n' + '* ``MapUnits``: ' + Qgis.CoordinateDisplayType.MapUnits.__doc__
+Qgis.CoordinateDisplayType.MapCrs.__doc__ = "Map CRS"
+Qgis.CoordinateDisplayType.MapGeographic.__doc__ = "Map Geographic CRS equivalent (stays unchanged if the map CRS is geographic)"
+Qgis.CoordinateDisplayType.CustomCrs.__doc__ = "Custom CRS"
+Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. versionadded:: 3.28\n\n' + '* ``MapCrs``: ' + Qgis.CoordinateDisplayType.MapCrs.__doc__ + '\n' + '* ``MapGeographic``: ' + Qgis.CoordinateDisplayType.MapGeographic.__doc__ + '\n' + '* ``CustomCrs``: ' + Qgis.CoordinateDisplayType.CustomCrs.__doc__
 # --
 Qgis.CoordinateDisplayType.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1916,3 +1916,9 @@ Qgis.RelationshipCardinality.ManyToMany.__doc__ = "Many to many relationship"
 Qgis.RelationshipCardinality.__doc__ = 'Relationship cardinality.\n\n.. versionadded:: 3.28\n\n' + '* ``OneToOne``: ' + Qgis.RelationshipCardinality.OneToOne.__doc__ + '\n' + '* ``OneToMany``: ' + Qgis.RelationshipCardinality.OneToMany.__doc__ + '\n' + '* ``ManyToOne``: ' + Qgis.RelationshipCardinality.ManyToOne.__doc__ + '\n' + '* ``ManyToMany``: ' + Qgis.RelationshipCardinality.ManyToMany.__doc__
 # --
 Qgis.RelationshipCardinality.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.CoordinateDisplayType.Geographic.__doc__ = "Geographic"
+Qgis.CoordinateDisplayType.MapUnits.__doc__ = "Map units"
+Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. versionadded:: 3.28\n\n' + '* ``Geographic``: ' + Qgis.CoordinateDisplayType.Geographic.__doc__ + '\n' + '* ``MapUnits``: ' + Qgis.CoordinateDisplayType.MapUnits.__doc__
+# --
+Qgis.CoordinateDisplayType.baseClass = Qgis

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1761,6 +1761,23 @@ Emitted when the project ``ellipsoid`` is changed.
 .. versionadded:: 3.0
 %End
 
+    void distanceUnitsChanged();
+%Docstring
+Emitted when the default distance units changes.
+
+.. seealso:: :py:func:`setDistanceUnits`
+
+.. versionadded:: 3.28
+%End
+
+    void areaUnitsChanged();
+%Docstring
+Emitted when the default area units changes.
+
+.. seealso:: :py:func:`setAreaUnits`
+
+.. versionadded:: 3.28
+%End
 
     void transformContextChanged();
 %Docstring

--- a/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
@@ -96,6 +96,10 @@ Sets the default coordinate ``type`` for the project.
 .. versionadded:: 3.28
 %End
 
+    QgsCoordinateReferenceSystem coordinateCustomCrs() const;
+
+    void setCoordinateCustomCrs( const QgsCoordinateReferenceSystem &crs );
+
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Reads the settings's state from a DOM element.
@@ -140,6 +144,8 @@ Emitted when the default coordinate format changes.
 
 .. versionadded:: 3.28
 %End
+
+    void coordinateCustomCrsChanged();
 
 };
 

--- a/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsProjectDisplaySettings : QObject
 {
 %Docstring(signature="appended")
@@ -21,6 +22,7 @@ values such as map coordinates and bearings.
 #include "qgsprojectdisplaysettings.h"
 %End
   public:
+
 
     QgsProjectDisplaySettings( QObject *parent = 0 );
 %Docstring
@@ -76,6 +78,24 @@ Returns the project's geographic coordinate format, which controls how geographi
 .. seealso:: :py:func:`geographicCoordinateFormatChanged`
 %End
 
+    Qgis::CoordinateDisplayType coordinateType() const;
+%Docstring
+Returns default coordinate type for the project.
+
+.. seealso:: :py:func:`setCoordinateType`
+
+.. versionadded:: 3.28
+%End
+
+    void setCoordinateType( Qgis::CoordinateDisplayType type );
+%Docstring
+Sets the default coordinate ``type`` for the project.
+
+.. seealso:: :py:func:`coordinateType`
+
+.. versionadded:: 3.28
+%End
+
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Reads the settings's state from a DOM element.
@@ -108,6 +128,17 @@ Emitted when the geographic coordinate format changes.
 .. seealso:: :py:func:`setGeographicCoordinateFormat`
 
 .. seealso:: :py:func:`geographicCoordinateFormat`
+%End
+
+    void coordinateTypeChanged();
+%Docstring
+Emitted when the default coordinate format changes.
+
+.. seealso:: :py:func:`setCoordinateType`
+
+.. seealso:: :py:func:`coordinateType`
+
+.. versionadded:: 3.28
 %End
 
 };

--- a/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
@@ -114,6 +114,19 @@ Sets the coordinate custom CRS used when the project coordinate type is set to Q
 .. versionadded:: 3.28
 %End
 
+    QgsCoordinateReferenceSystem coordinateCrs() const;
+%Docstring
+Returns the coordinate display CRS used derived from the coordinate type.
+
+.. seealso:: :py:func:`coordinateType`
+
+.. note::
+
+   if not parented to a project object, an invalid CRS will be returned.
+
+.. versionadded:: 3.28
+%End
+
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Reads the settings's state from a DOM element.
@@ -166,6 +179,17 @@ Emitted when the coordinate custom CRS changes.
 .. seealso:: :py:func:`setCoordinateCustomCrs`
 
 .. seealso:: :py:func:`coordinateCustomCrs`
+
+.. versionadded:: 3.28
+%End
+
+    void coordinateCrsChanged();
+%Docstring
+Emitted when the coordinate CRS changes.
+
+.. seealso:: :py:func:`coordinateCrs`
+
+.. seealso:: :py:func:`coordinateType`
 
 .. versionadded:: 3.28
 %End

--- a/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectdisplaysettings.sip.in
@@ -97,8 +97,22 @@ Sets the default coordinate ``type`` for the project.
 %End
 
     QgsCoordinateReferenceSystem coordinateCustomCrs() const;
+%Docstring
+Returns the coordinate custom CRS used when the project coordinate type is set to Qgis.CoordinateDisplayType.CustomCrs.
+
+.. seealso:: :py:func:`setCoordinateCustomCrs`
+
+.. versionadded:: 3.28
+%End
 
     void setCoordinateCustomCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the coordinate custom CRS used when the project coordinate type is set to Qgis.CoordinateDisplayType.CustomCrs.
+
+.. seealso:: :py:func:`setCoordinateCustomCrs`
+
+.. versionadded:: 3.28
+%End
 
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
@@ -146,6 +160,15 @@ Emitted when the default coordinate format changes.
 %End
 
     void coordinateCustomCrsChanged();
+%Docstring
+Emitted when the coordinate custom CRS changes.
+
+.. seealso:: :py:func:`setCoordinateCustomCrs`
+
+.. seealso:: :py:func:`coordinateCustomCrs`
+
+.. versionadded:: 3.28
+%End
 
 };
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1238,6 +1238,12 @@ The development version
       ManyToMany,
     };
 
+    enum class CoordinateDisplayType
+    {
+      Geographic,
+      MapUnits,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1240,8 +1240,9 @@ The development version
 
     enum class CoordinateDisplayType
     {
-      Geographic,
-      MapUnits,
+      MapCrs,
+      MapGeographic,
+      CustomCrs,
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -260,6 +260,9 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     static const char *GEO_NONE_DESC;
 
     void updateGuiForMapUnits();
+    void updateGuiForCoordinateType();
+    void updateGuiForCoordinateCrs();
+
     void addStyleDatabasePrivate( bool createNew );
 
     void showHelp();

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -206,13 +206,6 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
       */
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
-    //! Formats for displaying coordinates
-    enum CoordinateFormat
-    {
-      Geographic, //!< Geographic
-      MapUnits, //!< Show coordinates in map units
-    };
-
     QgsRelationManagerDialog *mRelationManagerDlg = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -60,7 +60,6 @@
 #include "qgsstyleentityvisitor.h"
 #include "qgsprojectviewsettings.h"
 #include "qgsprojectstylesettings.h"
-#include "qgsprojectdisplaysettings.h"
 #include "qgsprojecttimesettings.h"
 #include "qgsvectortilelayer.h"
 #include "qgsruntimeprofiler.h"
@@ -957,6 +956,14 @@ void QgsProject::clear()
   context.readSettings();
   setTransformContext( context );
 
+  //fallback to QGIS default measurement unit
+  bool ok = false;
+  const QgsUnitTypes::DistanceUnit distanceUnit = QgsUnitTypes::decodeDistanceUnit( mSettings.value( QStringLiteral( "/qgis/measure/displayunits" ) ).toString(), &ok );
+  setDistanceUnits( ok ? distanceUnit : QgsUnitTypes::DistanceMeters );
+  ok = false;
+  const QgsUnitTypes::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( mSettings.value( QStringLiteral( "/qgis/measure/areaunits" ) ).toString(), &ok );
+  setAreaUnits( ok ? areaUnits : QgsUnitTypes::AreaSquareMeters );
+
   mEmbeddedLayers.clear();
   mRelationManager->clear();
   mAnnotationManager->clear();
@@ -998,10 +1005,6 @@ void QgsProject::clear()
 
   const bool defaultRelativePaths = mSettings.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true ).toBool();
   setFilePathStorage( defaultRelativePaths ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute );
-
-  //copy default units to project
-  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), mSettings.value( QStringLiteral( "/qgis/measure/displayunits" ) ).toString() );
-  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), mSettings.value( QStringLiteral( "/qgis/measure/areaunits" ) ).toString() );
 
   int red = mSettings.value( QStringLiteral( "qgis/default_canvas_color_red" ), 255 ).toInt();
   int green = mSettings.value( QStringLiteral( "qgis/default_canvas_color_green" ), 255 ).toInt();
@@ -1645,6 +1648,15 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
                                readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), 255 ),
                                readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), 255 ) );
   setSelectionColor( selectionColor );
+
+
+  const QString distanceUnitString = readEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), QString() );
+  if ( !distanceUnitString.isEmpty() )
+    setDistanceUnits( QgsUnitTypes::decodeDistanceUnit( distanceUnitString ) );
+
+  const QString areaUnitString = readEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), QString() );
+  if ( !areaUnitString.isEmpty() )
+    setAreaUnits( QgsUnitTypes::decodeAreaUnit( areaUnitString ) );
 
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
@@ -2724,6 +2736,9 @@ bool QgsProject::writeProjectFile( const QString &filename )
   writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), mSelectionColor.blue() );
   writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), mSelectionColor.alpha() );
 
+  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), QgsUnitTypes::encodeUnit( mDistanceUnits ) );
+  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), QgsUnitTypes::encodeUnit( mAreaUnits ) );
+
   // now add the optional extra properties
 #if 0
   dump_( mProperties );
@@ -3371,38 +3386,24 @@ bool QgsProject::topologicalEditing() const
   return readNumEntry( QStringLiteral( "Digitizing" ), QStringLiteral( "/TopologicalEditing" ), 0 );
 }
 
-QgsUnitTypes::DistanceUnit QgsProject::distanceUnits() const
-{
-  const QString distanceUnitString = readEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), QString() );
-  if ( !distanceUnitString.isEmpty() )
-    return QgsUnitTypes::decodeDistanceUnit( distanceUnitString );
-
-  //fallback to QGIS default measurement unit
-  bool ok = false;
-  const QgsUnitTypes::DistanceUnit type = QgsUnitTypes::decodeDistanceUnit( mSettings.value( QStringLiteral( "/qgis/measure/displayunits" ) ).toString(), &ok );
-  return ok ? type : QgsUnitTypes::DistanceMeters;
-}
-
 void QgsProject::setDistanceUnits( QgsUnitTypes::DistanceUnit unit )
 {
-  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), QgsUnitTypes::encodeUnit( unit ) );
-}
+  if ( mDistanceUnits == unit )
+    return;
 
-QgsUnitTypes::AreaUnit QgsProject::areaUnits() const
-{
-  const QString areaUnitString = readEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), QString() );
-  if ( !areaUnitString.isEmpty() )
-    return QgsUnitTypes::decodeAreaUnit( areaUnitString );
+  mDistanceUnits = unit;
 
-  //fallback to QGIS default area unit
-  bool ok = false;
-  const QgsUnitTypes::AreaUnit type = QgsUnitTypes::decodeAreaUnit( mSettings.value( QStringLiteral( "/qgis/measure/areaunits" ) ).toString(), &ok );
-  return ok ? type : QgsUnitTypes::AreaSquareMeters;
+  emit distanceUnitsChanged();
 }
 
 void QgsProject::setAreaUnits( QgsUnitTypes::AreaUnit unit )
 {
-  writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/AreaUnits" ), QgsUnitTypes::encodeUnit( unit ) );
+  if ( mAreaUnits == unit )
+    return;
+
+  mAreaUnits = unit;
+
+  emit areaUnitsChanged();
 }
 
 QString QgsProject::homePath() const

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -47,6 +47,7 @@
 #include "qgsreadwritecontext.h"
 #include "qgsprojectmetadata.h"
 #include "qgstranslationcontext.h"
+#include "qgsprojectdisplaysettings.h"
 #include "qgsprojecttranslator.h"
 #include "qgscolorscheme.h"
 #include "qgssettings.h"
@@ -79,7 +80,6 @@ class QgsMapLayer;
 class QgsBookmarkManager;
 class QgsProjectViewSettings;
 class QgsProjectStyleSettings;
-class QgsProjectDisplaySettings;
 class QgsProjectTimeSettings;
 class QgsAnnotationLayer;
 class QgsAttributeEditorContainer;
@@ -118,6 +118,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged )
     Q_PROPERTY( QColor selectionColor READ selectionColor WRITE setSelectionColor NOTIFY selectionColorChanged )
     Q_PROPERTY( bool topologicalEditing READ topologicalEditing WRITE setTopologicalEditing NOTIFY topologicalEditingChanged )
+    Q_PROPERTY( QgsUnitTypes::DistanceUnit distanceUnits READ distanceUnits WRITE setDistanceUnits NOTIFY distanceUnitsChanged )
+    Q_PROPERTY( QgsUnitTypes::AreaUnit areaUnits READ areaUnits WRITE setAreaUnits NOTIFY areaUnitsChanged )
+    Q_PROPERTY( QgsProjectDisplaySettings *displaySettings READ displaySettings CONSTANT )
 
   public:
 
@@ -692,7 +695,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \see areaUnits()
      * \since QGIS 2.14
      */
-    QgsUnitTypes::DistanceUnit distanceUnits() const;
+    QgsUnitTypes::DistanceUnit distanceUnits() const { return mDistanceUnits; }
 
     /**
      * Sets the default distance measurement units for the project.
@@ -707,7 +710,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \see distanceUnits()
      * \since QGIS 2.14
      */
-    QgsUnitTypes::AreaUnit areaUnits() const;
+    QgsUnitTypes::AreaUnit areaUnits() const { return mAreaUnits; }
 
     /**
      * Sets the default area measurement units for the project.
@@ -1763,6 +1766,21 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void ellipsoidChanged( const QString &ellipsoid );
 
+    /**
+     * Emitted when the default distance units changes.
+     *
+     * \see setDistanceUnits()
+     * \since QGIS 3.28
+     */
+    void distanceUnitsChanged();
+
+    /**
+     * Emitted when the default area units changes.
+     *
+     * \see setAreaUnits()
+     * \since QGIS 3.28
+     */
+    void areaUnitsChanged();
 
     /**
      * Emitted when the project transformContext() is changed.
@@ -2261,6 +2279,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     QColor mBackgroundColor;
     QColor mSelectionColor;
+
+    QgsUnitTypes::DistanceUnit mDistanceUnits = QgsUnitTypes::DistanceMeters;
+    QgsUnitTypes::AreaUnit mAreaUnits = QgsUnitTypes::AreaSquareMeters;
 
     mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     Qgis::TransactionMode mTransactionMode = Qgis::TransactionMode::Disabled; // transaction grouped editing

--- a/src/core/project/qgsprojectdisplaysettings.h
+++ b/src/core/project/qgsprojectdisplaysettings.h
@@ -110,8 +110,18 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void setCoordinateType( Qgis::CoordinateDisplayType type );
 
+    /**
+     * Returns the coordinate custom CRS used when the project coordinate type is set to Qgis.CoordinateDisplayType.CustomCrs.
+     * \see setCoordinateCustomCrs()
+     * \since QGIS 3.28
+     */
     QgsCoordinateReferenceSystem coordinateCustomCrs() const { return mCoordinateCustomCrs; }
 
+    /**
+     * Sets the coordinate custom CRS used when the project coordinate type is set to Qgis.CoordinateDisplayType.CustomCrs.
+     * \see setCoordinateCustomCrs()
+     * \since QGIS 3.28
+     */
     void setCoordinateCustomCrs( const QgsCoordinateReferenceSystem &crs );
 
     /**
@@ -153,6 +163,13 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void coordinateTypeChanged();
 
+    /**
+     * Emitted when the coordinate custom CRS changes.
+     *
+     * \see setCoordinateCustomCrs()
+     * \see coordinateCustomCrs()
+     * \since QGIS 3.28
+     */
     void coordinateCustomCrsChanged();
 
   private:

--- a/src/core/project/qgsprojectdisplaysettings.h
+++ b/src/core/project/qgsprojectdisplaysettings.h
@@ -17,6 +17,9 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgis.h"
+#include "qgsunittypes.h"
+
 #include <QObject>
 #include <QVector>
 #include <memory>
@@ -39,6 +42,8 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
     Q_OBJECT
 
   public:
+
+    Q_PROPERTY( Qgis::CoordinateDisplayType coordinateType READ coordinateType WRITE setCoordinateType NOTIFY coordinateTypeChanged )
 
     /**
      * Constructor for QgsProjectDisplaySettings with the specified \a parent object.
@@ -91,6 +96,20 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
     const QgsGeographicCoordinateNumericFormat *geographicCoordinateFormat() const;
 
     /**
+     * Returns default coordinate type for the project.
+     * \see setCoordinateType()
+     * \since QGIS 3.28
+     */
+    Qgis::CoordinateDisplayType coordinateType() const { return mCoordinateType; }
+
+    /**
+     * Sets the default coordinate \a type for the project.
+     * \see coordinateType()
+     * \since QGIS 3.28
+     */
+    void setCoordinateType( Qgis::CoordinateDisplayType type );
+
+    /**
      * Reads the settings's state from a DOM element.
      * \see writeXml()
      */
@@ -120,9 +139,20 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void geographicCoordinateFormatChanged();
 
+    /**
+     * Emitted when the default coordinate format changes.
+     *
+     * \see setCoordinateType()
+     * \see coordinateType()
+     * \since QGIS 3.28
+     */
+    void coordinateTypeChanged();
+
   private:
     std::unique_ptr< QgsBearingNumericFormat > mBearingFormat;
     std::unique_ptr< QgsGeographicCoordinateNumericFormat > mGeographicCoordinateFormat;
+
+    Qgis::CoordinateDisplayType mCoordinateType = Qgis::CoordinateDisplayType::MapUnits;
 
 };
 

--- a/src/core/project/qgsprojectdisplaysettings.h
+++ b/src/core/project/qgsprojectdisplaysettings.h
@@ -19,6 +19,7 @@
 #include "qgis_sip.h"
 #include "qgis.h"
 #include "qgsunittypes.h"
+#include "qgscoordinatereferencesystem.h"
 
 #include <QObject>
 #include <QVector>
@@ -109,6 +110,10 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void setCoordinateType( Qgis::CoordinateDisplayType type );
 
+    QgsCoordinateReferenceSystem coordinateCustomCrs() const { return mCoordinateCustomCrs; }
+
+    void setCoordinateCustomCrs( const QgsCoordinateReferenceSystem &crs );
+
     /**
      * Reads the settings's state from a DOM element.
      * \see writeXml()
@@ -148,11 +153,14 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void coordinateTypeChanged();
 
+    void coordinateCustomCrsChanged();
+
   private:
     std::unique_ptr< QgsBearingNumericFormat > mBearingFormat;
     std::unique_ptr< QgsGeographicCoordinateNumericFormat > mGeographicCoordinateFormat;
 
-    Qgis::CoordinateDisplayType mCoordinateType = Qgis::CoordinateDisplayType::MapUnits;
+    Qgis::CoordinateDisplayType mCoordinateType = Qgis::CoordinateDisplayType::MapCrs;
+    QgsCoordinateReferenceSystem mCoordinateCustomCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
 
 };
 

--- a/src/core/project/qgsprojectdisplaysettings.h
+++ b/src/core/project/qgsprojectdisplaysettings.h
@@ -45,6 +45,8 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
   public:
 
     Q_PROPERTY( Qgis::CoordinateDisplayType coordinateType READ coordinateType WRITE setCoordinateType NOTIFY coordinateTypeChanged )
+    Q_PROPERTY( QgsCoordinateReferenceSystem coordinateCustomCrs READ coordinateCustomCrs WRITE setCoordinateCustomCrs NOTIFY coordinateCustomCrsChanged )
+    Q_PROPERTY( QgsCoordinateReferenceSystem coordinateCrs READ coordinateCrs NOTIFY coordinateCrsChanged )
 
     /**
      * Constructor for QgsProjectDisplaySettings with the specified \a parent object.
@@ -125,6 +127,14 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
     void setCoordinateCustomCrs( const QgsCoordinateReferenceSystem &crs );
 
     /**
+     * Returns the coordinate display CRS used derived from the coordinate type.
+     * \see coordinateType()
+     * \note if not parented to a project object, an invalid CRS will be returned.
+     * \since QGIS 3.28
+     */
+    QgsCoordinateReferenceSystem coordinateCrs() const { return mCoordinateCrs; }
+
+    /**
      * Reads the settings's state from a DOM element.
      * \see writeXml()
      */
@@ -172,12 +182,24 @@ class CORE_EXPORT QgsProjectDisplaySettings : public QObject
      */
     void coordinateCustomCrsChanged();
 
+    /**
+     * Emitted when the coordinate CRS changes.
+     *
+     * \see coordinateCrs()
+     * \see coordinateType()
+     * \since QGIS 3.28
+     */
+    void coordinateCrsChanged();
+
   private:
+    void updateCoordinateCrs();
+
     std::unique_ptr< QgsBearingNumericFormat > mBearingFormat;
     std::unique_ptr< QgsGeographicCoordinateNumericFormat > mGeographicCoordinateFormat;
 
     Qgis::CoordinateDisplayType mCoordinateType = Qgis::CoordinateDisplayType::MapCrs;
     QgsCoordinateReferenceSystem mCoordinateCustomCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+    QgsCoordinateReferenceSystem mCoordinateCrs;
 
 };
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2129,8 +2129,9 @@ class CORE_EXPORT Qgis
      */
     enum class CoordinateDisplayType : int
     {
-      Geographic, //!< Geographic
-      MapUnits, //!< Map units
+      MapCrs, //!< Map CRS
+      MapGeographic, //!< Map Geographic CRS equivalent (stays unchanged if the map CRS is geographic)
+      CustomCrs, //!< Custom CRS
     };
     Q_ENUM( CoordinateDisplayType )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2123,6 +2123,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( RelationshipCardinality )
 
     /**
+     * Formats for displaying coordinates
+     *
+     * \since QGIS 3.28
+     */
+    enum class CoordinateDisplayType : int
+    {
+      Geographic, //!< Geographic
+      MapUnits, //!< Map units
+    };
+    Q_ENUM( CoordinateDisplayType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -42,9 +42,7 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
 
   if ( automatic )
   {
-    const QString format = project->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
-    // only MU or D is used now, but older projects may have DM/DMS
-    const bool formatGeographic = format == QLatin1String( "D" ) || format == QLatin1String( "DM" ) || format == QLatin1String( "DMS" );
+    const bool formatGeographic = project->displaySettings()->coordinateType() == Qgis::CoordinateDisplayType::Geographic;
 
     // we can only calculate an automatic precision if one of these is true:
     // - both map CRS and format are geographic
@@ -112,11 +110,8 @@ QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, con
   if ( !project )
     return QString();
 
-  const QString format = project->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
   const Qgis::CoordinateOrder axisOrder = qgsEnumKeyToValue( project->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/CoordinateOrder" ) ), Qgis::CoordinateOrder::Default );
-
-  // only MU or D is used now, but older projects may have DM/DMS
-  const bool formatGeographic = format == QLatin1String( "D" ) || format == QLatin1String( "DM" ) || format == QLatin1String( "DMS" );
+  const bool formatGeographic = project->displaySettings()->coordinateType() == Qgis::CoordinateDisplayType::Geographic;
 
   QgsPointXY geo = point;
   if ( formatGeographic )

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -651,21 +651,24 @@
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_18">
-                  <item row="4" column="0">
+                   
+                   
+                   
+                  <item row="5" column="0">
                    <widget class="QLabel" name="label_34">
                     <property name="text">
                      <string>Bearing format</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
+                  <item row="3" column="0">
                    <widget class="QLabel" name="label_26">
                     <property name="text">
                      <string>Coordinate precision</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="1">
+                  <item row="5" column="1">
                    <layout class="QHBoxLayout" name="horizontalLayout_19" stretch="3,6">
                     <item>
                      <widget class="QPushButton" name="mCustomizeBearingFormatButton">
@@ -696,7 +699,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
+                  <item row="3" column="1">
                    <widget class="QFrame" name="mFramePrecision">
                     <layout class="QHBoxLayout" name="horizontalLayout_12">
                      <item>
@@ -745,27 +748,27 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="3" column="0">
+                  <item row="4" column="0">
                    <widget class="QLabel" name="label_31">
                     <property name="text">
                      <string>Coordinate order</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="1">
+                  <item row="4" column="1">
                    <widget class="QComboBox" name="mCoordinateOrderComboBox"/>
                   </item>
                   <item row="0" column="1">
                    <widget class="QComboBox" name="mCoordinateDisplayComboBox"/>
                   </item>
-                  <item row="1" column="0">
+                  <item row="2" column="0">
                    <widget class="QLabel" name="label_38">
                     <property name="text">
                      <string>Coordinate format</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1">
+                  <item row="2" column="1">
                    <layout class="QHBoxLayout" name="horizontalLayout_20" stretch="3,6">
                     <item>
                      <widget class="QPushButton" name="mCustomizeCoordinateFormatButton">
@@ -788,6 +791,23 @@
                      </spacer>
                     </item>
                    </layout>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_43">
+                    <property name="text">
+                     <string>Coordinate CRS</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QgsProjectionSelectionWidget" name="mCoordinateCrs" native="true">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -3566,6 +3586,12 @@
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/python/test_qgsprojectdisplaysettings.py
+++ b/tests/src/python/test_qgsprojectdisplaysettings.py
@@ -19,6 +19,7 @@ from qgis.core import (QgsProjectDisplaySettings,
                        QgsSettings,
                        QgsLocalDefaultSettings,
                        QgsUnitTypes,
+                       QgsCoordinateReferenceSystem,
                        Qgis)
 
 from qgis.PyQt.QtCore import QCoreApplication
@@ -86,13 +87,25 @@ class TestQgsProjectDisplaySettings(unittest.TestCase):
         self.assertEqual(p.geographicCoordinateFormat().numberDecimalPlaces(), 3)
         self.assertEqual(p.geographicCoordinateFormat().angleFormat(), QgsGeographicCoordinateNumericFormat.AngleFormat.DegreesMinutes)
 
-    def testCoordinateType(self):
+    def testCoordinateTypeGeographic(self):
         p = QgsProjectDisplaySettings()
 
         spy = QSignalSpy(p.coordinateTypeChanged)
-        p.setCoordinateType(Qgis.CoordinateDisplayType.Geographic)
+        p.setCoordinateType(Qgis.CoordinateDisplayType.MapGeographic)
         self.assertEqual(len(spy), 1)
-        self.assertEqual(p.coordinateType(), Qgis.CoordinateDisplayType.Geographic)
+        self.assertEqual(p.coordinateType(), Qgis.CoordinateDisplayType.MapGeographic)
+
+    def testCoordinateTypeCustomCrs(self):
+        p = QgsProjectDisplaySettings()
+
+        spy = QSignalSpy(p.coordinateTypeChanged)
+        p.setCoordinateType(Qgis.CoordinateDisplayType.CustomCrs)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(p.coordinateType(), Qgis.CoordinateDisplayType.CustomCrs)
+        spy = QSignalSpy(p.coordinateCustomCrsChanged)
+        p.setCoordinateCustomCrs(QgsCoordinateReferenceSystem('EPSG:3148'))
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(p.coordinateCustomCrs().authid(), 'EPSG:3148')
 
     def testReset(self):
         """
@@ -125,19 +138,27 @@ class TestQgsProjectDisplaySettings(unittest.TestCase):
         format.setAngleFormat(QgsGeographicCoordinateNumericFormat.AngleFormat.DegreesMinutes)
         s.setGeographicCoordinateFormat(format)
 
+        p.setCoordinateType(Qgis.CoordinateDisplayType.MapGeographic)
+        p.setCoordinateCustomCrs(QgsCoordinateReferenceSystem('EPSG:3148'))
+
         spy = QSignalSpy(p.bearingFormatChanged)
         spy2 = QSignalSpy(p.geographicCoordinateFormatChanged)
         spy3 = QSignalSpy(p.coordinateTypeChanged)
+        spy4 = QSignalSpy(p.coordinateCustomCrsChanged)
         p.reset()
         self.assertEqual(len(spy), 1)
         self.assertEqual(len(spy2), 1)
         self.assertEqual(len(spy3), 1)
+        self.assertEqual(len(spy4), 1)
         # project should default to local default format
         self.assertEqual(p.bearingFormat().numberDecimalPlaces(), 9)
         self.assertEqual(p.bearingFormat().directionFormat(), QgsBearingNumericFormat.UseRange0To360)
 
         self.assertEqual(p.geographicCoordinateFormat().numberDecimalPlaces(), 5)
         self.assertEqual(p.geographicCoordinateFormat().angleFormat(), QgsGeographicCoordinateNumericFormat.AngleFormat.DegreesMinutes)
+
+        self.assertEqual(p.coordinateType(), Qgis.CoordinateDisplayType.MapCrs)
+        self.assertEqual(p.coordinateCustomCrs().authid(), 'EPSG:4326')
 
     def testReadWrite(self):
         p = QgsProjectDisplaySettings()

--- a/tests/src/python/test_qgsprojectdisplaysettings.py
+++ b/tests/src/python/test_qgsprojectdisplaysettings.py
@@ -17,7 +17,9 @@ from qgis.core import (QgsProjectDisplaySettings,
                        QgsBearingNumericFormat,
                        QgsGeographicCoordinateNumericFormat,
                        QgsSettings,
-                       QgsLocalDefaultSettings)
+                       QgsLocalDefaultSettings,
+                       QgsUnitTypes,
+                       Qgis)
 
 from qgis.PyQt.QtCore import QCoreApplication
 
@@ -84,6 +86,14 @@ class TestQgsProjectDisplaySettings(unittest.TestCase):
         self.assertEqual(p.geographicCoordinateFormat().numberDecimalPlaces(), 3)
         self.assertEqual(p.geographicCoordinateFormat().angleFormat(), QgsGeographicCoordinateNumericFormat.AngleFormat.DegreesMinutes)
 
+    def testCoordinateType(self):
+        p = QgsProjectDisplaySettings()
+
+        spy = QSignalSpy(p.coordinateTypeChanged)
+        p.setCoordinateType(Qgis.CoordinateDisplayType.Geographic)
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(p.coordinateType(), Qgis.CoordinateDisplayType.Geographic)
+
     def testReset(self):
         """
         Test that resetting inherits local default settings
@@ -117,9 +127,11 @@ class TestQgsProjectDisplaySettings(unittest.TestCase):
 
         spy = QSignalSpy(p.bearingFormatChanged)
         spy2 = QSignalSpy(p.geographicCoordinateFormatChanged)
+        spy3 = QSignalSpy(p.coordinateTypeChanged)
         p.reset()
         self.assertEqual(len(spy), 1)
         self.assertEqual(len(spy2), 1)
+        self.assertEqual(len(spy3), 1)
         # project should default to local default format
         self.assertEqual(p.bearingFormat().numberDecimalPlaces(), 9)
         self.assertEqual(p.bearingFormat().directionFormat(), QgsBearingNumericFormat.UseRange0To360)


### PR DESCRIPTION
## Description

Alright, while this started merely as a need to add a few Q_PROPERTYs, it ended up being a full fledged feature :)

This PR formalizes projects' default coordinate display type by adding a proper API in the QgsProjectDisplaySettings class. There are now three display types:
- Map Units (behaves exactly the same as before)
- Map Geographic (behavior tweaked)
- Custom Projection Units (new type)

The geographic type has changed a bit. Before, its behavior was a bit opaque: the coordinates would be in map CRS is the CRS was geographic, otherwise it'd transform to a hard-coded WGS84 CRS. Now, the behavior is as follow: if the map CRS is geographic, we use that, however if the map CRS isn't, we use the QgsCoordinateReferenceSystem::toGeographicCrs() to transform the coordinates into the map CRS' associated geographic CRS. This is helpful for non-earth celestial bodies for e.g.

The custom projection units type is new, and defaults to WGS84. The nice thing about this mode though is that it allows users to set _any_ CRS he/she/they desire as display coordinates.

Screencast:

https://user-images.githubusercontent.com/1728657/188088185-55f6a026-e5bd-452b-a0db-dffbcdb7371d.mp4



@nyalldawson , as discussed and requested ;)