### PR TITLE
Fix #47525

### DIFF
--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -561,6 +561,14 @@ Construct a new color line edit widget.
     virtual void setColor( const QColor &color, bool emitSignals = false );
 
 
+    void setAllowOpacity( bool allowOpacity );
+%Docstring
+Sets whether opacity modification (transparency) is permitted.
+Defaults to ``True``.
+
+:param allowOpacity: set to ``False`` to disable opacity modification
+%End
+
   protected:
     virtual void resizeEvent( QResizeEvent *event );
 

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -1556,22 +1556,30 @@ void QgsColorTextWidget::textChanged()
 void QgsColorTextWidget::showMenu()
 {
   QMenu colorContextMenu;
+  QAction *hexRgbaAction = nullptr;
+  QAction *rgbaAction = nullptr;
 
   QAction *hexRgbAction = new QAction( tr( "#RRGGBB" ), nullptr );
   colorContextMenu.addAction( hexRgbAction );
-  QAction *hexRgbaAction = new QAction( tr( "#RRGGBBAA" ), nullptr );
-  colorContextMenu.addAction( hexRgbaAction );
+  if ( mAllowAlpha )
+  {
+    hexRgbaAction = new QAction( tr( "#RRGGBBAA" ), nullptr );
+    colorContextMenu.addAction( hexRgbaAction );
+  }
   QAction *rgbAction = new QAction( tr( "rgb( r, g, b )" ), nullptr );
   colorContextMenu.addAction( rgbAction );
-  QAction *rgbaAction = new QAction( tr( "rgba( r, g, b, a )" ), nullptr );
-  colorContextMenu.addAction( rgbaAction );
+  if ( mAllowAlpha )
+  {
+    rgbaAction = new QAction( tr( "rgba( r, g, b, a )" ), nullptr );
+    colorContextMenu.addAction( rgbaAction );
+  }
 
   QAction *selectedAction = colorContextMenu.exec( QCursor::pos() );
   if ( selectedAction == hexRgbAction )
   {
     mFormat = QgsColorTextWidget::HexRgb;
   }
-  else if ( selectedAction == hexRgbaAction )
+  else if ( hexRgbaAction && selectedAction == hexRgbaAction )
   {
     mFormat = QgsColorTextWidget::HexRgbA;
   }
@@ -1579,7 +1587,7 @@ void QgsColorTextWidget::showMenu()
   {
     mFormat = QgsColorTextWidget::Rgb;
   }
-  else if ( selectedAction == rgbaAction )
+  else if ( rgbaAction && selectedAction == rgbaAction )
   {
     mFormat = QgsColorTextWidget::Rgba;
   }
@@ -1591,6 +1599,10 @@ void QgsColorTextWidget::showMenu()
   updateText();
 }
 
+void QgsColorTextWidget::setAllowOpacity( const bool allowOpacity )
+{
+  mAllowAlpha = allowOpacity;
+}
 
 //
 // QgsColorPreviewWidget

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -704,6 +704,13 @@ class GUI_EXPORT QgsColorTextWidget : public QgsColorWidget
 
     void setColor( const QColor &color, bool emitSignals = false ) override;
 
+    /**
+     * Sets whether opacity modification (transparency) is permitted.
+     * Defaults to TRUE.
+     * \param allowOpacity set to FALSE to disable opacity modification
+     */
+    void setAllowOpacity( bool allowOpacity );
+
   protected:
     void resizeEvent( QResizeEvent *event ) override;
 
@@ -716,6 +723,8 @@ class GUI_EXPORT QgsColorTextWidget : public QgsColorWidget
 
     /*Display format for colors*/
     ColorTextFormat mFormat = QgsColorTextWidget::HexRgb;
+
+    bool mAllowAlpha = true;
 
     /**
      * Updates the text based on the current color

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -309,6 +309,7 @@ void QgsCompoundColorWidget::setAllowOpacity( const bool allowOpacity )
   mAllowAlpha = allowOpacity;
   mAlphaLabel->setVisible( allowOpacity );
   mAlphaSlider->setVisible( allowOpacity );
+  mColorText->setAllowOpacity( allowOpacity );
   if ( !allowOpacity )
   {
     mAlphaLayout->setContentsMargins( 0, 0, 0, 0 );


### PR DESCRIPTION
## Description

The alpha channel is not supported for SVG background yet.

Therefore, it should not be possible in the dropdown list of the color widget to select #RRGGBBAA or rgba() in the text zone.

This PR adds a `setAllowOpacity` method to `QgsColorTextWidget`, to be used in `QgsCompoundColorWidget::setAllowOpacity`.

Fixes #47525 