### PR TITLE
[Clazy] Fix container-anti-pattern check and make it mandatory

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -416,6 +416,8 @@ jobs:
           - distro-version: '22.04'
             qt-version: 5
 
+      fail-fast: false
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -416,8 +416,6 @@ jobs:
           - distro-version: '22.04'
             qt-version: 5
 
-      fail-fast: false
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,7 +883,7 @@ if (WITH_CORE)
   if (WITH_CLAZY)
     set(CMAKE_CXX_BASE_FLAGS "${CMAKE_CXX_FLAGS}")
     #  qcolor-from-literal crashes clang with clazy 1.11
-    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count,missing-qobject-macro")
+    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count,missing-qobject-macro,container-anti-pattern")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_BASE_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_BASE_CHECKS}")
 
     if (WERROR AND NOT ${QGISDEBUG})

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1570,7 +1570,6 @@ Returns a double ``number``, rounded (as close as possible) to the specified num
 
 
 
-
 double qgsPermissiveToDouble( QString string, bool &ok );
 %Docstring
 Converts a string to a double in a permissive way, e.g., allowing for incorrect

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -197,9 +197,9 @@ QString Qgs3DExportObject::saveMaterial( QTextStream &mtlOut, const QString &fol
     mTextureImage.save( filePath, "JPG" );
     mtlOut << "\tmap_Kd " << materialName << ".jpg" << "\n";
   }
-  for ( const QString &key : mMaterialParameters.keys() )
+  for ( auto it = mMaterialParameters.constBegin(); it != mMaterialParameters.constEnd(); it++ )
   {
-    mtlOut << "\t" << key << " " << mMaterialParameters[key] << "\n";
+    mtlOut << "\t" << it.key() << " " << it.value() << "\n";
   }
   mtlOut << "\tillum 2\n";
   return materialName;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -328,7 +328,7 @@ void Qgs3DMapScene::registerPickHandler( Qgs3DMapScenePickHandler *pickHandler )
   if ( mPickHandlers.isEmpty() )
   {
     // we need to add object pickers
-    for ( Qt3DCore::QEntity *entity : mLayerEntities.values() )
+    for ( Qt3DCore::QEntity *entity : mLayerEntities )
     {
       if ( QgsChunkedEntity *chunkedEntity = qobject_cast<QgsChunkedEntity *>( entity ) )
         chunkedEntity->setPickingEnabled( true );
@@ -345,7 +345,7 @@ void Qgs3DMapScene::unregisterPickHandler( Qgs3DMapScenePickHandler *pickHandler
   if ( mPickHandlers.isEmpty() )
   {
     // we need to remove pickers
-    for ( Qt3DCore::QEntity *entity : mLayerEntities.values() )
+    for ( Qt3DCore::QEntity *entity : mLayerEntities )
     {
       if ( QgsChunkedEntity *chunkedEntity = qobject_cast<QgsChunkedEntity *>( entity ) )
         chunkedEntity->setPickingEnabled( false );
@@ -750,8 +750,9 @@ void Qgs3DMapScene::onLayersChanged()
 
 void Qgs3DMapScene::updateTemporal()
 {
-  for ( auto layer : mLayerEntities.keys() )
+  for ( auto it = mLayerEntities.keyBegin(); it != mLayerEntities.keyEnd(); it++ )
   {
+    QgsMapLayer *layer = *it;
     if ( layer->temporalProperties()->isActive() )
     {
       removeLayerEntity( layer );
@@ -1219,9 +1220,10 @@ QgsRectangle Qgs3DMapScene::sceneExtent()
   QgsRectangle extent;
   extent.setMinimal();
 
-  for ( QgsMapLayer *layer : mLayerEntities.keys() )
+  for ( auto it = mLayerEntities.constBegin(); it != mLayerEntities.constEnd(); it++ )
   {
-    Qt3DCore::QEntity *layerEntity = mLayerEntities[ layer ];
+    QgsMapLayer *layer = it.key();
+    Qt3DCore::QEntity *layerEntity = it.value();
     QgsChunkedEntity *c = qobject_cast<QgsChunkedEntity *>( layerEntity );
     if ( !c )
       continue;

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -247,14 +247,16 @@ int QgsDemHeightMapGenerator::render( const QgsChunkNodeId &nodeId )
 
 void QgsDemHeightMapGenerator::waitForFinished()
 {
-  for ( QFutureWatcher<QByteArray> *fw : mJobs.keys() )
+  for ( auto it = mJobs.keyBegin(); it != mJobs.keyEnd(); it++ )
   {
+    QFutureWatcher<QByteArray> *fw = *it;
     disconnect( fw, &QFutureWatcher<QByteArray>::finished, this, &QgsDemHeightMapGenerator::onFutureFinished );
     disconnect( fw, &QFutureWatcher<QByteArray>::finished, fw, &QObject::deleteLater );
   }
   QVector<QFutureWatcher<QByteArray>*> toBeDeleted;
-  for ( QFutureWatcher<QByteArray> *fw : mJobs.keys() )
+  for ( auto it = mJobs.keyBegin(); it != mJobs.keyEnd(); it++ )
   {
+    QFutureWatcher<QByteArray> *fw = *it;
     fw->waitForFinished();
     JobData jobData = mJobs.value( fw );
     toBeDeleted.push_back( fw );

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -86,13 +86,14 @@ void QgsTerrainTextureGenerator::cancelJob( int jobId )
 
 void QgsTerrainTextureGenerator::waitForFinished()
 {
-  for ( QgsMapRendererSequentialJob *job : mJobs.keys() )
-    disconnect( job, &QgsMapRendererJob::finished, this, &QgsTerrainTextureGenerator::onRenderingFinished );
+  for ( auto it = mJobs.keyBegin(); it != mJobs.keyEnd(); it++ )
+    disconnect( *it, &QgsMapRendererJob::finished, this, &QgsTerrainTextureGenerator::onRenderingFinished );
   QVector<QgsMapRendererSequentialJob *> toBeDeleted;
-  for ( QgsMapRendererSequentialJob *mapJob : mJobs.keys() )
+  for ( auto it = mJobs.constBegin(); it != mJobs.constEnd(); it++ )
   {
+    QgsMapRendererSequentialJob *mapJob = it.key();
     mapJob->waitForFinished();
-    JobData jobData = mJobs.value( mapJob );
+    JobData jobData = it.value();
     toBeDeleted.push_back( mapJob );
 
     QImage img = mapJob->renderedImage();

--- a/src/analysis/processing/qgsalgorithmexplodehstore.cpp
+++ b/src/analysis/processing/qgsalgorithmexplodehstore.cpp
@@ -108,10 +108,10 @@ QVariantMap QgsExplodeHstoreAlgorithm::processAlgorithm( const QVariantMap &para
       feedback->setProgress( progress );
 
     QVariantMap currentHStore = QgsHstoreUtils::parse( feat.attribute( fieldName ).toString() );
-    for ( const QString &key : currentHStore.keys() )
+    for ( auto key = currentHStore.keyBegin(); key != currentHStore.keyEnd(); key++ )
     {
-      if ( expectedFields.isEmpty() && ! fieldsToAdd.contains( key ) )
-        fieldsToAdd.insert( 0, key );
+      if ( expectedFields.isEmpty() && ! fieldsToAdd.contains( *key ) )
+        fieldsToAdd.insert( 0, *key );
     }
     hstoreFeatures.insert( feat.id(), currentHStore );
     features.append( feat );

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
@@ -186,11 +186,11 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
   }
   recheckArea.grow( 10 * mContext->tolerance );
   QMap<QString, QgsFeatureIds> recheckAreaFeatures;
-  for ( const QString &layerId : mFeaturePools.keys() )
+  for ( auto it = mFeaturePools.constBegin(); it != mFeaturePools.constEnd(); it++ )
   {
-    QgsFeaturePool *featurePool = mFeaturePools[layerId];
+    QgsFeaturePool *featurePool = it.value();
     QgsCoordinateTransform t( mContext->mapCrs, featurePool->layer()->crs(), QgsProject::instance() );
-    recheckAreaFeatures[layerId] = featurePool->getIntersects( t.transform( recheckArea ) );
+    recheckAreaFeatures[it.key()] = featurePool->getIntersects( t.transform( recheckArea ) );
   }
 
   // Recheck feature / changed area to detect new errors
@@ -272,9 +272,9 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
 
   if ( triggerRepaint )
   {
-    for ( const QString &layerId : changes.keys() )
+    for ( auto itChange = changes.constBegin(); itChange != changes.constEnd(); itChange++ )
     {
-      mFeaturePools[layerId]->layer()->triggerRepaint();
+      mFeaturePools[itChange.key()]->layer()->triggerRepaint();
     }
   }
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
@@ -56,7 +56,7 @@ class ANALYSIS_EXPORT QgsGeometryChecker : public QObject
     QStringList getMessages() const { return mMessages; }
     void setMergeAttributeIndices( const QMap<QString, int> &mergeAttributeIndices ) { mMergeAttributeIndices = mergeAttributeIndices; }
     QgsGeometryCheckContext *getContext() const { return mContext; }
-    const QMap<QString, QgsFeaturePool *> featurePools() const {return mFeaturePools;}
+    const QMap<QString, QgsFeaturePool *> &featurePools() const {return mFeaturePools;}
 
   signals:
     void errorAdded( QgsGeometryCheckError *error );

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
@@ -274,10 +274,10 @@ void QgsMapToolsDigitizingTechniqueManager::enableDigitizingTechniqueActions( bo
     {
       if ( triggeredFromToolAction == tool->action() || ( !triggeredFromToolAction && QgisApp::instance()->mapCanvas()->mapTool() == tool ) )
       {
-        for ( Qgis::CaptureTechnique technique : mTechniqueActions.keys() )
+        for ( auto technique = mTechniqueActions.keyBegin(); technique != mTechniqueActions.keyEnd(); technique++ )
         {
-          if ( tool->supportsTechnique( technique ) )
-            supportedTechniques.insert( technique );
+          if ( tool->supportsTechnique( *technique ) )
+            supportedTechniques.insert( *technique );
         }
         break;
       }

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1984,9 +1984,8 @@ void QgsMapToolEditMeshFrame::prepareSelection()
   if ( !mSelectedVertices.isEmpty() )
   {
     double vertexZValue = 0;
-    const QList selectVertices = mSelectedVertices.keys();
-    for ( int i : selectVertices )
-      vertexZValue += mapVertex( i ).z();
+    for ( auto i = mSelectedVertices.keyBegin(); i != mSelectedVertices.keyEnd(); i++ )
+      vertexZValue += mapVertex( *i ).z();
     vertexZValue /= mSelectedVertices.count();
 
     if ( !mZValueWidget )
@@ -2168,9 +2167,9 @@ void QgsMapToolEditMeshFrame::updateSelectecVerticesMarker()
 {
   qDeleteAll( mSelectedVerticesMarker );
   mSelectedVerticesMarker.clear();
-  const QList selectVertices = mSelectedVertices.keys();
-  for ( const int vertexIndex : selectVertices )
+  for ( auto it = mSelectedVertices.keyBegin(); it != mSelectedVertices.keyEnd(); it ++ )
   {
+    const int vertexIndex = *it;
     QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
     marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
     marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1293,7 +1293,7 @@ void QgsOptions::checkPageWidgetNameMap()
   traverseModel( QModelIndex() );
 
   Q_ASSERT_X( pageNames.count() == pageTitles.count(),  "QgsOptions::checkPageWidgetNameMap()", QStringLiteral( "QgisApp::optionsPagesMap() is outdated, contains too many entries, "
-              " this is often a problem with missing translations for the entries (extra entries: %1)" ).arg( ( pageNames.keys().toSet() - pageTitles.toSet() ).values().join( ',' ) ).toLocal8Bit().constData() );
+              " this is often a problem with missing translations for the entries (extra entries: %1)" ).arg( qgsSetJoin( QSet( pageNames.keyBegin(), pageNames.keyEnd() ) - pageTitles.toSet(), QStringLiteral( "," ) ) ).toLocal8Bit().constData() );
 
   int page = 0;
   for ( const QString &pageTitle : std::as_const( pageTitles ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6218,7 +6218,7 @@ static QVariant fcnArrayMajority( const QVariantList &values, const QgsExpressio
     if ( hash.isEmpty() )
       return QVariant();
 
-    return QVariant( hash.keys( maxValue ).first() );
+    return QVariant( hash.key( maxValue ) );
   }
   else if ( option.compare( QLatin1String( "median" ), Qt::CaseInsensitive ) == 0 )
   {
@@ -6229,7 +6229,7 @@ static QVariant fcnArrayMajority( const QVariantList &values, const QgsExpressio
     if ( maxValue * 2 <= list.size() )
       return QVariant();
 
-    return QVariant( hash.keys( maxValue ).first() );
+    return QVariant( hash.key( maxValue ) );
   }
   else
   {
@@ -6262,7 +6262,7 @@ static QVariant fcnArrayMinority( const QVariantList &values, const QgsExpressio
     if ( hash.isEmpty() )
       return QVariant();
 
-    return QVariant( hash.keys( minValue ).first() );
+    return QVariant( hash.key( minValue ) );
   }
   else if ( option.compare( QLatin1String( "median" ), Qt::CaseInsensitive ) == 0 )
   {
@@ -6270,7 +6270,7 @@ static QVariant fcnArrayMinority( const QVariantList &values, const QgsExpressio
   }
   else if ( option.compare( QLatin1String( "real_minority" ), Qt::CaseInsensitive ) == 0 )
   {
-    if ( hash.keys().isEmpty() )
+    if ( hash.isEmpty() )
       return QVariant();
 
     // Remove the majority, all others are minority

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -413,19 +413,19 @@ QDomElement QgsMeshRendererSettings::writeXml( QDomDocument &doc, const QgsReadW
   elemActiveDatasetGroup.setAttribute( QStringLiteral( "vector" ), mActiveVectorDatasetGroup );
   elem.appendChild( elemActiveDatasetGroup );
 
-  for ( const int groupIndex : mRendererScalarSettings.keys() )
+  for ( auto groupIndex = mRendererScalarSettings.keyBegin(); groupIndex != mRendererScalarSettings.keyEnd(); groupIndex++ )
   {
-    const QgsMeshRendererScalarSettings &scalarSettings = mRendererScalarSettings[groupIndex];
+    const QgsMeshRendererScalarSettings &scalarSettings = mRendererScalarSettings[*groupIndex];
     QDomElement elemScalar = scalarSettings.writeXml( doc, context );
-    elemScalar.setAttribute( QStringLiteral( "group" ), groupIndex );
+    elemScalar.setAttribute( QStringLiteral( "group" ), *groupIndex );
     elem.appendChild( elemScalar );
   }
 
-  for ( const int groupIndex : mRendererVectorSettings.keys() )
+  for ( auto groupIndex = mRendererVectorSettings.keyBegin(); groupIndex != mRendererVectorSettings.keyEnd(); groupIndex++ )
   {
-    const QgsMeshRendererVectorSettings &vectorSettings = mRendererVectorSettings[groupIndex];
+    const QgsMeshRendererVectorSettings &vectorSettings = mRendererVectorSettings[*groupIndex];
     QDomElement elemVector = vectorSettings.writeXml( doc, context );
-    elemVector.setAttribute( QStringLiteral( "group" ), groupIndex );
+    elemVector.setAttribute( QStringLiteral( "group" ), *groupIndex );
     elem.appendChild( elemVector );
   }
 

--- a/src/core/pointcloud/qgspointcloudstatistics.cpp
+++ b/src/core/pointcloud/qgspointcloudstatistics.cpp
@@ -42,11 +42,11 @@ void QgsPointCloudAttributeStatistics::cumulateStatistics( const QgsPointCloudAt
   mean = newMean;
   count += stats.count;
 
-  for ( int key : stats.classCount.keys() )
+  for ( auto it = stats.classCount.constBegin(); it != stats.classCount.constEnd(); it++ )
   {
-    int c = classCount.value( key, 0 );
-    c += stats.classCount[ key ];
-    classCount[ key ] = c;
+    int c = classCount.value( it.key(), 0 );
+    c += it.value();
+    classCount[ it.key() ] = c;
   }
 }
 
@@ -131,9 +131,10 @@ double QgsPointCloudStatistics::stDev( const QString &attribute ) const
 
 void QgsPointCloudStatistics::combineWith( const QgsPointCloudStatistics &stats )
 {
-  for ( const QString &attribute : stats.mStatisticsMap.keys() )
+  for ( auto it = stats.mStatisticsMap.constBegin(); it != stats.mStatisticsMap.constEnd(); it++ )
   {
-    QgsPointCloudAttributeStatistics s = stats.mStatisticsMap[ attribute ];
+    const QString attribute = it.key();
+    QgsPointCloudAttributeStatistics s = it.value();
     if ( mStatisticsMap.contains( attribute ) )
     {
       s.cumulateStatistics( mStatisticsMap[ attribute ] );
@@ -148,10 +149,10 @@ QByteArray QgsPointCloudStatistics::toStatisticsJson() const
   QJsonObject obj;
   obj.insert( QStringLiteral( "sampled-points" ), QJsonValue::fromVariant( sampledPointsCount() ) );
   QJsonObject stats;
-  for ( const QString &attr : mStatisticsMap.keys() )
+  for ( auto it = mStatisticsMap.constBegin(); it != mStatisticsMap.constEnd(); it++ )
   {
-    QgsPointCloudAttributeStatistics stat = mStatisticsMap.value( attr );
-    stats.insert( attr, attributeStatisticsToJson( stat ) );
+    const QgsPointCloudAttributeStatistics stat = it.value();
+    stats.insert( it.key(), attributeStatisticsToJson( stat ) );
   }
   obj.insert( QStringLiteral( "stats" ), stats );
 
@@ -198,9 +199,9 @@ QJsonObject QgsPointCloudStatistics::attributeStatisticsToJson( const QgsPointCl
     obj.insert( QStringLiteral( "standard-deviation" ), stats.stDev );
   }
   QJsonObject classCount;
-  for ( const int &c : stats.classCount.keys() )
+  for ( auto it = stats.classCount.constBegin(); it != stats.classCount.constEnd(); it++ )
   {
-    classCount.insert( QString::number( c ), stats.classCount[c] );
+    classCount.insert( QString::number( it.key() ), it.value() );
   }
   obj.insert( QStringLiteral( "class-count" ), classCount );
   return obj;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -311,7 +311,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
   }
 
   if ( !broken.empty() )
-    throw QgsProcessingException( QCoreApplication::translate( "QgsProcessingModelAlgorithm", "Cannot run model, the following algorithms are not available on this system: %1" ).arg( broken.values().join( QLatin1String( ", " ) ) ) );
+    throw QgsProcessingException( QCoreApplication::translate( "QgsProcessingModelAlgorithm", "Cannot run model, the following algorithms are not available on this system: %1" ).arg( qgsSetJoin( broken, QLatin1String( ", " ) ) ) );
 
   QElapsedTimer totalTime;
   totalTime.start();

--- a/src/core/project/qgsmapviewsmanager.cpp
+++ b/src/core/project/qgsmapviewsmanager.cpp
@@ -48,7 +48,7 @@ bool QgsMapViewsManager::readXml( const QDomElement &element, const QDomDocument
 QDomElement QgsMapViewsManager::writeXml( QDomDocument &doc ) const
 {
   QDomElement dom = doc.createElement( "mapViewDocks3D" );
-  for ( QDomElement d : m3DMapViewsDom.values() )
+  for ( QDomElement d : m3DMapViewsDom )
     dom.appendChild( d );
   return dom;
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2706,8 +2706,58 @@ inline double qgsRound( double number, int places )
   return ( std::round( number * m * scaleFactor ) / scaleFactor ) * m;
 }
 
-
 #ifndef SIP_RUN
+
+/**
+ * Joins all the \a map keys into a single string with each element separated by the given
+ * \a separator.
+ * This method avoid calling keys() before joining because it creates an unneeded temporary list
+ * see clazy container-anti-pattern
+ */
+template<class Key, class Value>
+QString qgsMapJoinKeys( const QMap<Key, Value> &map, const QString &separator )
+{
+  QString result;
+  for ( auto it = map.constBegin(); it != map.constEnd(); it++ )
+    result += QString( "%1%2" ).arg( it.key() ).arg( separator );
+
+  result.chop( separator.size() );
+  return result;
+}
+
+/**
+ * Joins all the \a map values into a single string with each element separated by the given
+ * \a separator.
+ * This method avoid calling values() before joining because it creates an unneeded temporary list
+ * see clazy container-anti-pattern
+ */
+template<class Key, class Value>
+QString qgsMapJoinValues( const QMap<Key, Value> &map, const QString &separator )
+{
+  QString result;
+  for ( auto it = map.constBegin(); it != map.constEnd(); it++ )
+    result += QString( "%1%2" ).arg( it.value() ).arg( separator );
+
+  result.chop( separator.size() );
+  return result;
+}
+
+/**
+ * Joins all the \a set values into a single string with each element separated by the given
+ * \a separator.
+ * This method avoid calling values() before joining because it creates an unneeded temporary list
+ * see clazy container-anti-pattern
+ */
+template<class T>
+QString qgsSetJoin( const QSet<T> &set, const QString &separator )
+{
+  QString result;
+  for ( auto it = set.constBegin(); it != set.constEnd(); it++ )
+    result += QString( "%1%2" ).arg( *it ).arg( separator );
+
+  result.chop( separator.size() );
+  return result;
+}
 
 ///@cond PRIVATE
 

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -873,8 +873,9 @@ bool QgsDataSourceUri::hasParam( const QString &key ) const
 QSet<QString> QgsDataSourceUri::parameterKeys() const
 {
   QSet<QString> paramKeys;
-  for ( const QString &key : mParams.keys() )
-    paramKeys.insert( key );
+  for ( auto it = mParams.constBegin(); it != mParams.constEnd(); it++ )
+    paramKeys.insert( it.key() );
+
   if ( !mHost.isEmpty() )
     paramKeys.insert( QLatin1String( "host" ) );
   if ( !mPort.isEmpty() )

--- a/src/core/qgsmaplayerstore.cpp
+++ b/src/core/qgsmaplayerstore.cpp
@@ -240,10 +240,10 @@ QMap<QString, QgsMapLayer *> QgsMapLayerStore::mapLayers() const
 QMap<QString, QgsMapLayer *> QgsMapLayerStore::validMapLayers() const
 {
   QMap<QString, QgsMapLayer *> validLayers;
-  for ( const auto &id : mMapLayers.keys() )
+  for ( auto it = mMapLayers.constBegin(); it != mMapLayers.constEnd(); it++ )
   {
-    if ( mMapLayers[id]->isValid() )
-      validLayers[id] = mMapLayers[id];
+    if ( it.value()->isValid() )
+      validLayers[it.key()] = it.value();
   }
   return validLayers;
 }

--- a/src/core/qgsstringstatisticalsummary.h
+++ b/src/core/qgsstringstatisticalsummary.h
@@ -159,7 +159,7 @@ class CORE_EXPORT QgsStringStatisticalSummary
      * Returns the number of distinct string values.
      * \see distinctValues()
      */
-    int countDistinct() const { return mValues.keys().count(); }
+    int countDistinct() const { return mValues.count(); }
 
     /**
      * Returns the set of distinct string values.

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -331,7 +331,7 @@ QVariant QgsVectorLayerUtils::createUniqueValueFromCache( const QgsVectorLayer *
         {
           // no base seed - fetch first value from layer
           QgsFeatureRequest req;
-          base = existingValues.isEmpty() ? QString() : existingValues.values().first().toString();
+          base = existingValues.isEmpty() ? QString() : existingValues.constBegin()->toString();
         }
 
         // try variants like base_1, base_2, etc until a new value found

--- a/src/core/vectortile/qgsvectortilebasiclabeling.cpp
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.cpp
@@ -223,9 +223,9 @@ void QgsVectorTileBasicLabelProvider::registerTileFeatures( const QgsVectorTileR
     if ( layerStyle.layerName().isEmpty() )
     {
       // matching all layers
-      for ( QString layerName : tileData.keys() )
+      for ( const auto &features : tileData )
       {
-        for ( const QgsFeature &f : tileData[layerName] )
+        for ( const QgsFeature &f : features )
         {
           scope->setFeature( f );
           if ( filterExpression.isValid() && !filterExpression.evaluate( &context.expressionContext() ).toBool() )

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -191,9 +191,9 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
     else if ( layerStyle.layerName().isEmpty() )
     {
       // matching all layers
-      for ( QString layerName : tileData.keys() )
+      for ( const auto &features : tileData )
       {
-        for ( const QgsFeature &f : tileData[layerName] )
+        for ( const QgsFeature &f : features )
         {
           scope->setFeature( f );
           if ( filterExpression.isValid() && !filterExpression.evaluate( &context.expressionContext() ).toBool() )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -808,11 +808,11 @@ void QgsRelationReferenceWidget::filterChanged()
           QgsAttributeList subset = attrs;
 
           QString expression = filterExpression;
-          if ( ! filterExpression.isEmpty() && ! filtersAttrs.values().isEmpty() )
+          if ( ! filterExpression.isEmpty() && ! filtersAttrs.isEmpty() )
             expression += QLatin1String( " AND " );
 
           expression += filtersAttrs.isEmpty() ? QString() : QStringLiteral( " ( " );
-          expression += filtersAttrs.values().join( QLatin1String( " AND " ) );
+          expression += qgsMapJoinValues( filtersAttrs, QLatin1String( " AND " ) );
           expression += filtersAttrs.isEmpty() ? QString() : QStringLiteral( " ) " );
 
           subset << mReferencedLayer->fields().lookupField( fieldName );
@@ -844,11 +844,11 @@ void QgsRelationReferenceWidget::filterChanged()
     }
   }
 
-  if ( ! filterExpression.isEmpty() && ! filters.values().isEmpty() )
+  if ( ! filterExpression.isEmpty() && ! filters.isEmpty() )
     filterExpression += QLatin1String( " AND " );
 
   filterExpression += filters.isEmpty() ? QString() : QStringLiteral( " ( " );
-  filterExpression += filters.values().join( QLatin1String( " AND " ) );
+  filterExpression += qgsMapJoinValues( filters, QLatin1String( " AND " ) );
   filterExpression += filters.isEmpty() ? QString() : QStringLiteral( " ) " );
 
   mComboBox->setFilterExpression( filterExpression );

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -140,9 +140,9 @@ void QgsValueMapConfigDlg::removeSelectedButtonPushed()
       }
     }
   }
-  for ( i = 0; i < rowsToRemove.size(); i++ )
+  for ( const int rowToRemoved : rowsToRemove )
   {
-    tableWidget->removeRow( rowsToRemove.values().at( i ) - removed );
+    tableWidget->removeRow( rowToRemoved - removed );
     removed++;
   }
   emit changed();

--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
@@ -133,10 +133,10 @@ void QgsProcessingMeshDatasetGroupsWidget::showDialog()
   }
   else
   {
-    for ( int i : mDatasetGroupsNames.keys() )
+    for ( auto it = mDatasetGroupsNames.constBegin(); it != mDatasetGroupsNames.constEnd(); it++ )
     {
-      availableOptions.append( i );
-      options.append( mDatasetGroupsNames.value( i ) );
+      availableOptions.append( it.key() );
+      options.append( it.value() );
     }
   }
 
@@ -652,11 +652,11 @@ void QgsProcessingMeshDatasetTimeWidget::populateTimeSteps()
     }
   }
 
-  for ( qint64 key : timeStep.keys() )
+  for ( auto it = timeStep.constBegin(); it != timeStep.constEnd(); it++ )
   {
-    QString stringTime = QgsMeshLayerUtils::formatTime( key / 1000 / 3600, mReferenceTime, QgsMeshTimeSettings() );
+    QString stringTime = QgsMeshLayerUtils::formatTime( it.key() / 1000 / 3600, mReferenceTime, QgsMeshTimeSettings() );
     QVariantList data;
-    const QgsMeshDatasetIndex &index = timeStep.value( key );
+    const QgsMeshDatasetIndex &index = it.value();
     data << index.group() << index.dataset();
     whileBlocking( comboBoxDatasetTimeStep )->addItem( stringTime, data );
   }
@@ -688,11 +688,11 @@ void QgsProcessingMeshDatasetTimeWidget::populateTimeStepsFromLayer()
     }
   }
 
-  for ( qint64 key : timeStep.keys() )
+  for ( auto it = timeStep.constBegin(); it != timeStep.constEnd(); it++ )
   {
-    QString stringTime = mMeshLayer->formatTime( key / 1000.0 / 3600.0 );
+    QString stringTime = mMeshLayer->formatTime( it.key() / 1000.0 / 3600.0 );
     QVariantList data;
-    const QgsMeshDatasetIndex &index = timeStep.value( key );
+    const QgsMeshDatasetIndex &index = it.value();
     data << index.group() << index.dataset();
     whileBlocking( comboBoxDatasetTimeStep )->addItem( stringTime, data );
   }
@@ -888,4 +888,3 @@ QgsProcessingParameterDefinition *QgsProcessingMeshDatasetTimeParameterDefinitio
 }
 
 ///@endcond
-

--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
@@ -654,7 +654,7 @@ void QgsProcessingMeshDatasetTimeWidget::populateTimeSteps()
 
   for ( auto it = timeStep.constBegin(); it != timeStep.constEnd(); it++ )
   {
-    QString stringTime = QgsMeshLayerUtils::formatTime( it.key() / 1000 / 3600, mReferenceTime, QgsMeshTimeSettings() );
+    QString stringTime = QgsMeshLayerUtils::formatTime( static_cast<double>( it.key() ) / 1000. / 3600., mReferenceTime, QgsMeshTimeSettings() );
     QVariantList data;
     const QgsMeshDatasetIndex &index = it.value();
     data << index.group() << index.dataset();
@@ -690,7 +690,7 @@ void QgsProcessingMeshDatasetTimeWidget::populateTimeStepsFromLayer()
 
   for ( auto it = timeStep.constBegin(); it != timeStep.constEnd(); it++ )
   {
-    QString stringTime = mMeshLayer->formatTime( it.key() / 1000.0 / 3600.0 );
+    QString stringTime = mMeshLayer->formatTime( static_cast<double>( it.key() ) / 1000.0 / 3600.0 );
     QVariantList data;
     const QgsMeshDatasetIndex &index = it.value();
     data << index.group() << index.dataset();

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -133,7 +133,7 @@ namespace QgsGuiUtils
     QString outputFileName;
     QString ext;
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_LINUX)
-    outputFileName = QFileDialog::getSaveFileName( parent, message, initialPath, QStringList( filterMap.keys() ).join( QLatin1String( ";;" ) ), &selectedFilter );
+    outputFileName = QFileDialog::getSaveFileName( parent, message, initialPath, qgsMapJoinKeys( filterMap, QStringLiteral( ";;" ) ), &selectedFilter );
 
     if ( !outputFileName.isNull() )
     {
@@ -145,7 +145,7 @@ namespace QgsGuiUtils
 #else
 
     //create a file dialog using the filter list generated above
-    std::unique_ptr<QFileDialog> fileDialog( new QFileDialog( parent, message, initialPath, QStringList( filterMap.keys() ).join( ";;" ) ) );
+    std::unique_ptr<QFileDialog> fileDialog( new QFileDialog( parent, message, initialPath, qgsMapJoinKeys( filterMap, QStringLiteral( ";;" ) ) ) );
 
     // allow for selection of more than one file
     fileDialog->setFileMode( QFileDialog::AnyFile );

--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
@@ -286,11 +286,12 @@ void QgsOptionsDialogHighlightTree::reset()
       item->setHidden( !mTreeInitialVisible.value( item, true ) );
     };
     showChildren( treeWidget->invisibleRootItem() );
-    for ( QTreeWidgetItem *item : mTreeInitialExpand.keys() )
+    for ( auto it = mTreeInitialExpand.constBegin(); it != mTreeInitialExpand.constEnd(); it++ )
     {
+      QTreeWidgetItem *item = it.key();
       if ( item )
       {
-        item->setExpanded( mTreeInitialExpand.value( item ) );
+        item->setExpanded( it.value() );
       }
     }
     mTreeInitialExpand.clear();

--- a/src/gui/vector/qgswmsdimensiondialog.cpp
+++ b/src/gui/vector/qgswmsdimensiondialog.cpp
@@ -63,9 +63,9 @@ QgsWmsDimensionDialog::QgsWmsDimensionDialog( QgsVectorLayer *layer, QStringList
   // Set default display combobox
   mDefaultDisplayComboBox->clear();
   QMap<int, QString> defaultDisplayLabels = QgsMapLayerServerProperties::wmsDimensionDefaultDisplayLabels();
-  for ( const int &k : defaultDisplayLabels.keys() )
+  for ( auto it = defaultDisplayLabels.constBegin(); it != defaultDisplayLabels.constEnd(); it++ )
   {
-    mDefaultDisplayComboBox->addItem( defaultDisplayLabels[k], QVariant( k ) );
+    mDefaultDisplayComboBox->addItem( it.value(), QVariant( it.key() ) );
   }
   // Set default display to All values
   mDefaultDisplayComboBox->setCurrentIndex( mDefaultDisplayComboBox->findData( QVariant( QgsMapLayerServerProperties::WmsDimensionInfo::AllValues ) ) );

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -89,7 +89,7 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface *iface, 
   connect( ui.pushButtonExport, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::exportErrors );
 
   bool allLayersEditable = true;
-  for ( const QgsFeaturePool *featurePool : mChecker->featurePools().values() )
+  for ( const QgsFeaturePool *featurePool : mChecker->featurePools() )
   {
     if ( ( featurePool->layer()->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeGeometries ) == 0 )
     {
@@ -453,10 +453,11 @@ void QgsGeometryCheckerResultTab::openAttributeTable()
   {
     return;
   }
-  for ( const QString &layerId : ids.keys() )
+  for ( auto it = ids.constBegin(); it != ids.constEnd(); it++ )
   {
+    const QString layerId = it.key();
     QStringList expr;
-    for ( QgsFeatureId id : ids[layerId] )
+    for ( QgsFeatureId id : it.value() )
     {
       expr.append( QStringLiteral( "$id = %1 " ).arg( id ) );
     }
@@ -536,9 +537,9 @@ void QgsGeometryCheckerResultTab::fixErrors( bool prompt )
     ui.progressBarFixErrors->setVisible( false );
     unsetCursor();
   }
-  for ( const QString &layerId : mChecker->featurePools().keys() )
+  for ( const QgsFeaturePool *featurePool : mChecker->featurePools() )
   {
-    mChecker->featurePools()[layerId]->layer()->triggerRepaint();
+    featurePool->layer()->triggerRepaint();
   }
 
   if ( mStatistics.itemCount() > 0 )
@@ -629,9 +630,10 @@ void QgsGeometryCheckerResultTab::storeDefaultResolutionMethod( int id ) const
 void QgsGeometryCheckerResultTab::checkRemovedLayer( const QStringList &ids )
 {
   bool requiredLayersRemoved = false;
-  for ( const QString &layerId : mChecker->featurePools().keys() )
+  const QMap<QString, QgsFeaturePool *> &featurePools = mChecker->featurePools();
+  for ( auto it = featurePools.constBegin(); it != featurePools.constEnd(); it++ )
   {
-    if ( ids.contains( layerId ) )
+    if ( ids.contains( it.key() ) )
     {
       if ( isEnabled() )
         requiredLayersRemoved = true;

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -461,7 +461,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
     featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, selectedOnly ) );
   }
   // LineLayerIntersection check is enabled, make sure there is also a feature pool for that layer
-  if ( ui.checkLineLayerIntersection->isChecked() && !featurePools.keys().contains( ui.comboLineLayerIntersection->currentData().toString() ) )
+  if ( ui.checkLineLayerIntersection->isChecked() && !featurePools.contains( ui.comboLineLayerIntersection->currentData().toString() ) )
   {
     QgsVectorLayer *layer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( ui.comboLineLayerIntersection->currentData().toString() );
     Q_ASSERT( layer );

--- a/src/providers/hana/qgshanaconnection.cpp
+++ b/src/providers/hana/qgshanaconnection.cpp
@@ -63,9 +63,8 @@ namespace
     }
     rsStats->close();
 
-    for ( const QString &key : compositeKeys.keys() )
+    for ( const QStringList &indexColumns : compositeKeys )
     {
-      const QStringList indexColumns = compositeKeys.value( key );
       if ( indexColumns.size() <= 1 )
         continue;
       for ( const QString &clmName : indexColumns )

--- a/src/providers/hana/qgshanasettings.cpp
+++ b/src/providers/hana/qgshanasettings.cpp
@@ -307,10 +307,9 @@ void QgsHanaSettings::save()
       const auto &schemaKeys = mKeyColumns[schemaName];
       if ( schemaKeys.empty() )
         continue;
-      const QStringList objectNames = schemaKeys.keys();
       settings.beginGroup( schemaName );
-      for ( const QString &objectName : objectNames )
-        settings.setValue( objectName, schemaKeys[objectName] );
+      for ( auto it = schemaKeys.constBegin(); it != schemaKeys.constEnd(); it++ )
+        settings.setValue( it.key(), it.value() );
       settings.endGroup();
     }
     settings.endGroup();

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -544,7 +544,7 @@ bool QgsWmsProvider::setImageCrs( QString const &crs )
 
       if ( mSettings.mTileMatrixSetId.isEmpty() && tl->setLinks.size() == 1 )
       {
-        QString tms = tl->setLinks.keys()[0];
+        QString tms = tl->setLinks.constBegin().key();
 
         if ( !mCaps.mTileMatrixSets.contains( tms ) )
         {
@@ -579,8 +579,8 @@ bool QgsWmsProvider::setImageCrs( QString const &crs )
       }
       if ( !mTileMatrixSet->tileMatrices.empty() )
       {
-        setProperty( "tileWidth", mTileMatrixSet->tileMatrices.values().first().tileWidth );
-        setProperty( "tileHeight", mTileMatrixSet->tileMatrices.values().first().tileHeight );
+        setProperty( "tileWidth", mTileMatrixSet->tileMatrices.first().tileWidth );
+        setProperty( "tileHeight", mTileMatrixSet->tileMatrices.first().tileHeight );
       }
     }
     else

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1165,9 +1165,12 @@ void QgsWMSSourceSelect::filterLayers( const QString &searchText )
   {
     // show everything and reset tree nesting
     setChildrenVisible( lstLayers->invisibleRootItem(), true );
-    for ( QTreeWidgetItem *item : mTreeInitialExpand.keys() )
+    for ( auto it = mTreeInitialExpand.constBegin(); it != mTreeInitialExpand.constEnd(); it++ )
+    {
+      QTreeWidgetItem *item = it.key();
       if ( item )
-        item->setExpanded( mTreeInitialExpand.value( item ) );
+        item->setExpanded( it.value() );
+    }
     mTreeInitialExpand.clear();
   }
   else

--- a/src/server/qgscapabilitiescache.cpp
+++ b/src/server/qgscapabilitiescache.cpp
@@ -99,10 +99,11 @@ void QgsCapabilitiesCache::removeChangedEntry( const QString &path )
 void QgsCapabilitiesCache::removeOutdatedEntries()
 {
   QgsDebugMsg( QStringLiteral( "Checking for outdated entries" ) );
-  for ( const QString &configFilePath : mCachedCapabilitiesTimestamps.keys() )
+  for ( auto it = mCachedCapabilitiesTimestamps.constBegin(); it != mCachedCapabilitiesTimestamps.constEnd(); it++ )
   {
+    const QString configFilePath = it.key();
     const QFileInfo fi( configFilePath );
-    if ( !fi.exists() || mCachedCapabilitiesTimestamps[ configFilePath ] < fi.lastModified() )
+    if ( !fi.exists() || it.value() < fi.lastModified() )
       removeChangedEntry( configFilePath );
   }
 

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -108,7 +108,7 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
   setMethod( method );
 
   // Fill the headers dictionary
-  for ( const auto &headerKey : qgsEnumMap<QgsServerRequest::RequestHeader>().values() )
+  for ( const auto &headerKey : qgsEnumMap<QgsServerRequest::RequestHeader>() )
   {
     const QString headerName = QgsStringUtils::capitalize(
                                  QString( headerKey ).replace( QLatin1Char( '_' ), QLatin1Char( ' ' ) ), Qgis::Capitalization::TitleCase
@@ -256,9 +256,10 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
 
   qDebug() << "Headers:";
   qDebug() << "------------------------------------------------";
-  for ( const auto &headerName : headers().keys() )
+  const QMap<QString, QString> &hdrs = headers();
+  for ( auto it = hdrs.constBegin(); it != hdrs.constEnd(); it++ )
   {
-    qDebug() << headerName << ": " << headers().value( headerName );
+    qDebug() << it.key() << ": " << it.value();
   }
 }
 

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -334,7 +334,7 @@ namespace QgsWfs
       transactionUpdate &action = *tuIt;
       QString typeName = action.typeName;
 
-      if ( !mapLayerMap.keys().contains( typeName ) )
+      if ( !mapLayerMap.contains( typeName ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -552,7 +552,7 @@ namespace QgsWfs
       transactionDelete &action = *tdIt;
       QString typeName = action.typeName;
 
-      if ( !mapLayerMap.keys().contains( typeName ) )
+      if ( !mapLayerMap.contains( typeName ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -670,7 +670,7 @@ namespace QgsWfs
       transactionInsert &action = *tiIt;
       QString typeName = action.typeName;
 
-      if ( !mapLayerMap.keys().contains( typeName ) )
+      if ( !mapLayerMap.contains( typeName ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -1310,5 +1310,3 @@ namespace QgsWfs
   }
 
 } // namespace QgsWfs
-
-

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -311,7 +311,7 @@ namespace QgsWfs
         transactionUpdate &action = *tuIt;
         QString typeName = action.typeName;
 
-        if ( !mapLayerMap.keys().contains( typeName ) )
+        if ( !mapLayerMap.contains( typeName ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -528,7 +528,7 @@ namespace QgsWfs
         transactionDelete &action = *tdIt;
         QString typeName = action.typeName;
 
-        if ( !mapLayerMap.keys().contains( typeName ) )
+        if ( !mapLayerMap.contains( typeName ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -645,7 +645,7 @@ namespace QgsWfs
         transactionInsert &action = *tiIt;
         QString typeName = action.typeName;
 
-        if ( !mapLayerMap.keys().contains( typeName ) )
+        if ( !mapLayerMap.contains( typeName ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "TypeName '%1' unknown" ).arg( typeName );
@@ -1292,5 +1292,3 @@ namespace QgsWfs
 
   } // namespace v1_0_0
 } // namespace QgsWfs
-
-

--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -73,8 +73,10 @@ QgsLayerRestorer::QgsLayerRestorer( const QList<QgsMapLayer *> &layers )
 
 QgsLayerRestorer::~QgsLayerRestorer()
 {
-  for ( QgsMapLayer *layer : mLayerSettings.keys() )
+  for ( auto it = mLayerSettings.constBegin(); it != mLayerSettings.constEnd(); it++ )
   {
+    QgsMapLayer *layer = it.key();
+
     // Firstly check if a SLD file has been loaded for rendering and removed it
     const QString sldStyleName { layer->customProperty( "sldStyleName", "" ).toString() };
     if ( !sldStyleName.isEmpty() )
@@ -84,9 +86,9 @@ QgsLayerRestorer::~QgsLayerRestorer()
     }
 
     // Then restore the previous style
-    const QgsLayerSettings settings = mLayerSettings[layer];
+    const QgsLayerSettings settings = it.value();
     layer->styleManager()->setCurrentStyle( settings.mNamedStyle );
-    layer->setName( mLayerSettings[layer].name );
+    layer->setName( it.value().name );
 
     switch ( layer->type() )
     {

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -499,16 +499,17 @@ namespace QgsWmts
 
           //wmts:TileMatrixSetLimits
           QDomElement tmsLimitsElement = doc.createElement( QStringLiteral( "TileMatrixSetLimits" )/*wmts:TileMatrixSetLimits*/ );
-          for ( const int tmIdx : tmsl.tileMatrixLimits.keys() )
+
+          for ( auto it = tmsl.tileMatrixLimits.constBegin(); it != tmsl.tileMatrixLimits.constEnd(); it++ )
           {
             QDomElement tmLimitsElement = doc.createElement( QStringLiteral( "TileMatrixLimits" )/*wmts:TileMatrixLimits*/ );
 
             QDomElement tmIdentifierElem = doc.createElement( QStringLiteral( "TileMatrix" ) );
-            const QDomText tmIdentifierText = doc.createTextNode( QString::number( tmIdx ) );
+            const QDomText tmIdentifierText = doc.createTextNode( QString::number( it.key() ) );
             tmIdentifierElem.appendChild( tmIdentifierText );
             tmLimitsElement.appendChild( tmIdentifierElem );
 
-            const tileMatrixLimitDef tml = tmsl.tileMatrixLimits[tmIdx];
+            const tileMatrixLimitDef tml = it.value();
 
             QDomElement minTileColElem = doc.createElement( QStringLiteral( "MinTileCol" ) );
             const QDomText minTileColText = doc.createTextNode( QString::number( tml.minCol ) );
@@ -626,6 +627,3 @@ namespace QgsWmts
   } // namespace
 
 } // namespace QgsWmts
-
-
-

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -98,8 +98,10 @@ void TestQgisAppClipboard::copyPaste()
   filesCounts.insert( QStringLiteral( "lines.shp" ), 6 );
   filesCounts.insert( QStringLiteral( "polys.shp" ), 10 );
 
-  for ( const QString &fileName : filesCounts.keys() )
+  for ( auto it = filesCounts.constBegin(); it != filesCounts.constEnd(); it++ )
   {
+    const QString fileName = it.key();
+
     // add vector layer
     const QString filePath = mTestDataDir + fileName;
     qDebug() << "add vector layer: " << filePath;
@@ -113,13 +115,13 @@ void TestQgisAppClipboard::copyPaste()
     const QgsFeatureList features = mQgisApp->clipboard()->copyOf();
     qDebug() << features.size() << " features copied to clipboard";
 
-    QVERIFY( features.size() == filesCounts.value( fileName ) );
+    QVERIFY( features.size() == it.value() );
 
     QgsVectorLayer *pastedLayer = mQgisApp->pasteAsNewMemoryVector( QStringLiteral( "pasted" ) );
     QVERIFY( pastedLayer );
     QVERIFY( pastedLayer->isValid() );
     qDebug() << pastedLayer->featureCount() << " features in pasted layer";
-    QVERIFY( pastedLayer->featureCount() == filesCounts.value( fileName ) );
+    QVERIFY( pastedLayer->featureCount() == it.value() );
   }
 }
 

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -67,7 +67,8 @@ class TestQgis : public QgsTest
     void testQgsFlagValueToKeys();
     void testQgsFlagKeysToValue();
     void testQMapQVariantList();
-
+    void testQgsMapJoin();
+    void testQgsSetJoin();
 };
 
 void TestQgis::permissiveToDouble()
@@ -528,6 +529,49 @@ void TestQgis::testQMapQVariantList()
 
   QVERIFY( it != ids.constEnd() );
   QCOMPARE( it.value(), 5L );
+}
+
+void TestQgis::testQgsMapJoin()
+{
+  QMap< QString, int> map;
+
+  map.insert( "tutu", 3 );
+  map.insert( "titi", 4 );
+  map.insert( "tata", 5 );
+
+  QString res = qgsMapJoinValues( map, QStringLiteral( ", " ) );
+
+  QRegularExpression re( "[3|4|5], [3|4|5], [3|4|5]" );
+  QVERIFY( re.match( res ).hasMatch() );
+  QVERIFY( res.contains( "3" ) );
+  QVERIFY( res.contains( "4" ) );
+  QVERIFY( res.contains( "5" ) );
+
+  res = qgsMapJoinKeys( map, QStringLiteral( ", " ) );
+
+  re.setPattern( "(tutu|titi|tata), (tutu|titi|tata), (tutu|titi|tata)" );
+  QVERIFY( re.match( res ).hasMatch() );
+  QVERIFY( res.contains( "tutu" ) );
+  QVERIFY( res.contains( "titi" ) );
+  QVERIFY( res.contains( "tata" ) );
+}
+
+void TestQgis::testQgsSetJoin()
+{
+  QSet<int> set;
+
+  set.insert( 3 );
+  set.insert( 4 );
+  set.insert( 4 );
+  set.insert( 5 );
+
+  const QString res = qgsSetJoin( set, QStringLiteral( ", " ) );
+
+  QRegularExpression re( "[3|4|5], [3|4|5], [3|4|5]" );
+  QVERIFY( re.match( res ).hasMatch() );
+  QVERIFY( res.contains( "3" ) );
+  QVERIFY( res.contains( "4" ) );
+  QVERIFY( res.contains( "5" ) );
 }
 
 

--- a/tests/src/core/testqgsauthmanager.cpp
+++ b/tests/src/core/testqgsauthmanager.cpp
@@ -253,9 +253,10 @@ void TestQgsAuthManager::testAuthConfigs()
     QVERIFY( config == config2 );
 
     // changed config should update then correctly roundtrip
-    for ( const QString &key : config2.configMap().keys() )
+    const QgsStringMap configMap = config2.configMap();
+    for ( auto it = configMap.constBegin(); it != configMap.constEnd(); it++ )
     {
-      config2.setConfig( key, config2.configMap().value( key ) + "changed" );
+      config2.setConfig( it.key(), it.value() + "changed" );
     }
     config2.setName( config2.name() + "changed" );
     config2.setUri( config2.uri() + "changed" );

--- a/tests/src/core/testqgscompositionconverter.cpp
+++ b/tests/src/core/testqgscompositionconverter.cpp
@@ -385,7 +385,7 @@ void TestQgsCompositionConverter::importComposerTemplateMap()
 
   item->setLayers( project.mapLayers().values() );
 
-  for ( auto const &l : project.mapLayers().values() )
+  for ( auto const &l : project.mapLayers() )
   {
     QVERIFY( l->isValid() );
   }

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -354,8 +354,11 @@ void TestQgsMapLayer::styleCategories()
 {
   // control that AllStyleCategories is actually complete
   const QgsMapLayer::StyleCategories allStyleCategories = QgsMapLayer::AllStyleCategories;
-  for ( const QgsMapLayer::StyleCategory category : qgsEnumMap<QgsMapLayer::StyleCategory>().keys() )
+
+  const QMap<QgsMapLayer::StyleCategory, QString> styleCats = qgsEnumMap<QgsMapLayer::StyleCategory>();
+  for ( auto it = styleCats.keyBegin(); it != styleCats.keyEnd(); it++ )
   {
+    const QgsMapLayer::StyleCategory category = *it;
     if ( category == QgsMapLayer::AllStyleCategories )
       continue;
 

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1016,7 +1016,7 @@ void TestQgsMeshLayer::test_path()
   QCOMPARE( layers1.count(), 1 );
 
   // Check if the mesh is still here but invalid
-  QgsMeshLayer *meshLayer1 = qobject_cast<QgsMeshLayer *>( layers1.values().at( 0 ) );
+  QgsMeshLayer *meshLayer1 = qobject_cast<QgsMeshLayer *>( layers1.first() );
   QVERIFY( meshLayer1 );
   QVERIFY( !meshLayer1->isValid() );
   QCOMPARE( meshLayer1->name(), QStringLiteral( "mesh layer" ) );
@@ -1028,7 +1028,7 @@ void TestQgsMeshLayer::test_path()
   QMap<QString, QgsMapLayer *> layers2 = project2.mapLayers();
   QCOMPARE( layers2.count(), 1 );
 
-  QgsMeshLayer *meshLayer2 = qobject_cast<QgsMeshLayer *>( layers2.values().at( 0 ) );
+  QgsMeshLayer *meshLayer2 = qobject_cast<QgsMeshLayer *>( layers2.first() );
   QVERIFY( meshLayer2 );
   QVERIFY( meshLayer2->isValid() );
   QCOMPARE( meshLayer2->name(), QStringLiteral( "mesh layer" ) );

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -475,10 +475,12 @@ void TestQgsRasterLayer::checkScaleOffset()
   if ( identifyResult.isValid() )
   {
     const QMap<int, QVariant> values = identifyResult.results();
-    for ( const int bandNo : values.keys() )
+    for ( auto it = values.constBegin(); it != values.constEnd(); it++ )
     {
+      const int bandNo = it.key();
+
       QString valueString;
-      if ( values.value( bandNo ).isNull() )
+      if ( it.value().isNull() )
       {
         valueString = tr( "no data" );
         mReport += QStringLiteral( " %1 = %2 <br>\n" ).arg( myProvider->generateBandName( bandNo ), valueString );
@@ -488,7 +490,7 @@ void TestQgsRasterLayer::checkScaleOffset()
       else
       {
         const double expected = 0.99995432;
-        const double value = values.value( bandNo ).toDouble();
+        const double value = it.value().toDouble();
         valueString = QgsRasterBlock::printValue( value );
         mReport += QStringLiteral( " %1 = %2 <br>\n" ).arg( myProvider->generateBandName( bandNo ), valueString );
         mReport += QStringLiteral( " value = %1 expected = %2 diff = %3 <br>\n" ).arg( value ).arg( expected ).arg( std::fabs( value - expected ) );

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -382,9 +382,9 @@ void TestQgsCopcProvider::testIdentify()
     expected[ QStringLiteral( "Z" ) ] = 75.0;
     // compare values using toDouble() so that fuzzy comparison is used in case of
     // tiny rounding errors (e.g. 74.6 vs 74.60000000000001)
-    for ( const QString &k : expected.keys() )
+    for ( auto it = expected.constBegin(); it != expected.constEnd(); it++ )
     {
-      QCOMPARE( identifiedPoint[k].toDouble(), expected[k].toDouble() );
+      QCOMPARE( identifiedPoint[it.key()].toDouble(), it.value().toDouble() );
     }
   }
 

--- a/tests/src/providers/testqgswcspublicservers.cpp
+++ b/tests/src/providers/testqgswcspublicservers.cpp
@@ -306,9 +306,9 @@ void TestQgsWcsPublicServers::test()
       }
       myServerUri.setParam( QStringLiteral( "cache" ), QStringLiteral( "AlwaysNetwork" ) );
 
-      for ( const QString &key : myServer.params.keys() )
+      for ( auto it = myServer.params.constBegin(); it != myServer.params.constEnd(); it++ )
       {
-        myServerUri.setParam( key, myServer.params.value( key ) );
+        myServerUri.setParam( it.key(), it.value() );
       }
 
       QgsWcsCapabilities myCapabilities;
@@ -573,9 +573,9 @@ void TestQgsWcsPublicServers::report()
     if ( !myServer.params.isEmpty() )
     {
       myReport += QLatin1String( "<br>Additional params: " );
-      for ( const QString &key : myServer.params.keys() )
+      for ( auto it = myServer.params.constBegin(); it != myServer.params.constEnd(); it++ )
       {
-        myReport += key + '=' + myServer.params.value( key ) + " ";
+        myReport += it.key() + '=' + it.value() + " ";
       }
       myReport += QLatin1String( "<br>\n" );
     }


### PR DESCRIPTION
This allows to avoid the call to .keys() et .values() on QSet/QMap/QMap which create unneeded temporary data structure.
