### PR TITLE
Added GNSS constellation abbreviation

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -365,8 +365,6 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  char type;
-
   nsen = nmea_scanf( buff, buff_sz,
                      "$G%CGSV,%d,%d,%d,"
                      "%d,%d,%d,%d,"
@@ -383,7 +381,6 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
   nsat = ( pack->pack_index - 1 ) * NMEA_SATINPACK;
   nsat = ( nsat + NMEA_SATINPACK > pack->sat_count ) ? pack->sat_count - nsat : NMEA_SATINPACK;
   nsat = nsat * 4 + 3 /* first three sentence`s */;
-  type = pack->pack_type;
 
   if ( nsen - 1 < nsat || nsen - 1 > ( NMEA_SATINPACK * 4 + 3 ) )
   {
@@ -391,7 +388,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
     return 0;
   }
 
-  if ( type != 'P' && type != 'N' && type != 'L' && type != 'A' && type != 'B' && type != 'Q' )
+  if ( pack->pack_type != 'P' && pack->pack_type != 'N' && pack->pack_type != 'L' && pack->pack_type != 'A' && pack->pack_type != 'B' && pack->pack_type != 'Q' )
   {
     nmea_error( "G?GSV invalid type " );
     return 0;

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -373,7 +373,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
                      "%d,%d,%d,%d,"
                      "%d,%d,%d,%d,"
                      "%d,%d,%d,%d*",
-                     &( type ),
+                     &( pack->pack_type ),
                      &( pack->pack_count ), &( pack->pack_index ), &( pack->sat_count ),
                      &( pack->sat_data[0].id ), &( pack->sat_data[0].elv ), &( pack->sat_data[0].azimuth ), &( pack->sat_data[0].sig ),
                      &( pack->sat_data[1].id ), &( pack->sat_data[1].elv ), &( pack->sat_data[1].azimuth ), &( pack->sat_data[1].sig ),
@@ -383,6 +383,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
   nsat = ( pack->pack_index - 1 ) * NMEA_SATINPACK;
   nsat = ( nsat + NMEA_SATINPACK > pack->sat_count ) ? pack->sat_count - nsat : NMEA_SATINPACK;
   nsat = nsat * 4 + 3 /* first three sentence`s */;
+  type = pack->pack_type;
 
   if ( nsen - 1 < nsat || nsen - 1 > ( NMEA_SATINPACK * 4 + 3 ) )
   {

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -96,6 +96,7 @@ typedef struct _nmeaGPGSV
   int     pack_count; //!< Total number of messages of this type in this cycle
   int     pack_index; //!< Message number
   int     sat_count;  //!< Total number of satellites in view
+  char    pack_type;  //!< P=GPS - S=SBas - N=generic - L=GLONAS - A=GALILEO - B=BEIDOU - Q=QZSS
   nmeaSATELLITE sat_data[NMEA_SATINPACK];
 
 } nmeaGPGSV;

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -38,6 +38,8 @@ Encapsulates information relating to a GPS satellite.
 
     int signal;
 
+    QChar satType;
+
     bool operator==( const QgsSatelliteInfo &other ) const;
 
     bool operator!=( const QgsSatelliteInfo &other ) const;

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -88,6 +88,7 @@ class CORE_EXPORT QgsSatelliteInfo
      * Signal strength (0-99dB), or -1 if not available.
      */
     int signal = -1;
+
     /**
      * satType value from NMEA message $GxGSV, where x:
      * P = GPS; S = SBAS (GPSid> 32 then SBasid = GPSid + 87); N = generic satellite; L = GLONASS; A = GALILEO; B = BEIDOU; Q = QZSS;

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -88,6 +88,18 @@ class CORE_EXPORT QgsSatelliteInfo
      * Signal strength (0-99dB), or -1 if not available.
      */
     int signal = -1;
+  
+    /**
+     * satType value from NMEA message $GxGSV, where x:
+     * P = GPS
+     * S = SBAS (GPSid> 32 -> SBasid = GPSid + 87)
+     * N = generic satellite
+     * L = GLONASS
+     * A = GALILEO
+     * B = BEIDOU
+     * Q = QZSS
+     */
+    QChar satType;
 
     bool operator==( const QgsSatelliteInfo &other ) const
     {
@@ -95,7 +107,8 @@ class CORE_EXPORT QgsSatelliteInfo
              inUse == other.inUse &&
              elevation == other.elevation &&
              azimuth == other.azimuth &&
-             signal == other.signal;
+             signal == other.signal &&
+             satType == other.satType;
     }
 
     bool operator!=( const QgsSatelliteInfo &other ) const

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -90,13 +90,7 @@ class CORE_EXPORT QgsSatelliteInfo
     int signal = -1;
     /**
      * satType value from NMEA message $GxGSV, where x:
-     * P = GPS
-     * S = SBAS (GPSid> 32 -> SBasid = GPSid + 87)
-     * N = generic satellite
-     * L = GLONASS
-     * A = GALILEO
-     * B = BEIDOU
-     * Q = QZSS
+     * P = GPS; S = SBAS (GPSid> 32 then SBasid = GPSid + 87); N = generic satellite; L = GLONASS; A = GALILEO; B = BEIDOU; Q = QZSS;
      */
     QChar satType;
 

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -88,7 +88,6 @@ class CORE_EXPORT QgsSatelliteInfo
      * Signal strength (0-99dB), or -1 if not available.
      */
     int signal = -1;
-  
     /**
      * satType value from NMEA message $GxGSV, where x:
      * P = GPS

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -370,6 +370,13 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
       satelliteInfo.id = currentSatellite.id;
       satelliteInfo.inUse = 0;
       satelliteInfo.signal = currentSatellite.sig;
+      satelliteInfo.satType = result.pack_type;
+      if ( satelliteInfo.satType == 'P' && satelliteInfo.id > 32 )
+      {
+        satelliteInfo.satType = 'S';
+        satelliteInfo.id = currentSatellite.id + 87;
+      }
+
       IDfind = 0;
       if ( mLastGPSInformation.satellitesInView.size() > NMEA_SATINPACK )
       {


### PR DESCRIPTION
Value obtained from NMEA message $G**x**GSV, **where x**:
P = GPS
S = SBAS (GPSid> 32 -> SBasid = GPSid + 87)
N = generic satellite
L = GLONASS
A = GALILEO
B = BEIDOU
Q = QZSS

It can be used in src/app/gps/qgsgpsinformationwidget.cpp to color the various GNSS constellations in a different way.
For example:
https://receiverhelp.trimble.com/r750-gnss/satTrackingPlot.html?Highlight=skyplot.

It becomes easy to count the satellites in use for each GNSS constellation.
(I'm thinking of using it with QField, in a GNSS survey report)
@nyalldawson  if you also enable the Skyplot in the GPS Tools (WITH_QWTPOLAR true), I would have other changes to propose!!
Thank you
