### PR TITLE
[afs] When no explicit crs is set in the data source URI, just use the CRS retrieved from the service properties

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -42,7 +42,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   const QString authcfg = mSharedData->mDataSource.authConfigId();
 
   // Set CRS
-  mSharedData->mSourceCRS.createFromString( mSharedData->mDataSource.param( QStringLiteral( "crs" ) ) );
+  if ( !mSharedData->mDataSource.param( QStringLiteral( "crs" ) ).isEmpty() )
+    mSharedData->mSourceCRS.createFromString( mSharedData->mDataSource.param( QStringLiteral( "crs" ) ) );
 
   // Get layer info
   QString errorTitle, errorMessage;
@@ -121,6 +122,9 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     appendError( QgsErrorMessage( tr( "Could not parse spatial reference" ), QStringLiteral( "AFSProvider" ) ) );
     return;
   }
+
+  if ( !mSharedData->mSourceCRS.isValid() )
+    mSharedData->mSourceCRS = extentCrs;
 
   if ( xminOk && yminOk && xmaxOk && ymaxOk )
   {


### PR DESCRIPTION
This allows construction of AFS layers without having to know the CRS in advance
