### PR TITLE
[plugins] Default to checking for plugin updates every 3 days instead of manually

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -228,7 +228,7 @@ class Repositories(QObject):
     def checkingOnStart(self) -> bool:
         """ return true if checking for news and updates is enabled """
         settings = QgsSettings()
-        return settings.value(settingsGroup + "/checkOnStart", False, type=bool)
+        return settings.value(settingsGroup + "/checkOnStart", True, type=bool)
 
     def setCheckingOnStart(self, state: bool):
         """ set state of checking for news and updates """
@@ -240,12 +240,12 @@ class Repositories(QObject):
         settings = QgsSettings()
         try:
             # QgsSettings may contain non-int value...
-            i = settings.value(settingsGroup + "/checkOnStartInterval", 1, type=int)
+            i = settings.value(settingsGroup + "/checkOnStartInterval", 3, type=int)
         except:
-            # fallback do 1 day by default
-            i = 1
+            # fallback to 3 days by default
+            i = 3
         if i < 0:
-            i = 1
+            i = 3
         # allowed values: 0,1,3,7,14,30 days
         interval = 0
         for j in [1, 3, 7, 14, 30]:

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -243,7 +243,7 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
   mCheckingOnStartIntervals << 0 << 1 << 3 << 7 << 14 << 30;
 
   // Initialize the "Settings" tab widgets
-  if ( settings.value( settingsGroup + "/checkOnStart", false ).toBool() )
+  if ( settings.value( settingsGroup + "/checkOnStart", true ).toBool() )
   {
     ckbCheckUpdates->setChecked( true );
   }
@@ -258,7 +258,7 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
     ckbDeprecated->setChecked( true );
   }
 
-  const int interval = settings.value( settingsGroup + "/checkOnStartInterval", "" ).toInt();
+  const int interval = settings.value( settingsGroup + "/checkOnStartInterval", "3" ).toInt();
   const int indx = mCheckingOnStartIntervals.indexOf( interval ); // if none found, just use -1 index.
   comboInterval->setCurrentIndex( indx );
 }


### PR DESCRIPTION
Too many QGIS users use outdated plugins without even realising it, leading to an overall buggier QGIS experience then they should have...

(I'd be tempted to rename the settings key to re-FORCE the new default on all users, but there's potentially enterprise deployments which have overridden this for good reason)