### PR TITLE
Fix make_valid examples

### DIFF
--- a/resources/function_help/json/make_valid
+++ b/resources/function_help/json/make_valid
@@ -24,6 +24,9 @@
     "expression": "geom_to_wkt(make_valid(geom_from_wkt('POLYGON((3 2, 4 1, 5 8, 3 2, 4 2))')))",
     "returns": "'Polygon ((3 2, 5 8, 4 1, 3 2))'"
   }, {
+    "expression": "geom_to_wkt(make_valid(geom_from_wkt('POLYGON((3 2, 4 1, 5 8, 3 2, 4 2))'), 'linework'))",
+    "returns": "'GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'"
+  }, {
     "expression": "make_valid(geom_from_wkt('LINESTRING(0 0)'))",
     "returns": " &lt;empty geometry&gt;"
   }],

--- a/resources/function_help/json/make_valid
+++ b/resources/function_help/json/make_valid
@@ -22,10 +22,10 @@
   ],
   "examples": [{
     "expression": "geom_to_wkt(make_valid(geom_from_wkt('POLYGON((3 2, 4 1, 5 8, 3 2, 4 2))')))",
-    "returns": "'GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'"
+    "returns": "'Polygon ((3 2, 5 8, 4 1, 3 2))'"
   }, {
     "expression": "make_valid(geom_from_wkt('LINESTRING(0 0)'))",
-    "returns": "<empty geometry>"
+    "returns": " &lt;empty geometry&gt;"
   }],
-  "tags": ["rules", "valid", "ogc", "according", "formed"]
+  "tags": ["rules", "valid", "ogc", "according", "formed", "repair", "fix"]
 }


### PR DESCRIPTION
It outputs a polygon not a collection as currently stated (adapt examples to using GEOS 3.10)

![image](https://user-images.githubusercontent.com/7983394/188821672-691a472f-e997-4845-b949-f07d62b00ad5.png)

