### PR TITLE
Fixes spatialite savepoint not removed after rollback.

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -4360,7 +4360,7 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       ret = exec_sql( sqliteHandle(), QStringLiteral( "RELEASE SAVEPOINT \"%1\"" ).arg( savepointId ), uri().uri(), errMsg, QGS_QUERY_LOG_ORIGIN );
     }
 
-  } // BEGIN statement
+  } // SAVEPOINT statement
 
   if ( ret != SQLITE_OK )
   {
@@ -4374,6 +4374,8 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     {
       // ROLLBACK after some previous error
       ( void )exec_sql( sqliteHandle(), QStringLiteral( "ROLLBACK TRANSACTION TO SAVEPOINT \"%1\"" ).arg( savepointId ), uri().uri(), nullptr, QGS_QUERY_LOG_ORIGIN );
+      // Also release the savepoint or it will remain on the stack.
+      ( void ) exec_sql( sqliteHandle(), QStringLiteral( "RELEASE SAVEPOINT \"%1\"" ).arg( savepointId ), uri().uri(), errMsg, QGS_QUERY_LOG_ORIGIN );
     }
   }
   else

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -944,7 +944,7 @@ void QgsSpatiaLiteProvider::fetchConstraints()
 
     QString sqlDef = QString::fromUtf8( results[ 1 ] );
     // extract definition
-    QRegularExpression re( QStringLiteral( R"raw(\((.+)\))raw" ) );
+    QRegularExpression re( QStringLiteral( R"raw(\((.+)\))raw" ), QRegularExpression::PatternOption::DotMatchesEverythingOption );
     QRegularExpressionMatch match = re.match( sqlDef );
     if ( match.hasMatch() )
     {

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1825,7 +1825,10 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         con = spatialite_connect(self.dbname, isolation_level=None)
         cur = con.cursor()
         cur.execute("BEGIN")
-        sql = "CREATE TABLE table50523 (_id INTEGER PRIMARY KEY AUTOINCREMENT, atttext TEXT NOT NULL)"
+        sql = """CREATE TABLE table50523 (
+            _id INTEGER PRIMARY KEY AUTOINCREMENT,
+            atttext TEXT NOT NULL)"""
+
         cur.execute(sql)
         sql = "SELECT AddGeometryColumn('table50523', 'position', 25832, 'POLYGON', 'XY', 0)"
         cur.execute(sql)

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1819,6 +1819,47 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
         self.assertTrue(feature.isValid())
 
+    def testRegression50523(self):
+        """Test for issue GH #50523"""
+
+        con = spatialite_connect(self.dbname, isolation_level=None)
+        cur = con.cursor()
+        cur.execute("BEGIN")
+        sql = "CREATE TABLE table50523 (_id INTEGER PRIMARY KEY AUTOINCREMENT, atttext TEXT NOT NULL)"
+        cur.execute(sql)
+        sql = "SELECT AddGeometryColumn('table50523', 'position', 25832, 'POLYGON', 'XY', 0)"
+        cur.execute(sql)
+        cur.execute("COMMIT")
+        con.close()
+
+        layer = QgsVectorLayer(
+            'dbname=\'{}\' table="table50523" (position) sql='.format(self.dbname), 'test', 'spatialite')
+
+        self.assertTrue(layer.isValid())
+        self.assertTrue(layer.startEditing())
+
+        f = QgsFeature(layer.fields())
+        g = QgsGeometry.fromWkt('polygon((0 0, 1 1, 1 0, 0 0))')
+        g.isGeosValid()
+        self.assertTrue(g.isGeosValid())
+        f.setGeometry(g)
+        f.fields()
+        f.fields().names()
+        f.setAttribute(1, QVariant(QVariant.String))
+        f.setAttribute(0, 'Autogenerate')
+        self.assertTrue(layer.addFeatures([f]))
+        self.assertFalse(layer.commitChanges())
+        self.assertTrue(layer.rollBack())
+
+        self.assertTrue(layer.startEditing())
+        f.setAttribute(1, 'some text')
+        self.assertTrue(layer.addFeatures([f]))
+        self.assertTrue(layer.commitChanges())
+
+        layer = QgsVectorLayer(
+            'dbname=\'{}\' table="table50523" (position) sql='.format(self.dbname), 'test', 'spatialite')
+        self.assertEqual(len([f for f in layer.getFeatures()]), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1836,6 +1836,11 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
             'dbname=\'{}\' table="table50523" (position) sql='.format(self.dbname), 'test', 'spatialite')
 
         self.assertTrue(layer.isValid())
+
+        # Check NOT NULL constraint on atttext
+        field = layer.fields().at(1)
+        self.assertTrue(bool(field.constraints().constraints() & QgsFieldConstraints.ConstraintNotNull))
+
         self.assertTrue(layer.startEditing())
 
         f = QgsFeature(layer.fields())


### PR DESCRIPTION
Fixes #50523

According to  https://sqlite.org/lang_savepoint.html:

Note that unlike that plain ROLLBACK command (without the TO keyword) the ROLLBACK TO command does not cancel the transaction.

Also fixes the NOT NULL constraint not set.

