### PR TITLE
Fix #ifdef MSVC conditions leading to missing information in crash report

### DIFF
--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -116,7 +116,7 @@ void QgsCrashHandler::handleCrash( int processID, int threadID,
   args << fileName;
 
   QString prefixPath( getenv( "QGIS_PREFIX_PATH" ) ? getenv( "QGIS_PREFIX_PATH" ) : QApplication::applicationDirPath() );
-#ifdef MSVC
+#ifdef _MSC_VER
   QString path = prefixPath + QStringLiteral( "/qgiscrashhandler.exe" );
 #else
   QString path = prefixPath + QStringLiteral( "/qgiscrashhandler" );

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -295,7 +295,7 @@ std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 Qgis::DriveType QgsFileUtils::driveType( const QString &path )
 {
 #ifdef _MSC_VER
-  auto pathType = [ = ]( const QString & path ) -> DriveType
+  auto pathType = [ = ]( const QString & path ) -> Qgis::DriveType
   {
     std::unique_ptr< wchar_t[] > pathArray = pathToWChar( path );
     const UINT type = GetDriveTypeW( pathArray.get() );
@@ -323,7 +323,7 @@ Qgis::DriveType QgsFileUtils::driveType( const QString &path )
         return Qgis::DriveType::RamDisk;
     }
 
-    return Unknown;
+    return Qgis::DriveType::Unknown;
 
   };
 
@@ -334,8 +334,8 @@ Qgis::DriveType QgsFileUtils::driveType( const QString &path )
   {
     prevPath = currentPath;
     currentPath = QFileInfo( currentPath ).path();
-    const DriveType type = pathType( currentPath );
-    if ( type != Unknown && type != Invalid )
+    const Qgis::DriveType type = pathType( currentPath );
+    if ( type != Qgis::DriveType::Unknown && type != Qgis::DriveType::Invalid )
       return type;
   }
   return Unknown;

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -32,7 +32,7 @@
 #include <sys/time.h>
 #endif
 
-#ifdef MSVC
+#ifdef _MSC_VER
 #include <Windows.h>
 #include <ShlObj.h>
 #pragma comment(lib,"Shell32.lib")
@@ -280,7 +280,7 @@ QStringList QgsFileUtils::findFile( const QString &file, const QString &basePath
   return foundFiles;
 }
 
-#ifdef MSVC
+#ifdef _MSC_VER
 std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 {
   const QString nativePath = QDir::toNativeSeparators( path );
@@ -294,7 +294,7 @@ std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 
 Qgis::DriveType QgsFileUtils::driveType( const QString &path )
 {
-#ifdef MSVC
+#ifdef _MSC_VER
   auto pathType = [ = ]( const QString & path ) -> DriveType
   {
     std::unique_ptr< wchar_t[] > pathArray = pathToWChar( path );

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -68,7 +68,7 @@ int main( int argc, char *argv[] )
     versionInfo = info.split( "\n" );
   }
 
-#ifdef MSVC
+#ifdef _MSC_VER
   DWORD processId;
   DWORD threadId;
   LPEXCEPTION_POINTERS exception;
@@ -86,7 +86,7 @@ int main( int argc, char *argv[] )
 
   QgsCrashReport report;
   report.setVersionInfo( versionInfo );
-#ifdef MSVC
+#ifdef _MSC_VER
   report.setStackTrace( stackTrace.get() );
 #endif
   report.setPythonCrashLogFilePath( pythonCrashLogFile );
@@ -101,7 +101,7 @@ int main( int argc, char *argv[] )
   QApplication::exec();
 
 
-#ifdef MSVC
+#ifdef _MSC_VER
   for ( HANDLE threadHandle : stackTrace->threads )
   {
     ResumeThread( threadHandle );


### PR DESCRIPTION
Interestingly this revealed that the code in QgsFileUtils::driveType could not compile even on Windows, which means that it's not being currently used, likely the cause of continued reports of slow QGIS interface due to browser scanning monitoring slow network locations