### PR TITLE
Fix crash on empty polygon conversion to curve

### DIFF
--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -316,11 +316,14 @@ QgsPolygon *QgsPolygon::surfaceToPolygon() const
 QgsCurvePolygon *QgsPolygon::toCurveType() const
 {
   QgsCurvePolygon *curvePolygon = new QgsCurvePolygon();
-  curvePolygon->setExteriorRing( mExteriorRing->clone() );
-  int nInteriorRings = mInteriorRings.size();
-  for ( int i = 0; i < nInteriorRings; ++i )
+  if ( mExteriorRing )
   {
-    curvePolygon->addInteriorRing( mInteriorRings.at( i )->clone() );
+    curvePolygon->setExteriorRing( mExteriorRing->clone() );
+    int nInteriorRings = mInteriorRings.size();
+    for ( int i = 0; i < nInteriorRings; ++i )
+    {
+      curvePolygon->addInteriorRing( mInteriorRings.at( i )->clone() );
+    }
   }
   return curvePolygon;
 }

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -2602,7 +2602,10 @@ void TestQgsPolygon::toPolygon()
 
 void TestQgsPolygon::toCurveType()
 {
-  QgsPolygon pl;
+  QgsPolygon pl; // empty
+
+  std::unique_ptr< QgsCurvePolygon > curveType( pl.toCurveType() );
+  QCOMPARE( curveType->wkbType(), QgsWkbTypes::CurvePolygon );
 
   QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
@@ -2620,7 +2623,7 @@ void TestQgsPolygon::toCurveType()
                    << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
   pl.addInteriorRing( ring );
 
-  std::unique_ptr< QgsCurvePolygon > curveType( pl.toCurveType() );
+  curveType.reset( pl.toCurveType() );
 
   QCOMPARE( curveType->wkbType(), QgsWkbTypes::CurvePolygonZM );
 


### PR DESCRIPTION
Closes GH-50466

Empty polygons have no exterior ring, do not assume they always do