### PR TITLE
[quick] Add a map settings center property return the current extent center point as QgsPoint

### DIFF
--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -89,6 +89,11 @@ void QgsQuickMapSettings::setExtent( const QgsRectangle &extent )
   emit extentChanged();
 }
 
+QgsPoint QgsQuickMapSettings::center() const
+{
+  return QgsPoint( extent().center() );
+}
+
 void QgsQuickMapSettings::setCenter( const QgsPoint &center )
 {
   QgsVector delta = QgsPointXY( center ) - mMapSettings.extent().center();

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -58,6 +58,11 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
     Q_PROPERTY( QgsProject *project READ project WRITE setProject NOTIFY projectChanged )
 
     /**
+     * Geographical coordinate representing the center point of the current extent
+     */
+    Q_PROPERTY( QgsPoint center READ center WRITE setCenter NOTIFY extentChanged )
+
+    /**
      * Geographical coordinates of the rectangle that should be rendered.
      * The actual visible extent used for rendering could be slightly different
      * since the given extent may be expanded in order to fit the aspect ratio
@@ -136,6 +141,9 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
 
     //! \copydoc QgsQuickMapSettings::project
     QgsProject *project() const;
+
+    //! Returns the center point of the current map extent
+    QgsPoint center() const;
 
     //! Move current map extent to have center point defined by \a center
     Q_INVOKABLE void setCenter( const QgsPoint &center );


### PR DESCRIPTION
## Description

This PR upstreams a QgsQuickMapSettings center property we had for a while which returns the current extent's center point (served as a QgsPoint). This is both a nicer QML-esque way to deal with changing that property, but also makes it easier to use the property for other puproses (i.e. #50271). 