### PR TITLE
[feature][quick] Add temporal handling to map {canvas,settings}

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -180,6 +180,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     void onScreenChanged( QScreen *screen );
     void onExtentChanged();
     void onLayersChanged();
+    void onTemporalStateChanged();
 
   private:
 
@@ -190,6 +191,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QgsMapSettings prepareMapSettings() const;
     void updateTransform();
     void zoomToFullExtent();
+    void clearTemporalCache();
 
     std::unique_ptr<QgsQuickMapSettings> mMapSettings;
     bool mPinching = false;

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -226,6 +226,13 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
     int green = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 );
     int blue = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 );
     mMapSettings.setBackgroundColor( QColor( red, green, blue ) );
+
+    const bool isTemporal = mProject->readNumEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/NavigationMode" ), 0 ) != 0;
+    const QString startString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/StartDateTime" ) );
+    const QString endString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/EndDateTime" ) );
+    mMapSettings.setIsTemporal( isTemporal );
+    mMapSettings.setTemporalRange( QgsDateTimeRange( QDateTime::fromString( startString, Qt::ISODateWithMs ),
+                                   QDateTime::fromString( endString, Qt::ISODateWithMs ) ) );
   }
 
   QDomNodeList nodes = doc.elementsByTagName( "mapcanvas" );
@@ -260,6 +267,7 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
   emit outputSizeChanged();
   emit outputDpiChanged();
   emit layersChanged();
+  emit temporalStateChanged();
 }
 
 double QgsQuickMapSettings::rotation() const
@@ -296,4 +304,39 @@ void QgsQuickMapSettings::setDevicePixelRatio( const qreal &devicePixelRatio )
 {
   mDevicePixelRatio = devicePixelRatio;
   emit devicePixelRatioChanged();
+}
+
+bool QgsQuickMapSettings::isTemporal() const
+{
+  return mMapSettings.isTemporal();
+}
+
+void QgsQuickMapSettings::setIsTemporal( bool temporal )
+{
+  mMapSettings.setIsTemporal( temporal );
+  emit temporalStateChanged();
+}
+
+QDateTime QgsQuickMapSettings::temporalBegin() const
+{
+  return mMapSettings.temporalRange().begin();
+}
+
+void QgsQuickMapSettings::setTemporalBegin( const QDateTime &begin )
+{
+  const QgsDateTimeRange range = mMapSettings.temporalRange();
+  mMapSettings.setTemporalRange( QgsDateTimeRange( begin, range.end() ) );
+  emit temporalStateChanged();
+}
+
+QDateTime QgsQuickMapSettings::temporalEnd() const
+{
+  return mMapSettings.temporalRange().end();
+}
+
+void QgsQuickMapSettings::setTemporalEnd( const QDateTime &end )
+{
+  const QgsDateTimeRange range = mMapSettings.temporalRange();
+  mMapSettings.setTemporalRange( QgsDateTimeRange( range.begin(), end ) );
+  emit temporalStateChanged();
 }

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -117,6 +117,21 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
      */
     Q_PROPERTY( QList<QgsMapLayer *> layers READ layers WRITE setLayers NOTIFY layersChanged )
 
+    /**
+     * Returns TRUE if a temporal filtering is enabled
+     */
+    Q_PROPERTY( bool isTemporal READ isTemporal WRITE setIsTemporal NOTIFY temporalStateChanged )
+
+    /**
+     * The temporal range's begin (i.e. lower) value
+     */
+    Q_PROPERTY( QDateTime temporalBegin READ temporalBegin WRITE setTemporalBegin NOTIFY temporalStateChanged )
+
+    /**
+     * The temporal range's end (i.e. higher) value
+     */
+    Q_PROPERTY( QDateTime temporalEnd READ temporalEnd WRITE setTemporalEnd NOTIFY temporalStateChanged )
+
   public:
     //! Create new map settings
     explicit QgsQuickMapSettings( QObject *parent = nullptr );
@@ -249,6 +264,24 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
      */
     void setDevicePixelRatio( const qreal &devicePixelRatio );
 
+    //! \copydoc QgsQuickMapSettings::isTemporal
+    bool isTemporal() const;
+
+    //! \copydoc QgsQuickMapSettings::isTemporal
+    void setIsTemporal( bool temporal );
+
+    //! \copydoc QgsQuickMapSettings::temporalBegin
+    QDateTime temporalBegin() const;
+
+    //! \copydoc QgsQuickMapSettings::temporalBegin
+    void setTemporalBegin( const QDateTime &begin );
+
+    //! \copydoc QgsQuickMapSettings::temporalEnd
+    QDateTime temporalEnd() const;
+
+    //! \copydoc QgsQuickMapSettings::temporalEnd
+    void setTemporalEnd( const QDateTime &end );
+
   signals:
     //! \copydoc QgsQuickMapSettings::project
     void projectChanged();
@@ -281,6 +314,14 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
 
     //! \copydoc QgsQuickMapSettings::layers
     void layersChanged();
+
+    /**
+     * Emitted when the temporal state has changed.
+     * \see isTemporal()
+     * \see temporalBegin()
+     * \see temporalEnd()
+     */
+    void temporalStateChanged();
 
     //! \copydoc QgsQuickMapSettings::devicePixelRatio
     void devicePixelRatioChanged();


### PR DESCRIPTION
## Description

This PR adds the bits needed for QgsQuickMapCanvas and QgsQuickMapSettings to handle temporal settings. The reason why I'm using a pair of properties to set the temporal range (i.e. temporalBegin and temporalEnd) is to ease the use of the feature in QML environment.

It's been tested for a while now, works like a charm (thanks to QGIS' nice temporal implementation).