### PR TITLE
extend tags for "select within distance" so that "select by" search works

### DIFF
--- a/src/analysis/processing/qgsalgorithmdistancewithin.cpp
+++ b/src/analysis/processing/qgsalgorithmdistancewithin.cpp
@@ -245,7 +245,7 @@ QString QgsSelectWithinDistanceAlgorithm::displayName() const
 
 QStringList QgsSelectWithinDistanceAlgorithm::tags() const
 {
-  return QObject::tr( "select by,maximum,buffer" ).split( ',' );
+  return QObject::tr( "select,by,maximum,buffer" ).split( ',' );
 }
 
 QString QgsSelectWithinDistanceAlgorithm::group() const
@@ -331,7 +331,7 @@ QString QgsExtractWithinDistanceAlgorithm::displayName() const
 
 QStringList QgsExtractWithinDistanceAlgorithm::tags() const
 {
-  return QObject::tr( "extract by,filter,select,maximum,buffer" ).split( ',' );
+  return QObject::tr( "extract,by,filter,select,maximum,buffer" ).split( ',' );
 }
 
 QString QgsExtractWithinDistanceAlgorithm::group() const

--- a/src/analysis/processing/qgsalgorithmdistancewithin.cpp
+++ b/src/analysis/processing/qgsalgorithmdistancewithin.cpp
@@ -245,7 +245,7 @@ QString QgsSelectWithinDistanceAlgorithm::displayName() const
 
 QStringList QgsSelectWithinDistanceAlgorithm::tags() const
 {
-  return QObject::tr( "select,maximum,buffer" ).split( ',' );
+  return QObject::tr( "select by,maximum,buffer" ).split( ',' );
 }
 
 QString QgsSelectWithinDistanceAlgorithm::group() const
@@ -331,7 +331,7 @@ QString QgsExtractWithinDistanceAlgorithm::displayName() const
 
 QStringList QgsExtractWithinDistanceAlgorithm::tags() const
 {
-  return QObject::tr( "extract,filter,select,maximum,buffer" ).split( ',' );
+  return QObject::tr( "extract by,filter,select,maximum,buffer" ).split( ',' );
 }
 
 QString QgsExtractWithinDistanceAlgorithm::group() const


### PR DESCRIPTION
Maybe it's just me but so many times I found myself searching for the ``Select by distance`` algorithm by simply righting ``Select by `` with no results. I think it's because of the "Select by location" similarity.

In the case it isn't just me, here's the pull request that fixes it (it is ok?).
I don't know if it's ok to also extend the logic to the "extend by" part.

Opinions? Thank you!
![image](https://user-images.githubusercontent.com/3179646/193616411-9300bed5-2b65-422e-a089-b936bf56b795.png)
