### PR TITLE
New layer tree insertion methods (on top of tree, optimal) and sorting of drag and dropped layers

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2045,7 +2045,6 @@ Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. v
 # --
 Qgis.CoordinateDisplayType.baseClass = Qgis
 # monkey patching scoped based enum
-<<<<<<< HEAD
 Qgis.ScriptLanguage.Css.__doc__ = "CSS"
 Qgis.ScriptLanguage.QgisExpression.__doc__ = "QGIS expressions"
 Qgis.ScriptLanguage.Html.__doc__ = "HTML"
@@ -2058,11 +2057,10 @@ Qgis.ScriptLanguage.Unknown.__doc__ = "Unknown/other language"
 Qgis.ScriptLanguage.__doc__ = 'Scripting languages.\n\n.. versionadded:: 3.30\n\n' + '* ``Css``: ' + Qgis.ScriptLanguage.Css.__doc__ + '\n' + '* ``QgisExpression``: ' + Qgis.ScriptLanguage.QgisExpression.__doc__ + '\n' + '* ``Html``: ' + Qgis.ScriptLanguage.Html.__doc__ + '\n' + '* ``JavaScript``: ' + Qgis.ScriptLanguage.JavaScript.__doc__ + '\n' + '* ``Json``: ' + Qgis.ScriptLanguage.Json.__doc__ + '\n' + '* ``Python``: ' + Qgis.ScriptLanguage.Python.__doc__ + '\n' + '* ``R``: ' + Qgis.ScriptLanguage.R.__doc__ + '\n' + '* ``Sql``: ' + Qgis.ScriptLanguage.Sql.__doc__ + '\n' + '* ``Unknown``: ' + Qgis.ScriptLanguage.Unknown.__doc__
 # --
 Qgis.ScriptLanguage.baseClass = Qgis
-=======
+# monkey patching scoped based enum
 Qgis.LayerTreeInsertionMethod.AboveInsertionPoint.__doc__ = "Layers are added in the tree above the insertion point"
 Qgis.LayerTreeInsertionMethod.TopOfTree.__doc__ = "Layers are added at the top of the layer tree"
 Qgis.LayerTreeInsertionMethod.OptimalInInsertionGroup.__doc__ = "Layers are added at optimal locations across the insertion point's group"
 Qgis.LayerTreeInsertionMethod.__doc__ = 'Layer tree insertion methods\n\n.. versionadded:: 3.30\n\n' + '* ``AboveInsertionPoint``: ' + Qgis.LayerTreeInsertionMethod.AboveInsertionPoint.__doc__ + '\n' + '* ``TopOfTree``: ' + Qgis.LayerTreeInsertionMethod.TopOfTree.__doc__ + '\n' + '* ``OptimalInInsertionGroup``: ' + Qgis.LayerTreeInsertionMethod.OptimalInInsertionGroup.__doc__
 # --
 Qgis.LayerTreeInsertionMethod.baseClass = Qgis
->>>>>>> 4a95e2b0a8 (Add UI to select which insertion method should be used when adding new layers)

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2045,6 +2045,7 @@ Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. v
 # --
 Qgis.CoordinateDisplayType.baseClass = Qgis
 # monkey patching scoped based enum
+<<<<<<< HEAD
 Qgis.ScriptLanguage.Css.__doc__ = "CSS"
 Qgis.ScriptLanguage.QgisExpression.__doc__ = "QGIS expressions"
 Qgis.ScriptLanguage.Html.__doc__ = "HTML"
@@ -2057,3 +2058,11 @@ Qgis.ScriptLanguage.Unknown.__doc__ = "Unknown/other language"
 Qgis.ScriptLanguage.__doc__ = 'Scripting languages.\n\n.. versionadded:: 3.30\n\n' + '* ``Css``: ' + Qgis.ScriptLanguage.Css.__doc__ + '\n' + '* ``QgisExpression``: ' + Qgis.ScriptLanguage.QgisExpression.__doc__ + '\n' + '* ``Html``: ' + Qgis.ScriptLanguage.Html.__doc__ + '\n' + '* ``JavaScript``: ' + Qgis.ScriptLanguage.JavaScript.__doc__ + '\n' + '* ``Json``: ' + Qgis.ScriptLanguage.Json.__doc__ + '\n' + '* ``Python``: ' + Qgis.ScriptLanguage.Python.__doc__ + '\n' + '* ``R``: ' + Qgis.ScriptLanguage.R.__doc__ + '\n' + '* ``Sql``: ' + Qgis.ScriptLanguage.Sql.__doc__ + '\n' + '* ``Unknown``: ' + Qgis.ScriptLanguage.Unknown.__doc__
 # --
 Qgis.ScriptLanguage.baseClass = Qgis
+=======
+Qgis.LayerTreeInsertionMethod.AboveInsertionPoint.__doc__ = "Layers are added in the tree above the insertion point"
+Qgis.LayerTreeInsertionMethod.TopOfTree.__doc__ = "Layers are added at the top of the layer tree"
+Qgis.LayerTreeInsertionMethod.OptimalInInsertionGroup.__doc__ = "Layers are added at optimal locations across the insertion point's group"
+Qgis.LayerTreeInsertionMethod.__doc__ = 'Layer tree insertion methods\n\n.. versionadded:: 3.30\n\n' + '* ``AboveInsertionPoint``: ' + Qgis.LayerTreeInsertionMethod.AboveInsertionPoint.__doc__ + '\n' + '* ``TopOfTree``: ' + Qgis.LayerTreeInsertionMethod.TopOfTree.__doc__ + '\n' + '* ``OptimalInInsertionGroup``: ' + Qgis.LayerTreeInsertionMethod.OptimalInInsertionGroup.__doc__
+# --
+Qgis.LayerTreeInsertionMethod.baseClass = Qgis
+>>>>>>> 4a95e2b0a8 (Add UI to select which insertion method should be used when adding new layers)

--- a/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -69,6 +69,20 @@ By default it is root group with zero index.
 .. versionadded:: 3.10
 %End
 
+    void setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod method );
+%Docstring
+Sets the insertion ``method`` used to add layers to the tree
+
+.. versionadded:: 3.30
+%End
+
+    Qgis::LayerTreeInsertionMethod layerInsertionMethod() const;
+%Docstring
+Returns the insertion method used to add layers to the tree
+
+.. versionadded:: 3.30
+%End
+
   signals:
 
     void addedLayersToLayerTree( const QList<QgsMapLayer *> &layers );

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -142,6 +142,8 @@ or the group itself if it doesn't hold the property
 
 .. versionadded:: 3.8
 %End
+
+    static QgsLayerTreeLayer *insertLayerAtOptimalPlacement( QgsLayerTreeGroup *group, QgsMapLayer *layer );
 };
 
 /************************************************************************

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -144,6 +144,23 @@ or the group itself if it doesn't hold the property
 %End
 
     static QgsLayerTreeLayer *insertLayerAtOptimalPlacement( QgsLayerTreeGroup *group, QgsMapLayer *layer );
+%Docstring
+Inserts a ``layer`` within a given ``group`` at an optimal index position by insuring a given layer
+type will always sit on top of or below other types. From top to bottom, the stacking logic is
+as follow:
+
+- vector points
+- vector lines
+- vector polygons
+- point clouds
+- meshes
+- rasters
+- base maps
+
+A base map is defined as a non-gdal provider raster layer (e.g. XYZ raster layer, vector tile layer, etc.)
+
+.. versionadded:: 3.28
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1327,6 +1327,7 @@ The development version
       CustomCrs,
     };
 
+<<<<<<< HEAD
     enum class ScriptLanguage
     {
       Css,
@@ -1338,6 +1339,13 @@ The development version
       R,
       Sql,
       Unknown,
+=======
+    enum class LayerTreeInsertionMethod
+    {
+      AboveInsertionPoint,
+      TopOfTree,
+      OptimalInInsertionGroup,
+>>>>>>> 4a95e2b0a8 (Add UI to select which insertion method should be used when adding new layers)
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1327,7 +1327,6 @@ The development version
       CustomCrs,
     };
 
-<<<<<<< HEAD
     enum class ScriptLanguage
     {
       Css,
@@ -1339,13 +1338,13 @@ The development version
       R,
       Sql,
       Unknown,
-=======
+    };
+
     enum class LayerTreeInsertionMethod
     {
       AboveInsertionPoint,
       TopOfTree,
       OptimalInInsertionGroup,
->>>>>>> 4a95e2b0a8 (Add UI to select which insertion method should be used when adding new layers)
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -297,6 +297,7 @@ Returns width of contextual menu mark, at right of layer node items.
 
 
 
+
   public slots:
     void refreshLayerSymbology( const QString &layerId );
 %Docstring
@@ -353,6 +354,11 @@ Returns the show private layers status
 Emitted when a current layer is changed
 %End
 
+    void datasetsDropped( QDropEvent *event );
+%Docstring
+Emitted when datasets are dropped onto the layer tree view
+%End
+
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
@@ -365,6 +371,10 @@ Emitted when a current layer is changed
 
     virtual void keyPressEvent( QKeyEvent *event );
 
+
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+    virtual void dragMoveEvent( QDragMoveEvent *event );
 
     virtual void dropEvent( QDropEvent *event );
 

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -179,7 +179,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
   }
 
   QgsLayerTreeGroup *parent = nullptr;
-  QgsLayerTreeNode *currentNode { QgisApp::instance()->layerTreeView()->currentNode() };
+  QgsLayerTreeNode *currentNode = QgisApp::instance()->layerTreeView()->currentNode();
   int currentIndex = 0;
   if ( currentNode && currentNode->parent() )
   {
@@ -196,7 +196,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
         nodeIdx++;
         if ( child == currentNode )
         {
-          currentIndex = nodeIdx;
+          currentIndex = nodeIdx - 1;
           break;
         }
       }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -37,6 +37,7 @@
 #include "qgslayertree.h"
 #include "qgslayertreeview.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
 #include "qgsgui.h"
 #include "qgsmbtiles.h"
 #include "qgsmessagelog.h"
@@ -179,7 +180,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
 
   QgsLayerTreeGroup *parent = nullptr;
   QgsLayerTreeNode *currentNode { QgisApp::instance()->layerTreeView()->currentNode() };
-  int index = 0;
+  int currentIndex = 0;
   if ( currentNode && currentNode->parent() )
   {
     if ( QgsLayerTree::isGroup( currentNode ) )
@@ -188,14 +189,14 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
     }
     else if ( QgsLayerTree::isLayer( currentNode ) )
     {
-      const QList<QgsLayerTreeNode *> currentNodeSiblings { currentNode->parent()->children() };
+      const QList<QgsLayerTreeNode *> currentNodeSiblings = currentNode->parent()->children();
       int nodeIdx = 0;
       for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
       {
         nodeIdx++;
         if ( child == currentNode )
         {
-          index = nodeIdx;
+          currentIndex = nodeIdx;
           break;
         }
       }
@@ -213,7 +214,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
 
   for ( QgsMapLayer *layer : layers )
   {
-    parent->insertLayer( index, layer );
+    parent->insertLayer( currentIndex, layer );
   }
   QgisApp::instance()->layerTreeView()->setCurrentLayer( layers.at( 0 ) );
 }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -214,7 +214,18 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
 
   for ( QgsMapLayer *layer : layers )
   {
-    parent->insertLayer( currentIndex, layer );
+    switch ( QgsProject::instance()->layerTreeRegistryBridge()->layerInsertionMethod() )
+    {
+      case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
+        parent->insertLayer( currentIndex, layer );
+        break;
+      case Qgis::LayerTreeInsertionMethod::TopOfTree:
+        QgsProject::instance()->layerTreeRoot()->insertLayer( 0, layer );
+        break;
+      case Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup:
+        QgsLayerTreeUtils::insertLayerAtOptimalPlacement( parent, layer );
+        break;
+    }
   }
   QgisApp::instance()->layerTreeView()->setCurrentLayer( layers.at( 0 ) );
 }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -160,11 +160,8 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
       {
         QgsVectorLayer *av = qobject_cast<QgsVectorLayer *>( a );
         QgsVectorLayer *bv = qobject_cast<QgsVectorLayer *>( b );
-        if ( av->geometryType() == QgsWkbTypes::PointGeometry && bv->geometryType() != QgsWkbTypes::PointGeometry )
-        {
-          return false;
-        }
-        else if ( av->geometryType() == QgsWkbTypes::LineGeometry && bv->geometryType() == QgsWkbTypes::PolygonGeometry )
+        if ( ( av->geometryType() == QgsWkbTypes::PointGeometry && bv->geometryType() != QgsWkbTypes::PointGeometry ) ||
+             ( av->geometryType() == QgsWkbTypes::LineGeometry && bv->geometryType() == QgsWkbTypes::PolygonGeometry ) )
         {
           return false;
         }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -36,6 +36,7 @@
 #include "qgslayertreenode.h"
 #include "qgslayertree.h"
 #include "qgslayertreeview.h"
+#include "qgslayertreemodel.h"
 #include "qgsgui.h"
 #include "qgsmbtiles.h"
 #include "qgsmessagelog.h"
@@ -134,6 +135,87 @@ void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
       break;
     }
   }
+}
+
+void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers )
+{
+  if ( layers.size() > 1 )
+  {
+    std::sort( layers.begin(), layers.end(), []( QgsMapLayer * a, QgsMapLayer * b )
+    {
+      const static QMap<QgsMapLayerType, int> layerTypeOrdering =
+      {
+        { QgsMapLayerType::AnnotationLayer, -1 },
+        { QgsMapLayerType::VectorLayer, 0 },
+        { QgsMapLayerType::PointCloudLayer, 1 },
+        { QgsMapLayerType::MeshLayer, 2 },
+        { QgsMapLayerType::VectorTileLayer, 3 },
+        { QgsMapLayerType::RasterLayer, 4 },
+        { QgsMapLayerType::GroupLayer, 5 },
+        { QgsMapLayerType::PluginLayer, 6 },
+      };
+
+      if ( a->type() == QgsMapLayerType::VectorLayer && b->type() == QgsMapLayerType::VectorLayer )
+      {
+        QgsVectorLayer *av = qobject_cast<QgsVectorLayer *>( a );
+        QgsVectorLayer *bv = qobject_cast<QgsVectorLayer *>( b );
+        if ( av->geometryType() == QgsWkbTypes::PointGeometry && bv->geometryType() != QgsWkbTypes::PointGeometry )
+        {
+          return false;
+        }
+        else if ( av->geometryType() == QgsWkbTypes::LineGeometry && bv->geometryType() == QgsWkbTypes::PolygonGeometry )
+        {
+          return false;
+        }
+        else
+        {
+          return true;
+        }
+      }
+
+      return layerTypeOrdering.value( a->type() ) > layerTypeOrdering.value( b->type() );
+    } );
+  }
+
+  QgsLayerTreeGroup *parent = nullptr;
+  QgsLayerTreeNode *currentNode { QgisApp::instance()->layerTreeView()->currentNode() };
+  int index = 0;
+  if ( currentNode && currentNode->parent() )
+  {
+    if ( QgsLayerTree::isGroup( currentNode ) )
+    {
+      parent = qobject_cast<QgsLayerTreeGroup *>( currentNode );
+    }
+    else if ( QgsLayerTree::isLayer( currentNode ) )
+    {
+      const QList<QgsLayerTreeNode *> currentNodeSiblings { currentNode->parent()->children() };
+      int nodeIdx = 0;
+      for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
+      {
+        nodeIdx++;
+        if ( child == currentNode )
+        {
+          index = nodeIdx;
+          break;
+        }
+      }
+      parent = qobject_cast<QgsLayerTreeGroup *>( currentNode->parent() );
+    }
+    else
+    {
+      parent = qobject_cast<QgsLayerTreeGroup *>( QgsProject::instance()->layerTreeRoot() );
+    }
+  }
+  else
+  {
+    parent = qobject_cast<QgsLayerTreeGroup *>( QgsProject::instance()->layerTreeRoot() );
+  }
+
+  for ( QgsMapLayer *layer : layers )
+  {
+    parent->insertLayer( index, layer );
+  }
+  QgisApp::instance()->layerTreeView()->setCurrentLayer( layers.at( 0 ) );
 }
 
 void QgsAppLayerHandling::postProcessAddedLayers( const QList<QgsMapLayer *> &layers )
@@ -370,7 +452,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addOgrVectorLayers( const QStringLis
   return addedLayers;
 }
 
-QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri, const QString &baseName, const QString &provider, bool showWarningOnInvalid )
+QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri, const QString &baseName, const QString &provider, bool showWarningOnInvalid, bool addToLegend )
 {
   QgsCanvasRefreshBlocker refreshBlocker;
   QgsSettings settings;
@@ -402,13 +484,13 @@ QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri,
   QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
 
 
-  QgsProject::instance()->addMapLayer( layer.get() );
+  QgsProject::instance()->addMapLayer( layer.get(), addToLegend );
   QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
 
   return layer.release();
 }
 
-QgsPluginLayer *QgsAppLayerHandling::addPluginLayer( const QString &uri, const QString &baseName, const QString &provider )
+QgsPluginLayer *QgsAppLayerHandling::addPluginLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend )
 {
   QgsPluginLayer *layer = QgsApplication::pluginLayerRegistry()->createLayer( provider, uri );
   if ( !layer )
@@ -416,12 +498,12 @@ QgsPluginLayer *QgsAppLayerHandling::addPluginLayer( const QString &uri, const Q
 
   layer->setName( baseName );
 
-  QgsProject::instance()->addMapLayer( layer );
+  QgsProject::instance()->addMapLayer( layer, addToLegend );
 
   return layer;
 }
 
-QgsVectorTileLayer *QgsAppLayerHandling::addVectorTileLayer( const QString &uri, const QString &baseName, bool showWarningOnInvalid )
+QgsVectorTileLayer *QgsAppLayerHandling::addVectorTileLayer( const QString &uri, const QString &baseName, bool showWarningOnInvalid, bool addToLegend )
 {
   QgsCanvasRefreshBlocker refreshBlocker;
   QgsSettings settings;
@@ -453,7 +535,7 @@ QgsVectorTileLayer *QgsAppLayerHandling::addVectorTileLayer( const QString &uri,
 
   QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
 
-  QgsProject::instance()->addMapLayer( layer.get() );
+  QgsProject::instance()->addMapLayer( layer.get(), addToLegend );
   QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
 
   return layer.release();
@@ -577,10 +659,10 @@ QgsAppLayerHandling::SublayerHandling QgsAppLayerHandling::shouldAskUserForSubla
   return SublayerHandling::AskUser;
 }
 
-QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName )
+QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName, bool addToLegend )
 {
   QgsLayerTreeGroup *group = nullptr;
-  if ( !groupName.isEmpty() )
+  if ( !groupName.isEmpty() && addToLegend )
   {
     int index { 0 };
     QgsLayerTreeNode *currentNode { QgisApp::instance()->layerTreeView()->currentNode() };
@@ -659,14 +741,17 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
     // filename in the layer's name, because the group is already titled with the filename.
     // But otherwise, we DO include the file name so that users can differentiate the source
     // when multiple layers are loaded from a GPX file or similar (refs https://github.com/qgis/QGIS/issues/37551)
-    if ( group )
+    if ( !groupName.isEmpty() )
     {
       if ( !layerName.isEmpty() )
         layer->setName( layerName );
       else if ( !baseName.isEmpty() )
         layer->setName( baseName );
-      QgsProject::instance()->addMapLayer( layer.release(), false );
-      group->addLayer( ml );
+      QgsProject::instance()->addMapLayer( layer.release(), addToLegend );
+      if ( group )
+      {
+        group->addLayer( ml );
+      }
     }
     else
     {
@@ -676,7 +761,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
         layer->setName( layerName );
       else if ( !baseName.isEmpty() )
         layer->setName( baseName );
-      QgsProject::instance()->addMapLayer( layer.release() );
+      QgsProject::instance()->addMapLayer( layer.release(), addToLegend );
     }
 
     // Some of the logic relating to matching a new project's CRS to the first layer added CRS is deferred to happen when the event loop
@@ -718,7 +803,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
   return result;
 }
 
-QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, bool &ok, bool allowInteractive, bool suppressBulkLayerPostProcessing )
+QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, bool &ok, bool allowInteractive, bool suppressBulkLayerPostProcessing, bool addToLegend )
 {
   QList< QgsMapLayer * > openedLayers;
   auto postProcessAddedLayers = [suppressBulkLayerPostProcessing, &openedLayers]
@@ -749,7 +834,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
 
       case QgsMapLayerType::PointCloudLayer:
       {
-        if ( QgsPointCloudLayer *layer = addPointCloudLayer( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), true ) )
+        if ( QgsPointCloudLayer *layer = addPointCloudLayer( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), true, addToLegend ) )
         {
           ok = true;
           openedLayers << layer;
@@ -800,7 +885,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
         if ( vtLayer->isValid() )
         {
           openedLayers << vtLayer.get();
-          QgsProject::instance()->addMapLayer( vtLayer.release() );
+          QgsProject::instance()->addMapLayer( vtLayer.release(), addToLegend );
           postProcessAddedLayers();
           ok = true;
           return openedLayers;
@@ -812,7 +897,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
         QUrlQuery uq;
         uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
         uq.addQueryItem( QStringLiteral( "url" ), QUrl::fromLocalFile( fileName ).toString() );
-        if ( QgsRasterLayer *rasterLayer = addRasterLayer( uq.toString(), fileInfo.completeBaseName(), QStringLiteral( "wms" ) ) )
+        if ( QgsRasterLayer *rasterLayer = addRasterLayer( uq.toString(), fileInfo.completeBaseName(), QStringLiteral( "wms" ), addToLegend ) )
         {
           openedLayers << rasterLayer;
           postProcessAddedLayers();
@@ -834,7 +919,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
     {
       openedLayers << vtLayer.get();
       QgsAppLayerHandling::postProcessAddedLayer( vtLayer.get() );
-      QgsProject::instance()->addMapLayer( vtLayer.release() );
+      QgsProject::instance()->addMapLayer( vtLayer.release(), addToLegend );
       postProcessAddedLayers();
       ok = true;
       return openedLayers;
@@ -925,7 +1010,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
         base = QgsMapLayer::formatLayerName( base );
       }
 
-      openedLayers.append( addSublayers( sublayers, base, groupName ) );
+      openedLayers.append( addSublayers( sublayers, base, groupName, addToLegend ) );
       QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
     }
     else if ( !nonLayerItems.empty() )
@@ -978,19 +1063,19 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
   return openedLayers;
 }
 
-QgsVectorLayer *QgsAppLayerHandling::addVectorLayer( const QString &uri, const QString &baseName, const QString &provider )
+QgsVectorLayer *QgsAppLayerHandling::addVectorLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend )
 {
-  return addLayerPrivate< QgsVectorLayer >( QgsMapLayerType::VectorLayer, uri, baseName, !provider.isEmpty() ? provider : QLatin1String( "ogr" ), true );
+  return addLayerPrivate< QgsVectorLayer >( QgsMapLayerType::VectorLayer, uri, baseName, !provider.isEmpty() ? provider : QLatin1String( "ogr" ), true, addToLegend );
 }
 
-QgsRasterLayer *QgsAppLayerHandling::addRasterLayer( const QString &uri, const QString &baseName, const QString &provider )
+QgsRasterLayer *QgsAppLayerHandling::addRasterLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend )
 {
-  return addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, uri, baseName, !provider.isEmpty() ? provider : QLatin1String( "gdal" ), true );
+  return addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, uri, baseName, !provider.isEmpty() ? provider : QLatin1String( "gdal" ), true, addToLegend );
 }
 
-QgsMeshLayer *QgsAppLayerHandling::addMeshLayer( const QString &uri, const QString &baseName, const QString &provider )
+QgsMeshLayer *QgsAppLayerHandling::addMeshLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend )
 {
-  return addLayerPrivate< QgsMeshLayer >( QgsMapLayerType::MeshLayer, uri, baseName, provider, true );
+  return addLayerPrivate< QgsMeshLayer >( QgsMapLayerType::MeshLayer, uri, baseName, provider, true, addToLegend );
 }
 
 QList<QgsMapLayer *> QgsAppLayerHandling::addGdalRasterLayers( const QStringList &uris, bool &ok, bool showWarningOnInvalid )
@@ -1088,16 +1173,14 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addGdalRasterLayers( const QStringList
   return res;
 }
 
-void QgsAppLayerHandling::addMapLayer( QgsMapLayer *mapLayer )
+void QgsAppLayerHandling::addMapLayer( QgsMapLayer *mapLayer, bool addToLegend )
 {
   QgsCanvasRefreshBlocker refreshBlocker;
 
   if ( mapLayer->isValid() )
   {
     // Register this layer with the layers registry
-    QList<QgsMapLayer *> myList;
-    myList << mapLayer;
-    QgsProject::instance()->addMapLayers( myList );
+    QgsProject::instance()->addMapLayer( mapLayer, addToLegend );
 
     QgisApp::instance()->askUserForDatumTransform( mapLayer->crs(), QgsProject::instance()->crs(), mapLayer );
   }
@@ -1247,7 +1330,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addDatabaseLayers( const QStringList
 }
 
 template<typename T>
-T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &name, const QString &providerKey, bool guiWarnings )
+T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &name, const QString &providerKey, bool guiWarnings, bool addToLegend )
 {
   QgsSettings settings;
 
@@ -1317,14 +1400,14 @@ T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &ur
             const QList< QgsProviderSublayerDetails > selectedLayers = dlg.selectedLayers();
             if ( !selectedLayers.isEmpty() )
             {
-              result = qobject_cast< T * >( addSublayers( selectedLayers, baseName, dlg.groupName() ).value( 0 ) );
+              result = qobject_cast< T * >( addSublayers( selectedLayers, baseName, dlg.groupName(), addToLegend ).value( 0 ) );
             }
           }
           break;
         }
         case SublayerHandling::LoadAll:
         {
-          result = qobject_cast< T * >( addSublayers( sublayers, baseName, QString() ).value( 0 ) );
+          result = qobject_cast< T * >( addSublayers( sublayers, baseName, QString(), addToLegend ).value( 0 ) );
           break;
         }
         case SublayerHandling::AbortLoading:
@@ -1333,7 +1416,7 @@ T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &ur
     }
     else
     {
-      result = qobject_cast< T * >( addSublayers( sublayers, name, QString() ).value( 0 ) );
+      result = qobject_cast< T * >( addSublayers( sublayers, name, QString(), addToLegend ).value( 0 ) );
 
       if ( result )
       {
@@ -1359,7 +1442,7 @@ T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &ur
         base = QgsMapLayer::formatLayerName( base );
       }
       result->setName( base );
-      QgsProject::instance()->addMapLayer( result );
+      QgsProject::instance()->addMapLayer( result, addToLegend );
 
       QgisApp::instance()->askUserForDatumTransform( result->crs(), QgsProject::instance()->crs(), result );
       QgsAppLayerHandling::postProcessAddedLayer( result );

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -56,7 +56,7 @@ class APP_EXPORT QgsAppLayerHandling
      * \note This may trigger a dialog asking users to select from available sublayers in the datasource,
      * depending on the contents of the datasource and the user's current QGIS settings.
      */
-    static QgsVectorLayer *addVectorLayer( const QString &uri, const QString &baseName, const QString &provider = QLatin1String( "ogr" ) );
+    static QgsVectorLayer *addVectorLayer( const QString &uri, const QString &baseName, const QString &provider = QLatin1String( "ogr" ), bool addToLegend = true );
 
     /**
      * Adds a list of vector layers from a list of layer \a uris supported by the OGR provider.
@@ -77,7 +77,7 @@ class APP_EXPORT QgsAppLayerHandling
      * \note This may trigger a dialog asking users to select from available sublayers in the datasource,
      * depending on the contents of the datasource and the user's current QGIS settings.
      */
-    static QgsRasterLayer *addRasterLayer( QString const &uri, const QString &baseName, const QString &provider = QLatin1String( "gdal" ) );
+    static QgsRasterLayer *addRasterLayer( QString const &uri, const QString &baseName, const QString &provider = QLatin1String( "gdal" ), bool addToLegend = true );
 
     /**
      * Adds a list of raster layers from a list of layer \a uris supported by the GDAL provider.
@@ -98,7 +98,7 @@ class APP_EXPORT QgsAppLayerHandling
      * \note This may trigger a dialog asking users to select from available sublayers in the datasource,
      * depending on the contents of the datasource and the user's current QGIS settings.
      */
-    static QgsMeshLayer *addMeshLayer( const QString &uri, const QString &baseName, const QString &provider );
+    static QgsMeshLayer *addMeshLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend = true );
 
     /**
      * Adds a point cloud layer from a given \a uri and \a provider.
@@ -111,14 +111,15 @@ class APP_EXPORT QgsAppLayerHandling
     static QgsPointCloudLayer *addPointCloudLayer( const QString &uri,
         const QString &baseName,
         const QString &provider,
-        bool showWarningOnInvalid = true );
+        bool showWarningOnInvalid = true,
+        bool addToLegend = true );
 
     /**
      * Adds a plugin layer from a given \a uri and \a provider.
      *
      * The \a baseName parameter will be used as the layer name (and shown in the map legend).
      */
-    static QgsPluginLayer *addPluginLayer( const QString &uri, const QString &baseName, const QString &providerKey );
+    static QgsPluginLayer *addPluginLayer( const QString &uri, const QString &baseName, const QString &providerKey, bool addToLegend = true );
 
     /**
      * Adds a vector tile layer from a given \a uri.
@@ -128,7 +129,7 @@ class APP_EXPORT QgsAppLayerHandling
      * If \a showWarningOnInvalid layers is TRUE then a user facing warning will be raised
      * if the \a uri does not result in a valid vector tile layer.
      */
-    static QgsVectorTileLayer *addVectorTileLayer( const QString &uri, const QString &baseName, bool showWarningOnInvalid = true );
+    static QgsVectorTileLayer *addVectorTileLayer( const QString &uri, const QString &baseName, bool showWarningOnInvalid = true, bool addToLegend = true );
 
     /**
      * Post processes an entire group of added \a layers.
@@ -139,6 +140,8 @@ class APP_EXPORT QgsAppLayerHandling
      */
     static void postProcessAddedLayers( const QList< QgsMapLayer * > &layers );
 
+    static void addSortedLayersToLegend( QList< QgsMapLayer * > &layers );
+
     /**
      * Open a map layer from a file.
      *
@@ -147,10 +150,10 @@ class APP_EXPORT QgsAppLayerHandling
      *
      * \returns a list of added map layers if the file is successfully opened
      */
-    static QList< QgsMapLayer * > openLayer( const QString &fileName, bool &ok, bool allowInteractive = false, bool suppressBulkLayerPostProcessing = false );
+    static QList< QgsMapLayer * > openLayer( const QString &fileName, bool &ok, bool allowInteractive = false, bool suppressBulkLayerPostProcessing = false, bool addToLegend = true );
 
     //! Add a 'pre-made' map layer to the project
-    static void addMapLayer( QgsMapLayer *mapLayer );
+    static void addMapLayer( QgsMapLayer *mapLayer, bool addToLegend = true );
 
     static void openLayerDefinition( const QString &filename );
 
@@ -216,7 +219,7 @@ class APP_EXPORT QgsAppLayerHandling
 
   private:
 
-    template<typename T> static T *addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &baseName, const QString &providerKey, bool guiWarnings = true );
+    template<typename T> static T *addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &baseName, const QString &providerKey, bool guiWarnings = true, bool addToLegend = true );
 
     /**
      * Post processes a single added \a layer, applying any default behavior which should
@@ -236,7 +239,7 @@ class APP_EXPORT QgsAppLayerHandling
 
     static SublayerHandling shouldAskUserForSublayers( const QList< QgsProviderSublayerDetails > &layers, bool hasNonLayerItems = false );
 
-    static QList< QgsMapLayer * > addSublayers( const QList< QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName );
+    static QList< QgsMapLayer * > addSublayers( const QList< QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName, bool addToLegend = true );
 
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAppLayerHandling::DependencyFlags );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -711,6 +711,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   cmbLegendDoubleClickAction->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/legendDoubleClickAction" ), 0 ).toInt() );
 
+  mLayerTreeInsertionMethod->addItem( tr( "Above currently currently selected layer" ), QVariant::fromValue( Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
+  mLayerTreeInsertionMethod->addItem( tr( "Always on top of the layer tree" ), QVariant::fromValue( Qgis::LayerTreeInsertionMethod::TopOfTree ) );
+  mLayerTreeInsertionMethod->addItem( tr( "Optimal index within current layer tree group" ), QVariant::fromValue( Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup ) );
+  mLayerTreeInsertionMethod->setCurrentIndex( mLayerTreeInsertionMethod->findData( QVariant::fromValue( mSettings->enumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) ) ) );
+
   // Legend symbol minimum / maximum values
   mLegendSymbolMinimumSizeSpinBox->setClearValue( 0.0, tr( "none" ) );
   mLegendSymbolMaximumSizeSpinBox->setClearValue( 0.0, tr( "none" ) );
@@ -1586,6 +1591,7 @@ void QgsOptions::saveOptions()
   QgisApp::instance()->setMapTipsDelay( mMapTipsDelaySpinBox->value() );
 
   mSettings->setValue( QStringLiteral( "/qgis/legendDoubleClickAction" ), cmbLegendDoubleClickAction->currentIndex() );
+  mSettings->setEnumValue( QStringLiteral( "/qgis/layerTreeInsertionMethod" ), mLayerTreeInsertionMethod->currentData().value<Qgis::LayerTreeInsertionMethod>() );
 
   // project
   mSettings->setValue( QStringLiteral( "/qgis/projOpenAtLaunch" ), mProjectOnLaunchCmbBx->currentIndex() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5577,6 +5577,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
 
   QgsProject *prj = QgsProject::instance();
   prj->layerTreeRegistryBridge()->setNewLayersVisible( settings.value( QStringLiteral( "qgis/new_layers_visible" ), true ).toBool() );
+  prj->layerTreeRegistryBridge()->setLayerInsertionMethod( settings.enumValue( QStringLiteral( "qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
 
   //set the canvas to the default project background color
   mOverviewCanvas->setBackgroundColor( prj->backgroundColor() );
@@ -12333,6 +12334,7 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
   if ( optionsDialog->exec() )
   {
     QgsProject::instance()->layerTreeRegistryBridge()->setNewLayersVisible( mySettings.value( QStringLiteral( "qgis/new_layers_visible" ), true ).toBool() );
+    QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionMethod( mySettings.enumValue( QStringLiteral( "qgis/layerTreeInsertionMethod" ), Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
 
     setupLayerTreeViewFromSettings();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2103,7 +2103,6 @@ void QgisApp::dropEvent( QDropEvent *event )
     lst = QgsMimeDataUtils::decodeUriList( event->mimeData() );
   }
 
-  qDebug() << files;
   connect( timer, &QTimer::timeout, this, [this, timer, files, lst]
   {
     QgsCanvasRefreshBlocker refreshBlocker;
@@ -2146,7 +2145,6 @@ void QgisApp::dropEvent( QDropEvent *event )
 
     if ( !addedLayers.isEmpty() )
     {
-      qDebug() << addedLayers.size();
       QgsAppLayerHandling::addSortedLayersToLegend( addedLayers );
       QgsAppLayerHandling::postProcessAddedLayers( addedLayers );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2066,7 +2066,7 @@ void QgisApp::dropEvent( QDropEvent *event )
   Qgis::LayerTreeInsertionMethod method = QgsProject::instance()->layerTreeRegistryBridge()->layerInsertionMethod();
   if ( mLayerTreeDrop )
   {
-    // Override current method to always add layers on top of the node over which the drop occured
+    // Override current method to always add layers on top of the node over which the drop occurred
     QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod::AboveInsertionPoint );
   }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -905,14 +905,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      *
      * Returns a list of layers loaded as a result of opening the URIs.
      */
-    QList< QgsMapLayer * > handleDropUriList( const QgsMimeDataUtils::UriList &lst, bool suppressBulkLayerPostProcessing = false );
+    QList< QgsMapLayer * > handleDropUriList( const QgsMimeDataUtils::UriList &lst, bool suppressBulkLayerPostProcessing = false, bool addToLegend = true );
 
     /**
      * Convenience function to open either a project or a layer file.
      *
      * Returns a list of layers loaded as a result of opening the file.
      */
-    QList< QgsMapLayer * > openFile( const QString &fileName, const QString &fileTypeHint = QString(), bool suppressBulkLayerPostProcessing = false );
+    QList< QgsMapLayer * > openFile( const QString &fileName, const QString &fileTypeHint = QString(), bool suppressBulkLayerPostProcessing = false, bool addToLegend = true );
     void layerTreeViewDoubleClicked( const QModelIndex &index );
     //! Make sure the insertion point for new layers is up-to-date with the current item in layer tree view
     void updateNewLayerInsertionPoint();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2457,6 +2457,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsMapOverviewCanvas *mOverviewCanvas = nullptr;
     //! Table of contents (legend) for the map
     QgsLayerTreeView *mLayerTreeView = nullptr;
+    //! Keep track of whether ongoing dataset(s) is/are being dropped through the table of contens
+    bool mLayerTreeDrop = false;
+
     //! Helper class that connects layer tree with map canvas
     QgsLayerTreeMapCanvasBridge *mLayerTreeCanvasBridge = nullptr;
     //! Table of contents (legend) to order layers of the map

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -21,6 +21,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgis.h"
 
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
@@ -84,6 +85,18 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
      */
     void setLayerInsertionPoint( const InsertionPoint &insertionPoint );
 
+    /**
+     * Sets the insertion \a method used to add layers to the tree
+     * \since QGIS 3.30
+     */
+    void setLayerInsertionMethod( Qgis::LayerTreeInsertionMethod method ) { mInsertionMethod = method; }
+
+    /**
+     * Returns the insertion method used to add layers to the tree
+     * \since QGIS 3.30
+     */
+    Qgis::LayerTreeInsertionMethod layerInsertionMethod() const { return mInsertionMethod; }
+
   signals:
 
     /**
@@ -110,6 +123,7 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     bool mNewLayersVisible;
 
     InsertionPoint mInsertionPoint;
+    Qgis::LayerTreeInsertionMethod mInsertionMethod = Qgis::LayerTreeInsertionMethod::AboveInsertionPoint;
 };
 
 #endif // QGSLAYERTREEREGISTRYBRIDGE_H

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -623,26 +623,14 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
       if ( vlayer->geometryType() == QgsWkbTypes::PointGeometry )
       {
         index = 0;
-        vectorLineIndex++;
-        vectorPolygonIndex++;
-        pointCloudIndex++;
-        meshIndex++;
-        rasterIndex++;
       }
       else if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry )
       {
         index = vectorLineIndex;
-        vectorPolygonIndex++;
-        pointCloudIndex++;
-        meshIndex++;
-        rasterIndex++;
       }
       else if ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
       {
         index = vectorPolygonIndex;
-        pointCloudIndex++;
-        meshIndex++;
-        rasterIndex++;
       }
       break;
     }
@@ -650,15 +638,12 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
     case QgsMapLayerType::PointCloudLayer:
     {
       index = pointCloudIndex;
-      meshIndex++;
-      rasterIndex++;
       break;
     }
 
     case QgsMapLayerType::MeshLayer:
     {
       index = meshIndex;
-      rasterIndex++;
       break;
     }
 

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -538,6 +538,7 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
   int pointCloudIndex = 0;
   int meshIndex = 0;
   int rasterIndex = 0;
+  int basemapIndex = 0;
 
   const QList<QgsLayerTreeNode *> children = group->children();
   int nodeIdx = 0;
@@ -564,6 +565,8 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
               meshIndex = nodeIdx;
             if ( rasterIndex < nodeIdx )
               rasterIndex = nodeIdx;
+            if ( basemapIndex < nodeIdx )
+              basemapIndex = nodeIdx;
           }
           else if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry )
           {
@@ -575,6 +578,8 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
               meshIndex = nodeIdx;
             if ( rasterIndex < nodeIdx )
               rasterIndex = nodeIdx;
+            if ( basemapIndex < nodeIdx )
+              basemapIndex = nodeIdx;
           }
           else if ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
           {
@@ -584,6 +589,8 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
               meshIndex = nodeIdx;
             if ( rasterIndex < nodeIdx )
               rasterIndex = nodeIdx;
+            if ( basemapIndex < nodeIdx )
+              basemapIndex = nodeIdx;
           }
           break;
         }
@@ -594,6 +601,8 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
             meshIndex = nodeIdx;
           if ( rasterIndex < nodeIdx )
             rasterIndex = nodeIdx;
+          if ( basemapIndex < nodeIdx )
+            basemapIndex = nodeIdx;
           break;
         }
 
@@ -601,10 +610,24 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
         {
           if ( rasterIndex < nodeIdx )
             rasterIndex = nodeIdx;
+          if ( basemapIndex < nodeIdx )
+            basemapIndex = nodeIdx;
           break;
         }
 
         case QgsMapLayerType::RasterLayer:
+        {
+          if ( layer->dataProvider() && layer->dataProvider()->name() == QStringLiteral( "gdal" ) )
+          {
+            // Assume non-gdal raster layers are most likely to be base maps (e.g. XYZ raster)
+            // Admittedly a gross assumption, but better than nothing
+            if ( basemapIndex < nodeIdx )
+              basemapIndex = nodeIdx;
+          }
+          break;
+        }
+
+        case QgsMapLayerType::VectorTileLayer:
         case QgsMapLayerType::AnnotationLayer:
         case QgsMapLayerType::GroupLayer:
         case QgsMapLayerType::PluginLayer:
@@ -649,9 +672,23 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerAtOptimalPlacement( QgsLayerTre
 
     case QgsMapLayerType::RasterLayer:
     {
-      index = rasterIndex;
+      if ( layer->dataProvider() && layer->dataProvider()->name() == QStringLiteral( "gdal" ) )
+      {
+        index = rasterIndex;
+      }
+      else
+      {
+        index = basemapIndex;
+      }
       break;
     }
+
+    case QgsMapLayerType::VectorTileLayer:
+    {
+      index = basemapIndex;
+      break;
+    }
+
     case QgsMapLayerType::AnnotationLayer:
     case QgsMapLayerType::GroupLayer:
     case QgsMapLayerType::PluginLayer:

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -130,6 +130,22 @@ class CORE_EXPORT QgsLayerTreeUtils
      */
     static QgsLayerTreeGroup *firstGroupWithoutCustomProperty( QgsLayerTreeGroup *group, const QString &property );
 
+    /**
+     * Inserts a \a layer within a given \a group at an optimal index position by insuring a given layer
+     * type will always sit on top of or below other types. From top to bottom, the stacking logic is
+     * as follow:
+     *
+     * - vector points
+     * - vector lines
+     * - vector polygons
+     * - point clouds
+     * - meshes
+     * - rasters
+     * - base maps
+     *
+     * A base map is defined as a non-gdal provider raster layer (e.g. XYZ raster layer, vector tile layer, etc.)
+     * \since QGIS 3.28
+     */
     static QgsLayerTreeLayer *insertLayerAtOptimalPlacement( QgsLayerTreeGroup *group, QgsMapLayer *layer );
 };
 

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -129,6 +129,8 @@ class CORE_EXPORT QgsLayerTreeUtils
      * \since QGIS 3.8
      */
     static QgsLayerTreeGroup *firstGroupWithoutCustomProperty( QgsLayerTreeGroup *group, const QString &property );
+
+    static QgsLayerTreeLayer *insertLayerAtOptimalPlacement( QgsLayerTreeGroup *group, QgsMapLayer *layer );
 };
 
 #endif // QGSLAYERTREEUTILS_H

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2305,6 +2305,19 @@ class CORE_EXPORT Qgis
     Q_ENUM( ScriptLanguage )
 
     /**
+     * Layer tree insertion methods
+     *
+     * \since QGIS 3.30
+     */
+    enum class LayerTreeInsertionMethod : int
+    {
+      AboveInsertionPoint, //!< Layers are added in the tree above the insertion point
+      TopOfTree, //!< Layers are added at the top of the layer tree
+      OptimalInInsertionGroup, //!< Layers are added at optimal locations across the insertion point's group
+    };
+    Q_ENUM( LayerTreeInsertionMethod )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QHeaderView>
+#include <QMimeData>
 #include <QScrollBar>
 
 #ifdef ENABLE_MODELTEST
@@ -618,8 +619,53 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
   layerTreeModel()->setFlags( oldFlags );
 }
 
+void QgsLayerTreeView::dragEnterEvent( QDragEnterEvent *event )
+{
+  if ( event->mimeData()->hasUrls() || event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.uri" ) ) )
+  {
+    // the mime data are coming from layer tree, so ignore that, do not import those layers again
+    if ( !event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    {
+      event->accept();
+      return;
+    }
+  }
+  QTreeView::dragEnterEvent( event );
+}
+
+void QgsLayerTreeView::dragMoveEvent( QDragMoveEvent *event )
+{
+  if ( event->mimeData()->hasUrls() || event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.uri" ) ) )
+  {
+    // the mime data are coming from layer tree, so ignore that, do not import those layers again
+    if ( !event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    {
+      event->accept();
+      return;
+    }
+  }
+  QTreeView::dragMoveEvent( event );
+}
+
 void QgsLayerTreeView::dropEvent( QDropEvent *event )
 {
+  if ( event->mimeData()->hasUrls() || event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.uri" ) ) )
+  {
+    // the mime data are coming from layer tree, so ignore that, do not import those layers again
+    if ( !event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    {
+      event->accept();
+
+      QModelIndex index = indexAt( event->pos() );
+      if ( index.isValid() )
+      {
+        setCurrentIndex( index );
+      }
+
+      emit datasetsDropped( event );
+      return;
+    }
+  }
   if ( event->keyboardModifiers() & Qt::AltModifier )
   {
     event->accept();

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -303,6 +303,7 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      * \since QGIS 3.2
      */
     static QStringList viewOnlyCustomProperties() SIP_SKIP;
+
 ///@endcond
 
   public slots:
@@ -350,6 +351,9 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     //! Emitted when a current layer is changed
     void currentLayerChanged( QgsMapLayer *layer );
 
+    //! Emitted when datasets are dropped onto the layer tree view
+    void datasetsDropped( QDropEvent *event );
+
   protected:
     void contextMenuEvent( QContextMenuEvent *event ) override;
 
@@ -360,6 +364,8 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     void mouseReleaseEvent( QMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dragMoveEvent( QDragMoveEvent *event ) override;
     void dropEvent( QDropEvent *event ) override;
 
     void resizeEvent( QResizeEvent *event ) override;

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2552,225 +2552,159 @@
                  <property name="title">
                   <string>Layer Legend</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_21">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_8">
-                    <item>
-                     <widget class="QLabel" name="label_15">
-                      <property name="text">
-                       <string>Double-click action in legend</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="cmbLegendDoubleClickAction">
-                      <item>
-                       <property name="text">
-                        <string>Open layer properties</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Open attribute table</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Open layer styling dock</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
+                 <layout class="QGridLayout" name="gridLayout_35">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_15">
+                   <property name="text">
+                     <string>Double-click action in legend</string>
+                   </property>
+                   </widget>
                   </item>
-                  <item>
+                  <item row="0" column="1">
+                   <widget class="QComboBox" name="cmbLegendDoubleClickAction">
+                    <item>
+                      <property name="text">
+                      <string>Open layer properties</string>
+                      </property>
+                    </item>
+                    <item>
+                      <property name="text">
+                      <string>Open attribute table</string>
+                      </property>
+                    </item>
+                    <item>
+                      <property name="text">
+                      <string>Open layer styling dock</string>
+                      </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                    <widget class="QLabel" name="mLayerTreeInsertionMethodLabel">
+                    <property name="text">
+                      <string>Behavior used when adding new layers</string>
+                    </property>
+                    </widget>
+                  </item>
+                  <item row="1" column="1">
+                    <widget class="QComboBox" name="mLayerTreeInsertionMethod">
+                    </widget>
+                  </item>
+                  <item row="2" column="0" colspan="2">
                    <widget class="QCheckBox" name="mShowFeatureCountByDefaultCheckBox">
                     <property name="text">
                      <string>Show feature count for newly added layers</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="3" column="0" colspan="2">
                    <widget class="QCheckBox" name="cbxLegendClassifiers">
                     <property name="text">
                      <string>Display classification attribute in layer titles</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_34">
-                    <item>
-                     <widget class="QLabel" name="label_58">
-                      <property name="text">
-                       <string>WMS getLegendGraphic resolution</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_48">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Preferred</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>30</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="mLegendGraphicResolutionSpinBox">
-                      <property name="toolTip">
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_58">
+                    <property name="text">
+                      <string>WMS getLegendGraphic resolution</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                    <widget class="QgsSpinBox" name="mLegendGraphicResolutionSpinBox">
+                     <property name="toolTip">
                        <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
-                      </property>
-                      <property name="whatsThis">
+                     </property>
+                     <property name="whatsThis">
                        <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
-                      </property>
-                      <property name="suffix">
+                     </property>
+                     <property name="suffix">
                        <string> dpi</string>
-                      </property>
-                      <property name="minimum">
+                     </property>
+                     <property name="minimum">
                        <number>0</number>
-                      </property>
-                      <property name="maximum">
+                     </property>
+                     <property name="maximum">
                        <number>1000000</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                     </property>
+                    </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_41">
-                    <item>
-                     <widget class="QLabel" name="labelLegendSymbolMinimumSize">
-                      <property name="text">
-                       <string>Minimum legend symbol size</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_49">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Preferred</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>30</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QgsDoubleSpinBox" name="mLegendSymbolMinimumSizeSpinBox">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="toolTip">
-                       <string extracomment="(set value to 0 to skip minimum size)"/>
-                      </property>
-                      <property name="suffix">
-                       <string> mm</string>
-                      </property>
-                      <property name="decimals">
-                       <number>2</number>
-                      </property>
-                      <property name="maximum">
-                       <double>999.000000000000000</double>
-                      </property>
-                      <property name="singleStep">
-                       <double>0.200000000000000</double>
-                      </property>
-                      <property name="value">
-                       <double>0.100000000000000</double>
-                      </property>
-                      <property name="showClearButton" stdset="0">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                  <item row="5" column="0">
+                    <widget class="QLabel" name="labelLegendSymbolMinimumSize">
+                    <property name="text">
+                      <string>Minimum legend symbol size</string>
+                    </property>
+                    </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_43">
-                    <item>
-                     <widget class="QLabel" name="labelLegendSymbolMaximumSize">
-                      <property name="text">
-                       <string>Maximum legend symbol size</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_50">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Preferred</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>30</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QgsDoubleSpinBox" name="mLegendSymbolMaximumSizeSpinBox">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="toolTip">
-                       <string extracomment="(set value to 0 to skip maximum size)"/>
-                      </property>
-                      <property name="suffix">
-                       <string> mm</string>
-                      </property>
-                      <property name="decimals">
-                       <number>2</number>
-                      </property>
-                      <property name="maximum">
-                       <double>999.000000000000000</double>
-                      </property>
-                      <property name="singleStep">
-                       <double>0.200000000000000</double>
-                      </property>
-                      <property name="value">
-                       <double>20.000000000000000</double>
-                      </property>
-                      <property name="showClearButton" stdset="0">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                  <item row="5" column="1">
+                   <widget class="QgsDoubleSpinBox" name="mLegendSymbolMinimumSizeSpinBox">
+                    <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                      </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                      <string extracomment="(set value to 0 to skip minimum size)"/>
+                    </property>
+                    <property name="suffix">
+                      <string> mm</string>
+                    </property>
+                    <property name="decimals">
+                      <number>2</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.200000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="showClearButton" stdset="0">
+                      <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                    <widget class="QLabel" name="labelLegendSymbolMaximumSize">
+                    <property name="text">
+                      <string>Maximum legend symbol size</string>
+                    </property>
+                    </widget>
+                  </item>
+                  <item row="6" column="1">
+                   <widget class="QgsDoubleSpinBox" name="mLegendSymbolMaximumSizeSpinBox">
+                   <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                     </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                     <string extracomment="(set value to 0 to skip maximum size)"/>
+                   </property>
+                   <property name="suffix">
+                     <string> mm</string>
+                   </property>
+                   <property name="decimals">
+                     <number>2</number>
+                   </property>
+                   <property name="maximum">
+                     <double>999.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                     <double>0.200000000000000</double>
+                   </property>
+                   <property name="value">
+                     <double>20.000000000000000</double>
+                   </property>
+                   <property name="showClearButton" stdset="0">
+                     <bool>true</bool>
+                   </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -2780,37 +2714,15 @@
                  <property name="title">
                   <string>Map Tips</string>
                  </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_42">
-                  <item>
+                 <layout class="QGridLayout" name="gridLayout_40">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="textLabel1_16">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
                     <property name="text">
                      <string>Delay (in milliseconds)</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
-                   <spacer name="horizontalSpacer_39">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeType">
-                     <enum>QSizePolicy::Preferred</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>30</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item>
+                  <item row="0" column="1">
                    <widget class="QgsSpinBox" name="mMapTipsDelaySpinBox">
                     <property name="toolTip">
                      <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>


### PR DESCRIPTION
## Description

This PR improves the addition of datasets into the layer tree in three ways.

### Sorting of a group of layers being drag and dropped into the map

Newly added group of layers to a project via drag and drag are now sorted in such a way as to increase the chance of their stacking being logical and features being visible. Whereas before the layers stacking would be dictated by the file manager (o browser panel) order of selection, the code now sorts using the following logic (top to bottom):
- vector point
- vector line
- vector polygon
- point cloud
- mesh
- raster

Here's a practical example. This video shows the old behavior when drag and dropping a few layers from the file manager onto QGIS:

https://user-images.githubusercontent.com/1728657/192675870-d727e785-796b-4378-a3ea-af9267ec4728.mp4

_Note the bad stacking, where lines and points are hidden _below_ the polygon._

Same action, using the introduced sorting logic:

https://user-images.githubusercontent.com/1728657/192675935-3e0884f4-3209-471e-914c-13df7f12ffdb.mp4

_Visibility of features increased, and likelihood of the current stacking being desirable higher_

### New layer tree insertion methods

The PR also adds two new layer tree insertion methods (in addition to the pre-existing behavior). The three insertion methods are:
- Above of the currently active layer (pre-existing)
- On top of the layer tree (new)
- Optimal index/position within the currently active layer's group (new and exciting :smile: )

The second method, on top of the layer tree, doesn't need much explaining. Layers are just thrown on top of the tree, so content never risks being inserted below (and covered by) a basemap.

The third method is more exciting. The method inserts newly added layers in an "optimal" fashion by insuring that point layers sit on top, followed by line layers, polygon layers, etc. It essentially matches the sorting discussed above, except it extents it to the whole layer tree, not only the layers being added within one drag and drop.

This screencast should do a better job than the above paragraph at explaining the method:

https://user-images.githubusercontent.com/1728657/192676988-c7887cd9-cbaa-4c3e-b3f8-2609c6b4fc5e.mp4

This is super handy, and should come in as a life changer for newcomers and novice GIS users who are mostly interested in consuming a few datasets at a time. 

Users can pick their favored layer tree insertion method in the options dialog's canvas & legend panel:

![image](https://user-images.githubusercontent.com/1728657/192677383-d7b058d4-cfa9-4006-8955-f7c4a31af3b6.png)

I've taken the opportunity to clean up widget alignment in that panel.

### Inserting datasets at location dropped over the layer tree

It is quite counterintuitive to drag datasets (from the browser panel or file manager) onto a specific position within the layer tree only to see those added in different location. Counterintuitive no more! The PR addresses this UX shortcoming. 

Screencast:

https://user-images.githubusercontent.com/1728657/192922082-d8580832-e9f3-4b2a-b010-111d24b20790.mp4

_Funded by the [QGIS user group Switzerland](https://www.qgis.ch/)._