### PR TITLE
QgsVectorFileWriter map NaN to -DBL_MAX exporting to Shape

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -210,6 +210,7 @@ Sets the geometry from a WKT string.
     enum WkbFlag
     {
       FlagExportTrianglesAsPolygons,
+      FlagExportNanAsDoubleMin,
     };
     typedef QFlags<QgsAbstractGeometry::WkbFlag> WkbFlags;
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -273,6 +273,7 @@ class CORE_EXPORT QgsAbstractGeometry
     enum WkbFlag
     {
       FlagExportTrianglesAsPolygons = 1 << 0, //!< Triangles should be exported as polygon geometries
+      FlagExportNanAsDoubleMin = 1 << 1, //!< Use -DOUBLE_MAX to represent NaN (since QGIS 3.30)
     };
     Q_DECLARE_FLAGS( WkbFlags, WkbFlag )
 

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -517,7 +517,7 @@ QByteArray QgsCircularString::asWkb( WkbFlags flags ) const
   wkb << static_cast<quint32>( wkbType() );
   QgsPointSequence pts;
   points( pts );
-  QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
+  QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure(), flags );
   return wkbArray;
 }
 

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1227,7 +1227,7 @@ void QgsGeometryUtils::pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &poin
       double z = point.z();
       if ( flags & QgsAbstractGeometry::FlagExportNanAsDoubleMin
            && std::isnan( z ) )
-        z = -DBL_MAX;
+        z = -std::numeric_limits<double>::max();
 
       wkb << z;
     }
@@ -1236,7 +1236,7 @@ void QgsGeometryUtils::pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &poin
       double m = point.m();
       if ( flags & QgsAbstractGeometry::FlagExportNanAsDoubleMin
            && std::isnan( m ) )
-        m = -DBL_MAX;
+        m = -std::numeric_limits<double>::max();
 
       wkb << m;
     }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1216,7 +1216,7 @@ QgsPointSequence QgsGeometryUtils::pointsFromWKT( const QString &wktCoordinateLi
   return points;
 }
 
-void QgsGeometryUtils::pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &points, bool is3D, bool isMeasure )
+void QgsGeometryUtils::pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &points, bool is3D, bool isMeasure, QgsAbstractGeometry::WkbFlags flags )
 {
   wkb << static_cast<quint32>( points.size() );
   for ( const QgsPoint &point : points )
@@ -1224,11 +1224,21 @@ void QgsGeometryUtils::pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &poin
     wkb << point.x() << point.y();
     if ( is3D )
     {
-      wkb << point.z();
+      double z = point.z();
+      if ( flags & QgsAbstractGeometry::FlagExportNanAsDoubleMin
+           && std::isnan( z ) )
+        z = -DBL_MAX;
+
+      wkb << z;
     }
     if ( isMeasure )
     {
-      wkb << point.m();
+      double m = point.m();
+      if ( flags & QgsAbstractGeometry::FlagExportNanAsDoubleMin
+           && std::isnan( m ) )
+        m = -DBL_MAX;
+
+      wkb << m;
     }
   }
 }

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -455,7 +455,7 @@ class CORE_EXPORT QgsGeometryUtils
      * Returns a LinearRing { uint32 numPoints; Point points[numPoints]; }
      * \note not available in Python bindings
      */
-    static void pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &points, bool is3D, bool isMeasure ) SIP_SKIP;
+    static void pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequence &points, bool is3D, bool isMeasure, QgsAbstractGeometry::WkbFlags flags ) SIP_SKIP;
 
     /**
      * Returns a WKT coordinate list

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -703,7 +703,7 @@ QByteArray QgsLineString::asWkb( WkbFlags flags ) const
   wkb << static_cast<quint32>( wkbType() );
   QgsPointSequence pts;
   points( pts );
-  QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
+  QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure(), flags );
   return wkbArray;
 }
 

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -173,13 +173,13 @@ QByteArray QgsPolygon::asWkb( QgsAbstractGeometry::WkbFlags flags ) const
   {
     QgsPointSequence pts;
     mExteriorRing->points( pts );
-    QgsGeometryUtils::pointsToWKB( wkb, pts, mExteriorRing->is3D(), mExteriorRing->isMeasure() );
+    QgsGeometryUtils::pointsToWKB( wkb, pts, mExteriorRing->is3D(), mExteriorRing->isMeasure(), flags );
   }
   for ( const QgsCurve *curve : mInteriorRings )
   {
     QgsPointSequence pts;
     curve->points( pts );
-    QgsGeometryUtils::pointsToWKB( wkb, pts, curve->is3D(), curve->isMeasure() );
+    QgsGeometryUtils::pointsToWKB( wkb, pts, curve->is3D(), curve->isMeasure(), flags );
   }
 
   return wkbArray;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2798,9 +2798,19 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
         // add m/z values if not present in the input wkb type -- this is needed for formats which determine
         // geometry type based on features, e.g. geojson
         if ( QgsWkbTypes::hasZ( mWkbType ) && !QgsWkbTypes::hasZ( geom.wkbType() ) )
-          geom.get()->addZValue( std::numeric_limits<double>::quiet_NaN() );
+        {
+          if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
+            geom.get()->addZValue( std::numeric_limits<double>::quiet_NaN() );
+          else
+            geom.get()->addZValue( 0 );
+        }
         if ( QgsWkbTypes::hasM( mWkbType ) && !QgsWkbTypes::hasM( geom.wkbType() ) )
-          geom.get()->addMValue( std::numeric_limits<double>::quiet_NaN() );
+        {
+          if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
+            geom.get()->addMValue( std::numeric_limits<double>::quiet_NaN() );
+          else
+            geom.get()->addMValue( 0 );
+        }
 
         if ( !mGeom2 )
         {

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2840,7 +2840,11 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
       }
       else // wkb type matches
       {
-        QByteArray wkb( geom.asWkb( QgsAbstractGeometry::FlagExportTrianglesAsPolygons ) );
+        QgsAbstractGeometry::WkbFlags wkbFlags = QgsAbstractGeometry::FlagExportTrianglesAsPolygons;
+        if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
+          wkbFlags |= QgsAbstractGeometry::FlagExportNanAsDoubleMin;
+
+        QByteArray wkb( geom.asWkb( wkbFlags ) );
         OGRGeometryH ogrGeom = createEmptyGeometry( mWkbType );
         OGRErr err = OGR_G_ImportFromWkb( ogrGeom, reinterpret_cast<unsigned char *>( const_cast<char *>( wkb.constData() ) ), wkb.length() );
         if ( err != OGRERR_NONE )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2798,9 +2798,9 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
         // add m/z values if not present in the input wkb type -- this is needed for formats which determine
         // geometry type based on features, e.g. geojson
         if ( QgsWkbTypes::hasZ( mWkbType ) && !QgsWkbTypes::hasZ( geom.wkbType() ) )
-          geom.get()->addZValue( 0 );
+          geom.get()->addZValue( std::numeric_limits<double>::quiet_NaN() );
         if ( QgsWkbTypes::hasM( mWkbType ) && !QgsWkbTypes::hasM( geom.wkbType() ) )
-          geom.get()->addMValue( 0 );
+          geom.get()->addMValue( std::numeric_limits<double>::quiet_NaN() );
 
         if ( !mGeom2 )
         {
@@ -2824,7 +2824,11 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
           return nullptr;
         }
 
-        QByteArray wkb( geom.asWkb() );
+        QgsAbstractGeometry::WkbFlags wkbFlags;
+        if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
+          wkbFlags |= QgsAbstractGeometry::FlagExportNanAsDoubleMin;
+
+        QByteArray wkb( geom.asWkb( wkbFlags ) );
         OGRErr err = OGR_G_ImportFromWkb( mGeom2, reinterpret_cast<unsigned char *>( const_cast<char *>( wkb.constData() ) ), wkb.length() );
         if ( err != OGRERR_NONE )
         {

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -110,7 +110,8 @@ class TestQgsVectorFileWriter: public QObject
     void testExportToGpxMultiLineStringForceRoute();
     //! Test export using custom field names
     void testExportCustomFieldNames();
-
+    //! Test export to shape with NaN values for Z
+    void testExportToShapeNanValuesForZ();
   private:
     // a little util fn used by all tests
     bool cleanupFile( QString fileBase );
@@ -702,6 +703,52 @@ void TestQgsVectorFileWriter::testExportCustomFieldNames()
   QgsVectorFileWriter::prepareWriteAsVectorFormat( &ml, options, details );
   QCOMPARE( details.outputFields.at( 0 ).name(), "firstfield" );
   QCOMPARE( details.outputFields.at( 1 ).name(), "customfieldname" );
+}
+
+void TestQgsVectorFileWriter::testExportToShapeNanValuesForZ()
+{
+  //
+  // Remove old copies that may be lying around
+  //
+  QString myFileName = QStringLiteral( "/testln.shp" );
+  myFileName = QDir::tempPath() + myFileName;
+  QVERIFY( QgsVectorFileWriter::deleteShapeFile( myFileName ) );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::LineStringZ, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
+  //
+  // Create a feature
+  //
+  QgsLineString *ls = new QgsLineString();
+  ls->setPoints( QgsPointSequence() << QgsPoint( mPoint1 )
+                 << QgsPoint( mPoint2 )
+                 << QgsPoint( mPoint3 ) );
+  ls->setZAt( 1, std::numeric_limits<double>::quiet_NaN() );
+  const QgsGeometry mypLineGeometry( ls );
+  QgsFeature myFeature;
+  myFeature.setGeometry( mypLineGeometry );
+  myFeature.initAttributes( 1 );
+  myFeature.setAttribute( 0, "HelloWorld" );
+  //
+  // Write the feature to the filewriter
+  // and check for errors
+  //
+  QVERIFY( writer->addFeature( myFeature ) );
+  mError = writer->hasError();
+  if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
+  {
+    std::cout << "Driver not found error" << std::endl;
+  }
+  else if ( mError == QgsVectorFileWriter::ErrCreateDataSource )
+  {
+    std::cout << "Create data source error" << std::endl;
+  }
+  else if ( mError == QgsVectorFileWriter::ErrCreateLayer )
+  {
+    std::cout << "Create layer error" << std::endl;
+  }
+  QVERIFY( mError == QgsVectorFileWriter::NoError );
 }
 
 QGSTEST_MAIN( TestQgsVectorFileWriter )


### PR DESCRIPTION
Shape format does not support NaN for Z or M. This pr want to map NaN to -DBL_MAX when creating the WKB to pass to OGR.
A new `WkbFlag` value `FlagExportNanAsDoubleMin` was introduced to control that behaviour on WKB conversion.
This aims to fix only the "Save layer as" function. The provider was not touched.

See also discussion on #47034
