### PR TITLE
Save original layout item picture mode

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -250,9 +250,20 @@ Sets the stroke ``width`` (in layout units) used for parametrized SVG files.
 
     Format mode() const;
 %Docstring
-Returns the current picture mode (image format).
+Returns the current picture mode (image format), FormatUnknown if given
+picture format is unknown
 
 .. seealso:: :py:func:`setMode`
+%End
+
+    Format originalMode() const;
+%Docstring
+Returns the original set picture mode (image format).
+It could differ from :py:func:`~QgsLayoutItemPicture.mode` if given picture format is unknown
+
+.. seealso:: :py:func:`setMode`
+
+.. versionadded:: 3.22
 %End
 
     void setMode( Format mode );

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -543,7 +543,6 @@ void QgsLayoutItemPicture::updateNorthArrowRotation( double rotation )
 
 void QgsLayoutItemPicture::loadPicture( const QVariant &data )
 {
-  const Format origFormat = mMode;
   mIsMissingImage = false;
   QVariant imageData( data );
   mEvaluatedPath = data.toString();
@@ -584,14 +583,14 @@ void QgsLayoutItemPicture::loadPicture( const QVariant &data )
   {
     //trying to load an invalid file or bad expression, show cross picture
     mIsMissingImage = true;
-    if ( origFormat == FormatRaster )
+    if ( mOriginalMode == FormatRaster )
     {
       const QString badFile( QStringLiteral( ":/images/composer/missing_image.png" ) );
       QImageReader imageReader( badFile );
       if ( imageReader.read( &mImage ) )
         mMode = FormatRaster;
     }
-    else
+    else if ( mOriginalMode == FormatSVG )
     {
       const QString badFile( QStringLiteral( ":/images/composer/missing_image.svg" ) );
       mSVG.load( badFile );
@@ -768,6 +767,7 @@ void QgsLayoutItemPicture::refreshDataDefinedProperty( const QgsLayoutObject::Da
 
 void QgsLayoutItemPicture::setPicturePath( const QString &path, Format format )
 {
+  mOriginalMode = format;
   mMode = format;
   mSourcePath = path;
   refreshPicture();
@@ -797,7 +797,7 @@ bool QgsLayoutItemPicture::writePropertiesToElement( QDomElement &elem, QDomDocu
   elem.setAttribute( QStringLiteral( "svgFillColor" ), QgsSymbolLayerUtils::encodeColor( mSvgFillColor ) );
   elem.setAttribute( QStringLiteral( "svgBorderColor" ), QgsSymbolLayerUtils::encodeColor( mSvgStrokeColor ) );
   elem.setAttribute( QStringLiteral( "svgBorderWidth" ), QString::number( mSvgStrokeWidth ) );
-  elem.setAttribute( QStringLiteral( "mode" ), mMode );
+  elem.setAttribute( QStringLiteral( "mode" ), mOriginalMode );
 
   //rotation
   elem.setAttribute( QStringLiteral( "pictureRotation" ), QString::number( mPictureRotation ) );
@@ -825,7 +825,8 @@ bool QgsLayoutItemPicture::readPropertiesFromElement( const QDomElement &itemEle
   mSvgFillColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "svgFillColor" ), QgsSymbolLayerUtils::encodeColor( QColor( 255, 255, 255 ) ) ) );
   mSvgStrokeColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "svgBorderColor" ), QgsSymbolLayerUtils::encodeColor( QColor( 0, 0, 0 ) ) ) );
   mSvgStrokeWidth = itemElem.attribute( QStringLiteral( "svgBorderWidth" ), QStringLiteral( "0.2" ) ).toDouble();
-  mMode = static_cast< Format >( itemElem.attribute( QStringLiteral( "mode" ), QString::number( FormatUnknown ) ).toInt() );
+  mOriginalMode = static_cast< Format >( itemElem.attribute( QStringLiteral( "mode" ), QString::number( FormatUnknown ) ).toInt() );
+  mMode = mOriginalMode;
 
   const QDomNodeList composerItemList = itemElem.elementsByTagName( QStringLiteral( "ComposerItem" ) );
   if ( !composerItemList.isEmpty() )
@@ -930,9 +931,10 @@ void QgsLayoutItemPicture::setSvgStrokeWidth( double width )
 
 void QgsLayoutItemPicture::setMode( QgsLayoutItemPicture::Format mode )
 {
-  if ( mMode == mode )
+  if ( mOriginalMode == mode )
     return;
 
+  mOriginalMode = mode;
   mMode = mode;
   refreshPicture();
 }

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -229,10 +229,19 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
     void setSvgStrokeWidth( double width );
 
     /**
-     * Returns the current picture mode (image format).
-     * \see setMode()
+     * Returns the current picture mode (image format), FormatUnknown if given
+     * picture format is unknown
+     * \see setMode() originalMode()
      */
     Format mode() const { return mMode; }
+
+    /**
+     * Returns the original set picture mode (image format).
+     * It could differ from mode() if given picture format is unknown
+     * \see setMode() mode()
+     * \since 3.22
+     */
+    Format originalMode() const { return mOriginalMode; }
 
     /**
      * Sets the current picture \a mode (image format).
@@ -330,6 +339,7 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
     //! Absolute path to the image (may be also HTTP URL)
     QString mSourcePath;
     Format mMode = FormatUnknown;
+    Format mOriginalMode = FormatUnknown;
 
     QSize mDefaultSvgSize;
 

--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -319,7 +319,7 @@ void QgsLayoutPictureWidget::setGuiElementValues()
       mAnchorPointComboBox->setEnabled( false );
     }
 
-    switch ( mPicture->mode() )
+    switch ( mPicture->originalMode() )
     {
       case QgsLayoutItemPicture::FormatSVG:
       case QgsLayoutItemPicture::FormatUnknown:
@@ -499,4 +499,3 @@ void QgsLayoutPictureWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mStrokeColorDDBtn );
   updateDataDefinedButton( mStrokeWidthDDBtn );
 }
-

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -496,20 +496,78 @@ void TestQgsLayoutPicture::valid()
   picture->setPicturePath( mPngImage );
   QVERIFY( !picture->isMissingImage() );
   QCOMPARE( picture->evaluatedPath(), mPngImage );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatRaster );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
 
   picture->setPicturePath( QStringLiteral( "bad" ) );
   QVERIFY( picture->isMissingImage() );
   QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatUnknown );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
 
   picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'%1'" ).arg( mSvgImage ) ) );
   picture->refreshPicture();
   QVERIFY( !picture->isMissingImage() );
   QCOMPARE( picture->evaluatedPath(), mSvgImage );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatSVG );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
 
   picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'bad'" ) ) );
   picture->refreshPicture();
   QVERIFY( picture->isMissingImage() );
   QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatUnknown );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
+
+  // same tests with a given format
+
+  picture->dataDefinedProperties().clear();
+
+  picture->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatRaster );
+  QVERIFY( !picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), mPngImage );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatRaster );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatRaster );
+
+  picture->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatUnknown );
+  QVERIFY( !picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), mPngImage );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatRaster );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
+
+  picture->setPicturePath( QStringLiteral( "bad" ), QgsLayoutItemPicture::FormatUnknown );
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatUnknown );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
+
+  picture->setPicturePath( QStringLiteral( "bad" ), QgsLayoutItemPicture::FormatRaster );
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatRaster ); // cross image for missing image
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatRaster );
+
+  picture->setPicturePath( QStringLiteral( "bad" ), QgsLayoutItemPicture::FormatSVG );
+  picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'%1'" ).arg( mSvgImage ) ) );
+  picture->refreshPicture();
+  QVERIFY( !picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), mSvgImage );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatSVG );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatSVG );
+
+  picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'bad'" ) ) );
+  picture->refreshPicture();
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatSVG ); // cross image for missing picture
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatSVG );
+
+  picture->setPicturePath( QStringLiteral( "bad" ), QgsLayoutItemPicture::FormatUnknown );
+  picture->refreshPicture();
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+  QCOMPARE( picture->mode(), QgsLayoutItemPicture::FormatUnknown );
+  QCOMPARE( picture->originalMode(), QgsLayoutItemPicture::FormatUnknown );
 }
 
 QGSTEST_MAIN( TestQgsLayoutPicture )


### PR DESCRIPTION
Supersedes #49615

This PR propose to add an original mode different than the one computed by QgsLayoutItemPicture (which could be equal to FormatUnknown if the given picture is missing/invalid), to use it in the UI and save it in the project

I set the since doxy tag to 3.22 because I would like to backport it. 

Fixes https://github.com/qgis/QGIS/issues/49165 (stale and close)
Fixes https://github.com/qgis/QGIS/issues/47981
Fixes https://github.com/qgis/QGIS/issues/38031
Fixes https://github.com/qgis/QGIS/issues/37804

cc @nicogodet 