### PR TITLE
Added split/merge metadata support to QGIS split/merge tools.

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1743,7 +1743,31 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void deleteRing();
     //! deletes part of polygon
     void deletePart();
-    //! merges the selected features together
+    /**
+     * Merge selected features together
+     * 
+     * Meta-Information about the merge operation can be stored in the affected (existing and new) features.
+     * The following environmental variables must be set to enable the metadata storage:
+     * 
+     * To enable merge metadata for specific layers the following variable must be set with comma separated layer names:
+     * QGIS_SM_SAVE_INFO_LAYERS="layer_1,layer_2,layer_3"
+     * The name of the layers that should store the merge information must be in this list.
+     * 
+     * The name of the field that should store the feature ids of the predecessors must be set with:
+     * QGIS_SM_PREDECESSORS_FIELD="predecessors"
+     * The type of the field must be set to text, since the ids will be stored as comma seperated values in a single string.
+     * 
+     * The type of the field that stores the type of the opration (split==1 or merge==2) must be set with:
+     * QGIS_SM_OPERATION_TYPE_FIELD="sm_type"
+     * The type of this field must be set to integer.
+     * 
+     * To store the exact datetime of the operation, the name of this field must be set with:
+     * QGIS_SM_DATETIME_FIELD="sm_datetime"
+     * The type of this field must be datetime.
+     * 
+     * The fields will only be filled with data, if the individuell environmentl variables are set and the layer on which the merge operation is performed is
+     * in the list of QGIS_SM_SAVE_INFO_LAYERS.
+     */
     void mergeSelectedFeatures();
     //! merges the attributes of selected features
     void mergeAttributesOfSelectedFeatures();

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -165,6 +165,14 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           tr( "The geometry is invalid. Please repair before trying to split it." ),
           Qgis::MessageLevel::Warning );
         break;
+      case Qgis::GeometryOperationResult::UnableToStoreMetadataForSplitting:
+        // If split metadta should be stored in the layer, then all primary keys/feature ids must be
+        // generated beforehand, othrwise wrong feature ids will be stored as predecessor
+        QgisApp::instance()->messageBar()->pushMessage(
+          tr( "No feature split done" ),
+          tr( "The layer must be saved first to add split metadata to the resulting features." ),
+          Qgis::MessageLevel::Warning );
+        break;
       default:
         //several intersections but only one split (most likely line)
         QgisApp::instance()->messageBar()->pushMessage(

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -951,6 +951,7 @@ class CORE_EXPORT Qgis
       AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
       /* Split features */
       SplitCannotSplitPoint, //!< Cannot split points
+      UnableToStoreMetadataForSplitting, // !< Split-operation specific metadata cannot be stored in the features, for example the predecessor id is invalid (negative)
     };
     Q_ENUM( GeometryOperationResult )
 

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -195,6 +195,29 @@ class CORE_EXPORT QgsVectorLayerEditUtils
 
     /**
      * Splits features cut by the given line
+     * 
+     * Meta-Information about the split operation can be stored in the affected (existing and new) features.
+     * The following environmental variables must be set to enable the metadata storage:
+     * 
+     * To enable split metadata for specific layers the following variable must be set with comma separated layer names:
+     * QGIS_SM_SAVE_INFO_LAYERS="layer_1,layer_2,layer_3"
+     * The name of the layers that should store the split information must be in this list.
+     * 
+     * The name of the field that should store the feature ids of the predecessors must be set with:
+     * QGIS_SM_PREDECESSORS_FIELD="predecessors"
+     * The type of the field must be set to text, since the ids will be stored as comma seperated values in a single string
+     * 
+     * The type of the field that stored the type of the opration (split==1 or merge==2) must be set with:
+     * QGIS_SM_OPERATION_TYPE_FIELD="sm_type"
+     * The type of this field must be set to integer.
+     * 
+     * To store the exact datetime of the operation, the name of this field must be set with:
+     * QGIS_SM_DATETIME_FIELD="sm_datetime"
+     * The type of this field must be datetime.
+     * 
+     * The fields will only be filled with data, if the individuell environmentl variables are set and the layer on which the split operation is performed is
+     * in the list of QGIS_SM_SAVE_INFO_LAYERS.
+     * 
      * \param splitLine line that splits the layer features
      * \param topologicalEditing TRUE if topological editing is enabled
      * \returns QgsGeometry::OperationResult


### PR DESCRIPTION
We introduced split/merge metadata generation for features into the split/merge QGIS buildin tools.

## Description

If split/merge metadata was configured using environment variables: the predecessors of split and merge operations as well as the type of the operation and datetime are stored in the affected features in specific fields. This allows to identify split and merge operations and the predecessors of such operations from the features in a layer.

Meta-Information about the split and merge operation can be stored in the affected (existing and new) features in specific fields. The following environmental variables must be set to enable the metadata storage:

To enable split/merge metadata for specific layers the following variable must be set with comma separated layer names:
QGIS_SM_SAVE_INFO_LAYERS="layer_1,layer_2,layer_3"
The name of the layers that should store the merge information must be in this list.

The name of the field that should store the feature ids of the predecessors must be set with:
QGIS_SM_PREDECESSORS_FIELD="predecessors"
The type of the field must be set to text, since the ids will be stored a comma seperated values in a single string.

The type of the field that stores the type of the opration (split==1 or merge==2) must be set with:
QGIS_SM_OPERATION_TYPE_FIELD="sm_type"
The type of this field must be set to integer.

To store the exact datetime of the operation, the name of this field must be set with:
QGIS_SM_DATETIME_FIELD="sm_datetime"
The type of this field must be datetime.

The fields will only be filled with data, if the individual environmental variables are set and the layer on which the merge operation is performed is
in the list of QGIS_SM_SAVE_INFO_LAYERS.

Settings in QGIS:
![QGIS with enables split and merge metadata settings](https://user-images.githubusercontent.com/10548365/188199725-b0a8bd4f-55e2-4445-b275-15915873c6b5.PNG)

Creating a single polygon:
![01 QGIS with enables split and merge metadata new polygon](https://user-images.githubusercontent.com/10548365/188200696-46622593-32c2-43cc-882e-75fd2fefaf0f.PNG)

Splitting the polygon, showing the generated metadata, the predecessor is stored in the feature:
![02 QGIS with enables split and merge metadata splitted polygon](https://user-images.githubusercontent.com/10548365/188200797-86d9d5b2-294b-4d30-b63c-ed4075a993fd.PNG)

Selecting splitted polygons for merging:
![03 QGIS with enables split and merge metadata merge polygons](https://user-images.githubusercontent.com/10548365/188200923-7b8a331d-738e-48aa-9bbe-cd6c8ffcb96e.PNG)

After merging, all predecessors are stored in the feature:
![04 QGIS with enables split and merge metadata merged polygons](https://user-images.githubusercontent.com/10548365/188201057-e98618b7-885d-4697-b323-084021d421ab.PNG)


This implementation was initiated and financed by:

Landesforst Mecklenburg-Vorpommern
Betriebsteil Forstplanung / Versuchswesen / Informationssysteme
Zeppelinstraße 3
19061 Schwerin

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
