### PR TITLE
Avoid a redundant calculation of visible layer extent in overview canvas

### DIFF
--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -266,8 +266,6 @@ void QgsMapOverviewCanvas::setLayers( const QList<QgsMapLayer *> &layers )
     connect( ml, &QgsMapLayer::repaintRequested, this, &QgsMapOverviewCanvas::layerRepaintRequested );
   }
 
-  updateFullExtent();
-
   refresh();
 }
 


### PR DESCRIPTION
This was being called twice immediately in a row, and the first time was skipping the "isVisible" check used before the second call. As a result we were ALWAYS recalculating the full extent of the project with every layer set change, even when the overview canvas was not open (and this is non-trivial for very large projects!)

On one test project this reduces a multi-second pause when checking/unchecking layers/groups in the tree to no pause.
