### PR TITLE
Fix missing tiles in 3D view

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -534,6 +534,14 @@ void QgsChunkedEntity::onActiveJobFinished()
 
     if ( entity )
     {
+      // The returned QEntity is initially enabled, so let's add it to active nodes too.
+      // Soon afterwards updateScene() will be called, which would remove it from the scene
+      // if the node should not be shown anymore. Ideally entities should be initially disabled,
+      // but there seems to be a bug in Qt3D - if entity is disabled initially, showing it
+      // by setting setEnabled(true) is not reliable (entity eventually gets shown, but only after
+      // some more changes in the scene) - see #48334
+      mActiveNodes << node;
+
       // load into node (should be in main thread again)
       node->setLoaded( entity );
 

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -539,7 +539,7 @@ void QgsChunkedEntity::onActiveJobFinished()
       // if the node should not be shown anymore. Ideally entities should be initially disabled,
       // but there seems to be a bug in Qt3D - if entity is disabled initially, showing it
       // by setting setEnabled(true) is not reliable (entity eventually gets shown, but only after
-      // some more changes in the scene) - see #48334
+      // some more changes in the scene) - see https://github.com/qgis/QGIS/issues/48334
       mActiveNodes << node;
 
       // load into node (should be in main thread again)

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -126,7 +126,6 @@ Qt3DCore::QEntity *QgsDemTerrainTileLoader::createEntity( Qt3DCore::QEntity *par
   mNode->setExactBbox( QgsAABB( x0, zMin * map.terrainVerticalScale(), -y0, x0 + side, zMax * map.terrainVerticalScale(), -( y0 + side ) ) );
   mNode->updateParentBoundingBoxesRecursively();
 
-  entity->setEnabled( false );
   entity->setParent( parent );
   return entity;
 }

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -69,7 +69,6 @@ Qt3DCore::QEntity *FlatTerrainChunkLoader::createEntity( Qt3DCore::QEntity *pare
   transform->setScale( side );
   transform->setTranslation( QVector3D( bbox.xMin + half, 0, bbox.zMin + half ) );
 
-  entity->setEnabled( false );
   entity->setParent( parent );
   return entity;
 }


### PR DESCRIPTION
Fixes #48334

With these changes, the test project is not missing any tiles on load, and the animation export also gives correct results.

It turns out this is most likely a Qt3D bug - if an entity is initially added to the scene as disabled, sometimes it does not get shown after enabling it, it need some extra refresh of the scene to actually appear. There does not seem to be any existing Qt3D bug, but there are indications this may be the case:
- https://stackoverflow.com/questions/52424008/qentitys-setenabled-does-not-work-properly-when-entities-are-created-in-a-metho
- https://github.com/florianblume/qt3d-gizmo (see caveats in readme, although that's related to picking)

We work this around by returning enabled 3D entities (actually only DEM-based terrain and flat terrain was returning disabled entities) and that seems to help.

In theory it's not great that we immediately show an entity right after it was created (because the scene may have changed since the time it was requested), but the scene gets updated very soon afterwards anyway.
