### PR TITLE
Take responsibility for managing the app GPS connection away from the GPS information dock

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -263,6 +263,7 @@ set(QGIS_APP_SRCS
   options/qgsrenderingoptions.cpp
   options/qgsvectorrenderingoptions.cpp
 
+  gps/qgsappgpsconnection.cpp
   gps/qgsgpsbearingitem.cpp
   gps/qgsgpsinformationwidget.cpp
   gps/qgsgpsmarker.cpp

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -1,0 +1,173 @@
+/***************************************************************************
+    qgsappgpsconnection.cpp
+    -------------------------
+    begin                : October 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsappgpsconnection.h"
+#include "qgsapplication.h"
+#include "qgsgpsconnection.h"
+#include "qgsgpsconnectionregistry.h"
+#include "qgsgpsdetector.h"
+#include "qgisapp.h"
+#include "qgsstatusbar.h"
+
+QgsAppGpsConnection::QgsAppGpsConnection( QObject *parent )
+  : QObject( parent )
+{
+
+}
+
+QgsAppGpsConnection::~QgsAppGpsConnection()
+{
+  if ( mConnection )
+  {
+    disconnectGps();
+  }
+}
+
+QgsGpsConnection *QgsAppGpsConnection::connection()
+{
+  return mConnection;
+}
+
+bool QgsAppGpsConnection::isConnected() const
+{
+  return static_cast< bool >( mConnection );
+}
+
+void QgsAppGpsConnection::setConnection( QgsGpsConnection *connection )
+{
+  if ( mConnection )
+  {
+    disconnectGps();
+  }
+
+  onConnected( connection );
+}
+
+void QgsAppGpsConnection::connectGps()
+{
+  QString port;
+
+  Qgis::GpsConnectionType connectionType = Qgis::GpsConnectionType::Automatic;
+  QString gpsdHost;
+  int gpsdPort = 0;
+  QString gpsdDevice;
+  QString serialDevice;
+  if ( QgsGpsConnection::settingsGpsConnectionType.exists() )
+  {
+    connectionType = QgsGpsConnection::settingsGpsConnectionType.value();
+    gpsdHost = QgsGpsConnection::settingsGpsdHostName.value();
+    gpsdPort = static_cast< int >( QgsGpsConnection::settingsGpsdPortNumber.value() );
+    gpsdDevice = QgsGpsConnection::settingsGpsdDeviceName.value();
+    serialDevice = QgsGpsConnection::settingsGpsSerialDevice.value();
+  }
+  else
+  {
+    // legacy settings
+    QgsSettings settings;
+    const QString portMode = settings.value( QStringLiteral( "portMode" ), "scanPorts", QgsSettings::Gps ).toString();
+
+    if ( portMode == QLatin1String( "scanPorts" ) )
+    {
+      connectionType = Qgis::GpsConnectionType::Automatic;
+    }
+    else if ( portMode == QLatin1String( "internalGPS" ) )
+    {
+      connectionType = Qgis::GpsConnectionType::Internal;
+    }
+    else if ( portMode == QLatin1String( "explicitPort" ) )
+    {
+      connectionType = Qgis::GpsConnectionType::Serial;
+    }
+    else if ( portMode == QLatin1String( "gpsd" ) )
+    {
+      connectionType = Qgis::GpsConnectionType::Gpsd;
+    }
+
+    gpsdHost = settings.value( QStringLiteral( "gpsdHost" ), "localhost", QgsSettings::Gps ).toString();
+    gpsdPort = settings.value( QStringLiteral( "gpsdPort" ), 2947, QgsSettings::Gps ).toInt();
+    gpsdDevice = settings.value( QStringLiteral( "gpsdDevice" ), QVariant(), QgsSettings::Gps ).toString();
+    serialDevice = settings.value( QStringLiteral( "lastPort" ), "", QgsSettings::Gps ).toString();
+  }
+
+  switch ( connectionType )
+  {
+    case Qgis::GpsConnectionType::Automatic:
+      break;
+    case Qgis::GpsConnectionType::Internal:
+      port = QStringLiteral( "internalGPS" );
+      break;
+    case Qgis::GpsConnectionType::Serial:
+      port = QgsGpsConnection::settingsGpsSerialDevice.value();
+      if ( port.isEmpty() )
+      {
+        emit connectionError( tr( "No path to the GPS port "
+                                  "is specified. Please set a path then try again." ) );
+        return;
+      }
+      break;
+    case Qgis::GpsConnectionType::Gpsd:
+    {
+      port = QStringLiteral( "%1:%2:%3" ).arg( gpsdHost ).arg( gpsdPort ).arg( gpsdDevice );
+      break;
+    }
+  }
+
+  emit connecting();
+  showStatusBarMessage( tr( "Connecting to GPS device %1…" ).arg( port ) );
+
+  QgsGpsDetector *detector = new QgsGpsDetector( port );
+  connect( detector, static_cast < void ( QgsGpsDetector::* )( QgsGpsConnection * ) > ( &QgsGpsDetector::detected ), this, &QgsAppGpsConnection::onConnected );
+  connect( detector, &QgsGpsDetector::detectionFailed, this, &QgsAppGpsConnection::onTimeOut );
+  detector->advance();   // start the detection process
+}
+
+void QgsAppGpsConnection::disconnectGps()
+{
+  if ( mConnection )
+  {
+    QgsApplication::gpsConnectionRegistry()->unregisterConnection( mConnection );
+    delete mConnection;
+    mConnection = nullptr;
+
+    emit disconnected();
+
+    showStatusBarMessage( tr( "Disconnected from GPS device." ) );
+  }
+}
+
+void QgsAppGpsConnection::onTimeOut()
+{
+  mConnection = nullptr;
+  emit connectionTimedOut();
+  showStatusBarMessage( tr( "Failed to connect to GPS device." ) );
+}
+
+void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )
+{
+  mConnection = conn;
+  connect( mConnection, &QgsGpsConnection::stateChanged, this, &QgsAppGpsConnection::stateChanged );
+  connect( mConnection, &QgsGpsConnection::nmeaSentenceReceived, this, &QgsAppGpsConnection::nmeaSentenceReceived );
+
+  //insert connection into registry such that it can also be used by other dialogs or plugins
+  QgsApplication::gpsConnectionRegistry()->registerConnection( mConnection );
+
+  emit connected();
+  showStatusBarMessage( tr( "Connected to GPS device." ) );
+}
+
+void QgsAppGpsConnection::showStatusBarMessage( const QString &msg )
+{
+  QgisApp::instance()->statusBarIface()->showMessage( msg );
+}

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -20,6 +20,7 @@
 #include "qgsgpsdetector.h"
 #include "qgisapp.h"
 #include "qgsstatusbar.h"
+#include "qgsmessagebar.h"
 
 QgsAppGpsConnection::QgsAppGpsConnection( QObject *parent )
   : QObject( parent )
@@ -112,8 +113,9 @@ void QgsAppGpsConnection::connectGps()
       port = QgsGpsConnection::settingsGpsSerialDevice.value();
       if ( port.isEmpty() )
       {
-        emit connectionError( tr( "No path to the GPS port "
-                                  "is specified. Please set a path then try again." ) );
+        QgisApp::instance()->statusBarIface()->clearMessage();
+        QgisApp::instance()->messageBar()->pushCritical( QString(), tr( "No path to the GPS port is specified. Please set a path then try again." ) );
+        emit connectionError( tr( "No path to the GPS port is specified. Please set a path then try again." ) );
         return;
       }
       break;
@@ -151,7 +153,9 @@ void QgsAppGpsConnection::onTimeOut()
 {
   mConnection = nullptr;
   emit connectionTimedOut();
-  showStatusBarMessage( tr( "Failed to connect to GPS device." ) );
+
+  QgisApp::instance()->statusBarIface()->clearMessage();
+  QgisApp::instance()->messageBar()->pushCritical( QString(), tr( "Failed to connect to GPS device." ) );
 }
 
 void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )

--- a/src/app/gps/qgsappgpsconnection.h
+++ b/src/app/gps/qgsappgpsconnection.h
@@ -1,0 +1,124 @@
+/***************************************************************************
+    qgsappgpsconnection.h
+    -------------------------
+    begin                : October 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSAPPGPSCONNECTION_H
+#define QGSAPPGPSCONNECTION_H
+
+#include "qgis_app.h"
+
+#include <QObject>
+class QgsGpsConnection;
+class QgsGpsInformation;
+
+/**
+ * Manages a single "canonical" GPS connection for use in the QGIS app, eg for displaying GPS
+ * coordinates and recording GPS tracks.
+ *
+ * While the underlying core API for GPS connections is designed to support multiple connections,
+ * the QGIS app interface (and all related GPS widgets) only allow for a single user-defined GPS connection
+ * at a time. This class tracks this canonical connection, and advises clients when the user-set
+ * GPS devices has state changes.
+ */
+class APP_EXPORT QgsAppGpsConnection : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    QgsAppGpsConnection( QObject *parent );
+
+    ~QgsAppGpsConnection() override;
+
+    /**
+     * Returns the associated GPS connection, or NULLPTR if not connected.
+     */
+    QgsGpsConnection *connection();
+
+    /**
+     * Returns TRUE if the GPS device is currently connected.
+     */
+    bool isConnected() const;
+
+    /**
+     * Sets a GPS \a connection to use within QGIS app.
+     *
+     * Any existing GPS connection used by the app will be disconnected and replaced with this connection. The connection
+     * is automatically registered within the QgsApplication::gpsConnectionRegistry().
+     */
+    void setConnection( QgsGpsConnection *connection );
+
+  public slots:
+
+    /**
+     * Starts a connection to the user-specified GPS device.
+     */
+    void connectGps();
+
+    /**
+     * Disconnects from the user-specified GPS device.
+     */
+    void disconnectGps();
+
+  signals:
+
+    /**
+     * Emitted when a connection attempt starts.
+     */
+    void connecting();
+
+    /**
+     * Emitted when an \a error occurs during the connection.
+     */
+    void connectionError( const QString &error );
+
+    /**
+     * Emitted when the GPS connection has been successfully made.
+     */
+    void connected();
+
+    /**
+     * Emitted when the GPS device has been disconnected.
+     */
+    void disconnected();
+
+    /**
+     * Emitted when a connection timeout occurs.
+     */
+    void connectionTimedOut();
+
+    /**
+     * Emitted when the state of the associated GPS device changes.
+     */
+    void stateChanged( const QgsGpsInformation &info );
+
+    /**
+     * Emitted when the associated GPS device receives an NMEA sentence.
+     */
+    void nmeaSentenceReceived( const QString &substring );
+
+  private slots:
+
+    void onTimeOut();
+
+    void onConnected( QgsGpsConnection *conn );
+
+  private:
+
+    void showStatusBarMessage( const QString &msg );
+
+    QgsGpsConnection *mConnection = nullptr;
+};
+
+
+#endif // QGSAPPGPSCONNECTION_H

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -584,9 +584,8 @@ void QgsGpsInformationWidget::gpsConnecting()
   mGPSPlainTextEdit->appendPlainText( tr( "Connecting…" ) );
 }
 
-void QgsGpsInformationWidget::gpsConnectionError( const QString &error )
+void QgsGpsInformationWidget::gpsConnectionError( const QString & )
 {
-  QMessageBox::information( this, tr( "GPS Connection" ), error );
   //toggle the button back off
   mConnectButton->setChecked( false );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -249,6 +249,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsguiutils.h"
 #include "qgsprojectionselectiondialog.h"
 #include "qgsgpsinformationwidget.h"
+#include "qgsappgpsconnection.h"
 #include "qgsguivectorlayertools.h"
 #include "qgsdiagramproperties.h"
 #include "qgslayerdefinition.h"
@@ -1391,7 +1392,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   mBookMarksDockWidget->hide();
 
   // create the GPS tool on starting QGIS - this is like the browser
-  mpGpsWidget = new QgsGpsInformationWidget( mMapCanvas );
+  mGpsConnection = new QgsAppGpsConnection( this );
+
+  mpGpsWidget = new QgsGpsInformationWidget( mGpsConnection, mMapCanvas );
   QgsPanelWidgetStack *gpsStack = new QgsPanelWidgetStack();
   gpsStack->setMainPanel( mpGpsWidget );
   mpGpsWidget->setDockMode( true );
@@ -1965,6 +1968,9 @@ QgisApp::~QgisApp()
   delete mpMaptip;
 
   delete mpGpsWidget;
+  mpGpsWidget = nullptr;
+  delete mGpsConnection;
+  mGpsConnection = nullptr;
 
   delete mOverviewMapCursor;
 
@@ -4876,7 +4882,7 @@ QgsLayerTreeRegistryBridge::InsertionPoint QgisApp::layerTreeInsertionPoint() co
 
 void QgisApp::setGpsPanelConnection( QgsGpsConnection *connection )
 {
-  mpGpsWidget->setConnection( connection );
+  mGpsConnection->setConnection( connection );
 }
 
 void QgisApp::autoSelectAddedLayer( QList<QgsMapLayer *> layers )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -153,6 +153,7 @@ class QgsAppQueryLogger;
 class QgsMapToolCapture;
 class QgsElevationProfileWidget;
 class QgsScreenHelper;
+class QgsAppGpsConnection;
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -2555,6 +2556,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QList<QgsDecorationItem *> mDecorationItems;
 
     //! Persistent GPS toolbox
+    QgsAppGpsConnection *mGpsConnection = nullptr;
     QgsGpsInformationWidget *mpGpsWidget = nullptr;
 
     QgsMessageBarItem *mLastMapToolMessage = nullptr;

--- a/tests/src/app/testqgsgpsinformationwidget.cpp
+++ b/tests/src/app/testqgsgpsinformationwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgssettingsregistrycore.h"
+#include "qgsappgpsconnection.h"
 #include "gps/qgsgpsinformationwidget.h"
 #include "nmeatime.h"
 
@@ -111,7 +112,8 @@ void TestQgsGpsInformationWidget::cleanupTestCase()
 std::unique_ptr<QgsGpsInformationWidget> TestQgsGpsInformationWidget::prepareWidget()
 {
   QgsMapCanvas *canvas = mQgisApp->mapCanvas();
-  std::unique_ptr<QgsGpsInformationWidget> widget = std::make_unique<QgsGpsInformationWidget>( canvas );
+  QgsAppGpsConnection connection( nullptr );
+  std::unique_ptr<QgsGpsInformationWidget> widget = std::make_unique<QgsGpsInformationWidget>( &connection, canvas );
   // Widget config and input values
   // 2019/06/19 12:27:34.543[UTC]
   widget->mLastNmeaTime = { 119, 5, 19, 12, 27, 34, 543 };
@@ -307,7 +309,8 @@ void TestQgsGpsInformationWidget::testMultiPartLayers()
       QStringLiteral( "memory" ) );
 
   QgsMapCanvas *canvas = mQgisApp->mapCanvas();
-  std::unique_ptr<QgsGpsInformationWidget> widget = std::make_unique<QgsGpsInformationWidget>( canvas );
+  QgsAppGpsConnection connection( nullptr );
+  std::unique_ptr<QgsGpsInformationWidget> widget = std::make_unique<QgsGpsInformationWidget>( &connection, canvas );
   widget->mMapCanvas->setCurrentLayer( multiLineString.get() );
   multiLineString->startEditing();
 
@@ -332,7 +335,7 @@ void TestQgsGpsInformationWidget::testMultiPartLayers()
       QStringLiteral( "vl4" ),
       QStringLiteral( "memory" ) );
 
-  widget = std::make_unique<QgsGpsInformationWidget>( canvas );
+  widget = std::make_unique<QgsGpsInformationWidget>( &connection, canvas );
   widget->mMapCanvas->setCurrentLayer( multiPolygon.get() );
   multiPolygon->startEditing();
 


### PR DESCRIPTION
(temporarily includes https://github.com/qgis/QGIS/pull/50678)

Take responsibility for managing the app GPS connection away from the GPS information dock class and move it to separate common class

This allows for other parts of the QGIS interface to hook into the app GPS device, and provides a cleaner separation from the GPS information panel GUI code.