### PR TITLE
Use auth as set in the gui for the "Detect" button

### DIFF
--- a/src/providers/wfs/qgswfsnewconnection.cpp
+++ b/src/providers/wfs/qgswfsnewconnection.cpp
@@ -41,9 +41,15 @@ QgsDataSourceUri QgsWFSNewConnection::createUri()
   // Honor any defined authentication settings
   QgsDataSourceUri uri;
   uri.setParam( QStringLiteral( "url" ), urlTrimmed().toString() );
-  uri.setUsername( authSettingsWidget()->username() );
-  uri.setPassword( authSettingsWidget()->password() );
-  uri.setAuthConfigId( authSettingsWidget()->configId() );
+  if ( authSettingsWidget()->configurationTabIsSelected() )
+  {
+    uri.setAuthConfigId( authSettingsWidget()->configId() );
+  }
+  else
+  {
+    uri.setUsername( authSettingsWidget()->username() );
+    uri.setPassword( authSettingsWidget()->password() );
+  }
   return uri;
 }
 


### PR DESCRIPTION
The "Detect" button was not respecting the choosen authentification method and was always setting authId e username and password

![image](https://user-images.githubusercontent.com/9881900/193890522-c3020725-6952-448e-9e9e-7fffa8a6437c.png)
