### PR TITLE
Remove empty first row from the 'User defined CRS' table (fixes issue #50119)

### DIFF
--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -47,33 +47,33 @@ QgsCustomProjectionOptionsWidget::QgsCustomProjectionOptionsWidget( QWidget *par
   populateList();
   if ( mDefinitions.empty() )
   {
-    // create an empty definition which corresponds to the initial state of the dialog
-    mDefinitions << Definition();
-    QTreeWidgetItem *newItem = new QTreeWidgetItem( leNameList, QStringList() );
-    newItem->setText( QgisCrsNameColumn, QString() );
-    newItem->setText( QgisCrsParametersColumn, QString() );
-  }
-  whileBlocking( leName )->setText( mDefinitions[0].name );
-
-  mBlockUpdates++;
-
-  QgsCoordinateReferenceSystem crs;
-  Qgis::CrsDefinitionFormat format;
-  if ( mDefinitions.at( 0 ).wkt.isEmpty() )
-  {
-    crs.createFromProj( mDefinitions[0].proj );
-    format = Qgis::CrsDefinitionFormat::Proj;
+    leName->setEnabled(false);
+    mCrsDefinitionWidget->setEnabled(false);
   }
   else
   {
-    crs.createFromWkt( mDefinitions[0].wkt );
-    format = Qgis::CrsDefinitionFormat::Wkt;
+    whileBlocking( leName )->setText( mDefinitions[0].name );
+
+    mBlockUpdates++;
+
+    QgsCoordinateReferenceSystem crs;
+    Qgis::CrsDefinitionFormat format;
+    if ( mDefinitions.at( 0 ).wkt.isEmpty() )
+    {
+      crs.createFromProj( mDefinitions[0].proj );
+      format = Qgis::CrsDefinitionFormat::Proj;
+    }
+    else
+    {
+      crs.createFromWkt( mDefinitions[0].wkt );
+      format = Qgis::CrsDefinitionFormat::Wkt;
+    }
+    mCrsDefinitionWidget->setCrs( crs, format );
+
+    mBlockUpdates--;
+
+    leNameList->setCurrentItem( leNameList->topLevelItem( 0 ) );
   }
-  mCrsDefinitionWidget->setCrs( crs, format );
-
-  mBlockUpdates--;
-
-  leNameList->setCurrentItem( leNameList->topLevelItem( 0 ) );
 
   leNameList->hideColumn( QgisCrsIdColumn );
 
@@ -155,6 +155,9 @@ void QgsCustomProjectionOptionsWidget::pbnAdd_clicked()
 
   QTreeWidgetItem *newItem = new QTreeWidgetItem( leNameList, QStringList() );
 
+  leName->setEnabled(true);
+  mCrsDefinitionWidget->setEnabled(true);
+
   newItem->setText( QgisCrsNameColumn, name );
   newItem->setText( QgisCrsIdColumn, QString() );
   newItem->setText( QgisCrsParametersColumn, QString() );
@@ -203,6 +206,9 @@ void QgsCustomProjectionOptionsWidget::pbnRemove_clicked()
     }
     mDefinitions.erase( mDefinitions.begin() + row );
   }
+
+  leName->setEnabled(false);
+  mCrsDefinitionWidget->setEnabled(false);
 }
 
 void QgsCustomProjectionOptionsWidget::leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )

--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -47,8 +47,8 @@ QgsCustomProjectionOptionsWidget::QgsCustomProjectionOptionsWidget( QWidget *par
   populateList();
   if ( mDefinitions.empty() )
   {
-    leName->setEnabled(false);
-    mCrsDefinitionWidget->setEnabled(false);
+    leName->setEnabled( false );
+    mCrsDefinitionWidget->setEnabled( false );
   }
   else
   {
@@ -155,8 +155,8 @@ void QgsCustomProjectionOptionsWidget::pbnAdd_clicked()
 
   QTreeWidgetItem *newItem = new QTreeWidgetItem( leNameList, QStringList() );
 
-  leName->setEnabled(true);
-  mCrsDefinitionWidget->setEnabled(true);
+  leName->setEnabled( true );
+  mCrsDefinitionWidget->setEnabled( true );
 
   newItem->setText( QgisCrsNameColumn, name );
   newItem->setText( QgisCrsIdColumn, QString() );
@@ -207,8 +207,8 @@ void QgsCustomProjectionOptionsWidget::pbnRemove_clicked()
     mDefinitions.erase( mDefinitions.begin() + row );
   }
 
-  leName->setEnabled(false);
-  mCrsDefinitionWidget->setEnabled(false);
+  leName->setEnabled( false );
+  mCrsDefinitionWidget->setEnabled( false );
 }
 
 void QgsCustomProjectionOptionsWidget::leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )


### PR DESCRIPTION
## Description

Improving the "User defined CRS" dialog as follows : 
- if the list of CRS is empty, the form is disabled
- removing the empty CRS element that was added automatically when the was empty

This solve the issue #50119 

It is a new version of the PR https://github.com/qgis/QGIS/pull/50167

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
