### PR TITLE
build QGIS-core with Qt6 + Win (VS 2019)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_subdirectory(native)
 add_subdirectory(core)
 
 if (WITH_AUTH)
@@ -12,6 +11,7 @@ endif()
 if (WITH_GUI)
   add_subdirectory(ui)
   add_subdirectory(gui)
+  add_subdirectory(native)
 endif()
 
 add_subdirectory(providers)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2280,10 +2280,6 @@ if (APPLE)
   target_link_libraries(qgis_core ${LIBTASN1_LIBRARY})
 endif()
 
-if (APPLE AND NOT IOS)
-  target_link_libraries(qgis_core qgis_native)
-endif()
-
 target_link_libraries(qgis_core
   ${QT_VERSION_BASE}::Core
   ${QT_VERSION_BASE}::Gui

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -899,7 +899,11 @@ QString QgsApplication::resolvePkgPath()
       QgsDebugMsgLevel( QStringLiteral( "- source directory: %1" ).arg( sBuildSourcePath()->toUtf8().constData() ), 4 );
       QgsDebugMsgLevel( QStringLiteral( "- output directory of the build: %1" ).arg( sBuildOutputPath()->toUtf8().constData() ), 4 );
 #if defined(_MSC_VER) && !defined(USING_NMAKE) && !defined(USING_NINJA)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
       *sCfgIntDir() = prefix.split( '/', QString::SkipEmptyParts ).last();
+#else
+      *sCfgIntDir() = prefix.split( '/', Qt::SkipEmptyParts ).last();
+#endif
       qDebug( "- cfg: %s", sCfgIntDir()->toUtf8().constData() );
 #endif
     }
@@ -1236,8 +1240,13 @@ QString QgsApplication::userLoginName()
 
   if ( GetUserName( ( TCHAR * )name, &size ) )
   {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     *sUserName() = QString::fromLocal8Bit( name );
+#else
+    *sUserName() = QString::fromWCharArray( name );
+#endif
   }
+
 
 #elif QT_CONFIG(process)
   QProcess process;
@@ -1272,7 +1281,11 @@ QString QgsApplication::userFullName()
   //note - this only works for accounts connected to domain
   if ( GetUserNameEx( NameDisplay, ( TCHAR * )name, &size ) )
   {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     *sUserFullName() = QString::fromLocal8Bit( name );
+#else
+    *sUserFullName() = QString::fromWCharArray( name );
+#endif
   }
 
   //fall back to login name

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -63,7 +63,7 @@ if(APPLE)
   )
 endif()
 
-if(MSVC)
+if(MSVC AND NOT BUILD_WITH_QT6)
   set(QGIS_NATIVE_SRCS ${QGIS_NATIVE_SRCS}
     ../../external/wintoast/src/wintoastlib.cpp
     win/qgswinnative.cpp
@@ -96,7 +96,7 @@ target_include_directories(qgis_native PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-if(MSVC)
+if(MSVC AND NOT BUILD_WITH_QT6)
   target_include_directories(qgis_native SYSTEM PUBLIC
       ../../external/wintoast/src
   )
@@ -144,12 +144,13 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
   target_link_libraries(qgis_native ${QT_VERSION_BASE}::DBus)
 endif()
 
-if (MSVC)
+if (MSVC AND NOT BUILD_WITH_QT6)
   find_package(${QT_VERSION_BASE}WinExtras)
 
   target_link_libraries(qgis_native shell32)
   target_link_libraries(qgis_native ${QT_VERSION_BASE}::Widgets ${QT_QTMAIN_LIBRARY})
   target_link_libraries(qgis_native ${QT_VERSION_BASE}::WinExtras)
+
 endif()
 # install
 

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -63,7 +63,7 @@ if(APPLE)
   )
 endif()
 
-if(MSVC AND NOT BUILD_WITH_QT6)
+if(MSVC)
   set(QGIS_NATIVE_SRCS ${QGIS_NATIVE_SRCS}
     ../../external/wintoast/src/wintoastlib.cpp
     win/qgswinnative.cpp
@@ -96,7 +96,7 @@ target_include_directories(qgis_native PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-if(MSVC AND NOT BUILD_WITH_QT6)
+if(MSVC)
   target_include_directories(qgis_native SYSTEM PUBLIC
       ../../external/wintoast/src
   )
@@ -144,7 +144,7 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
   target_link_libraries(qgis_native ${QT_VERSION_BASE}::DBus)
 endif()
 
-if (MSVC AND NOT BUILD_WITH_QT6)
+if (MSVC)
   find_package(${QT_VERSION_BASE}WinExtras)
 
   target_link_libraries(qgis_native shell32)

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -89,7 +89,7 @@ bool QgsDelimitedTextFile::open()
     }
     if ( mFile )
     {
-      mCodec = QTextCodec::codecForName( !mEncoding.isEmpty() ? mEncoding.toLatin1() : "UTF-8" );
+      mCodec = QTextCodec::codecForName( !mEncoding.isEmpty() ? mEncoding.toLatin1() : QByteArray( "UTF-8" ) );
       if ( ! mCodec )
       {
         QgsDebugMsgLevel( QStringLiteral( "Wrong codec '%1' for %2, falling back to locale default." ).arg( mEncoding, mFileName ), 2 );

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(qgis_bench
 )
 
 if(APPLE)
+  target_link_libraries(qgis_bench qgis_native)
+
   set_target_properties(qgis_bench PROPERTIES
     INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
     INSTALL_RPATH_USE_LINK_PATH true


### PR DESCRIPTION
Building qgis-core with Qt 6.3.2 I needed to apply this patch (see https://github.com/MerginMaps/input-sdk/actions/runs/3097356533)

WinExtras:
- Qt6.3.2 doesn't have Qt6WinExtras any more, see https://www.qt.io/blog/qt-extras-modules-in-qt-6 (classes moved or been removed altogether).  
- I am not sure what the code in the qgsnative doing, but I think we do not need it for Mergin Maps
- This is effort to just be able to compile on windows, so the qgsnative rewritten is "TODO"

Other:
- Qt6.3.2 + VS 2019 has a problem with some functions overloads