### PR TITLE
Fix regression where attribute table dialogs do not open as proper top level windows with their own taskbar entries

### DIFF
--- a/src/app/qgsdockablewidgethelper.cpp
+++ b/src/app/qgsdockablewidgethelper.cpp
@@ -241,7 +241,10 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
   else
   {
     // going from dock -> window
-    mDialog = new QDialog( mOwnerWindow, Qt::Window );
+    // note -- we explicitly DO NOT set the parent for the dialog, as we want these treated as
+    // proper top level windows and have their own taskbar entries. See https://github.com/qgis/QGIS/issues/49286
+    mDialog = new QDialog( nullptr, Qt::Window );
+    mDialog->setStyleSheet( QgisApp::instance()->styleSheet() );
 
     mDialog->setWindowTitle( mWindowTitle );
     QVBoxLayout *vl = new QVBoxLayout();


### PR DESCRIPTION
Fixes #49286
