### PR TITLE
fix ARMv7 build

### DIFF
--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsWkbPtr
     inline const QgsWkbPtr &operator>>( double &v ) const { read( v ); return *this; } SIP_SKIP
     inline const QgsWkbPtr &operator>>( float &r ) const { double v; read( v ); r = v; return *this; } SIP_SKIP
     inline const QgsWkbPtr &operator>>( int &v ) const { read( v ); return *this; } SIP_SKIP
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if !defined(Q_OS_ANDROID) || ( defined(Q_OS_ANDROID) && defined(__aarch64__))
     //! Reads an integer value into a qsizetype
     inline const QgsWkbPtr &operator>>( qsizetype &r ) const { int v; read( v ); r = v; return *this; } SIP_SKIP
 #endif
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsWkbPtr
     inline QgsWkbPtr &operator<<( float r ) { double v = r; write( v ); return *this; } SIP_SKIP
     //! Writes an int to the pointer
     inline QgsWkbPtr &operator<<( int v ) { write( v ); return *this; } SIP_SKIP
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if !defined(Q_OS_ANDROID) || ( defined(Q_OS_ANDROID) && defined(__aarch64__))
     //! Writes a size as int to the pointer
     inline QgsWkbPtr &operator<<( qsizetype r ) { int v = r; write( v ); return *this; } SIP_SKIP
 #endif


### PR DESCRIPTION
The change done in https://github.com/qgis/QGIS/pull/43215 is not related to QT6 (the type was introduced in qt 5.10). , but we do not build 32b win anymore. Now ARMv7 doesn't build with Qt6.

Q_PROCESSOR_ARM_V7 cannot be used since it is true on both aarch64 and arm_v7. 

related to https://github.com/MerginMaps/input/issues/2257
see https://developer.android.com/google/play/requirements/64-bit