### PR TITLE
Plugins manager dialog

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -600,12 +600,12 @@ void QgsPluginManager::reloadModelData()
       mypDetailItem->setEditable( false );
 
       // Set checkable if the plugin is installed and not disabled due to incompatibility.
-      // Broken plugins are checkable to to allow disabling them
+      // Broken plugins are checkable to allow disabling them
       mypDetailItem->setCheckable( it->value( QStringLiteral( "installed" ) ) == QLatin1String( "true" ) && it->value( QStringLiteral( "error" ) ) != QLatin1String( "incompatible" ) );
 
       // Set ckeckState depending on the plugin is loaded or not.
       // Initially mark all unchecked, then overwrite state of loaded ones with checked.
-      // Only do it with installed plugins, not not initialize checkboxes of not installed plugins at all.
+      // Only do it with installed plugins, do not initialize checkboxes of not installed plugins at all.
       if ( it->value( QStringLiteral( "installed" ) ) == QLatin1String( "true" ) )
       {
         mypDetailItem->setCheckState( Qt::Unchecked );
@@ -917,7 +917,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
   if ( ! metadata->value( QStringLiteral( "about" ) ).isEmpty() )
   {
     QString about = metadata->value( QStringLiteral( "about" ) );
-    // The regular expression insures that a new line will be present after the closure of a paragraph tag (i.e. </p>)
+    // The regular expression ensures that a new line will be present after the closure of a paragraph tag (i.e. </p>)
     about = about.replace( QRegularExpression( QStringLiteral( "&lt;\\/p&gt;([^\\n])" ) ), QStringLiteral( "&lt;/p&gt;\n\\1" ) ).remove( stripHtml );
     html += about.replace( '\n', QLatin1String( "<br/>" ) );
     html += QLatin1String( "<br/><br/>" );
@@ -1035,7 +1035,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     {
       const QDateTime dateUpdated = QDateTime::fromString( metadata->value( QStringLiteral( "update_date_stable" ) ).trimmed(), Qt::ISODate );
       if ( dateUpdated.isValid() )
-        dateUpdatedStr += QStringLiteral( "%1 %2" ).arg( tr( "updated at" ), dateUpdated.toString() );
+        dateUpdatedStr += tr( "updated at %1" ).arg( dateUpdated.toString() );
     }
 
     html += QStringLiteral( "<tr><td class='key'>%1 </td><td title='%2'><a href='%2'>%3</a> %4</td></tr>"
@@ -1059,7 +1059,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     {
       const QDateTime dateUpdated = QDateTime::fromString( metadata->value( QStringLiteral( "update_date_experimental" ) ).trimmed(), Qt::ISODate );
       if ( dateUpdated.isValid() )
-        dateUpdatedStr += QStringLiteral( "%1 %2" ).arg( tr( "updated at" ), dateUpdated.toString() );
+        dateUpdatedStr += tr( "updated at %1" ).arg( dateUpdated.toString() );
     }
 
     html += QStringLiteral( "<tr><td class='key'>%1 </td><td title='%2'><a href='%2'>%3</a> %4</td></tr>"
@@ -1094,20 +1094,24 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
   if ( metadata->value( QStringLiteral( "status" ) ) == QLatin1String( "upgradeable" ) )
   {
     buttonInstall->setText( tr( "Upgrade Plugin" ) );
+    buttonInstall->setToolTip( tr( "Upgrades selected plugin to latest stable version" ) );
     buttonInstall->setDefault( true );
   }
   else if ( metadata->value( QStringLiteral( "status" ) ) == QLatin1String( "newer" ) )
   {
     buttonInstall->setText( tr( "Downgrade Plugin" ) );
+    buttonInstall->setToolTip( tr( "Downgrades selected plugin to latest stable version" ) );
   }
   else if ( metadata->value( QStringLiteral( "status" ) ) == QLatin1String( "not installed" ) || metadata->value( QStringLiteral( "status" ) ) == QLatin1String( "new" ) )
   {
     buttonInstall->setText( tr( "Install Plugin" ) );
+    buttonInstall->setToolTip( tr( "Installs latest stable version of the selected plugin" ) );
   }
   else
   {
     // Default (will be grayed out if not available for reinstallation)
     buttonInstall->setText( tr( "Reinstall Plugin" ) );
+    buttonInstall->setToolTip( tr( "Reinstalls latest stable version of the selected plugin" ) );
   }
 
   // Set buttonInstall text (and sometimes focus)
@@ -1115,19 +1119,23 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
   if ( metadata->value( QStringLiteral( "status_exp" ) ) == QLatin1String( "upgradeable" ) )
   {
     buttonInstallExperimental->setText( tr( "Upgrade Experimental Plugin" ) );
+    buttonInstallExperimental->setToolTip( tr( "Upgrades selected plugin to the experimental version" ) );
   }
   else if ( metadata->value( QStringLiteral( "status_exp" ) ) == QLatin1String( "newer" ) )
   {
     buttonInstallExperimental->setText( tr( "Downgrade Experimental Plugin" ) );
+    buttonInstallExperimental->setToolTip( tr( "Downgrades selected plugin to the experimental version" ) );
   }
   else if ( metadata->value( QStringLiteral( "status_exp" ) ) == QLatin1String( "not installed" ) || metadata->value( QStringLiteral( "status" ) ) == QLatin1String( "new" ) )
   {
     buttonInstallExperimental->setText( tr( "Install Experimental Plugin" ) );
+    buttonInstallExperimental->setToolTip( tr( "Installs experimental version of the selected plugin" ) );
   }
   else
   {
     // Default (will be grayed out if not available for reinstallation)
     buttonInstallExperimental->setText( tr( "Reinstall Experimental Plugin" ) );
+    buttonInstallExperimental->setToolTip( tr( "Reinstalls experimental version of the selected plugin" ) );
   }
 
   // Enable/disable buttons
@@ -1147,9 +1155,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
 
   buttonUninstall->setEnabled( metadata->value( QStringLiteral( "pythonic" ) ).toUpper() == QLatin1String( "TRUE" ) && metadata->value( QStringLiteral( "readonly" ) ) != QLatin1String( "true" ) && ! metadata->value( QStringLiteral( "version_installed" ) ).isEmpty() );
 
-  buttonUninstall->setHidden(
-    metadata->value( QStringLiteral( "version_installed" ) ).isEmpty()
-  );
+  buttonUninstall->setHidden( metadata->value( QStringLiteral( "version_installed" ) ).isEmpty() );
 
   // Store the id of the currently displayed plugin
   mCurrentlyDisplayedPlugin = metadata->value( QStringLiteral( "id" ) );

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>875</width>
-    <height>471</height>
+    <width>887</width>
+    <height>741</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -540,6 +540,18 @@
          </widget>
          <widget class="QWidget" name="pageInstallFromZip">
           <layout class="QVBoxLayout" name="verticalLayout_14">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <spacer name="verticalSpacer_2">
              <property name="orientation">
@@ -618,7 +630,7 @@
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>ZIP file:</string>
+                <string>ZIP file</string>
                </property>
               </widget>
              </item>
@@ -732,7 +744,7 @@
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>78</height>
+               <height>0</height>
               </size>
              </property>
             </spacer>
@@ -741,6 +753,9 @@
          </widget>
          <widget class="QWidget" name="pageSettings">
           <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="spacing">
+            <number>6</number>
+           </property>
            <property name="leftMargin">
             <number>2</number>
            </property>
@@ -793,11 +808,20 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_3">
+              <property name="spacing">
+               <number>6</number>
+              </property>
               <property name="margin">
                <number>0</number>
               </property>
               <item>
                <widget class="QgsScrollArea" name="scrollArea">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -809,11 +833,14 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>460</width>
-                   <height>613</height>
+                   <width>720</width>
+                   <height>612</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                  <property name="margin">
+                   <number>0</number>
+                  </property>
                   <item>
                    <widget class="QGroupBox" name="ckbCheckUpdates">
                     <property name="enabled">
@@ -826,7 +853,7 @@
                      </sizepolicy>
                     </property>
                     <property name="title">
-                     <string>Check for updates on startup</string>
+                     <string>Check for Updates on Startup</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -836,7 +863,7 @@
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_6">
                      <property name="leftMargin">
-                      <number>6</number>
+                      <number>9</number>
                      </property>
                      <item>
                       <widget class="QComboBox" name="comboInterval">
@@ -848,32 +875,32 @@
                        </property>
                        <item>
                         <property name="text">
-                         <string>every time QGIS starts</string>
+                         <string>Every Time QGIS Starts</string>
                         </property>
                        </item>
                        <item>
                         <property name="text">
-                         <string>once a day</string>
+                         <string>Once a Day</string>
                         </property>
                        </item>
                        <item>
                         <property name="text">
-                         <string>every 3 days</string>
+                         <string>Every 3 Days</string>
                         </property>
                        </item>
                        <item>
                         <property name="text">
-                         <string>every week</string>
+                         <string>Every Week</string>
                         </property>
                        </item>
                        <item>
                         <property name="text">
-                         <string>every 2 weeks</string>
+                         <string>Every 2 Weeks</string>
                         </property>
                        </item>
                        <item>
                         <property name="text">
-                         <string>every month</string>
+                         <string>Every Month</string>
                         </property>
                        </item>
                       </widget>
@@ -881,7 +908,7 @@
                      <item>
                       <widget class="QLabel" name="lblCheckUpdates">
                        <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                          <horstretch>0</horstretch>
                          <verstretch>0</verstretch>
                         </sizepolicy>
@@ -893,11 +920,7 @@
                         </size>
                        </property>
                        <property name="text">
-                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; If this function is enabled, QGIS will inform you whenever a new plugin or plugin update is available. Otherwise, fetching repositories will be performed during opening of the Plugin Manager window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;If this function is enabled, QGIS will inform you whenever a plugin update is available.&lt;/span&gt; Otherwise, fetching repositories will be performed during opening of the Plugin Manager window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>
@@ -910,7 +933,7 @@ p, li { white-space: pre-wrap; }
                   <item>
                    <widget class="QgsCollapsibleGroupBox" name="ckbExperimental">
                     <property name="title">
-                     <string>Show also experimental plugins</string>
+                     <string>Show also Experimental Plugins</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -931,7 +954,7 @@ p, li { white-space: pre-wrap; }
                      <item>
                       <widget class="QLabel" name="lblExperimental">
                        <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                          <horstretch>0</horstretch>
                          <verstretch>0</verstretch>
                         </sizepolicy>
@@ -943,11 +966,7 @@ p, li { white-space: pre-wrap; }
                         </size>
                        </property>
                        <property name="text">
-                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Experimental plugins are generally unsuitable for production use. These plugins are in early stages of development, and should be considered 'incomplete' or 'proof of concept' tools. QGIS does not recommend installing these plugins unless you intend to use them for testing purposes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Experimental plugins are generally unsuitable for production use.&lt;/span&gt; These plugins are in early stages of development, and should be considered 'incomplete' or 'proof of concept' tools. QGIS does not recommend installing these plugins unless you intend to use them for testing purposes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="textFormat">
                         <enum>Qt::RichText</enum>
@@ -965,8 +984,14 @@ p, li { white-space: pre-wrap; }
                   </item>
                   <item>
                    <widget class="QgsCollapsibleGroupBox" name="ckbDeprecated">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="title">
-                     <string>Show also deprecated plugins</string>
+                     <string>Show also Deprecated Plugins</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -987,7 +1012,7 @@ p, li { white-space: pre-wrap; }
                      <item>
                       <widget class="QLabel" name="lblDeprecated">
                        <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                          <horstretch>0</horstretch>
                          <verstretch>0</verstretch>
                         </sizepolicy>
@@ -999,11 +1024,7 @@ p, li { white-space: pre-wrap; }
                         </size>
                        </property>
                        <property name="text">
-                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Droid Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:600;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt; Deprecated plugins are generally unsuitable for production use. These plugins are unmaintained, and should be considered 'obsolete' tools. QGIS does not recommend installing these plugins unless you still need it and there are no other alternatives available.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Deprecated plugins are generally unsuitable for production use.&lt;/span&gt; These plugins are unmaintained, and should be considered 'obsolete' tools. QGIS does not recommend installing these plugins unless you still need it and there are no other alternatives available.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="textFormat">
                         <enum>Qt::RichText</enum>
@@ -1021,6 +1042,12 @@ p, li { white-space: pre-wrap; }
                   </item>
                   <item>
                    <widget class="QGroupBox" name="groupBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="title">
                      <string>Plugin Repositories</string>
                     </property>
@@ -1082,6 +1109,10 @@ p, li { white-space: pre-wrap; }
                          <property name="text">
                           <string>Reload Repository</string>
                          </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/mActionReload.svg</normaloff>:/images/themes/default/mActionReload.svg</iconset>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -1108,6 +1139,10 @@ p, li { white-space: pre-wrap; }
                          <property name="text">
                           <string>Add…</string>
                          </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -1127,6 +1162,10 @@ p, li { white-space: pre-wrap; }
                          <property name="text">
                           <string>Edit…</string>
                          </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/symbologyEdit.svg</normaloff>:/images/themes/default/symbologyEdit.svg</iconset>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -1139,6 +1178,10 @@ p, li { white-space: pre-wrap; }
                          </property>
                          <property name="text">
                           <string>Delete</string>
+                         </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                          </property>
                         </widget>
                        </item>
@@ -1158,7 +1201,7 @@ p, li { white-space: pre-wrap; }
                     <property name="sizeHint" stdset="0">
                      <size>
                       <width>20</width>
-                      <height>40</height>
+                      <height>0</height>
                      </size>
                     </property>
                    </spacer>
@@ -1190,12 +1233,6 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
@@ -1215,6 +1252,12 @@ p, li { white-space: pre-wrap; }
    <class>QgsWebView</class>
    <extends>QWidget</extends>
    <header>qgswebview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
Updates tooltip of (re)install/update buttons to match the action they do (in various scenarios)
Harmonize the margins and spacing across the tabs and to match other QGIS dialogs
Improve text size and case
Add icons next to buttons

![Capture d’écran du 2022-09-09 03-02-26](https://user-images.githubusercontent.com/7983394/189546357-bba942bf-aed2-4f56-9d08-0025284bf398.png)