### PR TITLE
Fix QgsVariantUtils::isNull not building on some compilers

### DIFF
--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -366,7 +366,6 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
       }
       return false;
 
-    case QVariant::LastCoreType:
     case QVariant::Color:
     case QVariant::Font:
     case QVariant::Brush:
@@ -381,7 +380,6 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
     case QVariant::Transform:
     case QVariant::Matrix4x4:
     case QVariant::SizePolicy:
-    case QVariant::LastGuiType:
       break;
 
     case QVariant::UserType:


### PR DESCRIPTION
## Description

QGIS 3.28 fails to build on some compilers due to the introduction of duplicate case values in the new QgsVariantUtils::isNull function. The error looks like this:

```
/home/runner/builddir/_deps/vcpkg-src/buildtrees/qgis/src/nal-3_28_0-53d43ef2a6.clean/src/core/qgsvariantutils.cpp: In static member function ‘static bool QgsVariantUtils::isNull(const QVariant&)’:
/home/runner/builddir/_deps/vcpkg-src/buildtrees/qgis/src/nal-3_28_0-53d43ef2a6.clean/src/core/qgsvariantutils.cpp:384:5: error: duplicate case value
  384 |     case QVariant::LastGuiType:
      |     ^~~~
/home/runner/builddir/_deps/vcpkg-src/buildtrees/qgis/src/nal-3_28_0-53d43ef2a6.clean/src/core/qgsvariantutils.cpp:379:5: note: previously used here
  379 |     case QVariant::PolygonF:
      |     ^~~~
```

Looking at Qt's QMetaType header, the Last{Core,Gui}Type is indeed a repetition of declared type (see https://github.com/qt/qtbase/blob/5.15.2/src/corelib/kernel/qmetatype.h#L441).

This PR removes those duplicated values.