### PR TITLE
Python Console: Don't throw exception if compiled without 3D

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -40,13 +40,36 @@ from qgis.gui import QgsCodeEditor
 
 from .ui_console_history_dlg import Ui_HistoryDialogPythonConsole
 
-_init_commands = ["import sys", "import os", "from pathlib import Path", "import re", "import math", "from qgis.core import *",
-                  "from qgis.gui import *", "from qgis.analysis import *", "from qgis._3d import *",
-                  "import processing", "import qgis.utils",
-                  "from qgis.utils import iface", "from qgis.PyQt.QtCore import *", "from qgis.PyQt.QtGui import *",
-                  "from qgis.PyQt.QtWidgets import *",
-                  "from qgis.PyQt.QtNetwork import *", "from qgis.PyQt.QtXml import *"]
 _historyFile = os.path.join(QgsApplication.qgisSettingsDirPath(), "console_history.txt")
+
+_init_statements = [
+    # Python
+    "import sys",
+    "import os",
+    "from pathlib import Path",
+    "import re",
+    "import math",
+    # QGIS
+    "from qgis.core import *",
+    "from qgis.gui import *",
+    "from qgis.analysis import *",
+    ## 3D might not be compiled in
+    """
+try:
+    from qgis._3d import *
+except ModuleNotFoundError:
+    pass
+""",
+    "import processing",
+    "import qgis.utils",
+    "from qgis.utils import iface",
+    # Qt
+    "from qgis.PyQt.QtCore import *",
+    "from qgis.PyQt.QtGui import *",
+    "from qgis.PyQt.QtWidgets import *",
+    "from qgis.PyQt.QtNetwork import *",
+    "from qgis.PyQt.QtXml import *",
+]
 
 
 class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
@@ -69,9 +92,9 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
 
         self.displayPrompt(self.continuationLine)
 
-        for line in _init_commands:
+        for statement in _init_statements:
             try:
-                self.runsource(line)
+                self.runsource(statement)
             except ModuleNotFoundError:
                 pass
 

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -53,7 +53,7 @@ _init_statements = [
     "from qgis.core import *",
     "from qgis.gui import *",
     "from qgis.analysis import *",
-    ## 3D might not be compiled in
+    # # 3D might not be compiled in
     """
 try:
     from qgis._3d import *


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/49987: Python console emits `qgis._3d` import error if built with `WITH_3D=off`

It's a minor annoyance with a non-fatal import error printed to stderr but it surprised me and I thought I'd fix it.

The idea for this final, easy approach came from **grayshade** in IRC, thank you!

I took the opportunity to nicely format and comment the imports, and also renamed "`commands`" and "`line`" to "`statement[s]`" as that is more correct now. I did not touch the order of the imports, just in case it is relevant with all the `*`s.

Two other optional modules are imported, `analysis` and `gui`. However since they are mandatory for `WITH_DESKTOP` and this change is all about a GUI feature, they will always exist in its context. So I left those imports as they were.