### PR TITLE
Ignore stderr when checking astyle version

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -22,7 +22,7 @@ fi
 
 min_version="3"
 astyle_version_check() {
-	[ $(printf "$($1 --version 2>&1 | cut -d ' ' -f4)\\n$min_version" | sort -${SV} | head -n1) = "$min_version" ]
+	[ $(printf "$($1 --version 2>/dev/null | cut -d ' ' -f4)\\n$min_version" | sort -${SV} | head -n1) = "$min_version" ]
 }
 
 for ASTYLE in ${QGISSTYLE} $(dirname "$0")/qgisstyle $(dirname "$0")/RelWithDebInfo/qgisstyle astyle


### PR DESCRIPTION
## Description
Do we need to parse `stderr` when checking for `astyle` version?

For some reason my astyle reports:
```
uclaros@lutra-lutra:~/dev/cpp/QGIS/src$ astyle --version

Cannot set native locale, reverting to English

Artistic Style Version 3.1
uclaros@lutra-lutra:~/dev/cpp/QGIS/src$ 
```

which breaks `astyle.sh` / pre-commit hook:
```
../scripts/astyle.sh: line 25: [: =: unary operator expected
../scripts/astyle.sh: line 25: [: =: unary operator expected
qgisstyle / astyle not found - please install astyle >= 3 or enable WITH_ASTYLE in cmake and build
```



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
