### PR TITLE
Remove some SIP_SKIP for QgsMeshLayer and related class

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -13,11 +13,16 @@
 
 
 
+
 typedef QgsPoint QgsMeshVertex;
 
 typedef QVector<int> QgsMeshFace;
 
 typedef QPair<int, int> QgsMeshEdge;
+
+typedef QVector<QgsPoint> QgsMeshVertices;
+typedef QVector<QVector<int>> QgsMeshFaces;
+typedef QVector<QPair<int, int>> QgsMeshEdges;
 
 struct QgsMesh
 {
@@ -81,6 +86,28 @@ Compare two faces, return ``True`` if they are equivalent : same indexes and sam
 
 .. versionadded:: 3.16
 %End
+
+  void setVertices(const QgsMeshVertices& vertices);
+%Docstring
+Define mesh vertices
+
+.. versionadded:: 3.16
+%End
+  
+  void setFaces(const  QgsMeshFaces & faces);
+%Docstring
+Define mesh faces
+
+.. versionadded:: 3.16
+%End
+
+  void setEdges(const  QgsMeshEdges & edges);
+%Docstring
+Define mesh edges
+
+.. versionadded:: 3.16
+%End
+
 
 };
 

--- a/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
@@ -56,8 +56,34 @@ Returns invalid dataset index if ``timeSinceGlobalReference`` is outside the tim
    for non temporal dataset group, ``timeSinceGlobalReference`` is not used and the unique dataset is returned
 %End
 
+    void addGroupReferenceDateTime( int group, const QDateTime &reference );
+%Docstring
+Adds a ``reference`` date/time from a dataset ``group``
 
+.. note::
 
+   must be used only by the mesh data provider
+%End
+
+    void addDatasetTimeInMilliseconds( int group, qint64 time );
+%Docstring
+Adds a ``time`` (in milliseconds) from a dataset contained in ``group``
+
+.. note::
+
+   must be used only by the mesh data provider,
+   all dataset need to be added one after one
+%End
+
+    void addDatasetTime( int group, double  time );
+%Docstring
+Adds a ``time`` (in provider unit) from a dataset contained in ``group``
+
+.. note::
+
+   must be used only by the mesh data provider,
+   all dataset need to be added one after one
+%End
 
     bool hasReferenceTime() const;
 %Docstring

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -211,6 +211,10 @@ Saves datasets group on file with the specified ``driver``
 .. versionadded:: 3.16
 %End
 
+    QgsMesh *nativeMesh();
+%Docstring
+Returns native mesh (``None`` before rendering or calling to updateMesh)
+%End
 
 
 

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -5,6 +5,8 @@ which are not wrapped by PyQt:
 - QVector< QVector< QVector<TYPE> > >
 - QList< QList<TYPE> >
 - QList<qint64>
+- QVector<QVector<int>>
+- QVector<QPair<int, int>>
 - QSet<int>
 - QSet<qint64>
 - QSet<TYPE>
@@ -348,6 +350,124 @@ template <TYPE>
   }
 
   *sipCppPtr = ql;
+  return sipGetState(sipTransferObj);
+%End
+};
+
+
+%MappedType QVector<QPair<int, int>>
+{
+%TypeHeaderCode
+#include <QVector>
+#include <QPair>
+%End
+
+%ConvertFromTypeCode
+  // Create the list.
+  PyObject *l;
+
+  if ((l = PyList_New(sipCpp->size())) == NULL)
+    return NULL;
+
+  // Set the list elements.
+  for (int i = 0; i < sipCpp->size(); ++i)
+  {
+    PyObject *tobj;
+    if ( ( tobj = PyTuple_New( 2 ) ) == NULL )
+    {
+      return NULL;
+    }
+
+    // build key
+    PyObject *t1obj = PyLong_FromLong(sipCpp->at(i).first);
+    PyTuple_SetItem( tobj, 0, t1obj );
+    PyObject *t2obj = PyLong_FromLong(sipCpp->at(i).second);
+    PyTuple_SetItem( tobj, 1, t2obj );
+
+    PyList_SET_ITEM(l, i, tobj);
+  }
+
+  return l;
+%End
+
+%ConvertToTypeCode
+  // Check the type if that is all that is required.
+  if (sipIsErr == NULL)
+    return PyList_Check(sipPy);
+
+  QVector<QPair<int,int>> * qvector = new QVector<QPair<int,int>>;
+
+  for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
+  {
+    PyObject *t1obj        = PyList_GET_ITEM(sipPy, i);
+    PyObject *sipKeyFirst  = PyTuple_GetItem( t1obj, 0 );
+    PyObject *sipKeySecond = PyTuple_GetItem( t1obj, 1 );
+
+    *qvector << QPair<int,int>(PyLong_AsLong(sipKeyFirst), PyLong_AsLong(sipKeySecond));
+  }
+
+  *sipCppPtr = qvector;
+  return sipGetState(sipTransferObj);
+%End
+};
+
+
+%MappedType QVector<QVector<int>>
+{
+%TypeHeaderCode
+#include <QVector>
+%End
+
+%ConvertFromTypeCode
+  // Create the list.
+  PyObject *l;
+
+  if ((l = PyList_New(sipCpp->size())) == NULL)
+    return NULL;
+
+  // Set the list elements.
+  for (int i = 0; i < sipCpp->size(); ++i)
+  {
+    // Create the list.
+    PyObject *l2;
+    if ((l2 = PyList_New(sipCpp->at(i).size())) == NULL)
+      return NULL;
+
+      for (int j =0; j < sipCpp->at(i).size(); ++j)
+      {
+        PyObject *tobj;
+
+        if ((tobj = PyLong_FromLong(sipCpp->at(i).at(j))) == NULL)
+        {
+          Py_DECREF(l);
+          return NULL;
+        }
+        PyList_SET_ITEM(l2, j, tobj);
+      }
+    PyList_SET_ITEM(l, i, l2);
+  }
+
+  return l;
+%End
+
+%ConvertToTypeCode
+  // Check the type if that is all that is required.
+  if (sipIsErr == NULL)
+    return PyList_Check(sipPy);
+
+  QVector<QVector<int>> * qvector = new QVector<QVector<int>>;
+
+  for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
+  {
+    QVector<int> l2 = QVector<int>();
+    for (int j = 0; j < PyList_GET_SIZE(PyList_GET_ITEM(sipPy, i)); j++)
+    {
+      l2 << PyLong_AsLong(PyList_GET_ITEM(PyList_GET_ITEM(sipPy, i), j));
+    }
+    *qvector << l2;
+  }
+
+  *sipCppPtr = qvector;
   return sipGetState(sipTransferObj);
 %End
 };

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -212,6 +212,21 @@ int QgsMesh::edgeCount() const
   return edges.size();
 }
 
+void QgsMesh::setVertices(const QgsMeshVertices& _vertices)
+{
+  vertices=_vertices;
+}
+
+void QgsMesh::setFaces(const  QgsMeshFaces & _faces)
+{
+  faces=_faces;
+}
+
+void QgsMesh::setEdges(const  QgsMeshEdges & _edges)
+{
+  edges=_edges;
+}
+
 bool QgsMeshDataSourceInterface::contains( const QgsMesh::ElementType &type ) const
 {
   switch ( type )

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -26,6 +26,7 @@
 #include <limits>
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 #include "qgspoint.h"
 #include "qgsdataprovider.h"
 #include "qgsprovidermetadata.h"
@@ -34,6 +35,7 @@
 
 
 class QgsRectangle;
+
 
 //! xyz coords of vertex
 typedef QgsPoint QgsMeshVertex;
@@ -47,6 +49,17 @@ typedef QVector<int> QgsMeshFace;
  * \since QGIS 3.14
  */
 typedef QPair<int, int> QgsMeshEdge;
+
+// To avoid too many conversion in python/core/conversions.sip use specific typedef for python bindings
+#ifndef SIP_RUN
+typedef QVector<QgsMeshVertex> QgsMeshVertices;
+typedef QVector<QgsMeshFace> QgsMeshFaces;
+typedef QVector<QgsMeshEdge> QgsMeshEdges;
+#else
+typedef QVector<QgsPoint> QgsMeshVertices;
+typedef QVector<QVector<int>> QgsMeshFaces;
+typedef QVector<QPair<int, int>> QgsMeshEdges;
+#endif
 
 /**
  * \ingroup core
@@ -109,9 +122,29 @@ struct CORE_EXPORT QgsMesh
    */
   static bool compareFaces( const QgsMeshFace &face1, const QgsMeshFace &face2 );
 
-  QVector<QgsMeshVertex> vertices SIP_SKIP;
-  QVector<QgsMeshEdge> edges SIP_SKIP;
-  QVector<QgsMeshFace> faces SIP_SKIP;
+  /**
+   * Define mesh vertices
+    * \since QGIS 3.16
+   */
+  void setVertices(const QgsMeshVertices& vertices);
+  
+  /**
+   * Define mesh faces
+    * \since QGIS 3.16
+   */
+  void setFaces(const  QgsMeshFaces & faces);
+
+  /**
+   * Define mesh edges
+    * \since QGIS 3.16
+   */
+  void setEdges(const  QgsMeshEdges & edges);
+
+
+  QgsMeshVertices vertices; SIP_SKIP
+  QgsMeshEdges edges; SIP_SKIP
+  QgsMeshFaces faces; SIP_SKIP
+
 };
 
 /**

--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
      *
      * \note must be used only by the mesh data provider
      */
-    void addGroupReferenceDateTime( int group, const QDateTime &reference ) SIP_SKIP;
+    void addGroupReferenceDateTime( int group, const QDateTime &reference );
 
     /**
      * Adds a \a time (in milliseconds) from a dataset contained in \a group
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
      * \note must be used only by the mesh data provider,
      * all dataset need to be added one after one
      */
-    void addDatasetTimeInMilliseconds( int group, qint64 time ) SIP_SKIP;
+    void addDatasetTimeInMilliseconds( int group, qint64 time );
 
     /**
      * Adds a \a time (in provider unit) from a dataset contained in \a group
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsMeshDataProviderTemporalCapabilities: public QgsDataProvide
      * \note must be used only by the mesh data provider,
      * all dataset need to be added one after one
      */
-    void addDatasetTime( int group, double  time ) SIP_SKIP;
+    void addDatasetTime( int group, double  time );
 
     /**
      * Returns whether the reference time is set

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -236,9 +236,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     /**
      * Returns native mesh (NULLPTR before rendering or calling to updateMesh)
      *
-     * \note Not available in Python bindings
      */
-    QgsMesh *nativeMesh() SIP_SKIP;
+    QgsMesh *nativeMesh();
 
     /**
      * Returns native mesh (NULLPTR before rendering or calling to updateMesh)


### PR DESCRIPTION
## Description

related #50219 

In this PR some SIP_SKIP or removed for better integration of `QgsMeshLayer` in python bindings

# Python conversion
- Add some conversion in `python/core/conversions.sip` to be able to use some typedef in `QgsMeshLayer`

# `QgsMeshLayer`
- remove some SIP_SKIP

 # `QgsMeshDataProvider`
- define some typedef to be able to update `QgsMesh` vertices, edges and faces
- remove some SIP_SKIP

 # `QgsMeshDataProviderTemporalCapabilities`
- remove some SIP_SKIP

I would like this to be backported.
