### PR TITLE
make_valid - Add an example of unclosed polygon

### DIFF
--- a/resources/function_help/json/make_valid
+++ b/resources/function_help/json/make_valid
@@ -27,8 +27,11 @@
     "expression": "geom_to_wkt(make_valid(geom_from_wkt('POLYGON((3 2, 4 1, 5 8, 3 2, 4 2))'), 'linework'))",
     "returns": "'GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'"
   }, {
+    "expression": "geom_to_wkt(make_valid(geom_from_wkt('POLYGON((3 2, 4 1, 5 8))'), method:='linework'))",
+    "returns": "'Polygon ((3 2, 4 1, 5 8, 3 2))'"
+  }, {
     "expression": "make_valid(geom_from_wkt('LINESTRING(0 0)'))",
-    "returns": " &lt;empty geometry&gt;"
+    "returns": "An empty geometry"
   }],
   "tags": ["rules", "valid", "ogc", "according", "formed", "repair", "fix"]
 }


### PR DESCRIPTION
 and reedit empty geometry example. The idea is to avoid last example at https://docs.qgis.org/testing/en/docs/user_manual/expressions/functions_list.html#make-valid (A clean fix in the docs would need a deeper rework of methods to format the returns values, not worthy IMHO)
 
![image](https://user-images.githubusercontent.com/7983394/190354984-93d3c277-27a7-48f0-aa8d-5c182e95a38e.png)

Also, if someone has examples involving the keep_collapsed argument, it could be nice to show them.
