### PR TITLE
Format between and not between functions syntax to match other operators'

### DIFF
--- a/resources/function_help/json/BETWEEN
+++ b/resources/function_help/json/BETWEEN
@@ -4,6 +4,9 @@
   "groups": ["Operators"],
   "description": "Returns TRUE if value is within the specified range. The range is considered inclusive of the bounds. To test for exclusion NOT BETWEEN can be used.",
   "arguments": [{
+    "arg": "value",
+    "description": "the value to compare with a range. It can be a string, a number or a date."
+  }, {
     "arg": "lower_bound AND higher_bound",
     "description": "range bounds"
   }],
@@ -23,5 +26,6 @@
     "expression": "lower('B') BETWEEN 'a' AND 'b'",
     "returns": "TRUE"
   }],
+  "notes": "<i>value BETWEEN lower_bound AND higher_bound</i> is the same as \"<i>value &gt;= lower_bound AND value &lt;= higher_bound</i>\".",
   "tags": ["bound", "contained", "found", "include", "range", "within"]
 }

--- a/resources/function_help/json/NOT BETWEEN
+++ b/resources/function_help/json/NOT BETWEEN
@@ -4,6 +4,9 @@
   "groups": ["Operators"],
   "description": "Returns TRUE if value is not within the specified range. The range is considered inclusive of the bounds.",
   "arguments": [{
+    "arg": "value",
+    "description": "the value to compare with a range. It can be a string, a number or a date."
+  }, {
     "arg": "lower_bound AND higher_bound",
     "description": "range bounds"
   }],
@@ -23,5 +26,6 @@
     "expression": "lower('B') NOT BETWEEN 'a' AND 'b'",
     "returns": "FALSE"
   }],
+  "notes": "<i>value NOT BETWEEN lower_bound AND higher_bound</i> is the same as \"<i>value &lt; lower_bound OR value &gt; higher_bound</i>\".",
   "tags": ["bound", "contained", "exclude", "found", "range"]
 }


### PR DESCRIPTION
This PR is a revival of #49185, harmonizing the between based functions help with the others', with a bit more details.
Fixes https://github.com/qgis/QGIS/issues/49168
![image](https://user-images.githubusercontent.com/7983394/192166150-1c47232e-13d3-4c82-a8a4-9a4d8f37c0d5.png)

