### PR TITLE
Preview expression result in widgets for mesh layer

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -377,9 +377,10 @@ Creates a new scope which contains variables and functions relating to provider 
 Registers all known core functions provided by :py:class:`QgsExpressionContextScope` objects.
 %End
 
-    static QgsExpressionContextScope *meshExpressionScope( QgsMesh::ElementType elementType ) /Factory/;
+    static QgsExpressionContextScope *meshExpressionScope( QgsMesh::ElementType elementType, int defaultIndex = 0 ) /Factory/;
 %Docstring
-Creates a new scope which contains functions relating to mesh layer element ``elementType``
+Creates a new scope which contains functions relating to mesh layer element ``elementType``,
+using \defaultIndex if not overriden later
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -380,7 +380,7 @@ Registers all known core functions provided by :py:class:`QgsExpressionContextSc
     static QgsExpressionContextScope *meshExpressionScope( QgsMesh::ElementType elementType, int defaultIndex = 0 ) /Factory/;
 %Docstring
 Creates a new scope which contains functions relating to mesh layer element ``elementType``,
-using \defaultIndex if not overriden later
+using ``defaultIndex`` if not overridden later
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -14,7 +14,7 @@
 
 
 
-class QgsMapLayer : QObject
+class QgsMapLayer : QObject, QgsExpressionContextGenerator, QgsExpressionContextScopeGenerator
 {
 %Docstring(signature="appended")
 Base class for all map layer types.
@@ -127,6 +127,11 @@ is still unique.
 
 .. versionadded:: 3.0
 %End
+
+    virtual QgsExpressionContext createExpressionContext() const;
+
+    virtual QgsExpressionContextScope *createExpressionContextScope() const /Factory/;
+
 
     QgsMapLayerType type() const;
 %Docstring

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -18,7 +18,7 @@ typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
 
 
-class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator, QgsExpressionContextScopeGenerator, QgsFeatureSink, QgsFeatureSource, QgsAbstractProfileSource
+class QgsVectorLayer : QgsMapLayer, QgsFeatureSink, QgsFeatureSource, QgsAbstractProfileSource
 {
 %Docstring(signature="appended")
 Represents a vector layer which manages a vector based data sets.

--- a/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
@@ -20,7 +20,7 @@ A generic dialog for building expression strings
 #include "qgsexpressionbuilderdialog.h"
 %End
   public:
-    QgsExpressionBuilderDialog( QgsVectorLayer *layer,
+    QgsExpressionBuilderDialog( QgsMapLayer *layer,
                                 const QString &startText = QString(),
                                 QWidget *parent /TransferThis/ = 0,
                                 const QString &key = "generic",

--- a/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderdialog.sip.in
@@ -25,6 +25,9 @@ A generic dialog for building expression strings
                                 QWidget *parent /TransferThis/ = 0,
                                 const QString &key = "generic",
                                 const QgsExpressionContext &context = QgsExpressionContext() );
+%Docstring
+Constructor
+%End
 
     QgsExpressionBuilderWidget *expressionBuilder();
 %Docstring

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -51,9 +51,16 @@ Initialize without any layer
 
     void initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
 %Docstring
-Initialize with a layer
+Initialize with a vector layer
 
 .. versionadded:: 3.14
+%End
+
+    void initWithMapLayer( QgsMapLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
+%Docstring
+Initialize with a map layer
+
+.. versionadded:: 3.28
 %End
 
     void initWithFields( const QgsFields &fields, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
@@ -63,18 +70,41 @@ Initialize with given fields without any layer
 .. versionadded:: 3.14
 %End
 
-    void setLayer( QgsVectorLayer *layer );
+ void setLayer( QgsVectorLayer *layer );
 %Docstring
 Sets layer in order to get the fields and values
 
 .. note::
 
    this needs to be called before calling :py:func:`~QgsExpressionBuilderWidget.loadFieldNames`.
+
+.. deprecated:: QGIS 3.28
+  use :py:func:`~QgsExpressionBuilderWidget.setMapLayer` instead
 %End
 
-    QgsVectorLayer *layer() const;
+
+    void setMapLayer( QgsMapLayer *layer );
 %Docstring
-Returns the current layer or a None.
+Sets layer in order to get the fields and values
+
+.. note::
+
+   it the layer type is vector, this needs to be called before calling :py:func:`~QgsExpressionBuilderWidget.loadFieldNames`.
+%End
+
+ QgsVectorLayer *layer() const;
+%Docstring
+Returns the current vector layer or a None, if the layer type is not vector
+
+.. deprecated:: QGIS 3.28
+  use :py:func:`~QgsExpressionBuilderWidget.mapLayer` instead
+%End
+
+    QgsMapLayer *mapLayer() const;
+%Docstring
+Returns the current map layer
+
+.. versionadded:: 3.28
 %End
 
  void loadFieldNames();

--- a/python/gui/auto_generated/qgsexpressionlineedit.sip.in
+++ b/python/gui/auto_generated/qgsexpressionlineedit.sip.in
@@ -92,9 +92,9 @@ Set the geometry calculator used in the expression dialog.
 :param distanceArea: calculator
 %End
 
-    void setLayer( QgsVectorLayer *layer );
+    void setLayer( QgsMapLayer *layer );
 %Docstring
-Sets a layer associated with the widget. Required in order to get the fields and values
+Sets a layer associated with the widget. Required in order to get information
 from the layer.
 This will also automatically register the layer as expression context generator if
 no generator has been set before or the previous layer has been used as generator.

--- a/python/gui/auto_generated/qgsexpressionpreviewwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionpreviewwidget.sip.in
@@ -29,7 +29,7 @@ If the layer is set, one can browse across features to see the different outputs
 Constructor
 %End
 
-    void setLayer( QgsVectorLayer *layer );
+    void setLayer( QgsMapLayer *layer );
 %Docstring
 Sets the layer used in the preview
 %End

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -150,9 +150,9 @@ Returns a newly created menu instance
 Constructor
 %End
 
-    void setLayer( QgsVectorLayer *layer );
+    void setLayer(QgsMapLayer *layer );
 %Docstring
-Sets layer in order to get the fields and values
+Sets layer in order to get layer information
 %End
 
     void loadFieldNames( const QgsFields &fields );

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -150,7 +150,7 @@ Returns a newly created menu instance
 Constructor
 %End
 
-    void setLayer(QgsMapLayer *layer );
+    void setLayer( QgsMapLayer *layer );
 %Docstring
 Sets layer in order to get layer information
 %End

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -2751,6 +2751,7 @@ void QgsMapToolEditMeshFrame::showSelectByExpressionDialog()
   onEditingStarted();
   QgsMeshSelectByExpressionDialog *dialog = new QgsMeshSelectByExpressionDialog( canvas() );
   dialog->setAttribute( Qt::WA_DeleteOnClose );
+  dialog->setMeshLayer( mCurrentLayer );
   dialog->show();
   connect( dialog, &QgsMeshSelectByExpressionDialog::select, this, &QgsMapToolEditMeshFrame::selectByExpression );
   connect( dialog, &QgsMeshSelectByExpressionDialog::zoomToSelected, this, &QgsMapToolEditMeshFrame::onZoomToSelected );

--- a/src/app/mesh/qgsmeshselectbyexpressiondialog.cpp
+++ b/src/app/mesh/qgsmeshselectbyexpressiondialog.cpp
@@ -21,6 +21,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgshelp.h"
 #include "qgsgui.h"
+#include "qgsmeshlayer.h"
 
 QgsMeshSelectByExpressionDialog::QgsMeshSelectByExpressionDialog( QWidget *parent ):
   QDialog( parent )
@@ -77,13 +78,19 @@ QgsMeshSelectByExpressionDialog::QgsMeshSelectByExpressionDialog( QWidget *paren
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMeshSelectByExpressionDialog::showHelp );
 
   connect( mComboBoxElementType, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsMeshSelectByExpressionDialog::onElementTypeChanged );
-
-  mExpressionBuilder->setExpressionPreviewVisible( false );
 }
 
 QString QgsMeshSelectByExpressionDialog::expression() const
 {
   return mExpressionBuilder->expressionText();
+}
+
+void QgsMeshSelectByExpressionDialog::setMeshLayer( QgsMeshLayer *layer )
+{
+  mLayer = layer;
+
+  QgsExpressionContext expressionContext( {QgsExpressionContextUtils::meshExpressionScope( currentElementType() )} );
+  mExpressionBuilder->initWithMapLayer( mLayer, expressionContext, QStringLiteral( "mesh_vertex_selection" ), QgsExpressionBuilderWidget::LoadAll );
 }
 
 void QgsMeshSelectByExpressionDialog::showHelp() const
@@ -96,14 +103,14 @@ void QgsMeshSelectByExpressionDialog::saveRecent() const
   mExpressionBuilder->expressionTree()->saveToRecent( mExpressionBuilder->expressionText(), QStringLiteral( "mesh_vertex_selection" ) );
 }
 
-void QgsMeshSelectByExpressionDialog::onElementTypeChanged() const
+void QgsMeshSelectByExpressionDialog::onElementTypeChanged()
 {
   QgsMesh::ElementType elementType = currentElementType() ;
   QgsSettings settings;
   settings.setValue( QStringLiteral( "/meshSelection/elementType" ), elementType );
 
   QgsExpressionContext expressionContext( {QgsExpressionContextUtils::meshExpressionScope( elementType )} );
-  mExpressionBuilder->init( expressionContext, QStringLiteral( "mesh_vertex_selection" ), QgsExpressionBuilderWidget::LoadAll );
+  mExpressionBuilder->initWithMapLayer( mLayer, expressionContext, QStringLiteral( "mesh_vertex_selection" ), QgsExpressionBuilderWidget::LoadAll );
 }
 
 QgsMesh::ElementType QgsMeshSelectByExpressionDialog::currentElementType() const

--- a/src/app/mesh/qgsmeshselectbyexpressiondialog.h
+++ b/src/app/mesh/qgsmeshselectbyexpressiondialog.h
@@ -41,6 +41,9 @@ class APP_EXPORT QgsMeshSelectByExpressionDialog : public QDialog, private Ui::Q
     //! Returns the text expression defined in the dialog
     QString expression() const;
 
+    //! Sets the mesh layer
+    void setMeshLayer( QgsMeshLayer *layer );
+
   signals:
     //! Emitted when one of the select tool button is clicked
     void select( const QString &expression, Qgis::SelectBehavior behavior, QgsMesh::ElementType elementType );
@@ -51,13 +54,14 @@ class APP_EXPORT QgsMeshSelectByExpressionDialog : public QDialog, private Ui::Q
   private slots:
     void showHelp() const;
     void saveRecent() const;
-    void onElementTypeChanged() const;
+    void onElementTypeChanged();
 
   private:
     QAction *mActionSelect = nullptr;
     QAction *mActionAddToSelection = nullptr;
     QAction *mActionRemoveFromSelection = nullptr;
 
+    QgsMeshLayer *mLayer = nullptr;
     QgsMesh::ElementType currentElementType() const;
 };
 

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -1007,24 +1007,24 @@ class CurrentVertexZValueExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentVertexZValueExpressionFunction():
-      QgsScopedExpressionFunction( "$vertex_z",
+      QgsScopedExpressionFunction( QStringLiteral( "$vertex_z" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
 
     QgsScopedExpressionFunction *clone() const override {return new CurrentVertexZValueExpressionFunction();}
 
-    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * ) override
     {
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       int vertexIndex = context->variable( QStringLiteral( "_mesh_vertex_index" ) ).toInt();
 
-      QgsMeshLayer *layer = qobject_cast<QgsMeshLayer *>( qvariant_cast<QgsMapLayer *>( context->variable( QStringLiteral( "_mesh_layer" ) ) ) );
+      QgsMeshLayer *layer = QgsExpressionUtils::getMeshLayer( context->variable( QStringLiteral( "layer" ) ), parent );
       if ( !layer || !layer->nativeMesh() || layer->nativeMesh()->vertexCount() <= vertexIndex )
         return QVariant();
 
@@ -1045,24 +1045,24 @@ class CurrentVertexXValueExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentVertexXValueExpressionFunction():
-      QgsScopedExpressionFunction( "$vertex_x",
+      QgsScopedExpressionFunction( QStringLiteral( "$vertex_x" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
 
     QgsScopedExpressionFunction *clone() const override {return new CurrentVertexXValueExpressionFunction();}
 
-    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * ) override
     {
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       int vertexIndex = context->variable( QStringLiteral( "_mesh_vertex_index" ) ).toInt();
 
-      QgsMeshLayer *layer = qobject_cast<QgsMeshLayer *>( qvariant_cast<QgsMapLayer *>( context->variable( QStringLiteral( "_mesh_layer" ) ) ) );
+      QgsMeshLayer *layer = QgsExpressionUtils::getMeshLayer( context->variable( QStringLiteral( "layer" ) ), parent );
       if ( !layer || !layer->nativeMesh() || layer->nativeMesh()->vertexCount() <= vertexIndex )
         return QVariant();
 
@@ -1083,24 +1083,24 @@ class CurrentVertexYValueExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentVertexYValueExpressionFunction():
-      QgsScopedExpressionFunction( "$vertex_y",
+      QgsScopedExpressionFunction( QStringLiteral( "$vertex_y" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
 
     QgsScopedExpressionFunction *clone() const override {return new CurrentVertexYValueExpressionFunction();}
 
-    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * ) override
     {
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       int vertexIndex = context->variable( QStringLiteral( "_mesh_vertex_index" ) ).toInt();
 
-      QgsMeshLayer *layer = qobject_cast<QgsMeshLayer *>( qvariant_cast<QgsMapLayer *>( context->variable( QStringLiteral( "_mesh_layer" ) ) ) );
+      QgsMeshLayer *layer = QgsExpressionUtils::getMeshLayer( context->variable( QStringLiteral( "layer" ) ), parent );
       if ( !layer || !layer->nativeMesh() || layer->nativeMesh()->vertexCount() <= vertexIndex )
         return QVariant();
 
@@ -1121,24 +1121,24 @@ class CurrentVertexExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentVertexExpressionFunction():
-      QgsScopedExpressionFunction( "$vertex_as_point",
+      QgsScopedExpressionFunction( QStringLiteral( "$vertex_as_point" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
 
     QgsScopedExpressionFunction *clone() const override {return new CurrentVertexExpressionFunction();}
 
-    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    QVariant func( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * ) override
     {
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       int vertexIndex = context->variable( QStringLiteral( "_mesh_vertex_index" ) ).toInt();
 
-      QgsMeshLayer *layer = qobject_cast<QgsMeshLayer *>( qvariant_cast<QgsMapLayer *>( context->variable( QStringLiteral( "_mesh_layer" ) ) ) );
+      QgsMeshLayer *layer = QgsExpressionUtils::getMeshLayer( context->variable( QStringLiteral( "layer" ) ), parent );
       if ( !layer || !layer->nativeMesh() || layer->nativeMesh()->vertexCount() <= vertexIndex )
         return QVariant();
 
@@ -1159,7 +1159,7 @@ class CurrentVertexIndexExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentVertexIndexExpressionFunction():
-      QgsScopedExpressionFunction( "$vertex_index",
+      QgsScopedExpressionFunction( QStringLiteral( "$vertex_index" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
@@ -1171,7 +1171,7 @@ class CurrentVertexIndexExpressionFunction: public QgsScopedExpressionFunction
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_vertex_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       return context->variable( QStringLiteral( "_mesh_vertex_index" ) );
@@ -1188,7 +1188,7 @@ class CurrentFaceAreaExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentFaceAreaExpressionFunction():
-      QgsScopedExpressionFunction( "$face_area",
+      QgsScopedExpressionFunction( QStringLiteral( "$face_area" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
@@ -1200,12 +1200,12 @@ class CurrentFaceAreaExpressionFunction: public QgsScopedExpressionFunction
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_face_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_face_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       int faceIndex = context->variable( QStringLiteral( "_mesh_face_index" ) ).toInt();
 
-      QgsMeshLayer *layer = qobject_cast<QgsMeshLayer *>( qvariant_cast<QgsMapLayer *>( context->variable( QStringLiteral( "_mesh_layer" ) ) ) );
+      QgsMeshLayer *layer = QgsExpressionUtils::getMeshLayer( context->variable( QStringLiteral( "layer" ) ), parent );
       if ( !layer || !layer->nativeMesh() || layer->nativeMesh()->faceCount() <= faceIndex )
         return QVariant();
 
@@ -1239,7 +1239,7 @@ class CurrentFaceIndexExpressionFunction: public QgsScopedExpressionFunction
 {
   public:
     CurrentFaceIndexExpressionFunction():
-      QgsScopedExpressionFunction( "$face_index",
+      QgsScopedExpressionFunction( QStringLiteral( "$face_index" ),
                                    0,
                                    QStringLiteral( "Meshes" ) )
     {}
@@ -1251,7 +1251,7 @@ class CurrentFaceIndexExpressionFunction: public QgsScopedExpressionFunction
       if ( !context )
         return QVariant();
 
-      if ( !context->hasVariable( QStringLiteral( "_mesh_face_index" ) ) || !context->hasVariable( QStringLiteral( "_mesh_layer" ) ) )
+      if ( !context->hasVariable( QStringLiteral( "_mesh_face_index" ) ) || !context->hasVariable( QStringLiteral( "layer" ) ) )
         return QVariant();
 
       return context->variable( QStringLiteral( "_mesh_face_index" ) ).toInt();
@@ -1266,7 +1266,7 @@ class CurrentFaceIndexExpressionFunction: public QgsScopedExpressionFunction
 
 
 
-QgsExpressionContextScope *QgsExpressionContextUtils::meshExpressionScope( QgsMesh::ElementType elementType )
+QgsExpressionContextScope *QgsExpressionContextUtils::meshExpressionScope( QgsMesh::ElementType elementType, int defaultIndex )
 {
   std::unique_ptr<QgsExpressionContextScope> scope = std::make_unique<QgsExpressionContextScope>();
 
@@ -1279,19 +1279,21 @@ QgsExpressionContextScope *QgsExpressionContextUtils::meshExpressionScope( QgsMe
       QgsExpression::registerFunction( new CurrentVertexYValueExpressionFunction, true );
       QgsExpression::registerFunction( new CurrentVertexZValueExpressionFunction, true );
       QgsExpression::registerFunction( new CurrentVertexIndexExpressionFunction, true );
-      scope->addFunction( "$vertex_as_point", new CurrentVertexExpressionFunction );
-      scope->addFunction( "$vertex_x", new CurrentVertexXValueExpressionFunction );
-      scope->addFunction( "$vertex_y", new CurrentVertexYValueExpressionFunction );
-      scope->addFunction( "$vertex_z", new CurrentVertexZValueExpressionFunction );
-      scope->addFunction( "$vertex_index", new CurrentVertexIndexExpressionFunction );
+      scope->addFunction( QStringLiteral( "$vertex_as_point" ), new CurrentVertexExpressionFunction );
+      scope->addFunction( QStringLiteral( "$vertex_x" ), new CurrentVertexXValueExpressionFunction );
+      scope->addFunction( QStringLiteral( "$vertex_y" ), new CurrentVertexYValueExpressionFunction );
+      scope->addFunction( QStringLiteral( "$vertex_z" ), new CurrentVertexZValueExpressionFunction );
+      scope->addFunction( QStringLiteral( "$vertex_index" ), new CurrentVertexIndexExpressionFunction );
+      scope->setVariable( QStringLiteral( "_mesh_vertex_index" ), defaultIndex );
     }
     break;
     case QgsMesh::Face:
     {
       QgsExpression::registerFunction( new CurrentFaceAreaExpressionFunction, true );
       QgsExpression::registerFunction( new CurrentFaceIndexExpressionFunction, true );
-      scope->addFunction( "$face_area", new CurrentFaceAreaExpressionFunction );
-      scope->addFunction( "$face_index", new CurrentFaceIndexExpressionFunction );
+      scope->addFunction( QStringLiteral( "$face_area" ), new CurrentFaceAreaExpressionFunction );
+      scope->addFunction( QStringLiteral( "$face_index" ), new CurrentFaceIndexExpressionFunction );
+      scope->setVariable( QStringLiteral( "_mesh_face_index" ), defaultIndex );
     }
     break;
     case QgsMesh::Edge:

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -1027,7 +1027,7 @@ class CurrentVertexZValueExpressionFunction: public QgsScopedExpressionFunction
       auto lambdaFunc = [vertexIndex]( QgsMapLayer * layer )->QVariant
       {
         QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
-        if ( !layer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
+        if ( !meshLayer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
           return QVariant();
 
         const QgsMeshVertex &vertex = meshLayer->nativeMesh()->vertex( vertexIndex );
@@ -1076,7 +1076,7 @@ class CurrentVertexXValueExpressionFunction: public QgsScopedExpressionFunction
       auto lambdaFunc = [vertexIndex]( QgsMapLayer * layer )->QVariant
       {
         QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
-        if ( !layer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
+        if ( !meshLayer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
           return QVariant();
 
         const QgsMeshVertex &vertex = meshLayer->nativeMesh()->vertex( vertexIndex );
@@ -1125,7 +1125,7 @@ class CurrentVertexYValueExpressionFunction: public QgsScopedExpressionFunction
       auto lambdaFunc = [vertexIndex]( QgsMapLayer * layer )->QVariant
       {
         QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
-        if ( !layer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
+        if ( !meshLayer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
           return QVariant();
 
         const QgsMeshVertex &vertex = meshLayer->nativeMesh()->vertex( vertexIndex );
@@ -1174,7 +1174,7 @@ class CurrentVertexExpressionFunction: public QgsScopedExpressionFunction
       auto lambdaFunc = [vertexIndex]( QgsMapLayer * layer )->QVariant
       {
         QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
-        if ( !layer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
+        if ( !meshLayer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->vertexCount() <= vertexIndex )
           return QVariant();
 
         const QgsMeshVertex &vertex = meshLayer->nativeMesh()->vertex( vertexIndex );
@@ -1261,7 +1261,7 @@ class CurrentFaceAreaExpressionFunction: public QgsScopedExpressionFunction
       auto lambdaFunc = [faceIndex, calc, areaUnit, useDistanceArea]( QgsMapLayer * layer )->QVariant
       {
         QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer );
-        if ( !layer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->faceCount() <= faceIndex )
+        if ( !meshLayer || !meshLayer->nativeMesh() || meshLayer->nativeMesh()->faceCount() <= faceIndex )
           return QVariant();
 
         const QgsMeshFace &face = meshLayer->nativeMesh()->face( faceIndex );

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -333,7 +333,7 @@ class CORE_EXPORT QgsExpressionContextUtils
 
     /**
      * Creates a new scope which contains functions relating to mesh layer element \a elementType,
-     * using \defaultIndex if not overriden later
+     * using \a defaultIndex if not overridden later
      *
      * \since QGIS 3.22
      */

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -332,10 +332,12 @@ class CORE_EXPORT QgsExpressionContextUtils
     static void registerContextFunctions();
 
     /**
-     * Creates a new scope which contains functions relating to mesh layer element \a elementType
+     * Creates a new scope which contains functions relating to mesh layer element \a elementType,
+     * using \defaultIndex if not overriden later
+     *
      * \since QGIS 3.22
      */
-    static QgsExpressionContextScope *meshExpressionScope( QgsMesh::ElementType elementType ) SIP_FACTORY;
+    static QgsExpressionContextScope *meshExpressionScope( QgsMesh::ElementType elementType, int defaultIndex = 0 ) SIP_FACTORY;
 
   private:
 

--- a/src/core/mesh/qgsmeshadvancedediting.cpp
+++ b/src/core/mesh/qgsmeshadvancedediting.cpp
@@ -635,10 +635,9 @@ bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
   QSet<int> concernedFaces;
   mChangingVertexMap = QHash<int, int>();
 
-  std::unique_ptr<QgsExpressionContextScope> expScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Vertex ) );
   QgsExpressionContext context;
-  context.appendScope( expScope.release() );
-  context.lastScope()->setVariable( QStringLiteral( "_mesh_layer" ), QVariant::fromValue( layer ) );
+  context << layer->createExpressionContextScope()
+          << QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Vertex );
 
   QVector<QgsMeshVertex> newVertices;
   newVertices.reserve( mInputVertices.count() );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1434,9 +1434,8 @@ QList<int> QgsMeshLayer::selectVerticesByExpression( QgsExpression expression )
     return ret;
 
   QgsExpressionContext context;
-  std::unique_ptr<QgsExpressionContextScope> expScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Vertex ) );
-  context.appendScope( expScope.release() );
-  context.lastScope()->setVariable( QStringLiteral( "_mesh_layer" ), QVariant::fromValue( this ) );
+  context << createExpressionContextScope()
+          << QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Vertex );
 
   expression.prepare( &context );
 
@@ -1467,9 +1466,8 @@ QList<int> QgsMeshLayer::selectFacesByExpression( QgsExpression expression )
     return ret;
 
   QgsExpressionContext context;
-  std::unique_ptr<QgsExpressionContextScope> expScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Face ) );
-  context.appendScope( expScope.release() );
-  context.lastScope()->setVariable( QStringLiteral( "_mesh_layer" ), QVariant::fromValue( this ) );
+  context << createExpressionContextScope()
+          << QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Face );
 
   expression.prepare( &context );
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -47,6 +47,7 @@
 #include "qgsdatums.h"
 #include "qgsprojoperation.h"
 #include "qgsthreadingutils.h"
+#include <qgsexpressioncontextutils.h>
 
 #include <QDir>
 #include <QDomDocument>
@@ -2761,3 +2762,14 @@ QString QgsMapLayer::crsHtmlMetadata() const
   metadata += QLatin1String( "</table>\n<br><br>\n" );
   return metadata;
 }
+
+QgsExpressionContext QgsMapLayer::createExpressionContext() const
+{
+  return QgsExpressionContext( QgsExpressionContextUtils::globalProjectLayerScopes( this ) );
+}
+
+QgsExpressionContextScope *QgsMapLayer::createExpressionContextScope() const
+{
+  return QgsExpressionContextUtils::layerScope( this );
+}
+

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -41,6 +41,8 @@
 #include "qgsdataprovider.h"
 #include "qgis.h"
 #include "qgslogger.h"
+#include "qgsexpressioncontextgenerator.h"
+#include "qgsexpressioncontextscopegenerator.h"
 
 class QgsAbstract3DRenderer;
 class QgsDataProvider;
@@ -69,7 +71,7 @@ class QgsRenderContext;
  * \brief Base class for all map layer types.
  * This is the base class for all map layer types (vector, raster).
  */
-class CORE_EXPORT QgsMapLayer : public QObject
+class CORE_EXPORT QgsMapLayer : public QObject, public QgsExpressionContextGenerator, public QgsExpressionContextScopeGenerator
 {
     Q_OBJECT
 
@@ -205,6 +207,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.0
      */
     virtual QgsMapLayer *clone() const = 0;
+
+    QgsExpressionContext createExpressionContext() const override ;
+    QgsExpressionContextScope *createExpressionContextScope() const override SIP_FACTORY;
 
     /**
      * Returns the type of the layer.

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -388,7 +388,7 @@ typedef QSet<int> QgsAttributeIds;
  *
  * \see QgsVectorLayerUtils()
  */
-class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionContextGenerator, public QgsExpressionContextScopeGenerator, public QgsFeatureSink, public QgsFeatureSource, public QgsAbstractProfileSource
+class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsFeatureSink, public QgsFeatureSource, public QgsAbstractProfileSource
 {
     Q_OBJECT
 

--- a/src/gui/layout/qgslayouthtmlwidget.cpp
+++ b/src/gui/layout/qgslayouthtmlwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgscodeeditorcss.h"
 #include "qgssettings.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
 
 #include <QFileDialog>
 #include <QUrl>

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2293,7 +2293,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
     if ( mFieldExpWidget )
       mFieldExpWidget->setLayer( nullptr );
     else if ( mExpBuilderWidget )
-      mExpBuilderWidget->setLayer( nullptr );
+      mExpBuilderWidget->setMapLayer( nullptr );
     else if ( mExpLineEdit )
       mExpLineEdit->setLayer( nullptr );
     return;
@@ -2315,7 +2315,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
   if ( mFieldExpWidget )
     mFieldExpWidget->setLayer( layer );
   if ( mExpBuilderWidget )
-    mExpBuilderWidget->setLayer( layer );
+    mExpBuilderWidget->setMapLayer( layer );
   else if ( mExpLineEdit )
     mExpLineEdit->setLayer( layer );
 }
@@ -2371,8 +2371,8 @@ const QgsVectorLayer *QgsProcessingExpressionWidgetWrapper::linkedVectorLayer() 
   if ( mFieldExpWidget && mFieldExpWidget->layer() )
     return mFieldExpWidget->layer();
 
-  if ( mExpBuilderWidget && mExpBuilderWidget->layer() )
-    return mExpBuilderWidget->layer();
+  if ( mExpBuilderWidget && mExpBuilderWidget->mapLayer() )
+    return qobject_cast<QgsVectorLayer *>( mExpBuilderWidget->mapLayer() );
 
   return QgsAbstractProcessingParameterWidgetWrapper::linkedVectorLayer();
 }

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -19,7 +19,7 @@
 #include "qgsgui.h"
 #include <QMessageBox>
 
-QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, const QString &startText, QWidget *parent, const QString &key, const QgsExpressionContext &context )
+QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsMapLayer *layer, const QString &startText, QWidget *parent, const QString &key, const QgsExpressionContext &context )
   : QDialog( parent )
   , mInitialText( startText )
   , mRecentKey( key )
@@ -31,7 +31,7 @@ QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, c
   connect( builder, &QgsExpressionBuilderWidget::evalErrorChanged, this, &QgsExpressionBuilderDialog::syncOkButtonEnabledState );
 
   builder->setExpressionContext( context );
-  builder->setLayer( layer );
+  builder->setMapLayer( layer );
   builder->setExpressionText( startText );
   builder->expressionTree()->loadRecent( mRecentKey );
   builder->expressionTree()->loadUserExpressions( );

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -34,6 +34,7 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
     Q_PROPERTY( bool allowEvalErrors READ allowEvalErrors WRITE setAllowEvalErrors NOTIFY allowEvalErrorsChanged )
 
   public:
+    //! Constructor
     QgsExpressionBuilderDialog( QgsMapLayer *layer,
                                 const QString &startText = QString(),
                                 QWidget *parent SIP_TRANSFERTHIS = nullptr,

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -34,7 +34,7 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
     Q_PROPERTY( bool allowEvalErrors READ allowEvalErrors WRITE setAllowEvalErrors NOTIFY allowEvalErrorsChanged )
 
   public:
-    QgsExpressionBuilderDialog( QgsVectorLayer *layer,
+    QgsExpressionBuilderDialog( QgsMapLayer *layer,
                                 const QString &startText = QString(),
                                 QWidget *parent SIP_TRANSFERTHIS = nullptr,
                                 const QString &key = "generic",

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -265,7 +265,7 @@ void QgsExpressionBuilderWidget::init( const QgsExpressionContext &context, cons
 void QgsExpressionBuilderWidget::initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context, const QString &recentCollection, QgsExpressionBuilderWidget::Flags flags )
 {
   init( context, recentCollection, flags );
-  setLayer( layer );
+  setMapLayer( layer );
 }
 
 void QgsExpressionBuilderWidget::initWithMapLayer( QgsMapLayer *layer, const QgsExpressionContext &context, const QString &recentCollection, QgsExpressionBuilderWidget::Flags flags )
@@ -1220,7 +1220,7 @@ QString QgsExpressionBuilderWidget::loadFunctionHelp( QgsExpressionItem *express
 QMenu *QgsExpressionBuilderWidget::ExpressionTreeMenuProvider::createContextMenu( QgsExpressionItem *item )
 {
   QMenu *menu = nullptr;
-  QgsVectorLayer *layer = mExpressionBuilderWidget->layer();
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( mExpressionBuilderWidget->mapLayer() );
   if ( item->getItemType() == QgsExpressionItem::Field && layer )
   {
     menu = new QMenu( mExpressionBuilderWidget );

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -72,10 +72,16 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void init( const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
 
     /**
-     * Initialize with a layer
+     * Initialize with a vector layer
      * \since QGIS 3.14
      */
     void initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
+
+    /**
+     * Initialize with a map layer
+     * \since QGIS 3.28
+     */
+    void initWithMapLayer( QgsMapLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), QgsExpressionBuilderWidget::Flags flags = LoadAll );
 
     /**
      * Initialize with given fields without any layer
@@ -86,13 +92,31 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     /**
      * Sets layer in order to get the fields and values
      * \note this needs to be called before calling loadFieldNames().
+     *
+     * \deprecated since QGIS 3.28, use setMapLayer() instead
      */
-    void setLayer( QgsVectorLayer *layer );
+    Q_DECL_DEPRECATED void setLayer( QgsVectorLayer *layer );
+
 
     /**
-     * Returns the current layer or a nullptr.
+     * Sets layer in order to get the fields and values
+     * \note it the layer type is vector, this needs to be called before calling loadFieldNames().
      */
-    QgsVectorLayer *layer() const;
+    void setMapLayer( QgsMapLayer *layer );
+
+    /**
+     * Returns the current vector layer or a nullptr, if the layer type is not vector
+     *
+     * \deprecated since QGIS 3.28, use mapLayer() instead
+     */
+    Q_DECL_DEPRECATED QgsVectorLayer *layer() const;
+
+    /**
+     * Returns the current map layer
+     *
+     * \since QGIS 3.28
+     */
+    QgsMapLayer *mapLayer() const;
 
     //! \deprecated since QGIS 3.14 this is now done automatically
     Q_DECL_DEPRECATED void loadFieldNames() {} SIP_DEPRECATED
@@ -438,7 +462,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     bool mAutoSave = true;
     QString mFunctionsPath;
-    QgsVectorLayer *mLayer = nullptr;
+    QgsMapLayer *mLayer = nullptr;
     QgsExpressionHighlighter *highlighter = nullptr;
     bool mExpressionValid = false;
     QgsExpressionContext mExpressionContext;

--- a/src/gui/qgsexpressionlineedit.cpp
+++ b/src/gui/qgsexpressionlineedit.cpp
@@ -122,7 +122,7 @@ void QgsExpressionLineEdit::setGeomCalculator( const QgsDistanceArea &da )
   mDa.reset( new QgsDistanceArea( da ) );
 }
 
-void QgsExpressionLineEdit::setLayer( QgsVectorLayer *layer )
+void QgsExpressionLineEdit::setLayer( QgsMapLayer *layer )
 {
   if ( !mExpressionContextGenerator || mExpressionContextGenerator == mLayer )
     mExpressionContextGenerator = layer;

--- a/src/gui/qgsexpressionlineedit.h
+++ b/src/gui/qgsexpressionlineedit.h
@@ -102,14 +102,14 @@ class GUI_EXPORT QgsExpressionLineEdit : public QWidget
     void setGeomCalculator( const QgsDistanceArea &distanceArea );
 
     /**
-     * Sets a layer associated with the widget. Required in order to get the fields and values
+     * Sets a layer associated with the widget. Required in order to get information
      * from the layer.
      * This will also automatically register the layer as expression context generator if
      * no generator has been set before or the previous layer has been used as generator.
      *
      * \see registerExpressionContextGenerator
      */
-    void setLayer( QgsVectorLayer *layer );
+    void setLayer( QgsMapLayer *layer );
 
     /**
      * Returns the current expression shown in the widget.
@@ -177,7 +177,7 @@ class GUI_EXPORT QgsExpressionLineEdit : public QWidget
     std::unique_ptr<QgsDistanceArea> mDa;
     QgsExpressionContext mExpressionContext;
     const QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
-    QgsVectorLayer *mLayer = nullptr;
+    QgsMapLayer *mLayer = nullptr;
     QString mExpectedOutputFormat;
 
     bool isExpressionValid( const QString &expressionStr );

--- a/src/gui/qgsexpressionpreviewwidget.cpp
+++ b/src/gui/qgsexpressionpreviewwidget.cpp
@@ -39,10 +39,31 @@ QgsExpressionPreviewWidget::QgsExpressionPreviewWidget( QWidget *parent )
   connect( mCopyPreviewAction, &QAction::triggered, this, &QgsExpressionPreviewWidget::copyFullExpressionValue );
 }
 
-void QgsExpressionPreviewWidget::setLayer( QgsVectorLayer *layer )
+void QgsExpressionPreviewWidget::setLayer( QgsMapLayer *layer )
 {
   mLayer = layer;
-  mFeaturePickerWidget->setLayer( layer );
+  QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mLayer );
+
+  if ( layer )
+  {
+    switch ( mLayer->type() )
+    {
+      case QgsMapLayerType::VectorLayer:
+        setFeaturePickerVisible( true );
+        break;
+      case QgsMapLayerType::VectorTileLayer:
+      case QgsMapLayerType::RasterLayer:
+      case QgsMapLayerType::PluginLayer:
+      case QgsMapLayerType::MeshLayer:
+      case QgsMapLayerType::PointCloudLayer:
+      case QgsMapLayerType::AnnotationLayer:
+      case QgsMapLayerType::GroupLayer:
+        setFeaturePickerVisible( false );
+        break;
+    }
+  }
+
+  mFeaturePickerWidget->setLayer( vl );
 }
 
 void QgsExpressionPreviewWidget::setExpressionText( const QString &expression )
@@ -150,6 +171,12 @@ void QgsExpressionPreviewWidget::refreshPreview()
       mCopyPreviewAction->setEnabled( true );
     }
   }
+}
+
+void QgsExpressionPreviewWidget::setFeaturePickerVisible( bool b )
+{
+  mPickerLabel->setVisible( b );
+  mFeaturePickerWidget->setVisible( b );
 }
 
 void QgsExpressionPreviewWidget::linkActivated( const QString & )

--- a/src/gui/qgsexpressionpreviewwidget.h
+++ b/src/gui/qgsexpressionpreviewwidget.h
@@ -39,8 +39,10 @@ class GUI_EXPORT QgsExpressionPreviewWidget : public QWidget, private Ui::QgsExp
     //! Constructor
     explicit QgsExpressionPreviewWidget( QWidget *parent = nullptr );
 
-    //! Sets the layer used in the preview
-    void setLayer( QgsVectorLayer *layer );
+    /**
+     * Sets the layer used in the preview
+     */
+    void setLayer( QgsMapLayer *layer );
 
     //! Sets the expression
     void setExpressionText( const QString &expression );
@@ -119,8 +121,9 @@ class GUI_EXPORT QgsExpressionPreviewWidget : public QWidget, private Ui::QgsExp
   private:
     void setExpressionToolTip( const QString &toolTip );
     void refreshPreview();
+    void setFeaturePickerVisible( bool b );
 
-    QgsVectorLayer *mLayer = nullptr;
+    QgsMapLayer *mLayer = nullptr;
     QgsExpressionContext mExpressionContext;
     QgsDistanceArea mDa;
     bool mUseGeomCalculator = false;

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -134,7 +134,7 @@ QgsExpressionTreeView::QgsExpressionTreeView( QWidget *parent )
   setCurrentIndex( firstItem );
 }
 
-void QgsExpressionTreeView::setLayer( QgsVectorLayer *layer )
+void QgsExpressionTreeView::setLayer( QgsMapLayer *layer )
 {
   mLayer = layer;
 
@@ -467,7 +467,7 @@ void QgsExpressionTreeView::loadFieldNames()
     registerItem( QStringLiteral( "Fields and Values" ), QStringLiteral( "NULL" ), QStringLiteral( "NULL" ), QString(), QgsExpressionItem::ExpressionNode, false, -1 );
   }
 
-  if ( mLayer )
+  if ( mLayer && mLayer->type() == QgsMapLayerType::VectorLayer )
   {
     // Add feature variables to record and attributes group (and highlighted items)
 
@@ -486,15 +486,11 @@ void QgsExpressionTreeView::loadFieldNames()
     registerItem( tr( "Record and Attributes" ), QStringLiteral( "feature" ), QStringLiteral( "@feature" ), currentFeatureHelp, QgsExpressionItem::ExpressionNode, true, -1 );
     registerItem( tr( "Record and Attributes" ), QStringLiteral( "id" ), QStringLiteral( "@id" ), currentFeatureIdHelp, QgsExpressionItem::ExpressionNode, true, -1 );
     registerItem( tr( "Record and Attributes" ), QStringLiteral( "geometry" ), QStringLiteral( "@geometry" ), currentGeometryHelp, QgsExpressionItem::ExpressionNode, true, -1 );
+
+
+    const QgsFields &fields = qobject_cast<QgsVectorLayer *>( mLayer )->fields();
+    loadFieldNames( fields );
   }
-
-  // this can happen if fields are manually set
-  if ( !mLayer )
-    return;
-
-  const QgsFields &fields = mLayer->fields();
-
-  loadFieldNames( fields );
 }
 
 void QgsExpressionTreeView::loadRelations()

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -174,9 +174,9 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     QgsExpressionTreeView( QWidget *parent = nullptr );
 
     /**
-     * Sets layer in order to get the fields and values
+     * Sets layer in order to get layer information
      */
-    void setLayer( QgsVectorLayer *layer );
+    void setLayer(QgsMapLayer *layer );
 
     /**
      * This allows loading fields without specifying a layer
@@ -370,7 +370,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
 
     MenuProvider *mMenuProvider = nullptr;
 
-    QgsVectorLayer *mLayer = nullptr;
+    QgsMapLayer *mLayer = nullptr;
     QPointer< QgsProject > mProject;
     QgsExpressionContext mExpressionContext;
     QString mRecentKey;

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -176,7 +176,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     /**
      * Sets layer in order to get layer information
      */
-    void setLayer(QgsMapLayer *layer );
+    void setLayer( QgsMapLayer *layer );
 
     /**
      * This allows loading fields without specifying a layer

--- a/src/gui/qgslegendfilterbutton.cpp
+++ b/src/gui/qgslegendfilterbutton.cpp
@@ -20,6 +20,7 @@
 
 #include "qgsapplication.h"
 #include "qgsexpressionbuilderdialog.h"
+#include "qgsvectorlayer.h"
 
 QgsLegendFilterButton::QgsLegendFilterButton( QWidget *parent )
   : QToolButton( parent )

--- a/src/ui/qgsexpressionpreviewbase.ui
+++ b/src/ui/qgsexpressionpreviewbase.ui
@@ -67,7 +67,7 @@
    <item row="0" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="mPickerLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -304,8 +304,8 @@ class TestQgsExpression: public QObject
     {
       QgsExpressionContext context;
       context.appendScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Vertex ) );
+      context.appendScope( mMeshLayer->createExpressionContextScope() );
       context.lastScope()->setVariable( QStringLiteral( "_mesh_vertex_index" ), 2 );
-      context.lastScope()->setVariable( QStringLiteral( "_mesh_layer" ), QVariant::fromValue( mMeshLayer ) );
 
       QgsExpression expression( QStringLiteral( "$vertex_x" ) );
       QCOMPARE( expression.evaluate( &context ).toDouble(), 2500.0 );


### PR DESCRIPTION
This PR allows expression results preview for mesh layer. For this, a generalization of expression related widget for all layer types is done.
fix #50044
This is a fix as the preview was not possible for mesh layer. For now, there is not mechanism to increment indexes in the preview. So, only the first index is used.

![preview_expression](https://user-images.githubusercontent.com/7416892/193720325-29a0b6fa-3ba5-4e6b-91f9-748bbc63592b.gif)

