### PR TITLE
add optional jump animation of map canvas movements

### DIFF
--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -103,6 +103,31 @@ Item {
     mapCanvasWrapper.refresh()
   }
 
+  /**
+   * Animates movement of map canvas from oldPos to newPos.
+   * oldPos and newPos need to be in device pixels.
+   */
+  function jump( oldPos, newPos )
+  {
+    freeze('jump')
+
+    let newPosMapCRS = mapCanvasWrapper.mapSettings.screenToCoordinate( newPos )
+    let oldPosMapCRS = mapCanvasWrapper.mapSettings.screenToCoordinate( oldPos )
+
+    // Disable animation until initial position is set
+    jumpAnimator.enabled = false
+
+    jumpAnimator.px = oldPosMapCRS.x
+    jumpAnimator.py = oldPosMapCRS.y
+
+    jumpAnimator.enabled = true
+
+    jumpAnimator.px = newPosMapCRS.x
+    jumpAnimator.py = newPosMapCRS.y
+
+    unfreeze('jump')
+  }
+
   QgsQuick.MapCanvasMap {
     id: mapCanvasWrapper
 
@@ -112,6 +137,32 @@ Item {
     property var __freezecount: ({})
 
     freeze: false
+  }
+
+  Item {
+    id: jumpAnimator
+
+    property double px: 0
+    property double py: 0
+
+    Behavior on py {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    Behavior on px {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    onPxChanged: mapCanvasWrapper.mapSettings.setCenter( mapCanvasWrapper.mapSettings.toQgsPoint( Qt.point( px, py ) ) )
+    onPyChanged: mapCanvasWrapper.mapSettings.setCenter( mapCanvasWrapper.mapSettings.toQgsPoint( Qt.point( px, py ) ) )
   }
 
   // Mouse, stylus and other pointer devices handler

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -297,3 +297,8 @@ void QgsQuickMapSettings::setDevicePixelRatio( const qreal &devicePixelRatio )
   mDevicePixelRatio = devicePixelRatio;
   emit devicePixelRatioChanged();
 }
+
+QgsPoint QgsQuickMapSettings::toQgsPoint( const QPointF &point )
+{
+  return QgsPoint( point );
+}

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -249,6 +249,12 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
      */
     void setDevicePixelRatio( const qreal &devicePixelRatio );
 
+    /**
+     * Helper function to convert QPointF to QgsPoint without any transformations.
+     * Useful for converting these values in QML.
+     */
+    Q_INVOKABLE static QgsPoint toQgsPoint( const QPointF &point );
+
   signals:
     //! \copydoc QgsQuickMapSettings::project
     void projectChanged();


### PR DESCRIPTION
## Description

Add optional jump animation for map canvas movements. Can be used to provide better UX, e.g. when moving to selected feature or in similar situations.