### PR TITLE
Insuring legendLayersAdded is called when adding sorted layers 

### DIFF
--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -175,40 +175,6 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
     } );
   }
 
-  QgsLayerTreeGroup *parent = nullptr;
-  QgsLayerTreeNode *currentNode = QgisApp::instance()->layerTreeView()->currentNode();
-  int currentIndex = 0;
-  if ( currentNode && currentNode->parent() )
-  {
-    if ( QgsLayerTree::isGroup( currentNode ) )
-    {
-      parent = qobject_cast<QgsLayerTreeGroup *>( currentNode );
-    }
-    else if ( QgsLayerTree::isLayer( currentNode ) )
-    {
-      const QList<QgsLayerTreeNode *> currentNodeSiblings = currentNode->parent()->children();
-      int nodeIdx = 0;
-      for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
-      {
-        nodeIdx++;
-        if ( child == currentNode )
-        {
-          currentIndex = nodeIdx - 1;
-          break;
-        }
-      }
-      parent = qobject_cast<QgsLayerTreeGroup *>( currentNode->parent() );
-    }
-    else
-    {
-      parent = qobject_cast<QgsLayerTreeGroup *>( QgsProject::instance()->layerTreeRoot() );
-    }
-  }
-  else
-  {
-    parent = qobject_cast<QgsLayerTreeGroup *>( QgsProject::instance()->layerTreeRoot() );
-  }
-
   for ( QgsMapLayer *layer : layers )
   {
     if ( layer->customProperty( QStringLiteral( "_legend_added" ), false ).toBool() )
@@ -216,19 +182,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
       layer->removeCustomProperty( QStringLiteral( "_legend_added" ) );
       continue;
     }
-
-    switch ( QgsProject::instance()->layerTreeRegistryBridge()->layerInsertionMethod() )
-    {
-      case Qgis::LayerTreeInsertionMethod::AboveInsertionPoint:
-        parent->insertLayer( currentIndex, layer );
-        break;
-      case Qgis::LayerTreeInsertionMethod::TopOfTree:
-        QgsProject::instance()->layerTreeRoot()->insertLayer( 0, layer );
-        break;
-      case Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup:
-        QgsLayerTreeUtils::insertLayerAtOptimalPlacement( parent, layer );
-        break;
-    }
+    emit QgsProject::instance()->legendLayersAdded( QList<QgsMapLayer *>() << layer );
   }
   QgisApp::instance()->layerTreeView()->setCurrentLayer( layers.at( 0 ) );
 }


### PR DESCRIPTION
This PR fixes  #50718 by restoring the QgsProject::legendLayersAdded signal when app handles insertion of sorted layers.

@rduivenvoorde , this should fix your issue.

