### PR TITLE
Move a bunch of python console code editor improvements up to base class

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -782,7 +782,7 @@ class PythonConsoleWidget(QWidget):
         self.settings.setValue("pythonConsole/splitterObj", self.splitterObj.saveState())
         self.settings.setValue("pythonConsole/splitterEditor", self.splitterEditor.saveState())
 
-        self.shell.writeHistoryFile(True)
+        self.shell.writeHistoryFile()
 
     def restoreSettingsConsole(self):
         storedTabScripts = self.settings.value("pythonConsole/tabScripts", [])

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -24,7 +24,11 @@ from qgis.PyQt.QtGui import QColor, QFont, QKeySequence, QFontDatabase
 from qgis.PyQt.QtWidgets import QGridLayout, QSpacerItem, QSizePolicy, QShortcut, QMenu, QApplication
 from qgis.PyQt.Qsci import QsciScintilla
 from qgis.core import Qgis, QgsApplication, QgsSettings
-from qgis.gui import QgsMessageBar, QgsCodeEditorPython
+from qgis.gui import (
+    QgsMessageBar,
+    QgsCodeEditorPython,
+    QgsCodeInterpreter
+)
 import sys
 
 

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -172,18 +172,6 @@ class ShellScintilla(QgsCodeEditorPython):
         self.sessionHistoryCleared.connect(self.on_session_history_cleared)
         self.persistentHistoryCleared.connect(self.on_persistent_history_cleared)
 
-    def initializeLexer(self):
-        super().initializeLexer()
-        self.setCaretLineVisible(False)
-        self.setLineNumbersVisible(False)  # NO linenumbers for the input line
-        self.setFoldingVisible(False)
-        # Margin 1 is used for the '>>>' prompt (console input)
-        self.setMarginLineNumbers(1, True)
-        self.setMarginWidth(1, "00000")
-        self.setMarginType(1, 5)  # TextMarginRightJustified=5
-        self.setMarginsBackgroundColor(self.color(QgsCodeEditorColorScheme.ColorRole.Background))
-        self.setEdgeMode(QsciScintilla.EdgeNone)
-
     def _setMinimumHeight(self):
         font = self.lexer().defaultFont(0)
         fm = QFontMetrics(font)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -84,7 +84,7 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         self.buffer = []
         self.continuationLine = False
 
-        self.displayPrompt()
+        self.updatePrompt()
 
         for statement in _init_statements:
             try:
@@ -144,15 +144,7 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         # Sets minimum height for input area based of font metric
         self._setMinimumHeight()
 
-    def moveCursorToStart(self):
-        super().moveCursorToStart()
-        self.displayPrompt()
-
-    def moveCursorToEnd(self):
-        super().moveCursorToEnd()
-        self.displayPrompt()
-
-    def displayPrompt(self):
+    def updatePrompt(self):
         self.SendScintilla(QsciScintilla.SCI_MARGINSETTEXT, 0,
                            str.encode("..." if self.continuationLine else ">>>"))
 
@@ -262,7 +254,7 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
                     self.setCursorPosition(line, index + 7)
             QsciScintilla.keyPressEvent(self, e)
 
-        self.displayPrompt()
+        self.updatePrompt()
 
     def populateContextMenu(self, menu):
         pyQGISHelpAction = menu.addAction(
@@ -365,11 +357,6 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
             self.continuationLine = self.runsource(src)
             if not self.continuationLine:
                 self.buffer = []
-
-        # prevents commands with more lines to break the console
-        # in the case they have an eol different from '\n'
-        self.clear('')
-        self.moveCursorToEnd()
 
     def write(self, txt):
         if sys.stderr:

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -344,10 +344,9 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         self.setFocus()
         self.moveCursorToEnd()
 
-    def runCommand(self, cmd):
+    def runCommandImpl(self, cmd):
         self.writeCMD(cmd)
         import webbrowser
-        self.updateHistory([cmd])
         version = 'master' if 'master' in Qgis.QGIS_VERSION.lower() else \
             re.findall(r'^\d.[0-9]*', Qgis.QGIS_VERSION)[0]
         if cmd in ('_pyqgis', '_api', '_cookbook'):
@@ -368,8 +367,8 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
             if not more:
                 self.buffer = []
 
-        # prevents to commands with more lines to break the console
-        # in the case they have a eol different from '\n'
+        # prevents commands with more lines to break the console
+        # in the case they have an eol different from '\n'
         self.setText('')
         self.moveCursorToEnd()
         self.displayPrompt(self.continuationLine)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -84,7 +84,7 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         self.buffer = []
         self.continuationLine = False
 
-        self.displayPrompt(self.continuationLine)
+        self.displayPrompt()
 
         for statement in _init_statements:
             try:
@@ -146,15 +146,15 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
 
     def moveCursorToStart(self):
         super().moveCursorToStart()
-        self.displayPrompt(self.continuationLine)
+        self.displayPrompt()
 
     def moveCursorToEnd(self):
         super().moveCursorToEnd()
-        self.displayPrompt(self.continuationLine)
+        self.displayPrompt()
 
-    def displayPrompt(self, more=False):
+    def displayPrompt(self):
         self.SendScintilla(QsciScintilla.SCI_MARGINSETTEXT, 0,
-                           str.encode("..." if more else ">>>"))
+                           str.encode("..." if self.continuationLine else ">>>"))
 
     def on_session_history_cleared(self):
         msgText = QCoreApplication.translate('PythonConsole',
@@ -262,7 +262,7 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
                     self.setCursorPosition(line, index + 7)
             QsciScintilla.keyPressEvent(self, e)
 
-        self.displayPrompt(self.continuationLine)
+        self.displayPrompt()
 
     def populateContextMenu(self, menu):
         pyQGISHelpAction = menu.addAction(
@@ -362,16 +362,14 @@ class ShellScintilla(QgsCodeEditorPython, code.InteractiveInterpreter):
         else:
             self.buffer.append(cmd)
             src = "\n".join(self.buffer)
-            more = self.runsource(src)
-            self.continuationLine = more
-            if not more:
+            self.continuationLine = self.runsource(src)
+            if not self.continuationLine:
                 self.buffer = []
 
         # prevents commands with more lines to break the console
         # in the case they have an eol different from '\n'
-        self.setText('')
+        self.clear('')
         self.moveCursorToEnd()
-        self.displayPrompt(self.continuationLine)
 
     def write(self, txt):
         if sys.stderr:

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2044,3 +2044,16 @@ Qgis.CoordinateDisplayType.CustomCrs.__doc__ = "Custom CRS"
 Qgis.CoordinateDisplayType.__doc__ = 'Formats for displaying coordinates\n\n.. versionadded:: 3.28\n\n' + '* ``MapCrs``: ' + Qgis.CoordinateDisplayType.MapCrs.__doc__ + '\n' + '* ``MapGeographic``: ' + Qgis.CoordinateDisplayType.MapGeographic.__doc__ + '\n' + '* ``CustomCrs``: ' + Qgis.CoordinateDisplayType.CustomCrs.__doc__
 # --
 Qgis.CoordinateDisplayType.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.ScriptLanguage.Css.__doc__ = "CSS"
+Qgis.ScriptLanguage.QgisExpression.__doc__ = "QGIS expressions"
+Qgis.ScriptLanguage.Html.__doc__ = "HTML"
+Qgis.ScriptLanguage.JavaScript.__doc__ = "JavaScript"
+Qgis.ScriptLanguage.Json.__doc__ = "JSON"
+Qgis.ScriptLanguage.Python.__doc__ = "Python"
+Qgis.ScriptLanguage.R.__doc__ = "R Stats"
+Qgis.ScriptLanguage.Sql.__doc__ = "SQL"
+Qgis.ScriptLanguage.Unknown.__doc__ = "Unknown/other language"
+Qgis.ScriptLanguage.__doc__ = 'Scripting languages.\n\n.. versionadded:: 3.30\n\n' + '* ``Css``: ' + Qgis.ScriptLanguage.Css.__doc__ + '\n' + '* ``QgisExpression``: ' + Qgis.ScriptLanguage.QgisExpression.__doc__ + '\n' + '* ``Html``: ' + Qgis.ScriptLanguage.Html.__doc__ + '\n' + '* ``JavaScript``: ' + Qgis.ScriptLanguage.JavaScript.__doc__ + '\n' + '* ``Json``: ' + Qgis.ScriptLanguage.Json.__doc__ + '\n' + '* ``Python``: ' + Qgis.ScriptLanguage.Python.__doc__ + '\n' + '* ``R``: ' + Qgis.ScriptLanguage.R.__doc__ + '\n' + '* ``Sql``: ' + Qgis.ScriptLanguage.Sql.__doc__ + '\n' + '* ``Unknown``: ' + Qgis.ScriptLanguage.Unknown.__doc__
+# --
+Qgis.ScriptLanguage.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1327,6 +1327,19 @@ The development version
       CustomCrs,
     };
 
+    enum class ScriptLanguage
+    {
+      Css,
+      QgisExpression,
+      Html,
+      JavaScript,
+      Json,
+      Python,
+      R,
+      Sql,
+      Unknown,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/gui/auto_additions/qgscodeeditor.py
+++ b/python/gui/auto_additions/qgscodeeditor.py
@@ -1,5 +1,12 @@
 # The following has been generated automatically from src/gui/codeeditors/qgscodeeditor.h
 # monkey patching scoped based enum
+QgsCodeEditor.Mode.ScriptEditor.__doc__ = "Standard mode, allows for display and edit of entire scripts"
+QgsCodeEditor.Mode.OutputDisplay.__doc__ = "Read only mode for display of command outputs"
+QgsCodeEditor.Mode.CommandInput.__doc__ = "Command input mode"
+QgsCodeEditor.Mode.__doc__ = 'Code editor modes.\n\n.. versionadded:: 3.30\n\n' + '* ``ScriptEditor``: ' + QgsCodeEditor.Mode.ScriptEditor.__doc__ + '\n' + '* ``OutputDisplay``: ' + QgsCodeEditor.Mode.OutputDisplay.__doc__ + '\n' + '* ``CommandInput``: ' + QgsCodeEditor.Mode.CommandInput.__doc__
+# --
+QgsCodeEditor.Mode.baseClass = QgsCodeEditor
+# monkey patching scoped based enum
 QgsCodeEditor.LineNumbers = QgsCodeEditor.MarginRole.LineNumbers
 QgsCodeEditor.LineNumbers.is_monkey_patched = True
 QgsCodeEditor.LineNumbers.__doc__ = "Line numbers"

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -377,6 +377,10 @@ this method with interpreter-specific logic for executing commands.
 
     virtual void populateContextMenu( QMenu *menu );
 
+  protected slots:
+
+    virtual void updatePrompt();
+
 };
 
 QFlags<QgsCodeEditor::Flag> operator|(QgsCodeEditor::Flag f1, QFlags<QgsCodeEditor::Flag> f2);

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -227,7 +227,31 @@ Returns ``True`` if the cursor is on the last line of the document.
 .. versionadded:: 3.28
 %End
 
+    void setHistoryFilePath( const QString &path );
+%Docstring
+Sets the file path to use for recording and retrieving previously
+executed commands.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
+
+
+    QStringList history() const;
+
   public slots:
+
+    virtual void runCommand( const QString &command );
+%Docstring
+Runs a command in the editor.
+
+The base class method does nothing.
+
+.. versionadded:: 3.30
+%End
 
     virtual void moveCursorToStart();
 %Docstring
@@ -245,6 +269,53 @@ it is visible.
 .. versionadded:: 3.28
 %End
 
+    void showPreviousCommand();
+%Docstring
+Shows the previous command from the session in the editor.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
+
+    void showNextCommand();
+%Docstring
+Shows the next command from the session in the editor.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
+
+    void showHistory();
+
+    void removeHistoryCommand( int index );
+
+    void clearSessionHistory();
+%Docstring
+Clears the history of commands run in the current session.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
+
+
+    void clearPersistentHistory();
+
+    bool writeHistoryFile();
+
+  signals:
+
+    void sessionHistoryCleared();
+    void persistentHistoryCleared();
+
   protected:
 
     bool isFixedPitch( const QFont &font );
@@ -252,6 +323,8 @@ it is visible.
     virtual void focusOutEvent( QFocusEvent *event );
 
     virtual void keyPressEvent( QKeyEvent *event );
+
+    virtual void contextMenuEvent( QContextMenuEvent *event );
 
 
     virtual void initializeLexer();
@@ -283,6 +356,13 @@ Performs tasks which must be run after a lexer has been set for the widget.
 
 .. versionadded:: 3.16
 %End
+
+
+    void syncSoftHistory();
+    void updateSoftHistory();
+    void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+
+    virtual void populateContextMenu( QMenu *menu );
 
 };
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -12,27 +12,51 @@
 
 
 
-
 class QgsCodeInterpreter
 {
+%Docstring(signature="appended")
+An interface for code interpreters.
+
+.. versionadded:: 3.30
+%End
 
 %TypeHeaderCode
 #include "qgscodeeditor.h"
 %End
   public:
 
-
     virtual ~QgsCodeInterpreter();
 
     int exec( const QString &command );
+%Docstring
+Executes a ``command`` in the interpreter.
+
+Returns an interpreter specific state value.
+%End
 
     virtual int currentState() const;
+%Docstring
+Returns the current interpreter state.
+
+The actual interpretation of the returned values depend on
+the interpreter subclass.
+%End
 
     virtual QString promptForState( int state ) const = 0;
+%Docstring
+Returns the interactive prompt string to use for the
+interpreter, given a ``state``.
+%End
 
   protected:
 
     virtual int execCommandImpl( const QString &command ) = 0;
+%Docstring
+Pure virtual method for executing commands in the interpreter.
+
+Subclasses must implement this method. It will be called internally
+whenever the public :py:func:`~QgsCodeInterpreter.exec` method is called.
+%End
 
 };
 
@@ -264,11 +288,35 @@ executed commands.
 .. versionadded:: 3.30
 %End
 
-
     QStringList history() const;
+%Docstring
+Returns the list of commands previously executed in the editor.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
 
     QgsCodeInterpreter *interpreter() const;
+%Docstring
+Returns the attached code interpreter, or ``None`` if not set.
+
+.. seealso:: :py:func:`setInterpreter`
+
+.. versionadded:: 3.30
+%End
+
     void setInterpreter( QgsCodeInterpreter *newInterpreter );
+%Docstring
+Sets an attached code interpreter for executing commands when the editor
+is in the QgsCodeEditor.Mode.CommandInput mode.
+
+.. seealso:: :py:func:`interpreter`
+
+.. versionadded:: 3.30
+%End
 
   public slots:
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -13,6 +13,31 @@
 
 
 
+class QgsCodeInterpreter
+{
+
+%TypeHeaderCode
+#include "qgscodeeditor.h"
+%End
+  public:
+
+
+    virtual ~QgsCodeInterpreter();
+
+    int exec( const QString &command );
+
+    virtual int currentState() const;
+
+    virtual QString promptForState( int state ) const = 0;
+
+  protected:
+
+    virtual int execCommandImpl( const QString &command ) = 0;
+
+};
+
+
+
 
 class QgsCodeEditor : QsciScintilla
 {
@@ -242,15 +267,16 @@ executed commands.
 
     QStringList history() const;
 
+    QgsCodeInterpreter *interpreter() const;
+    void setInterpreter( QgsCodeInterpreter *newInterpreter );
+
   public slots:
 
     void runCommand( const QString &command );
 %Docstring
 Runs a command in the editor.
 
-The base class method does nothing. Subclasses must implement
-the virtual :py:func:`~QgsCodeEditor.runCommandImpl` method with interpreter-specific
-logic for executing commands.
+An :py:func:`~QgsCodeEditor.interpreter` must be set.
 
 .. versionadded:: 3.30
 %End
@@ -364,22 +390,10 @@ Performs tasks which must be run after a lexer has been set for the widget.
     void updateSoftHistory();
     void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
 
-    virtual void runCommandImpl( const QString &command );
-%Docstring
-Executes a command.
-
-The base class method does nothing. Subclasses must implement
-this method with interpreter-specific logic for executing commands.
-
-.. versionadded:: 3.30
-%End
-
+    void updatePrompt();
 
     virtual void populateContextMenu( QMenu *menu );
 
-  protected slots:
-
-    virtual void updatePrompt();
 
 };
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -13,6 +13,7 @@
 
 
 
+
 class QgsCodeEditor : QsciScintilla
 {
 %Docstring(signature="appended")
@@ -71,6 +72,20 @@ Construct a new code editor.
 Set the widget title
 
 :param title: widget title
+%End
+
+    virtual Qgis::ScriptLanguage language() const;
+%Docstring
+Returns the associated scripting language.
+
+.. versionadded:: 3.30
+%End
+
+    static QString languageToString( Qgis::ScriptLanguage language );
+%Docstring
+Returns a user-friendly, translated name of the specified script ``language``.
+
+.. versionadded:: 3.30
 %End
 
  void setMarginVisible( bool margin ) /Deprecated/;

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -244,11 +244,13 @@ executed commands.
 
   public slots:
 
-    virtual void runCommand( const QString &command );
+    void runCommand( const QString &command );
 %Docstring
 Runs a command in the editor.
 
-The base class method does nothing.
+The base class method does nothing. Subclasses must implement
+the virtual :py:func:`~QgsCodeEditor.runCommandImpl` method with interpreter-specific
+logic for executing commands.
 
 .. versionadded:: 3.30
 %End
@@ -361,6 +363,17 @@ Performs tasks which must be run after a lexer has been set for the widget.
     void syncSoftHistory();
     void updateSoftHistory();
     void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+
+    virtual void runCommandImpl( const QString &command );
+%Docstring
+Executes a command.
+
+The base class method does nothing. Subclasses must implement
+this method with interpreter-specific logic for executing commands.
+
+.. versionadded:: 3.30
+%End
+
 
     virtual void populateContextMenu( QMenu *menu );
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -368,8 +368,22 @@ Shows the next command from the session in the editor.
 %End
 
     void showHistory();
+%Docstring
+Shows the command history dialog.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
 
     void removeHistoryCommand( int index );
+%Docstring
+Removes the command at the specified ``index`` from the history of the code editor.
+
+.. versionadded:: 3.30
+%End
 
     void clearSessionHistory();
 %Docstring
@@ -382,19 +396,46 @@ Clears the history of commands run in the current session.
 .. versionadded:: 3.30
 %End
 
-
     void clearPersistentHistory();
+%Docstring
+Clears the entire persistent history of commands run in the editor.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
 
     bool writeHistoryFile();
+%Docstring
+Stores the commands executed in the editor to the persistent history file.
+
+.. versionadded:: 3.30
+%End
 
   signals:
 
     void sessionHistoryCleared();
+%Docstring
+Emitted when the history of commands run in the current session is cleared.
+
+.. versionadded:: 3.30
+%End
+
     void persistentHistoryCleared();
+%Docstring
+Emitted when the persistent history of commands run in the editor is cleared.
+
+.. versionadded:: 3.30
+%End
 
   protected:
 
-    bool isFixedPitch( const QFont &font );
+    static bool isFixedPitch( const QFont &font );
+%Docstring
+Returns ``True`` if a ``font`` is a fixed pitch font.
+%End
 
     virtual void focusOutEvent( QFocusEvent *event );
 
@@ -433,15 +474,34 @@ Performs tasks which must be run after a lexer has been set for the widget.
 .. versionadded:: 3.16
 %End
 
-
-    void syncSoftHistory();
     void updateSoftHistory();
-    void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+%Docstring
+Updates the soft history by storing the current editor text in the history.
+
+.. versionadded:: 3.30
+%End
 
     void updatePrompt();
+%Docstring
+Triggers an update of the interactive prompt part of the editor.
+
+.. note::
+
+   Applies to code editors in the QgsCodeEditor.Mode.CommandInput mode only.
+
+.. versionadded:: 3.30
+%End
 
     virtual void populateContextMenu( QMenu *menu );
+%Docstring
+Called when the context ``menu`` for the widget is about to be shown, after it
+has been fully populated with the standard actions created by the base class.
 
+This method provides an opportunity for subclasses to add additional non-standard
+actions to the context menu.
+
+.. versionadded:: 3.30
+%End
 
 };
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -30,6 +30,13 @@ A text editor based on QScintilla2.
 %End
   public:
 
+    enum class Mode
+    {
+      ScriptEditor,
+      OutputDisplay,
+      CommandInput,
+    };
+
     enum class MarginRole
       {
       LineNumbers,
@@ -45,7 +52,7 @@ A text editor based on QScintilla2.
     typedef QFlags<QgsCodeEditor::Flag> Flags;
 
 
-    QgsCodeEditor( QWidget * parent /TransferThis/ = 0, const QString & title = QString(), bool folding = false, bool margin = false, QgsCodeEditor::Flags flags = QgsCodeEditor::Flags() );
+    QgsCodeEditor( QWidget * parent /TransferThis/ = 0, const QString & title = QString(), bool folding = false, bool margin = false, QgsCodeEditor::Flags flags = QgsCodeEditor::Flags(), QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 %Docstring
 Construct a new code editor.
 
@@ -54,6 +61,7 @@ Construct a new code editor.
 :param folding: ``False``: Enable folding for code editor (deprecated, use ``flags`` instead)
 :param margin: ``False``: Enable margin for code editor (deprecated)
 :param flags: flags controlling behavior of code editor (since QGIS 3.28)
+:param mode: code editor mode (since QGIS 3.30)
 
 .. versionadded:: 2.6
 %End
@@ -190,6 +198,13 @@ Clears all warning messages from the editor.
 .. versionadded:: 3.16
 %End
 
+    QgsCodeEditor::Mode mode() const;
+%Docstring
+Returns the code editor mode.
+
+.. versionadded:: 3.30
+%End
+
     bool isCursorOnLastLine() const;
 %Docstring
 Returns ``True`` if the cursor is on the last line of the document.
@@ -217,11 +232,11 @@ it is visible.
 
   protected:
 
-    bool isFixedPitch( const QFont & font );
+    bool isFixedPitch( const QFont &font );
 
-    virtual void focusOutEvent( QFocusEvent * event );
+    virtual void focusOutEvent( QFocusEvent *event );
 
-    virtual void keyPressEvent( QKeyEvent * event );
+    virtual void keyPressEvent( QKeyEvent *event );
 
 
     virtual void initializeLexer();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorcss.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorcss.sip.in
@@ -30,6 +30,8 @@ code autocompletion.
 %Docstring
 Constructor for QgsCodeEditorCSS
 %End
+    virtual Qgis::ScriptLanguage language() const;
+
 
   protected:
     virtual void initializeLexer();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorexpression.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorexpression.sip.in
@@ -29,6 +29,9 @@ code autocompletion.
 Constructor for QgsCodeEditorExpression
 %End
 
+    virtual Qgis::ScriptLanguage language() const;
+
+
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring
 Variables and functions from this expression context will be added to

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorhtml.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorhtml.sip.in
@@ -32,6 +32,9 @@ code autocompletion.
 Constructor for QgsCodeEditorHTML
 %End
 
+    virtual Qgis::ScriptLanguage language() const;
+
+
   protected:
     virtual void initializeLexer();
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorjs.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorjs.sip.in
@@ -28,6 +28,8 @@ code autocompletion.
 %Docstring
 Constructor for QgsCodeEditorJavascript
 %End
+    virtual Qgis::ScriptLanguage language() const;
+
 
   protected:
     virtual void initializeLexer();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorjson.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorjson.sip.in
@@ -29,6 +29,9 @@ code autocompletion.
 Constructor for QgsCodeEditorJson
 %End
 
+    virtual Qgis::ScriptLanguage language() const;
+
+
   protected:
     virtual void initializeLexer();
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -28,7 +28,8 @@ code autocompletion.
 %End
   public:
 
-    QgsCodeEditorPython( QWidget *parent /TransferThis/ = 0, const QList<QString> &filenames = QList<QString>() );
+    QgsCodeEditorPython( QWidget *parent /TransferThis/ = 0, const QList<QString> &filenames = QList<QString>(),
+                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 %Docstring
 Construct a new Python editor.
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -35,6 +35,7 @@ Construct a new Python editor.
 
 :param parent: The parent QWidget
 :param filenames: The list of apis files to load for the Python lexer
+:param mode: code editor mode (since QGIS 3.30)
 
 .. versionadded:: 2.6
 %End
@@ -51,9 +52,7 @@ Load APIs from one or more files
 
     bool loadScript( const QString &script );
 %Docstring
-Load a script file
-
-:param script: The script file to load
+Loads a ``script`` file.
 %End
 
   public slots:

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -38,6 +38,9 @@ Construct a new Python editor.
 .. versionadded:: 2.6
 %End
 
+    virtual Qgis::ScriptLanguage language() const;
+
+
     void loadAPIs( const QList<QString> &filenames );
 %Docstring
 Load APIs from one or more files

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorr.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorr.sip.in
@@ -24,7 +24,7 @@ code autocompletion.
 %End
   public:
 
-    QgsCodeEditorR( QWidget *parent /TransferThis/ = 0 );
+    QgsCodeEditorR( QWidget *parent /TransferThis/ = 0, QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 %Docstring
 Constructor for QgsCodeEditorR
 %End

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorr.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorr.sip.in
@@ -28,6 +28,8 @@ code autocompletion.
 %Docstring
 Constructor for QgsCodeEditorR
 %End
+    virtual Qgis::ScriptLanguage language() const;
+
 
   protected:
     virtual void initializeLexer();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorsql.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorsql.sip.in
@@ -31,6 +31,8 @@ code autocompletion.
 Constructor for QgsCodeEditorSQL
 %End
 
+    virtual Qgis::ScriptLanguage language() const;
+
 
     virtual ~QgsCodeEditorSQL();
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2286,6 +2286,25 @@ class CORE_EXPORT Qgis
     Q_ENUM( CoordinateDisplayType )
 
     /**
+     * Scripting languages.
+     *
+     * \since QGIS 3.30
+     */
+    enum class ScriptLanguage : int
+    {
+      Css, //!< CSS
+      QgisExpression, //!< QGIS expressions
+      Html, //!< HTML
+      JavaScript, //!< JavaScript
+      Json, //!< JSON
+      Python, //!< Python
+      R, //!< R Stats
+      Sql, //!< SQL
+      Unknown, //!< Unknown/other language
+    };
+    Q_ENUM( ScriptLanguage )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -128,6 +128,7 @@ set(QGIS_GUI_SRCS
   codeeditors/qgscodeeditorcolorscheme.cpp
   codeeditors/qgscodeeditorcolorschemeregistry.cpp
   codeeditors/qgscodeeditorcss.cpp
+  codeeditors/qgscodeeditorhistorydialog.cpp
   codeeditors/qgscodeeditorhtml.cpp
   codeeditors/qgscodeeditorjs.cpp
   codeeditors/qgscodeeditorjson.cpp
@@ -998,6 +999,7 @@ set(QGIS_GUI_HDRS
   codeeditors/qgscodeeditorcolorschemeregistry.h
   codeeditors/qgscodeeditorcss.h
   codeeditors/qgscodeeditorexpression.h
+  codeeditors/qgscodeeditorhistorydialog.h
   codeeditors/qgscodeeditorhtml.h
   codeeditors/qgscodeeditorjs.h
   codeeditors/qgscodeeditorjson.h

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -296,6 +296,37 @@ void QgsCodeEditor::setTitle( const QString &title )
   setWindowTitle( title );
 }
 
+Qgis::ScriptLanguage QgsCodeEditor::language() const
+{
+  return Qgis::ScriptLanguage::Unknown;
+}
+
+QString QgsCodeEditor::languageToString( Qgis::ScriptLanguage language )
+{
+  switch ( language )
+  {
+    case Qgis::ScriptLanguage::Css:
+      return tr( "CSS" );
+    case Qgis::ScriptLanguage::QgisExpression:
+      return tr( "Expression" );
+    case Qgis::ScriptLanguage::Html:
+      return tr( "HTML" );
+    case Qgis::ScriptLanguage::JavaScript:
+      return tr( "JavaScript" );
+    case Qgis::ScriptLanguage::Json:
+      return tr( "JSON" );
+    case Qgis::ScriptLanguage::Python:
+      return tr( "Python" );
+    case Qgis::ScriptLanguage::R:
+      return tr( "R" );
+    case Qgis::ScriptLanguage::Sql:
+      return tr( "SQL" );
+    case Qgis::ScriptLanguage::Unknown:
+      return QString();
+  }
+  BUILTIN_UNREACHABLE
+}
+
 void QgsCodeEditor::setMarginVisible( bool margin )
 {
   mMargin = margin;

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -174,6 +174,43 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
   {
     // Shortcut QScintilla and redirect the event to the QWidget handler
     QWidget::keyPressEvent( event ); // clazy:exclude=skipped-base-method
+    return;
+  }
+
+  if ( mMode == QgsCodeEditor::Mode::CommandInput )
+  {
+    switch ( event->key() )
+    {
+      case Qt::Key_Return:
+      case Qt::Key_Enter:
+        runCommand( text() );
+        updatePrompt();
+        return;
+
+      case Qt::Key_Down:
+
+        if ( !isListActive() )
+        {
+          showPreviousCommand();
+          updatePrompt();
+          return;
+        }
+        break;
+
+      case Qt::Key_Up:
+
+        if ( !isListActive() )
+        {
+          showNextCommand();
+          updatePrompt();
+          return;
+        }
+        break;
+
+      default:
+        break;
+    }
+    QsciScintilla::keyPressEvent( event );
   }
   else
   {

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -69,11 +69,12 @@ QMap< QgsCodeEditorColorScheme::ColorRole, QString > QgsCodeEditor::sColorRoleTo
 };
 
 
-QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool folding, bool margin, QgsCodeEditor::Flags flags )
+QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool folding, bool margin, QgsCodeEditor::Flags flags, QgsCodeEditor::Mode mode )
   : QsciScintilla( parent )
   , mWidgetTitle( title )
   , mMargin( margin )
   , mFlags( flags )
+  , mMode( mode )
 {
   if ( !parent && mWidgetTitle.isEmpty() )
   {
@@ -104,6 +105,31 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
     setSciWidget();
     initializeLexer();
   } );
+
+  switch ( mMode )
+  {
+    case QgsCodeEditor::Mode::ScriptEditor:
+      break;
+
+    case QgsCodeEditor::Mode::OutputDisplay:
+    {
+      // Don't want to see the horizontal scrollbar at all
+      SendScintilla( QsciScintilla::SCI_SETHSCROLLBAR, 0 );
+
+      setWrapMode( QsciScintilla::WrapCharacter );
+      break;
+    }
+
+    case QgsCodeEditor::Mode::CommandInput:
+    {
+      // Don't want to see the horizontal scrollbar at all
+      SendScintilla( QsciScintilla::SCI_SETHSCROLLBAR, 0 );
+
+      setWrapMode( QsciScintilla::WrapCharacter );
+      SendScintilla( QsciScintilla::SCI_EMPTYUNDOBUFFER );
+      break;
+    }
+  }
 }
 
 // Workaround a bug in QScintilla 2.8.X
@@ -335,7 +361,7 @@ bool QgsCodeEditor::foldingVisible()
 
 void QgsCodeEditor::updateFolding()
 {
-  if ( mFlags & QgsCodeEditor::Flag::CodeFolding )
+  if ( ( mFlags & QgsCodeEditor::Flag::CodeFolding ) && mMode == QgsCodeEditor::Mode::ScriptEditor )
   {
     setMarginWidth( static_cast< int >( QgsCodeEditor::MarginRole::FoldingControls ), "0" );
     setMarginsForegroundColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::MarginForeground ) );

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -504,7 +504,13 @@ QStringList QgsCodeEditor::history() const
   return mHistory;
 }
 
-void QgsCodeEditor::runCommand( const QString & )
+void QgsCodeEditor::runCommand( const QString &command )
+{
+  updateHistory( { command } );
+  runCommandImpl( command );
+}
+
+void QgsCodeEditor::runCommandImpl( const QString & )
 {
 
 }

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -499,6 +499,11 @@ void QgsCodeEditor::populateContextMenu( QMenu * )
 
 }
 
+void QgsCodeEditor::updatePrompt()
+{
+
+}
+
 QStringList QgsCodeEditor::history() const
 {
   return mHistory;
@@ -508,6 +513,9 @@ void QgsCodeEditor::runCommand( const QString &command )
 {
   updateHistory( { command } );
   runCommandImpl( command );
+
+  clear();
+  moveCursorToEnd();
 }
 
 void QgsCodeEditor::runCommandImpl( const QString & )
@@ -810,6 +818,9 @@ void QgsCodeEditor::moveCursorToStart()
   setCursorPosition( 0, 0 );
   ensureCursorVisible();
   ensureLineVisible( 0 );
+
+  if ( mMode == QgsCodeEditor::Mode::CommandInput )
+    updatePrompt();
 }
 
 void QgsCodeEditor::moveCursorToEnd()
@@ -819,4 +830,7 @@ void QgsCodeEditor::moveCursorToEnd()
   setCursorPosition( endLine, endLineLength );
   ensureCursorVisible();
   ensureLineVisible( endLine );
+
+  if ( mMode == QgsCodeEditor::Mode::CommandInput )
+    updatePrompt();
 }

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -313,6 +313,18 @@ void QgsCodeEditor::runPostLexerConfigurationTasks()
   SendScintilla( SCI_MARKERSETBACK, SC_MARKNUM_FOLDER,  lexerColor( QgsCodeEditorColorScheme::ColorRole::FoldIconForeground ) );
   SendScintilla( SCI_STYLESETFORE, STYLE_INDENTGUIDE, lexerColor( QgsCodeEditorColorScheme::ColorRole::IndentationGuide ) );
   SendScintilla( SCI_STYLESETBACK, STYLE_INDENTGUIDE,  lexerColor( QgsCodeEditorColorScheme::ColorRole::IndentationGuide ) );
+
+  if ( mMode == QgsCodeEditor::Mode::CommandInput )
+  {
+    setCaretLineVisible( false );
+    setLineNumbersVisible( false ); // NO linenumbers for the input line
+    // Margin 1 is used for the '>' prompt (console input)
+    setMarginLineNumbers( 1, true );
+    setMarginWidth( 1, "00000" );
+    setMarginType( 1, QsciScintilla::MarginType::TextMarginRightJustified );
+    setMarginsBackgroundColor( color( QgsCodeEditorColorScheme::ColorRole::Background ) );
+    setEdgeMode( QsciScintilla::EdgeNone );
+  }
 }
 
 void QgsCodeEditor::setSciWidget()

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -389,8 +389,20 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void showNextCommand();
 
+    /**
+     * Shows the command history dialog.
+
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
     void showHistory();
 
+    /**
+     * Removes the command at the specified \a index from the history of the code editor.
+     *
+     * \since QGIS 3.30
+     */
     void removeHistoryCommand( int index );
 
     /**
@@ -402,19 +414,44 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void clearSessionHistory();
 
-
+    /**
+     * Clears the entire persistent history of commands run in the editor.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
     void clearPersistentHistory();
 
+    /**
+     * Stores the commands executed in the editor to the persistent history file.
+     *
+     * \since QGIS 3.30
+     */
     bool writeHistoryFile();
 
   signals:
 
+    /**
+     * Emitted when the history of commands run in the current session is cleared.
+     *
+     * \since QGIS 3.30
+     */
     void sessionHistoryCleared();
+
+    /**
+     * Emitted when the persistent history of commands run in the editor is cleared.
+     *
+     * \since QGIS 3.30
+     */
     void persistentHistoryCleared();
 
   protected:
 
-    bool isFixedPitch( const QFont &font );
+    /**
+     * Returns TRUE if a \a font is a fixed pitch font.
+     */
+    static bool isFixedPitch( const QFont &font );
 
     void focusOutEvent( QFocusEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
@@ -450,21 +487,40 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void runPostLexerConfigurationTasks();
 
-
-    void syncSoftHistory();
+    /**
+     * Updates the soft history by storing the current editor text in the history.
+     *
+     * \since QGIS 3.30
+     */
     void updateSoftHistory();
-    void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
 
+    /**
+     * Triggers an update of the interactive prompt part of the editor.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
     void updatePrompt();
 
+    /**
+     * Called when the context \a menu for the widget is about to be shown, after it
+     * has been fully populated with the standard actions created by the base class.
+     *
+     * This method provides an opportunity for subclasses to add additional non-standard
+     * actions to the context menu.
+     *
+     * \since QGIS 3.30
+     */
     virtual void populateContextMenu( QMenu *menu );
-
 
   private:
 
     void setSciWidget();
     void updateFolding();
     bool readHistoryFile();
+    void syncSoftHistory();
+    void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
 
     QString mWidgetTitle;
     bool mMargin = false;

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -19,6 +19,8 @@
 
 #include <QString>
 #include "qgscodeeditorcolorscheme.h"
+#include "qgis.h"
+
 // qscintilla includes
 #include <Qsci/qsciapis.h>
 #include "qgis_sip.h"
@@ -109,6 +111,20 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      * \param title widget title
      */
     void setTitle( const QString & title );
+
+    /**
+     * Returns the associated scripting language.
+     *
+     * \since QGIS 3.30
+     */
+    virtual Qgis::ScriptLanguage language() const;
+
+    /**
+     * Returns a user-friendly, translated name of the specified script \a language.
+     *
+     * \since QGIS 3.30
+     */
+    static QString languageToString( Qgis::ScriptLanguage language );
 
     /**
      * Set margin visible state

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -45,6 +45,19 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
   public:
 
     /**
+     * Code editor modes.
+     *
+     * \since QGIS 3.30
+     */
+    enum class Mode
+    {
+      ScriptEditor, //!< Standard mode, allows for display and edit of entire scripts
+      OutputDisplay, //!< Read only mode for display of command outputs
+      CommandInput, //!< Command input mode
+    };
+    Q_ENUM( Mode )
+
+    /**
      * Margin roles.
      *
      * This enum contains the roles which the different numbered margins are used for.
@@ -86,9 +99,10 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      * \param folding FALSE: Enable folding for code editor (deprecated, use \a flags instead)
      * \param margin FALSE: Enable margin for code editor (deprecated)
      * \param flags flags controlling behavior of code editor (since QGIS 3.28)
+     * \param mode code editor mode (since QGIS 3.30)
      * \since QGIS 2.6
      */
-    QgsCodeEditor( QWidget * parent SIP_TRANSFERTHIS = nullptr, const QString & title = QString(), bool folding = false, bool margin = false, QgsCodeEditor::Flags flags = QgsCodeEditor::Flags() );
+    QgsCodeEditor( QWidget * parent SIP_TRANSFERTHIS = nullptr, const QString & title = QString(), bool folding = false, bool margin = false, QgsCodeEditor::Flags flags = QgsCodeEditor::Flags(), QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 
     /**
      * Set the widget title
@@ -216,6 +230,13 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     void clearWarnings();
 
     /**
+     * Returns the code editor mode.
+     *
+     * \since QGIS 3.30
+     */
+    QgsCodeEditor::Mode mode() const { return mMode; }
+
+    /**
      * Returns TRUE if the cursor is on the last line of the document.
      *
      * \since QGIS 3.28
@@ -242,10 +263,10 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 
   protected:
 
-    bool isFixedPitch( const QFont & font );
+    bool isFixedPitch( const QFont &font );
 
-    void focusOutEvent( QFocusEvent * event ) override;
-    void keyPressEvent( QKeyEvent * event ) override;
+    void focusOutEvent( QFocusEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
 
     /**
      * Called when the dialect specific code lexer needs to be initialized (or reinitialized).
@@ -285,6 +306,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     QString mWidgetTitle;
     bool mMargin = false;
     QgsCodeEditor::Flags mFlags;
+    QgsCodeEditor::Mode mMode = QgsCodeEditor::Mode::ScriptEditor;
 
     bool mUseDefaultSettings = true;
     // used if above is false, inplace of values taken from QSettings:

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -32,6 +32,31 @@
 SIP_IF_MODULE( HAVE_QSCI_SIP )
 
 
+class GUI_EXPORT QgsCodeInterpreter
+{
+  public:
+
+
+    virtual ~QgsCodeInterpreter();
+
+    int exec( const QString &command );
+
+    virtual int currentState() const { return mState; }
+
+    virtual QString promptForState( int state ) const = 0;
+
+  protected:
+
+    virtual int execCommandImpl( const QString &command ) = 0;
+
+  private:
+
+    int mState = 0;
+
+};
+
+
+
 class QWidget;
 
 /**
@@ -272,14 +297,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 
     QStringList history() const;
 
+    QgsCodeInterpreter *interpreter() const;
+    void setInterpreter( QgsCodeInterpreter *newInterpreter );
+
   public slots:
 
     /**
      * Runs a command in the editor.
      *
-     * The base class method does nothing. Subclasses must implement
-     * the virtual runCommandImpl() method with interpreter-specific
-     * logic for executing commands.
+     * An interpreter() must be set.
      *
      * \since QGIS 3.30
      */
@@ -385,22 +411,10 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     void updateSoftHistory();
     void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
 
-    /**
-     * Executes a command.
-     *
-     * The base class method does nothing. Subclasses must implement
-     * this method with interpreter-specific logic for executing commands.
-     *
-     * \since QGIS 3.30
-     */
-    virtual void runCommandImpl( const QString &command );
-
+    void updatePrompt();
 
     virtual void populateContextMenu( QMenu *menu );
 
-  protected slots:
-
-    virtual void updatePrompt();
 
   private:
 
@@ -428,6 +442,8 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     QStringList mSoftHistory;
     int mSoftHistoryIndex = 0;
     QString mHistoryFilePath;
+
+    QgsCodeInterpreter *mInterpreter = nullptr;
 
     static QMap< QgsCodeEditorColorScheme::ColorRole, QString > sColorRoleToSettingsKey;
 

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -259,7 +259,29 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     bool isCursorOnLastLine() const;
 
+    /**
+     * Sets the file path to use for recording and retrieving previously
+     * executed commands.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
+    void setHistoryFilePath( const QString &path );
+
+
+    QStringList history() const;
+
   public slots:
+
+    /**
+     * Runs a command in the editor.
+     *
+     * The base class method does nothing.
+
+     * \since QGIS 3.30
+     */
+    virtual void runCommand( const QString &command );
 
     /**
      * Moves the cursor to the start of the document and scrolls to ensure
@@ -277,12 +299,54 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     virtual void moveCursorToEnd();
 
+    /**
+     * Shows the previous command from the session in the editor.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
+    void showPreviousCommand();
+
+    /**
+     * Shows the next command from the session in the editor.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
+    void showNextCommand();
+
+    void showHistory();
+
+    void removeHistoryCommand( int index );
+
+    /**
+     * Clears the history of commands run in the current session.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
+    void clearSessionHistory();
+
+
+    void clearPersistentHistory();
+
+    bool writeHistoryFile();
+
+  signals:
+
+    void sessionHistoryCleared();
+    void persistentHistoryCleared();
+
   protected:
 
     bool isFixedPitch( const QFont &font );
 
     void focusOutEvent( QFocusEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
+    void contextMenuEvent( QContextMenuEvent *event ) override;
 
     /**
      * Called when the dialect specific code lexer needs to be initialized (or reinitialized).
@@ -314,10 +378,18 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void runPostLexerConfigurationTasks();
 
+
+    void syncSoftHistory();
+    void updateSoftHistory();
+    void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+
+    virtual void populateContextMenu( QMenu *menu );
+
   private:
 
     void setSciWidget();
     void updateFolding();
+    bool readHistoryFile();
 
     QString mWidgetTitle;
     bool mMargin = false;
@@ -333,6 +405,12 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     int mFontSize = 0;
 
     QVector< int > mWarningLines;
+
+    // for use in command input mode
+    QStringList mHistory;
+    QStringList mSoftHistory;
+    int mSoftHistoryIndex = 0;
+    QString mHistoryFilePath;
 
     static QMap< QgsCodeEditorColorScheme::ColorRole, QString > sColorRoleToSettingsKey;
 

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -398,6 +398,10 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 
     virtual void populateContextMenu( QMenu *menu );
 
+  protected slots:
+
+    virtual void updatePrompt();
+
   private:
 
     void setSciWidget();

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -31,22 +31,46 @@
 
 SIP_IF_MODULE( HAVE_QSCI_SIP )
 
-
+/**
+ * \ingroup gui
+ * \brief An interface for code interpreters.
+ * \since QGIS 3.30
+ */
 class GUI_EXPORT QgsCodeInterpreter
 {
   public:
 
-
     virtual ~QgsCodeInterpreter();
 
+    /**
+     * Executes a \a command in the interpreter.
+     *
+     * Returns an interpreter specific state value.
+     */
     int exec( const QString &command );
 
+    /**
+     * Returns the current interpreter state.
+     *
+     * The actual interpretation of the returned values depend on
+     * the interpreter subclass.
+     */
     virtual int currentState() const { return mState; }
 
+    /**
+     * Returns the interactive prompt string to use for the
+     * interpreter, given a \a state.
+     */
     virtual QString promptForState( int state ) const = 0;
 
   protected:
 
+    /**
+     * Pure virtual method for executing commands in the interpreter.
+     *
+     * Subclasses must implement this method. It will be called internally
+     * whenever the public exec() method is called.
+     */
     virtual int execCommandImpl( const QString &command ) = 0;
 
   private:
@@ -294,10 +318,30 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void setHistoryFilePath( const QString &path );
 
-
+    /**
+     * Returns the list of commands previously executed in the editor.
+     *
+     * \note Applies to code editors in the QgsCodeEditor::Mode::CommandInput mode only.
+     *
+     * \since QGIS 3.30
+     */
     QStringList history() const;
 
+    /**
+     * Returns the attached code interpreter, or NULLPTR if not set.
+     *
+     * \see setInterpreter()
+     * \since QGIS 3.30
+     */
     QgsCodeInterpreter *interpreter() const;
+
+    /**
+     * Sets an attached code interpreter for executing commands when the editor
+     * is in the QgsCodeEditor::Mode::CommandInput mode.
+     *
+     * \see interpreter()
+     * \since QGIS 3.30
+     */
     void setInterpreter( QgsCodeInterpreter *newInterpreter );
 
   public slots:

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -277,11 +277,13 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     /**
      * Runs a command in the editor.
      *
-     * The base class method does nothing.
-
+     * The base class method does nothing. Subclasses must implement
+     * the virtual runCommandImpl() method with interpreter-specific
+     * logic for executing commands.
+     *
      * \since QGIS 3.30
      */
-    virtual void runCommand( const QString &command );
+    void runCommand( const QString &command );
 
     /**
      * Moves the cursor to the start of the document and scrolls to ensure
@@ -382,6 +384,17 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     void syncSoftHistory();
     void updateSoftHistory();
     void updateHistory( const QStringList &commands, bool skipSoftHistory = false );
+
+    /**
+     * Executes a command.
+     *
+     * The base class method does nothing. Subclasses must implement
+     * this method with interpreter-specific logic for executing commands.
+     *
+     * \since QGIS 3.30
+     */
+    virtual void runCommandImpl( const QString &command );
+
 
     virtual void populateContextMenu( QMenu *menu );
 

--- a/src/gui/codeeditors/qgscodeeditorcss.cpp
+++ b/src/gui/codeeditors/qgscodeeditorcss.cpp
@@ -36,6 +36,11 @@ QgsCodeEditorCSS::QgsCodeEditorCSS( QWidget *parent )
   QgsCodeEditorCSS::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorCSS::language() const
+{
+  return Qgis::ScriptLanguage::Css;
+}
+
 void QgsCodeEditorCSS::initializeLexer()
 {
   QsciLexerCSS *lexer = new QgsQsciLexerCSS( this );

--- a/src/gui/codeeditors/qgscodeeditorcss.cpp
+++ b/src/gui/codeeditors/qgscodeeditorcss.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorcss.h"
 
 #include <QWidget>

--- a/src/gui/codeeditors/qgscodeeditorcss.h
+++ b/src/gui/codeeditors/qgscodeeditorcss.h
@@ -54,6 +54,7 @@ class GUI_EXPORT QgsCodeEditorCSS : public QgsCodeEditor
 
     //! Constructor for QgsCodeEditorCSS
     QgsCodeEditorCSS( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    Qgis::ScriptLanguage language() const override;
 
   protected:
     void initializeLexer() override;

--- a/src/gui/codeeditors/qgscodeeditorexpression.cpp
+++ b/src/gui/codeeditors/qgscodeeditorexpression.cpp
@@ -31,6 +31,11 @@ QgsCodeEditorExpression::QgsCodeEditorExpression( QWidget *parent )
   QgsCodeEditorExpression::initializeLexer(); // avoid cppcheck warning by explicitly specifying namespace
 }
 
+Qgis::ScriptLanguage QgsCodeEditorExpression::language() const
+{
+  return Qgis::ScriptLanguage::QgisExpression;
+}
+
 void QgsCodeEditorExpression::setExpressionContext( const QgsExpressionContext &context )
 {
   mVariables.clear();

--- a/src/gui/codeeditors/qgscodeeditorexpression.cpp
+++ b/src/gui/codeeditors/qgscodeeditorexpression.cpp
@@ -13,9 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorexpression.h"
-#include "qgssymbollayerutils.h"
+#include "qgsexpression.h"
 
 #include <QString>
 #include <QFont>

--- a/src/gui/codeeditors/qgscodeeditorexpression.h
+++ b/src/gui/codeeditors/qgscodeeditorexpression.h
@@ -41,6 +41,8 @@ class GUI_EXPORT QgsCodeEditorExpression : public QgsCodeEditor
     //! Constructor for QgsCodeEditorExpression
     QgsCodeEditorExpression( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    Qgis::ScriptLanguage language() const override;
+
     /**
      * Variables and functions from this expression context will be added to
      * the API.

--- a/src/gui/codeeditors/qgscodeeditorhistorydialog.cpp
+++ b/src/gui/codeeditors/qgscodeeditorhistorydialog.cpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+    qgscodeeditorhistorydialog.cpp
+    ----------------------
+    begin                : October 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscodeeditorhistorydialog.h"
+#include "qgscodeeditor.h"
+#include <QStandardItemModel>
+#include <QShortcut>
+
+QgsCodeEditorHistoryDialog::QgsCodeEditorHistoryDialog( QgsCodeEditor *editor, QWidget *parent )
+  : QDialog( parent )
+  , mEditor( editor )
+{
+  setupUi( this );
+
+  if ( mEditor )
+  {
+    setWindowTitle( tr( "%1 Console - Command History" ).arg( QgsCodeEditor::languageToString( mEditor->language() ) ) );
+  }
+
+  listView->setToolTip( tr( "Double-click on item to execute" ) );
+
+  mModel = new CodeHistoryModel( listView );
+  listView->setModel( mModel );
+
+  reloadHistory();
+
+  QShortcut *deleteShortcut = new QShortcut( QKeySequence( Qt::Key_Delete ), this );
+  connect( deleteShortcut, &QShortcut::activated, this, &QgsCodeEditorHistoryDialog::deleteItem );
+  connect( listView, &QListView::doubleClicked, this, &QgsCodeEditorHistoryDialog::runCommand );
+  connect( mButtonReloadHistory, &QPushButton::clicked, this, & QgsCodeEditorHistoryDialog::reloadHistory );
+  connect( mButtonSaveHistory, &QPushButton::clicked, this, & QgsCodeEditorHistoryDialog::saveHistory );
+  connect( mButtonRunHistory, &QPushButton::clicked, this, &QgsCodeEditorHistoryDialog::executeSelectedHistory );
+}
+
+void QgsCodeEditorHistoryDialog::executeSelectedHistory()
+{
+  if ( !mEditor )
+    return;
+
+  QModelIndexList selection = listView->selectionModel()->selectedIndexes();
+  std::sort( selection.begin(), selection.end() );
+  for ( const QModelIndex &index : std::as_const( selection ) )
+  {
+    mEditor->runCommand( index.data( Qt::DisplayRole ).toString() );
+  }
+}
+
+void QgsCodeEditorHistoryDialog::runCommand( const QModelIndex &index )
+{
+  if ( !mEditor )
+    return;
+
+  mEditor->runCommand( index.data( Qt::DisplayRole ).toString() );
+}
+
+void QgsCodeEditorHistoryDialog::saveHistory()
+{
+  if ( !mEditor )
+    return;
+
+  mEditor->writeHistoryFile();
+}
+
+void QgsCodeEditorHistoryDialog::reloadHistory()
+{
+  if ( mEditor )
+  {
+    mModel->setStringList( mEditor->history() );
+  }
+
+  listView->scrollToBottom();
+  listView->setCurrentIndex( mModel->index( mModel->rowCount() - 1, 0 ) );
+}
+
+void QgsCodeEditorHistoryDialog::deleteItem()
+{
+  const QModelIndexList selection = listView->selectionModel()->selectedRows();
+  if ( selection.empty() )
+    return;
+
+  QList< int > selectedRows;
+  selectedRows.reserve( selection.size() );
+  for ( const QModelIndex &index : selection )
+    selectedRows << index.row();
+  std::sort( selectedRows.begin(), selectedRows.end(), std::greater< int >() );
+
+  for ( int row : std::as_const( selectedRows ) )
+  {
+    if ( mEditor )
+      mEditor->removeHistoryCommand( row );
+
+    // Remove row from the command history dialog
+    mModel->removeRow( row );
+  }
+}
+
+///@cond PRIVATE
+CodeHistoryModel::CodeHistoryModel( QObject *parent )
+  : QStringListModel( parent )
+{
+  mFont = QgsCodeEditor::getMonospaceFont();
+}
+
+QVariant CodeHistoryModel::data( const QModelIndex &index, int role ) const
+{
+  if ( role == Qt::FontRole )
+  {
+    return mFont;
+  }
+
+  return QStringListModel::data( index, role );
+}
+///@endcond

--- a/src/gui/codeeditors/qgscodeeditorhistorydialog.h
+++ b/src/gui/codeeditors/qgscodeeditorhistorydialog.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+    qgscodeeditorhistorydialog.h
+    ----------------------
+    begin                : October 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCODEEDITORHISTORYDIALOG_H
+#define QGSCODEEDITORHISTORYDIALOG_H
+
+#include "ui_qgscodeditorhistorydialogbase.h"
+#include <QDialog>
+#include <QPointer>
+#include <QStringListModel>
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+
+#define SIP_NO_FILE
+
+class QgsCodeEditor;
+
+
+///@cond PRIVATE
+
+class CodeHistoryModel : public QStringListModel
+{
+    Q_OBJECT
+
+  public:
+    CodeHistoryModel( QObject *parent );
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+
+  private:
+
+    QFont mFont;
+};
+
+///@endcond
+
+
+/**
+ * \ingroup gui
+ * \class QgsCodeEditorHistoryDialog
+ * \brief A dialog for displaying and managing command history for a QgsCodeEditor widget.
+ * \note Not available in Python bindings
+ * \since QGIS 3.30
+ */
+class GUI_EXPORT QgsCodeEditorHistoryDialog : public QDialog, private Ui::QgsCodeEditorHistoryDialogBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsCodeEditorHistoryDialog.
+     * \param editor associated code editor widget
+     * \param parent parent widget
+     */
+    QgsCodeEditorHistoryDialog( QgsCodeEditor *editor, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+  private slots:
+
+    void executeSelectedHistory();
+    void runCommand( const QModelIndex &index );
+    void saveHistory();
+    void reloadHistory();
+    void deleteItem();
+
+  private:
+
+    QPointer< QgsCodeEditor > mEditor;
+    CodeHistoryModel *mModel = nullptr;
+
+};
+
+#endif // QGSCODEEDITORHISTORYDIALOG_H

--- a/src/gui/codeeditors/qgscodeeditorhtml.cpp
+++ b/src/gui/codeeditors/qgscodeeditorhtml.cpp
@@ -13,9 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorhtml.h"
-#include "qgssymbollayerutils.h"
 
 #include <QWidget>
 #include <QString>

--- a/src/gui/codeeditors/qgscodeeditorhtml.cpp
+++ b/src/gui/codeeditors/qgscodeeditorhtml.cpp
@@ -37,6 +37,11 @@ QgsCodeEditorHTML::QgsCodeEditorHTML( QWidget *parent )
   QgsCodeEditorHTML::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorHTML::language() const
+{
+  return Qgis::ScriptLanguage::Html;
+}
+
 void QgsCodeEditorHTML::initializeLexer()
 {
   QFont font = lexerFont();

--- a/src/gui/codeeditors/qgscodeeditorhtml.h
+++ b/src/gui/codeeditors/qgscodeeditorhtml.h
@@ -38,6 +38,8 @@ class GUI_EXPORT QgsCodeEditorHTML : public QgsCodeEditor
     //! Constructor for QgsCodeEditorHTML
     QgsCodeEditorHTML( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    Qgis::ScriptLanguage language() const override;
+
   protected:
     void initializeLexer() override;
 };

--- a/src/gui/codeeditors/qgscodeeditorjs.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjs.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorjs.h"
 
 #include <QWidget>

--- a/src/gui/codeeditors/qgscodeeditorjs.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjs.cpp
@@ -36,6 +36,11 @@ QgsCodeEditorJavascript::QgsCodeEditorJavascript( QWidget *parent )
   QgsCodeEditorJavascript::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorJavascript::language() const
+{
+  return Qgis::ScriptLanguage::JavaScript;
+}
+
 void QgsCodeEditorJavascript::initializeLexer()
 {
   QsciLexerJavaScript *lexer = new QsciLexerJavaScript( this );

--- a/src/gui/codeeditors/qgscodeeditorjs.h
+++ b/src/gui/codeeditors/qgscodeeditorjs.h
@@ -37,6 +37,7 @@ class GUI_EXPORT QgsCodeEditorJavascript : public QgsCodeEditor
 
     //! Constructor for QgsCodeEditorJavascript
     QgsCodeEditorJavascript( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    Qgis::ScriptLanguage language() const override;
 
   protected:
     void initializeLexer() override;

--- a/src/gui/codeeditors/qgscodeeditorjson.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjson.cpp
@@ -36,6 +36,11 @@ QgsCodeEditorJson::QgsCodeEditorJson( QWidget *parent )
   QgsCodeEditorJson::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorJson::language() const
+{
+  return Qgis::ScriptLanguage::Json;
+}
+
 void QgsCodeEditorJson::initializeLexer()
 {
   QsciLexerJSON *lexer = new QsciLexerJSON( this );

--- a/src/gui/codeeditors/qgscodeeditorjson.cpp
+++ b/src/gui/codeeditors/qgscodeeditorjson.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorjson.h"
 
 #include <QWidget>

--- a/src/gui/codeeditors/qgscodeeditorjson.h
+++ b/src/gui/codeeditors/qgscodeeditorjson.h
@@ -38,6 +38,8 @@ class GUI_EXPORT QgsCodeEditorJson : public QgsCodeEditor
     //! Constructor for QgsCodeEditorJson
     QgsCodeEditorJson( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    Qgis::ScriptLanguage language() const override;
+
   protected:
     void initializeLexer() override;
 

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -48,6 +48,11 @@ QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> 
   QgsCodeEditorPython::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorPython::language() const
+{
+  return Qgis::ScriptLanguage::Python;
+}
+
 void QgsCodeEditorPython::initializeLexer()
 {
   // current line

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -30,12 +30,12 @@
 #include <Qsci/qscilexerpython.h>
 #include <QDesktopServices>
 
-QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> &filenames )
+QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> &filenames, Mode mode )
   : QgsCodeEditor( parent,
                    QString(),
                    false,
                    false,
-                   QgsCodeEditor::Flag::CodeFolding )
+                   QgsCodeEditor::Flag::CodeFolding, mode )
   , mAPISFilesList( filenames )
 {
   if ( !parent )

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -58,7 +58,8 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      * \param filenames The list of apis files to load for the Python lexer
      * \since QGIS 2.6
      */
-    QgsCodeEditorPython( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QList<QString> &filenames = QList<QString>() );
+    QgsCodeEditorPython( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QList<QString> &filenames = QList<QString>(),
+                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 
     Qgis::ScriptLanguage language() const override;
 

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      *
      * \param parent The parent QWidget
      * \param filenames The list of apis files to load for the Python lexer
+     * \param mode code editor mode (since QGIS 3.30)
      * \since QGIS 2.6
      */
     QgsCodeEditorPython( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QList<QString> &filenames = QList<QString>(),
@@ -70,8 +71,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
     void loadAPIs( const QList<QString> &filenames );
 
     /**
-     * Load a script file
-     * \param script The script file to load
+     * Loads a \a script file.
      */
     bool loadScript( const QString &script );
 

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -60,6 +60,8 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      */
     QgsCodeEditorPython( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QList<QString> &filenames = QList<QString>() );
 
+    Qgis::ScriptLanguage language() const override;
+
     /**
      * Load APIs from one or more files
      * \param filenames The list of apis files to load for the Python lexer

--- a/src/gui/codeeditors/qgscodeeditorr.cpp
+++ b/src/gui/codeeditors/qgscodeeditorr.cpp
@@ -37,6 +37,11 @@ QgsCodeEditorR::QgsCodeEditorR( QWidget *parent, Mode mode )
   QgsCodeEditorR::initializeLexer();
 }
 
+Qgis::ScriptLanguage QgsCodeEditorR::language() const
+{
+  return Qgis::ScriptLanguage::R;
+}
+
 void QgsCodeEditorR::initializeLexer()
 {
   QgsQsciLexerR *lexer = new QgsQsciLexerR( this );

--- a/src/gui/codeeditors/qgscodeeditorr.cpp
+++ b/src/gui/codeeditors/qgscodeeditorr.cpp
@@ -28,7 +28,7 @@ QgsCodeEditorR::QgsCodeEditorR( QWidget *parent, Mode mode )
                    false,
                    false,
                    QgsCodeEditor::Flag::CodeFolding,
-	           mode )
+                   mode )
 {
   if ( !parent )
   {

--- a/src/gui/codeeditors/qgscodeeditorr.cpp
+++ b/src/gui/codeeditors/qgscodeeditorr.cpp
@@ -22,12 +22,13 @@
 #include <Qsci/qscilexerjson.h>
 
 
-QgsCodeEditorR::QgsCodeEditorR( QWidget *parent )
+QgsCodeEditorR::QgsCodeEditorR( QWidget *parent, Mode mode )
   : QgsCodeEditor( parent,
                    QString(),
                    false,
                    false,
-                   QgsCodeEditor::Flag::CodeFolding )
+                   QgsCodeEditor::Flag::CodeFolding,
+	           mode )
 {
   if ( !parent )
   {

--- a/src/gui/codeeditors/qgscodeeditorr.h
+++ b/src/gui/codeeditors/qgscodeeditorr.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsCodeEditorR : public QgsCodeEditor
   public:
 
     //! Constructor for QgsCodeEditorR
-    QgsCodeEditorR( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsCodeEditorR( QWidget *parent SIP_TRANSFERTHIS = nullptr, QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 
   protected:
     void initializeLexer() override;

--- a/src/gui/codeeditors/qgscodeeditorr.h
+++ b/src/gui/codeeditors/qgscodeeditorr.h
@@ -77,6 +77,7 @@ class GUI_EXPORT QgsCodeEditorR : public QgsCodeEditor
 
     //! Constructor for QgsCodeEditorR
     QgsCodeEditorR( QWidget *parent SIP_TRANSFERTHIS = nullptr, QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
+    Qgis::ScriptLanguage language() const override;
 
   protected:
     void initializeLexer() override;

--- a/src/gui/codeeditors/qgscodeeditorsql.cpp
+++ b/src/gui/codeeditors/qgscodeeditorsql.cpp
@@ -13,9 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsapplication.h"
 #include "qgscodeeditorsql.h"
-#include "qgssymbollayerutils.h"
 
 #include <QWidget>
 #include <QString>
@@ -35,7 +33,7 @@ QgsCodeEditorSQL::QgsCodeEditorSQL( QWidget *parent )
 
 Qgis::ScriptLanguage QgsCodeEditorSQL::language() const
 {
-  return Qgis::ScriptLanguage::SQL;
+  return Qgis::ScriptLanguage::Sql;
 }
 
 QgsCodeEditorSQL::~QgsCodeEditorSQL()

--- a/src/gui/codeeditors/qgscodeeditorsql.cpp
+++ b/src/gui/codeeditors/qgscodeeditorsql.cpp
@@ -33,6 +33,11 @@ QgsCodeEditorSQL::QgsCodeEditorSQL( QWidget *parent )
   QgsCodeEditorSQL::initializeLexer(); // avoid cppcheck warning by explicitly specifying namespace
 }
 
+Qgis::ScriptLanguage QgsCodeEditorSQL::language() const
+{
+  return Qgis::ScriptLanguage::SQL;
+}
+
 QgsCodeEditorSQL::~QgsCodeEditorSQL()
 {
   if ( mApis )

--- a/src/gui/codeeditors/qgscodeeditorsql.h
+++ b/src/gui/codeeditors/qgscodeeditorsql.h
@@ -39,6 +39,7 @@ class GUI_EXPORT QgsCodeEditorSQL : public QgsCodeEditor
     //! Constructor for QgsCodeEditorSQL
     QgsCodeEditorSQL( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    Qgis::ScriptLanguage language() const override;
 
     virtual ~QgsCodeEditorSQL();
 

--- a/src/ui/qgscodeditorhistorydialogbase.ui
+++ b/src/ui/qgscodeditorhistorydialogbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>HistoryDialogPythonConsole</class>
- <widget class="QDialog" name="HistoryDialogPythonConsole">
+ <class>QgsCodeEditorHistoryDialogBase</class>
+ <widget class="QDialog" name="QgsCodeEditorHistoryDialogBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -27,7 +27,7 @@
     <number>4</number>
    </property>
    <item row="1" column="0">
-    <widget class="QPushButton" name="reloadHistory">
+    <widget class="QPushButton" name="mButtonReloadHistory">
      <property name="text">
       <string>Reload</string>
      </property>
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QPushButton" name="saveHistory">
+    <widget class="QPushButton" name="mButtonSaveHistory">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -65,7 +65,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="runHistoryButton">
+      <widget class="QPushButton" name="mButtonRunHistory">
        <property name="text">
         <string>Run</string>
        </property>
@@ -124,7 +124,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>HistoryDialogPythonConsole</receiver>
+   <receiver>QgsCodeEditorHistoryDialogBase</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -140,7 +140,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>HistoryDialogPythonConsole</receiver>
+   <receiver>QgsCodeEditorHistoryDialogBase</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
(temporarily includes https://github.com/qgis/QGIS/pull/50430 )

Moves a bunch of the python console improvements to QgsCodeEditor up to the base class, so that other language implementations of QgsCodeEditor can take advantage of these without having to reimplement them all.

