### PR TITLE
Fix legend icon geom generator is involved

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -125,7 +125,7 @@ Returns the symbol's type.
 %End
 
 
-    QgsSymbolLayerList symbolLayers();
+    QgsSymbolLayerList symbolLayers() const;
 %Docstring
 Returns the list of symbol layers contained in the symbol.
 
@@ -779,7 +779,6 @@ Render editing vertex marker at specified point
   private:
     QgsSymbol( const QgsSymbol & );
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -971,7 +971,7 @@ Returns -1 if the ``renderer`` is not animated.
 .. versionadded:: 3.26
 %End
 
-    static QgsSymbol *restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height );
+    static QgsSymbol *restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height, bool *ok = 0 );
 %Docstring
 Creates a new symbol with size restricted to min/max size if original size is out of min/max range
 
@@ -979,10 +979,10 @@ Creates a new symbol with size restricted to min/max size if original size is ou
 :param minSize: the minimum size in mm
 :param maxSize: the maximum size in mm
 :param context: the render context
-:param width: expected width
-:param height: expected height, can be changed by this function
-               ``width`` and ``height`` are changed to 0 if no restricted size symbol is needed, -1 if it's not possible to
-               compute a restricted size symbol (geometry generator is involved for instance).
+:param width: expected width, can be changed by the function
+:param height: expected height, can be changed by the function
+:param ok: if not None, ok is set to false if it's not possible to compute a restricted symbol (if geometry generators
+           are involved for instance)
 
 :return: None if size is within minSize/maxSize range or if it's not possible to compute a
          restricted size symbol. New symbol if size was out of min/max range.

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -979,10 +979,14 @@ Creates a new symbol with size restricted to min/max size if original size is ou
 :param minSize: the minimum size in mm
 :param maxSize: the maximum size in mm
 :param context: the render context
-:param width: expected width, can be changed by the function
+:param width: expected width
 :param height: expected height, can be changed by this function
+               ``width`` and ``height`` are changed to 0 if no restricted size symbol is needed, -1 if it's not possible to
+               compute a restricted size symbol (geometry generator is involved for instance).
 
-:return: 0 if size is within minSize/maxSize range. New symbol if size was out of min/max range. Caller takes ownership
+:return: None if size is within minSize/maxSize range or if it's not possible to compute a
+         restricted size symbol. New symbol if size was out of min/max range.
+         Caller takes ownership
 %End
 
     static QgsStringMap evaluatePropertiesMap( const QMap<QString, QgsProperty> &propertiesMap, const QgsExpressionContext &context );
@@ -994,8 +998,6 @@ Evaluates a map of properties using the given ``context`` and returns a variant 
 
 
 };
-
-
 
 
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -352,11 +352,12 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext *context ) const
     // unusued width, height variables
     double width = 0.0;
     double height = 0.0;
-    std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
+    bool ok;
+    std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height, &ok ) );
 
-    if ( width == -1 && height == -1 && context )
+    if ( !ok && context )
     {
-      // Tt's not possible to get a restricted size symbol, so we restrict
+      // It's not possible to get a restricted size symbol, so we restrict
       // pixmap target size to be sure it would fit MAXIMUM_SIZE
       maxSize = static_cast<int>( std::round( MAXIMUM_SIZE * context->scaleFactor() ) );
     }

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -347,24 +347,16 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext *context ) const
   if ( mItem.symbol() && ( mItem.symbol()->type() == Qgis::SymbolType::Marker
                            || mItem.symbol()->type() == Qgis::SymbolType::Line ) )
   {
-
-    bool hasRestrictedSizeSymbol = true;
-    for ( QgsSymbolLayer *sl : mItem.symbol()->symbolLayers() )
-      if ( dynamic_cast<QgsGeometryGeneratorSymbolLayer *>( sl ) )
-        hasRestrictedSizeSymbol = false;
-
     int maxSize = largeIconSize;
-    std::unique_ptr<QgsSymbol> symbol;
-    if ( hasRestrictedSizeSymbol )
+
+    // unusued width, height variables
+    double width = 0.0;
+    double height = 0.0;
+    std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
+
+    if ( width == -1 && height == -1 && context )
     {
-      // unusued width, height variables
-      double width = 0.0;
-      double height = 0.0;
-      symbol.reset( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
-    }
-    else if ( context )
-    {
-      // when it's not possible to get a restricted size symbol, we restrict
+      // Tt's not possible to get a restricted size symbol, so we restrict
       // pixmap target size to be sure it would fit MAXIMUM_SIZE
       maxSize = static_cast<int>( std::round( MAXIMUM_SIZE * context->scaleFactor() ) );
     }

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -37,6 +37,7 @@
 #include "qgsmarkersymbol.h"
 #include "qgsvariantutils.h"
 #include "qgslayertreelayer.h"
+#include "qgsgeometrygeneratorsymbollayer.h"
 
 #include <QBuffer>
 
@@ -343,25 +344,36 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext *context ) const
   const int iconSize = QgsLayerTreeModel::scaleIconSize( 16 );
   const int largeIconSize = QgsLayerTreeModel::scaleIconSize( 512 );
   QSize minSz( iconSize, iconSize );
-  if ( mItem.symbol() && mItem.symbol()->type() == Qgis::SymbolType::Marker )
+  if ( mItem.symbol() && ( mItem.symbol()->type() == Qgis::SymbolType::Marker
+                           || mItem.symbol()->type() == Qgis::SymbolType::Line ) )
   {
-    // unusued width, height variables
-    double width = 0.0;
-    double height = 0.0;
-    const std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
+
+    bool hasRestrictedSizeSymbol = true;
+    for ( QgsSymbolLayer *sl : mItem.symbol()->symbolLayers() )
+      if ( dynamic_cast<QgsGeometryGeneratorSymbolLayer *>( sl ) )
+        hasRestrictedSizeSymbol = false;
+
+    int maxSize = largeIconSize;
+    std::unique_ptr<QgsSymbol> symbol;
+    if ( hasRestrictedSizeSymbol )
+    {
+      // unusued width, height variables
+      double width = 0.0;
+      double height = 0.0;
+      symbol.reset( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
+    }
+    else if ( context )
+    {
+      // when it's not possible to get a restricted size symbol, we restrict
+      // pixmap target size to be sure it would fit MAXIMUM_SIZE
+      maxSize = static_cast<int>( std::round( MAXIMUM_SIZE * context->scaleFactor() ) );
+    }
+
+    const QSize size( mItem.symbol()->type() == Qgis::SymbolType::Marker ? maxSize : minSz.width(),
+                      maxSize );
+
     minSz = QgsImageOperation::nonTransparentImageRect(
-              QgsSymbolLayerUtils::symbolPreviewPixmap( symbol ? symbol.get() : mItem.symbol(), QSize( largeIconSize, largeIconSize ), 0,
-                  context ).toImage(),
-              minSz,
-              true ).size();
-  }
-  else if ( mItem.symbol() && mItem.symbol()->type() == Qgis::SymbolType::Line )
-  {
-    double width = 0.0;
-    double height = 0.0;
-    const std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context, width, height ) );
-    minSz = QgsImageOperation::nonTransparentImageRect(
-              QgsSymbolLayerUtils::symbolPreviewPixmap( symbol ? symbol.get() : mItem.symbol(), QSize( minSz.width(), largeIconSize ), 0,
+              QgsSymbolLayerUtils::symbolPreviewPixmap( symbol ? symbol.get() : mItem.symbol(), size, 0,
                   context ).toImage(),
               minSz,
               true ).size();
@@ -1564,4 +1576,3 @@ void QgsVectorLabelLegendNode::textWidthHeight( double &width, double &height, Q
   height = QgsTextRenderer::textHeight( ctx, textFormat, 'A', true );
   width = QgsTextRenderer::textWidth( ctx, textFormat, textLines, &fm );
 }
-

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -160,7 +160,7 @@ class CORE_EXPORT QgsSymbol
      * \see symbolLayerCount
      * \since QGIS 2.7
      */
-    QgsSymbolLayerList symbolLayers() { return mLayers; }
+    QgsSymbolLayerList symbolLayers() const { return mLayers; }
 
 #ifndef SIP_RUN
 
@@ -856,4 +856,3 @@ class CORE_EXPORT QgsSymbol
 };
 
 #endif
-

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -4996,14 +4996,15 @@ double QgsSymbolLayerUtils::rendererFrameRate( const QgsFeatureRenderer *rendere
   return visitor.refreshRate;
 }
 
-QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height )
+QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height, bool *ok )
 {
-  height = width = -1;
-
   if ( !s || !context )
   {
     return nullptr;
   }
+
+  if ( ok )
+    *ok = true;
 
   double size;
   const QgsMarkerSymbol *markerSymbol = dynamic_cast<const QgsMarkerSymbol *>( s );
@@ -5016,6 +5017,9 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
       // geometry generators involved, there is no way to get a restricted size symbol
       if ( sl->type() != Qgis::SymbolType::Marker )
       {
+        if ( ok )
+          *ok = false;
+
         return nullptr;
       }
     }
@@ -5028,6 +5032,9 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
   }
   else
   {
+    if ( ok )
+      *ok = false;
+
     return nullptr; //not size restriction implemented for other symbol types
   }
 
@@ -5044,7 +5051,6 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
   else
   {
     // no need to restricted size symbol
-    height = width = 0;
     return nullptr;
   }
 

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -4998,9 +4998,11 @@ double QgsSymbolLayerUtils::rendererFrameRate( const QgsFeatureRenderer *rendere
 
 QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height )
 {
+  height = width = -1;
+
   if ( !s || !context )
   {
-    return 0;
+    return nullptr;
   }
 
   double size;
@@ -5008,6 +5010,16 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
   const QgsLineSymbol *lineSymbol = dynamic_cast<const QgsLineSymbol *>( s );
   if ( markerSymbol )
   {
+    const QgsSymbolLayerList sls = s->symbolLayers();
+    for ( const QgsSymbolLayer *sl : std::as_const( sls ) )
+    {
+      // geometry generators involved, there is no way to get a restricted size symbol
+      if ( sl->type() != Qgis::SymbolType::Marker )
+      {
+        return nullptr;
+      }
+    }
+
     size = markerSymbol->size( *context );
   }
   else if ( lineSymbol )
@@ -5016,7 +5028,7 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
   }
   else
   {
-    return 0; //not size restriction implemented for other symbol types
+    return nullptr; //not size restriction implemented for other symbol types
   }
 
   size /= context->scaleFactor();
@@ -5031,7 +5043,9 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
   }
   else
   {
-    return 0;
+    // no need to restricted size symbol
+    height = width = 0;
+    return nullptr;
   }
 
   if ( markerSymbol )
@@ -5051,7 +5065,8 @@ QgsSymbol *QgsSymbolLayerUtils::restrictedSizeSymbol( const QgsSymbol *s, double
     height = size;
     return ls;
   }
-  return 0;
+
+  return nullptr;
 }
 
 QgsStringMap QgsSymbolLayerUtils::evaluatePropertiesMap( const QMap<QString, QgsProperty> &propertiesMap, const QgsExpressionContext &context )
@@ -5064,4 +5079,3 @@ QgsStringMap QgsSymbolLayerUtils::evaluatePropertiesMap( const QMap<QString, Qgs
   }
   return properties;
 }
-

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -880,9 +880,13 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \param minSize the minimum size in mm
      * \param maxSize the maximum size in mm
      * \param context the render context
-     * \param width expected width, can be changed by the function
+     * \param width expected width
      * \param height expected height, can be changed by this function
-     * \return 0 if size is within minSize/maxSize range. New symbol if size was out of min/max range. Caller takes ownership
+     * \a width and \a height are changed to 0 if no restricted size symbol is needed, -1 if it's not possible to
+     * compute a restricted size symbol (geometry generator is involved for instance).
+     * \return nullptr if size is within minSize/maxSize range or if it's not possible to compute a
+     * restricted size symbol. New symbol if size was out of min/max range.
+     * Caller takes ownership
      */
     static QgsSymbol *restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height );
 
@@ -925,5 +929,3 @@ class QPolygonF;
 QList<QPolygonF> offsetLine( QPolygonF polyline, double dist, QgsWkbTypes::GeometryType geometryType ) SIP_SKIP;
 
 #endif
-
-

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -880,15 +880,15 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \param minSize the minimum size in mm
      * \param maxSize the maximum size in mm
      * \param context the render context
-     * \param width expected width
-     * \param height expected height, can be changed by this function
-     * \a width and \a height are changed to 0 if no restricted size symbol is needed, -1 if it's not possible to
-     * compute a restricted size symbol (geometry generator is involved for instance).
+     * \param width expected width, can be changed by the function
+     * \param height expected height, can be changed by the function
+     * \param ok if not nullptr, ok is set to false if it's not possible to compute a restricted symbol (if geometry generators
+     * are involved for instance)
      * \return nullptr if size is within minSize/maxSize range or if it's not possible to compute a
      * restricted size symbol. New symbol if size was out of min/max range.
      * Caller takes ownership
      */
-    static QgsSymbol *restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height );
+    static QgsSymbol *restrictedSizeSymbol( const QgsSymbol *s, double minSize, double maxSize, QgsRenderContext *context, double &width, double &height, bool *ok = nullptr );
 
     /**
      * Evaluates a map of properties using the given \a context and returns a variant map with evaluated expressions from the properties.


### PR DESCRIPTION
Fixes #33755

When geometry generator is involved we cannot get a valid *restrictedSymbolSize*, and so when the generated geometry is too big the displayed icon has a 512x512 size (largeIconSize maximum). 

I propose to have a special case when geometry generator is involved and to limit the total size of the icon to the settings legendsymbolMaximumSize. 

The result gives this for instance with a buffer($geometry,200) on point
![withscaleFalse](https://user-images.githubusercontent.com/14358135/190191893-03a5e10d-6630-4ed7-b6e7-5f69c38f2c51.png)

Note that the generated buffered circle exceed bounds and is not scaled to the icon size. But it seems to be the [intented behavior](https://github.com/qgis/QGIS/blob/master/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp#L262) 

**Sponsored by Metropole de Lille** cc @Jean-Roc 
