### PR TITLE
 Mesh 3D stacked, don't use volume height when only one level

### DIFF
--- a/src/core/mesh/qgsmesh3daveraging.cpp
+++ b/src/core/mesh/qgsmesh3daveraging.cpp
@@ -104,7 +104,20 @@ QgsMeshDataBlock QgsMesh3dAveragingMethod::calculate( const QgsMesh3dDataBlock &
                         singleVerticalIndex,
                         verticalLevelsForFace );
 
-    if ( !std::isnan( methodLevelTop ) && !std::isnan( methodLevelBottom ) )
+    if ( singleVerticalIndex != -1 )
+    {
+      int volumeIndex = singleVerticalIndex + startVolumeIndex;
+      if ( isVector )
+      {
+        valuesFaces[2 * faceIndex] = volumeValues.at( 2 * volumeIndex );
+        valuesFaces[2 * faceIndex + 1 ] = volumeValues.at( 2 * volumeIndex + 1 );
+      }
+      else
+      {
+        valuesFaces[faceIndex] = volumeValues.at( volumeIndex );
+      }
+    }
+    else if ( !std::isnan( methodLevelTop ) && !std::isnan( methodLevelBottom ) )
     {
       // the level is value below surface, so top level (-0.1m) is usually higher number than bottom level (e.g. -1.2m)
       if ( methodLevelTop < methodLevelBottom )
@@ -126,19 +139,6 @@ QgsMeshDataBlock QgsMesh3dAveragingMethod::calculate( const QgsMesh3dDataBlock &
           volumeValues,
           valuesFaces
         );
-      }
-    }
-    else if ( singleVerticalIndex != -1 )
-    {
-      int volumeIndex = singleVerticalIndex + startVolumeIndex;
-      if ( isVector )
-      {
-        valuesFaces[2 * faceIndex] = volumeValues.at( 2 * volumeIndex );
-        valuesFaces[2 * faceIndex + 1 ] = volumeValues.at( 2 * volumeIndex + 1 );
-      }
-      else
-      {
-        valuesFaces[faceIndex] = volumeValues.at( volumeIndex );
       }
     }
 

--- a/src/core/mesh/qgsmesh3daveraging.cpp
+++ b/src/core/mesh/qgsmesh3daveraging.cpp
@@ -329,7 +329,8 @@ void QgsMeshMultiLevelsAveragingMethod::volumeRangeForFace( double &startVertica
     const int startIndex = mStartVerticalLevel - 1;
     if ( mStartVerticalLevel == mEndVerticalLevel )
     {
-      singleVerticalIndex = std::clamp( startIndex, 0, verticalLevels.size() - 2 );
+      if ( startIndex >= 0 && startIndex < verticalLevels.size() - 1 )
+        singleVerticalIndex = startIndex;
     }
     else
     {
@@ -354,7 +355,8 @@ void QgsMeshMultiLevelsAveragingMethod::volumeRangeForFace( double &startVertica
     const int startIndex = volumesBelowFaceCount - mEndVerticalLevel;
     if ( mStartVerticalLevel == mEndVerticalLevel )
     {
-      singleVerticalIndex = std::clamp( startIndex, 0, verticalLevels.size() - 2 );
+      if ( startIndex >= 0 && startIndex < verticalLevels.size() - 1 )
+        singleVerticalIndex = startIndex;
     }
     else
     {

--- a/src/core/mesh/qgsmesh3daveraging.h
+++ b/src/core/mesh/qgsmesh3daveraging.h
@@ -140,6 +140,7 @@ class CORE_EXPORT QgsMesh3dAveragingMethod SIP_ABSTRACT
     virtual void volumeRangeForFace(
       double &startVerticalLevel,
       double &endVerticalLevel,
+      int &singleVerticalLevel,
       const QVector<double> &verticalLevels ) const = 0;
 
     Method mMethod;
@@ -218,6 +219,7 @@ class CORE_EXPORT QgsMeshMultiLevelsAveragingMethod: public QgsMesh3dAveragingMe
     bool hasValidInputs() const override;
     void volumeRangeForFace( double &startVerticalLevel,
                              double &endVerticalLevel,
+                             int &singleVerticalIndex,
                              const QVector<double> &verticalLevels ) const override;
     void setLevels( int startVerticalLevel, int endVerticalLevel );
     int mStartVerticalLevel = 1;
@@ -274,6 +276,7 @@ class CORE_EXPORT QgsMeshSigmaAveragingMethod: public QgsMesh3dAveragingMethod
     bool hasValidInputs() const override;
     void volumeRangeForFace( double &startVerticalLevel,
                              double &endVerticalLevel,
+                             int &singleVerticalIndex,
                              const QVector<double> &verticalLevels ) const override;
 
     double mStartFraction = 0;
@@ -341,6 +344,7 @@ class CORE_EXPORT QgsMeshRelativeHeightAveragingMethod: public QgsMesh3dAveragin
     bool hasValidInputs() const override;
     void volumeRangeForFace( double &startVerticalLevel,
                              double &endVerticalLevel,
+                             int &singleVerticalIndex,
                              const QVector<double> &verticalLevels ) const override;
     double mStartHeight = 0;
     double mEndHeight = 0;
@@ -392,6 +396,7 @@ class CORE_EXPORT QgsMeshElevationAveragingMethod: public QgsMesh3dAveragingMeth
     bool hasValidInputs() const override;
     void volumeRangeForFace( double &startVerticalLevel,
                              double &endVerticalLevel,
+                             int &singleVerticalIndex,
                              const QVector<double> &verticalLevels ) const override;
     double mStartElevation = 0;
     double mEndElevation = 0;

--- a/tests/src/core/testqgsmesh3daveraging.cpp
+++ b/tests/src/core/testqgsmesh3daveraging.cpp
@@ -163,6 +163,25 @@ void TestQgsMesh3dAveraging::testMeshSingleLevelFromTopAveragingMethod()
 
   QgsMeshMultiLevelsAveragingMethod method( level, true );
   compare( &method, expected, level >= 1 );
+
+  // Same test but with some vertical height equal to 0
+  QVector<double> verticalLevels = { -1.0, -2.0, -4.0, -4.0, -5.0,
+                                     -2.0, -2.0, -2.5, -4.0, -5.0
+                                   };
+
+  scalarBlock.setVerticalLevels( verticalLevels );
+  vectorBlock.setVerticalLevels( verticalLevels );
+
+  compare( &method, expected, level >= 1 );
+
+  verticalLevels = { -1.0, -2.0, -2.5, -4.0, -5.0,
+                     -1.0, -2.0, -2.5, -4.0, -5.0
+                   };
+
+  // Reset vertical levels
+  scalarBlock.setVerticalLevels( verticalLevels );
+  vectorBlock.setVerticalLevels( verticalLevels );
+
 }
 
 void TestQgsMesh3dAveraging::testMeshSingleLevelFromBottomAveragingMethod_data()
@@ -185,6 +204,24 @@ void TestQgsMesh3dAveraging::testMeshSingleLevelFromBottomAveragingMethod()
 
   QgsMeshMultiLevelsAveragingMethod method( level, false );
   compare( &method, expected, level >= 1 );
+
+  // Same test but with some vertical height equal to 0
+  QVector<double> verticalLevels = { -1.0, -2.0, -4.0, -4.0, -5.0,
+                                     -2.0, -2.0, -2.5, -4.0, -5.0
+                                   };
+
+  scalarBlock.setVerticalLevels( verticalLevels );
+  vectorBlock.setVerticalLevels( verticalLevels );
+
+  compare( &method, expected, level >= 1 );
+
+  verticalLevels = { -1.0, -2.0, -2.5, -4.0, -5.0,
+                     -1.0, -2.0, -2.5, -4.0, -5.0
+                   };
+
+  // Reset vertical levels
+  scalarBlock.setVerticalLevels( verticalLevels );
+  vectorBlock.setVerticalLevels( verticalLevels );
 }
 
 void TestQgsMesh3dAveraging::testMeshMultiLevelsFromTopAveragingMethod_data()


### PR DESCRIPTION
For Mesh 3D stacked rendering, even if the "Single Vertical Level" averaging method is selected, that is only one volume is concerned, QGIS use the volume height to calculate the average value in volume, in place of returning directly the volume value.

With this PR, QGIS returns directly the volume value if the "Single Vertical Level" averaging method is selected. If this is a micro-optimization, that also fixes the case where the volume height varying with time is not consistent with a non temporal dataset group, for example min/max value.