### PR TITLE
Make annotations actions tooltip more explicit

### DIFF
--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -179,7 +179,7 @@ QList<int> QgsAnnotationItemGuiRegistry::itemMetadataIds() const
 void QgsAnnotationItemGuiRegistry::addDefaultItems()
 {
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "polygon" ),
-                                QObject::tr( "Polygon" ),
+                                QObject::tr( "Polygon Annotation" ),
                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPolygon.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
@@ -193,7 +193,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
   } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "linestring" ),
-                                QObject::tr( "Line" ),
+                                QObject::tr( "Line Annotation" ),
                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPolyline.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
@@ -207,7 +207,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
   } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "marker" ),
-                                QObject::tr( "Marker" ),
+                                QObject::tr( "Marker Annotation" ),
                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddMarker.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
@@ -221,7 +221,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
   } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "pointtext" ),
-                                QObject::tr( "Text at Point" ),
+                                QObject::tr( "Text Annotation at Point" ),
                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionText.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {


### PR DESCRIPTION
so that they show e.g. "Create Polygon Annotation" instead of "Create Polygon".
Fixes #50243

