### PR TITLE
Check QgsNetworkReplyContent headers case insensitively

### DIFF
--- a/src/core/network/qgsnetworkreply.cpp
+++ b/src/core/network/qgsnetworkreply.cpp
@@ -51,7 +51,7 @@ bool QgsNetworkReplyContent::hasRawHeader( const QByteArray &headerName ) const
 {
   for ( auto &header : mRawHeaderPairs )
   {
-    if ( header.first == headerName )
+    if ( ! QString::fromLocal8Bit( header.first ).compare( QString::fromLocal8Bit( headerName ), Qt::CaseInsensitive ) )
       return true;
   }
   return false;
@@ -72,7 +72,7 @@ QByteArray QgsNetworkReplyContent::rawHeader( const QByteArray &headerName ) con
 {
   for ( auto &header : mRawHeaderPairs )
   {
-    if ( header.first == headerName )
+    if ( ! QString::fromLocal8Bit( header.first ).compare( QString::fromLocal8Bit( headerName ), Qt::CaseInsensitive ) )
       return header.second;
   }
   return QByteArray();

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -353,9 +353,10 @@ bool QgsLazInfo::supportsRangeQueries( QUrl &url )
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
   nr.setRawHeader( "Range", "bytes=0-0" );
   QgsBlockingNetworkRequest req;
-  QgsBlockingNetworkRequest::ErrorCode errCode = req.head( nr );
+  // ignore the reply's status, we only care if accept-ranges is in the headers
+  req.head( nr );
   QgsNetworkReplyContent reply = req.reply();
 
-  QString acceptRangesHeader = reply.rawHeader( QStringLiteral( "Accept-Ranges" ).toLocal8Bit() );
-  return errCode == QgsBlockingNetworkRequest::NoError && acceptRangesHeader.compare( QStringLiteral( "bytes" ), Qt::CaseSensitivity::CaseInsensitive ) == 0;
+  const QString acceptRangesHeader = reply.rawHeader( QStringLiteral( "Accept-Ranges" ).toLocal8Bit() );
+  return acceptRangesHeader.compare( QStringLiteral( "bytes" ), Qt::CaseSensitivity::CaseInsensitive ) == 0;
 }

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -355,17 +355,7 @@ bool QgsLazInfo::supportsRangeQueries( QUrl &url )
   QgsBlockingNetworkRequest req;
   QgsBlockingNetworkRequest::ErrorCode errCode = req.head( nr );
   QgsNetworkReplyContent reply = req.reply();
-  const QList<QgsNetworkReplyContent::RawHeaderPair> pairs = reply.rawHeaderPairs();
-  bool acceptsRanges = false;
-  for ( const auto &pair : pairs )
-  {
-    if ( QString::fromLocal8Bit( pair.first ).compare( QStringLiteral( "Accept-Ranges" ), Qt::CaseInsensitive ) == 0 &&
-         QString::fromLocal8Bit( pair.second ).compare( QStringLiteral( "bytes" ), Qt::CaseInsensitive ) == 0 )
-    {
-      acceptsRanges = true;
-      break;
-    }
-  }
 
-  return errCode == QgsBlockingNetworkRequest::NoError && acceptsRanges;
+  QString acceptRangesHeader = reply.rawHeader( QStringLiteral( "Accept-Ranges" ).toLocal8Bit() );
+  return errCode == QgsBlockingNetworkRequest::NoError && acceptRangesHeader.compare( QStringLiteral( "bytes" ), Qt::CaseSensitivity::CaseInsensitive ) == 0;
 }


### PR DESCRIPTION
## Description
Properly handle `QgsNetworkReplyContent` headers case insensitively.
This pr replaces #49966

Also, avoids returning misleading "server does not support range requests" if the server has responded with an error ie. 4xx

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
