### PR TITLE
Fix and add examples to geometries_to_array function

### DIFF
--- a/resources/function_help/json/geometries_to_array
+++ b/resources/function_help/json/geometries_to_array
@@ -7,7 +7,8 @@
     "arg": "geometry",
      "description": "the input geometry"
   }],
-  "examples": [{ "expression":"geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))", "returns":"[<QgsGeometry: Polygon ((5 8, 4 1, 3 2, 5 8))>, <QgsGeometry: LineString (3 2, 4 2)>]"},
-                { "expression":"geometries_to_array(geom_from_wkt('MULTIPOLYGON(((5 5,0 0,0 10,5 5)),((5 5,10 10,10 0,5 5))'))", "returns":"[<QgsGeometry: Polygon ((5 5, 0 0, 0 10, 5 5))>, <QgsGeometry: Polygon ((5 5, 10 10, 10 0, 5 5))>]"}],
+  "examples": [{ "expression":"geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))", "returns":"an array of a polygon and a line geometries"},
+               { "expression":"geom_to_wkt(geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))[0])", "returns":"'Polygon ((5 8, 4 1, 3 2, 5 8))'"},
+               { "expression":"geometries_to_array(geom_from_wkt('MULTIPOLYGON(((5 5,0 0,0 10,5 5)),((5 5,10 10,10 0,5 5))'))", "returns":"an array of two polygon geometries"}],
   "tags": [ "split", "convert", "separate", "collection", "multi", "part" ]
 }


### PR DESCRIPTION
The current output in the help is not displayed due to use of `<` and `>` instead of  `&lt;` and `&gt;`
![image](https://user-images.githubusercontent.com/7983394/188283131-8f35ef36-14d8-484a-8806-43403f9613d8.png)

Fix: I also replace old examples outputs because other than being wrong, I don't find them helpful as they were: the actual geometries are not displayed in the result as can be seen in the preview. Let's just explain what kind of returns is expected

![image](https://user-images.githubusercontent.com/7983394/188282720-7e70ba1e-25d7-48ea-843d-a115ec0fcad2.png)
