### PR TITLE
Dataset index consistency

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -887,11 +887,18 @@ Emitted when active vector group dataset is changed
 .. versionadded:: 3.14
 %End
 
-    void timeSettingsChanged( );
+    void timeSettingsChanged();
 %Docstring
 Emitted when time format is changed
 
 .. versionadded:: 3.8
+%End
+
+    void reloaded();
+%Docstring
+Emitted when the mesh layer is reloaded, see :py:func:`~QgsMeshLayer.reload`
+
+.. versionadded:: 3.28
 %End
 
   private: // Private methods

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -636,6 +636,8 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
             mMeshStyleWidget->setDockMode( true );
             connect( mMeshStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
             mWidgetStack->setMainPanel( mMeshStyleWidget );
+
+            connect( meshLayer, &QgsMeshLayer::reloaded, this, [this] {mMeshStyleWidget->syncToLayer( mCurrentLayer );} );
             break;
           }
 #ifdef HAVE_3D
@@ -649,6 +651,8 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
             }
             mMesh3DWidget->syncToLayer( meshLayer );
             mWidgetStack->setMainPanel( mMesh3DWidget );
+
+            connect( meshLayer, &QgsMeshLayer::reloaded, this, [this] {mMesh3DWidget->syncToLayer( mCurrentLayer );} );
             break;
           }
 #endif

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -127,17 +127,15 @@ class QgsMeshDatasetGroupStore: public QObject
     //! Constructor
     QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
 
-    //!  Sets the persistent mesh data provider with the path of its extra dataset
+    //!  Sets the persistent mesh data provider with the path of its extra dataset to be loaded by the provider
     void setPersistentProvider( QgsMeshDataProvider *provider, const QStringList &extraDatasetUri );
 
     //! Adds persistent datasets from a file with \a path
     bool addPersistentDatasets( const QString &path );
 
     /**
-     * Adds a extra dataset \a group, take ownership
-     *
-     * \note as QgsMeshDatasetGroup doesn't support reference time,
-     * the dataset group is supposed to have the same reference time than the pesristent provider
+     * Adds a extra dataset \a group, take ownership, returns True if the group is effectivly added.
+     * If returns False, the ownership is not taken
      */
     bool addDatasetGroup( QgsMeshDatasetGroup *group );
 
@@ -222,7 +220,7 @@ class QgsMeshDatasetGroupStore: public QObject
     void readXml( const QDomElement &storeElem, const QgsReadWriteContext &context );
 
     /**
-     * Returns the global dataset group index of the dataset group with native index \a globalGroupIndex in the \a source
+     * Returns the global dataset group index of the dataset group with native index \a nativeGroupIndex in the \a source
      * Returns -1 if the group or the source is not registered
      *
      * Since QGIS 3.22
@@ -239,18 +237,20 @@ class QgsMeshDatasetGroupStore: public QObject
   private:
     QgsMeshLayer *mLayer = nullptr;
     QgsMeshDataProvider *mPersistentProvider = nullptr;
-    QList<int> mPersistentExtraDatasetGroupIndexes;
     std::unique_ptr<QgsMeshExtraDatasetStore> mExtraDatasets;
     QMap < int, DatasetGroup> mRegistery;
+    QList<int> mPersistentExtraDatasetGroupIndexes;
+    QMap<QString, int> mGroupNameToGlobalIndex;
     std::unique_ptr<QgsMeshDatasetGroupTreeItem> mDatasetGroupTreeRootItem;
 
     void removePersistentProvider();
 
     DatasetGroup datasetGroup( int index ) const;
+
+    //! Returns a index that is not alredy used
     int newIndex();
 
     int registerDatasetGroup( const DatasetGroup &group );
-    int nativeIndexToGroupIndex( QgsMeshDatasetSourceInterface *source, int providerIndex );
     void createDatasetGroupTreeItems( const QList<int> &indexes );
 
     //! Erases from the where this is store, not from the store (registry and tree item), for persistent dataset group, do nothing

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -247,7 +247,7 @@ class QgsMeshDatasetGroupStore: public QObject
 
     DatasetGroup datasetGroup( int index ) const;
 
-    //! Returns a index that is not alredy used
+    //! Returns a index that is not already used
     int newIndex();
 
     int registerDatasetGroup( const DatasetGroup &group );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -999,7 +999,11 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
   // All dataset group are removed and replace by a unique virtual dataset group that provide vertices elevation value.
   mExtraDatasetUri.clear();
   mDatasetGroupStore.reset( new QgsMeshDatasetGroupStore( this ) );
-  mDatasetGroupStore->addDatasetGroup( mMeshEditor->createZValueDatasetGroup() );
+
+  std::unique_ptr<QgsMeshDatasetGroup> zValueDatasetGroup( mMeshEditor->createZValueDatasetGroup() );
+  if ( mDatasetGroupStore->addDatasetGroup( zValueDatasetGroup.get() ) )
+    zValueDatasetGroup.release();
+
   resetDatasetGroupTreeItem();
 
   connect( mMeshEditor, &QgsMeshEditor::meshEdited, this, &QgsMeshLayer::onMeshEdited );
@@ -1415,6 +1419,23 @@ QgsAbstractProfileGenerator *QgsMeshLayer::createProfileGenerator( const QgsProf
   return new QgsMeshLayerProfileGenerator( this, request );
 }
 
+void QgsMeshLayer::checkSymbologyConsistency()
+{
+  const QList<int> groupIndexes = mDatasetGroupStore->datasetGroupIndexes();
+  if ( !groupIndexes.contains( mRendererSettings.activeScalarDatasetGroup() ) )
+  {
+    if ( !groupIndexes.empty() )
+      mRendererSettings.setActiveScalarDatasetGroup( groupIndexes.first() );
+    else
+      mRendererSettings.setActiveScalarDatasetGroup( -1 );
+  }
+
+  if ( !groupIndexes.contains( mRendererSettings.activeVectorDatasetGroup() ) )
+  {
+    mRendererSettings.setActiveVectorDatasetGroup( -1 );
+  }
+}
+
 bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
                                   QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories )
 {
@@ -1428,6 +1449,8 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
   const QDomElement elemRendererSettings = elem.firstChildElement( "mesh-renderer-settings" );
   if ( !elemRendererSettings.isNull() )
     mRendererSettings.readXml( elemRendererSettings, context );
+
+  checkSymbologyConsistency();
 
   const QDomElement elemSimplifySettings = elem.firstChildElement( "mesh-simplify-settings" );
   if ( !elemSimplifySettings.isNull() )
@@ -1655,6 +1678,7 @@ void QgsMeshLayer::reload()
   if ( !mMeshEditor && mDataProvider && mDataProvider->isValid() )
   {
     mDataProvider->reloadData();
+    mDatasetGroupStore->setPersistentProvider( mDataProvider, QStringList() ); //extra dataset are already loaded
 
     //reload the mesh structure
     if ( !mNativeMesh )
@@ -1670,6 +1694,10 @@ void QgsMeshLayer::reload()
 
     //clear the rendererCache
     mRendererCache.reset( new QgsMeshLayerRendererCache() );
+
+    checkSymbologyConsistency();
+
+    emit reloaded();
   }
 }
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -896,7 +896,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
      *
      * \since QGIS 3.8
      */
-    void timeSettingsChanged( );
+    void timeSettingsChanged();
+
+    /**
+     * Emitted when the mesh layer is reloaded, see reload()
+     *
+     * \since QGIS 3.28
+     */
+    void reloaded();
 
   private: // Private methods
 
@@ -981,6 +988,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     QgsPointXY snapOnFace( const QgsPointXY &point, double searchRadius );
 
     void updateActiveDatasetGroups();
+
+    void checkSymbologyConsistency();
 
     void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
                                const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags ) override;

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -306,7 +306,7 @@ void TestQgsMeshCalculator::calcAndSave()
   const QString tempFilePath = QDir::tempPath() + '/' + "meshCalculatorResult.out";
   QgsMeshCalculator rc( QStringLiteral( "\"VertexScalarDataset\" + \"FaceScalarDataset\"" ),
                         QStringLiteral( "BINARY_DAT" ),
-                        "NewMixScalarDataset",
+                        "NewMixScalarDataset_saved",
                         tempFilePath,
                         extent,
                         0,

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1969,7 +1969,7 @@ void TestQgsMeshLayer::testSetDataSourceRetainStyle()
 void TestQgsMeshLayer::keepDatasetIndexConsistency()
 {
   const QString uri_1( mDataDir + QStringLiteral( "/mesh_z_ws_d_vel.nc" ) ); //mesh with dataset group "Bed Elevation", "Water Level", "Depth" and "Velocity"
-  const QString uri_2( mDataDir + QStringLiteral( "/mesh_z_ws_d.nc" ) ); //exacly the same mesh except without "Velocity"
+  const QString uri_2( mDataDir + QStringLiteral( "/mesh_z_ws_d.nc" ) ); //exactly the same mesh except without "Velocity"
 
   QTemporaryDir tempDir;
   const QString uri( tempDir.filePath( QStringLiteral( "mesh.nc" ) ) );

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -104,6 +104,8 @@ class TestQgsMeshLayer : public QObject
     void testSelectByExpression();
 
     void testSetDataSourceRetainStyle();
+
+    void keepDatasetIndexConsistency();
     void updateTimePropertiesWhenReloading();
 };
 
@@ -1147,12 +1149,17 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   //copy the qad_and_triangle_vertex_scalar.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_1, testFileDataSet );
 
-  //add the data set from temporary file and test
+  //add the dataset from temporary file and test
   QVERIFY( layer.addDatasets( testFileDataSet.fileName() ) );
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 );
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 2 );
   QCOMPARE( layer.datasetGroupCount(), 2 );
   QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 2 );
+
+  QMap<int, QString> indexToName;
+  QList<int> indexes = layer.datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    indexToName.insert( index, layer.datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
 
   //copy the qad_and_triangle_vertex_scalar_incompatible_mesh.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_2, testFileDataSet );
@@ -1162,19 +1169,27 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   //test if dataset presence
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 ); //uri still present
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 1 ); //dataset not loaded in the provider
-  QCOMPARE( layer.datasetGroupCount(), 2 ); //dataset group still registered in the layer
-  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 2 ); //dataset group tree item still have all dataset group
+  QCOMPARE( layer.datasetGroupCount(), 1 ); //dataset not registered anymore in the mesh layer
+  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 1 ); //dataset group tree item hasn't anymore the item
+
+  indexes = layer.datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer.datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
 
   //copy again the qad_and_triangle_vertex_scalar.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_1, testFileDataSet );
 
   layer.reload();
 
-  //add the data set from temporary tesFile and test
+  //add the data set from temporary test File and test
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 );
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 2 );
   QCOMPARE( layer.datasetGroupCount(), 2 );
   QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 2 );
+
+  indexes = layer.datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer.datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
 
   //copy a invalid file to the temporary testFile
   QVERIFY( testFileDataSet.open() );
@@ -1187,8 +1202,12 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   //test dataset presence
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 );
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 1 );
-  QCOMPARE( layer.datasetGroupCount(), 2 ); //dataset group still registered in the layer
-  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 2 ); //dataset group tree item still have all dataset groups
+  QCOMPARE( layer.datasetGroupCount(), 1 ); //dataset not registered anymore in the mesh layer
+  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 1 ); //dataset group tree item hasn't anymore the item
+
+  indexes = layer.datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer.datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
 
   //copy again the qad_and_triangle_vertex_scalar.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_1, testFileDataSet );
@@ -1204,14 +1223,12 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   QVERIFY( layer.addDatasets( testFileDataSet.fileName() ) ); //dataset added
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 ); //uri not dupplicated
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 3 ); //dataset added
-  QCOMPARE( layer.datasetGroupCount(), 3 );
-  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 3 );
+  QCOMPARE( layer.datasetGroupCount(), 2 ); // meshLayer do not allow dataset group with same name
+  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 2 );
 
-  //test dataset presence
-  QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 );
-  QCOMPARE( layer.dataProvider()->datasetGroupCount(), 3 );
-  QCOMPARE( layer.datasetGroupCount(), 3 );
-  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 3 );
+  indexes = layer.datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer.datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
 
   //add another dataset
   QTemporaryFile testFileDataSet_3;
@@ -1220,11 +1237,11 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   QVERIFY( layer.addDatasets( testFileDataSet_3.fileName() ) );
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 2 );
   QCOMPARE( layer.dataProvider()->datasetGroupCount(), 4 );
-  QCOMPARE( layer.datasetGroupCount(), 4 );
-  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 4 );
+  QCOMPARE( layer.datasetGroupCount(), 3 );
+  QCOMPARE( layer.datasetGroupTreeRootItem()->childCount(), 3 );
 
   //Test dataSet
-  const QgsMeshDatasetIndex ds( 3, 0 );
+  const QgsMeshDatasetIndex ds( 2, 0 );
   QCOMPARE( QgsMeshDatasetValue( 1, 1 ), layer.datasetValue( ds, 0 ) );
   QCOMPARE( QgsMeshDatasetValue( 2, 1 ), layer.datasetValue( ds, 1 ) );
   QCOMPARE( QgsMeshDatasetValue( 3, 2 ), layer.datasetValue( ds, 2 ) );
@@ -1254,7 +1271,7 @@ void TestQgsMeshLayer::test_mesh_simplification()
   QCOMPARE( simplifiedMeshes.at( 4 )->triangles().count(), 5 );
 
   // Delete simplified meshes
-  for ( QgsTriangularMesh *m : simplifiedMeshes )
+  for ( QgsTriangularMesh *m : std::as_const( simplifiedMeshes ) )
     delete m;
 }
 
@@ -1554,6 +1571,7 @@ void TestQgsMeshLayer::test_memory_dataset_group_1d()
 
   std::unique_ptr<QgsMeshMemoryDatasetGroup> goodDatasetGroupEdges( new QgsMeshMemoryDatasetGroup );
   std::unique_ptr<QgsMeshMemoryDatasetGroup>  badDatasetGroupEdges( new QgsMeshMemoryDatasetGroup );
+  goodDatasetGroupEdges->setName( QStringLiteral( "dataset on edges" ) );
   goodDatasetGroupEdges->setDataType( QgsMeshDatasetGroupMetadata::DataOnEdges );
   badDatasetGroupEdges->setDataType( QgsMeshDatasetGroupMetadata::DataOnEdges );
   for ( int i = 1; i < 10; i++ )
@@ -1946,6 +1964,103 @@ void TestQgsMeshLayer::testSetDataSourceRetainStyle()
   QCOMPARE( layer->rendererSettings().scalarSettings( 0 ).classificationMaximum(), 2.0 );
   QVERIFY( layer->rendererSettings().nativeMeshSettings().isEnabled() );
   QCOMPARE( layer->rendererSettings().nativeMeshSettings().color().name(), QStringLiteral( "#ff0000" ) );
+}
+
+void TestQgsMeshLayer::keepDatasetIndexConsistency()
+{
+  const QString uri_1( mDataDir + QStringLiteral( "/mesh_z_ws_d_vel.nc" ) ); //mesh with dataset group "Bed Elevation", "Water Level", "Depth" and "Velocity"
+  const QString uri_2( mDataDir + QStringLiteral( "/mesh_z_ws_d.nc" ) ); //exacly the same mesh except without "Velocity"
+
+  QTemporaryDir tempDir;
+  const QString uri( tempDir.filePath( QStringLiteral( "mesh.nc" ) ) );
+
+  QFile::copy( uri_1, uri );
+  // start with a layer with valid path
+  std::unique_ptr< QgsMeshLayer > layer = std::make_unique< QgsMeshLayer >( uri, QStringLiteral( "mesh" ), QStringLiteral( "mdal" ) );
+  QVERIFY( layer->isValid() );
+  QCOMPARE( layer->datasetGroupCount(), 4 );
+
+  QList<int> indexes = layer->datasetGroupsIndexes();
+  QMap<int, QString> indexToName;
+
+  int vectorIndex = -1;
+  for ( int index : std::as_const( indexes ) )
+  {
+    QgsMeshDatasetGroupMetadata meta = layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) );
+    indexToName.insert( index, layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
+    if ( meta.isVector() )
+      vectorIndex = index;
+  }
+  QgsMeshRendererSettings settings = layer->rendererSettings();
+  settings.setActiveVectorDatasetGroup( vectorIndex );
+  settings.setActiveScalarDatasetGroup( vectorIndex );
+  layer->setRendererSettings( settings );
+  QCOMPARE( layer->rendererSettings().activeScalarDatasetGroup(), vectorIndex );
+  QCOMPARE( layer->rendererSettings().activeVectorDatasetGroup(), vectorIndex );
+
+  QgsReadWriteContext readWriteContext;
+  QDomDocument doc( QStringLiteral( "doc" ) );
+  QDomElement meshLayerElement = doc.createElement( QStringLiteral( "maplayer" ) );
+  layer->writeLayerXml( meshLayerElement, doc, readWriteContext );
+  layer.reset();
+
+  QFile::remove( uri );
+  QVERIFY( QFile::copy( uri_2, uri ) );
+
+  // create a new mesh layer from XML
+  layer.reset( new QgsMeshLayer() );
+  layer->readLayerXml( meshLayerElement, readWriteContext );
+  QVERIFY( layer->isValid() );
+
+  // test if "Velocity" dataset group is gone and indexes are consistent with dataset group name
+  QCOMPARE( layer->datasetGroupCount(), 3 );
+  indexes = layer->datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
+  QVERIFY( !indexes.contains( vectorIndex ) );
+  QVERIFY( layer->rendererSettings().activeScalarDatasetGroup() != vectorIndex );
+  QVERIFY( layer->rendererSettings().activeVectorDatasetGroup() != vectorIndex );
+
+  layer.reset();
+
+  QFile::remove( uri );
+  QVERIFY( QFile::copy( uri_1, uri ) );
+  layer.reset( new QgsMeshLayer() );
+  layer->readLayerXml( meshLayerElement, readWriteContext );
+  QVERIFY( layer->isValid() );
+
+  // test if "Velocity" dataset group is come back indexes are consistent with dataset group name
+  QCOMPARE( layer->datasetGroupCount(), 4 );
+  indexes = layer->datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
+  QVERIFY( indexes.contains( vectorIndex ) );
+  QCOMPARE( layer->rendererSettings().activeScalarDatasetGroup(), vectorIndex );
+  QCOMPARE( layer->rendererSettings().activeVectorDatasetGroup(), vectorIndex );
+
+  // Same test but with layer reloading from QgsMeshLayer::reload();
+  QFile::remove( uri );
+  QVERIFY( QFile::copy( uri_2, uri ) );
+  layer->reload();
+  QCOMPARE( layer->datasetGroupCount(), 3 );
+  indexes = layer->datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
+  QVERIFY( !indexes.contains( vectorIndex ) );
+  QVERIFY( layer->rendererSettings().activeScalarDatasetGroup() != vectorIndex );
+  QVERIFY( layer->rendererSettings().activeVectorDatasetGroup() != vectorIndex );
+
+  QFile::remove( uri );
+  QVERIFY( QFile::copy( uri_1, uri ) );
+  layer->reload();
+  QCOMPARE( layer->datasetGroupCount(), 4 );
+  indexes = layer->datasetGroupsIndexes();
+  for ( int index : std::as_const( indexes ) )
+    QCOMPARE( indexToName.value( index ), layer->datasetGroupMetadata( QgsMeshDatasetIndex( index, 0 ) ).name() );
+  QVERIFY( indexes.contains( vectorIndex ) );
+  QVERIFY( layer->rendererSettings().activeScalarDatasetGroup() != vectorIndex );
+  QVERIFY( layer->rendererSettings().activeVectorDatasetGroup() != vectorIndex );
+
 }
 
 void TestQgsMeshLayer::test_temporal()


### PR DESCRIPTION
This PR improves mesh dataset group indexing consistency and fixes some issues when file(s) containing dataset groups change.
Indeed before this PR, when dataset groups changed, there were the following issues:

- if a dataset group  is not anymore present in the file, even if the project is closed and reopen, the dataset group was still present in dataset group tree, but can't be rendered. If only the "reload" button is pressed without closing/reopen the project, the dataset group tree does not change and the rendering of dataset groups is broken.

- if a new dataset group appears and is before prexisting dataset group, the new one took the index of the next preexisting, and leads to an offset with indexes for each following group. As renderer settings are linked by indexes, the rendering of all following dataset group is broken.

- new dataset groups were not visible in QGIS even the "reload" button is pressed. The user need to close and reopen the project.
