### PR TITLE
[spatialite] Fix corrupted default attribute values when fields are loaded using gaiaVectorLayer

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -759,7 +759,6 @@ void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr 
   int ret = sqlite3_get_table( mSqliteHandle, sql.toUtf8().constData(), &results, &rows, &columns, &errMsg );
   if ( ret == SQLITE_OK )
   {
-    int realFieldIndex = 0;
     for ( int i = 1; i <= rows; i++ )
     {
       QString name = QString::fromUtf8( results[( i * columns ) + 1] );
@@ -767,7 +766,12 @@ void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr 
       if ( name.compare( mGeometryColumn, Qt::CaseInsensitive ) == 0 )
         continue;
 
-      insertDefaultValue( realFieldIndex, QString::fromUtf8( results[( i * columns ) + 4] ) );
+      const QString defaultValue = QString::fromUtf8( results[( i * columns ) + 4] );
+      const int realFieldIndex = mAttributeFields.lookupField( name );
+      if ( realFieldIndex >= 0 )
+      {
+        insertDefaultValue( realFieldIndex, defaultValue );
+      }
 
       QString pk = results[( i * columns ) + 5];
       QString type = results[( i * columns ) + 2];
@@ -798,7 +802,6 @@ void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr 
       else
         mPrimaryKey.clear();
       mPrimaryKeyAttrs << i - 1;
-      realFieldIndex += 1;
     }
   }
 


### PR DESCRIPTION
Unfortunately I can't write a test for this one -- I can't find the magic formula to get this particular code path hit with any newly created spatialite databases, and am only able to reproduce this issue on a customer's sensitive db.

The underlying cause of the issue is that the "continue" statements are hit while iterating over the pragma results table, which means that the "realFieldIndex +=1" code at the end of this loop is never hit, and we end up always inserting the default values into field index 0.