### PR TITLE
Improve selection of PostGIS raster overviews

### DIFF
--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -401,7 +401,8 @@ bool QgsPostgresRasterProvider::readBlock( int bandNo, const QgsRectangle &viewE
     const double yRes = viewExtent.height() / height;
 
     // Find overview
-    const int minPixelSize { static_cast<int>( std::min( xRes, yRes ) ) };
+    const double minPixelSize { std::min( xRes, yRes ) };
+
     // TODO: round?
     const unsigned int desiredOverviewFactor { static_cast<unsigned int>( minPixelSize / std::max( std::abs( mScaleX ), std::abs( mScaleY ) ) ) };
 


### PR DESCRIPTION
## Description

Using an integer `minPixelSize` seems to lead to an inefficient use of overviews.

#### Default layer extent

![im0](https://user-images.githubusercontent.com/9266424/195871669-a6867f15-890b-4a0d-8b34-b78b1675bd39.png)

- on master: `desiredOverviewFactor = 0` -> the layer `mylayer` is rendered (no overview)
- with this MR: `desiredOverviewFactor = 2` -> the layer `o_2_mylayer` is rendered (overview level 2)

#### Unzoom

![im1](https://user-images.githubusercontent.com/9266424/195872219-856ec650-af14-4a60-9712-f0c583664831.png)

- on master: `desiredOverviewFactor = 0` -> the layer `mylayer` is rendered (no overview)
- with this MR: `desiredOverviewFactor = 5` -> the layer `o_4_mylayer` is rendered (overview level 4)

#### Unzoom

![im2](https://user-images.githubusercontent.com/9266424/195872382-acf25cc3-d15b-4464-bedb-4b34e925ca14.png)

- on master: `desiredOverviewFactor = 0` -> the layer `mylayer` is rendered (no overview)
- with this MR: `desiredOverviewFactor = 11` -> the layer `o_8_mylayer` is rendered (overview level 8)

#### Unzoom

![im3](https://user-images.githubusercontent.com/9266424/195872610-6358b95f-b1bd-43e5-bc3d-91422090fe8d.png)

- on master: `desiredOverviewFactor = 0` -> the layer `mylayer` is rendered (no overview)
- with this MR: `desiredOverviewFactor = 21` -> the layer `o_16_mylayer` is rendered (overview level 16)

#### Unzoom

![im4](https://user-images.githubusercontent.com/9266424/195872731-0428767a-bde1-4ca9-83e4-2716232eeb2f.png)

- on master: `desiredOverviewFactor = 81` -> the layer `o_32_mylayer` is rendered (overview level 32)
- with this MR: `desiredOverviewFactor = 43` -> the layer `o_32_mylayer` is rendered (overview level 32)
