### PR TITLE
Expose layout item position

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1159,7 +1159,10 @@ void QgsLayoutItem::rotateItem( const double angle, const QPointF transformOrigi
 QgsExpressionContext QgsLayoutItem::createExpressionContext() const
 {
   QgsExpressionContext context = QgsLayoutObject::createExpressionContext();
-  context.appendScope( QgsExpressionContextUtils::layoutItemScope( this ) );
+  QgsExpressionContextScope *scope = QgsExpressionContextUtils::layoutItemScope( this );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_item_x" ), mItemPosition.x(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_item_y" ), mItemPosition.y(), true ) );
+  context.appendScope( scope );
   return context;
 }
 


### PR DESCRIPTION
## Description
This PR adds the item's x and y coordinated to the variables available.

Though this approach may have one issue if the user uses the variable to increment it, at each refresh the incrementation would apply, this may lead to a bug ticket or some confusion. This still seems acceptable but I'm unsure if failsafe are needed and just ensure that things don't keep shifting if the user increment the variable..

Test would follow the suggested implementation.
