### PR TITLE
[server] Add custom template function "starts_with" for OGC API Features

### DIFF
--- a/python/server/auto_generated/qgsserverogcapihandler.sip.in
+++ b/python/server/auto_generated/qgsserverogcapihandler.sip.in
@@ -204,6 +204,7 @@ Available custom template functions:
 - links_filter( links, key, value ): returns filtered links from a link list
 - content_type_name( content_type ): returns a short name from a content type for example "text/html" will return "HTML"
 - nl2br( text ): returns the input text with all newlines replaced by "<br>" tags
+- starts_with( string, prefix ): returns true if a string begins with the provided string prefix, false otherwise
 %End
 
     std::string href( const QgsServerApiContext &context, const QString &extraPath = QString(), const QString &extension = QString() ) const;

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -417,6 +417,13 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
       return matchedPath.toStdString() + "/static/" + asset;
     } );
 
+
+    // Returns true if a string begins with the provided string prefix, false otherwise
+    env.add_callback( "starts_with", 2, [ ]( Arguments & args )
+    {
+      return string_view::starts_with( args.at( 0 )->get<std::string_view>( ), args.at( 1 )->get<std::string_view>( ) );
+    } );
+
     context.response()->write( env.render_file( pathInfo.fileName().toStdString(), data ) );
   }
   catch ( std::exception &e )

--- a/src/server/qgsserverogcapihandler.h
+++ b/src/server/qgsserverogcapihandler.h
@@ -219,6 +219,7 @@ class SERVER_EXPORT QgsServerOgcApiHandler
      * - links_filter( links, key, value ): returns filtered links from a link list
      * - content_type_name( content_type ): returns a short name from a content type for example "text/html" will return "HTML"
      * - nl2br( text ): returns the input text with all newlines replaced by "<br>" tags
+     * - starts_with( string, prefix ): returns true if a string begins with the provided string prefix, false otherwise
      *
      * \note not available in Python bindings
      */
@@ -307,6 +308,7 @@ class SERVER_EXPORT QgsServerOgcApiHandler
      * - links_filter( links, key, value ): returns filtered links from a link list
      * - content_type_name( content_type ): returns a short name from a content type for example "text/html" will return "HTML"
      * - nl2br( text ): returns the input text with all newlines replaced by "<br>" tags
+     * - starts_with( string, prefix ): returns true if a string begins with the provided string prefix, false otherwise
      *
      */
     void write( QVariant &data, const QgsServerApiContext &context, const QVariantMap &htmlMetadata = QVariantMap() ) const SIP_THROW( QgsServerApiBadRequestException );


### PR DESCRIPTION
## Description

Add custom template function `starts_with` for [OGC API Features HTML templates](https://docs.qgis.org/3.22/en/docs/server_manual/services/ogcapif.html#custom-template-functions):

`starts_with( string, prefix ): returns true if a string begins with the provided string prefix, false otherwise`

Motivation is here to make feature string values appear as links if they start e.g. with `"https"`.