### PR TITLE
Get x-y-z data type from attribute collection when exporting point clouds

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -357,12 +357,10 @@ void QgsPointCloudLayerExporter::ExporterBase::run()
     int recordSize = attributesCollection.pointRecordSize();
     const QgsVector3D scale = block->scale();
     const QgsVector3D offset = block->offset();
-    int xOffset;
-    int yOffset;
-    int zOffset;
-    attributesCollection.find( QStringLiteral( "X" ), xOffset );
-    attributesCollection.find( QStringLiteral( "Y" ), yOffset );
-    attributesCollection.find( QStringLiteral( "Z" ), zOffset );
+    int xOffset = 0, yOffset = 0, zOffset = 0;
+    const QgsPointCloudAttribute::DataType xType = attributesCollection.find( QStringLiteral( "X" ), xOffset )->type();
+    const QgsPointCloudAttribute::DataType yType = attributesCollection.find( QStringLiteral( "Y" ), yOffset )->type();
+    const QgsPointCloudAttribute::DataType zType = attributesCollection.find( QStringLiteral( "Z" ), zOffset )->type();
     for ( int i = 0; i < count; ++i )
     {
 
@@ -382,9 +380,9 @@ void QgsPointCloudLayerExporter::ExporterBase::run()
 
       double x, y, z;
       QgsPointCloudAttribute::getPointXYZ( ptr, i, recordSize,
-                                           xOffset, QgsPointCloudAttribute::DataType::Int32,
-                                           yOffset, QgsPointCloudAttribute::DataType::Int32,
-                                           zOffset, QgsPointCloudAttribute::DataType::Int32,
+                                           xOffset, xType,
+                                           yOffset, yType,
+                                           zOffset, zType,
                                            scale, offset,
                                            x, y, z );
       if ( ! mParent->mZRange.contains( z ) ||


### PR DESCRIPTION
## Description
This should fix exporting from ept point clouds

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
