### PR TITLE
Allow no dataset group when exporting mesh elements in processing

### DIFF
--- a/src/analysis/processing/qgsalgorithmexportmesh.cpp
+++ b/src/analysis/processing/qgsalgorithmexportmesh.cpp
@@ -210,7 +210,7 @@ void QgsExportMeshOnElement::initAlgorithm( const QVariantMap &configuration )
                   QStringLiteral( "DATASET_GROUPS" ),
                   QObject::tr( "Dataset groups" ),
                   QStringLiteral( "INPUT" ),
-                  supportedDataType() ) );
+                  supportedDataType(), true ) );
 
   addParameter( new QgsProcessingParameterMeshDatasetTime(
                   QStringLiteral( "DATASET_TIME" ),
@@ -333,7 +333,7 @@ QVariantMap QgsExportMeshOnElement::processAlgorithm( const QVariantMap &paramet
 
   QList<QgsMeshDatasetGroupMetadata> metaList;
   metaList.reserve( mDataPerGroup.size() );
-  for ( const DataGroup &dataGroup : mDataPerGroup )
+  for ( const DataGroup &dataGroup : std::as_const( mDataPerGroup ) )
     metaList.append( dataGroup.metadata );
   QgsFields fields = createFields( metaList, mExportVectorOption );
 

--- a/src/core/processing/qgsprocessingparametermeshdataset.cpp
+++ b/src/core/processing/qgsprocessingparametermeshdataset.cpp
@@ -117,18 +117,13 @@ QList<int> QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( const Q
   QList<int> ret;
 
   // if invalid or empty, return only the group 0
-  if ( !value.isValid() )
-    ret << 0;
-  else
+  if ( value.isValid() )
   {
     if ( value.type() == QVariant::List )
     {
       const QVariantList varList = value.toList();
-      if ( varList.isEmpty() )
-        ret << 0;
-      else
-        for ( const QVariant &v : varList )
-          ret << v.toInt();
+      for ( const QVariant &v : varList )
+        ret << v.toInt();
     }
     else
     {

--- a/src/core/processing/qgsprocessingparametermeshdataset.cpp
+++ b/src/core/processing/qgsprocessingparametermeshdataset.cpp
@@ -116,7 +116,6 @@ QList<int> QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( const Q
 
   QList<int> ret;
 
-  // if invalid or empty, return only the group 0
   if ( value.isValid() )
   {
     if ( value.type() == QVariant::List )

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9718,8 +9718,8 @@ void TestQgsProcessing::parameterMeshDatasetGroups()
   QgsProject project;
   context.setProject( &project );
 
-  QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariant() ), QList<int>( {0} ) );
-  QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariantList() ), QList<int>( {0} ) );
+  QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariant() ), QList<int>() );
+  QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariantList() ), QList<int>() );
   QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( 3 ), QList<int>( {3} ) );
   QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariant( "3" ) ), QList<int>( {3} ) );
   QCOMPARE( QgsProcessingParameterMeshDatasetGroups::valueAsDatasetGroup( QVariantList( { "3", "4", "5"} ) ), QList<int>( {3, 4, 5 } ) );


### PR DESCRIPTION
https://github.com/qgis/QGIS/pull/47197 make mandatory to select at least one dataset group. But this fix leads to regression #49973. Indeed, in some cases, faces or vertices  haven't dataset group associated with.

So in this PR, we allow to not select dataset group, but in this case, instead of considering by default the first dataset group, there is no dataset group to be exported.

fix #49973