### PR TITLE
Fix crash on exit

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2023,6 +2023,8 @@ QgisApp::~QgisApp()
   mUserInputDockWidget = nullptr;
   delete mMapStylingDock;
   mMapStylingDock = nullptr;
+  delete mCoordsEdit;
+  mCoordsEdit = nullptr;
 
   QgsGui::nativePlatformInterface()->cleanup();
 


### PR DESCRIPTION
The status bar coordinates widget can listen to some project signals emitted during project destruction and then access QgsProject properties as a result, so we need to ensure it is completely deleted before we do the application cleanup.