### PR TITLE
QgsMapToolAddRing: Add ring to all layers

### DIFF
--- a/src/app/qgsmaptooladdring.h
+++ b/src/app/qgsmaptooladdring.h
@@ -28,6 +28,6 @@ class APP_EXPORT QgsMapToolAddRing: public QgsMapToolCapture
 
     // QgsMapToolCapture interface
   private:
-    QgsVectorLayer *getCheckLayer();
+    QgsVectorLayer *getCheckLayer( QgsMapLayer *layer );
     void polygonCaptured( const QgsCurvePolygon *polygon ) override;
 };


### PR DESCRIPTION
## Description

Originally, the tool only worked for the active layer. This PR proposes to iterate on all layers and add the ring on all layers.

Fixes #23113

I wonder if we shouldn't add the ring on selected features only, but this is a major change…