### PR TITLE
Limit fixed interval classification to generate at most 999 classes

### DIFF
--- a/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -247,6 +247,7 @@ This will calculate the classes for a given layer to define the classes.
 :param layer: The vector layer
 :param expression: The name of the field on which the classes are calculated
 :param nclasses: The number of classes to be returned
+:param error: Optional parameter for error reporting
 %End
 
     QList<QgsClassificationRange> classes( const QList<double> &values, int nclasses );

--- a/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -240,7 +240,7 @@ Defines if the trailing 0 are trimmed in the label
 Transforms a list of classes to a list of breaks
 %End
 
-    QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses );
+    QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses, QString *error = 0 );
 %Docstring
 This will calculate the classes for a given layer to define the classes.
 

--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -276,7 +276,7 @@ Recalculate classes for a layer
 .. deprecated:: QGIS 3.10
 %End
 
-    void updateClasses( const QgsVectorLayer *vl, int nclasses );
+    void updateClasses( const QgsVectorLayer *vl, int nclasses, QString *error = 0 );
 %Docstring
 Recalculate classes for a layer
 

--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -282,6 +282,7 @@ Recalculate classes for a layer
 
 :param vl: The layer being rendered (from which data values are calculated)
 :param nclasses: the number of classes
+:param error: Optional parameter for error reporting
 %End
 
 

--- a/src/core/classification/qgsclassificationcustom.cpp
+++ b/src/core/classification/qgsclassificationcustom.cpp
@@ -43,11 +43,12 @@ QString QgsClassificationCustom::id() const
 }
 
 QList<double> QgsClassificationCustom::calculateBreaks( double &minimum, double &maximum,
-    const QList<double> &values, int nclasses )
+    const QList<double> &values, int nclasses, QString *error )
 {
   Q_UNUSED( minimum )
   Q_UNUSED( maximum )
   Q_UNUSED( values )
   Q_UNUSED( nclasses )
+  Q_UNUSED( error )
   return QList<double>();
 }

--- a/src/core/classification/qgsclassificationcustom.h
+++ b/src/core/classification/qgsclassificationcustom.h
@@ -40,7 +40,7 @@ class CORE_EXPORT QgsClassificationCustom : public QgsClassificationMethod
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 };
 
 #endif // QGSCLASSIFICATIONCUSTOM_H

--- a/src/core/classification/qgsclassificationequalinterval.cpp
+++ b/src/core/classification/qgsclassificationequalinterval.cpp
@@ -36,9 +36,10 @@ QString QgsClassificationEqualInterval::id() const
 }
 
 QList<double> QgsClassificationEqualInterval::calculateBreaks( double &minimum, double &maximum,
-    const QList<double> &values, int nclasses )
+    const QList<double> &values, int nclasses, QString *error )
 {
   Q_UNUSED( values )
+  Q_UNUSED( error )
 
   // Equal interval algorithm
   // Returns breaks based on dividing the range ('minimum' to 'maximum') into 'classes' parts.

--- a/src/core/classification/qgsclassificationequalinterval.h
+++ b/src/core/classification/qgsclassificationequalinterval.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsClassificationEqualInterval : public QgsClassificationMetho
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 
 };
 

--- a/src/core/classification/qgsclassificationfixedinterval.cpp
+++ b/src/core/classification/qgsclassificationfixedinterval.cpp
@@ -54,7 +54,17 @@ QList<double> QgsClassificationFixedInterval::calculateBreaks( double &minimum, 
 {
   const QgsProcessingContext context;
   const QgsProcessingParameterDefinition *def = parameterDefinition( QStringLiteral( "INTERVAL" ) );
-  const double interval = QgsProcessingParameters::parameterAsDouble( def, parameterValues(), context );
+  double interval = QgsProcessingParameters::parameterAsDouble( def, parameterValues(), context );
+
+  // Limit the interval so we do not get more than 999 classes
+  const double minInterval = ( maximum - minimum ) / 999;
+  if ( minInterval > interval )
+  {
+    interval = minInterval;
+    auto parameters = parameterValues();
+    parameters["INTERVAL"] = interval;
+    setParameterValues( parameters );
+  }
 
   QList<double> breaks;
   if ( qgsDoubleNear( interval, 0 ) || interval < 0 )

--- a/src/core/classification/qgsclassificationfixedinterval.cpp
+++ b/src/core/classification/qgsclassificationfixedinterval.cpp
@@ -58,12 +58,14 @@ QList<double> QgsClassificationFixedInterval::calculateBreaks( double &minimum, 
 
   // Limit the interval so we do not get more than 999 classes
   const double minInterval = ( maximum - minimum ) / 999;
+  bool maxClassesReached = false;
   if ( minInterval > interval )
   {
     interval = minInterval;
     auto parameters = parameterValues();
     parameters["INTERVAL"] = interval;
     setParameterValues( parameters );
+    maxClassesReached = true;
   }
 
   QList<double> breaks;
@@ -74,10 +76,13 @@ QList<double> QgsClassificationFixedInterval::calculateBreaks( double &minimum, 
   }
 
   double value = minimum;
-  while ( value < maximum )
+  while ( true )
   {
     value += interval;
     breaks << value;
+    if ( value > maximum ||
+         ( maxClassesReached && qgsDoubleNear( value, maximum, 1e-12 ) ) )
+      break;
   }
 
   return breaks;

--- a/src/core/classification/qgsclassificationfixedinterval.h
+++ b/src/core/classification/qgsclassificationfixedinterval.h
@@ -37,7 +37,7 @@ class CORE_EXPORT QgsClassificationFixedInterval : public QgsClassificationMetho
     bool valuesRequired() const override;
 
   private:
-    QList<double> calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses ) override;
+    QList<double> calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 
 
 };

--- a/src/core/classification/qgsclassificationjenks.cpp
+++ b/src/core/classification/qgsclassificationjenks.cpp
@@ -51,8 +51,9 @@ QIcon QgsClassificationJenks::icon() const
 
 
 QList<double> QgsClassificationJenks::calculateBreaks( double &minimum, double &maximum,
-    const QList<double> &values, int nclasses )
+    const QList<double> &values, int nclasses, QString *error )
 {
+  Q_UNUSED( error )
   // Jenks Optimal (Natural Breaks) algorithm
   // Based on the Jenks algorithm from the 'classInt' package available for
   // the R statistical prgramming language, and from Python code from here:

--- a/src/core/classification/qgsclassificationjenks.h
+++ b/src/core/classification/qgsclassificationjenks.h
@@ -37,7 +37,7 @@ class CORE_EXPORT QgsClassificationJenks : public QgsClassificationMethod
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 
     int mMaximumSize = 3000;
 };

--- a/src/core/classification/qgsclassificationlogarithmic.cpp
+++ b/src/core/classification/qgsclassificationlogarithmic.cpp
@@ -51,8 +51,9 @@ QIcon QgsClassificationLogarithmic::icon() const
   return QgsApplication::getThemeIcon( "classification_methods/mClassificationLogarithmic.svg" );
 }
 
-QList<double> QgsClassificationLogarithmic::calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses )
+QList<double> QgsClassificationLogarithmic::calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses, QString *error )
 {
+  Q_UNUSED( error )
   const QgsProcessingContext context;
   const QgsProcessingParameterDefinition *def = parameterDefinition( QStringLiteral( "ZERO_NEG_VALUES_HANDLE" ) );
   const NegativeValueHandling nvh = static_cast< NegativeValueHandling >( QgsProcessingParameters::parameterAsEnum( def, parameterValues(), context ) );

--- a/src/core/classification/qgsclassificationlogarithmic.h
+++ b/src/core/classification/qgsclassificationlogarithmic.h
@@ -49,7 +49,7 @@ class CORE_EXPORT QgsClassificationLogarithmic : public QgsClassificationMethod
     bool valuesRequired() const override;
 
   private:
-    QList<double> calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses ) override;
+    QList<double> calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses, QString *error = nullptr ) override;
     QString valueToLabel( double value ) const override;
 
 

--- a/src/core/classification/qgsclassificationmethod.cpp
+++ b/src/core/classification/qgsclassificationmethod.cpp
@@ -206,7 +206,7 @@ void QgsClassificationMethod::setParameterValues( const QVariantMap &values )
   }
 }
 
-QList<QgsClassificationRange> QgsClassificationMethod::classes( const QgsVectorLayer *layer, const QString &expression, int nclasses )
+QList<QgsClassificationRange> QgsClassificationMethod::classes( const QgsVectorLayer *layer, const QString &expression, int nclasses, QString *error )
 {
   if ( expression.isEmpty() )
     return QList<QgsClassificationRange>();
@@ -242,7 +242,7 @@ QList<QgsClassificationRange> QgsClassificationMethod::classes( const QgsVectorL
   }
 
   // get the breaks, minimum and maximum might be updated by implementation
-  QList<double> breaks = calculateBreaks( minimum, maximum, values, nclasses );
+  QList<double> breaks = calculateBreaks( minimum, maximum, values, nclasses, error );
   breaks.insert( 0, minimum );
   // create classes
   return breaksToClasses( breaks );

--- a/src/core/classification/qgsclassificationmethod.h
+++ b/src/core/classification/qgsclassificationmethod.h
@@ -236,7 +236,7 @@ class CORE_EXPORT QgsClassificationMethod SIP_ABSTRACT
      * \param expression The name of the field on which the classes are calculated
      * \param nclasses The number of classes to be returned
      */
-    QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses );
+    QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses, QString *error = nullptr );
 
     /**
      * This will calculate the classes for a list of values.
@@ -335,7 +335,7 @@ class CORE_EXPORT QgsClassificationMethod SIP_ABSTRACT
      * The maximum value is expected to be added at the end of the list, but not the minimum
      */
     virtual QList<double> calculateBreaks( double &minimum, double &maximum,
-                                           const QList<double> &values, int nclasses ) = 0;
+                                           const QList<double> &values, int nclasses, QString *error = nullptr ) = 0;
 
     //! This is called after calculating the breaks or restoring from XML, so it can rely on private variables
     virtual QString valueToLabel( double value ) const {return formatNumber( value );}

--- a/src/core/classification/qgsclassificationmethod.h
+++ b/src/core/classification/qgsclassificationmethod.h
@@ -235,6 +235,7 @@ class CORE_EXPORT QgsClassificationMethod SIP_ABSTRACT
      * \param layer The vector layer
      * \param expression The name of the field on which the classes are calculated
      * \param nclasses The number of classes to be returned
+     * \param error Optional parameter for error reporting
      */
     QList<QgsClassificationRange> classes( const QgsVectorLayer *layer, const QString &expression, int nclasses, QString *error = nullptr );
 

--- a/src/core/classification/qgsclassificationprettybreaks.cpp
+++ b/src/core/classification/qgsclassificationprettybreaks.cpp
@@ -36,7 +36,7 @@ QString QgsClassificationPrettyBreaks::id() const
   return QStringLiteral( "Pretty" );
 }
 
-QList<double> QgsClassificationPrettyBreaks::calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses )
+QList<double> QgsClassificationPrettyBreaks::calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses, QString *error )
 {
   Q_UNUSED( values );
   QList<double> breaks = QgsSymbolLayerUtils::prettyBreaks( minimum, maximum, nclasses );

--- a/src/core/classification/qgsclassificationprettybreaks.cpp
+++ b/src/core/classification/qgsclassificationprettybreaks.cpp
@@ -39,6 +39,7 @@ QString QgsClassificationPrettyBreaks::id() const
 QList<double> QgsClassificationPrettyBreaks::calculateBreaks( double &minimum, double &maximum, const QList<double> &values, int nclasses, QString *error )
 {
   Q_UNUSED( values );
+  Q_UNUSED( error );
   QList<double> breaks = QgsSymbolLayerUtils::prettyBreaks( minimum, maximum, nclasses );
 
   if ( symmetricModeEnabled() )

--- a/src/core/classification/qgsclassificationprettybreaks.h
+++ b/src/core/classification/qgsclassificationprettybreaks.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsClassificationPrettyBreaks : public QgsClassificationMethod
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 };
 
 #endif // QGSCLASSIFICATIONPRETTYBREAKS_H

--- a/src/core/classification/qgsclassificationquantile.cpp
+++ b/src/core/classification/qgsclassificationquantile.cpp
@@ -46,10 +46,11 @@ QIcon QgsClassificationQuantile::icon() const
 
 
 QList<double> QgsClassificationQuantile::calculateBreaks( double &minimum, double &maximum,
-    const QList<double> &values, int nclasses )
+    const QList<double> &values, int nclasses, QString *error )
 {
   Q_UNUSED( minimum )
   Q_UNUSED( maximum )
+  Q_UNUSED( error )
 
   // q-th quantile of a data set:
   // value where q fraction of data is below and (1-q) fraction is above this value

--- a/src/core/classification/qgsclassificationquantile.h
+++ b/src/core/classification/qgsclassificationquantile.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsClassificationQuantile : public QgsClassificationMethod
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 };
 
 #endif // QGSCLASSIFICATIONQUANTILE_H

--- a/src/core/classification/qgsclassificationstandarddeviation.cpp
+++ b/src/core/classification/qgsclassificationstandarddeviation.cpp
@@ -53,8 +53,9 @@ QIcon QgsClassificationStandardDeviation::icon() const
 
 
 QList<double> QgsClassificationStandardDeviation::calculateBreaks( double &minimum, double &maximum,
-    const QList<double> &values, int nclasses )
+    const QList<double> &values, int nclasses, QString *error )
 {
+  Q_UNUSED( error )
   // C++ implementation of the standard deviation class interval algorithm
   // as implemented in the 'classInt' package available for the R statistical
   // prgramming language.

--- a/src/core/classification/qgsclassificationstandarddeviation.h
+++ b/src/core/classification/qgsclassificationstandarddeviation.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsClassificationStandardDeviation : public QgsClassificationM
 
   private:
     QList<double> calculateBreaks( double &minimum, double &maximum,
-                                   const QList<double> &values, int nclasses ) override;
+                                   const QList<double> &values, int nclasses, QString *error = nullptr ) override;
 
     QString valueToLabel( double value ) const override;
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -436,12 +436,13 @@ void QgsGraduatedSymbolRenderer::updateClasses( QgsVectorLayer *vlayer, Mode mod
   updateClasses( vlayer, nclasses );
 }
 
-void QgsGraduatedSymbolRenderer::updateClasses( const QgsVectorLayer *vl, int nclasses )
+void QgsGraduatedSymbolRenderer::updateClasses( const QgsVectorLayer *vl, int nclasses, QString *error )
 {
+  Q_UNUSED( error )
   if ( mClassificationMethod->id() == QgsClassificationCustom::METHOD_ID )
     return;
 
-  QList<QgsClassificationRange> classes = mClassificationMethod->classes( vl, mAttrName, nclasses );
+  QList<QgsClassificationRange> classes = mClassificationMethod->classes( vl, mAttrName, nclasses, error );
 
   deleteAllClasses();
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -237,6 +237,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      * Recalculate classes for a layer
      * \param vl  The layer being rendered (from which data values are calculated)
      * \param nclasses the number of classes
+     * \param error Optional parameter for error reporting
      */
     void updateClasses( const QgsVectorLayer *vl, int nclasses, QString *error = nullptr );
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      * \param vl  The layer being rendered (from which data values are calculated)
      * \param nclasses the number of classes
      */
-    void updateClasses( const QgsVectorLayer *vl, int nclasses );
+    void updateClasses( const QgsVectorLayer *vl, int nclasses, QString *error = nullptr );
 
     Q_NOWARN_DEPRECATED_PUSH;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -1095,7 +1095,11 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     mRenderer->setSourceColorRamp( nullptr );
   }
 
-  mRenderer->updateClasses( mLayer, nclasses );
+  QString error;
+  mRenderer->updateClasses( mLayer, nclasses, &error );
+
+  if ( ! error.isEmpty() )
+    QMessageBox::critical( this, tr( "Apply Classification" ), error );
 
   if ( methodComboBox->currentData() == SizeMode )
     mRenderer->setSymbolSizes( minSizeSpinBox->value(), maxSizeSpinBox->value() );

--- a/tests/src/python/test_qgsclassificationmethod.py
+++ b/tests/src/python/test_qgsclassificationmethod.py
@@ -159,7 +159,9 @@ class TestQgsClassificationMethods(unittest.TestCase):
         m.setParameterValues({'INTERVAL': 0})
 
         r = m.classes(vl, 'value', 4)
-        self.assertEqual(len(r), 999)
+        self.assertEqual(len(r), 1)
+        self.assertEqual(QgsClassificationMethod.rangesToBreaks(r),
+                         [57.0])
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsclassificationmethod.py
+++ b/tests/src/python/test_qgsclassificationmethod.py
@@ -159,9 +159,7 @@ class TestQgsClassificationMethods(unittest.TestCase):
         m.setParameterValues({'INTERVAL': 0})
 
         r = m.classes(vl, 'value', 4)
-        self.assertEqual(len(r), 1)
-        self.assertEqual(QgsClassificationMethod.rangesToBreaks(r),
-                         [57.0])
+        self.assertEqual(len(r), 999)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Fixed interval has a default value of *1* which can generate way too many classes, leading to crashes - see #49333.
This PR automatically changes the *interval size* to a value that will not cause more than 999 classes.
999 is the maximum number of classes that we allow for the other interval types so I used this as a ceiling.

Editing the *Interval size* line edit widget can be a little klutzy when trying to change the forced minimum value, but that's a way better side effect than what we have now (potential crash).
@nyalldawson is there a more elegant way to change the parameter's default value dynamically?

Fix #49333
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
