### PR TITLE
Make QgsFeature::clearGeometry a no-op if feature already has no geometry

### DIFF
--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -183,6 +183,9 @@ void QgsFeature::setGeometry( std::unique_ptr<QgsAbstractGeometry> geometry )
 
 void QgsFeature::clearGeometry()
 {
+  if ( d->geometry.isNull() && d->valid )
+    return;
+
   setGeometry( QgsGeometry() );
 }
 


### PR DESCRIPTION
Shaves ~1.5% off the iteration time when iterating a large ogr layer with no geometry retrieval