### PR TITLE
Make it clear when feature count is estimated

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -177,11 +177,11 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
     {
       QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
       QString name = nodeLayer->name();
-      if ( nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt() && role == Qt::DisplayRole )
+      QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
+      if ( vlayer && nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt() && role == Qt::DisplayRole )
       {
-        QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
         const bool estimatedCount = QgsDataSourceUri( vlayer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
-        const qlonglong count = vlayer ? vlayer->featureCount() : -1;
+        const qlonglong count = vlayer->featureCount();
 
         // if you modify this line, please update QgsSymbolLegendNode::updateLabel
         name += QStringLiteral( " [%1%2]" ).arg(

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -326,8 +326,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         const bool estimatedCount = QgsDataSourceUri( layer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
         if ( showFeatureCount && estimatedCount )
         {
-          parts << QStringLiteral( "<b>%1</b> %2" ).arg(
-                  tr( "Feature Count is estimated" ), tr( ": the feature count is determined by the database statistics" ) );
+          parts << tr( "<b>Feature count is estimated</b> : the feature count is determined by the database statistics" );
         }
 
         return parts.join( QLatin1String( "<br/>" ) );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -180,8 +180,12 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       if ( nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt() && role == Qt::DisplayRole )
       {
         QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
+        const bool estimatedCount = QgsDataSourceUri( vlayer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
+
         if ( vlayer && vlayer->featureCount() >= 0 )
-          name += QStringLiteral( " [%1]" ).arg( vlayer->featureCount() );
+          name += QStringLiteral( " [%1%2]" ).arg(
+                    estimatedCount ? QStringLiteral( "~" ) : QString(),
+                    QLocale().toString( vlayer->featureCount() ) );
       }
       return name;
     }
@@ -315,6 +319,14 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         }
 
         parts << "<i>" + source.toHtmlEscaped() + "</i>";
+
+        QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+        const bool showFeatureCount = nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toBool();
+        const bool estimatedCount = QgsDataSourceUri( layer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
+        if ( showFeatureCount && estimatedCount )
+        {
+          parts << "<b>Feature Count is estimated</b> : Please consider keeping database statistics up to date";
+        }
 
         return parts.join( QLatin1String( "<br/>" ) );
       }

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -181,11 +181,12 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       {
         QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() );
         const bool estimatedCount = QgsDataSourceUri( vlayer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
+        const qlonglong count = vlayer ? vlayer->featureCount() : -1;
 
-        if ( vlayer && vlayer->featureCount() >= 0 )
-          name += QStringLiteral( " [%1%2]" ).arg(
-                    estimatedCount ? QStringLiteral( "~" ) : QString(),
-                    QLocale().toString( vlayer->featureCount() ) );
+        // if you modify this line, please update QgsSymbolLegendNode::updateLabel
+        name += QStringLiteral( " [%1%2]" ).arg(
+                  estimatedCount ? QStringLiteral( "≈" ) : QString(),
+                  count != -1 ? QLocale().toString( count ) : tr( "N/A" ) );
       }
       return name;
     }
@@ -325,7 +326,8 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         const bool estimatedCount = QgsDataSourceUri( layer->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
         if ( showFeatureCount && estimatedCount )
         {
-          parts << "<b>Feature Count is estimated</b> : Please consider keeping database statistics up to date";
+          parts << QStringLiteral( "<b>%1</b> %2" ).arg(
+                  tr( "Feature Count is estimated" ), tr( ": the feature count is determined by the database statistics" ) );
         }
 
         return parts.join( QLatin1String( "<br/>" ) );

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -846,10 +846,11 @@ void QgsSymbolLegendNode::updateLabel()
   if ( showFeatureCount && vl )
   {
     const bool estimatedCount = QgsDataSourceUri( vl->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
-
     const qlonglong count = mEmbeddedInParent ? vl->featureCount() : vl->featureCount( mItem.ruleKey() ) ;
+
+    // if you modify this line, please update QgsLayerTreeModel::data (DisplayRole)
     mLabel += QStringLiteral( " [%1%2]" ).arg(
-                estimatedCount ? QStringLiteral( "~" ) : QString(),
+                estimatedCount ? QStringLiteral( "≈" ) : QString(),
                 count != -1 ? QLocale().toString( count ) : tr( "N/A" ) );
   }
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -845,8 +845,12 @@ void QgsSymbolLegendNode::updateLabel()
 
   if ( showFeatureCount && vl )
   {
+    const bool estimatedCount = QgsDataSourceUri( vl->dataProvider()->dataSourceUri() ).useEstimatedMetadata();
+
     const qlonglong count = mEmbeddedInParent ? vl->featureCount() : vl->featureCount( mItem.ruleKey() ) ;
-    mLabel += QStringLiteral( " [%1]" ).arg( count != -1 ? QLocale().toString( count ) : tr( "N/A" ) );
+    mLabel += QStringLiteral( " [%1%2]" ).arg(
+                estimatedCount ? QStringLiteral( "~" ) : QString(),
+                count != -1 ? QLocale().toString( count ) : tr( "N/A" ) );
   }
 
   emit dataChanged();


### PR DESCRIPTION
Fixes #46790 : This PR proposes to add informations when feature count is estimated

A **≈** character to indicate that the count is approximatively X
![estcount](https://user-images.githubusercontent.com/14358135/191244196-8d037857-b7b6-4013-9fc7-3881aa3a23f5.png)


A comment in tooltip to inform user about updating statistics
![estcounttt](https://user-images.githubusercontent.com/14358135/191243973-d8654293-8c6c-4d24-8eac-383b43a2f076.png)

I would finish the PR when we agree those informations are relevant and enough to avoid misunderstandings

@m-kuhn @elpaso I would be glad to have your opinion on this
