### PR TITLE
Tighten includes

### DIFF
--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMapBoxGlStyleConversionContext
 {
 %Docstring(signature="appended")

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -43,6 +43,7 @@
 #include "qgslabellinesettings.h"
 #include "qgslabeling.h"
 #include "qgscoordinatetransform.h"
+#include "qgsexpression.h"
 
 class QgsTextDocument;
 class QgsTextDocumentMetrics;

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
@@ -21,6 +21,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsunittypes.h"
 #include "qgsmaplayerelevationproperties.h"
 
 /**

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -17,7 +17,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgsexpression.h"
 #include "qgsexpressioncontext.h"
 
 #include <QVariant>

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -269,6 +269,11 @@ void QgsGeometryGeneratorSymbolLayer::setGeometryExpression( const QString &exp 
   mExpression.reset( new QgsExpression( exp ) );
 }
 
+QString QgsGeometryGeneratorSymbolLayer::geometryExpression() const
+{
+  return mExpression->expression();
+}
+
 bool QgsGeometryGeneratorSymbolLayer::setSubSymbol( QgsSymbol *symbol )
 {
   switch ( symbol->type() )

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
     /**
      * Gets the expression to generate this geometry.
      */
-    QString geometryExpression() const { return mExpression->expression(); }
+    QString geometryExpression() const;
 
     /**
      * Returns the unit for the geometry expression.

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -26,14 +26,12 @@
 #include "qgspainteffectregistry.h"
 #include "qgsapplication.h"
 #include "qgspathresolver.h"
-#include "qgsproject.h"
 #include "qgsogcutils.h"
 #include "qgslogger.h"
 #include "qgsreadwritecontext.h"
 #include "qgsrendercontext.h"
 #include "qgsunittypes.h"
 #include "qgsexpressioncontextutils.h"
-#include "qgseffectstack.h"
 #include "qgsstyleentityvisitor.h"
 #include "qgsrenderer.h"
 #include "qgsxmlutils.h"
@@ -58,6 +56,7 @@
 #include <QUrlQuery>
 #include <QMimeData>
 #include <QRegularExpression>
+#include <QDir>
 
 #define POINTS_TO_MM 2.83464567
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -21,8 +21,9 @@
 #include "qgsproperty.h"
 #include "qgspropertycollection.h"
 #include "qgsunittypes.h"
-#include <QVariantMap>
+
 #include <memory>
+#include <QVariantMap>
 #include <QImage>
 
 class QgsVectorTileRenderer;

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -20,6 +20,7 @@
 #include "qgis_sip.h"
 #include "qgsproperty.h"
 #include "qgspropertycollection.h"
+#include "qgsunittypes.h"
 #include <QVariantMap>
 #include <memory>
 #include <QImage>

--- a/src/gui/qgsexternalstoragefilewidget.cpp
+++ b/src/gui/qgsexternalstoragefilewidget.cpp
@@ -24,17 +24,12 @@
 #include <QRegularExpression>
 #include <QProgressBar>
 
-#include "qgssettings.h"
-#include "qgsfilterlineedit.h"
-#include "qgsfocuskeeper.h"
 #include "qgslogger.h"
-#include "qgsproject.h"
 #include "qgsapplication.h"
-#include "qgsfileutils.h"
-#include "qgsmimedatautils.h"
 #include "qgsexternalstorage.h"
 #include "qgsexternalstorageregistry.h"
 #include "qgsmessagebar.h"
+#include "qgsexpression.h"
 
 #define FILEPATH_VARIABLE "selected_file_path"
 


### PR DESCRIPTION
Avoid unnecessary expensive qgsexpression.h include in widely used qgsproperty.h header
