### PR TITLE
Fix unreported endless alg splitwithlines

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -222,8 +222,8 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
                 }
                 else
                 {
-                  inGeoms.append( inGeom );
-                  inGeoms.append( newGeometries );
+                  outGeoms.append( inGeom );
+                  outGeoms.append( newGeometries );
                 }
               }
               else


### PR DESCRIPTION
Fix an unreported bug I discovered while investigating #50227 (unfortunately this PR does not fix that issue).

By adding the splitted geometries to ingeoms the while loop `while ( !inGeoms.empty() )` was never ending and the inGeoms list was growing until all the available memory was exhausted.

A simple test case was sufficient to reproduce the issue:

![immagine](https://user-images.githubusercontent.com/142164/191544781-dc0281fb-f72c-49d4-9425-f6cbd2b2ef79.png)

