### PR TITLE
[Clazy] Fix qenums check and make it mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,7 +887,7 @@ if (WITH_CORE)
   if (WITH_CLAZY)
     set(CMAKE_CXX_BASE_FLAGS "${CMAKE_CXX_FLAGS}")
     #  qcolor-from-literal crashes clang with clazy 1.11
-    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count,missing-qobject-macro")
+    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count,missing-qobject-macro,qenums")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_BASE_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_BASE_CHECKS}")
 
     if (WERROR AND NOT ${QGISDEBUG})

--- a/external/o2/src/o2.h
+++ b/external/o2/src/o2.h
@@ -16,7 +16,6 @@ class O2ReplyServer;
 /// Simple OAuth2 authenticator.
 class O0_EXPORT O2: public O0BaseAuth {
     Q_OBJECT
-    Q_ENUMS(GrantFlow)
 
 public:
     /// Authorization flow types.
@@ -25,6 +24,7 @@ public:
         GrantFlowImplicit, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.2
         GrantFlowResourceOwnerPasswordCredentials,
     };
+    Q_ENUM(GrantFlow)
 
     /// Authorization flow.
     Q_PROPERTY(GrantFlow grantFlow READ grantFlow WRITE setGrantFlow NOTIFY grantFlowChanged)

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -30,10 +30,7 @@
 class QgsAuthOAuth2Config : public QObject
 {
     Q_OBJECT
-    Q_ENUMS( ConfigType )
-    Q_ENUMS( GrantFlow )
-    Q_ENUMS( ConfigFormat )
-    Q_ENUMS( AccessMethod )
+
     Q_PROPERTY( QString id READ id WRITE setId NOTIFY idChanged )
     Q_PROPERTY( int version READ version WRITE setVersion NOTIFY versionChanged )
     Q_PROPERTY( ConfigType configType READ configType WRITE setConfigType NOTIFY configTypeChanged )
@@ -65,6 +62,7 @@ class QgsAuthOAuth2Config : public QObject
       Predefined,
       Custom,
     };
+    Q_ENUM( ConfigType )
 
     //! OAuth2 grant flow
     enum GrantFlow
@@ -73,12 +71,14 @@ class QgsAuthOAuth2Config : public QObject
       Implicit,      //!< See http://tools.ietf.org/html/rfc6749#section-4.2
       ResourceOwner, //!< See http://tools.ietf.org/html/rfc6749#section-4.3
     };
+    Q_ENUM( GrantFlow )
 
     //! Configuration format for serialize/unserialize operations
     enum ConfigFormat
     {
       JSON,
     };
+    Q_ENUM( ConfigFormat )
 
     //! Access method
     enum AccessMethod
@@ -87,6 +87,7 @@ class QgsAuthOAuth2Config : public QObject
       Form,
       Query,
     };
+    Q_ENUM( AccessMethod )
 
     //! Construct a QgsAuthOAuth2Config instance
     explicit QgsAuthOAuth2Config( QObject *parent = nullptr );


### PR DESCRIPTION
The `Q_ENUMS` macro is obsolete. This PR replaces all `Q_ENUMS` by `Q_ENUM`