### PR TITLE
Removed some unnecessary repeated multiplications in loops

### DIFF
--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1915,11 +1915,13 @@ QgsPoint QgsLineString::centroid() const
       continue;
 
     totalLineLength += segmentLength;
-    sumX += segmentLength * 0.5 * ( currentX + prevX );
-    sumY += segmentLength * 0.5 * ( currentY + prevY );
+    sumX += segmentLength * ( currentX + prevX );
+    sumY += segmentLength * ( currentY + prevY );
     prevX = currentX;
     prevY = currentY;
   }
+  sumX *= 0.5;
+  sumY *= 0.5;
 
   if ( qgsDoubleNear( totalLineLength, 0.0 ) )
     return QgsPoint( mX.at( 0 ), mY.at( 0 ) );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1953,10 +1953,11 @@ void QgsLineString::sumUpArea( double &sum ) const
   double prevY = *y++;
   for ( int i = 1; i < maxIndex; ++i )
   {
-    mSummedUpArea += 0.5 * ( prevX * ( *y ) - prevY * ( *x ) );
+    mSummedUpArea += prevX * ( *y ) - prevY * ( *x );
     prevX = *x++;
     prevY = *y++;
   }
+  mSummedUpArea *= 0.5;
 
   mHasCachedSummedUpArea = true;
   sum += mSummedUpArea;


### PR DESCRIPTION
Refactoring.
As suggested in a [comment](https://github.com/qgis/QGIS/pull/49583#issuecomment-1264131362) for PR 49583, I am now creating a PR with code that avoids some unnecessary duplicate multiplications, in the method 'QgsLineString::sumUpArea()'.
Also added a similar refactoring for the method 'QgsLineString::centroid()'