### PR TITLE
Fix array_get argument name

### DIFF
--- a/resources/function_help/json/array_get
+++ b/resources/function_help/json/array_get
@@ -7,7 +7,7 @@
     "arg": "array",
     "description": "an array"
   }, {
-    "arg": "index",
+    "arg": "pos",
     "description": "the index to get (0 based)"
   }],
   "examples": [{


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS-Documentation/issues/7814

![image](https://user-images.githubusercontent.com/7983394/193127541-98ffa881-cddb-4d70-9633-81ff03f7d3ba.png)