### PR TITLE
Fix OGR database connection dialog

### DIFF
--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -60,6 +60,12 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
   }
   txtName->setEnabled( true );
   cmbDatabaseTypes->setEnabled( true );
+
+  if ( !connType.isEmpty() )
+  {
+    cmbDatabaseTypes->setCurrentIndex( cmbDatabaseTypes->findText( connType ) );
+  }
+
   if ( !connName.isEmpty() )
   {
     // populate the dialog with the information stored for the connection
@@ -80,7 +86,6 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
       mAuthSettingsDatabase->setStorePasswordChecked( true );
     }
     mAuthSettingsDatabase->setConfigId( settings.value( key + "/configid" ).toString() );
-    cmbDatabaseTypes->setCurrentIndex( cmbDatabaseTypes->findText( connType ) );
     txtName->setText( connName );
     txtName->setEnabled( false );
     cmbDatabaseTypes->setEnabled( false );

--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -54,8 +54,9 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
   const QStringList dbDrivers = QgsProviderRegistry::instance()->databaseDrivers().split( ';' );
   for ( int i = 0; i < dbDrivers.count(); i++ )
   {
-    const QString dbDrive = dbDrivers.at( i );
-    cmbDatabaseTypes->addItem( dbDrive.split( ',' ).at( 0 ) );
+    const QString dbDriver = dbDrivers.at( i );
+    if ( ( !dbDriver.isEmpty() ) && ( !dbDriver.isNull() ) )
+      cmbDatabaseTypes->addItem( dbDriver.split( ',' ).at( 0 ) );
   }
   txtName->setEnabled( true );
   cmbDatabaseTypes->setEnabled( true );

--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -55,7 +55,7 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
   for ( int i = 0; i < dbDrivers.count(); i++ )
   {
     const QString dbDriver = dbDrivers.at( i );
-    if ( ( !dbDriver.isEmpty() ) && ( !dbDriver.isNull() ) )
+    if ( !dbDriver.isEmpty() )
       cmbDatabaseTypes->addItem( dbDriver.split( ',' ).at( 0 ) );
   }
   txtName->setEnabled( true );

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -170,7 +170,7 @@ bool QgsOgrSourceSelect::isProtocolCloudType()
 
 void QgsOgrSourceSelect::addNewConnection()
 {
-  QgsNewOgrConnection *nc = new QgsNewOgrConnection( this );
+  QgsNewOgrConnection *nc = new QgsNewOgrConnection( this, cmbDatabaseTypes->currentText() );
   nc->exec();
   delete nc;
 

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -78,7 +78,7 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   for ( int i = 0; i < dbDrivers.count(); i++ )
   {
     QString dbDriver = dbDrivers.at( i );
-    if ( ( !dbDriver.isEmpty() ) && ( !dbDriver.isNull() ) )
+    if ( !dbDriver.isEmpty() )
       cmbDatabaseTypes->addItem( dbDriver.split( ',' ).at( 0 ) );
   }
 
@@ -87,7 +87,7 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   for ( int i = 0; i < dirDrivers.count(); i++ )
   {
     QString dirDriver = dirDrivers.at( i );
-    if ( ( !dirDriver.isEmpty() ) && ( !dirDriver.isNull() ) )
+    if ( !dirDriver.isEmpty() )
       cmbDirectoryTypes->addItem( dirDriver.split( ',' ).at( 0 ) );
   }
 
@@ -98,7 +98,7 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   for ( int i = 0; i < protocolTypes.count(); i++ )
   {
     QString protocolType = protocolTypes.at( i );
-    if ( ( !protocolType.isEmpty() ) && ( !protocolType.isNull() ) )
+    if ( !protocolType.isEmpty() )
       cmbProtocolTypes->addItem( protocolType.split( ',' ).at( 0 ) );
   }
   cmbDatabaseTypes->blockSignals( false );

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -72,7 +72,6 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   cmbEncodings->setCurrentIndex( 0 );
 
   //add database drivers
-  mVectorFileFilter = QgsProviderRegistry::instance()->fileVectorFilters();
   QgsDebugMsgLevel( "Database drivers :" + QgsProviderRegistry::instance()->databaseDrivers(), 2 );
   QStringList dbDrivers = QgsProviderRegistry::instance()->databaseDrivers().split( ';' );
 
@@ -108,6 +107,7 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   mAuthWarning->setText( tr( " Additional credential options are required as documented <a href=\"%1\">here</a>." ).arg( QLatin1String( "http://gdal.org/gdal_virtual_file_systems.html#gdal_virtual_file_systems_network" ) ) );
 
   mFileWidget->setDialogTitle( tr( "Open OGR Supported Vector Dataset(s)" ) );
+  mVectorFileFilter = QgsProviderRegistry::instance()->fileVectorFilters();
   mFileWidget->setFilter( mVectorFileFilter );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
   mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );


### PR DESCRIPTION
## Description

Fixes the following unreported issue about the Data Source Manager -> Vector -> Database -> "New OGR Database Connection" dialog window:

- the database type combo box incorrectly contains an empty item

![image](https://user-images.githubusercontent.com/16253859/190078316-aa034508-b577-474d-9771-263dc32d3fd1.png)

- the dialog always opens with the first database type item selected, even if a different database type is selected in the Data Source Manager -> Vector -> Database dialog window before clicking on the "New" button

![image](https://user-images.githubusercontent.com/16253859/190078847-71a57d1e-26e1-43fd-9a88-fac5fe2d95de.png)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
