### PR TITLE
Expose WCS layer time settings in the layer properties source tab.

### DIFF
--- a/src/gui/qgsowssourcewidget.cpp
+++ b/src/gui/qgsowssourcewidget.cpp
@@ -71,16 +71,16 @@ QgsRectangle QgsOWSSourceWidget::extent() const
   return mSpatialExtentBox->outputExtent();
 }
 
-void QgsOWSSourceWidget::setTime(const QString &time)
+void QgsOWSSourceWidget::setTime( const QString &time )
 {
   int index = mTimeBox->findText( time );
   if ( index != -1 )
-     mTimeBox->setCurrentIndex(index);
+    mTimeBox->setCurrentIndex( index );
 }
 
 QString QgsOWSSourceWidget::time() const
 {
-    return mTimeBox->currentText();
+  return mTimeBox->currentText();
 }
 
 void QgsOWSSourceWidget::setSourceUri( const QString &uri )
@@ -118,11 +118,12 @@ void QgsOWSSourceWidget::setSourceUri( const QString &uri )
 
   if ( !timeList.isEmpty() )
   {
-      timeListParts = timeList.split( QStringLiteral( "," ) );
+    timeListParts = timeList.split( QStringLiteral( "," ) );
   }
 
-  for ( QString part : timeListParts ){
-      mTimeBox->addItem( part );
+  for ( QString part : timeListParts )
+  {
+    mTimeBox->addItem( part );
   }
 
   setTime( time );
@@ -151,7 +152,7 @@ QString QgsOWSSourceWidget::sourceUri() const
   QString time = mTimeBox->currentText();
 
   if ( !time.isEmpty() )
-      parts.insert( QStringLiteral( "time" ), time );
+    parts.insert( QStringLiteral( "time" ), time );
 
 
   return QgsProviderRegistry::instance()->encodeUri( mProviderKey, parts );

--- a/src/gui/qgsowssourcewidget.cpp
+++ b/src/gui/qgsowssourcewidget.cpp
@@ -125,7 +125,7 @@ void QgsOWSSourceWidget::setSourceUri( const QString &uri )
       mTimeBox->addItem( part );
   }
 
-  setTime(time);
+  setTime( time );
 
 }
 
@@ -147,6 +147,11 @@ QString QgsOWSSourceWidget::sourceUri() const
 
     parts.insert( QStringLiteral( "bbox" ), bbox );
   }
+
+  QString time = mTimeBox->currentText();
+
+  if ( !time.isEmpty() )
+      parts.insert( QStringLiteral( "time" ), time );
 
 
   return QgsProviderRegistry::instance()->encodeUri( mProviderKey, parts );

--- a/src/gui/qgsowssourcewidget.cpp
+++ b/src/gui/qgsowssourcewidget.cpp
@@ -71,6 +71,18 @@ QgsRectangle QgsOWSSourceWidget::extent() const
   return mSpatialExtentBox->outputExtent();
 }
 
+void QgsOWSSourceWidget::setTime(const QString &time)
+{
+  int index = mTimeBox->findText( time );
+  if ( index != -1 )
+     mTimeBox->setCurrentIndex(index);
+}
+
+QString QgsOWSSourceWidget::time() const
+{
+    return mTimeBox->currentText();
+}
+
 void QgsOWSSourceWidget::setSourceUri( const QString &uri )
 {
   mSourceParts = QgsProviderRegistry::instance()->decodeUri( mProviderKey, uri );
@@ -99,6 +111,22 @@ void QgsOWSSourceWidget::setSourceUri( const QString &uri )
 
   setExtent( extent );
   mSpatialExtentBox->setChecked( !extent.isNull() );
+
+  QString time = mSourceParts.value( QStringLiteral( "time" ) ).toString();
+  QString timeList = mSourceParts.value( QStringLiteral( "timeExtent" ) ).toString();
+  QStringList timeListParts;
+
+  if ( !timeList.isEmpty() )
+  {
+      timeListParts = timeList.split( QStringLiteral( "," ) );
+  }
+
+  for ( QString part : timeListParts ){
+      mTimeBox->addItem( part );
+  }
+
+  setTime(time);
+
 }
 
 QString QgsOWSSourceWidget::sourceUri() const

--- a/src/gui/qgsowssourcewidget.h
+++ b/src/gui/qgsowssourcewidget.h
@@ -60,14 +60,16 @@ class GUI_EXPORT QgsOWSSourceWidget : public QgsProviderSourceWidget, private Ui
     QgsRectangle extent() const;
 
     /**
-     * Sets time instant.
+     * Sets the current layer time instant value on
+     * the source widget time combo box.
      *
      * \since QGIS 3.28
      */
     void setTime( const QString &time );
 
     /**
-     * Retuns widget time instant.
+     * Returns the time value from the
+     * time combo box on the source widget.
      *
      * \since QGIS 3.28
      */

--- a/src/gui/qgsowssourcewidget.h
+++ b/src/gui/qgsowssourcewidget.h
@@ -59,6 +59,19 @@ class GUI_EXPORT QgsOWSSourceWidget : public QgsProviderSourceWidget, private Ui
      */
     QgsRectangle extent() const;
 
+    /**
+     * Sets time instant.
+     *
+     * \since QGIS 3.28
+     */
+    void setTime( const QString &time );
+
+    /**
+     * Retuns widget time instant.
+     *
+     * \since QGIS 3.28
+     */
+    QString time() const;
 
     void setMapCanvas( QgsMapCanvas *canvas ) override;
 

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -141,6 +141,11 @@ void QgsWCSSourceSelect::addButtonClicked()
     uri.setParam( QStringLiteral( "time" ), selectedTime() );
   }
 
+  if ( !selectedLayersTimes().isEmpty() )
+  {
+    uri.setParam( QStringLiteral( "timeExtent" ), selectedLayersTimes().join( "," ) );
+  }
+
   if ( mSpatialExtentBox->isChecked() )
   {
     const QgsRectangle spatialExtent = mSpatialExtentBox->outputExtent();

--- a/src/ui/qgsowssourcewidgetbase.ui
+++ b/src/ui/qgsowssourcewidgetbase.ui
@@ -16,20 +16,26 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QWidget" name="mWcsSettings" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Time</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="mTimeBox"/>
-        </item>
-       </layout>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Time</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="mTimeBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsowssourcewidgetbase.ui
+++ b/src/ui/qgsowssourcewidgetbase.ui
@@ -14,6 +14,18 @@
    <string>XYZ Connection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QWidget" name="mWcsSettings" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/ui/qgsowssourcewidgetbase.ui
+++ b/src/ui/qgsowssourcewidgetbase.ui
@@ -15,6 +15,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QWidget" name="mWcsSettings" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Time</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="mTimeBox"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="mSpatialExtentBoxWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
@@ -52,12 +72,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsProviderSourceWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprovidersourcewidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
@@ -67,6 +81,12 @@
    <class>QgsExtentGroupBox</class>
    <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProviderSourceWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprovidersourcewidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
These changes add the time input widgets in the WCS layer properties source widget and gives user the ability to change WCS layer time value through the layer properties dialog.

Before these changes only the spatial extent setting was exposed to the WCS layer source widget.

Look of the source widget after adding time settings widgets
![wcs_time_properties](https://user-images.githubusercontent.com/2663775/189547378-f564e3cb-d2b0-4d5e-b50c-454094f32c62.png)
