### PR TITLE
Pdf with clickable links

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -92,12 +92,27 @@ Returns the label's current mode.
 .. seealso:: :py:func:`setMode`
 %End
 
+    bool useHtmlSubset() const;
+%Docstring
+Returns true if the HTML subset mode is enabled
+
+.. seealso:: :py:func:`setUseHtmlSubset`
+%End
+
     void setMode( Mode mode );
 %Docstring
 Sets the label's current ``mode``, allowing the label
 to switch between font based and HTML based rendering.
 
 .. seealso:: :py:func:`mode`
+%End
+
+    void setUseHtmlSubset( bool enabled );
+%Docstring
+If enabled the label will be rendered using the HTML subset provided
+by QTextDocument.
+
+.. seealso:: :py:func:`useHtmlSubset`
 %End
 
  QFont font() const /Deprecated/;

--- a/src/core/layout/qgslayoutitemlabel.cpp
+++ b/src/core/layout/qgslayoutitemlabel.cpp
@@ -147,10 +147,21 @@ void QgsLayoutItemLabel::draw( QgsLayoutItemRenderContext &context )
 
       if ( mWebPage )
       {
-        painter->scale( 1.0 / mHtmlUnitsToLayoutUnits / 10.0, 1.0 / mHtmlUnitsToLayoutUnits / 10.0 );
-        mWebPage->setViewportSize( QSize( painterRect.width() * mHtmlUnitsToLayoutUnits * 10.0, painterRect.height() * mHtmlUnitsToLayoutUnits * 10.0 ) );
-        mWebPage->settings()->setUserStyleSheetUrl( createStylesheetUrl() );
-        mWebPage->mainFrame()->render( painter );
+        if ( mUseHtmlSubset )
+        {
+          QTextDocument document;
+          document.setPageSize( QSize( painterRect.width() * mHtmlUnitsToLayoutUnits * 10.0, painterRect.height() * mHtmlUnitsToLayoutUnits * 10.0 ) );
+          document.setDefaultStyleSheet( createStylesheet() );
+          document.setHtml( currentText() );
+          document.drawContents( painter );
+        }
+        else
+        {
+          painter->scale( 1.0 / mHtmlUnitsToLayoutUnits / 10.0, 1.0 / mHtmlUnitsToLayoutUnits / 10.0 );
+          mWebPage->setViewportSize( QSize( painterRect.width() * mHtmlUnitsToLayoutUnits * 10.0, painterRect.height() * mHtmlUnitsToLayoutUnits * 10.0 ) );
+          mWebPage->settings()->setUserStyleSheetUrl( createStylesheetUrl() );
+          mWebPage->mainFrame()->render( painter );
+        }
       }
       break;
     }
@@ -273,6 +284,21 @@ void QgsLayoutItemLabel::setMode( Mode mode )
   }
 }
 
+void QgsLayoutItemLabel::setUseHtmlSubset( bool enabled )
+{
+  if ( enabled == mUseHtmlSubset )
+    return;
+
+  mUseHtmlSubset = enabled;
+  contentChanged();
+
+  if ( mLayout && id().isEmpty() )
+  {
+    //notify the model that the display name has changed
+    mLayout->itemsModel()->updateItemDisplayName( this );
+  }
+}
+
 void QgsLayoutItemLabel::refreshExpressionContext()
 {
   if ( !mLayout )
@@ -330,6 +356,39 @@ void QgsLayoutItemLabel::replaceDateText( QString &text ) const
       text.replace( QLatin1String( "$CURRENT_DATE" ), QDate::currentDate().toString() );
     }
   }
+}
+
+QString QgsLayoutItemLabel::createStylesheet() const
+{
+  QString stylesheet;
+  stylesheet += QStringLiteral( "body { margin: %1 %2;" ).arg( std::max( mMarginY * mHtmlUnitsToLayoutUnits, 0.0 ) ).arg( std::max( mMarginX * mHtmlUnitsToLayoutUnits, 0.0 ) );
+  QFont f = mFormat.font();
+  switch ( mFormat.sizeUnit() )
+  {
+    case QgsUnitTypes::RenderMillimeters:
+      f.setPointSizeF( mFormat.size() / 0.352778 );
+      break;
+    case QgsUnitTypes::RenderPixels:
+      f.setPixelSize( mFormat.size() );
+      break;
+    case QgsUnitTypes::RenderPoints:
+      f.setPointSizeF( mFormat.size() );
+      break;
+    case QgsUnitTypes::RenderInches:
+      f.setPointSizeF( mFormat.size() * 72 );
+      break;
+    case QgsUnitTypes::RenderUnknownUnit:
+    case QgsUnitTypes::RenderPercentage:
+    case QgsUnitTypes::RenderMetersInMapUnits:
+    case QgsUnitTypes::RenderMapUnits:
+      break;
+  }
+
+  stylesheet += QgsFontUtils::asCSS( f, 0.352778 * mHtmlUnitsToLayoutUnits );
+  stylesheet += QStringLiteral( "color: rgba(%1,%2,%3,%4);" ).arg( mFormat.color().red() ).arg( mFormat.color().green() ).arg( mFormat.color().blue() ).arg( QString::number( mFormat.color().alphaF(), 'f', 4 ) );
+  stylesheet += QStringLiteral( "text-align: %1; }" ).arg( mHAlignment == Qt::AlignLeft ? QStringLiteral( "left" ) : mHAlignment == Qt::AlignRight ? QStringLiteral( "right" ) : mHAlignment == Qt::AlignHCenter ? QStringLiteral( "center" ) : QStringLiteral( "justify" ) );
+
+  return stylesheet;
 }
 
 void QgsLayoutItemLabel::setFont( const QFont &f )
@@ -663,36 +722,8 @@ void QgsLayoutItemLabel::itemShiftAdjustSize( double newWidth, double newHeight,
 
 QUrl QgsLayoutItemLabel::createStylesheetUrl() const
 {
-  QString stylesheet;
-  stylesheet += QStringLiteral( "body { margin: %1 %2;" ).arg( std::max( mMarginY * mHtmlUnitsToLayoutUnits, 0.0 ) ).arg( std::max( mMarginX * mHtmlUnitsToLayoutUnits, 0.0 ) );
-  QFont f = mFormat.font();
-  switch ( mFormat.sizeUnit() )
-  {
-    case QgsUnitTypes::RenderMillimeters:
-      f.setPointSizeF( mFormat.size() / 0.352778 );
-      break;
-    case QgsUnitTypes::RenderPixels:
-      f.setPixelSize( mFormat.size() );
-      break;
-    case QgsUnitTypes::RenderPoints:
-      f.setPointSizeF( mFormat.size() );
-      break;
-    case QgsUnitTypes::RenderInches:
-      f.setPointSizeF( mFormat.size() * 72 );
-      break;
-    case QgsUnitTypes::RenderUnknownUnit:
-    case QgsUnitTypes::RenderPercentage:
-    case QgsUnitTypes::RenderMetersInMapUnits:
-    case QgsUnitTypes::RenderMapUnits:
-      break;
-  }
-
-  stylesheet += QgsFontUtils::asCSS( f, 0.352778 * mHtmlUnitsToLayoutUnits );
-  stylesheet += QStringLiteral( "color: rgba(%1,%2,%3,%4);" ).arg( mFormat.color().red() ).arg( mFormat.color().green() ).arg( mFormat.color().blue() ).arg( QString::number( mFormat.color().alphaF(), 'f', 4 ) );
-  stylesheet += QStringLiteral( "text-align: %1; }" ).arg( mHAlignment == Qt::AlignLeft ? QStringLiteral( "left" ) : mHAlignment == Qt::AlignRight ? QStringLiteral( "right" ) : mHAlignment == Qt::AlignHCenter ? QStringLiteral( "center" ) : QStringLiteral( "justify" ) );
-
   QByteArray ba;
-  ba.append( stylesheet.toUtf8() );
+  ba.append( createStylesheet().toUtf8() );
   QUrl cssFileURL = QUrl( QString( "data:text/css;charset=utf-8;base64," + ba.toBase64() ) );
 
   return cssFileURL;

--- a/src/core/layout/qgslayoutitemlabel.h
+++ b/src/core/layout/qgslayoutitemlabel.h
@@ -278,7 +278,7 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     QString mText;
 
     Mode mMode = ModeFont;
-    bool mUseHtmlSubset;
+    bool mUseHtmlSubset = false;
     double mHtmlUnitsToLayoutUnits = 1.0;
     double htmlUnitsToLayoutUnits(); //calculate scale factor
     bool mHtmlLoaded = false;
@@ -304,6 +304,8 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
 
     //! Replaces replace '$CURRENT_DATE<(FORMAT)>' with the current date (e.g. $CURRENT_DATE(d 'June' yyyy)
     void replaceDateText( QString &text ) const;
+
+    QFont getRenderFont() const;
 
     //! Creates stylesheet content using the current font and label appearance settings
     QString createStylesheet() const;

--- a/src/core/layout/qgslayoutitemlabel.h
+++ b/src/core/layout/qgslayoutitemlabel.h
@@ -102,11 +102,24 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     Mode mode() const { return mMode; }
 
     /**
+     * Returns true if the HTML subset mode is enabled
+     * \see setUseHtmlSubset()
+     */
+    bool useHtmlSubset() const { return mUseHtmlSubset; }
+
+    /**
      * Sets the label's current \a mode, allowing the label
      * to switch between font based and HTML based rendering.
      * \see mode()
      */
     void setMode( Mode mode );
+
+    /**
+     * If enabled the label will be rendered using the HTML subset provided
+     * by QTextDocument.
+     * \see useHtmlSubset()
+     */
+    void setUseHtmlSubset( bool enabled );
 
     /**
      * Returns the label's current font.
@@ -265,6 +278,7 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     QString mText;
 
     Mode mMode = ModeFont;
+    bool mUseHtmlSubset;
     double mHtmlUnitsToLayoutUnits = 1.0;
     double htmlUnitsToLayoutUnits(); //calculate scale factor
     bool mHtmlLoaded = false;
@@ -290,6 +304,9 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
 
     //! Replaces replace '$CURRENT_DATE<(FORMAT)>' with the current date (e.g. $CURRENT_DATE(d 'June' yyyy)
     void replaceDateText( QString &text ) const;
+
+    //! Creates stylesheet content using the current font and label appearance settings
+    QString createStylesheet() const;
 
     //! Creates an encoded stylesheet url using the current font and label appearance settings
     QUrl createStylesheetUrl() const;

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -38,6 +38,7 @@ QgsLayoutLabelWidget::QgsLayoutLabelWidget( QgsLayoutItemLabel *label )
 
   setupUi( this );
   connect( mHtmlCheckBox, &QCheckBox::stateChanged, this, &QgsLayoutLabelWidget::mHtmlCheckBox_stateChanged );
+  connect( mUseHtmlSubset, &QCheckBox::stateChanged, this, &QgsLayoutLabelWidget::mUseHtmlSubset_stateChanged );
   connect( mTextEdit, &QPlainTextEdit::textChanged, this, &QgsLayoutLabelWidget::mTextEdit_textChanged );
   connect( mInsertExpressionButton, &QPushButton::clicked, this, &QgsLayoutLabelWidget::mInsertExpressionButton_clicked );
   connect( mMarginXDoubleSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutLabelWidget::mMarginXDoubleSpinBox_valueChanged );
@@ -279,6 +280,16 @@ void QgsLayoutLabelWidget::mHtmlCheckBox_stateChanged( int state )
   }
 }
 
+void QgsLayoutLabelWidget::mUseHtmlSubset_stateChanged( int state )
+{
+  Q_UNUSED( state )
+
+  if ( label )
+  {
+    mLabel->setUseHtmlSubset( mUseHtmlSubset->isChecked() );
+  }
+}
+
 void QgsLayoutLabelWidget::mTextEdit_textChanged()
 {
   if ( mLabel )
@@ -445,6 +456,7 @@ void QgsLayoutLabelWidget::setGuiElementValues()
   mMarginXDoubleSpinBox->setValue( mLabel->marginX() );
   mMarginYDoubleSpinBox->setValue( mLabel->marginY() );
   mHtmlCheckBox->setChecked( mLabel->mode() == QgsLayoutItemLabel::ModeHtml );
+  mUseHtmlSubset->setChecked( mLabel->useHtmlSubset() );
   mTopRadioButton->setChecked( mLabel->vAlign() == Qt::AlignTop );
   mMiddleRadioButton->setChecked( mLabel->vAlign() == Qt::AlignVCenter );
   mBottomRadioButton->setChecked( mLabel->vAlign() == Qt::AlignBottom );
@@ -465,6 +477,7 @@ void QgsLayoutLabelWidget::blockAllSignals( bool block )
 {
   mTextEdit->blockSignals( block );
   mHtmlCheckBox->blockSignals( block );
+  mUseHtmlSubset->blockSignals( block );
   mMarginXDoubleSpinBox->blockSignals( block );
   mMarginYDoubleSpinBox->blockSignals( block );
   mTopRadioButton->blockSignals( block );

--- a/src/gui/layout/qgslayoutlabelwidget.h
+++ b/src/gui/layout/qgslayoutlabelwidget.h
@@ -64,7 +64,8 @@ class GUI_EXPORT QgsLayoutLabelWidget: public QgsLayoutItemBaseWidget, public Qg
     bool setNewItem( QgsLayoutItem *item ) override;
 
   private slots:
-    void mHtmlCheckBox_stateChanged( int i );
+    void mHtmlCheckBox_stateChanged( int state );
+    void mUseHtmlSubset_stateChanged( int state );
     void mTextEdit_textChanged();
     void mInsertExpressionButton_clicked();
     void mMarginXDoubleSpinBox_valueChanged( double d );

--- a/src/ui/layout/qgslayoutlabelwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlabelwidgetbase.ui
@@ -84,7 +84,7 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QToolButton" name="mDynamicTextButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -100,7 +100,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="mHtmlCheckBox">
+            <property name="text">
+             <string>Render as HTML</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QToolButton" name="mInsertExpressionButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -122,13 +129,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="mHtmlCheckBox">
-            <property name="text">
-             <string>Render as HTML</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0" colspan="2">
            <widget class="QPlainTextEdit" name="mTextEdit">
             <property name="minimumSize">
@@ -136,6 +136,16 @@
               <width>0</width>
               <height>150</height>
              </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="mUseHtmlSubset">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked only a subset of the HTML language can be rendered but exported hyperlink are clickable in exported PDF documents.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://doc.qt.io/qt-5/richtext-html-subset.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;More informations&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Use HTML subset</string>
             </property>
            </widget>
           </item>
@@ -384,7 +394,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Add an option in Layout's HTML frame to use QTextDocument to render HTML content. HTML links exported in PDF with QTextDocument are clickable in opposition as with WebKit.
But QTextDocument can render only a subset of HTML, so a new option was added.

Note: I think the optimal solution would be to replace WebKit with WebView but it is not possible at the moment to use it parallel to Qt 3D (https://github.com/qgis/QGIS/issues/49512#issuecomment-1221632895)

![image](https://user-images.githubusercontent.com/9881900/198048800-b58dbf38-5096-487e-9dfa-0d9df96efe01.png)
