### PR TITLE
[Clang-tidy] Run clang-tidy on modified code

### DIFF
--- a/.docker/docker-qgis-build.sh
+++ b/.docker/docker-qgis-build.sh
@@ -75,6 +75,12 @@ if [[ ${BUILD_WITH_QT6} = "ON" ]]; then
   )
 fi
 
+if [[ "${WITH_COMPILE_COMMANDS}" == "ON" ]]; then
+  CMAKE_EXTRA_ARGS+=(
+    "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+  )
+fi
+
 if [[ ${WITH_GRASS7} == "ON" || ${WITH_GRASS8} == "ON" ]]; then
   CMAKE_EXTRA_ARGS+=(
     "-DGRASS_PREFIX$( grass --config version | cut -b 1 )=$( grass --config path )"

--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -43,4 +43,4 @@ echo -e "\e[1;34m - launch cmake with option -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 echo -e "\e[1;34m - update build by calling Ninja"
 echo -e "\e[1;34m - launch command ./scripts/clang-tidy.sh -p <your_build_dir> <source_file>"
 
-exit $(grep "warning:" clang-tidy.log | wc -l)
+exit $(grep -c "warning:" clang-tidy.log)

--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -23,7 +23,7 @@ cd ${SRCDIR}
 # https://github.com/qgis/QGIS/runs/6733585841?check_suite_focus=true#step:13:89
 git config --global --add safe.directory ${SRCDIR}
 
-echo "::group::Install cland tidy"
+echo "::group::Install clang tidy"
 apt install -y \
     clang-tidy
 echo "::endgroup::"

--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+###########################################################################
+#    docker-qgis-clangtidy.sh
+#    ---------------------
+#    Date                 : September 2022
+#    Copyright            : (C) 2022 by Julien Cabieces
+#    Email                : julien dot cabieces at oslandia dot com
+###########################################################################
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+###########################################################################
+
+set -e
+
+SRCDIR=${CTEST_SOURCE_DIR-/root/QGIS}
+cd ${SRCDIR}
+
+# This is needed for `git status` to work, see
+# https://github.com/qgis/QGIS/runs/6733585841?check_suite_focus=true#step:13:89
+git config --global --add safe.directory ${SRCDIR}
+
+echo "::group::Install cland tidy"
+apt install -y \
+    clang-tidy
+echo "::endgroup::"
+
+cd ${SRCDIR}
+
+echo "::group::Download clang-tidy-diff"
+curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-14.0.6/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o clang-tidy-diff.py
+echo "::endgroup::"
+
+echo "${bold}Run clang-tidy on modifications...${endbold}"
+CLANG_TIDY_CHECKS=$(cat tests/code_layout/clangtidy_checks.txt | grep -ve "^#" | grep -ve "^$" | tr -d '\n')
+git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -checks="$CLANG_TIDY_CHECKS" | tee clang-tidy.log
+
+echo -e "\e[1;34mTo reproduce locally:"
+echo -e "\e[1;34m - launch cmake with option -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+echo -e "\e[1;34m - update build by calling Ninja"
+echo -e "\e[1;34m - launch command ./scripts/clang-tidy.sh -p <your_build_dir> <source_file>"
+
+exit $(grep "warning:" clang-tidy.log | wc -l)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,6 +48,7 @@ jobs:
             patch-qt-3d: false
             with-grass7: OFF
             with-grass8: OFF
+            with-compile-commands: ON
             # LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
             experimental: false
 
@@ -63,6 +64,7 @@ jobs:
             patch-qt-3d: false
             with-grass7: OFF
             with-grass8: OFF
+            with-compile-commands: OFF
             LD_PRELOAD: ''
             experimental: false
 
@@ -167,6 +169,7 @@ jobs:
                      --env WITH_GRASS8=${{ matrix.with-grass8 }} \
                      --env LD_PRELOAD=${{ matrix.LD_PRELOAD }} \
                      --env WITH_CLAZY=${{ matrix.with-clazy }} \
+                     --env WITH_COMPILE_COMMANDS=${{ matrix.with-compile-commands }} \
                      qgis3-build-deps \
                      /root/QGIS/.docker/docker-qgis-build.sh
 
@@ -405,3 +408,68 @@ jobs:
           name: test-results
           path: qgis_test_report
 
+  clang-tidy:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        include:
+          - distro-version: '22.04'
+            qt-version: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Build Docker Container with Testing Environment
+        id: docker-build
+        uses: whoan/docker-build-with-cache-action@v5
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          image_name: qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only
+          dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
+          build_extra_args: "--build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"
+          push_git_tag: true
+          push_image_and_stages: on:push
+          pull_image_and_stages: ${{ github.event_name != 'workflow_dispatch' }}
+
+      - name: Tag image
+        run: |
+          docker tag ${DOCKER_IMAGE} qgis3-build-deps
+        env:
+          DOCKER_IMAGE: ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }}
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}.tgz
+          path: .
+
+      - name: Extract build artifact
+        run: |
+          tar xvzf build.tgz
+          rm -Rf build.tgz
+
+      - name: Run Clang-Tidy
+        run: |
+          docker run -t --name qgis_container \
+          -v $(pwd):/root/QGIS \
+          -v /home/runner/QGIS/.ccache:/root/.ccache \
+          --env-file .docker/docker-variables.env \
+          --env PUSH_TO_CDASH=false \
+          --env WITH_QT5=TRUE \
+          --env BUILD_WITH_QT6=OFF \
+          --env WITH_QUICK=ON \
+          --env WITH_3D=TRUE \
+          --env PATCH_QT_3D=FALSE \
+          --env WITH_GRASS7=OFF \
+          --env WITH_GRASS8=OFF \
+          --env WITH_CLAZY=OFF \
+          qgis3-build-deps \
+          /root/QGIS/.docker/docker-qgis-clangtidy.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -462,14 +462,5 @@ jobs:
           -v $(pwd):/root/QGIS \
           -v /home/runner/QGIS/.ccache:/root/.ccache \
           --env-file .docker/docker-variables.env \
-          --env PUSH_TO_CDASH=false \
-          --env WITH_QT5=TRUE \
-          --env BUILD_WITH_QT6=OFF \
-          --env WITH_QUICK=ON \
-          --env WITH_3D=TRUE \
-          --env PATCH_QT_3D=FALSE \
-          --env WITH_GRASS7=OFF \
-          --env WITH_GRASS8=OFF \
-          --env WITH_CLAZY=OFF \
           qgis3-build-deps \
           /root/QGIS/.docker/docker-qgis-clangtidy.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1020,26 +1020,6 @@ if (WITH_CORE)
 endif()
 
 ####################################################
-# clang-tidy
-set (WITH_CLANG_TIDY FALSE CACHE BOOL "Use Clang tidy")
-mark_as_advanced(WITH_CLANG_TIDY)
-if (WITH_CORE)
-  if(WITH_CLANG_TIDY)
-    find_program(
-      CLANG_TIDY_EXE
-      NAMES "clang-tidy"
-      DOC "Path to clang-tidy executable"
-      )
-    if(NOT CLANG_TIDY_EXE)
-      message(STATUS "clang-tidy not found.")
-    else()
-      message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-      set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-checks=*,-clang-analyzer-alpha.*,-cppcoreguidelines*,-readability-implicit-bool-cast,-llvm-include-order,-cert-err58-cpp,-modernize-pass-by-value,-google-readability-braces-around-statements,-modernize-use-auto,-modernize-loop-convert,-readability-else-after-return,-readability-braces-around-statements,-google-runtime-references,-readability-named-parameter,-google-default-arguments,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-cert-flp30-c,-google-readability-casting,-clang-analyzer-security.FloatLoopCounter,-google-runtime-int,-modernize-use-using,-google-explicit-constructor,-google-build-using-namespace,-cert-err34-c,-clang-analyzer-core.CallAndMessage,-google-readability-function-size,-modernize-make-shared,-modernize-use-nullptr,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-core.NonNullParamChecker,performance-unnecessary-copy-initialization,-readability-simplify-boolean-expr,-modernize-raw-string-literal,-performance-unnecessary-copy-initialization")
-    endif()
-  endif()
-endif()
-
-####################################################
 # asan
 set (WITH_ASAN FALSE CACHE BOOL "Use AddressSanitizer")
 mark_as_advanced(WITH_ASAN)

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -34,13 +34,13 @@ while getopts "p:am:" o; do
           BUILD_DIR=${OPTARG}
           ;;
       a)
-          if [[ ! -z "$FILE_OPT" ]]; then
+          if [[ -n "$FILE_OPT" ]]; then
             usage
           fi
           FILE_OPT="ALL"
           ;;
         m)
-          if [[ ! -z "$FILE_OPT" ]]; then
+          if [[ -n "$FILE_OPT" ]]; then
             usage
           fi
           FILE_OPT=${OPTARG}

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+###########################################################################
+#    clang-tidy.sh
+#    ---------------------
+#    Date                 : September 2022
+#    Copyright            : (C) 2022 by Julien Cabieces
+#    Email                : julien dot cabieces at oslandia dot com
+###########################################################################
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+###########################################################################
+
+set -e
+
+usage() {
+  echo 'Usage: '$(basename $0)' [-p <build_dir>] [-a] [-m <module_name>] [source_files]
+
+       -a : run clang-tidy on all source files
+       -m <module> : run clang-tidy on all module source files (core, gui, analysis...)
+
+       Use either -a or -m, or source files' 1>&2; exit 1; }
+
+SCRIPT_DIR=$(dirname $0)/..
+SOURCE_DIR=$(realpath $SCRIPT_DIR)
+
+BUILD_DIR=$(pwd)
+while getopts "p:am:" o; do
+    case "${o}" in
+      p)
+          BUILD_DIR=${OPTARG}
+          ;;
+      a)
+          if [[ ! -z "$FILE_OPT" ]]; then
+            usage
+          fi
+          FILE_OPT="ALL"
+          ;;
+        m)
+          if [[ ! -z "$FILE_OPT" ]]; then
+            usage
+          fi
+          FILE_OPT=${OPTARG}
+          ;;
+        *)
+          usage
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+CLANG_TIDY_CHECKS=$(cat ${SOURCE_DIR}/tests/code_layout/clangtidy_checks.txt | grep -ve "^#" | grep -ve "^$" | tr -d '\n')
+
+if [[ ! -f "$BUILD_DIR/compile_commands.json" ]]; then
+  echo "compile_commands.json file is missing, you need to add -DCMAKE_EXPORT_COMPILE_COMMANDS=ON when you run cmake to generate it."
+  exit 1
+fi
+
+if [[ -z "$FILE_OPT" ]]; then
+  if [[ $# -lt 1 ]]; then
+    echo "Missing files"
+    usage
+  else
+    FILES=$*
+  fi
+else
+  if [[ $# -gt 0 ]]; then
+    usage
+  elif [[ "$FILE_OPT" = "ALL" ]]; then
+       FILES=$(find $SOURCE_DIR/src -name "*.cpp" -o -name "*.h")
+  else
+       FILES=$(find $SOURCE_DIR/src/$FILE_OPT -name "*.cpp" -o -name "*.h")
+  fi
+fi
+
+set +e
+
+for file in $FILES;
+do
+  clang-tidy -p=$BUILD_DIR -checks="$CLANG_TIDY_CHECKS" $file
+done

--- a/tests/code_layout/clangtidy_checks.txt
+++ b/tests/code_layout/clangtidy_checks.txt
@@ -1,0 +1,5 @@
+bugprone-*,
+
+# Those we don't want to fix
+-bugprone-easily-swappable-parameters,
+-bugprone-virtual-near-miss


### PR DESCRIPTION
This PR proposes to run clang-tidy on modified/added code for every PR. 

I removed the CMake option WITH_CLANG_TIDY because it takes way too much time to then compile QGIS (reached Github 6 hours timeout when trying). In order to reproduce locally, I added a script clang-tidy.sh that runs clang-tidy on some files with the appropriate options (it just needs to have the CMAKE_EXPORT_COMPILE_COMMANDS defined.

I reduced the number of check categories to *bugprone-*, *clang-diagnostic-*, *clang-analyzer-* (the two last one are default in clang-tidy, in order to not raise too much non-relevant checks. But the content of clangtidy_checks.txt is opened to discussions.

