### PR TITLE
New command line parameter --py-args

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1557,7 +1557,8 @@ int main( int argc, char *argv[] )
 #endif
       pythonArgs.prepend( pythonfile );
     }
-    QgsPythonRunner::run( QStringLiteral( "sys.argv = ['%1']" ).arg( pythonArgs.join( "','" ) ) );
+
+    QgsPythonRunner::run( QStringLiteral( "sys.argv = [r'%1']" ).arg( pythonArgs.join( "',r'" ) ) );
   }
 
   if ( !pythonfile.isEmpty() )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1558,7 +1558,7 @@ int main( int argc, char *argv[] )
       pythonArgs.prepend( pythonfile );
     }
 
-    QgsPythonRunner::run( QStringLiteral( "sys.argv = [r'%1']" ).arg( pythonArgs.join( "',r'" ) ) );
+    QgsPythonRunner::run( QStringLiteral( "sys.argv = ['%1']" ).arg( pythonArgs.replaceInStrings( QChar( '\'' ), QStringLiteral( "\\'" ) ).join( "','" ) ) );
   }
 
   if ( !pythonfile.isEmpty() )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1547,15 +1547,26 @@ int main( int argc, char *argv[] )
     }
   }
 
+  if ( !pythonArgs.isEmpty() )
+  {
+    if ( !pythonfile.isEmpty() )
+    {
+#ifdef Q_OS_WIN
+      //replace backslashes with forward slashes
+      pythonfile.replace( '\\', '/' );
+#endif
+      pythonArgs.prepend( pythonfile );
+    }
+    QgsPythonRunner::run( QStringLiteral( "sys.argv = ['%1']" ).arg( pythonArgs.join( "','" ) ) );
+  }
+
   if ( !pythonfile.isEmpty() )
   {
 #ifdef Q_OS_WIN
     //replace backslashes with forward slashes
     pythonfile.replace( '\\', '/' );
 #endif
-    pythonArgs.prepend( pythonfile );
-    QgsPythonRunner::run( QStringLiteral( "sys.argv = ['%1']\n"
-                                          "with open('%2','r') as f: exec(f.read())" ).arg( pythonArgs.join( "','" ), pythonfile ) );
+    QgsPythonRunner::run( QStringLiteral( "with open('%1','r') as f: exec(f.read())" ).arg( pythonfile ) );
   }
 
   /////////////////////////////////`////////////////////////////////////

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -160,7 +160,7 @@ void usage( const QString &appName )
       << QStringLiteral( "\t[-g, --globalsettingsfile path]\tuse the given ini file as Global Settings (defaults)\n" )
       << QStringLiteral( "\t[-a, --authdbdirectory path] use the given directory for authentication database\n" )
       << QStringLiteral( "\t[-f, --code path]\trun the given python file on load\n" )
-      << QStringLiteral( "\t[-F, --code-args arguments]\targuments for the python file specified by --code. All arguments till '--' are passed to the python file and ignored by QGIS\n" )
+      << QStringLiteral( "\t[-F, --py-args arguments]\targuments for python. This arguments will be available for each python execution via 'sys.argv' included the file specified by '--code'. All arguments till '--' are passed to python and ignored by QGIS\n" )
       << QStringLiteral( "\t[-d, --defaultui]\tstart by resetting user ui settings to default\n" )
       << QStringLiteral( "\t[--hide-browser]\thide the browser widget\n" )
       << QStringLiteral( "\t[--dxf-export filename.dxf]\temit dxf output of loaded datasets to given file\n" )
@@ -617,7 +617,7 @@ int main( int argc, char *argv[] )
   QString authdbdirectory;
 
   QString pythonfile;
-  QStringList pythonfileArgs;
+  QStringList pythonArgs;
 
   QString customizationfile;
   QString globalsettingsfile;
@@ -738,7 +738,7 @@ int main( int argc, char *argv[] )
         {
           pythonfile = QDir::toNativeSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
         }
-        else if ( i + 1 < argc && ( arg == QLatin1String( "--code-args" ) || arg == QLatin1String( "-F" ) ) )
+        else if ( i + 1 < argc && ( arg == QLatin1String( "--py-args" ) || arg == QLatin1String( "-F" ) ) )
         {
           // Handle all parameters till '--' as code args
           for ( i++; i < args.size(); ++i )
@@ -748,7 +748,7 @@ int main( int argc, char *argv[] )
               i--;
               break;
             }
-            pythonfileArgs << args[i];
+            pythonArgs << args[i];
           }
         }
         else if ( i + 1 < argc && ( arg == QLatin1String( "--customizationfile" ) || arg == QLatin1String( "-z" ) ) )
@@ -1553,10 +1553,9 @@ int main( int argc, char *argv[] )
     //replace backslashes with forward slashes
     pythonfile.replace( '\\', '/' );
 #endif
-    pythonfileArgs.prepend( pythonfile );
+    pythonArgs.prepend( pythonfile );
     QgsPythonRunner::run( QStringLiteral( "sys.argv = ['%1']\n"
-                                          "with open('%2','r') as f: exec(f.read())\n"
-                                          "sys.argv = []" ).arg( pythonfileArgs.join( "','" ), pythonfile ) );
+                                          "with open('%2','r') as f: exec(f.read())" ).arg( pythonArgs.join( "','" ), pythonfile ) );
   }
 
   /////////////////////////////////`////////////////////////////////////

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -89,14 +89,13 @@ class TestPyQgsAppStartup(unittest.TestCase):
         with open(myTestFile, 'rt', encoding='utf-8') as res_file:
             lines = res_file.readlines()
 
-        # platform should be "Desktop"
-        self.assertEqual(lines, ['Platform: desktop'])
-
         try:
             p.terminate()
         except OSError as e:
             if e.errno != errno.ESRCH:
                 raise e
+
+        return lines
 
     def testPyQgisStartupEnvVar(self):
         # verify PYQGIS_STARTUP env variable file is run by embedded interpreter
@@ -113,10 +112,38 @@ class TestPyQgsAppStartup(unittest.TestCase):
         f = open(testmod, 'w')
         f.writelines(testcode)
         f.close()
-        self.doTestStartup(
+        testfile_lines = self.doTestStartup(
             testFile=testfilepath,
             timeOut=360,
             env={'PYQGIS_STARTUP': testmod})
+
+        # platform should be "Desktop"
+        self.assertEqual(testfile_lines, ['Platform: desktop'])
+
+    def testPyArgs(self):
+        testfile = 'pyqgis_code.txt'
+        testfilepath = os.path.join(self.TMP_DIR, testfile).replace('\\', '/')
+        testcode = [
+            "import sys\n"
+            "f = open('{0}', 'a')\n".format(testfilepath),
+            "for arg in sys.argv:\n"
+            "  f.write(arg)\n",
+            "  f.write('\\n')\n",
+            "f.close()\n"
+        ]
+        testmod = os.path.join(self.TMP_DIR, 'pyqgis_code.py').replace('\\', '/')
+        f = open(testmod, 'w')
+        f.writelines(testcode)
+        f.close()
+
+        testfile_lines = self.doTestStartup(
+            testFile=testfilepath,
+            timeOut=10,
+            additionalArguments=["--code", testmod, "--py-args", "--specialScriptArguments", "a text arg", "--"])
+
+        self.assertEqual(testfile_lines, [testmod + '\n',
+                                          '--specialScriptArguments\n',
+                                          'a text arg\n'])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -139,11 +139,11 @@ class TestPyQgsAppStartup(unittest.TestCase):
         testfile_lines = self.doTestStartup(
             testFile=testfilepath,
             timeOut=10,
-            additionalArguments=["--code", testmod, "--py-args", "--specialScriptArguments", "a text arg", "--"])
+            additionalArguments=["--code", testmod, "--py-args", "--specialScriptArgument's", 'a "Quoted" text arg', "--"])
 
         self.assertEqual(testfile_lines, [testmod + '\n',
-                                          '--specialScriptArguments\n',
-                                          'a text arg\n'])
+                                          "--specialScriptArgument's\n",
+                                          'a "Quoted" text arg\n'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR will allow to pass arguments to the script provided via `--code` parameter and more generally to each python execution. All arguments after `--py-args` till `--` are passed over to the python interpreter and ignored by QGIS.

Note: After `--code-args` is not possible to pass any other parameter than `--` to QGIS

For example:
```
qgis --code /home/domi/test.py --py-args --specialScriptArguments "a text arg" 'and another arg' -- layer1 layer2
```
- `test.py` will have this content in `sys.argv`: `['/home/domi/test.py', '--specialScriptArguments', 'a text arg', 'and another arg']`
- `layer1` and `layer2` will be normally handled by QGIS as layers to load