### PR TITLE
Add setting to enable WMS tile prefetch

### DIFF
--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -107,6 +107,7 @@ class CORE_EXPORT QgsSettings : public QObject
         static const inline char *CORE_LAYERTREE = "core/layer-tree";
         static const inline char *STYLE_MANAGER = "app/style-manager";
         static const inline char *FONTS = "fonts";
+        static const inline char *WMS = "wms";
     };
 
     /**

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -106,6 +106,7 @@ QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   addSettingsEntry( &settingsDigitizingTracingMaxFeatureCount );
   addSettingsEntry( &settingsGpsBabelPath );
   addSettingsEntry( &settingsLayerTreeShowFeatureCountForNewLayers );
+  addSettingsEntry( &settingsEnableWMSTilePrefetching );
 
   addSettingsEntry( &QgsOwsConnection::settingsConnectionSelected );
   addSettingsEntryGroup( &QgsOwsConnection::settingsServiceConnectionDetailsGroup );

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -175,7 +175,7 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::CORE_LAYERTREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
 
     //! Settings entry enable WMS tile prefetching.
-    static const inline QgsSettingsEntryBool settingsEnableWMSTilePrefetching = QgsSettingsEntryBool( QStringLiteral( "enable_wms_tile_prefetch" ), QgsSettings::Prefix::WMS, false );
+    static const inline QgsSettingsEntryBool settingsEnableWMSTilePrefetching = QgsSettingsEntryBool( QStringLiteral( "enable_wms_tile_prefetch" ), QgsSettings::Prefix::WMS, false, QStringLiteral( "Whether to include WMS layers when rendering tiles adjacent to the visible map area")  );
 #endif
 
 };

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -175,7 +175,7 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::CORE_LAYERTREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
 
     //! Settings entry enable WMS tile prefetching.
-    static const inline QgsSettingsEntryBool settingsEnableWMSTilePrefetching = QgsSettingsEntryBool( QStringLiteral( "enable_wms_tile_prefetch" ), QgsSettings::Prefix::WMS, false, QStringLiteral( "Whether to include WMS layers when rendering tiles adjacent to the visible map area")  );
+    static const inline QgsSettingsEntryBool settingsEnableWMSTilePrefetching = QgsSettingsEntryBool( QStringLiteral( "enable_wms_tile_prefetch" ), QgsSettings::Prefix::WMS, false, QStringLiteral( "Whether to include WMS layers when rendering tiles adjacent to the visible map area" ) );
 #endif
 
 };

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -173,6 +173,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
 
     //! Settings entry show feature counts for newly added layers by default
     static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::CORE_LAYERTREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
+
+    //! Settings entry enable WMS tile prefetching.
+    static const inline QgsSettingsEntryBool settingsEnableWMSTilePrefetching = QgsSettingsEntryBool( QStringLiteral( "enable_wms_tile_prefetch" ), QgsSettings::Prefix::WMS, false );
 #endif
 
 };

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -49,6 +49,7 @@
 #include "qgswmscapabilities.h"
 #include "qgsexception.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsogrutils.h"
 #include "qgsproviderregistry.h"
 #include "qgsruntimeprofiler.h"
@@ -2363,7 +2364,9 @@ int QgsWmsProvider::capabilities() const
     }
   }
 
-  if ( mSettings.mXyz )
+  QgsSettings s;
+  bool enablePrefetch = QgsSettingsRegistryCore::settingsEnableWMSTilePrefetching.value();
+  if ( mSettings.mXyz || enablePrefetch )
   {
     capability |= Capability::Prefetch;
   }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2364,7 +2364,6 @@ int QgsWmsProvider::capabilities() const
     }
   }
 
-  QgsSettings s;
   bool enablePrefetch = QgsSettingsRegistryCore::settingsEnableWMSTilePrefetching.value();
   if ( mSettings.mXyz || enablePrefetch )
   {


### PR DESCRIPTION
I appreciate that the up and downsides of WMS tile prefetching has been discussed in previous tickets, but I'd like to suggest to introduce a setting so that third-party consumers can control this behaviour - in my case WMS tile prefetching is a feature that is desired in KADAS Albireo.