### PR TITLE
Followup layer metadata search widget

### DIFF
--- a/python/gui/auto_generated/qgslayermetadataresultsproxymodel.sip.in
+++ b/python/gui/auto_generated/qgslayermetadataresultsproxymodel.sip.in
@@ -31,11 +31,21 @@ Constructs a QgsLayerMetadataResultsProxyModel with an optional ``parent``.
 Returns the filter string.
 %End
 
+    const QString filterGeometryTypeName() const;
+%Docstring
+Returns the geometry type name filter string.
+%End
+
   public slots:
 
     void setFilterExtent( const QgsRectangle &extent );
 %Docstring
-Sett the extent filter to ``extent``.
+Sets the extent filter to ``extent``.
+%End
+
+    void setFilterGeometryTypeName( const QString &geometryTypeName );
+%Docstring
+Sets the geometry type filter to ``geometryTypeName``.
 %End
 
     void setFilterString( const QString &filterString );

--- a/python/gui/auto_generated/qgslayermetadataresultsproxymodel.sip.in
+++ b/python/gui/auto_generated/qgslayermetadataresultsproxymodel.sip.in
@@ -31,9 +31,14 @@ Constructs a QgsLayerMetadataResultsProxyModel with an optional ``parent``.
 Returns the filter string.
 %End
 
-    const QString filterGeometryTypeName() const;
+    void setFilterGeometryTypeEnabled( bool enabled );
 %Docstring
-Returns the geometry type name filter string.
+Sets the geometry type filter status to ``enabled``.
+%End
+
+    void setFilterMapLayerTypeEnabled( bool enabled );
+%Docstring
+Sets the map layer type filter status to ``enabled``.
 %End
 
   public slots:
@@ -43,9 +48,9 @@ Returns the geometry type name filter string.
 Sets the extent filter to ``extent``.
 %End
 
-    void setFilterGeometryTypeName( const QString &geometryTypeName );
+    void setFilterGeometryType( const QgsWkbTypes::GeometryType geometryType );
 %Docstring
-Sets the geometry type filter to ``geometryTypeName``.
+Sets the geometry type filter to ``geometryType``.
 %End
 
     void setFilterString( const QString &filterString );
@@ -53,8 +58,14 @@ Sets the geometry type filter to ``geometryTypeName``.
 Sets the text filter to ``filterString``.
 %End
 
+    void setFilterMapLayerType( const QgsMapLayerType mapLayerType );
+%Docstring
+Sets the map layer type filter to ``mapLayerType``.
+%End
+
   protected:
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
+
 
 
 };

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -412,7 +412,7 @@ QList<QgsLayerMetadataProviderResult> QgsGeoPackageProviderConnection::searchLay
         gpkg_metadata_reference AS ref
       JOIN
         gpkg_metadata AS md ON md.id = ref.md_file_id
-      JOIN
+      LEFT JOIN
         gpkg_geometry_columns AS gc ON gc.table_name = ref.table_name
       WHERE
         md.md_standard_uri = 'http://mrcc.com/qgis.dtd'

--- a/src/gui/qgslayermetadataresultsmodel.cpp
+++ b/src/gui/qgslayermetadataresultsmodel.cpp
@@ -129,7 +129,7 @@ QVariant QgsLayerMetadataResultsModel::headerData( int section, Qt::Orientation 
         case Sections::DataProviderName:
           return tr( "Provider" );
         case Sections::GeometryType:
-          return tr( "Geometry Type" );
+          return tr( "Layer Type" );
       }
     }
     // other roles here ...

--- a/src/gui/qgslayermetadataresultsmodel.cpp
+++ b/src/gui/qgslayermetadataresultsmodel.cpp
@@ -69,7 +69,12 @@ QVariant QgsLayerMetadataResultsModel::data( const QModelIndex &index, int role 
             return md ? md->description() : providerName;
           }
           case Sections::GeometryType:
-            return QgsWkbTypes::geometryDisplayString( mResult.metadata().at( index.row() ).geometryType() );
+          {
+            const QgsLayerMetadataProviderResult &md { mResult.metadata().at( index.row() ) };
+            if ( md.layerType() == QgsMapLayerType::RasterLayer )
+              return tr( "Raster" );
+            return md.geometryType() == QgsWkbTypes::GeometryType::UnknownGeometry ? QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::NullGeometry ) : QgsWkbTypes::geometryDisplayString( md.geometryType() );
+          }
           default:
             return QVariant();
         }
@@ -87,7 +92,10 @@ QVariant QgsLayerMetadataResultsModel::data( const QModelIndex &index, int role 
       {
         if ( index.column() == 0 )
         {
-          return QgsIconUtils::iconForGeometryType( mResult.metadata().at( index.row() ).geometryType() );
+          const QgsLayerMetadataProviderResult &md { mResult.metadata().at( index.row() ) };
+          if ( md.layerType() == QgsMapLayerType::RasterLayer )
+            return QgsApplication::getThemeIcon( QStringLiteral( "mIconRaster.svg" ) );
+          return QgsIconUtils::iconForGeometryType( md.geometryType() == QgsWkbTypes::GeometryType::UnknownGeometry ? QgsWkbTypes::GeometryType::NullGeometry : md.geometryType() );
         }
         break;
       }

--- a/src/gui/qgslayermetadataresultsproxymodel.cpp
+++ b/src/gui/qgslayermetadataresultsproxymodel.cpp
@@ -53,14 +53,15 @@ bool QgsLayerMetadataResultsProxyModel::filterAcceptsRow( int sourceRow, const Q
   {
     const QgsLayerMetadataProviderResult &metadataResult { sourceModel()->data( index0, Qt::ItemDataRole::UserRole ).value<QgsLayerMetadataProviderResult>( ) };
 
-    if ( mFilterString.isEmpty() )
+    if ( ! mFilterString.isEmpty() )
     {
       result = result && metadataResult.contains( mFilterString );
     }
 
     if ( result && ! mFilterExtent.isEmpty() )
     {
-      result = result && mFilterExtent.intersects( metadataResult.geographicExtent().boundingBox() );
+      // Exclude aspatial from extent filter
+      result = result && ( metadataResult.geometryType() != QgsWkbTypes::UnknownGeometry && metadataResult.geometryType() != QgsWkbTypes::NullGeometry ) && mFilterExtent.intersects( metadataResult.geographicExtent().boundingBox() );
     }
 
     if ( result && mFilterMapLayerTypeEnabled )

--- a/src/gui/qgslayermetadataresultsproxymodel.cpp
+++ b/src/gui/qgslayermetadataresultsproxymodel.cpp
@@ -53,10 +53,11 @@ bool QgsLayerMetadataResultsProxyModel::filterAcceptsRow( int sourceRow, const Q
   {
     const QgsLayerMetadataProviderResult &metadataResult { sourceModel()->data( index0, Qt::ItemDataRole::UserRole ).value<QgsLayerMetadataProviderResult>( ) };
 
-    if ( result && ! mFilterString.isEmpty() )
+    if ( mFilterString.isEmpty() )
     {
       result = result && metadataResult.contains( mFilterString );
     }
+
     if ( result && ! mFilterExtent.isEmpty() )
     {
       result = result && mFilterExtent.intersects( metadataResult.geographicExtent().boundingBox() );

--- a/src/gui/qgslayermetadataresultsproxymodel.h
+++ b/src/gui/qgslayermetadataresultsproxymodel.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include "qgis_gui.h"
 #include "qgsrectangle.h"
+#include "qgswkbtypes.h"
 
 /**
  * The QgsLayerMetadataResultsProxyModel class is a proxy model for QgsLayerMetadataResultsModel,
@@ -44,9 +45,14 @@ class GUI_EXPORT QgsLayerMetadataResultsProxyModel : public QSortFilterProxyMode
     const QString filterString() const;
 
     /**
-     * Returns the geometry type name filter string.
+     * Sets the geometry type filter status to \a enabled.
      */
-    const QString filterGeometryTypeName() const;
+    void setFilterGeometryTypeEnabled( bool enabled );
+
+    /**
+     * Sets the map layer type filter status to \a enabled.
+     */
+    void setFilterMapLayerTypeEnabled( bool enabled );
 
   public slots:
 
@@ -56,24 +62,33 @@ class GUI_EXPORT QgsLayerMetadataResultsProxyModel : public QSortFilterProxyMode
     void setFilterExtent( const QgsRectangle &extent );
 
     /**
-     * Sets the geometry type filter to \a geometryTypeName.
+     * Sets the geometry type filter to \a geometryType.
      */
-    void setFilterGeometryTypeName( const QString &geometryTypeName );
+    void setFilterGeometryType( const QgsWkbTypes::GeometryType geometryType );
 
     /**
      * Sets the text filter to \a filterString.
      */
     void setFilterString( const QString &filterString );
 
+    /**
+     * Sets the map layer type filter to \a mapLayerType.
+     */
+    void setFilterMapLayerType( const QgsMapLayerType mapLayerType );
+
     // QSortFilterProxyModel interface
   protected:
     bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
+
 
   private:
 
     QgsRectangle mFilterExtent;
     QString mFilterString;
-    QString mFilterGeometryTypeName;
+    QgsWkbTypes::GeometryType mFilterGeometryType = QgsWkbTypes::GeometryType::PointGeometry;
+    QgsMapLayerType mFilterMapLayerType = QgsMapLayerType::VectorLayer;
+    bool mFilterGeometryTypeEnabled = false;
+    bool mFilterMapLayerTypeEnabled = false;
 };
 
 #endif // QGSLAYERMETADATARESULTSPROXYMODEL_H

--- a/src/gui/qgslayermetadataresultsproxymodel.h
+++ b/src/gui/qgslayermetadataresultsproxymodel.h
@@ -43,12 +43,22 @@ class GUI_EXPORT QgsLayerMetadataResultsProxyModel : public QSortFilterProxyMode
      */
     const QString filterString() const;
 
+    /**
+     * Returns the geometry type name filter string.
+     */
+    const QString filterGeometryTypeName() const;
+
   public slots:
 
     /**
-     * Sett the extent filter to \a extent.
+     * Sets the extent filter to \a extent.
      */
     void setFilterExtent( const QgsRectangle &extent );
+
+    /**
+     * Sets the geometry type filter to \a geometryTypeName.
+     */
+    void setFilterGeometryTypeName( const QString &geometryTypeName );
 
     /**
      * Sets the text filter to \a filterString.
@@ -63,6 +73,7 @@ class GUI_EXPORT QgsLayerMetadataResultsProxyModel : public QSortFilterProxyMode
 
     QgsRectangle mFilterExtent;
     QString mFilterString;
+    QString mFilterGeometryTypeName;
 };
 
 #endif // QGSLAYERMETADATARESULTSPROXYMODEL_H

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -48,6 +48,19 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
   mExtentFilterComboBox->addItem( QStringLiteral( "Map Canvas Extent" ) );
   mExtentFilterComboBox->addItem( QStringLiteral( "Current Project Extent" ) );
   mExtentFilterComboBox->setCurrentIndex( 0 );
+  mExtentFilterComboBox->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToContents );
+  mExtentFilterComboBox->adjustSize();
+
+  mGeometryTypeComboBox->addItem( QString( ), QVariant() );
+  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PointGeometry ) );
+  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::LineGeometry ) );
+  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PolygonGeometry ) );
+  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::NullGeometry ) );
+  // Note: unknown geometry is mapped to null and missing from the combo
+  mGeometryTypeComboBox->addItem( tr( "Raster" ) );
+  mGeometryTypeComboBox->setCurrentIndex( 0 );
+  mGeometryTypeComboBox->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToContents );
+  mGeometryTypeComboBox->adjustSize();
 
   auto updateLoadBtn = [ = ]
   {
@@ -99,6 +112,11 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
   connect( mSearchFilterLineEdit, &QLineEdit::textEdited, mProxyModel, &QgsLayerMetadataResultsProxyModel::setFilterString );
   connect( mSearchFilterLineEdit, &QgsFilterLineEdit::cleared, mProxyModel, [ = ] { mProxyModel->setFilterString( QString() ); } );
   connect( mExtentFilterComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsLayerMetadataSearchWidget::updateExtentFilter );
+
+  connect( mGeometryTypeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]
+  {
+    mProxyModel->setFilterGeometryTypeName( mGeometryTypeComboBox->currentText() );
+  } );
 
   connect( QgsProject::instance(), &QgsProject::layersAdded, this, [ = ]( const QList<QgsMapLayer *> & )
   {

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -123,7 +123,7 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
     }
     else
     {
-      const QVariant geomTypeFilterValue { mGeometryTypeComboBox->currentData() };
+      const QVariant geomTypeFilterValue( mGeometryTypeComboBox->currentData() );
       if ( geomTypeFilterValue.isValid() )  // Vector layers
       {
         mProxyModel->setFilterGeometryTypeEnabled( true );

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgsmapcanvas.h"
 #include "qgsprojectviewsettings.h"
+#include "qgsiconutils.h"
 
 
 QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
@@ -52,12 +53,12 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
   mExtentFilterComboBox->adjustSize();
 
   mGeometryTypeComboBox->addItem( QString( ), QVariant() );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PointGeometry ) );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::LineGeometry ) );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PolygonGeometry ) );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::NullGeometry ) );
+  mGeometryTypeComboBox->addItem( QgsIconUtils::iconForGeometryType( QgsWkbTypes::GeometryType::PointGeometry ), QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PointGeometry ), QgsWkbTypes::GeometryType::PointGeometry );
+  mGeometryTypeComboBox->addItem( QgsIconUtils::iconForGeometryType( QgsWkbTypes::GeometryType::LineGeometry ), QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::LineGeometry ), QgsWkbTypes::GeometryType::LineGeometry );
+  mGeometryTypeComboBox->addItem( QgsIconUtils::iconForGeometryType( QgsWkbTypes::GeometryType::PolygonGeometry ), QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::PolygonGeometry ), QgsWkbTypes::GeometryType::PolygonGeometry );
   // Note: unknown geometry is mapped to null and missing from the combo
-  mGeometryTypeComboBox->addItem( tr( "Raster" ) );
+  mGeometryTypeComboBox->addItem( QgsIconUtils::iconForGeometryType( QgsWkbTypes::GeometryType::NullGeometry ), QgsWkbTypes::geometryDisplayString( QgsWkbTypes::GeometryType::NullGeometry ), QgsWkbTypes::GeometryType::NullGeometry );
+  mGeometryTypeComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconRaster.svg" ) ), tr( "Raster" ), QVariant() );
   mGeometryTypeComboBox->setCurrentIndex( 0 );
   mGeometryTypeComboBox->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToContents );
   mGeometryTypeComboBox->adjustSize();
@@ -113,9 +114,31 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
   connect( mSearchFilterLineEdit, &QgsFilterLineEdit::cleared, mProxyModel, [ = ] { mProxyModel->setFilterString( QString() ); } );
   connect( mExtentFilterComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsLayerMetadataSearchWidget::updateExtentFilter );
 
-  connect( mGeometryTypeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]
+  connect( mGeometryTypeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int index )
   {
-    mProxyModel->setFilterGeometryTypeName( mGeometryTypeComboBox->currentText() );
+    if ( index == 0 ) // reset all filters
+    {
+      mProxyModel->setFilterGeometryTypeEnabled( false );
+      mProxyModel->setFilterMapLayerTypeEnabled( false );
+    }
+    else
+    {
+      const QVariant geomTypeFilterValue { mGeometryTypeComboBox->currentData() };
+      if ( geomTypeFilterValue.isValid() )  // Vector layers
+      {
+        mProxyModel->setFilterGeometryTypeEnabled( true );
+        mProxyModel->setFilterGeometryType( geomTypeFilterValue.value<QgsWkbTypes::GeometryType>( ) );
+        mProxyModel->setFilterMapLayerTypeEnabled( true );
+        mProxyModel->setFilterMapLayerType( QgsMapLayerType::VectorLayer );
+      }
+      else // Raster layers
+      {
+        mProxyModel->setFilterGeometryTypeEnabled( false );
+        mProxyModel->setFilterMapLayerTypeEnabled( true );
+        mProxyModel->setFilterMapLayerType( QgsMapLayerType::RasterLayer );
+      }
+    }
+
   } );
 
   connect( QgsProject::instance(), &QgsProject::layersAdded, this, [ = ]( const QList<QgsMapLayer *> & )

--- a/src/ui/qgslayermetadatasearchwidget.ui
+++ b/src/ui/qgslayermetadatasearchwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>645</width>
+    <width>718</width>
     <height>399</height>
    </rect>
   </property>
@@ -34,7 +34,31 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="mExtentFilterComboBox"/>
+      <widget class="QComboBox" name="mExtentFilterComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>geometry type</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mGeometryTypeComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer">
@@ -69,9 +93,6 @@
     <widget class="QTableView" name="mMetadataTableView"/>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout"/>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Help</set>
@@ -87,6 +108,13 @@
    <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mSearchFilterLineEdit</tabstop>
+  <tabstop>mExtentFilterComboBox</tabstop>
+  <tabstop>mGeometryTypeComboBox</tabstop>
+  <tabstop>mAbortPushButton</tabstop>
+  <tabstop>mMetadataTableView</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgslayermetadatasearchwidget.ui
+++ b/src/ui/qgslayermetadatasearchwidget.ui
@@ -46,7 +46,7 @@
      <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>geometry type</string>
+        <string>layer type</string>
        </property>
       </widget>
      </item>

--- a/tests/src/python/test_qgslayermetadataprovider_postgres.py
+++ b/tests/src/python/test_qgslayermetadataprovider_postgres.py
@@ -45,6 +45,7 @@ class TestPostgresLayerMetadataProvider(unittest.TestCase, LayerMetadataProvider
     def clearMetadataTable(self):
 
         self.conn.execSql('DROP TABLE IF EXISTS qgis_test.qgis_layer_metadata')
+        self.conn.execSql('DROP TABLE IF EXISTS public.qgis_layer_metadata')
 
     def setUp(self):
 

--- a/tests/src/python/test_qgslayermetadataprovider_postgresraster.py
+++ b/tests/src/python/test_qgslayermetadataprovider_postgresraster.py
@@ -43,6 +43,11 @@ class TestPostgresLayerMetadataProvider(unittest.TestCase, LayerMetadataProvider
 
         return dbconn
 
+    def clearMetadataTable(self):
+
+        self.conn.execSql('DROP TABLE IF EXISTS qgis_test.qgis_layer_metadata')
+        self.conn.execSql('DROP TABLE IF EXISTS public.qgis_layer_metadata')
+
     def setUp(self):
 
         super().setUp()
@@ -57,6 +62,8 @@ class TestPostgresLayerMetadataProvider(unittest.TestCase, LayerMetadataProvider
         conn.execSql('DROP TABLE IF EXISTS qgis_test.qgis_layer_metadata')
         conn.setConfiguration({'metadataInDatabase': True})
         conn.store('PG Metadata Enabled Connection')
+        self.conn = conn
+        self.clearMetadataTable()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fix a bug with PG SQL update
- Handle raster icons
- Fix tab order in the widget
- Proxy model and GUI filter by geometry type

Ok, the last qualifies as small new feature sneaking in... 


![immagine](https://user-images.githubusercontent.com/142164/191694648-58714908-80cd-41a7-8979-5f15d360b42d.png)

Funded by: ARPA Piemonte
