### PR TITLE
Move plugins "automatically check for updates" settings key to a new key, ensure all users get this default behaviour now

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -41,6 +41,7 @@ import re
 import configparser
 import qgis.utils
 from qgis.core import QgsNetworkAccessManager, QgsApplication
+from qgis.gui import QgsGui
 from qgis.utils import iface, plugin_paths
 from .version_compare import pyQgisVersion, compareVersions, normalizeVersion, isCompatible
 
@@ -229,13 +230,11 @@ class Repositories(QObject):
 
     def checkingOnStart(self) -> bool:
         """ return true if checking for news and updates is enabled """
-        settings = QgsSettings()
-        return settings.value(settingsGroup + "/checkOnStart", True, type=bool)
+        return QgsGui.settingsRegistryGui().settingsEntry('plugins/automatically-check-for-updates').value()
 
     def setCheckingOnStart(self, state: bool):
         """ set state of checking for news and updates """
-        settings = QgsSettings()
-        settings.setValue(settingsGroup + "/checkOnStart", state)
+        QgsGui.settingsRegistryGui().settingsEntry('plugins/automatically-check-for-updates').setValue(state)
 
     def saveCheckingOnStartLastDate(self):
         """ set today's date as the day of last checking  """

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -172,6 +172,8 @@ class Repositories(QObject):
     STATE_UNAVAILABLE = 3
     STATE_REJECTED = 4
 
+    CHECK_ON_START_INTERVAL = 3
+
     anythingChanged = pyqtSignal(str, int, int)
     repositoryFetched = pyqtSignal(str)
     checkingDone = pyqtSignal()
@@ -235,29 +237,6 @@ class Repositories(QObject):
         settings = QgsSettings()
         settings.setValue(settingsGroup + "/checkOnStart", state)
 
-    def checkingOnStartInterval(self) -> int:
-        """ return checking for news and updates interval (in days)"""
-        settings = QgsSettings()
-        try:
-            # QgsSettings may contain non-int value...
-            i = settings.value(settingsGroup + "/checkOnStartInterval", 3, type=int)
-        except:
-            # fallback to 3 days by default
-            i = 3
-        if i < 0:
-            i = 3
-        # allowed values: 0,1,3,7,14,30 days
-        interval = 0
-        for j in [1, 3, 7, 14, 30]:
-            if i >= j:
-                interval = j
-        return interval
-
-    def setCheckingOnStartInterval(self, interval: int):
-        """ set checking for news and updates interval (in days)"""
-        settings = QgsSettings()
-        settings.setValue(settingsGroup + "/checkOnStartInterval", interval)
-
     def saveCheckingOnStartLastDate(self):
         """ set today's date as the day of last checking  """
         settings = QgsSettings()
@@ -265,15 +244,13 @@ class Repositories(QObject):
 
     def timeForChecking(self) -> bool:
         """ determine whether it's the time for checking for news and updates now """
-        if self.checkingOnStartInterval() == 0:
-            return True
         settings = QgsSettings()
         try:
             # QgsSettings may contain ivalid value...
             interval = settings.value(settingsGroup + "/checkOnStartLastDate", type=QDate).daysTo(QDate.currentDate())
         except:
             interval = 0
-        if interval >= self.checkingOnStartInterval():
+        if interval >= Repositories.CHECK_ON_START_INTERVAL:
             return True
         else:
             return False

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -48,6 +48,8 @@
 #include "qgslogger.h"
 #include "qgspluginitemdelegate.h"
 #include "qgssettings.h"
+#include "qgsgui.h"
+#include "qgssettingsregistrygui.h"
 #ifdef WITH_BINDINGS
 #include "qgspythonutils.h"
 #endif
@@ -239,7 +241,7 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
   connect( buttonInstallFromZip, &QPushButton::clicked, this, &QgsPluginManager::buttonInstallFromZip_clicked );
 
   // Initialize the "Settings" tab widgets
-  if ( settings.value( settingsGroup + "/checkOnStart", true ).toBool() )
+  if ( QgsSettingsRegistryGui::settingsAutomaticallyCheckForPluginUpdates.value() )
   {
     ckbCheckUpdates->setChecked( true );
   }
@@ -1286,8 +1288,7 @@ void QgsPluginManager::reject()
     // get the QgsSettings group from the installer
     QString settingsGroup;
     QgsPythonRunner::eval( QStringLiteral( "pyplugin_installer.instance().exportSettingsGroup()" ), settingsGroup );
-    QgsSettings settings;
-    settings.setValue( settingsGroup + "/checkOnStart", QVariant( ckbCheckUpdates->isChecked() ) );
+    QgsSettingsRegistryGui::settingsAutomaticallyCheckForPluginUpdates.setValue( ckbCheckUpdates->isChecked() );
     QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().onManagerClose()" ) );
   }
 #endif

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -32,13 +32,12 @@
 #include <QDesktopServices>
 #include <QRegularExpression>
 #include <QUrl>
+#include <QCheckBox>
 
 #include "qgsmessagelog.h"
 
 #include "qgis.h"
-#include "qgisapp.h"
 #include "qgsapplication.h"
-#include "qgsconfig.h"
 #include "qgsmessagebar.h"
 #include "qgsproviderregistry.h"
 #include "qgspluginregistry.h"
@@ -239,9 +238,6 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
   connect( mZipFileWidget, &QgsFileWidget::fileChanged, this, &QgsPluginManager::mZipFileWidget_fileChanged );
   connect( buttonInstallFromZip, &QPushButton::clicked, this, &QgsPluginManager::buttonInstallFromZip_clicked );
 
-  // Initialize list of allowed checking intervals
-  mCheckingOnStartIntervals << 0 << 1 << 3 << 7 << 14 << 30;
-
   // Initialize the "Settings" tab widgets
   if ( settings.value( settingsGroup + "/checkOnStart", true ).toBool() )
   {
@@ -257,13 +253,7 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
   {
     ckbDeprecated->setChecked( true );
   }
-
-  const int interval = settings.value( settingsGroup + "/checkOnStartInterval", "3" ).toInt();
-  const int indx = mCheckingOnStartIntervals.indexOf( interval ); // if none found, just use -1 index.
-  comboInterval->setCurrentIndex( indx );
 }
-
-
 
 void QgsPluginManager::loadPlugin( const QString &id )
 {
@@ -1298,7 +1288,6 @@ void QgsPluginManager::reject()
     QgsPythonRunner::eval( QStringLiteral( "pyplugin_installer.instance().exportSettingsGroup()" ), settingsGroup );
     QgsSettings settings;
     settings.setValue( settingsGroup + "/checkOnStart", QVariant( ckbCheckUpdates->isChecked() ) );
-    settings.setValue( settingsGroup + "/checkOnStartInterval", QVariant( mCheckingOnStartIntervals.value( comboInterval->currentIndex() ) ) );
     QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().onManagerClose()" ) );
   }
 #endif

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -236,8 +236,6 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
 
     QString mCurrentlyDisplayedPlugin;
 
-    QList<int> mCheckingOnStartIntervals;
-
     QgsMessageBar *msgBar = nullptr;
 
 #ifndef WITH_QTWEBKIT

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -23,6 +23,7 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
   addSettingsEntry( &settingsRespectScreenDPI );
+  addSettingsEntry( &settingsAutomaticallyCheckForPluginUpdates );
   addSettingsEntry( &QgsStyleManagerDialog::settingLastStyleDatabaseFolder );
 
   QgsApplication::settingsRegistryCore()->addSubRegistry( this );

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -47,6 +47,10 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
 #ifndef SIP_RUN
     //! Settings entry respect screen dpi
     static const inline QgsSettingsEntryBool settingsRespectScreenDPI = QgsSettingsEntryBool( QStringLiteral( "respect_screen_dpi" ), QgsSettings::Prefix::GUI_QGIS, false );
+
+    //! Check for plugin updates automatically on startup
+    static const inline QgsSettingsEntryBool settingsAutomaticallyCheckForPluginUpdates = QgsSettingsEntryBool( QStringLiteral( "automatically-check-for-updates" ), QgsSettings::Prefix::PLUGINS, true, QStringLiteral( "Automatically check for plugin updates on startup" ) );
+
 #endif
 
 };

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -60,7 +60,7 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="margin" stdset="0">
         <number>0</number>
        </property>
        <item>
@@ -236,7 +236,7 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <property name="margin">
+       <property name="margin" stdset="0">
         <number>0</number>
        </property>
        <item>
@@ -355,7 +355,7 @@
                   <enum>QFrame::Sunken</enum>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_12">
-                  <property name="margin">
+                  <property name="margin" stdset="0">
                    <number>0</number>
                   </property>
                   <item>
@@ -368,7 +368,7 @@
                     </property>
                     <property name="url" stdset="0">
                      <url>
-                      <string notr="true">about:blank</string>
+                      <string>about:blank</string>
                      </url>
                     </property>
                    </widget>
@@ -811,7 +811,7 @@
               <property name="spacing">
                <number>6</number>
               </property>
-              <property name="margin">
+              <property name="margin" stdset="0">
                <number>0</number>
               </property>
               <item>
@@ -834,11 +834,11 @@
                    <x>0</x>
                    <y>0</y>
                    <width>720</width>
-                   <height>612</height>
+                   <height>609</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">
-                  <property name="margin">
+                  <property name="margin" stdset="0">
                    <number>0</number>
                   </property>
                   <item>
@@ -865,46 +865,6 @@
                      <property name="leftMargin">
                       <number>9</number>
                      </property>
-                     <item>
-                      <widget class="QComboBox" name="comboInterval">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <item>
-                        <property name="text">
-                         <string>Every Time QGIS Starts</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Once a Day</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Every 3 Days</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Every Week</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Every 2 Weeks</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Every Month</string>
-                        </property>
-                       </item>
-                      </widget>
-                     </item>
                      <item>
                       <widget class="QLabel" name="lblCheckUpdates">
                        <property name="sizePolicy">
@@ -1271,6 +1231,7 @@
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -1232,7 +1232,6 @@
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
  </resources>
  <connections>
   <connection>


### PR DESCRIPTION
This change moves the old "app/plugin_installer/checkOnStart" setting key to a new "plugins/automatically-check-for-updates" key, and switches the default value to enable automatic checks

This is designed to switch all existing QGIS users to the new default behavior of checking for plugin updates at startup (at
a maximum of once every 3 days).

It is intended to offer a better QGIS experience to our users, by proactively informing all users when plugins should be
updated, ensuring that ALL users are more likely to upgrade plugins and get the bug fixes for plugins promptly.

**Enterprise users who have customised this setting in their deployments will need to adapt their scripts for the new setting key.**

Additionally, the option to control the number of days between plugin startup checks has been removed and is hardcoded at 3 days.