### PR TITLE
[Server] WMS GetCapabilities: Cleaning and simplifying the GetCapabilities building

### DIFF
--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -22,6 +22,7 @@ set (WMS_SRCS
   qgswmsrestorer.cpp
   qgswmsrendercontext.cpp
   qgswmsrequest.cpp
+  qgswmslayerinfos.cpp
 )
 
 set (WMS_HDRS

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -42,10 +42,8 @@
 #include "qgsrasterrenderer.h"
 #include "qgsmaplayerserverproperties.h"
 
-
 namespace QgsWms
 {
-
   namespace
   {
 
@@ -54,22 +52,9 @@ namespace QgsWms
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,
                              const QgsProject *project );
 
-    void combineExtentAndCrsOfGroupChildren( QDomDocument &doc, QDomElement &groupElem, const QgsProject *project,
-        bool considerMapExtent = false );
+    void appendLayerWgs84BoundingRect( QDomDocument &doc, QDomElement &layerElement, const QgsRectangle &wgs84BoundingRect );
 
-    bool crsSetFromLayerElement( const QDomElement &layerElement, QSet<QString> &crsSet );
-
-    QgsRectangle layerBoundingBoxInProjectCrs( const QDomDocument &doc, const QDomElement &layerElem,
-        const QgsProject *project );
-
-    void appendLayerBoundingBox( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &layerExtent,
-                                 const QgsCoordinateReferenceSystem &layerCRS, const QString &crsText,
-                                 const QgsProject *project );
-
-    void appendLayerBoundingBoxes( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &lExtent,
-                                   const QgsCoordinateReferenceSystem &layerCRS, const QStringList &crsList,
-                                   const QStringList &constrainedCrsList, const QgsProject *project,
-                                   const QgsRectangle &geoExtent = QgsRectangle() );
+    void appendLayerCrsExtents( QDomDocument &doc, QDomElement &layerElement, const QMap<QString, QgsRectangle> &crsExtents );
 
     void appendCrsElementToLayer( QDomDocument &doc, QDomElement &layerElement, const QDomElement &precedingElement,
                                   const QString &crsText );
@@ -77,7 +62,7 @@ namespace QgsWms
     void appendCrsElementsToLayer( QDomDocument &doc, QDomElement &layerElement,
                                    const QStringList &crsList, const QStringList &constrainedCrsList );
 
-    void appendLayerStyles( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer,
+    void appendLayerStyles( QDomDocument &doc, QDomElement &layerElem, const QgsWmsLayerInfos &layerInfos,
                             const QgsProject *project, const QgsWmsRequest &request, const QgsServerSettings *settings );
 
     void appendLayersFromTreeGroup( QDomDocument &doc,
@@ -86,6 +71,7 @@ namespace QgsWms
                                     const QgsProject *project,
                                     const QgsWmsRequest &request,
                                     const QgsLayerTreeGroup *layerTreeGroup,
+                                    const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos,
                                     bool projectSettings );
 
     void addKeywordListElement( const QgsProject *project, QDomDocument &doc, QDomElement &parent );
@@ -798,6 +784,32 @@ namespace QgsWms
     return wfsLayersElem;
   }
 
+  void handleLayersFromTreeGroup( QDomDocument &doc,
+                                  QDomElement &parentLayer,
+                                  QgsServerInterface *serverIface,
+                                  const QgsProject *project,
+                                  const QgsWmsRequest &request,
+                                  const QgsLayerTreeGroup *layerTreeGroup,
+                                  const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos,
+                                  bool projectSettings )
+  {
+    const auto layerIds = layerTreeGroup->findLayerIds();
+
+    parentLayer.setAttribute(
+      QStringLiteral( "queryable" ),
+      hasQueryableLayers( layerIds, wmsLayerInfos ) ? QStringLiteral( "1" ) : QStringLiteral( "0" )
+    );
+
+    const QgsRectangle wgs84BoundingRect = combineWgs84BoundingRect( layerIds, wmsLayerInfos );
+    QMap<QString, QgsRectangle> crsExtents = combineCrsExtents( layerIds, wmsLayerInfos );
+
+    appendCrsElementsToLayer( doc, parentLayer, crsExtents.keys(), QStringList() );
+    appendLayerWgs84BoundingRect( doc, parentLayer, wgs84BoundingRect );
+    appendLayerCrsExtents( doc, parentLayer, crsExtents );
+
+    appendLayersFromTreeGroup( doc, parentLayer, serverIface, project, request, layerTreeGroup, wmsLayerInfos, projectSettings );
+  }
+
   QDomElement getLayersAndStylesCapabilitiesElement( QDomDocument &doc, QgsServerInterface *serverIface,
       const QgsProject *project,
       const QgsWmsRequest &request, bool projectSettings )
@@ -849,18 +861,73 @@ namespace QgsWms
       layerParentElem.appendChild( treeNameElem );
     }
 
-    if ( hasQueryableChildren( projectLayerTreeRoot, QgsServerProjectUtils::wmsRestrictedLayers( *project ) ) )
+    // Instantiate CRS's from the project's crs list
+    // This will prevent us to re-instantiate all the crs's each
+    // time we will need to rebuild a bounding box.
+    auto outputCrsList = QList<QgsCoordinateReferenceSystem>();
+    for ( const QString &crsDef :  QgsServerProjectUtils::wmsOutputCrsList( *project ) )
     {
-      layerParentElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "1" ) );
+      const auto crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsDef );
+      if ( crs.isValid() )
+      {
+        outputCrsList.append( crs );
+      }
+    }
+
+    // Get WMS layer infos
+    const QMap< QString, QgsWmsLayerInfos > wmsLayerInfos = QgsWmsLayerInfos::buildWmsLayerInfos( serverIface, project, outputCrsList );
+
+    const QgsRectangle wmsExtent = QgsServerProjectUtils::wmsExtent( *project );
+
+    if ( !wmsExtent.isEmpty() )
+    {
+      const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() );
+
+      // Get WMS WGS84 bounding rectangle
+      QgsRectangle wmsWgs84BoundingRect;
+      try
+      {
+        wmsWgs84BoundingRect = QgsWmsLayerInfos::transformExtent(
+                                 wmsExtent, project->crs(), wgs84, project->transformContext(), true
+                               );
+      }
+      catch ( QgsCsException &cse )
+      {
+        QgsMessageLog::logMessage(
+          QStringLiteral( "Error transforming extent: %1" ).arg( cse.what() ),
+          QStringLiteral( "Server" ),
+          Qgis::MessageLevel::Warning
+        );
+      }
+
+      // Get WMS extents in output CRSes
+      QMap< QString, QgsRectangle > wmsCrsExtents;
+      try
+      {
+        wmsCrsExtents = QgsWmsLayerInfos::transformExtentToCrsList(
+                          wmsExtent, project->crs(), outputCrsList, project->transformContext()
+                        );
+      }
+      catch ( QgsCsException &cse )
+      {
+        QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent: %1" ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
+      }
+
+      layerParentElem.setAttribute(
+        QStringLiteral( "queryable" ),
+        hasQueryableLayers( projectLayerTreeRoot->findLayerIds(), wmsLayerInfos ) ? QStringLiteral( "1" ) : QStringLiteral( "0" )
+      );
+
+      appendCrsElementsToLayer( doc, layerParentElem, wmsCrsExtents.keys(), QStringList() );
+      appendLayerWgs84BoundingRect( doc, layerParentElem, wmsWgs84BoundingRect );
+      appendLayerCrsExtents( doc, layerParentElem, wmsCrsExtents );
+
+      appendLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings );
     }
     else
     {
-      layerParentElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "0" ) );
+      handleLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings );
     }
-
-    appendLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, projectSettings );
-
-    combineExtentAndCrsOfGroupChildren( doc, layerParentElem, project, true );
 
     return layerParentElem;
   }
@@ -874,11 +941,11 @@ namespace QgsWms
                                     const QgsProject *project,
                                     const QgsWmsRequest &request,
                                     const QgsLayerTreeGroup *layerTreeGroup,
+                                    const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos,
                                     bool projectSettings )
     {
       const QString version = request.wmsParameters().version();
 
-      bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );
       bool siaFormat = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
       const QStringList restrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *project );
 
@@ -949,90 +1016,50 @@ namespace QgsWms
             layerElem.appendChild( treeNameElem );
           }
 
-          // Set queryable if any of the children are
-          if ( hasQueryableChildren( treeNode, restrictedLayers ) )
-          {
-            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "1" ) );
-          }
-          else
-          {
-            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "0" ) );
-          }
-
-          appendLayersFromTreeGroup( doc, layerElem, serverIface, project, request, treeGroupChild, projectSettings );
-
-          combineExtentAndCrsOfGroupChildren( doc, layerElem, project );
+          handleLayersFromTreeGroup( doc, layerElem, serverIface, project, request, treeGroupChild, wmsLayerInfos, projectSettings );
         }
         else
         {
           QgsLayerTreeLayer *treeLayer = static_cast<QgsLayerTreeLayer *>( treeNode );
           QgsMapLayer *l = treeLayer->layer();
-          if ( !l || restrictedLayers.contains( l->name() ) ) //unpublished layer
+          if ( !wmsLayerInfos.contains( treeLayer->layerId() ) ) //unpublished layer
           {
             continue;
           }
 
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-          QgsAccessControl *accessControl = serverIface->accessControls();
-          if ( accessControl && !accessControl->layerReadPermission( l ) )
-          {
-            continue;
-          }
-#endif
-          QString wmsName = l->name();
-          if ( useLayerIds )
-          {
-            wmsName = l->id();
-          }
-          else if ( !l->shortName().isEmpty() )
-          {
-            wmsName = l->shortName();
-          }
+          const QgsWmsLayerInfos &layerInfos = wmsLayerInfos[ treeLayer->layerId() ];
 
-          // queryable layer
-          if ( !l->flags().testFlag( QgsMapLayer::Identifiable ) )
-          {
-            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "0" ) );
-          }
-          else
-          {
-            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "1" ) );
-          }
+          layerElem.setAttribute(
+            QStringLiteral( "queryable" ),
+            layerInfos.queryable ? QStringLiteral( "1" ) : QStringLiteral( "0" )
+          );
 
           QDomElement nameElem = doc.createElement( QStringLiteral( "Name" ) );
-          QDomText nameText = doc.createTextNode( wmsName );
+          QDomText nameText = doc.createTextNode( layerInfos.name );
           nameElem.appendChild( nameText );
           layerElem.appendChild( nameElem );
 
           QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
-          QString title = l->title();
-          if ( title.isEmpty() )
-          {
-            title = l->name();
-          }
-          QDomText titleText = doc.createTextNode( title );
+          QDomText titleText = doc.createTextNode( layerInfos.title );
           titleElem.appendChild( titleText );
           layerElem.appendChild( titleElem );
 
-          QString abstract = l->abstract();
-          if ( !abstract.isEmpty() )
+          if ( ! layerInfos.abstract.isEmpty() )
           {
             QDomElement abstractElem = doc.createElement( QStringLiteral( "Abstract" ) );
-            QDomText abstractText = doc.createTextNode( abstract );
+            QDomText abstractText = doc.createTextNode( layerInfos.abstract );
             abstractElem.appendChild( abstractText );
             layerElem.appendChild( abstractElem );
           }
 
           //keyword list
-          if ( !l->keywordList().isEmpty() )
+          if ( ! layerInfos.keywords.isEmpty() )
           {
-            QStringList keywordStringList = l->keywordList().split( ',' );
-
             QDomElement keywordListElem = doc.createElement( QStringLiteral( "KeywordList" ) );
-            for ( int i = 0; i < keywordStringList.size(); ++i )
+            for ( const QString &keyword : std::as_const( layerInfos.keywords ) )
             {
               QDomElement keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
-              QDomText keywordText = doc.createTextNode( keywordStringList.at( i ).trimmed() );
+              QDomText keywordText = doc.createTextNode( keyword.trimmed() );
               keywordElem.appendChild( keywordText );
               if ( siaFormat )
               {
@@ -1043,70 +1070,21 @@ namespace QgsWms
             layerElem.appendChild( keywordListElem );
           }
 
-          //vector layer without geometry
-          bool geometryLayer = true;
-          if ( l->type() == QgsMapLayerType::VectorLayer )
+          // Append not null Bounding rectangles
+          if ( ! layerInfos.wgs84BoundingRect.isNull() )
           {
-            QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( l );
-            if ( vLayer )
-            {
-              if ( vLayer->wkbType() == QgsWkbTypes::NoGeometry )
-              {
-                geometryLayer = false;
-              }
-            }
-          }
+            appendCrsElementsToLayer( doc, layerElem, layerInfos.crsExtents.keys(), QStringList() );
 
-          //CRS
-          if ( geometryLayer )
-          {
-            QStringList crsList;
-            crsList << l->crs().authid();
-            QStringList outputCrsList = QgsServerProjectUtils::wmsOutputCrsList( *project );
-            appendCrsElementsToLayer( doc, layerElem, crsList, outputCrsList );
+            appendLayerWgs84BoundingRect( doc, layerElem, layerInfos.wgs84BoundingRect );
 
-            //Ex_GeographicBoundingBox
-            QgsRectangle extent = l->extent();  // layer extent by default
-            QgsRectangle wgs84Extent;
-            if ( extent.isEmpty() )
-            {
-              // if the extent is empty (not only Null), use the wms extent
-              // defined in the project...
-              extent = QgsServerProjectUtils::wmsExtent( *project );
-              if ( extent.isNull() )
-              {
-                // or the CRS extent otherwise
-                extent = l->crs().bounds();
-              }
-              else if ( l->crs() != project->crs() )
-              {
-                // If CRS is different transform it to layer's CRS
-                try
-                {
-                  QgsCoordinateTransform ct( project->crs(), l->crs(), project->transformContext() );
-                  extent = ct.transform( extent );
-                }
-                catch ( QgsCsException &cse )
-                {
-                  QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent for layer %1: %2" ).arg( l->name() ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
-                  continue;
-                }
-              }
-            }
-            else
-            {
-              // Get the wgs84 extent from layer
-              wgs84Extent = l->wgs84Extent();
-            }
-
-            appendLayerBoundingBoxes( doc, layerElem, extent, l->crs(), crsList, outputCrsList, project, wgs84Extent );
+            appendLayerCrsExtents( doc, layerElem, layerInfos.crsExtents );
           }
 
           // add details about supported styles of the layer
-          appendLayerStyles( doc, layerElem, l, project, request, serverIface->serverSettings() );
+          appendLayerStyles( doc, layerElem, layerInfos, project, request, serverIface->serverSettings() );
 
           //min/max scale denominatorScaleBasedVisibility
-          if ( l->hasScaleBasedVisibility() )
+          if ( layerInfos.hasScaleBasedVisibility )
           {
             if ( version == QLatin1String( "1.1.1" ) )
             {
@@ -1114,29 +1092,26 @@ namespace QgsWms
               double SCALE_TO_SCALEHINT = OGC_PX_M * M_SQRT2;
 
               QDomElement scaleHintElem = doc.createElement( QStringLiteral( "ScaleHint" ) );
-              scaleHintElem.setAttribute( QStringLiteral( "min" ), QString::number( l->maximumScale() * SCALE_TO_SCALEHINT ) );
-              scaleHintElem.setAttribute( QStringLiteral( "max" ), QString::number( l->minimumScale() * SCALE_TO_SCALEHINT ) );
+              scaleHintElem.setAttribute( QStringLiteral( "min" ), QString::number( layerInfos.maxScale * SCALE_TO_SCALEHINT ) );
+              scaleHintElem.setAttribute( QStringLiteral( "max" ), QString::number( layerInfos.minScale * SCALE_TO_SCALEHINT ) );
               layerElem.appendChild( scaleHintElem );
             }
             else
             {
-              QString minScaleString = QString::number( l->maximumScale() );
               QDomElement minScaleElem = doc.createElement( QStringLiteral( "MinScaleDenominator" ) );
-              QDomText minScaleText = doc.createTextNode( minScaleString );
+              QDomText minScaleText = doc.createTextNode( QString::number( layerInfos.maxScale ) );
               minScaleElem.appendChild( minScaleText );
               layerElem.appendChild( minScaleElem );
 
-              QString maxScaleString = QString::number( l->minimumScale() );
               QDomElement maxScaleElem = doc.createElement( QStringLiteral( "MaxScaleDenominator" ) );
-              QDomText maxScaleText = doc.createTextNode( maxScaleString );
+              QDomText maxScaleText = doc.createTextNode( QString::number( layerInfos.minScale ) );
               maxScaleElem.appendChild( maxScaleText );
               layerElem.appendChild( maxScaleElem );
             }
           }
 
           // layer data URL
-          QString dataUrl = l->dataUrl();
-          if ( !dataUrl.isEmpty() )
+          if ( !layerInfos.dataUrl.isEmpty() )
           {
             QDomElement dataUrlElem = doc.createElement( QStringLiteral( "DataURL" ) );
             QDomElement dataUrlFormatElem = doc.createElement( QStringLiteral( "Format" ) );
@@ -1147,38 +1122,35 @@ namespace QgsWms
             QDomElement dataORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
             dataORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
             dataORElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
-            dataORElem.setAttribute( QStringLiteral( "xlink:href" ), dataUrl );
+            dataORElem.setAttribute( QStringLiteral( "xlink:href" ), layerInfos.dataUrl );
             dataUrlElem.appendChild( dataORElem );
             layerElem.appendChild( dataUrlElem );
           }
 
           // layer attribution
-          QString attribution = l->attribution();
-          if ( !attribution.isEmpty() )
+          if ( ! layerInfos.attribution.isEmpty() )
           {
             QDomElement attribElem = doc.createElement( QStringLiteral( "Attribution" ) );
             QDomElement attribTitleElem = doc.createElement( QStringLiteral( "Title" ) );
-            QDomText attribText = doc.createTextNode( attribution );
+            QDomText attribText = doc.createTextNode( layerInfos.attribution );
             attribTitleElem.appendChild( attribText );
             attribElem.appendChild( attribTitleElem );
-            QString attributionUrl = l->attributionUrl();
-            if ( !attributionUrl.isEmpty() )
+            if ( ! layerInfos.attributionUrl.isEmpty() )
             {
               QDomElement attribORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
               attribORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
               attribORElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
-              attribORElem.setAttribute( QStringLiteral( "xlink:href" ), attributionUrl );
+              attribORElem.setAttribute( QStringLiteral( "xlink:href" ), layerInfos.attributionUrl );
               attribElem.appendChild( attribORElem );
             }
             layerElem.appendChild( attribElem );
           }
 
           // layer metadata URL
-          const QList<QgsMapLayerServerProperties::MetadataUrl> urls = l->serverProperties()->metadataUrls();
-          for ( const QgsMapLayerServerProperties::MetadataUrl &url : urls )
+          for ( const QgsMapLayerServerProperties::MetadataUrl &metadataUrl : std::as_const( layerInfos.metadataUrls ) )
           {
             QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
-            QString metadataUrlType = url.type;
+            const QString metadataUrlType = metadataUrl.type;
             if ( version == QLatin1String( "1.1.1" ) )
             {
               metaUrlElem.setAttribute( QStringLiteral( "type" ), metadataUrlType );
@@ -1195,7 +1167,7 @@ namespace QgsWms
             {
               metaUrlElem.setAttribute( QStringLiteral( "type" ), metadataUrlType );
             }
-            QString metadataUrlFormat = url.format;
+            const QString metadataUrlFormat = metadataUrl.format;
             if ( !metadataUrlFormat.isEmpty() )
             {
               QDomElement metaUrlFormatElem = doc.createElement( QStringLiteral( "Format" ) );
@@ -1206,7 +1178,7 @@ namespace QgsWms
             QDomElement metaUrlORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
             metaUrlORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
             metaUrlORElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
-            metaUrlORElem.setAttribute( QStringLiteral( "xlink:href" ), url.url );
+            metaUrlORElem.setAttribute( QStringLiteral( "xlink:href" ), metadataUrl.url );
             metaUrlElem.appendChild( metaUrlORElem );
             layerElem.appendChild( metaUrlElem );
           }
@@ -1384,7 +1356,7 @@ namespace QgsWms
       }
     }
 
-    void appendLayerStyles( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer,
+    void appendLayerStyles( QDomDocument &doc, QDomElement &layerElem, const QgsWmsLayerInfos &layerInfos,
                             const QgsProject *project, const QgsWmsRequest &request, const QgsServerSettings *settings )
     {
       // Get service URL
@@ -1393,7 +1365,7 @@ namespace QgsWms
       //href needs to be a prefix
       QString hrefString = href.toString();
       hrefString.append( href.hasQuery() ? "&" : "?" );
-      for ( const QString &styleName : currentLayer->styleManager()->styles() )
+      for ( const QString &styleName : std::as_const( layerInfos.styles ) )
       {
         QDomElement styleElem = doc.createElement( QStringLiteral( "Style" ) );
         QDomElement styleNameElem = doc.createElement( QStringLiteral( "Name" ) );
@@ -1408,22 +1380,21 @@ namespace QgsWms
         // QString LegendURL for explicit layerbased GetLegendGraphic request
         QDomElement getLayerLegendGraphicElem = doc.createElement( QStringLiteral( "LegendURL" ) );
 
-        QString customHrefString = currentLayer->legendUrl();
+        QString customHrefString = layerInfos.legendUrl;
 
         QStringList getLayerLegendGraphicFormats;
         if ( !customHrefString.isEmpty() )
         {
-          getLayerLegendGraphicFormats << currentLayer->legendUrlFormat();
+          getLayerLegendGraphicFormats << layerInfos.legendUrlFormat;
         }
         else
         {
           getLayerLegendGraphicFormats << QStringLiteral( "image/png" ); // << "jpeg" << "image/jpeg"
         }
 
-        for ( int i = 0; i < getLayerLegendGraphicFormats.size(); ++i )
+        for ( const QString &getLayerLegendGraphicFormat : std::as_const( getLayerLegendGraphicFormats ) )
         {
           QDomElement getLayerLegendGraphicFormatElem = doc.createElement( QStringLiteral( "Format" ) );
-          QString getLayerLegendGraphicFormat = getLayerLegendGraphicFormats[i];
           QDomText getLayerLegendGraphicFormatText = doc.createTextNode( getLayerLegendGraphicFormat );
           getLayerLegendGraphicFormatElem.appendChild( getLayerLegendGraphicFormatText );
           getLayerLegendGraphicElem.appendChild( getLayerLegendGraphicFormatElem );
@@ -1432,19 +1403,14 @@ namespace QgsWms
         // no parameters on custom hrefUrl, because should link directly to graphic
         if ( customHrefString.isEmpty() )
         {
-          QString layerName = currentLayer->name();
-          if ( QgsServerProjectUtils::wmsUseLayerIds( *project ) )
-            layerName = currentLayer->id();
-          else if ( !currentLayer->shortName().isEmpty() )
-            layerName = currentLayer->shortName();
           QUrl mapUrl( hrefString );
           QUrlQuery mapUrlQuery( mapUrl.query() );
           mapUrlQuery.addQueryItem( QStringLiteral( "SERVICE" ), QStringLiteral( "WMS" ) );
           mapUrlQuery.addQueryItem( QStringLiteral( "VERSION" ), request.wmsParameters().version() );
           mapUrlQuery.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "GetLegendGraphic" ) );
-          mapUrlQuery.addQueryItem( QStringLiteral( "LAYER" ), layerName );
+          mapUrlQuery.addQueryItem( QStringLiteral( "LAYER" ), layerInfos.name );
           mapUrlQuery.addQueryItem( QStringLiteral( "FORMAT" ), QStringLiteral( "image/png" ) );
-          mapUrlQuery.addQueryItem( QStringLiteral( "STYLE" ), styleNameText.data() );
+          mapUrlQuery.addQueryItem( QStringLiteral( "STYLE" ), styleName );
           if ( request.wmsParameters().version() == QLatin1String( "1.3.0" ) )
           {
             mapUrlQuery.addQueryItem( QStringLiteral( "SLD_VERSION" ), QStringLiteral( "1.1.0" ) );
@@ -1523,48 +1489,12 @@ namespace QgsWms
       layerElement.insertAfter( crsElement, precedingElement );
     }
 
-    void appendLayerBoundingBoxes( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &lExtent,
-                                   const QgsCoordinateReferenceSystem &layerCRS, const QStringList &crsList,
-                                   const QStringList &constrainedCrsList, const QgsProject *project,
-                                   const QgsRectangle &lGeoExtent )
+    void appendLayerWgs84BoundingRect( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &wgs84BoundingRect )
     {
-      if ( layerElem.isNull() )
-      {
-        return;
-      }
-
-      QgsRectangle layerExtent = lExtent;
-      if ( qgsDoubleNear( layerExtent.xMinimum(), layerExtent.xMaximum() ) || qgsDoubleNear( layerExtent.yMinimum(), layerExtent.yMaximum() ) )
-      {
-        //layer bbox cannot be empty
-        layerExtent.grow( 0.000001 );
-      }
-
-      QgsRectangle wgs84BoundingRect = lGeoExtent;
+      //LatLonBoundingBox / Ex_GeographicBounding box is optional
       if ( wgs84BoundingRect.isNull() )
       {
-        const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() );
-
-        //transform the layers native CRS into WGS84
-        if ( !layerExtent.isNull() )
-        {
-          QgsCoordinateTransform exGeoTransform( layerCRS, wgs84, project );
-          try
-          {
-            wgs84BoundingRect = exGeoTransform.transformBoundingBox( layerExtent );
-          }
-          catch ( const QgsCsException &cse )
-          {
-            QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent: %1" ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
-            wgs84BoundingRect = QgsRectangle();
-          }
-        }
-      }
-
-      if ( qgsDoubleNear( wgs84BoundingRect.xMinimum(), wgs84BoundingRect.xMaximum() ) || qgsDoubleNear( wgs84BoundingRect.yMinimum(), wgs84BoundingRect.yMaximum() ) )
-      {
-        //layer bbox cannot be empty
-        wgs84BoundingRect.grow( 0.000001 );
+        return;
       }
 
       //Ex_GeographicBoundingBox
@@ -1600,284 +1530,73 @@ namespace QgsWms
         ExGeoBBoxElement.appendChild( nBoundLatitudeElement );
       }
 
-      if ( !wgs84BoundingRect.isNull() ) //LatLonBoundingBox / Ex_GeographicBounding box is optional
+      const QDomElement lastCRSElem = layerElem.lastChildElement( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" );
+      if ( !lastCRSElem.isNull() )
       {
-        QDomElement lastCRSElem = layerElem.lastChildElement( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" );
-        if ( !lastCRSElem.isNull() )
-        {
-          layerElem.insertAfter( ExGeoBBoxElement, lastCRSElem );
-        }
-        else
-        {
-          layerElem.appendChild( ExGeoBBoxElement );
-        }
-      }
-
-      //In case the number of advertised CRS is constrained
-      if ( !constrainedCrsList.isEmpty() )
-      {
-        for ( int i = constrainedCrsList.size() - 1; i >= 0; --i )
-        {
-          appendLayerBoundingBox( doc, layerElem, layerExtent, layerCRS, constrainedCrsList.at( i ), project );
-        }
-      }
-      else //no crs constraint
-      {
-        for ( const QString &crs : crsList )
-        {
-          appendLayerBoundingBox( doc, layerElem, layerExtent, layerCRS, crs, project );
-        }
-      }
-    }
-
-
-    void appendLayerBoundingBox( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &layerExtent,
-                                 const QgsCoordinateReferenceSystem &layerCRS, const QString &crsText,
-                                 const QgsProject *project )
-    {
-      if ( layerElem.isNull() )
-      {
-        return;
-      }
-
-      if ( crsText.isEmpty() )
-      {
-        return;
-      }
-
-      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
-
-      QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsText );
-
-      //transform the layers native CRS into CRS
-      QgsRectangle crsExtent;
-      if ( !layerExtent.isNull() )
-      {
-        QgsCoordinateTransform crsTransform( layerCRS, crs, project );
-        try
-        {
-          crsExtent = crsTransform.transformBoundingBox( layerExtent );
-        }
-        catch ( QgsCsException &cse )
-        {
-          QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent: %1" ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
-          return;
-        }
-      }
-
-      if ( crsExtent.isNull() )
-      {
-        return;
-      }
-
-      int precision = 3;
-      if ( crs.isGeographic() )
-      {
-        precision = 6;
-      }
-
-      //BoundingBox element
-      QDomElement bBoxElement = doc.createElement( QStringLiteral( "BoundingBox" ) );
-      if ( crs.isValid() )
-      {
-        bBoxElement.setAttribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS", crs.authid() );
-      }
-
-      if ( version != QLatin1String( "1.1.1" ) && crs.hasAxisInverted() )
-      {
-        crsExtent.invert();
-      }
-
-      bBoxElement.setAttribute( QStringLiteral( "minx" ), qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( crsExtent.xMinimum(), precision ), precision ) );
-      bBoxElement.setAttribute( QStringLiteral( "miny" ), qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( crsExtent.yMinimum(), precision ), precision ) );
-      bBoxElement.setAttribute( QStringLiteral( "maxx" ), qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( crsExtent.xMaximum(), precision ), precision ) );
-      bBoxElement.setAttribute( QStringLiteral( "maxy" ), qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( crsExtent.yMaximum(), precision ), precision ) );
-
-      QDomElement lastBBoxElem = layerElem.lastChildElement( QStringLiteral( "BoundingBox" ) );
-      if ( !lastBBoxElem.isNull() )
-      {
-        layerElem.insertAfter( bBoxElement, lastBBoxElem );
+        layerElem.insertAfter( ExGeoBBoxElement, lastCRSElem );
       }
       else
       {
-        lastBBoxElem = layerElem.lastChildElement( version == QLatin1String( "1.1.1" ) ? "LatLonBoundingBox" : "EX_GeographicBoundingBox" );
+        layerElem.appendChild( ExGeoBBoxElement );
+      }
+    }
+
+    void appendLayerCrsExtents( QDomDocument &doc, QDomElement &layerElem, const QMap<QString, QgsRectangle> &crsExtents )
+    {
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+
+      const auto &keys =  crsExtents.keys();
+      for ( const QString &crsText : std::as_const( keys ) )
+      {
+        QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsText );
+        QgsRectangle crsExtent( crsExtents[ crsText ] );
+
+        if ( crsExtent.isNull() )
+        {
+          continue;
+        }
+
+        int precision = 3;
+        if ( crs.isGeographic() )
+        {
+          precision = 6;
+        }
+
+        //BoundingBox element
+        QDomElement bBoxElement = doc.createElement( QStringLiteral( "BoundingBox" ) );
+        if ( crs.isValid() )
+        {
+          bBoxElement.setAttribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS", crs.authid() );
+        }
+
+        if ( version != QLatin1String( "1.1.1" ) && crs.hasAxisInverted() )
+        {
+          crsExtent.invert();
+        }
+
+        bBoxElement.setAttribute( QStringLiteral( "minx" ), qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( crsExtent.xMinimum(), precision ), precision ) );
+        bBoxElement.setAttribute( QStringLiteral( "miny" ), qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( crsExtent.yMinimum(), precision ), precision ) );
+        bBoxElement.setAttribute( QStringLiteral( "maxx" ), qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( crsExtent.xMaximum(), precision ), precision ) );
+        bBoxElement.setAttribute( QStringLiteral( "maxy" ), qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( crsExtent.yMaximum(), precision ), precision ) );
+
+        QDomElement lastBBoxElem = layerElem.lastChildElement( QStringLiteral( "BoundingBox" ) );
         if ( !lastBBoxElem.isNull() )
         {
           layerElem.insertAfter( bBoxElement, lastBBoxElem );
         }
         else
         {
-          layerElem.appendChild( bBoxElement );
-        }
-      }
-    }
-
-    QgsRectangle layerBoundingBoxInProjectCrs( const QDomDocument &doc, const QDomElement &layerElem,
-        const QgsProject *project )
-    {
-      QgsRectangle BBox;
-      if ( layerElem.isNull() )
-      {
-        return BBox;
-      }
-
-      //read box coordinates and layer auth. id
-      QDomElement boundingBoxElem = layerElem.firstChildElement( QStringLiteral( "BoundingBox" ) );
-      if ( boundingBoxElem.isNull() )
-      {
-        return BBox;
-      }
-
-      double minx, miny, maxx, maxy;
-      bool conversionOk;
-      minx = boundingBoxElem.attribute( QStringLiteral( "minx" ) ).toDouble( &conversionOk );
-      if ( !conversionOk )
-      {
-        return BBox;
-      }
-      miny = boundingBoxElem.attribute( QStringLiteral( "miny" ) ).toDouble( &conversionOk );
-      if ( !conversionOk )
-      {
-        return BBox;
-      }
-      maxx = boundingBoxElem.attribute( QStringLiteral( "maxx" ) ).toDouble( &conversionOk );
-      if ( !conversionOk )
-      {
-        return BBox;
-      }
-      maxy = boundingBoxElem.attribute( QStringLiteral( "maxy" ) ).toDouble( &conversionOk );
-      if ( !conversionOk )
-      {
-        return BBox;
-      }
-
-
-      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
-
-      //create layer crs
-      QgsCoordinateReferenceSystem layerCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( boundingBoxElem.attribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" ) );
-      if ( !layerCrs.isValid() )
-      {
-        return BBox;
-      }
-
-      BBox.setXMinimum( minx );
-      BBox.setXMaximum( maxx );
-      BBox.setYMinimum( miny );
-      BBox.setYMaximum( maxy );
-
-      if ( version != QLatin1String( "1.1.1" ) && layerCrs.hasAxisInverted() )
-      {
-        BBox.invert();
-      }
-
-      //get project crs
-      QgsCoordinateTransform t( layerCrs, project->crs(), project );
-
-      //transform
-      try
-      {
-        BBox = t.transformBoundingBox( BBox );
-      }
-      catch ( const QgsCsException &cse )
-      {
-        QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent: %1" ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
-        BBox = QgsRectangle();
-      }
-
-      return BBox;
-    }
-
-    bool crsSetFromLayerElement( const QDomElement &layerElement, QSet<QString> &crsSet )
-    {
-      if ( layerElement.isNull() )
-      {
-        return false;
-      }
-
-      crsSet.clear();
-
-      QDomNodeList crsNodeList;
-      crsNodeList = layerElement.elementsByTagName( QStringLiteral( "CRS" ) ); // WMS 1.3.0
-      for ( int i = 0; i < crsNodeList.size(); ++i )
-      {
-        crsSet.insert( crsNodeList.at( i ).toElement().text() );
-      }
-
-      crsNodeList = layerElement.elementsByTagName( QStringLiteral( "SRS" ) ); // WMS 1.1.1
-      for ( int i = 0; i < crsNodeList.size(); ++i )
-      {
-        crsSet.insert( crsNodeList.at( i ).toElement().text() );
-      }
-
-      return true;
-    }
-
-    void combineExtentAndCrsOfGroupChildren( QDomDocument &doc, QDomElement &groupElem, const QgsProject *project,
-        bool considerMapExtent )
-    {
-      QgsRectangle combinedBBox;
-      QSet<QString> combinedCRSSet;
-      bool firstBBox = true;
-      bool firstCRSSet = true;
-
-      QDomNodeList layerChildren = groupElem.childNodes();
-      for ( int j = 0; j < layerChildren.size(); ++j )
-      {
-        QDomElement childElem = layerChildren.at( j ).toElement();
-
-        if ( childElem.tagName() != QLatin1String( "Layer" ) )
-          continue;
-
-        QgsRectangle bbox = layerBoundingBoxInProjectCrs( doc, childElem, project );
-        if ( bbox.isNull() )
-        {
-          continue;
-        }
-
-        if ( !bbox.isEmpty() )
-        {
-          if ( firstBBox )
+          lastBBoxElem = layerElem.lastChildElement( version == QLatin1String( "1.1.1" ) ? "LatLonBoundingBox" : "EX_GeographicBoundingBox" );
+          if ( !lastBBoxElem.isNull() )
           {
-            combinedBBox = bbox;
-            firstBBox = false;
+            layerElem.insertAfter( bBoxElement, lastBBoxElem );
           }
           else
           {
-            combinedBBox.combineExtentWith( bbox );
-          }
-        }
-
-        //combine crs set
-        QSet<QString> crsSet;
-        if ( crsSetFromLayerElement( childElem, crsSet ) )
-        {
-          if ( firstCRSSet )
-          {
-            combinedCRSSet = crsSet;
-            firstCRSSet = false;
-          }
-          else
-          {
-            combinedCRSSet.intersect( crsSet );
+            layerElem.appendChild( bBoxElement );
           }
         }
       }
-
-      QStringList outputCrsList = QgsServerProjectUtils::wmsOutputCrsList( *project );
-      appendCrsElementsToLayer( doc, groupElem, qgis::setToList( combinedCRSSet ), outputCrsList );
-
-      QgsCoordinateReferenceSystem groupCRS = project->crs();
-      if ( considerMapExtent )
-      {
-        QgsRectangle mapRect = QgsServerProjectUtils::wmsExtent( *project );
-        if ( !mapRect.isEmpty() )
-        {
-          combinedBBox = mapRect;
-        }
-      }
-      appendLayerBoundingBoxes( doc, groupElem, combinedBBox, groupCRS, qgis::setToList( combinedCRSSet ), outputCrsList, project );
-
     }
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,
@@ -2113,32 +1832,97 @@ namespace QgsWms
     }
   }
 
-  bool hasQueryableChildren( const QgsLayerTreeNode *childNode, const QStringList &wmsRestrictedLayers )
+  bool hasQueryableLayers( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos )
   {
-    if ( childNode->nodeType() == QgsLayerTreeNode::NodeGroup )
+    for ( const QString &id : std::as_const( layerIds ) )
     {
-      for ( int j = 0; j < childNode->children().size(); ++j )
+      if ( !wmsLayerInfos.contains( id ) )
       {
-        if ( hasQueryableChildren( childNode->children().at( j ), wmsRestrictedLayers ) )
-          return  true;
+        continue;
       }
-      return false;
-    }
-    else if ( childNode->nodeType() == QgsLayerTreeNode::NodeLayer )
-    {
-      const auto treeLayer { static_cast<const QgsLayerTreeLayer *>( childNode ) };
-      const auto l { treeLayer->layer() };
-      if ( l )
+      if ( wmsLayerInfos[id].queryable )
       {
-        return ! wmsRestrictedLayers.contains( l->name() ) && l->flags().testFlag( QgsMapLayer::Identifiable );
-      }
-      else
-      {
-        QgsMessageLog::logMessage( QStringLiteral( "Broken/corrupted layer tree, layer '%1' does not exist: check your project!" ).arg( treeLayer->name() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
+        return true;
       }
     }
     return false;
   }
 
+  QgsRectangle combineWgs84BoundingRect( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos )
+  {
+    QgsRectangle combined;
+    bool empty = true;
+
+    for ( const QString &id : std::as_const( layerIds ) )
+    {
+      if ( !wmsLayerInfos.contains( id ) )
+      {
+        continue;
+      }
+
+      QgsRectangle rect = wmsLayerInfos[ id ].wgs84BoundingRect;
+      if ( rect.isNull() )
+      {
+        continue;
+      }
+
+      if ( rect.isEmpty() )
+      {
+        continue;
+      }
+
+      if ( empty )
+      {
+        combined = rect;
+        empty = false;
+      }
+      else
+      {
+        combined.combineExtentWith( rect );
+      }
+    }
+
+    return combined;
+  }
+
+  QMap<QString, QgsRectangle> combineCrsExtents( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos )
+  {
+    QMap<QString, QgsRectangle> combined;
+
+    for ( const QString &id : std::as_const( layerIds ) )
+    {
+      if ( !wmsLayerInfos.contains( id ) )
+      {
+        continue;
+      }
+
+      const QgsWmsLayerInfos &layerInfos = wmsLayerInfos[ id ];
+      const auto keys = layerInfos.crsExtents.keys();
+      for ( const QString &crs : std::as_const( keys ) )
+      {
+        const QgsRectangle rect = layerInfos.crsExtents[ crs ];
+        if ( rect.isNull() )
+        {
+          continue;
+        }
+
+        if ( rect.isEmpty() )
+        {
+          continue;
+        }
+
+        if ( !combined.contains( crs ) )
+        {
+          combined[ crs ] = rect;
+        }
+        else
+        {
+          combined[ crs ].combineExtentWith( rect );
+        }
+      }
+    }
+
+    return combined;
+  }
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -27,6 +27,7 @@
 #include "qgslayertree.h"
 
 #include "qgswmsrequest.h"
+#include "qgswmslayerinfos.h"
 
 namespace QgsWms
 {
@@ -89,7 +90,33 @@ namespace QgsWms
                                 const QgsWmsRequest &request,
                                 bool projectSettings );
 
-  bool hasQueryableChildren( const QgsLayerTreeNode *childNode, const QStringList &wmsRestrictedLayers );
+  /**
+   * Returns true if at least one layer from the layers ids is queryable
+   * \param layerIds  list of layer ids
+   * \param wmsLayerInfos WMS layers definition to build WMS capabilities
+   * \returns True if at least one layer form the layers ids is queryable
+   * \since QGIS 3.28.0
+   */
+  bool hasQueryableLayers( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos );
+
+  /**
+   * Returns the combination of the WGS84 bounding rectangle of the layers from the list of layers ids
+   * \param layerIds  list of layer ids
+   * \param wmsLayerInfos WMS layers definition to build WMS capabilities
+   * \returns the extent combination of the WGS84 bounding rectangle of the layers from the list of layers ids
+   * \since QGIS 3.28.0
+   */
+  QgsRectangle combineWgs84BoundingRect( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos );
+
+  /**
+   * Returns the combinations of the extent CRSes of the layers from the list of layers ids
+   * \param layerIds  list of layer ids
+   * \param wmsLayerInfos WMS layers definition to build WMS capabilities
+   * \returns the extent combination of the WGS84 bounding rectangle of the layers from the list of layers ids
+   * \since QGIS 3.28.0
+   */
+  QMap<QString, QgsRectangle> combineCrsExtents( const QStringList &layerIds, const QMap< QString, QgsWmsLayerInfos > &wmsLayerInfos );
+
 } // namespace QgsWms
 
 #endif

--- a/src/server/services/wms/qgswmslayerinfos.cpp
+++ b/src/server/services/wms/qgswmslayerinfos.cpp
@@ -1,0 +1,240 @@
+/***************************************************************************
+                              qgswmslayerinfos.cpp
+
+  Layer's information
+  ------------------------------------
+  begin                : September 26 , 2022
+  copyright            : (C) 2022 by René-Luc D'Hont and David Marteau
+  email                : rldhont at 3liz doc com
+         dmarteau at 3liz dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsserverprojectutils.h"
+#include "qgscoordinatetransform.h"
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "qgswmslayerinfos.h"
+#include "qgsmessagelog.h"
+#include "qgsserverinterface.h"
+#include "qgsmaplayerstylemanager.h"
+
+#include <algorithm>
+
+QgsRectangle QgsWmsLayerInfos::transformExtent(
+  const QgsRectangle &extent,
+  const QgsCoordinateReferenceSystem &source,
+  const QgsCoordinateReferenceSystem &destination,
+  const QgsCoordinateTransformContext &context,
+  const bool &ballparkTransformsAreAppropriate )
+{
+  QgsCoordinateTransform transformer { source, destination, context };
+  transformer.setBallparkTransformsAreAppropriate( ballparkTransformsAreAppropriate );
+  // Transform extent and do not catch exception
+  return transformer.transformBoundingBox( extent );
+}
+
+QMap< QString, QgsRectangle > QgsWmsLayerInfos::transformExtentToCrsList(
+  const QgsRectangle &extent,
+  const QgsCoordinateReferenceSystem &source,
+  const QList<QgsCoordinateReferenceSystem> &destinations,
+  const QgsCoordinateTransformContext &context )
+{
+  QMap< QString, QgsRectangle > crsExtents;
+  if ( extent.isEmpty() )
+  {
+    return crsExtents;
+  }
+  for ( const QgsCoordinateReferenceSystem &destination : std::as_const( destinations ) )
+  {
+    // Transform extent and do not catch exception
+    QgsCoordinateTransform crsTransform { source, destination, context };
+    crsExtents[ destination.authid() ] = crsTransform.transformBoundingBox( extent );
+  }
+  return crsExtents;
+}
+
+
+bool setBoundingRect(
+  const QgsProject *project,
+  QgsWmsLayerInfos &pLayer,
+  QgsMapLayer *ml,
+  const QgsRectangle &wmsExtent,
+  const QgsCoordinateReferenceSystem &wgs84,
+  const QList<QgsCoordinateReferenceSystem> &outputCrsList )
+{
+  QgsRectangle layerExtent = ml->extent();
+  if ( layerExtent.isEmpty() )
+  {
+    // if the extent is empty (not only Null), use the wms extent
+    // defined in the project...
+    if ( wmsExtent.isNull() )
+    {
+      // or the CRS extent otherwise
+      layerExtent = ml->crs().bounds();
+    }
+    else
+    {
+      layerExtent = QgsRectangle( wmsExtent );
+      if ( ml->crs() != project->crs() )
+      {
+        // If CRS is different transform it to layer's CRS
+        try
+        {
+          layerExtent = QgsWmsLayerInfos::transformExtent( wmsExtent, project->crs(), ml->crs(), project->transformContext() );
+        }
+        catch ( QgsCsException &cse )
+        {
+          QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent for layer %1: %2" ).arg( ml->name() ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
+          return false;
+        }
+      }
+    }
+
+    // Now we have a layer Extent we need the WGS84 bounding rectangle
+    try
+    {
+      pLayer.wgs84BoundingRect = QgsWmsLayerInfos::transformExtent( layerExtent, ml->crs(), wgs84, project->transformContext(), true );
+    }
+    catch ( const QgsCsException &cse )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent for layer %1: %2" ).arg( ml->name() ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
+      return false;
+    }
+  }
+  else
+  {
+    pLayer.wgs84BoundingRect = ml->wgs84Extent();
+  }
+
+  try
+  {
+    pLayer.crsExtents = QgsWmsLayerInfos::transformExtentToCrsList(
+                          layerExtent, ml->crs(), outputCrsList, project->transformContext()
+                        );
+  }
+  catch ( QgsCsException &cse )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Error transforming extent for layer %1: %2" ).arg( ml->name() ).arg( cse.what() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Warning );
+    return false;
+  }
+
+  return true;
+}
+
+// ===================================
+// Get wms layer infos
+// ===================================
+QMap< QString, QgsWmsLayerInfos > QgsWmsLayerInfos::buildWmsLayerInfos(
+  QgsServerInterface *serverIface,
+  const QgsProject *project,
+  const QList<QgsCoordinateReferenceSystem> &outputCrsList )
+{
+  QMap< QString, QgsWmsLayerInfos > wmsLayers;
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+  QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+  ( void )serverIface;
+#endif
+
+  bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );
+  const QStringList restrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *project );
+  const QgsRectangle wmsExtent = QgsServerProjectUtils::wmsExtent( *project );
+  const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( geoEpsgCrsAuthId() );
+
+  for ( QgsMapLayer *ml : project->mapLayers() )
+  {
+    if ( !ml || restrictedLayers.contains( ml->name() ) ) //unpublished layer
+    {
+      continue;
+    }
+
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+    if ( accessControl && !accessControl->layerReadPermission( ml ) )
+    {
+      continue;
+    }
+#endif
+
+    QgsWmsLayerInfos pLayer;
+    pLayer.id = ml->id();
+
+    // Calculate layer extents for the WMS output CRSes list
+    // First define if the layer has an extent
+    // Vector layer with No Geometry has no extent the other has one
+    bool hasExtent = true;
+    if ( ml->type() == QgsMapLayerType::VectorLayer )
+    {
+      QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( ml );
+      if ( !vLayer || vLayer->wkbType() == QgsWkbTypes::NoGeometry )
+      {
+        hasExtent = false;
+      }
+    }
+
+    // If the layer has an extent and we cannot get CRS bounding boxes, do not keep the layer
+    if ( hasExtent && !setBoundingRect( project, pLayer, ml, wmsExtent, wgs84, outputCrsList ) )
+      continue;
+
+    // layer type
+    pLayer.type = ml->type();
+    // layer wms name
+    pLayer.name = ml->name();
+    if ( useLayerIds )
+    {
+      pLayer.name = ml->id();
+    }
+    else if ( !ml->shortName().isEmpty() )
+    {
+      pLayer.name = ml->shortName();
+    }
+    // layer title
+    pLayer.title = ml->title();
+    if ( pLayer.title.isEmpty() )
+    {
+      pLayer.title = ml->name();
+    }
+    // layer abstract
+    pLayer.abstract = ml->abstract();
+    // layer is queryable
+    pLayer.queryable = ml->flags().testFlag( QgsMapLayer::Identifiable );
+    // layer keywords
+    if ( !ml->keywordList().isEmpty() )
+    {
+      pLayer.keywords = ml->keywordList().split( ',' );
+    }
+    // layer styles
+    pLayer.styles = ml->styleManager()->styles();
+    // layer legend URL
+    pLayer.legendUrl = ml->legendUrl();
+    // layer legend URL format
+    pLayer.legendUrlFormat = ml->legendUrlFormat();
+    // layer min/max scales
+    if ( ml->hasScaleBasedVisibility() )
+    {
+      pLayer.hasScaleBasedVisibility = ml->hasScaleBasedVisibility();
+      pLayer.maxScale = ml->maximumScale();
+      pLayer.minScale = ml->minimumScale();
+    }
+    // layer data URL
+    pLayer.dataUrl = ml->dataUrl();
+    // layer attribution
+    pLayer.attribution = ml->attribution();
+    pLayer.attributionUrl = ml->attributionUrl();
+    // layer metadata URLs
+    pLayer.metadataUrls = ml->serverProperties()->metadataUrls();
+
+    wmsLayers[pLayer.id] = pLayer;
+  }
+
+  return wmsLayers;
+}
+

--- a/src/server/services/wms/qgswmslayerinfos.h
+++ b/src/server/services/wms/qgswmslayerinfos.h
@@ -1,0 +1,157 @@
+/***************************************************************************
+                              qgswmslayerinfos.h
+
+  Layer's information
+  ------------------------------------
+  begin                : September 26 , 2022
+  copyright            : (C) 2022 by René-Luc D'Hont and David Marteau
+  email                : rldhont at 3liz doc com
+         dmarteau at 3liz dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSWMSLAYERINFOS_H
+#define QGSWMSLAYERINFOS_H
+
+#include "qgsrectangle.h"
+#include "qgsmaplayerserverproperties.h"
+
+class QgsServerInterface;
+class QgsProject;
+
+/**
+ * \ingroup server
+ * \class QgsWmsLayerInfos
+ * \brief WMS Layer infos
+ *
+ * \since QGIS 3.28
+ */
+class QgsWmsLayerInfos
+{
+  public:
+    //! QGIS layer id
+    QString id;
+
+    //! WMS layer name
+    QString name;
+
+    //! WMS layer title
+    QString title;
+
+    //! WMS layer abstract
+    QString abstract;
+
+    //! WMS layer keywords
+    QStringList keywords;
+
+    //! WMS layer WGS84 bounding rectangle (can be empty)
+    QgsRectangle wgs84BoundingRect;
+
+    //! WMS layer CRS extents (can be empty)
+    QMap<QString, QgsRectangle> crsExtents;
+
+    //! WMS layer styles
+    QStringList styles;
+
+    //! WMS layer legend URL
+    QString legendUrl;
+
+    //! WMS layer legend URL format
+    QString legendUrlFormat;
+
+    //! WMS layer is queryable
+    bool queryable = false;
+
+    //! WMS layer has scale based visibility
+    bool hasScaleBasedVisibility = false;
+
+    //! WMS layer maximum scale (if negative, no maximum scale is defined)
+    double maxScale = -1.0;
+
+    //! WMS layer minimum scale (if negative, no maximum scale is defined)
+    double minScale = -1.0;
+
+    //! WMS layer dataUrl
+    QString dataUrl;
+
+    //! WMS layer attribution
+    QString attribution;
+
+    //! WMS layer attribution URL
+    QString attributionUrl;
+
+    //! WMS layer metadata URLs
+    QList<QgsMapLayerServerProperties::MetadataUrl> metadataUrls;
+
+    //! QGIS layer type
+    QgsMapLayerType type;
+
+  public:
+
+    /**
+     * Returns the WMS layers definition to build WMS capabilities
+     *
+     * The output will only contain the published and available after
+     * access control layers and layers without extent projection exception.
+     *
+     * \param serverIface Interface for plugins
+     * \param project Project
+     * \param outputCrsList the WMS output CRS list.
+     *
+     * \returns the WMS layers definition
+     *
+     * \since QGIS 3.28.0
+     */
+    static QMap< QString, QgsWmsLayerInfos > buildWmsLayerInfos(
+      QgsServerInterface *serverIface,
+      const QgsProject *project,
+      const QList<QgsCoordinateReferenceSystem> &outputCrsList );
+
+    /**
+     * Returns a map with CRS authid as key and the transformed extent as value
+     *
+     * \param extent the extent to transform
+     * \param source the extent CRS
+     * \param destinations the CRSes destinations
+     * \param context the transformation context
+     *
+     * \returns the transformed extents
+     *
+     * \since QGIS 3.28.0
+     */
+    static QMap< QString, QgsRectangle > transformExtentToCrsList(
+      const QgsRectangle &extent,
+      const QgsCoordinateReferenceSystem &source,
+      const QList<QgsCoordinateReferenceSystem> &destinations,
+      const QgsCoordinateTransformContext &context );
+
+    /**
+     * Returns a transformed extent
+     *
+     * \param extent the extent to transform
+     * \param source the extent CRS
+     * \param destination the destination CRS
+     * \param context the transformation context
+     * \param ballparkTransformsAreAppropriate whether approximate "ballpark" results are appropriate for the destination CRS
+     *
+     * \returns the transformed extents
+     *
+     * \since QGIS 3.28.0
+     */
+    static QgsRectangle transformExtent(
+      const QgsRectangle &extent,
+      const QgsCoordinateReferenceSystem &source,
+      const QgsCoordinateReferenceSystem &destination,
+      const QgsCoordinateTransformContext &context,
+      const bool &ballparkTransformsAreAppropriate = false );
+
+}; // class QgsWmsLayerInfos
+
+#endif

--- a/tests/testdata/qgis_server/getcapabilities-map.txt
+++ b/tests/testdata/qgis_server/getcapabilities-map.txt
@@ -255,12 +255,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -293,12 +293,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -255,12 +255,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -293,12 +293,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -301,12 +301,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithshortname</TreeName>
     <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
@@ -346,12 +346,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithoutshortname</TreeName>
     <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer3</Name>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -293,12 +293,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithshortname</TreeName>
     <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
@@ -338,12 +338,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <TreeName>groupwithoutshortname</TreeName>
     <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="0.8" expanded="1">
      <Name>testlayer3</Name>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -216,9 +216,9 @@ Content-Type: text/xml; charset=utf-8
     <Abstract>Group abstract</Abstract>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
-    <LatLonBoundingBox maxy="44.901483" maxx="8.203548" miny="44.901394" minx="8.203459"/>
-    <BoundingBox maxy="5606025.239" SRS="EPSG:3857" maxx="913214.676" miny="5606011.456" minx="913204.911"/>
-    <BoundingBox maxy="44.901483" SRS="EPSG:4326" maxx="8.203548" miny="44.901394" minx="8.203459"/>
+    <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
+    <BoundingBox maxy="5606025.238" SRS="EPSG:3857" maxx="913214.675" miny="5606011.456" minx="913204.912"/>
+    <BoundingBox maxy="44.901483" SRS="EPSG:4326" maxx="8.203547" miny="44.901394" minx="8.203459"/>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -242,9 +242,9 @@ Content-Type: text/xml; charset=utf-8
     <Title>groupwithoutshortname</Title>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
-    <LatLonBoundingBox maxy="44.901483" maxx="8.203548" miny="44.901394" minx="8.203459"/>
-    <BoundingBox maxy="5606025.239" SRS="EPSG:3857" maxx="913214.676" miny="5606011.456" minx="913204.911"/>
-    <BoundingBox maxy="44.901483" SRS="EPSG:4326" maxx="8.203548" miny="44.901394" minx="8.203459"/>
+    <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
+    <BoundingBox maxy="5606025.238" SRS="EPSG:3857" maxx="913214.675" miny="5606011.456" minx="913204.912"/>
+    <BoundingBox maxy="44.901483" SRS="EPSG:4326" maxx="8.203547" miny="44.901394" minx="8.203459"/>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -255,12 +255,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -293,12 +293,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -99,30 +99,30 @@ Content-Type: text/xml; charset=utf-8
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
    <CRS>CRS:84</CRS>
-   <CRS>EPSG:3857</CRS>
    <CRS>EPSG:4326</CRS>
+   <CRS>EPSG:3857</CRS>
    <EX_GeographicBoundingBox>
     <westBoundLongitude>6.565019</westBoundLongitude>
     <eastBoundLongitude>15.224411</eastBoundLongitude>
     <southBoundLatitude>42.875379</southBoundLatitude>
     <northBoundLatitude>45.828505</northBoundLatitude>
    </EX_GeographicBoundingBox>
-   <BoundingBox maxy="15.224411" maxx="45.828505" miny="6.565019" CRS="EPSG:4326" minx="42.875379"/>
    <BoundingBox maxy="5752909.361" maxx="1694773.614" miny="5293022.486" CRS="EPSG:3857" minx="730814.655"/>
+   <BoundingBox maxy="15.224411" maxx="45.828505" miny="6.565019" CRS="EPSG:4326" minx="42.875379"/>
    <Layer queryable="1">
     <Name>bug_gh30264_empty_layer_wrong_bbox</Name>
     <Title>bug_gh30264_empty_layer_wrong_bbox</Title>
     <CRS>CRS:84</CRS>
-    <CRS>EPSG:3857</CRS>
     <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>6.565019</westBoundLongitude>
      <eastBoundLongitude>15.224411</eastBoundLongitude>
      <southBoundLatitude>42.875379</southBoundLatitude>
      <northBoundLatitude>45.828505</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="15.224411" maxx="45.828505" miny="6.565019" CRS="EPSG:4326" minx="42.875379"/>
     <BoundingBox maxy="5752909.361" maxx="1694773.614" miny="5293022.486" CRS="EPSG:3857" minx="730814.655"/>
+    <BoundingBox maxy="15.224411" maxx="45.828505" miny="6.565019" CRS="EPSG:4326" minx="42.875379"/>
     <Style>
      <Name>default</Name>
      <Title>default</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
@@ -255,12 +255,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -293,12 +293,12 @@ Content-Type: text/xml; charset=utf-8
     <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>8.203459</westBoundLongitude>
-     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
      <southBoundLatitude>44.901394</southBoundLatitude>
      <northBoundLatitude>44.901483</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
-    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -109,7 +109,7 @@ Content-Type: text/xml; charset=utf-8
     <southBoundLatitude>46.27919</southBoundLatitude>
     <northBoundLatitude>49.726475</northBoundLatitude>
    </EX_GeographicBoundingBox>
-   <BoundingBox maxy="6399040.039" maxx="347086.26" miny="5825203.208" CRS="EPSG:3857" minx="-571361.416"/>
+   <BoundingBox maxy="6399040.039" maxx="347086.259" miny="5825203.209" CRS="EPSG:3857" minx="-571361.416"/>
    <BoundingBox maxy="3.117929" maxx="49.726475" miny="-5.132627" CRS="EPSG:4326" minx="46.27919"/>
    <Layer queryable="1">
     <Name>france_parts</Name>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -110,30 +110,30 @@ Content-Type: text/xml; charset=utf-8
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
    <CRS>CRS:84</CRS>
-   <CRS>EPSG:3857</CRS>
    <CRS>EPSG:4326</CRS>
+   <CRS>EPSG:3857</CRS>
    <EX_GeographicBoundingBox>
     <westBoundLongitude>-174.766579</westBoundLongitude>
     <eastBoundLongitude>177.930822</eastBoundLongitude>
     <southBoundLatitude>-69.957839</southBoundLatitude>
     <northBoundLatitude>84.307877</northBoundLatitude>
    </EX_GeographicBoundingBox>
-   <BoundingBox CRS="EPSG:4326" miny="-174.766579" minx="-69.957839" maxy="177.930822" maxx="84.307877"/>
    <BoundingBox CRS="EPSG:3857" miny="-11055007" minx="-20609694" maxy="19143773" maxx="20961936"/>
+   <BoundingBox CRS="EPSG:4326" miny="-174.766579" minx="-69.957839" maxy="177.930822" maxx="84.307877"/>
    <Layer queryable="1">
     <Name>Datetime_dim</Name>
     <Title>Datetime_dim</Title>
     <CRS>CRS:84</CRS>
-    <CRS>EPSG:3857</CRS>
     <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>-7.99492</westBoundLongitude>
      <eastBoundLongitude>-0.855025</eastBoundLongitude>
      <southBoundLatitude>37.4402</southBoundLatitude>
      <northBoundLatitude>43.0264</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox miny="-7.99492" minx="37.4402" maxy="-0.855025" maxx="43.0264" CRS="EPSG:4326"/>
     <BoundingBox miny="4500643.903" minx="-889990.424" maxy="5315991.06" maxx="-95180.947" CRS="EPSG:3857"/>
+    <BoundingBox miny="-7.99492" minx="37.4402" maxy="-0.855025" maxx="43.0264" CRS="EPSG:4326"/>
     <Style>
      <Name>défaut</Name>
      <Title>défaut</Title>
@@ -149,16 +149,16 @@ Content-Type: text/xml; charset=utf-8
     <Name>Contours</Name>
     <Title>Contours</Title>
     <CRS>CRS:84</CRS>
-    <CRS>EPSG:3857</CRS>
     <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>-28.761387</westBoundLongitude>
      <eastBoundLongitude>0.000001</eastBoundLongitude>
      <southBoundLatitude>29.999996</southBoundLatitude>
      <northBoundLatitude>60</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox maxy="0.000001" minx="29.999996" CRS="EPSG:4326" maxx="60" miny="-28.761387"/>
     <BoundingBox maxy="8399737.89" minx="-3201702.942" CRS="EPSG:3857" maxx="0.001" miny="3503549.353"/>
+    <BoundingBox maxy="0.000001" minx="29.999996" CRS="EPSG:4326" maxx="60" miny="-28.761387"/>
     <Style>
      <Name>default</Name>
      <Title>default</Title>
@@ -173,16 +173,16 @@ Content-Type: text/xml; charset=utf-8
     <Name>Slopes</Name>
     <Title>Slopes</Title>
     <CRS>CRS:84</CRS>
-    <CRS>EPSG:3857</CRS>
     <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>-9.40375</westBoundLongitude>
      <eastBoundLongitude>0.000001</eastBoundLongitude>
      <southBoundLatitude>36.0667</southBoundLatitude>
      <northBoundLatitude>43.7562</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox CRS="EPSG:4326" miny="-9.40375" minx="36.0667" maxy="0.000001" maxx="43.7562"/>
     <BoundingBox CRS="EPSG:3857" miny="4309803.074" minx="-1046820.662" maxy="5427790.763" maxx="0.001"/>
+    <BoundingBox CRS="EPSG:4326" miny="-9.40375" minx="36.0667" maxy="0.000001" maxx="43.7562"/>
     <Style>
      <Name>default</Name>
      <Title>default</Title>
@@ -197,16 +197,16 @@ Content-Type: text/xml; charset=utf-8
     <Name>dem</Name>
     <Title>dem</Title>
     <CRS>CRS:84</CRS>
-    <CRS>EPSG:3857</CRS>
     <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
     <EX_GeographicBoundingBox>
      <westBoundLongitude>-30</westBoundLongitude>
      <eastBoundLongitude>0.000001</eastBoundLongitude>
      <southBoundLatitude>29.999999</southBoundLatitude>
      <northBoundLatitude>60</northBoundLatitude>
     </EX_GeographicBoundingBox>
-    <BoundingBox CRS="EPSG:4326" miny="-30" minx="29.999999" maxy="0.000001" maxx="60"/>
     <BoundingBox CRS="EPSG:3857" miny="3503549.843" minx="-3339584.724" maxy="8399737.89" maxx="0.001"/>
+    <BoundingBox CRS="EPSG:4326" miny="-30" minx="29.999999" maxy="0.000001" maxx="60"/>
     <Style>
      <Name>default</Name>
      <Title>default</Title>


### PR DESCRIPTION
The objectives of these changes are:
* Improvement of the quality of the code for a better maintenance of it
* Simplification of layer group extent calculation

To do so, we introduced WMS Layer infos to collect layer informations for WMS GetCapabilities and calculate layer extent in the different available CRSes for WMS.

With WMS Layer infos, we can combine extent to calculate layer group extent and removed the WMS GetCapabilities method `combineExtentAndCrsOfGroupChildren`.

We probably can alo removed searching of preceding element in the methods to insert CRS and BoundingBox.

Funded by Ifremer https://wwz.ifremer.fr/