### PR TITLE
mesh editing, fix default Z value when snap on 2D feature

### DIFF
--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -2594,7 +2594,9 @@ void QgsMapToolEditMeshFrame::addVertex(
 
   if ( mCadDockWidget->cadEnabled() && mCurrentFaceIndex == -1 )
     zValue = currentZValue();
-  else if ( mapPointMatch.isValid() )
+  else if ( mapPointMatch.isValid() &&
+            mapPointMatch.layer() &&
+            QgsWkbTypes::hasZ( mapPointMatch.layer()->wkbType() ) )
   {
     const QgsPoint layerPoint = mapPointMatch.interpolatedPoint( mCanvas->mapSettings().destinationCrs() );
     zValue = layerPoint.z();


### PR DESCRIPTION
Before this PR, in mesh editing, when a vertex is created by snapping on a 2D vector layer feature, the Z value of the vertex is not defined. 
With this PR, the user value is used (from Z value widget).