### PR TITLE
Add user interface for `--extent` gdalcalc option

### DIFF
--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -50,6 +50,10 @@ class gdalcalc(GdalAlgorithm):
     BAND_E = 'BAND_E'
     BAND_F = 'BAND_F'
     FORMULA = 'FORMULA'
+    # TODO QGIS 4.0 : Rename EXTENT_OPT to EXTENT
+    EXTENT_OPT = 'EXTENT_OPT'
+    EXTENT_OPTIONS = ['ignore', 'fail', 'union', 'intersect']
+    # TODO QGIS 4.0 : Rename EXTENT to PROJWIN or CUSTOM_EXTENT
     EXTENT = 'PROJWIN'
     OUTPUT = 'OUTPUT'
     NO_DATA = 'NO_DATA'
@@ -142,6 +146,15 @@ class gdalcalc(GdalAlgorithm):
                 optional=True))
 
         if GdalUtils.version() >= 3030000:
+            extent_opt_param = QgsProcessingParameterEnum(
+                self.EXTENT_OPT,
+                self.tr('Handling of extent differences'),
+                options=[o.title() for o in self.EXTENT_OPTIONS],
+                defaultValue=0)
+            extent_opt_param.setHelp(self.tr('This option determines how to handle rasters with different extents'))
+            self.addParameter(extent_opt_param)
+
+        if GdalUtils.version() >= 3030000:
             extent_param = QgsProcessingParameterExtent(self.EXTENT,
                                                         self.tr('Output extent'),
                                                         optional=True)
@@ -193,8 +206,33 @@ class gdalcalc(GdalAlgorithm):
         return 'gdal_calc'
 
     def processAlgorithm(self, parameters, context, feedback):
+        def all_equal(iterator):
+            iterator = iter(iterator)
+            try:
+                first = next(iterator)
+            except StopIteration:
+                return True
+            return all(first == x for x in iterator)
+
+        # Check GDAL version for projwin and extent options (GDAL 3.3 is required)
         if GdalUtils.version() < 3030000 and self.EXTENT in parameters.keys():
-            raise QgsProcessingException(self.tr('The output extent option is only available on GDAL 3.3 or later'))
+            raise QgsProcessingException(self.tr('The custom output extent option (--projwin) is only available on GDAL 3.3 or later'))
+        if GdalUtils.version() < 3030000 and self.EXTENT_OPT in parameters.keys():
+            raise QgsProcessingException(self.tr('The output extent option (--extent) is only available on GDAL 3.3 or later'))
+        # --projwin and --extent option are mutually exclusive
+        if (self.EXTENT in parameters.keys() and parameters[self.EXTENT] is not None) and (self.EXTENT_OPT in parameters.keys() and parameters[self.EXTENT_OPT] != 0):
+            raise QgsProcessingException(self.tr('The custom output extent option (--projwin) and output extent option (--extent) are mutually exclusive'))
+        # If extent option is defined, pixel size and SRS of all input raster must be the same
+        if self.EXTENT_OPT in parameters.keys() and parameters[self.EXTENT_OPT] != 0:
+            pixel_size_X, pixel_size_Y, srs = [], [], []
+            for input_layer in [self.INPUT_A, self.INPUT_B, self.INPUT_C, self.INPUT_D, self.INPUT_E, self.INPUT_F]:
+                if input_layer in parameters and parameters[input_layer] is not None:
+                    layer = self.parameterAsRasterLayer(parameters, input_layer, context)
+                    pixel_size_X.append(layer.rasterUnitsPerPixelX())
+                    pixel_size_Y.append(layer.rasterUnitsPerPixelY())
+                    srs.append(layer.crs().authid())
+            if not (all_equal(pixel_size_X) and all_equal(pixel_size_Y) and all_equal(srs)):
+                raise QgsProcessingException(self.tr('For all output extent options, the pixel size (resolution) and SRS (Spatial Reference System) of all the input rasters must be the same'))
         return GdalAlgorithm.processAlgorithm(self, parameters, context, feedback)
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
@@ -222,6 +260,10 @@ class gdalcalc(GdalAlgorithm):
         layer = self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
         if layer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_A))
+
+        extent = self.EXTENT_OPTIONS[self.parameterAsEnum(parameters, self.EXTENT_OPT, context)]
+        if extent != 'ignore':
+            arguments.append(f'--extent={extent}')
 
         bbox = self.parameterAsExtent(parameters, self.EXTENT, context, layer.crs())
         if not bbox.isNull():


### PR DESCRIPTION
## Description

It exposes in a user-friendly way the `--extent` option of gdalcalc.
https://gdal.org/programs/gdal_calc.html#cmdoption-extent

Some of checks I add (mutually exclusive, same pixel size and crs) are performed by `gdal_calc.py` too but it's nicer to have the error sooner.

I remove the call of `processAlgorithm` as raised exception in this call can't be caught in tests.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
