### PR TITLE
Fix reversed iterator check when iterating over map

### DIFF
--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -32,7 +32,7 @@ template <class Key, class T> void mapToReversedLists( const QMap< Key, T > &map
   typename QMap<Key, T>::const_iterator i = map.constEnd();
   while ( i != map.constBegin() )
   {
-    i--;
+    --i;
     ks.append( i.key() );
     vs.append( i.value() );
   }

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -30,8 +30,9 @@ template <class Key, class T> void mapToReversedLists( const QMap< Key, T > &map
   ks.reserve( map.size() );
   vs.reserve( map.size() );
   typename QMap<Key, T>::const_iterator i = map.constEnd();
-  while ( i-- != map.constBegin() )
+  while ( i != map.constBegin() )
   {
+    i--;
     ks.append( i.key() );
     vs.append( i.value() );
   }


### PR DESCRIPTION
This piece of code was crashing macOS and iOS **Qt6** builds when calling `commit` on a vector layer after adding a new feature.

It crashed with a map of size 1, after evaluating the `while` condition the second time.