### PR TITLE
Fixes Digitizing: "Fill Ring" tool doesn't consider all the overlapping features

### DIFF
--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -21,6 +21,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsattributedialog.h"
 #include "qgisapp.h"
+#include "qgsvectorlayereditutils.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsmapmouseevent.h"
 #include "qgspolygon.h"
@@ -69,11 +70,12 @@ void QgsMapToolFillRing::polygonCaptured( const QgsCurvePolygon *polygon )
   if ( !vlayer )
     return;
 
-  QgsFeatureId fid;
+  QgsFeatureIds fids;
 
   vlayer->beginEditCommand( tr( "Ring added and filled" ) );
 
-  const Qgis::GeometryOperationResult addRingReturnCode = vlayer->addRing( polygon->exteriorRing()->clone(), &fid );
+  QgsVectorLayerEditUtils utils( vlayer );
+  const Qgis::GeometryOperationResult addRingReturnCode = utils.addRingV2( polygon->exteriorRing()->clone(), vlayer->selectedFeatureIds(), &fids );
 
   // AP: this is all dead code:
   //todo: open message box to communicate errors
@@ -110,7 +112,10 @@ void QgsMapToolFillRing::polygonCaptured( const QgsCurvePolygon *polygon )
     return;
   }
 
-  createFeature( QgsGeometry( polygon->clone() ), fid );
+  for ( const auto fid : fids )
+  {
+    createFeature( QgsGeometry( polygon->clone() ), fid );
+  }
 }
 
 


### PR DESCRIPTION
## Description
Follow up #50447 use addRingV2 to fill rings on all features.

Fixes #23114

@DelazJ I'm unsure about this fix, since, I don't understand this tool. Especially, is a new polygon should be created for each ring added, or only one polygon is sufficient (and for which feature ID )?