### PR TITLE
[Fix] Remove unnecessary geometryChanged calls

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2343,6 +2343,7 @@ Modifies geometry to avoid intersections with the layers specified in project pr
          1 if geometry is not of polygon type,
          2 if avoid intersection would change the geometry type,
          3 at least one geometry intersected is invalid. The algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
+         4 if the geometry is not intersected by one of the geometries present in the provided layers.
 
 .. versionadded:: 1.5
 %End

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2377,8 +2377,6 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
       editor->updateEditor( mLockedFeature.get() );
   }
 
-
-
   for ( it = edits.begin() ; it != edits.end(); ++it )
   {
     QgsVectorLayer *layer = it.key();
@@ -2399,7 +2397,6 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
           break;
       }
       QgsGeometry featGeom = it2.value();
-      layer->changeGeometry( it2.key(), featGeom );
       if ( avoidIntersectionsLayers.size() > 0 )
       {
         QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
@@ -2416,12 +2413,19 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
           case 3:
             emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::MessageLevel::Warning );
             break;
+
           default:
             break;
         }
+        // if the geometry has been changed
+        if ( avoidIntersectionsReturn != 4 )
+        {
+          layer->changeGeometry( it2.key(), featGeom );
+          edits[layer][it2.key()] = featGeom;
+        }
+
       }
-      layer->changeGeometry( it2.key(), featGeom );
-      edits[layer][it2.key()] = featGeom;
+
     }
     layer->endEditCommand();
     layer->triggerRepaint();

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2418,7 +2418,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
             break;
         }
         // if the geometry has been changed
-        if ( avoidIntersectionsReturn != 4 )
+        if ( avoidIntersectionsReturn != 1 && avoidIntersectionsReturn != 4 )
         {
           layer->changeGeometry( it2.key(), featGeom );
           edits[layer][it2.key()] = featGeom;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2850,15 +2850,20 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
   QgsWkbTypes::Type geomTypeBeforeModification = wkbType();
 
   bool haveInvalidGeometry = false;
+  bool geomModified = false;
+
   std::unique_ptr< QgsAbstractGeometry > diffGeom = QgsGeometryEditUtils::avoidIntersections( *( d->geometry ), avoidIntersectionsLayers, haveInvalidGeometry, ignoreFeatures );
   if ( diffGeom )
   {
     reset( std::move( diffGeom ) );
+    geomModified = true;
   }
 
   if ( geomTypeBeforeModification != wkbType() )
     return 2;
   if ( haveInvalidGeometry )
+    return 3;
+  if ( !geomModified )
     return 4;
 
   return 0;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2406,6 +2406,7 @@ class CORE_EXPORT QgsGeometry
      *          1 if geometry is not of polygon type,
      *          2 if avoid intersection would change the geometry type,
      *          3 at least one geometry intersected is invalid. The algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
+     *          4 if the geometry is not intersected by one of the geometries present in the provided layers.
      * \since QGIS 1.5
      */
     int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -343,6 +343,10 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
   }
 
   std::unique_ptr< QgsAbstractGeometry > diffGeom( geomEngine->difference( combinedGeometries.get() ) );
+  if ( geomEngine->isEqual( diffGeom.get() ) )
+  {
+    return nullptr;
+  }
 
   return diffGeom;
 }

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -73,6 +73,7 @@ class QgsGeometryEditUtils
      * \param avoidIntersectionsLayers list of layers to check for intersections
      * \param haveInvalidGeometry returns true if at least one geometry intersected is invalid. In this case, the algorithm may not work and return the same geometry as the input. You must fix your intersecting geometries.
      * \param ignoreFeatures map of layer to feature id of features to ignore
+     * \return the modified geometry or a null unique_ptr if the \a geom polygon doesn't intersect any geometry in \a avoidIntersectionsLayers
      */
     static std::unique_ptr< QgsAbstractGeometry > avoidIntersections( const QgsAbstractGeometry &geom,
         const QList<QgsVectorLayer *> &avoidIntersectionsLayers,


### PR DESCRIPTION
## Description

Before this PR, when a vertex is modified, `layer.geometryChanged` has been call three times.

With this PR, when "avoid intersections" does nothing (either it is disable or no geometry intersect the edited geometry), there is only one emitted `geometryChanged` signal. And when  "avoid intersections" modifies the geometry, 2 `geometryChanged` signal is emitted.

The reasons to keep 2 signals when "avoid intersections" modifies the geometry are:
 - Keep the ability to redo only the "avoid intersections" modifications.
 - The "avoid intersections" process can transform the geometry to an invalid one. A plugin can go back  before the "avoid intersections" modifications.

Fixes #47595

Founded by: Métropole Européenne de Lille, cc @Jean-Roc