### PR TITLE
UX - Use native extent widget for QGIS server settings

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -99,6 +99,9 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mExtentGroupBox->setTitleBase( tr( "Set Project Full Extent" ) );
   mExtentGroupBox->setMapCanvas( mapCanvas, false );
 
+  mAdvertisedExtentServer->setOutputCrs( QgsProject::instance()->crs() );
+  mAdvertisedExtentServer->setMapCanvas( mapCanvas, false );
+
   mMetadataWidget = new QgsMetadataWidget();
   mMetadataPage->layout()->addWidget( mMetadataWidget );
 
@@ -106,7 +109,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   connect( pbnRemoveScale, &QToolButton::clicked, this, &QgsProjectProperties::pbnRemoveScale_clicked );
   connect( pbnImportScales, &QToolButton::clicked, this, &QgsProjectProperties::pbnImportScales_clicked );
   connect( pbnExportScales, &QToolButton::clicked, this, &QgsProjectProperties::pbnExportScales_clicked );
-  connect( pbnWMSExtCanvas, &QPushButton::clicked, this, &QgsProjectProperties::pbnWMSExtCanvas_clicked );
+  connect( grpWMSExt, &QGroupBox::toggled, this, &QgsProjectProperties::wmsExtent_toggled );
   connect( pbnWMSAddSRS, &QToolButton::clicked, this, &QgsProjectProperties::pbnWMSAddSRS_clicked );
   connect( pbnWMSRemoveSRS, &QToolButton::clicked, this, &QgsProjectProperties::pbnWMSRemoveSRS_clicked );
   connect( pbnWMSSetUsedSRS, &QPushButton::clicked, this, &QgsProjectProperties::pbnWMSSetUsedSRS_clicked );
@@ -651,19 +654,19 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   bool ok = false;
   QStringList values;
 
-  mWMSExtMinX->setValidator( new QDoubleValidator( mWMSExtMinX ) );
-  mWMSExtMinY->setValidator( new QDoubleValidator( mWMSExtMinY ) );
-  mWMSExtMaxX->setValidator( new QDoubleValidator( mWMSExtMaxX ) );
-  mWMSExtMaxY->setValidator( new QDoubleValidator( mWMSExtMaxY ) );
-
   values = QgsProject::instance()->readListEntry( QStringLiteral( "WMSExtent" ), QStringLiteral( "/" ), QStringList(), &ok );
   grpWMSExt->setChecked( ok && values.size() == 4 );
   if ( grpWMSExt->isChecked() )
   {
-    mWMSExtMinX->setText( values[0] );
-    mWMSExtMinY->setText( values[1] );
-    mWMSExtMaxX->setText( values[2] );
-    mWMSExtMaxY->setText( values[3] );
+    mAdvertisedExtentServer->setOriginalExtent(
+      QgsRectangle(
+        values[0].toDouble(),
+        values[1].toDouble(),
+        values[2].toDouble(),
+        values[3].toDouble()
+      ),
+      QgsProject::instance()->crs() );
+    mAdvertisedExtentServer->setOutputExtentFromOriginal();
   }
 
   values = QgsProject::instance()->readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList(), &ok );
@@ -1439,12 +1442,15 @@ void QgsProjectProperties::apply()
 
   if ( grpWMSExt->isChecked() )
   {
-    QgsProject::instance()->writeEntry( QStringLiteral( "WMSExtent" ), QStringLiteral( "/" ),
-                                        QStringList()
-                                        << mWMSExtMinX->text()
-                                        << mWMSExtMinY->text()
-                                        << mWMSExtMaxX->text()
-                                        << mWMSExtMaxY->text() );
+    QgsRectangle wmsExtent = mAdvertisedExtentServer->outputExtent();
+    QgsProject::instance()->writeEntry(
+      QStringLiteral( "WMSExtent" ), QStringLiteral( "/" ),
+      QStringList()
+      << qgsDoubleToString( wmsExtent.xMinimum() )
+      << qgsDoubleToString( wmsExtent.yMinimum() )
+      << qgsDoubleToString( wmsExtent.xMaximum() )
+      << qgsDoubleToString( wmsExtent.yMaximum() )
+    );
   }
   else
   {
@@ -1976,15 +1982,18 @@ void QgsProjectProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )
   }
 
   mExtentGroupBox->setOutputCrs( crs );
+  mAdvertisedExtentServer->setOutputCrs( crs );
 }
 
-void QgsProjectProperties::pbnWMSExtCanvas_clicked()
+void QgsProjectProperties::wmsExtent_toggled()
 {
-  QgsRectangle ext = mMapCanvas->extent();
-  mWMSExtMinX->setText( qgsDoubleToString( ext.xMinimum() ) );
-  mWMSExtMinY->setText( qgsDoubleToString( ext.yMinimum() ) );
-  mWMSExtMaxX->setText( qgsDoubleToString( ext.xMaximum() ) );
-  mWMSExtMaxY->setText( qgsDoubleToString( ext.yMaximum() ) );
+  if ( grpWMSExt->isChecked() )
+  {
+    if ( mAdvertisedExtentServer->outputExtent().isEmpty() )
+    {
+      mAdvertisedExtentServer->setOutputExtentFromCurrent();
+    }
+  }
 }
 
 void QgsProjectProperties::pbnWMSAddSRS_clicked()

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -105,9 +105,9 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void onGenerateTsFileButton() const;
 
     /**
-     * Set WMS default extent to current canvas extent
+     * When the group box about advertised extent has been toggled
      */
-    void pbnWMSExtCanvas_clicked();
+    void wmsExtent_toggled();
 
     /**
      *

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -651,9 +651,6 @@
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_18">
-                   
-                   
-                   
                   <item row="5" column="0">
                    <widget class="QLabel" name="label_34">
                     <property name="text">
@@ -2339,399 +2336,7 @@
                      <string>WMS capabilities</string>
                     </attribute>
                     <layout class="QGridLayout" name="gridLayout_25">
-                     <item row="6" column="0" colspan="2">
-                      <widget class="QCheckBox" name="mSegmentizeFeatureInfoGeometryCheckBox">
-                       <property name="text">
-                        <string>Segmentize feature info geometry</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="horizontalLayout_2">
-                       <item>
-                        <widget class="QLabel" name="mWMSUrlLabel">
-                         <property name="text">
-                          <string>Advertised URL</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QLineEdit" name="mWMSUrlLineEdit"/>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="4" column="0" colspan="2">
-                      <widget class="QCheckBox" name="mUseAttributeFormSettingsCheckBox">
-                       <property name="text">
-                        <string>Use attribute form settings for GetFeatureInfo response</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="14" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="mWMSDefaultMapUnitsPerMmLayout">
-                       <property name="sizeConstraint">
-                        <enum>QLayout::SetFixedSize</enum>
-                       </property>
-                       <item>
-                        <widget class="QLabel" name="mWMSDefaultMapUnitsPerMmLabel">
-                         <property name="text">
-                          <string>Default map units per mm in legend</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QgsCollapsibleGroupBox" name="grpWMSExt">
-                       <property name="title">
-                        <string>Ad&amp;vertised extent</string>
-                       </property>
-                       <property name="checkable">
-                        <bool>true</bool>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                       <property name="collapsed" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="saveCollapsedState" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_4">
-                        <item row="0" column="1">
-                         <widget class="QLineEdit" name="mWMSExtMinX">
-                          <property name="text">
-                           <string/>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QLabel" name="label_17">
-                          <property name="text">
-                           <string>Min. &amp;Y</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>mWMSExtMinY</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="5" column="0" colspan="2">
-                         <spacer name="verticalSpacer_3">
-                          <property name="orientation">
-                           <enum>Qt::Vertical</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>20</width>
-                            <height>40</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                        <item row="0" column="0">
-                         <widget class="QLabel" name="label_16">
-                          <property name="text">
-                           <string>Min. &amp;X</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>mWMSExtMinX</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="1">
-                         <widget class="QLineEdit" name="mWMSExtMinY">
-                          <property name="text">
-                           <string/>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="0">
-                         <widget class="QLabel" name="label_18">
-                          <property name="text">
-                           <string>Max. X</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>mWMSExtMaxX</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="0" colspan="2">
-                         <widget class="QPushButton" name="pbnWMSExtCanvas">
-                          <property name="text">
-                           <string>Use Current Canvas Extent</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="0">
-                         <widget class="QLabel" name="label_19">
-                          <property name="text">
-                           <string>Max. Y</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>mWMSExtMaxY</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="1">
-                         <widget class="QLineEdit" name="mWMSExtMaxY">
-                          <property name="text">
-                           <string/>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="1">
-                         <widget class="QLineEdit" name="mWMSExtMaxX">
-                          <property name="text">
-                           <string/>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
-                       <property name="title">
-                        <string>CRS restrictions</string>
-                       </property>
-                       <property name="checkable">
-                        <bool>true</bool>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                       <property name="collapsed" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="saveCollapsedState" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_5">
-                        <item row="1" column="1">
-                         <widget class="QToolButton" name="pbnWMSRemoveSRS">
-                          <property name="toolTip">
-                           <string>Remove selected CRS</string>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="../../images/images.qrc">
-                            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="0" colspan="4">
-                         <widget class="QListWidget" name="mWMSList"/>
-                        </item>
-                        <item row="1" column="2">
-                         <widget class="QPushButton" name="pbnWMSSetUsedSRS">
-                          <property name="toolTip">
-                           <string>Fetch all CRS's from layers</string>
-                          </property>
-                          <property name="text">
-                           <string>Used</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QToolButton" name="pbnWMSAddSRS">
-                          <property name="toolTip">
-                           <string>Add new CRS</string>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="../../images/images.qrc">
-                            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QgsCollapsibleGroupBox" name="mWMSPrintLayoutGroupBox">
-                       <property name="title">
-                        <string>Excl&amp;ude layouts</string>
-                       </property>
-                       <property name="checkable">
-                        <bool>true</bool>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                       <property name="collapsed" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="saveCollapsedState" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_10">
-                        <item row="0" column="0" colspan="3">
-                         <widget class="QListWidget" name="mPrintLayoutListWidget"/>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QToolButton" name="mAddWMSPrintLayoutButton">
-                          <property name="toolTip">
-                           <string>Add layout to exclude</string>
-                          </property>
-                          <property name="text">
-                           <string/>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="../../images/images.qrc">
-                            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="1">
-                         <widget class="QToolButton" name="mRemoveWMSPrintLayoutButton">
-                          <property name="toolTip">
-                           <string>Remove selected layout</string>
-                          </property>
-                          <property name="text">
-                           <string/>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="../../images/images.qrc">
-                            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="2">
-                         <spacer name="horizontalSpacer_2">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>0</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="9" column="0" colspan="2">
-                      <layout class="QGridLayout" name="gridLayout_9">
-                       <item row="1" column="1">
-                        <widget class="QLabel" name="mMaxWidthLabel_2">
-                         <property name="text">
-                          <string>Width</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <spacer name="horizontalSpacer_6">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeType">
-                          <enum>QSizePolicy::Fixed</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>6</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                       <item row="1" column="4">
-                        <widget class="QLineEdit" name="mMaxHeightLineEdit"/>
-                       </item>
-                       <item row="1" column="2">
-                        <widget class="QLineEdit" name="mMaxWidthLineEdit"/>
-                       </item>
-                       <item row="1" column="3">
-                        <widget class="QLabel" name="mMaxHeightLabel">
-                         <property name="text">
-                          <string>Height</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="0" colspan="5">
-                        <widget class="QLabel" name="label_21">
-                         <property name="text">
-                          <string>Maximum image size for GetMap and GetLegendGraphic requests</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="7" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="grpWMSPrecision">
-                       <item>
-                        <widget class="QLabel" name="label_5">
-                         <property name="text">
-                          <string>GetFeatureInfo geometry precision (decimal places)</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="mWMSPrecisionSpinBox">
-                         <property name="minimum">
-                          <number>1</number>
-                         </property>
-                         <property name="maximum">
-                          <number>17</number>
-                         </property>
-                         <property name="value">
-                          <number>8</number>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="13" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="horizontalLayout_18">
-                       <item>
-                        <widget class="QLabel" name="label_33">
-                         <property name="toolTip">
-                          <string>When using tiles set this to the size of the larger symbols to avoid cut symbols at tile boundaries. This works by drawing features that are outside the tile extent.</string>
-                         </property>
-                         <property name="text">
-                          <string>Tile buffer in pixels</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="mWMSTileBufferSpinBox">
-                         <property name="maximum">
-                          <number>1024</number>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="12" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="horizontalLayout_17">
-                       <item>
-                        <widget class="QLabel" name="mWMSMaxAtlasFeaturesLabel">
-                         <property name="text">
-                          <string>Maximum features for Atlas print requests</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
-                         <property name="maximum">
-                          <number>9999999</number>
-                         </property>
-                         <property name="value">
-                          <number>1</number>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="3" column="0" colspan="2">
-                      <widget class="QCheckBox" name="mWmsUseLayerIDs">
-                       <property name="text">
-                        <string>Use layer ids as names</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
+                     <item row="2" column="1">
                       <widget class="QgsCollapsibleGroupBox" name="mLayerRestrictionsGroupBox">
                        <property name="title">
                         <string>Exclude layers</string>
@@ -2796,7 +2401,264 @@
                        </layout>
                       </widget>
                      </item>
-                     <item row="2" column="0" colspan="2">
+                     <item row="4" column="0" colspan="2">
+                      <widget class="QCheckBox" name="mWmsUseLayerIDs">
+                       <property name="text">
+                        <string>Use layer ids as names</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="5" column="0" colspan="2">
+                      <widget class="QCheckBox" name="mUseAttributeFormSettingsCheckBox">
+                       <property name="text">
+                        <string>Use attribute form settings for GetFeatureInfo response</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="0">
+                      <widget class="QgsCollapsibleGroupBox" name="mWMSPrintLayoutGroupBox">
+                       <property name="title">
+                        <string>Excl&amp;ude layouts</string>
+                       </property>
+                       <property name="checkable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                       <property name="collapsed" stdset="0">
+                        <bool>false</bool>
+                       </property>
+                       <property name="saveCollapsedState" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                       <layout class="QGridLayout" name="gridLayout_10">
+                        <item row="0" column="0" colspan="3">
+                         <widget class="QListWidget" name="mPrintLayoutListWidget"/>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QToolButton" name="mAddWMSPrintLayoutButton">
+                          <property name="toolTip">
+                           <string>Add layout to exclude</string>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="../../images/images.qrc">
+                            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QToolButton" name="mRemoveWMSPrintLayoutButton">
+                          <property name="toolTip">
+                           <string>Remove selected layout</string>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="../../images/images.qrc">
+                            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <spacer name="horizontalSpacer_2">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item row="0" column="0" colspan="2">
+                      <widget class="QgsCollapsibleGroupBox" name="grpWMSExt">
+                       <property name="title">
+                        <string>Ad&amp;vertised extent</string>
+                       </property>
+                       <property name="checkable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                       <property name="collapsed" stdset="0">
+                        <bool>false</bool>
+                       </property>
+                       <property name="saveCollapsedState" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                       <layout class="QVBoxLayout" name="verticalLayout_29">
+                        <item>
+                         <widget class="QgsExtentWidget" name="mAdvertisedExtentServer" native="true"/>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item row="10" column="0" colspan="2">
+                      <layout class="QGridLayout" name="gridLayout_9">
+                       <item row="1" column="1">
+                        <widget class="QLabel" name="mMaxWidthLabel_2">
+                         <property name="text">
+                          <string>Width</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <spacer name="horizontalSpacer_6">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeType">
+                          <enum>QSizePolicy::Fixed</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>6</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                       <item row="1" column="4">
+                        <widget class="QLineEdit" name="mMaxHeightLineEdit"/>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QLineEdit" name="mMaxWidthLineEdit"/>
+                       </item>
+                       <item row="1" column="3">
+                        <widget class="QLabel" name="mMaxHeightLabel">
+                         <property name="text">
+                          <string>Height</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0" colspan="5">
+                        <widget class="QLabel" name="label_21">
+                         <property name="text">
+                          <string>Maximum image size for GetMap and GetLegendGraphic requests</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="13" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="horizontalLayout_17">
+                       <item>
+                        <widget class="QLabel" name="mWMSMaxAtlasFeaturesLabel">
+                         <property name="text">
+                          <string>Maximum features for Atlas print requests</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QgsSpinBox" name="mWMSMaxAtlasFeaturesSpinBox">
+                         <property name="maximum">
+                          <number>9999999</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="12" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="horizontalLayout_10">
+                       <item>
+                        <widget class="QLabel" name="mWMSImageQualityLabel">
+                         <property name="text">
+                          <string>Quality for JPEG images ( 10 : smaller image - 100 : best quality )</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QgsSpinBox" name="mWMSImageQualitySpinBox">
+                         <property name="minimum">
+                          <number>10</number>
+                         </property>
+                         <property name="maximum">
+                          <number>100</number>
+                         </property>
+                         <property name="singleStep">
+                          <number>5</number>
+                         </property>
+                         <property name="value">
+                          <number>90</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="8" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="grpWMSPrecision">
+                       <item>
+                        <widget class="QLabel" name="label_5">
+                         <property name="text">
+                          <string>GetFeatureInfo geometry precision (decimal places)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QgsSpinBox" name="mWMSPrecisionSpinBox">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>17</number>
+                         </property>
+                         <property name="value">
+                          <number>8</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="7" column="0" colspan="2">
+                      <widget class="QCheckBox" name="mSegmentizeFeatureInfoGeometryCheckBox">
+                       <property name="text">
+                        <string>Segmentize feature info geometry</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="15" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="mWMSDefaultMapUnitsPerMmLayout">
+                       <property name="sizeConstraint">
+                        <enum>QLayout::SetFixedSize</enum>
+                       </property>
+                       <item>
+                        <widget class="QLabel" name="mWMSDefaultMapUnitsPerMmLabel">
+                         <property name="text">
+                          <string>Default map units per mm in legend</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="9" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="horizontalLayout_2">
+                       <item>
+                        <widget class="QLabel" name="mWMSUrlLabel">
+                         <property name="text">
+                          <string>Advertised URL</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLineEdit" name="mWMSUrlLineEdit"/>
+                       </item>
+                      </layout>
+                     </item>
+                     <item row="3" column="0" colspan="2">
                       <widget class="QgsCollapsibleGroupBox" name="mWMSInspire">
                        <property name="title">
                         <string>INSPIRE (European directive)</string>
@@ -2928,38 +2790,101 @@
                        </layout>
                       </widget>
                      </item>
-                     <item row="11" column="0" colspan="2">
-                      <layout class="QHBoxLayout" name="horizontalLayout_10">
+                     <item row="6" column="0" colspan="2">
+                      <widget class="QCheckBox" name="mAddWktGeometryCheckBox">
+                       <property name="text">
+                        <string>Add geometry to feature response</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="14" column="0" colspan="2">
+                      <layout class="QHBoxLayout" name="horizontalLayout_18">
                        <item>
-                        <widget class="QLabel" name="mWMSImageQualityLabel">
+                        <widget class="QLabel" name="label_33">
+                         <property name="toolTip">
+                          <string>When using tiles set this to the size of the larger symbols to avoid cut symbols at tile boundaries. This works by drawing features that are outside the tile extent.</string>
+                         </property>
                          <property name="text">
-                          <string>Quality for JPEG images ( 10 : smaller image - 100 : best quality )</string>
+                          <string>Tile buffer in pixels</string>
                          </property>
                         </widget>
                        </item>
                        <item>
-                        <widget class="QgsSpinBox" name="mWMSImageQualitySpinBox">
-                         <property name="minimum">
-                          <number>10</number>
-                         </property>
+                        <widget class="QgsSpinBox" name="mWMSTileBufferSpinBox">
                          <property name="maximum">
-                          <number>100</number>
-                         </property>
-                         <property name="singleStep">
-                          <number>5</number>
-                         </property>
-                         <property name="value">
-                          <number>90</number>
+                          <number>1024</number>
                          </property>
                         </widget>
                        </item>
                       </layout>
                      </item>
-                     <item row="5" column="0" colspan="2">
-                      <widget class="QCheckBox" name="mAddWktGeometryCheckBox">
-                       <property name="text">
-                        <string>Add geometry to feature response</string>
+                     <item row="1" column="0" colspan="2">
+                      <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
+                       <property name="title">
+                        <string>CRS restrictions</string>
                        </property>
+                       <property name="checkable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                       <property name="collapsed" stdset="0">
+                        <bool>false</bool>
+                       </property>
+                       <property name="saveCollapsedState" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                       <layout class="QGridLayout" name="gridLayout_5">
+                        <item row="0" column="0" colspan="5">
+                         <widget class="QListWidget" name="mWMSList"/>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QToolButton" name="pbnWMSRemoveSRS">
+                          <property name="toolTip">
+                           <string>Remove selected CRS</string>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="../../images/images.qrc">
+                            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="3">
+                         <widget class="QPushButton" name="pbnWMSSetUsedSRS">
+                          <property name="toolTip">
+                           <string>Fetch all CRS's from layers</string>
+                          </property>
+                          <property name="text">
+                           <string>Used</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QToolButton" name="pbnWMSAddSRS">
+                          <property name="toolTip">
+                           <string>Add new CRS</string>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="../../images/images.qrc">
+                            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <spacer name="horizontalSpacer">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
                       </widget>
                      </item>
                     </layout>
@@ -3593,6 +3518,12 @@
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsExtentWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsextentwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
@@ -3677,11 +3608,6 @@
   <tabstop>mWMSAccessConstraintsCb</tabstop>
   <tabstop>mWMSKeywordList</tabstop>
   <tabstop>grpWMSExt</tabstop>
-  <tabstop>mWMSExtMinX</tabstop>
-  <tabstop>mWMSExtMinY</tabstop>
-  <tabstop>mWMSExtMaxX</tabstop>
-  <tabstop>mWMSExtMaxY</tabstop>
-  <tabstop>pbnWMSExtCanvas</tabstop>
   <tabstop>grpWMSList</tabstop>
   <tabstop>mWMSList</tabstop>
   <tabstop>pbnWMSAddSRS</tabstop>
@@ -3733,8 +3659,6 @@
   <tabstop>mCalculateFromLayerButton</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
Use the native extent widget for QGIS server settings

There was a bug before, when changing project CRS, the extent was still using the old CRS. This is fixed now with the `crsChanged()`.

I kept the same behavior about the checkbox. Extent was not saved in the project if the checkbox was not checked.

![Screenshot from 2022-09-12 16-57-03](https://user-images.githubusercontent.com/1609292/189687240-a09842dc-e495-4641-b197-1a0e553ba0bc.png)
