### PR TITLE
Fix new face with mesh editing

### DIFF
--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -88,12 +88,16 @@ Tries to fix the topological ``error`` in the mesh. Returns ``False`` if the fix
 .. versionadded:: 3.28
 %End
 
-    bool faceCanBeAdded( const QgsMeshFace &face );
+    bool faceCanBeAdded( const QgsMeshFace &face ) const;
 %Docstring
 Returns ``True`` if a ``face`` can be added to the mesh
+
+.. note::
+
+   All vertices related to this face must be already in the mesh.
 %End
 
-    bool isFaceGeometricallyCompatible( const QgsMeshFace &face );
+    bool isFaceGeometricallyCompatible( const QgsMeshFace &face ) const;
 %Docstring
 Returns ``True`` if the face does not intersect or contains any other elements (faces or vertices)
 The topological compatibility is not checked

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -219,8 +219,9 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     QgsPointXY newFaceMarkerPosition( int vertexIndex );
 
-    void addVertexToFaceCanditate( int vertexIndex );
-    bool testNewVertexInFaceCanditate( int vertexIndex );
+    void addVertexToFaceCanditate( int vertexIndex ); //for existing vertex
+    void addVertexToFaceCanditate( const QgsPointXY &vertexPosition );
+    bool testNewVertexInFaceCanditate( bool testLast, int vertexIndex, const QgsPointXY &mapPoint ) const;
 
     // selection methods
     void select( const QgsPointXY &mapPoint, Qt::KeyboardModifiers modifiers, double tolerance );
@@ -265,6 +266,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     Edge mCurrentEdge = {-1, -1};
     int mCurrentVertexIndex = -1;
     QList<int> mNewFaceCandidate;
+    QList<QgsMeshVertex> mNewVerticesForNewFaceCandidate;
     bool mDoubleClicks = false;
     QgsPointXY mFirstClickPoint; //the first click point when double clicks, we need it when the point is constraint by the cad tool, second click could not be constraint
     double mFirstClickZValue;

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -341,18 +341,18 @@ bool QgsMeshEditor::faceCanBeAddedWithNewVertices( const QList<int> &verticesInd
     if ( !circulator.goBoundaryClockwise() ) //vertex not on boundary
       return false;
 
-    int prevOppositVertex = circulator.oppositeVertexClockwise();
-    if ( prevOppositVertex == nextIndex ) //manifold face
+    int prevOppVertex = circulator.oppositeVertexClockwise();
+    if ( prevOppVertex == nextIndex ) //manifold face
       return false;
 
     if ( !circulator.goBoundaryCounterClockwise() )
       return false;
 
-    int nextOppositVertex = circulator.oppositeVertexCounterClockwise();
-    if ( nextOppositVertex == prevIndex ) //manifold face
+    int nextOppVertex = circulator.oppositeVertexCounterClockwise();
+    if ( nextOppVertex == prevIndex ) //manifold face
       return false;
 
-    if ( nextIndex != nextOppositVertex && prevIndex != prevOppositVertex ) //unique shared vertex
+    if ( nextIndex != nextOppVertex && prevIndex != prevOppVertex ) //unique shared vertex
       return false;
   }
 

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -151,16 +151,26 @@ void QgsMeshEditor::resetTriangularMesh( QgsTriangularMesh *triangularMesh )
   mTriangularMesh = triangularMesh;
 }
 
-bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
+
+bool QgsMeshEditor::isFaceGeometricallyCompatible( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &vertices ) const
 {
-  const QgsGeometry newFaceGeom = QgsMeshUtils::toGeometry( face, mTriangularMesh->vertices() );
+  Q_ASSERT( vertexIndexes.count() == vertices.count() );
+
+  QVector<QgsPoint> ring;
+  for ( int i = 0; i < vertices.size(); ++i )
+  {
+    const QgsPoint &vertex = vertices[i];
+    ring.append( vertex );
+  }
+  std::unique_ptr< QgsPolygon > polygon = std::make_unique< QgsPolygon >();
+  polygon->setExteriorRing( new QgsLineString( ring ) );
+  const QgsGeometry newFaceGeom( polygon.release() );
   std::unique_ptr<QgsGeometryEngine> geomEngine( QgsGeometry::createGeometryEngine( newFaceGeom.constGet() ) );
   geomEngine->prepareGeometry();
 
-  QgsRectangle boundingBox = newFaceGeom.boundingBox();
-  QList<int> newFaceVerticesIndexes( face.toList() );
-  int newFaceSize = face.count();
-  QList<int> concernedFaceIndex = mTriangularMesh->nativeFaceIndexForRectangle( boundingBox );
+  const QgsRectangle boundingBox = newFaceGeom.boundingBox();
+  int newFaceSize = vertexIndexes.count();
+  const QList<int> concernedFaceIndex = mTriangularMesh->nativeFaceIndexForRectangle( boundingBox );
   if ( !concernedFaceIndex.isEmpty() )
   {
     // for each concerned face, we take edges and, if no common vertex with the new face,
@@ -172,7 +182,7 @@ bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
       bool shareVertex = false;
       for ( int i = 0; i < existingFaceSize; ++i )
       {
-        if ( newFaceVerticesIndexes.contains( existingFace.at( i ) ) )
+        if ( vertexIndexes.contains( existingFace.at( i ) ) )
         {
           shareVertex = true;
           break;
@@ -189,7 +199,7 @@ bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
           const QgsMeshVertex &v2 = mTriangularMesh->vertices().at( index2 );
           QgsGeometry edgeGeom = QgsGeometry( new QgsLineString( v1, v2 ) );
 
-          if ( ! newFaceVerticesIndexes.contains( index1 )  && !newFaceVerticesIndexes.contains( index2 ) )
+          if ( ! vertexIndexes.contains( index1 )  && !vertexIndexes.contains( index2 ) )
           {
             // test if the edge that not contains a shared vertex intersect the entire new face
             if ( geomEngine->intersects( edgeGeom.constGet() ) )
@@ -197,15 +207,34 @@ bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
           }
           else
           {
-            for ( int vi = 0; vi < newFaceVerticesIndexes.count(); ++vi )
+            for ( int vi = 0; vi < vertexIndexes.count(); ++vi )
             {
-              int vertInNewFace1 = newFaceVerticesIndexes.at( vi );
-              int vertInNewFace2 = newFaceVerticesIndexes.at( ( vi + 1 ) % newFaceSize );
-              if ( vertInNewFace1 != index1 && vertInNewFace2 != index2 && vertInNewFace1 != index2 && vertInNewFace2 != index1 )
+              int vertInNewFace1 = vertexIndexes.at( vi );
+              int vertInNewFace2 = vertexIndexes.at( ( vi + 1 ) % newFaceSize );
+              bool hasToBeTest = false;
+
+              if ( vertInNewFace1 != -1 && vertInNewFace2 != -1 )
               {
-                const QgsMeshVertex &nv1 = mTriangularMesh->vertices().at( vertInNewFace1 );
-                const QgsMeshVertex &nv2 = mTriangularMesh->vertices().at( vertInNewFace2 );
-                QgsGeometry newEdgeGeom = QgsGeometry( new QgsLineString( nv1, nv2 ) );
+                hasToBeTest = vertInNewFace1 != index1 &&
+                              vertInNewFace2 != index2 &&
+                              vertInNewFace1 != index2 &&
+                              vertInNewFace2 != index1;
+              }
+              else
+              {
+                if ( vertInNewFace1 == -1 )
+                  hasToBeTest &= vertInNewFace2 != index1 && vertInNewFace2 != index2;
+
+
+                if ( vertInNewFace2 == -1 )
+                  hasToBeTest &= vertInNewFace1 != index1 && vertInNewFace1 != index2;
+              }
+
+              if ( hasToBeTest )
+              {
+                const QgsMeshVertex &nv1 = vertices.at( vi );
+                const QgsMeshVertex &nv2 = vertices.at( ( vi + 1 ) % newFaceSize );
+                const QgsGeometry newEdgeGeom = QgsGeometry( new QgsLineString( nv1, nv2 ) );
 
                 if ( newEdgeGeom.intersects( edgeGeom ) )
                   return false;
@@ -225,10 +254,9 @@ bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
 
   // Then search for free vertices included in the new face
   const QList<int> &freeVertices = freeVerticesIndexes();
-
   for ( const int freeVertexIndex : freeVertices )
   {
-    if ( newFaceVerticesIndexes.contains( freeVertexIndex ) )
+    if ( vertexIndexes.contains( freeVertexIndex ) )
       continue;
 
     const QgsMeshVertex &vertex = mTriangularMesh->vertices().at( freeVertexIndex );
@@ -239,8 +267,20 @@ bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face )
   return true;
 }
 
+bool QgsMeshEditor::isFaceGeometricallyCompatible( const QgsMeshFace &face ) const
+{
+  const QList<int> newFaceVerticesIndexes( face.toList() );
+  QList<QgsMeshVertex> allVertices;
+  allVertices.reserve( face.count() );
+  for ( int i : face )
+    allVertices.append( mTriangularMesh->vertices().at( i ) );
 
-bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face )
+  return isFaceGeometricallyCompatible( newFaceVerticesIndexes, allVertices );
+
+}
+
+
+bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face ) const
 {
   QgsMeshEditingError error;
 
@@ -263,6 +303,60 @@ bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face )
   // First search for faces intersecting the bounding box of the new face.
 
   return isFaceGeometricallyCompatible( face );
+}
+
+bool QgsMeshEditor::faceCanBeAddedWithNewVertices( const QList<int> &verticesIndex, const QList<QgsMeshVertex> &newVertices ) const
+{
+  QgsMeshEditingError error;
+  QList<int> face = prepareFaceWithNewVertices( verticesIndex, newVertices, error );
+
+  if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
+    return false;
+
+  // if we are here, the face is convex and not flat
+
+  // Now we chekc the topology of the potential new face
+  int size = face.size();
+  QList<QgsMeshVertex> allVertices;
+  allVertices.reserve( verticesIndex.size() );
+  int newVertPos = 0;
+  for ( int i = 0; i < size; ++i )
+  {
+    int index = face.at( i );
+    if ( index == -1 )
+    {
+      allVertices.append( newVertices.at( newVertPos++ ) );
+      continue;
+    }
+
+    allVertices.append( mTriangularMesh->vertices().at( index ) );
+
+    if ( isVertexFree( index ) )
+      continue;
+
+    int prevIndex = face.at( ( i - 1 + size ) % size );
+    int nextIndex = face.at( ( i + 1 ) % size );
+
+    QgsMeshVertexCirculator circulator = mTopologicalMesh.vertexCirculator( index );
+    if ( !circulator.goBoundaryClockwise() ) //vertex not on boundary
+      return false;
+
+    int prevOppositVertex = circulator.oppositeVertexClockwise();
+    if ( prevOppositVertex == nextIndex ) //manifold face
+      return false;
+
+    if ( !circulator.goBoundaryCounterClockwise() )
+      return false;
+
+    int nextOppositVertex = circulator.oppositeVertexCounterClockwise();
+    if ( nextOppositVertex == prevIndex ) //manifold face
+      return false;
+
+    if ( nextIndex != nextOppositVertex && prevIndex != prevOppositVertex ) //unique shared vertex
+      return false;
+  }
+
+  return isFaceGeometricallyCompatible( face, allVertices );
 }
 
 void QgsMeshEditor::applyEdit( QgsMeshEditor::Edit &edit )
@@ -580,7 +674,7 @@ int QgsMeshEditor::splitFaces( const QList<int> &faceIndexes )
   return faceIndexesSplittable.count();
 }
 
-QVector<QgsMeshFace> QgsMeshEditor::prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error )
+QVector<QgsMeshFace> QgsMeshEditor::prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error ) const
 {
   QVector<QgsMeshFace> treatedFaces = faces;
 
@@ -601,6 +695,62 @@ QVector<QgsMeshFace> QgsMeshEditor::prepareFaces( const QVector<QgsMeshFace> &fa
   }
 
   return treatedFaces;
+}
+
+QList<int> QgsMeshEditor::prepareFaceWithNewVertices( const QList<int> &face, const QList<QgsMeshVertex> &newVertices, QgsMeshEditingError &error ) const
+{
+  if ( mMaximumVerticesPerFace != 0 && face.count() > mMaximumVerticesPerFace )
+  {
+    error = QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidFace, 0 );
+    return face;
+  }
+
+  int faceSize = face.count();
+  QVector<QgsMeshVertex> vertices( faceSize );
+  int newVertexPos = 0;
+  for ( int i = 0; i < faceSize; ++i )
+  {
+    if ( face.at( i ) == -1 )
+    {
+      vertices[i] = newVertices.at( newVertexPos++ );
+    }
+    else if ( face.at( i ) >= 0 )
+    {
+      if ( face.at( i ) >= mTriangularMesh->vertices().count() )
+      {
+        error = QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidFace, 11 );
+        break;
+      }
+      vertices[i] = mTriangularMesh->vertices().at( face.at( i ) );
+    }
+    else
+    {
+      error = QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidFace, 12 );
+      break;
+    }
+  }
+
+  if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
+    return face;
+
+  int direction = 0;
+  error = QgsTopologicalMesh::checkTopologyOfVerticesAsFace( vertices, direction );
+
+  if ( direction > 0 && error.errorType == Qgis::MeshEditingErrorType::NoError )
+  {
+
+    QList<int> newFace = face;
+    for ( int i = 0; i < faceSize / 2; ++i )
+    {
+      int temp = newFace[i];
+      newFace[i] = face.at( faceSize - i - 1 );
+      newFace[faceSize - i - 1] = temp;
+    }
+
+    return newFace;
+  }
+
+  return face;
 }
 
 QgsMeshEditingError QgsMeshEditor::addFaces( const QVector<QVector<int> > &faces )
@@ -626,6 +776,27 @@ QgsMeshEditingError QgsMeshEditor::addFaces( const QVector<QVector<int> > &faces
 QgsMeshEditingError QgsMeshEditor::addFace( const QVector<int> &vertexIndexes )
 {
   return addFaces( {vertexIndexes} );
+}
+
+QgsMeshEditingError QgsMeshEditor::addFaceWithNewVertices( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &newVertices )
+{
+  mUndoStack->beginMacro( tr( "Add a face with new %n vertices", nullptr, newVertices.count() ) );
+  int newVertexIndex = mMesh->vertexCount();
+  addVertices( newVertices.toVector(), 0 );
+  QgsMeshFace face( vertexIndexes.count() );
+  for ( int i = 0; i < vertexIndexes.count(); ++i )
+  {
+    int index = vertexIndexes.at( i );
+    if ( index == -1 )
+      face[i] = newVertexIndex++;
+    else
+      face[i] = index;
+  }
+
+  QgsMeshEditingError error = addFace( face );
+  mUndoStack->endMacro();
+
+  return error;
 }
 
 int QgsMeshEditor::addVertices( const QVector<QgsMeshVertex> &vertices, double tolerance )

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -315,7 +315,7 @@ bool QgsMeshEditor::faceCanBeAddedWithNewVertices( const QList<int> &verticesInd
 
   // if we are here, the face is convex and not flat
 
-  // Now we chekc the topology of the potential new face
+  // Now we check the topology of the potential new face
   int size = face.size();
   QList<QgsMeshVertex> allVertices;
   allVertices.reserve( verticesIndex.size() );

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -325,6 +325,8 @@ bool QgsMeshEditor::faceCanBeAddedWithNewVertices( const QList<int> &verticesInd
     int index = face.at( i );
     if ( index == -1 )
     {
+      if ( newVertPos >= newVertices.count() )
+        return false;
       allVertices.append( newVertices.at( newVertPos++ ) );
       continue;
     }
@@ -733,10 +735,10 @@ QList<int> QgsMeshEditor::prepareFaceWithNewVertices( const QList<int> &face, co
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return face;
 
-  int direction = 0;
-  error = QgsTopologicalMesh::checkTopologyOfVerticesAsFace( vertices, direction );
+  bool clockwise = false;
+  error = QgsTopologicalMesh::checkTopologyOfVerticesAsFace( vertices, clockwise );
 
-  if ( direction > 0 && error.errorType == Qgis::MeshEditingErrorType::NoError )
+  if ( clockwise && error.errorType == Qgis::MeshEditingErrorType::NoError )
   {
 
     QList<int> newFace = face;

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -308,7 +308,10 @@ bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face ) const
 bool QgsMeshEditor::faceCanBeAddedWithNewVertices( const QList<int> &verticesIndex, const QList<QgsMeshVertex> &newVertices ) const
 {
   QgsMeshEditingError error;
-  QList<int> face = prepareFaceWithNewVertices( verticesIndex, newVertices, error );
+  const QList<int> face = prepareFaceWithNewVertices( verticesIndex, newVertices, error );
+
+  if ( face.isEmpty() )
+    return false;
 
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return false;
@@ -714,6 +717,8 @@ QList<int> QgsMeshEditor::prepareFaceWithNewVertices( const QList<int> &face, co
   {
     if ( face.at( i ) == -1 )
     {
+      if ( newVertexPos >= newVertices.count() )
+        return QList<int>();
       vertices[i] = newVertices.at( newVertexPos++ );
     }
     else if ( face.at( i ) >= 0 )

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      * or the value -1 if the vertex is not existing for now in the mesh. The positions of new vertices are stored in \a newVertices
      * sorted by their positions in the face.
      *
-     * \since QGIS 3.28
+     * \since QGIS 3.30
      */
     bool faceCanBeAddedWithNewVertices( const QList<int> &verticesIndex, const QList<QgsMeshVertex> &newVertices ) const; SIP_SKIP
 
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      * or the value -1 if the vertex is not existing for now in the mesh. The positions of new vertices are stored in \a newVertices
      * sorted by their positions in the face.
      *
-     * \since QGIS 3.28
+     * \since QGIS 3.30
      */
     QgsMeshEditingError addFaceWithNewVertices( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &newVertices ); SIP_SKIP
 

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -103,20 +103,44 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     //! Resets the triangular mesh
     void resetTriangularMesh( QgsTriangularMesh *triangularMesh ); SIP_SKIP
 
-    //! Returns TRUE if a \a face can be added to the mesh
-    bool faceCanBeAdded( const QgsMeshFace &face );
+    /**
+     * Returns TRUE if a \a face can be added to the mesh
+     *
+     * \note All vertices related to this face must be already in the mesh.
+     */
+    bool faceCanBeAdded( const QgsMeshFace &face ) const;
+
+    /**
+     * Returns TRUE if a face formed by some vertices con be added to the mesh.
+     * The vertices are defined by \a verticesIndex that contains the index of already existing vertices
+     * or the value -1 if the vertex is not existing for now in the mesh. The positions of new vertices are stored in \a newVertices
+     * sorted by their positions in the face.
+     *
+     * \since QGIS 3.28
+     */
+    bool faceCanBeAddedWithNewVertices( const QList<int> &verticesIndex, const QList<QgsMeshVertex> &newVertices ) const; SIP_SKIP
 
     /**
      * Returns TRUE if the face does not intersect or contains any other elements (faces or vertices)
      * The topological compatibility is not checked
      */
-    bool isFaceGeometricallyCompatible( const QgsMeshFace &face );
+    bool isFaceGeometricallyCompatible( const QgsMeshFace &face ) const;
 
     //! Adds faces \a faces to the mesh, returns topological errors if this operation fails (operation is not realized)
     QgsMeshEditingError addFaces( const QVector<QgsMeshFace> &faces ); SIP_SKIP
 
     //! Adds a face \a face to the mesh with vertex indexes \a vertexIndexes, returns topological errors if this operation fails (operation is not realized)
     QgsMeshEditingError addFace( const QVector<int> &vertexIndexes );
+
+    /**
+     * Adds a face formed by some vertices \a vertexIndexes to the mesh, returns topological errors if this operation fails (operation is not realized)
+     * The vertices are defined by \a verticesIndex that contains the index of already existing vertices
+     * or the value -1 if the vertex is not existing for now in the mesh. The positions of new vertices are stored in \a newVertices
+     * sorted by their positions in the face.
+     *
+     * \since QGIS 3.28
+     */
+    QgsMeshEditingError addFaceWithNewVertices( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &newVertices );
 
     //! Removes faces \a faces to the mesh, returns topological errors if this operation fails (operation is not realized)
     QgsMeshEditingError removeFaces( const QList<int> &facesToRemove );
@@ -294,7 +318,9 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     int mValidVerticesCount = 0;
     int mValidFacesCount = 0;
 
-    QVector<QgsMeshFace> prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error );
+    QVector<QgsMeshFace> prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error ) const;
+    QList<int> prepareFaceWithNewVertices( const QList<int> &vertices, const QList<QgsMeshVertex> &newVertices, QgsMeshEditingError &error ) const;
+    bool isFaceGeometricallyCompatible( const QList<int> &vertexIndex, const QList<QgsMeshVertex> &vertices ) const;
 
     //! undo/redo stuff
     QUndoStack *mUndoStack = nullptr;

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      *
      * \since QGIS 3.28
      */
-    QgsMeshEditingError addFaceWithNewVertices( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &newVertices );
+    QgsMeshEditingError addFaceWithNewVertices( const QList<int> &vertexIndexes, const QList<QgsMeshVertex> &newVertices ); SIP_SKIP
 
     //! Removes faces \a faces to the mesh, returns topological errors if this operation fails (operation is not realized)
     QgsMeshEditingError removeFaces( const QList<int> &facesToRemove );

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -111,7 +111,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     bool faceCanBeAdded( const QgsMeshFace &face ) const;
 
     /**
-     * Returns TRUE if a face formed by some vertices con be added to the mesh.
+     * Returns TRUE if a face formed by some vertices can be added to the mesh.
      * The vertices are defined by \a verticesIndex that contains the index of already existing vertices
      * or the value -1 if the vertex is not existing for now in the mesh. The positions of new vertices are stored in \a newVertices
      * sorted by their positions in the face.

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -672,8 +672,8 @@ QgsMeshEditingError QgsTopologicalMesh::checkTopologyOfVerticesAsFace( const QVe
 
 QgsMeshEditingError QgsTopologicalMesh::counterClockwiseFaces( QgsMeshFace &face, QgsMesh *mesh )
 {
-  // First check if the topology of the face , then put it counter clockwise if needed
-  // If the index are not well ordered (edges intersect), invalid face
+  // First check the topology of the face, then put it counter clockwise if needed
+  // If the indexes are not well ordered (edges intersect), invalid face
   int faceSize = face.count();
   if ( faceSize < 3 )
     return QgsMeshEditingError( Qgis::MeshEditingErrorType::FlatFace, -1 );

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -37,18 +37,24 @@ static int vertexPositionInFace( const QgsMesh &mesh, int vertexIndex, int faceI
   return vertexPositionInFace( vertexIndex, mesh.face( faceIndex ) );
 }
 
-static double crossProduct( int centralVertex, int vertex1, int vertex2, const QgsMesh &mesh )
-{
-  QgsMeshVertex vc = mesh.vertices.at( centralVertex );
-  QgsMeshVertex v1 = mesh.vertices.at( vertex1 );
-  QgsMeshVertex v2 = mesh.vertices.at( vertex2 );
 
+static double crossProduct( const QgsMeshVertex &vc, const QgsMeshVertex &v1, const QgsMeshVertex &v2 )
+{
   double ux1 = v1.x() - vc.x();
   double uy1 = v1.y() - vc.y();
   double vx1 = v2.x() - vc.x();
   double vy1 = v2.y() - vc.y();
 
   return ux1 * vy1 - uy1 * vx1;
+}
+
+static double crossProduct( int centralVertex, int vertex1, int vertex2, const QgsMesh &mesh )
+{
+  QgsMeshVertex vc = mesh.vertices.at( centralVertex );
+  QgsMeshVertex v1 = mesh.vertices.at( vertex1 );
+  QgsMeshVertex v2 = mesh.vertices.at( vertex2 );
+
+  return crossProduct( vc, v1, v2 );
 }
 
 
@@ -629,33 +635,19 @@ QList<int> QgsTopologicalMesh::freeVerticesIndexes() const
   return QList<int>( mFreeVertices.begin(), mFreeVertices.end() );
 }
 
-QgsMeshEditingError QgsTopologicalMesh::counterClockwiseFaces( QgsMeshFace &face, QgsMesh *mesh )
+QgsMeshEditingError QgsTopologicalMesh::checkTopologyOfVerticesAsFace( const QVector<QgsMeshVertex> &vertices, int &direction )
 {
-  // First check if the face is convex and put it counter clockwise
-  // If the index are not well ordered (edges intersect), invalid face --> return false
-  int faceSize = face.count();
-  if ( faceSize < 3 )
-    return QgsMeshEditingError( Qgis::MeshEditingErrorType::FlatFace, -1 );
-
-  int direction = 0;
-  for ( int i = 0; i < faceSize; ++i )
+  int size = vertices.size();
+  direction = 0;
+  for ( int i = 0; i < size; ++i )
   {
-    int iv0 =  face[i];
-    int iv1 = face[( i + 1 ) % faceSize];
-    int iv2 = face[( i + 2 ) % faceSize];
+    int iv0 =  i;
+    int iv1 = ( i + 1 ) % size;
+    int iv2 = ( i + 2 ) % size;
 
-    if ( iv0 < 0 || iv0 >= mesh->vertexCount() )
-      return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv0 );
-
-    if ( iv1 < 0 || iv1 >= mesh->vertexCount() )
-      return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv1 );
-
-    if ( iv2 < 0 || iv2 >= mesh->vertexCount() )
-      return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv2 );
-
-    const QgsMeshVertex &v0 = mesh->vertices.at( iv0 ) ;
-    const QgsMeshVertex &v1 = mesh->vertices.at( iv1 ) ;
-    const QgsMeshVertex &v2 = mesh->vertices.at( iv2 ) ;
+    const QgsMeshVertex &v0 = vertices.at( iv0 ) ;
+    const QgsMeshVertex &v1 = vertices.at( iv1 ) ;
+    const QgsMeshVertex &v2 = vertices.at( iv2 ) ;
 
     if ( v0.isEmpty() )
       return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv0 );
@@ -666,7 +658,7 @@ QgsMeshEditingError QgsTopologicalMesh::counterClockwiseFaces( QgsMeshFace &face
     if ( v2.isEmpty() )
       return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv2 );
 
-    double crossProd = crossProduct( iv1, iv0, iv2, *mesh ); //if cross product>0, we have two edges clockwise
+    double crossProd = crossProduct( v1, v0, v2 ); //if cross product>0, we have two edges clockwise
     if ( direction != 0 && crossProd * direction < 0 )   // We have a convex face or a (partially) flat face
       return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidFace, -1 );
     else if ( crossProd == 0 )
@@ -674,6 +666,33 @@ QgsMeshEditingError QgsTopologicalMesh::counterClockwiseFaces( QgsMeshFace &face
     else if ( direction == 0 && crossProd != 0 )
       direction = crossProd / std::fabs( crossProd );
   }
+
+  return QgsMeshEditingError( Qgis::MeshEditingErrorType::NoError, -1 );
+}
+
+QgsMeshEditingError QgsTopologicalMesh::counterClockwiseFaces( QgsMeshFace &face, QgsMesh *mesh )
+{
+  // First check if the topology of the face , then put it counter clockwise if needed
+  // If the index are not well ordered (edges intersect), invalid face
+  int faceSize = face.count();
+  if ( faceSize < 3 )
+    return QgsMeshEditingError( Qgis::MeshEditingErrorType::FlatFace, -1 );
+
+  QVector<QgsMeshVertex> vertices( face.size() );
+
+  for ( int i = 0; i < faceSize; ++i )
+  {
+    int iv =  face[i];
+    if ( iv < 0 || iv >= mesh->vertexCount() )
+      return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, iv );
+
+    vertices[i] = mesh->vertices.at( face[i] );
+  }
+
+  int direction = 0;
+  QgsMeshEditingError error = QgsTopologicalMesh::checkTopologyOfVerticesAsFace( vertices, direction );
+  if ( error != QgsMeshEditingError() )
+    return error;
 
   if ( direction > 0 )// clockwise --> reverse the order of the index;
   {

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -307,6 +307,14 @@ class CORE_EXPORT QgsTopologicalMesh
     static QgsMeshEditingError counterClockwiseFaces( QgsMeshFace &face, QgsMesh *mesh );
 
     /**
+     * Checks the topology of the \a vertices as the are contained in a face and returns indication on direction.
+     * If \a direction > 0 the face would be clockwise
+     *
+     * \since QGIS 3.28
+     */
+    static QgsMeshEditingError checkTopologyOfVerticesAsFace( const QVector<QgsMeshVertex> &vertices, int &direction );
+
+    /**
      * Reindexes faces and vertices, after this operation, the topological
      * mesh can't be edited anymore and only the method mesh can be used to access to the raw mesh.
      */

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -307,7 +307,7 @@ class CORE_EXPORT QgsTopologicalMesh
     static QgsMeshEditingError counterClockwiseFaces( QgsMeshFace &face, QgsMesh *mesh );
 
     /**
-     * Checks the topology of the \a vertices as the are contained in a face and returns indication on direction.
+     * Checks the topology of the \a vertices as they are contained in a face and returns indication on direction.
      * If \a direction > 0 the face would be clockwise
      *
      * \since QGIS 3.28

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -213,13 +213,13 @@ class CORE_EXPORT QgsTopologicalMesh
      * Returns whether faces with index in \a faceIndexes can be removed/
      * The method an error object with type QgsMeshEditingError::NoError if the faces can be removed, otherwise returns the corresponding error
      */
-    QgsMeshEditingError facesCanBeRemoved( const QList<int> facesIndexes );
+    QgsMeshEditingError facesCanBeRemoved( const QList<int> &facesIndexes );
 
     /**
      * Removes faces with index in \a faceIndexes.
      * The method returns a instance of the class QgsTopologicalMesh::Change that can be used to reverse or reapply the operation.
      */
-    Changes removeFaces( const QList<int> facesIndexes );
+    Changes removeFaces( const QList<int> &facesIndexes );
 
     /**
      * Returns TRUE if the edge can be flipped (only available for edge shared by two faces with 3 vertices)
@@ -308,11 +308,11 @@ class CORE_EXPORT QgsTopologicalMesh
 
     /**
      * Checks the topology of the \a vertices as they are contained in a face and returns indication on direction.
-     * If \a direction > 0 the face would be clockwise
+     * If the face is clockwise, \a clockwise is TRUE
      *
-     * \since QGIS 3.28
+     * \since QGIS 3.30
      */
-    static QgsMeshEditingError checkTopologyOfVerticesAsFace( const QVector<QgsMeshVertex> &vertices, int &direction );
+    static QgsMeshEditingError checkTopologyOfVerticesAsFace( const QVector<QgsMeshVertex> &vertices, bool &clockwise );
 
     /**
      * Reindexes faces and vertices, after this operation, the topological
@@ -341,7 +341,7 @@ class CORE_EXPORT QgsTopologicalMesh
       bool allowUniqueSharedVertex );
 
     //! Returns all faces indexes that are concerned by the face with index in \a faceIndex, that is sharing a least one vertex or one edge
-    QSet<int> concernedFacesBy( const QList<int> faceIndexes ) const;
+    QSet<int> concernedFacesBy( const QList<int> &faceIndexes ) const;
 
     //! References the vertex as a free vertex to be able to access to all free vertices
     void referenceAsFreeVertex( int vertexIndex );

--- a/tests/src/app/testqgsmaptooleditmesh.cpp
+++ b/tests/src/app/testqgsmaptooleditmesh.cpp
@@ -168,7 +168,7 @@ void TestQgsMapToolEditMesh::editMesh()
   // add a face
   tool.mouseMove( 1999, 2999 ); //move near a vertex
   tool.mouseMove( 2000 + offsetInMapUnits / sqrt( 2 ), 3000 + offsetInMapUnits / sqrt( 2 ) ); //move on the new face marker
-  tool.mouseClick( 2000 + offsetInMapUnits / sqrt( 2 ), 3000 + offsetInMapUnits / sqrt( 2 ), Qt::LeftButton );
+  tool.mouseClick( 2000 + offsetInMapUnits / sqrt( 4 ), 3000 + offsetInMapUnits / sqrt( 2 ), Qt::LeftButton );
   tool.mouseMove( 2499, 3501 ); //move near the new free vertex
   tool.mouseClick( 2501, 3499, Qt::LeftButton ); // click near the vertex
   tool.mouseMove( 2490, 2600 ); //move elsewhere
@@ -177,6 +177,37 @@ void TestQgsMapToolEditMesh::editMesh()
   tool.mouseClick( 5000, 5000, Qt::RightButton ); // valid the face
 
   QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+
+  // add a face with new vertices
+  tool.mouseMove( 2500, 3500 ); //move near a vertex
+  tool.mouseMove( 2500, 3501 );
+  tool.mouseMove( 2500 + offsetInMapUnits / sqrt( 5 ), 3500 + 2 * offsetInMapUnits / sqrt( 5 ) ); //move on the new face marker
+  tool.mouseClick( 2500 + offsetInMapUnits / sqrt( 5 ), 3500 + 2 * offsetInMapUnits / sqrt( 5 ), Qt::LeftButton );
+  tool.mouseMove( 3000, 3000 ); //move to a new place outsite the mesh
+  tool.mouseClick( 3000, 3000, Qt::LeftButton );
+  tool.mouseMove( 3000, 3500 ); //move to a new place outsite the mesh (cross edge of new face: invalid)
+  tool.mouseClick( 3000, 3500, Qt::LeftButton );
+  tool.mouseMove( 2500, 2500 );
+  tool.mouseClick( 2500, 2500, Qt::LeftButton );// close the face
+  tool.mouseClick( 5000, 5000, Qt::RightButton ); // valid the fac
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 ); //-> face not added
+  QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 10 ); //-> vertices not added
+  tool.keyClick( Qt::Key_Backspace );
+  tool.keyClick( Qt::Key_Backspace );
+  tool.keyClick( Qt::Key_Backspace );
+  tool.mouseMove( 3000, 3500 );
+  tool.mouseClick( 3000, 3000, Qt::LeftButton );
+  tool.mouseMove( 2500, 2500 );
+  tool.mouseClick( 2500, 2500, Qt::LeftButton );
+  tool.mouseMove( 5000, 5000 );
+  tool.mouseClick( 5000, 5000, Qt::RightButton );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 10 );
+  QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 11 );
+
+  meshLayerQuadFlower->undoStack()->undo();
+
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 10 );
 
   // Remove vertex 7 and 9
   tool.mouseMove( 1500, 3250 );


### PR DESCRIPTION
This PR is related to #50033, #50035 and  #50037.

Indeed, before this PR, adding new faces with mesh editing suffered of several issues:
- when entered in adding new face mode, to create a new vertex outside the current mesh, user had to double click. A way of digitizing quite different from digitizing vector layer.
- to undo edges of the new face, during its creation, user can press backspace, as when digitizing vector layer. But, here, the new vertices created during this operation was still present as free vertex even after backspace or undo the newly created face. This behavior is quite ugly for the user...
- There was a bug when user, after starting to add a new face, go to another tool and come back to the mesh editing tool: rubber band is broken, and also the general behavior of adding face.

This PR fixes all this issues by changing the approach:
- when entering in "add new face" mode, adding new vertices is simply done by a simple click outside the mesh. The vertices is actually created only after the face is validated by a right click. Backspace undo new edge AND new vertices.
- when the user is not in the "add new face" mode, the user still need a double click to add a vertex outside the mesh (it is a free vertex, not related to any face) and inside the current mesh (a simple vertex related to faces). It is necessary because simple click could interact with other action possible (select element, move, ...) and because adding a new vertex is a strong action that has to be really wanted by the user.

ping @DelazJ 

**BEFORE**
![new_face_before](https://user-images.githubusercontent.com/7416892/193084564-be4a57a7-910f-4a4e-a9c3-ee3c0fc121b5.gif)

**AFTER**
![new_face_after](https://user-images.githubusercontent.com/7416892/193085356-6b47efce-b877-482e-9290-7a47897f29d0.gif)

