### PR TITLE
Avoid endless recursion when evaluating aggregate expressions

### DIFF
--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -82,6 +82,17 @@ std::tuple<QVariant::Type, int> QgsExpressionUtils::determineResultType( const Q
   request.setLimit( 10 );
   request.setExpressionContext( context );
 
+  // avoid endless recursion by removing virtual fields while going through features
+  // to determine result type
+  QgsAttributeList attributes;
+  const QgsFields fields = layer->fields();
+  for ( int i = 0; i < fields.count(); i++ )
+  {
+    if ( fields.fieldOrigin( i ) != QgsFields::OriginExpression )
+      attributes << i;
+  }
+  request.setSubsetOfAttributes( attributes );
+
   QVariant value;
   QgsFeature f;
   QgsFeatureIterator it = layer->getFeatures( request );
@@ -101,5 +112,3 @@ std::tuple<QVariant::Type, int> QgsExpressionUtils::determineResultType( const Q
   value = QVariant();
   return std::make_tuple( value.type(), value.userType() );
 }
-
-

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -434,7 +434,7 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature &f )
 
   if ( guard.hasStackOverflow() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Stack overflow, too many nested feature iterators.\nIterated layers:\n%3\n..." ).arg( mSource->id(), guard.topFrames() ), QObject::tr( "General" ), Qgis::MessageLevel::Critical );
+    QgsMessageLog::logMessage( QObject::tr( "Stack overflow, too many nested feature iterators.\nIterated layers:\n%1\n..." ).arg( guard.topFrames() ), QObject::tr( "General" ), Qgis::MessageLevel::Critical );
     return false;
   }
 


### PR DESCRIPTION
Fixes #49589 : we need to remove virtual/expression fields when we try to determine result type in order to avoid endless recursion that would block later on ogr connection.
