### PR TITLE
Include type name in message about unsupported qfield validations

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -594,7 +594,9 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
     v = QVariant( d->type );
 
     if ( errorMessage )
-      *errorMessage = QObject::tr( "Could not convert value \"%1\" to target type" ).arg( original.toString() );
+      *errorMessage = QObject::tr( "Could not convert value \"%1\" to target type \"%2\"" )
+                      .arg( original.toString() )
+                      .arg( d->typeName );
 
     return false;
   }

--- a/src/gui/qgsfieldvalidator.cpp
+++ b/src/gui/qgsfieldvalidator.cpp
@@ -161,7 +161,11 @@ QValidator::State QgsFieldValidator::validate( QString &s, int &i ) const
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "unsupported type %1 for validation" ).arg( mField.type() ) );
+    QgsDebugMsg(
+      QStringLiteral( "unsupported type %1 (%2) for validation" )
+      .arg( mField.type() )
+      .arg( mField.typeName() )
+    );
     return Invalid;
   }
 


### PR DESCRIPTION
Just a very small enhancement to print the type of the QField wer'e unable to validate.
Will help reducing debugging time ( see https://github.com/qgis/QGIS/issues/49380#issuecomment-1282040618 )