### PR TITLE
fix refinement crash when face has more than 4 vertices

### DIFF
--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -320,6 +320,8 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     //! members for split face
     int mSplittableFaceCount = 0;
+    //! menbers for refinement face
+    int mRefinableFaceCount = 0;
 
     // assiociated widget
     QgsZValueWidget *mZValueWidget = nullptr; //own by QgsUserInputWidget instance

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -2022,7 +2022,7 @@ void TestQgsMeshEditor::refineMesh()
     }
   }
   {
-    // Atempt to refine a face with 5 vertices (not allowed)
+    // Attempt to refine a face with 5 vertices (not allowed)
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
@@ -2069,8 +2069,8 @@ void TestQgsMeshEditor::refineMesh()
     refineEditing.createNewBorderFaces( &meshEditor, facesToRefine, facesRefinement, borderFaces );
 
     // refinement not done
-    QCOMPARE( meshEditor.mMesh->faceCount(), 8 );
-    QCOMPARE( meshEditor.mMesh->vertexCount(), 9 );
+    QVERIFY( facesRefinement.isEmpty() );
+    QVERIFY( borderFaces.isEmpty() );
 
     facesList.clear();
     facesList << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7;
@@ -2083,6 +2083,9 @@ void TestQgsMeshEditor::refineMesh()
 
     refineEditing.createNewVerticesAndRefinedFaces( &meshEditor, facesToRefine, facesRefinement );
     refineEditing.createNewBorderFaces( &meshEditor, facesToRefine, facesRefinement, borderFaces );
+
+    QVERIFY( !facesRefinement.isEmpty() );
+    QVERIFY( !borderFaces.isEmpty() );
 
   }
 }


### PR DESCRIPTION
fix #50541
The issue comes from that refinement of faces with vertices count greater than 4 is not allowed.

Also change the UI to not purpose to refine face if its vertices count is greater than 4.

Thanks @uclaros for your tries and to have report it!