### PR TITLE
[Fix] QgsOgcUtils: simplify convert PropertyIsLike to expression

### DIFF
--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3374,22 +3374,15 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodeBinaryOper
       QString oprValue = static_cast<const QgsExpressionNodeLiteral *>( opRight.get() )->value().toString();
       if ( !wildCard.isEmpty() && wildCard != QLatin1String( "%" ) )
       {
+        // escape default wildcard
         oprValue.replace( '%', QLatin1String( "\\%" ) );
-        if ( oprValue.startsWith( wildCard ) )
+        // split value by
+        QStringList splitOprValue;
+        for ( const QString &val : oprValue.split( escape + wildCard ) )
         {
-          oprValue.replace( 0, 1, QStringLiteral( "%" ) );
+          splitOprValue << QString( val ).replace( wildCard, QLatin1String( "%" ) );
         }
-        const QRegularExpression rx( "[^" + QgsStringUtils::qRegExpEscape( escape ) + "](" + QgsStringUtils::qRegExpEscape( wildCard ) + ")" );
-        QRegularExpressionMatch match = rx.match( oprValue );
-        int pos;
-        while ( match.hasMatch() )
-        {
-          pos = match.capturedStart();
-          oprValue.replace( pos + 1, 1, QStringLiteral( "%" ) );
-          pos += 1;
-          match = rx.match( oprValue, pos );
-        }
-        oprValue.replace( escape + wildCard, wildCard );
+        oprValue = splitOprValue.join( wildCard );
       }
       if ( !singleChar.isEmpty() && singleChar != QLatin1String( "_" ) )
       {

--- a/tests/src/python/test_qgsogcutils.py
+++ b/tests/src/python/test_qgsogcutils.py
@@ -481,6 +481,172 @@ class TestQgsOgcUtils(unittest.TestCase):
         e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
         self.assertEqual(e.expression(), 'id = \'\'')
 
+    def test_expressionFromOgcFilterWithPropertyIsLike(self):
+        """
+        Test expressionFromOgcFilter with PropertyIsLike with wildCard
+        """
+
+        vl = QgsVectorLayer('Point', 'vl', 'memory')
+        vl.dataProvider().addAttributes([QgsField('id', QVariant.LongLong), QgsField('THEME', QVariant.String), QgsField('PROGRAMME', QVariant.String)])
+        vl.updateFields()
+
+        # test with vector layer and PropertyIsLike default attributes
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:PropertyIsLike escape="\\" wildCard="%" singleChar="_">
+                <ogc:PropertyName>PROGRAMME</ogc:PropertyName>
+                <ogc:Literal>REPHY;%</ogc:Literal>
+              </ogc:PropertyIsLike>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'PROGRAMME LIKE \'REPHY;%\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:PropertyIsLike escape="\\" wildCard="%" singleChar="_">
+                <ogc:PropertyName>PROGRAMME</ogc:PropertyName>
+                <ogc:Literal>%;REPHY;%</ogc:Literal>
+              </ogc:PropertyIsLike>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'PROGRAMME LIKE \'%;REPHY;%\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:PropertyIsLike escape="\\" wildCard="%" singleChar="_">
+                <ogc:PropertyName>PROGRAMME</ogc:PropertyName>
+                <ogc:Literal>%;REPHY</ogc:Literal>
+              </ogc:PropertyIsLike>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'PROGRAMME LIKE \'%;REPHY\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:PropertyIsLike escape="\\" wildCard="%" singleChar="_">
+                <ogc:PropertyName>PROGRAMME</ogc:PropertyName>
+                <ogc:Literal>REPHY</ogc:Literal>
+              </ogc:PropertyIsLike>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'PROGRAMME LIKE \'REPHY\'')
+
+        # test with vector layer and PropertyIsLike without attributes
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:PropertyIsLike>
+                <ogc:PropertyName>PROGRAMME</ogc:PropertyName>
+                <ogc:Literal>%;REPHY;%</ogc:Literal>
+              </ogc:PropertyIsLike>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'PROGRAMME LIKE \'%;REPHY;%\'')
+
+        # test without vector layer
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>ct3*</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'ct3%\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>*ct3</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'%ct3\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>*ct3*</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'%ct3%\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>ct3</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'ct3\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>ct*3</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'ct%3\'')
+
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+          <ogc:Filter>
+            <ogc:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="?" wildCard="*">
+              <ogc:PropertyName>Nom_deploi</ogc:PropertyName>
+              <ogc:Literal>ct3\\** *ct1*\\*1 ct*3</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement())
+        self.assertEqual(e.expression(), 'Nom_deploi ILIKE \'ct3*% %ct1%*1 ct%3\'')
+
     def test_expressionFromOgcFilterWithAndOrPropertyIsLike(self):
         """
         Test expressionFromOgcFilter with And, Or and PropertyIsLike with wildCard


### PR DESCRIPTION
Simplifying the way the `wildcard` attribute defined in `PropertyIsLike` OGC Filter element is replaced in the `Literal` content.

Funded by 3liz https://3liz.com