### PR TITLE
[Processing] Fix typo in smoothing parameter name of gdal_grid algorithms

### DIFF
--- a/python/plugins/processing/algs/gdal/GridInverseDistance.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistance.py
@@ -177,7 +177,7 @@ class GridInverseDistance(GdalAlgorithm):
 
         params = 'invdist'
         params += ':power={}'.format(self.parameterAsDouble(parameters, self.POWER, context))
-        params += ':smothing={}'.format(self.parameterAsDouble(parameters, self.SMOOTHING, context))
+        params += ':smoothing={}'.format(self.parameterAsDouble(parameters, self.SMOOTHING, context))
         params += ':radius1={}'.format(self.parameterAsDouble(parameters, self.RADIUS_1, context))
         params += ':radius2={}'.format(self.parameterAsDouble(parameters, self.RADIUS_2, context))
         params += ':angle={}'.format(self.parameterAsDouble(parameters, self.ANGLE, context))

--- a/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
@@ -164,7 +164,7 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
 
         params = 'invdistnn'
         params += ':power={}'.format(self.parameterAsDouble(parameters, self.POWER, context))
-        params += ':smothing={}'.format(self.parameterAsDouble(parameters, self.SMOOTHING, context))
+        params += ':smoothing={}'.format(self.parameterAsDouble(parameters, self.SMOOTHING, context))
         params += ':radius={}'.format(self.parameterAsDouble(parameters, self.RADIUS, context))
         params += ':max_points={}'.format(self.parameterAsInt(parameters, self.MAX_POINTS, context))
         params += ':min_points={}'.format(self.parameterAsInt(parameters, self.MIN_POINTS, context))

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -956,7 +956,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 alg.getConsoleCommands({'INPUT': source,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdist:power=2.0:smothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # with NODATA value
@@ -965,7 +965,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'NODATA': 9999,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdist:power=2.0:smothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=9999.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=9999.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # with "0" NODATA value
@@ -974,7 +974,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'NODATA': 0,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdist:power=2.0:smothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # additional parameters
@@ -983,7 +983,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'EXTRA': '-z_multiply 1.5 -outsize 1754 1394',
                                         'OUTPUT': outdir + '/check.tif'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdist:power=2.0:smothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 ' +
+                 '-l points -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 ' +
                  '-ot Float32 -of GTiff -z_multiply 1.5 -outsize 1754 1394 ' +
                  source + ' ' +
                  outdir + '/check.tif'])
@@ -1001,7 +1001,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 alg.getConsoleCommands({'INPUT': source,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdistnn:power=2.0:smothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdistnn:power=2.0:smoothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # with NODATA value
@@ -1010,7 +1010,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'NODATA': 9999,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdistnn:power=2.0:smothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=9999.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdistnn:power=2.0:smoothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=9999.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # with "0" NODATA value
@@ -1019,7 +1019,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'NODATA': 0,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdistnn:power=2.0:smothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
+                 '-l points -a invdistnn:power=2.0:smoothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # additional parameters
@@ -1028,7 +1028,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'EXTRA': '-z_multiply 1.5 -outsize 1754 1394',
                                         'OUTPUT': outdir + '/check.tif'}, context, feedback),
                 ['gdal_grid',
-                 '-l points -a invdistnn:power=2.0:smothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 ' +
+                 '-l points -a invdistnn:power=2.0:smoothing=0.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 ' +
                  '-ot Float32 -of GTiff -z_multiply 1.5 -outsize 1754 1394 ' +
                  source + ' ' +
                  outdir + '/check.tif'])


### PR DESCRIPTION
The correct spelling is 'smoothing' (two o's): https://github.com/OSGeo/gdal/search?q=smoothing
No match with single o: https://github.com/OSGeo/gdal/search?q=smothing
