### PR TITLE
[WFS provider] Recognize OGC HTTP URIs

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -40,6 +40,7 @@
 #include "qgssettings.h"
 #include "qgsogrutils.h"
 #include "qgsdatums.h"
+#include "qgsogcutils.h"
 #include "qgsprojectionfactors.h"
 #include "qgsprojoperation.h"
 
@@ -402,32 +403,26 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 
   QString wmsCrs = crs;
 
-  thread_local const QRegularExpression re_uri( QRegularExpression::anchoredPattern( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ) ), QRegularExpression::CaseInsensitiveOption );
-  QRegularExpressionMatch match = re_uri.match( wmsCrs );
-  if ( match.hasMatch() )
+  QString authority;
+  QString code;
+  const QgsOgcCrsUtils::CRSFlavor crsFlavor = QgsOgcCrsUtils::parseCrsName( crs, authority, code );
+  const QString authorityLower = authority.toLower();
+  if ( crsFlavor == QgsOgcCrsUtils::CRSFlavor::AUTH_CODE &&
+       ( authorityLower == QLatin1String( "user" ) ||
+         authorityLower == QLatin1String( "custom" ) ||
+         authorityLower == QLatin1String( "qgis" ) ) )
   {
-    wmsCrs = match.captured( 1 ) + ':' + match.captured( 2 );
+    if ( createFromSrsId( code.toInt() ) )
+    {
+      locker.changeMode( QgsReadWriteLocker::Write );
+      if ( !sDisableOgcCache )
+        sOgcCache()->insert( crs, *this );
+      return d->mIsValid;
+    }
   }
-  else
+  else if ( crsFlavor != QgsOgcCrsUtils::CRSFlavor::UNKNOWN )
   {
-    thread_local const QRegularExpression re_urn( QRegularExpression::anchoredPattern( QStringLiteral( "urn:ogc:def:crs:([^:]+).+(?<=:)([^:]+)" ) ), QRegularExpression::CaseInsensitiveOption );
-    match = re_urn.match( wmsCrs );
-    if ( match.hasMatch() )
-    {
-      wmsCrs = match.captured( 1 ) + ':' + match.captured( 2 );
-    }
-    else
-    {
-      thread_local const QRegularExpression re_urn_custom( QRegularExpression::anchoredPattern( QStringLiteral( "(user|custom|qgis):(\\d+)" ) ), QRegularExpression::CaseInsensitiveOption );
-      match = re_urn_custom.match( wmsCrs );
-      if ( match.hasMatch() && createFromSrsId( match.captured( 2 ).toInt() ) )
-      {
-        locker.changeMode( QgsReadWriteLocker::Write );
-        if ( !sDisableOgcCache )
-          sOgcCache()->insert( crs, *this );
-        return d->mIsValid;
-      }
-    }
+    wmsCrs = authority + ':' + code;
   }
 
   // first chance for proj 6 - scan through legacy systems and try to use authid directly

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3678,3 +3678,48 @@ QString QgsOgcUtilsExpressionFromFilter::errorMessage() const
 {
   return mErrorMessage;
 }
+
+QgsOgcCrsUtils::CRSFlavor QgsOgcCrsUtils::parseCrsName( const QString &crsName, QString &authority, QString &code )
+{
+  const thread_local QRegularExpression re_url( QRegularExpression::anchoredPattern( QStringLiteral( "http://www\\.opengis\\.net/gml/srs/epsg\\.xml#(.+)" ) ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_url.match( crsName ); match.hasMatch() )
+  {
+    authority = QStringLiteral( "EPSG" );
+    code = match.captured( 1 );
+    return CRSFlavor::HTTP_EPSG_DOT_XML;
+  }
+
+  const thread_local QRegularExpression re_ogc_urn( QRegularExpression::anchoredPattern( QStringLiteral( "urn:ogc:def:crs:([^:]+).+(?<=:)([^:]+)" ) ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_ogc_urn.match( crsName ); match.hasMatch() )
+  {
+    authority = match.captured( 1 );
+    code = match.captured( 2 );
+    return CRSFlavor::OGC_URN;
+  }
+
+  const thread_local QRegularExpression re_x_ogc_urn( QRegularExpression::anchoredPattern( QStringLiteral( "urn:x-ogc:def:crs:([^:]+).+(?<=:)([^:]+)" ) ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_x_ogc_urn.match( crsName ); match.hasMatch() )
+  {
+    authority = match.captured( 1 );
+    code = match.captured( 2 );
+    return CRSFlavor::X_OGC_URN;
+  }
+
+  const thread_local QRegularExpression re_http_uri( QRegularExpression::anchoredPattern( QStringLiteral( "http://www\\.opengis\\.net/def/crs/([^/]+).+/([^/]+)" ) ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_http_uri.match( crsName ); match.hasMatch() )
+  {
+    authority = match.captured( 1 );
+    code = match.captured( 2 );
+    return CRSFlavor::OGC_HTTP_URI;
+  }
+
+  const thread_local QRegularExpression re_auth_code( QRegularExpression::anchoredPattern( QStringLiteral( "([^:]+):(.+)" ) ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_auth_code.match( crsName ); match.hasMatch() )
+  {
+    authority = match.captured( 1 );
+    code = match.captured( 2 );
+    return CRSFlavor::AUTH_CODE;
+  }
+
+  return CRSFlavor::UNKNOWN;
+}

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -571,6 +571,42 @@ class QgsOgcUtilsSQLStatementToFilter
                          QString &srsName,
                          bool &axisInversion );
 };
+
+/**
+ * \ingroup core
+ * \brief Utilities related to OGC CRS encodings.
+ * \note not available in Python bindings
+ * \since QGIS 3.28
+ */
+class CORE_EXPORT QgsOgcCrsUtils
+{
+  public:
+
+    //! CRS flavor
+    enum class CRSFlavor
+    {
+      UNKNOWN, //! unknown/unhandled flavor
+      AUTH_CODE, //! e.g EPSG:4326
+      HTTP_EPSG_DOT_XML, //! e.g. http://www.opengis.net/gml/srs/epsg.xml#4326 (called "OGC HTTP URL" in GeoServer WFS configuration panel)
+      OGC_URN, //! e.g. urn:ogc:def:crs:EPSG::4326
+      X_OGC_URN, //! e.g. urn:x-ogc:def:crs:EPSG::4326
+      OGC_HTTP_URI, //! e.g. http://www.opengis.net/def/crs/EPSG/0/4326
+    };
+
+    /**
+     * Parse a CRS name in one of the flavors of OGC services, and decompose it
+     * as authority and code.
+     *
+     * \param crsName CRS name, like "EPSG:4326", "http://www.opengis.net/gml/srs/epsg.xml#4326", "urn:ogc:def:crs:EPSG::4326", etc.
+     * \param[out] authority CRS authority.
+     * \param[out] code CRS code.
+     * \return CRS flavor (UNKNOWN if crsName could not been parsed.
+     */
+    static CRSFlavor parseCrsName( const QString &crsName, QString &authority, QString &code );
+};
+
+Q_DECLARE_METATYPE( QgsOgcCrsUtils::CRSFlavor )
+
 #endif // #ifndef SIP_RUN
 
 #endif // QGSOGCUTILS_H

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -657,16 +657,12 @@ void QgsWfsCapabilities::capabilitiesReplyFinished()
 
 QString QgsWfsCapabilities::NormalizeSRSName( const QString &crsName )
 {
-  const QRegularExpression re( QRegularExpression::anchoredPattern( QStringLiteral( "urn:ogc:def:crs:([^:]+).+?([^:]+)" ) ), QRegularExpression::CaseInsensitiveOption );
-  if ( const QRegularExpressionMatch match = re.match( crsName ); match.hasMatch() )
+  QString authority;
+  QString code;
+  const QgsOgcCrsUtils::CRSFlavor crsFlavor = QgsOgcCrsUtils::parseCrsName( crsName, authority, code );
+  if ( crsFlavor !=  QgsOgcCrsUtils::CRSFlavor::UNKNOWN )
   {
-    return match.captured( 1 ) + ':' + match.captured( 2 );
-  }
-  // urn:x-ogc:def:crs:EPSG:xxxx as returned by http://maps.warwickshire.gov.uk/gs/ows? in WFS 1.1
-  const QRegularExpression re2( QRegularExpression::anchoredPattern( QStringLiteral( "urn:x-ogc:def:crs:([^:]+).+?([^:]+)" ) ), QRegularExpression::CaseInsensitiveOption );
-  if ( const QRegularExpressionMatch match = re2.match( crsName ); match.hasMatch() )
-  {
-    return match.captured( 1 ) + ':' + match.captured( 2 );
+    return authority + ':' + code;
   }
   return crsName;
 }

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -75,6 +75,9 @@ class TestQgsOgcUtils : public QObject
 
     void testSQLStatementToOgcFilter();
     void testSQLStatementToOgcFilter_data();
+
+    void testParseCrsName();
+    void testParseCrsName_data();
 };
 
 
@@ -1246,6 +1249,41 @@ void TestQgsOgcUtils::testSQLStatementToOgcFilter_data()
                                  "</fes:PropertyIsEqualTo>"
                                  "</fes:Filter>" );
 }
+
+
+void TestQgsOgcUtils::testParseCrsName()
+{
+  QFETCH( QString, crsName );
+  QFETCH( QgsOgcCrsUtils::CRSFlavor, expectedFlavor );
+  QFETCH( QString, expectedAuthority );
+  QFETCH( QString, expectedCode );
+
+  QString authority;
+  QString code;
+  const QgsOgcCrsUtils::CRSFlavor crsFlavor = QgsOgcCrsUtils::parseCrsName( crsName, authority, code );
+  QCOMPARE( expectedFlavor, crsFlavor );
+  QCOMPARE( expectedAuthority, authority );
+  QCOMPARE( expectedCode, code );
+}
+
+void TestQgsOgcUtils::testParseCrsName_data()
+{
+  QTest::addColumn<QString>( "crsName" );
+  QTest::addColumn<QgsOgcCrsUtils::CRSFlavor>( "expectedFlavor" );
+  QTest::addColumn<QString>( "expectedAuthority" );
+  QTest::addColumn<QString>( "expectedCode" );
+
+  QTest::newRow( "unknown" ) << QStringLiteral( "foo" ) << QgsOgcCrsUtils::CRSFlavor::UNKNOWN << QString() << QString();
+  QTest::newRow( "unknown2" ) << QStringLiteral( "EPSG:" ) << QgsOgcCrsUtils::CRSFlavor::UNKNOWN << QString() << QString();
+  QTest::newRow( "AUTH_CODE" ) << QStringLiteral( "EPSG:1234" ) << QgsOgcCrsUtils::CRSFlavor::AUTH_CODE << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "HTTP_EPSG_DOT_XML" ) << QStringLiteral( "http://www.opengis.net/gml/srs/epsg.xml#1234" ) << QgsOgcCrsUtils::CRSFlavor::HTTP_EPSG_DOT_XML << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "OGC_URN" ) << QStringLiteral( "urn:ogc:def:crs:EPSG::1234" ) << QgsOgcCrsUtils::CRSFlavor::OGC_URN << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "OGC_URN missing col" ) << QStringLiteral( "urn:ogc:def:crs:EPSG:1234" ) << QgsOgcCrsUtils::CRSFlavor::OGC_URN << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "X_OGC_URN" ) << QStringLiteral( "urn:x-ogc:def:crs:EPSG::1234" ) << QgsOgcCrsUtils::CRSFlavor::X_OGC_URN << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "X_OGC_URN missing col" ) << QStringLiteral( "urn:x-ogc:def:crs:EPSG:1234" ) << QgsOgcCrsUtils::CRSFlavor::X_OGC_URN << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+  QTest::newRow( "OGC_HTTP_URI" ) << QStringLiteral( "http://www.opengis.net/def/crs/EPSG/0/1234" ) << QgsOgcCrsUtils::CRSFlavor::OGC_HTTP_URI << QStringLiteral( "EPSG" ) << QStringLiteral( "1234" );
+}
+
 
 QGSTEST_MAIN( TestQgsOgcUtils )
 #include "testqgsogcutils.moc"


### PR DESCRIPTION
Fixes #29391

*   Add a QgsOgcCrsUtils::parseCrsName() function to parse the different styles of OGC CRS names
    Recognizes the following flavors:
    ```
        //! CRS flavor
        enum class CRSFlavor
        {
          UNKNOWN, //! unknown/unhandled flavor
          AUTH_CODE, //! e.g EPSG:4326
          HTTP_EPSG_DOT_XML, //! e.g. http://www.opengis.net/gml/srs/epsg.xml#4326 (called "OGC HTTP URL" in GeoServer WFS configuration panel)
          OGC_URN, //! e.g. urn:ogc:def:crs:EPSG::4326
          X_OGC_URN, //! e.g. urn:x-ogc:def:crs:EPSG::4326
          OGC_HTTP_URI, //! e.g. http://www.opengis.net/def/crs/EPSG/0/4326
        };
    ```
*   QgsGmlStreamingParser::readEpsgFromAttribute(): use QgsOgcCrsUtils::parseCrsName()
*   QgsCoordinateReferenceSystem::createFromOgcWmsCrs(): use QgsOgcCrsUtils::parseCrsName()
*   [WFS provider] Use QgsOgcCrsUtils::parseCrsName() to be able to handle OGC HTTP URIs