### PR TITLE
Update provider flags according to project ones

### DIFF
--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2201,6 +2201,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Save auxiliary storage to database
     bool saveAuxiliaryStorage( const QString &filename = QString() );
 
+    //! load project flags
+    void loadProjectFlags( const QDomDocument *doc );
+
     //! Returns the property definition used for a data defined server property
     static QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions();
 

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -30,6 +30,7 @@ from qgis.core import (Qgis,
                        QgsApplication,
                        QgsUnitTypes,
                        QgsCoordinateReferenceSystem,
+                       QgsDataProvider,
                        QgsLabelingEngineSettings,
                        QgsVectorLayer,
                        QgsRasterLayer,
@@ -1565,6 +1566,36 @@ class TestQgsProject(unittest.TestCase):
         self.assertFalse(project4.mapLayer(layer_a.id()).isEditable())
         self.assertFalse(project4.mapLayer(layer_b.id()).isEditable())
         self.assertFalse(project4.mapLayer(layer_c.id()).isEditable())
+
+    def test_remember_evalutate_defaut_values(self):
+        """
+        Test that EvaluateDefaultValues property is correctly set when loading project
+        """
+
+        project = QgsProject()
+        project.removeAllMapLayers()
+
+        layer = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
+
+        project.addMapLayers([layer])
+
+        self.assertEqual(layer.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), None)
+        project.setFlags(project.flags() | Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
+        self.assertTrue(project.flags() & Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
+        self.assertEqual(layer.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
+
+        tmp_dir = QTemporaryDir()
+        tmp_project_file = "{}/project.qgs".format(tmp_dir.path())
+        self.assertTrue(project.write(tmp_project_file))
+
+        project2 = QgsProject()
+        self.assertTrue(project2.read(tmp_project_file))
+
+        layers = list(project2.mapLayers().values())
+        self.assertEqual(len(layers), 1)
+
+        self.assertTrue(project2.flags() & Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
+        self.assertEqual(layers[0].dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1567,13 +1567,12 @@ class TestQgsProject(unittest.TestCase):
         self.assertFalse(project4.mapLayer(layer_b.id()).isEditable())
         self.assertFalse(project4.mapLayer(layer_c.id()).isEditable())
 
-    def test_remember_evalutate_defaut_values(self):
+    def test_remember_evaluate_default_values(self):
         """
         Test that EvaluateDefaultValues property is correctly set when loading project
         """
 
         project = QgsProject()
-        project.removeAllMapLayers()
 
         layer = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
 


### PR DESCRIPTION
Fixes #49463

Since e4db7faed7339ce46d5c6f29077dc27eaeebad89 we need to call *setFlags()* to update providers when we read flags from project