### PR TITLE
Fix a crash when rendering a raster outside of its extent

### DIFF
--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -374,6 +374,9 @@ QgsFeedback *QgsRasterLayerRenderer::feedback() const
 
 bool QgsRasterLayerRenderer::forceRasterRender() const
 {
+  if ( !mRasterViewPort || !mPipe )
+    return false;  // this layer is not going to get rendered
+
   // preview of intermediate raster rendering results requires a temporary output image
   if ( renderContext()->testFlag( Qgis::RenderContextFlag::RenderPartialOutput ) )
     return true;

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -46,6 +46,7 @@
 #include "qgsrastertransparency.h"
 #include "qgspalettedrasterrenderer.h"
 #include "qgsrasterlayertemporalproperties.h"
+#include "qgsmaplayerrenderer.h"
 
 //qgis unit test includes
 #include <qgsrenderchecker.h>
@@ -101,6 +102,7 @@ class TestQgsRasterLayer : public QgsTest
     void sample();
     void testTemporalProperties();
     void rotatedRaster();
+    void forceRasterRender();
 
 
   private:
@@ -1053,6 +1055,19 @@ void TestQgsRasterLayer::rotatedRaster()
 
   mMapSettings->setLayers( QList<QgsMapLayer *>() << rgba.get() );
   QVERIFY( render( QStringLiteral( "raster_rotated_rgba" ) ) );
+}
+
+void TestQgsRasterLayer::forceRasterRender()
+{
+  QVERIFY2( mpLandsatRasterLayer->isValid(), "landsat.tif layer is not valid!" );
+
+  mMapSettings->setDestinationCrs( mpLandsatRasterLayer->crs() );
+  mMapSettings->setExtent( QgsRectangle( 10, 10, 11, 11 ) );  // outside of layer extent
+  mMapSettings->setLayers( QList<QgsMapLayer *>() << mpLandsatRasterLayer );
+
+  QgsRenderContext context( QgsRenderContext::fromMapSettings( *mMapSettings ) );
+  std::unique_ptr<QgsMapLayerRenderer> layerRenderer( mpLandsatRasterLayer->createMapRenderer( context ) );
+  layerRenderer->forceRasterRender();  // this should not crash
 }
 
 QGSTEST_MAIN( TestQgsRasterLayer )


### PR DESCRIPTION
If QgsRasterLayerRenderer constructor exists prematurely because there is nothing to render, its internal pointers end up null, but forceRasterRender() was expecting that mPipe was always allocated.

The crash was introduced recently in #50382

The crash was happening at least in 3D rendering when generating 2D map texture, with a backtrace like this:
```
#0  0x00007ffff1c0858e in QMap<Qgis::RasterPipeInterfaceRole, int>::contains(Qgis::RasterPipeInterfaceRole const&) const
    (this=0x8, akey=@0x7fffffffb7b4: Qgis::RasterPipeInterfaceRole::Renderer) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qmap.h:707
#1  0x00007ffff1c0644f in QgsRasterPipe::interface(Qgis::RasterPipeInterfaceRole) const (this=0x0, role=Qgis::RasterPipeInterfaceRole::Renderer)
    at /home/martin/qgis/git-master/src/core/raster/qgsrasterpipe.cpp:260
#2  0x00007ffff1c06559 in QgsRasterPipe::renderer() const (this=0x0) at /home/martin/qgis/git-master/src/core/raster/qgsrasterpipe.cpp:274
#3  0x00007ffff1bfeab4 in QgsRasterLayerRenderer::forceRasterRender() const (this=0x55555fa4d540)
    at /home/martin/qgis/git-master/src/core/raster/qgsrasterlayerrenderer.cpp:381
#4  0x00007ffff1a02b75 in QgsMapRendererJob::prepareJobs(QPainter*, QgsLabelingEngine*, bool)
     (this=0x55555ef10720, painter=0x55555ed119c0, labelingEngine2=0x0, deferredPainterSet=false) at /home/martin/qgis/git-master/src/core/maprenderer/qgsmaprendererjob.cpp:575
#5  0x00007ffff19f9864 in QgsMapRendererCustomPainterJob::startPrivate() (this=0x55555ef10720)
    at /home/martin/qgis/git-master/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp:120
#6  0x00007ffff19ff2a9 in QgsMapRendererJob::start() (this=0x55555ef10720) at /home/martin/qgis/git-master/src/core/maprenderer/qgsmaprendererjob.cpp:149
#7  0x00007ffff1a192b2 in QgsMapRendererSequentialJob::startPrivate() (this=0x55555a154b30)
    at /home/martin/qgis/git-master/src/core/maprenderer/qgsmaprenderersequentialjob.cpp:76
#8  0x00007ffff19ff2a9 in QgsMapRendererJob::start() (this=0x55555a154b30) at /home/martin/qgis/git-master/src/core/maprenderer/qgsmaprendererjob.cpp:149
#9  0x00007fffef28f440 in QgsTerrainTextureGenerator::render(QgsRectangle const&, QgsChunkNodeId, QString const&)
    (this=0x55555da027a0, extent=..., tileId=..., debugText=...) at /home/martin/qgis/git-master/src/3d/terrain/qgsterraintexturegenerator_p.cpp:64
#10 0x00007fffef293275 in QgsTerrainTileLoader::loadTexture() (this=0x55555879d9c0) at /home/martin/qgis/git-master/src/3d/terrain/qgsterraintileloader_p.cpp:65
#11 0x00007fffef27fb8f in QgsDemTerrainTileLoader::onHeightMapReady(int, QByteArray const&) (this=0x55555879d9c0, jobId=17, heightMap=...)
    at /home/martin/qgis/git-master/src/3d/terrain/qgsdemterraintileloader_p.cpp:142
```