### PR TITLE
Fix slow topological vertex editing

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2229,15 +2229,18 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
   }
 
   VertexEdits beforeEdits;
-  const auto editKeys = edits.keys();
-  for ( QgsVectorLayer *layer : editKeys )
+  VertexEdits::const_iterator editLayer = edits.constBegin();
+  while ( editLayer != edits.constEnd() )
   {
-    const auto editFid = edits[layer].keys();
-    for ( QgsFeatureId fid : editFid )
+    QgsVectorLayer *layer = editLayer.key();
+    QHash<QgsFeatureId, QgsGeometry>::const_iterator editGeometry = editLayer.value().constBegin();
+    while ( editGeometry != editLayer.value().constEnd() )
     {
-      const QgsGeometry g = edits[layer][fid];
+      QgsFeatureId fid = editGeometry.key();
       beforeEdits[layer][fid] = layer->getGeometry( fid );
+      ++editGeometry;
     }
+    ++editLayer;
   }
 
   applyEditsToLayers( edits );

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -348,5 +348,12 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
     return nullptr;
   }
 
+  if ( QgsWkbTypes::isMultiType( geomTypeBeforeModification ) && QgsWkbTypes::isSingleType( diffGeom->wkbType() ) )
+  {
+    QgsGeometry geom( std::move( diffGeom ) );
+    geom.convertToMultiType();
+    diffGeom.reset( geom.constGet()->clone() );
+  }
+
   return diffGeom;
 }

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -408,7 +408,7 @@ void TestQgsVertexTool::testTopologicalEditingMoveVertexOnIntersectionZ()
 
   // The undo stack gets two entries, one for the vertex move and one for the topological point
   QCOMPARE( mLayerLineZ->undoStack()->index(), 5 );
-  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 5.5 5.5 333, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 5.5 5.5 5, 6 6 1, 7 5 1)" ) );
   QCOMPARE( mLayerLineZ->getFeature( mFidLineZF3 ).geometry().asWkt(), QString( "LineStringZ (5.5 5.5 5, 7 5.5 10)" ) );
 
   QgsProject::instance()->setTopologicalEditing( topologicalEditing );


### PR DESCRIPTION
## Description

Fixes #44198

This PR changes the approach to adding topological points. Previously, there is a topological point added only on the snapped point, if there is one. In addition, if the `avoidIntersection` is enabled, there is a topological point added on each vertex of the geometry, leading the performance issue.

By testing, I remark other issues. The modified geometry is simplified when it is possible to a single-geometry even if the layer is a multi-geometry. Also, if the user moves 2 vertices, and they are both on a segment, only one topological point will be added. These 2 issues are fixed with this MR.

With this PR, there is a topological point added on each modified/added vertices (by comparing with the old geom). Also, a test on adding a topological point on intersection has been modified because, now, the tool can get the Z value instead of using the default one.

Before:

[before.webm](https://user-images.githubusercontent.com/37629967/193538807-22e060df-9a16-4f59-876b-2274302fcedc.webm)

[before2.webm](https://user-images.githubusercontent.com/37629967/193541281-19bd538f-9305-468e-ba29-adb981c65048.webm)


After:

[after.webm](https://user-images.githubusercontent.com/37629967/193538851-b2563b19-dd26-44f8-9551-9b320a99536c.webm)

[after2.webm](https://user-images.githubusercontent.com/37629967/193541296-ba411e88-25b5-4308-87ca-f3422633f460.webm)


The warning is fixed in #50233

Founded by: Métropole Européenne de Lille, cc @Jean-Roc