### PR TITLE
Show user friendly warnings when auto-loading relationships fails because of broken relationship definitions

### DIFF
--- a/python/core/auto_generated/qgsrelation.sip.in
+++ b/python/core/auto_generated/qgsrelation.sip.in
@@ -274,6 +274,19 @@ Returns the validity of this relation. Don't use the information if it's not val
 A relation is considered valid if both referenced and referencig layers are valid.
 
 :return: ``True`` if the relation is valid
+
+.. seealso:: :py:func:`validationError`
+%End
+
+    QString validationError() const;
+%Docstring
+Returns a user-friendly explanation for why the relationship is invalid.
+
+Returns an empty string if the relationship :py:func:`~QgsRelation.isValid`.
+
+.. seealso:: :py:func:`isValid`
+
+.. versionadded:: 3.28
 %End
 
     bool hasEqualDefinition( const QgsRelation &other ) const;

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -163,7 +163,7 @@ void QgsAppLayerHandling::postProcessAddedLayers( const QList<QgsMapLayer *> &la
             {
               vl->setWeakRelations( relations );
               resolveVectorLayerDependencies( vl, QgsMapLayer::StyleCategory::Relations, QgsVectorLayerRef::MatchType::Source, DependencyFlag::LoadAllRelationships | DependencyFlag::SilentLoad );
-              resolveVectorLayerWeakRelations( vl, QgsVectorLayerRef::MatchType::Source );
+              resolveVectorLayerWeakRelations( vl, QgsVectorLayerRef::MatchType::Source, true );
             }
           }
         }
@@ -1578,7 +1578,7 @@ void QgsAppLayerHandling::resolveVectorLayerDependencies( QgsVectorLayer *vl, Qg
   }
 }
 
-void QgsAppLayerHandling::resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer, QgsVectorLayerRef::MatchType matchType )
+void QgsAppLayerHandling::resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer, QgsVectorLayerRef::MatchType matchType, bool guiWarnings )
 {
   if ( vectorLayer && vectorLayer->isValid() )
   {
@@ -1600,6 +1600,10 @@ void QgsAppLayerHandling::resolveVectorLayerWeakRelations( QgsVectorLayer *vecto
             }
           }
           QgsProject::instance()->relationManager()->addRelation( relation );
+        }
+        else if ( guiWarnings )
+        {
+          QgisApp::instance()->messageBar()->pushWarning( QObject::tr( "Invalid relationship %1" ).arg( relation.name() ), relation.validationError() );
         }
       }
     }

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -202,8 +202,11 @@ class APP_EXPORT QgsAppLayerHandling
      *
      * This method will automatically attempt to repair any relations using
      * other layers already present in the current project.
+     *
+     * If \a guiWarnings is TRUE then the explanation for invalid relationships
+     * will be shown to the user.
      */
-    static void resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer, QgsVectorLayerRef::MatchType matchType = QgsVectorLayerRef::MatchType::Name );
+    static void resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer, QgsVectorLayerRef::MatchType matchType = QgsVectorLayerRef::MatchType::Name, bool guiWarnings = false );
 
     /**
      * Triggered when a vector layer style has changed, checks for widget config layer dependencies

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -366,11 +366,21 @@ QString QgsRelation::validationError() const
     return QString();
 
   if ( d->mReferencingLayer.isNull() )
-    return QObject::tr( "Referencing layer %1 does not exist" ).arg( d->mReferencingLayerId );
+  {
+    if ( d->mReferencingLayerId.isEmpty() )
+      return QObject::tr( "Referencing layer not set" );
+    else
+      return QObject::tr( "Referencing layer %1 does not exist" ).arg( d->mReferencingLayerId );
+  }
   else if ( !d->mReferencingLayer.data()->isValid() )
     return QObject::tr( "Referencing layer %1 is not valid" ).arg( d->mReferencingLayerId );
   else if ( d->mReferencedLayer.isNull() )
-    return QObject::tr( "Referenced layer %1 does not exist" ).arg( d->mReferencedLayerId );
+  {
+    if ( d->mReferencedLayerId.isEmpty() )
+      return QObject::tr( "Referenced layer not set" );
+    else
+      return QObject::tr( "Referenced layer %1 does not exist" ).arg( d->mReferencedLayerId );
+  }
   else if ( !d->mReferencedLayer.data()->isValid() )
     return QObject::tr( "Referenced layer %1 is not valid" ).arg( d->mReferencedLayerId );
   else

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -339,8 +339,20 @@ class CORE_EXPORT QgsRelation
      * A relation is considered valid if both referenced and referencig layers are valid.
      *
      * \returns TRUE if the relation is valid
+     *
+     * \see validationError()
      */
     bool isValid() const;
+
+    /**
+     * Returns a user-friendly explanation for why the relationship is invalid.
+     *
+     * Returns an empty string if the relationship isValid().
+     *
+     * \see isValid()
+     * \since QGIS 3.28
+     */
+    QString validationError() const;
 
     /**
      * Compares the two QgsRelation, ignoring the name and the ID.

--- a/src/core/qgsrelation_p.h
+++ b/src/core/qgsrelation_p.h
@@ -66,6 +66,7 @@ class QgsRelationPrivate : public QSharedData
     QList< QgsRelation::FieldPair > mFieldPairs;
 
     bool mValid = false;
+    QString mValidationError;
 };
 
 /// @endcond

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -86,21 +86,35 @@ class TestQgsRelation(unittest.TestCase):
     def test_isValid(self):
         rel = QgsRelation()
         self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referencing layer not set')
 
         rel.setId('rel1')
         self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referencing layer not set')
 
         rel.setName('Relation Number One')
         self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referencing layer not set')
+
+        rel.setReferencingLayer('xxx')
+        self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referencing layer xxx does not exist')
 
         rel.setReferencingLayer(self.referencingLayer.id())
         self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referenced layer not set')
+
+        rel.setReferencedLayer('yyy')
+        self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'Referenced layer yyy does not exist')
 
         rel.setReferencedLayer(self.referencedLayer.id())
         self.assertFalse(rel.isValid())
+        self.assertEqual(rel.validationError(), 'No fields specified for relationship')
 
         rel.addFieldPair('foreignkey', 'y')
         self.assertTrue(rel.isValid())
+        self.assertEqual(rel.validationError(), '')
 
     def test_getRelatedFeatures(self):
         rel = QgsRelation()


### PR DESCRIPTION
When we can't auto load a relationship because its definition is broken, show a warning to users instead of silently failing