### PR TITLE
Cleanup GPS fix status handling, remove duplicate code and add tests

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -850,6 +850,23 @@ Qgis.GpsConnectionType.Gpsd.__doc__ = "GPSD device"
 Qgis.GpsConnectionType.__doc__ = 'GPS connection types.\n\n.. versionadded:: 3.30\n\n' + '* ``Automatic``: ' + Qgis.GpsConnectionType.Automatic.__doc__ + '\n' + '* ``Internal``: ' + Qgis.GpsConnectionType.Internal.__doc__ + '\n' + '* ``Serial``: ' + Qgis.GpsConnectionType.Serial.__doc__ + '\n' + '* ``Gpsd``: ' + Qgis.GpsConnectionType.Gpsd.__doc__
 # --
 Qgis.GpsConnectionType.baseClass = Qgis
+QgsGpsInformation.FixStatus = Qgis.GpsFixStatus
+# monkey patching scoped based enum
+QgsGpsInformation.NoData = Qgis.GpsFixStatus.NoData
+QgsGpsInformation.NoData.is_monkey_patched = True
+QgsGpsInformation.NoData.__doc__ = "No fix data available"
+QgsGpsInformation.NoFix = Qgis.GpsFixStatus.NoFix
+QgsGpsInformation.NoFix.is_monkey_patched = True
+QgsGpsInformation.NoFix.__doc__ = "GPS is not fixed"
+QgsGpsInformation.Fix2D = Qgis.GpsFixStatus.Fix2D
+QgsGpsInformation.Fix2D.is_monkey_patched = True
+QgsGpsInformation.Fix2D.__doc__ = "2D fix"
+QgsGpsInformation.Fix3D = Qgis.GpsFixStatus.Fix3D
+QgsGpsInformation.Fix3D.is_monkey_patched = True
+QgsGpsInformation.Fix3D.__doc__ = "3D fix"
+Qgis.GpsFixStatus.__doc__ = 'GPS fix status.\n\n.. note::\n\n   Prior to QGIS 3.30 this was available as :py:class:`QgsGpsInformation`.FixStatus\n\n.. versionadded:: 3.30\n\n' + '* ``NoData``: ' + Qgis.GpsFixStatus.NoData.__doc__ + '\n' + '* ``NoFix``: ' + Qgis.GpsFixStatus.NoFix.__doc__ + '\n' + '* ``Fix2D``: ' + Qgis.GpsFixStatus.Fix2D.__doc__ + '\n' + '* ``Fix3D``: ' + Qgis.GpsFixStatus.Fix3D.__doc__
+# --
+Qgis.GpsFixStatus.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.GpsQualityIndicator.Unknown.__doc__ = "Unknown"
 Qgis.GpsQualityIndicator.Invalid.__doc__ = "Invalid"

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -56,14 +56,6 @@ Encapsulates information relating to a GPS position fix.
 %End
   public:
 
-    enum FixStatus
-    {
-      NoData,
-      NoFix,
-      Fix2D,
-      Fix3D
-    };
-
     double latitude;
 
     double longitude;
@@ -117,7 +109,7 @@ Returns whether the connection information is valid
 .. versionadded:: 3.10
 %End
 
-    FixStatus fixStatus() const;
+    Qgis::GpsFixStatus fixStatus() const;
 %Docstring
 Returns the fix status
 
@@ -212,6 +204,7 @@ Returns the current gps information (lat, lon, etc.)
 Parse available data source content
 %End
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -193,8 +193,24 @@ Returns the current gps information (lat, lon, etc.)
 %End
 
   signals:
+
     void stateChanged( const QgsGpsInformation &info );
-    void nmeaSentenceReceived( const QString &substring ); // added to capture 'raw' data
+%Docstring
+Emitted whenever the GPS state is changed.
+%End
+
+
+    void nmeaSentenceReceived( const QString &substring );
+%Docstring
+Emitted whenever the GPS device receives a raw NMEA sentence.
+%End
+
+    void fixStatusChanged( Qgis::GpsFixStatus status );
+%Docstring
+Emitted when the GPS device fix status is changed.
+
+.. versionadded:: 3.30
+%End
 
   protected:
 
@@ -203,6 +219,7 @@ Returns the current gps information (lat, lon, etc.)
 %Docstring
 Parse available data source content
 %End
+
 };
 
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -572,6 +572,14 @@ The development version
       Gpsd,
     };
 
+    enum class GpsFixStatus
+      {
+      NoData,
+      NoFix,
+      Fix2D,
+      Fix3D
+    };
+
     enum class GpsQualityIndicator
     {
       Unknown,

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -760,12 +760,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
   } //satellites
 #endif
 
-  bool validFlag = info.isValid();
-  if ( validFlag )
-  {
-    validFlag = info.longitude >= -180.0 && info.longitude <= 180.0 && info.latitude >= -90.0 && info.latitude <= 90.0;
-  }
-
+  const bool validFlag = info.isValid();
   QgsPointXY myNewCenter;
   nmeaPOS newNmeaPosition;
   nmeaTIME newNmeaTime;

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -19,7 +19,6 @@
 
 #include "ui_qgsgpsinformationwidgetbase.h"
 #include "qgis_app.h"
-#include "gmath.h"
 #include "info.h"
 #include "nmeatime.h"
 #include "qgsgpsmarker.h"
@@ -111,12 +110,9 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCa
     void gpsConnected();
 
   private:
-    enum FixStatus  //GPS status
-    {
-      NoData, NoFix, Fix2D, Fix3D
-    };
+
     void addVertex();
-    void setStatusIndicator( FixStatus statusValue );
+    void setStatusIndicator( Qgis::GpsFixStatus statusValue );
     void showStatusBarMessage( const QString &msg );
     void updateTimeZones();
     QVariant timestamp( QgsVectorLayer *vlayer, int idx );
@@ -147,7 +143,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, public QgsMapCa
     QgsPointXY mSecondLastGpsPosition;
     QVector<QgsPoint> mCaptureList;
     double mLastElevation = 0.0;
-    FixStatus mLastFixStatus;
+    Qgis::GpsFixStatus mLastFixStatus = Qgis::GpsFixStatus::NoData;
     QString mDateTimeFormat; // user specified format string in registry (no UI presented)
     QPointer< QgsVectorLayer > mLastLayer;
     QFile *mLogFile = nullptr;

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -44,22 +44,22 @@ bool QgsGpsInformation::isValid() const
   return valid;
 }
 
-QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
+Qgis::GpsFixStatus QgsGpsInformation::fixStatus() const
 {
-  FixStatus fixStatus = NoData;
+  Qgis::GpsFixStatus fixStatus = Qgis::GpsFixStatus::NoData;
 
   // no fix if any of the three report bad; default values are invalid values and won't be changed if the corresponding NMEA msg is not received
   if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
-    fixStatus = NoFix;
+    fixStatus = Qgis::GpsFixStatus::NoFix;
   }
   else if ( fixType == NMEA_FIX_2D ) // 2D indication (from GGA)
   {
-    fixStatus = Fix2D;
+    fixStatus = Qgis::GpsFixStatus::Fix2D;
   }
   else if ( status == 'A' || fixType == NMEA_FIX_3D || qualityIndicator != Qgis::GpsQualityIndicator::Invalid ) // good
   {
-    fixStatus = Fix3D;
+    fixStatus = Qgis::GpsFixStatus::Fix3D;
   }
   return fixStatus;
 }
@@ -105,8 +105,8 @@ QgsGpsConnection::QgsGpsConnection( QIODevice *dev )
   : QObject( nullptr )
   , mSource( dev )
 {
-  clearLastGPSInformation();
-  QObject::connect( dev, &QIODevice::readyRead, this, &QgsGpsConnection::parseData );
+  if ( mSource )
+    QObject::connect( mSource.get(), &QIODevice::readyRead, this, &QgsGpsConnection::parseData );
 }
 
 QgsGpsConnection::~QgsGpsConnection()
@@ -153,6 +153,8 @@ void QgsGpsConnection::setSource( QIODevice *source )
 {
   cleanupSource();
   mSource.reset( source );
+  QObject::connect( mSource.get(), &QIODevice::readyRead, this, &QgsGpsConnection::parseData );
+
   clearLastGPSInformation();
 }
 

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -41,6 +41,8 @@ bool QgsGpsInformation::isValid() const
     valid = true;
   }
 
+  valid &= longitude >= -180.0 && longitude <= 180.0 && latitude >= -90.0 && latitude <= 90.0;
+
   return valid;
 }
 

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -123,18 +123,6 @@ class CORE_EXPORT QgsGpsInformation
   public:
 
     /**
-     * GPS fix status
-     * \since QGIS 3.10
-     */
-    enum FixStatus
-    {
-      NoData,
-      NoFix,
-      Fix2D,
-      Fix3D
-    };
-
-    /**
      * Latitude in decimal degrees, using the WGS84 datum. A positive value indicates the Northern Hemisphere, and
      * a negative value indicates the Southern Hemisphere.
      */
@@ -279,7 +267,7 @@ class CORE_EXPORT QgsGpsInformation
      * Returns the fix status
      * \since QGIS 3.10
      */
-    FixStatus fixStatus() const;
+    Qgis::GpsFixStatus fixStatus() const;
 
     /**
      * Returns a descriptive string for the signal quality.
@@ -388,5 +376,7 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Parse available data source content
     virtual void parseData() = 0;
 };
+
+Q_DECLARE_METATYPE( QgsGpsInformation )
 
 #endif // QGSGPSCONNECTION_H

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -356,8 +356,25 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     QgsGpsInformation currentGPSInformation() const { return mLastGPSInformation; }
 
   signals:
+
+    /**
+     * Emitted whenever the GPS state is changed.
+     */
     void stateChanged( const QgsGpsInformation &info );
-    void nmeaSentenceReceived( const QString &substring ); // added to capture 'raw' data
+
+    // TODO QGIS 4.0 -- move to QgsNmeaConnection, it makes no sense in the base class
+
+    /**
+     * Emitted whenever the GPS device receives a raw NMEA sentence.
+     */
+    void nmeaSentenceReceived( const QString &substring );
+
+    /**
+     * Emitted when the GPS device fix status is changed.
+     *
+     * \since QGIS 3.30
+     */
+    void fixStatusChanged( Qgis::GpsFixStatus status );
 
   protected:
     //! Data source (e.g. serial device, socket, file,...)
@@ -367,6 +384,10 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Connection status
     Status mStatus = NotConnected;
 
+  private slots:
+
+    void onStateChanged( const QgsGpsInformation &info );
+
   private:
     //! Closes and deletes mSource
     void cleanupSource();
@@ -375,6 +396,12 @@ class CORE_EXPORT QgsGpsConnection : public QObject
   protected slots:
     //! Parse available data source content
     virtual void parseData() = 0;
+
+  private:
+
+    //! Last fix status
+    Qgis::GpsFixStatus mLastFixStatus = Qgis::GpsFixStatus::NoData;
+
 };
 
 Q_DECLARE_METATYPE( QgsGpsInformation )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -933,6 +933,22 @@ class CORE_EXPORT Qgis
     Q_ENUM( GpsConnectionType )
 
     /**
+     * GPS fix status.
+     *
+     * \note Prior to QGIS 3.30 this was available as QgsGpsInformation::FixStatus
+     *
+     * \since QGIS 3.30
+     */
+    enum class GpsFixStatus SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGpsInformation, FixStatus ) : int
+      {
+      NoData, //!< No fix data available
+      NoFix, //!< GPS is not fixed
+      Fix2D, //!< 2D fix
+      Fix3D //!< 3D fix
+    };
+    Q_ENUM( GpsFixStatus );
+
+    /**
      * GPS signal quality indicator
      *
      * \since QGIS 3.22.6

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -83,6 +83,7 @@
 #include "qgsunsetattributevalue.h"
 #include "qgscolorrampimpl.h"
 #include "qgsinterval.h"
+#include "qgsgpsconnection.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -323,6 +324,7 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );
     qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
     qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
+    qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
   } );
 
   ( void ) resolvePkgPath();

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -280,6 +280,7 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QgsFeatureStoreList>( "QgsFeatureStoreList" );
     qRegisterMetaType<Qgis::MessageLevel>( "Qgis::MessageLevel" );
     qRegisterMetaType<Qgis::BrowserItemState>( "Qgis::BrowserItemState" );
+    qRegisterMetaType<Qgis::GpsFixStatus>( "Qgis::GpsFixStatus" );
     qRegisterMetaType<QgsReferencedRectangle>( "QgsReferencedRectangle" );
     qRegisterMetaType<QgsReferencedPointXY>( "QgsReferencedPointXY" );
     qRegisterMetaType<QgsReferencedGeometry>( "QgsReferencedGeometry" );

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -128,6 +128,7 @@ set(TESTS
  testqgsnetworkaccessmanager.cpp
  testqgsnetworkcontentfetcher.cpp
  testqgsnewsfeedparser.cpp
+ testqgsnmeaconnection.cpp
  testqgsofflineediting.cpp
  testqgsogcutils.cpp
  testqgsogrprovider.cpp

--- a/tests/src/core/testqgsnmeaconnection.cpp
+++ b/tests/src/core/testqgsnmeaconnection.cpp
@@ -213,6 +213,30 @@ void TestQgsNmeaConnection::testFixStatus()
   info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
   QVERIFY( !info.isValid() );
   QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::NoFix );
+
+  // invalid fix due to bad lat / long values
+  connection.push( QStringLiteral( "$GPGSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  // latitude 99 degrees => out of range
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,9933.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QGSCOMPARENEAR( info.latitude, 99.563666, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, -0.70400000, 0.00001 );
+  QVERIFY( !info.isValid() );
+
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,9933.82,S,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QGSCOMPARENEAR( info.latitude, -99.563666, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, -0.70400000, 0.00001 );
+  QVERIFY( !info.isValid() );
+
+  // longitude 192 degrees => out of range
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,1933.82,N,19192.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QGSCOMPARENEAR( info.latitude, 19.5636666667, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, -192.5373333333, 0.00001 );
+  QVERIFY( !info.isValid() );
+
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,1933.82,N,19192.24,E,173.8,231.8,130694,004.2,W*70" ) );
+  QGSCOMPARENEAR( info.latitude, 19.5636666667, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 192.5373333333, 0.00001 );
+  QVERIFY( !info.isValid() );
 }
 
 QGSTEST_MAIN( TestQgsNmeaConnection )

--- a/tests/src/core/testqgsnmeaconnection.cpp
+++ b/tests/src/core/testqgsnmeaconnection.cpp
@@ -1,0 +1,219 @@
+/***************************************************************************
+  testqgsnmeaconnection.cpp
+
+ ---------------------
+ begin                : October 2022
+ copyright            : (C) 2022 by Nyall Dawson
+ email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+#include "qgis.h"
+#include "qgsnmeaconnection.h"
+
+#include <QObject>
+#include <QBuffer>
+#include <QSignalSpy>
+
+class ReplayNmeaConnection : public QgsNmeaConnection
+{
+    Q_OBJECT
+  public:
+
+    ReplayNmeaConnection()
+      : QgsNmeaConnection( nullptr )
+    {
+      mBuffer = new QBuffer();
+      setSource( mBuffer );
+      Q_ASSERT( connect() );
+    }
+
+    QgsGpsInformation push( const QString &message )
+    {
+      const QString messageTerminated = message + QStringLiteral( "\r\n" );
+
+      QSignalSpy spy( this, &QgsNmeaConnection::stateChanged );
+      const qint64 pos = mBuffer->pos();
+      mBuffer->write( messageTerminated.toLocal8Bit().constData() );
+      mBuffer->seek( pos );
+
+      spy.wait();
+      return spy.constLast().at( 0 ).value< QgsGpsInformation >();
+    }
+
+  private:
+
+    QBuffer *mBuffer = nullptr;
+};
+
+
+class TestQgsNmeaConnection : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+
+    TestQgsNmeaConnection() : QgsTest( QStringLiteral( "NMEA Connection Tests" ) ) {}
+
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void testBasic();
+    void testFixStatus();
+
+};
+
+void TestQgsNmeaConnection::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsNmeaConnection::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsNmeaConnection::testBasic()
+{
+  ReplayNmeaConnection connection;
+
+  QgsGpsInformation info = connection.push( QStringLiteral( "$GPGSV,3,1,12,07,41,181,26,05,34,292,30,16,34,060,36,26,24,031,24*7B" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( !info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Unknown (-1)" ) );
+  QCOMPARE( info.latitude, 0 );
+  QCOMPARE( info.longitude, 0 );
+  QCOMPARE( info.elevation, 0 );
+  QVERIFY( std::isnan( info.direction ) );
+
+  info = connection.push( QStringLiteral( "$GPGSV,3,2,12,02,61,115,,21,53,099,,03,51,111,,19,32,276,*72" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( !info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Unknown (-1)" ) );
+  QCOMPARE( info.latitude, 0 );
+  QCOMPARE( info.longitude, 0 );
+  QCOMPARE( info.elevation, 0 );
+  QVERIFY( std::isnan( info.direction ) );
+
+  info =  connection.push( QStringLiteral( "$GPGSV,3,3,12,17,31,279,,28,27,320,,23,23,026,,14,22,060,*7B" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Unknown (-1)" ) );
+  QCOMPARE( info.latitude, 0 );
+  QCOMPARE( info.longitude, 0 );
+  QCOMPARE( info.elevation, 0 );
+  QVERIFY( std::isnan( info.direction ) );
+
+  info = connection.push( QStringLiteral( "$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 0 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPGGA,084112.185,6938.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 35 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPGSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 35 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPRMC,084112.185,A,6938.6532,N,01856.8526,E,0.08,2.00,220120,,,A*60" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 35 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPGGA,084113.185,6938.6532,N,01856.8526,E,1,04,1.4,34.0,M,29.4,M,,0000*63" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 34 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPGSA,A,3,07,05,16,26,,,,,,,,,3.4,1.4,3.1*33" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 34 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+
+  info = connection.push( QStringLiteral( "$GPRMC,084113.185,A,6938.6532,N,01856.8526,E,0.05,2.00,220120,,,A*6C" ) );
+  QVERIFY( info.isValid() );
+  QVERIFY( info.satInfoComplete );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+  QCOMPARE( info.qualityDescription(), QStringLiteral( "Autonomous" ) );
+  QGSCOMPARENEAR( info.latitude, 69.6442183333, 0.00001 );
+  QGSCOMPARENEAR( info.longitude, 18.947545, 0.00001 );
+  QCOMPARE( info.elevation, 34 );
+  QGSCOMPARENEAR( info.direction, 2.0000000000, 0.0001 );
+}
+
+void TestQgsNmeaConnection::testFixStatus()
+{
+  ReplayNmeaConnection connection;
+
+  QgsGpsInformation info = connection.push( QStringLiteral( "$GPRMC,220516,V,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QVERIFY( !info.isValid() );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::NoFix );
+
+  // simulate 3d fix
+  connection.push( QStringLiteral( "$GPGSA,A,3,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QVERIFY( info.isValid() );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix3D );
+
+  // simulate 2d fix
+  connection.push( QStringLiteral( "$GPGSA,A,2,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QVERIFY( info.isValid() );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::Fix2D );
+
+  // simulate fix not available
+  connection.push( QStringLiteral( "$GPGSA,A,1,,,,,,16,18,,22,24,,,3.6,2.1,2.2*3C" ) );
+  info = connection.push( QStringLiteral( "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70" ) );
+  QVERIFY( !info.isValid() );
+  QCOMPARE( info.fixStatus(), Qgis::GpsFixStatus::NoFix );
+}
+
+QGSTEST_MAIN( TestQgsNmeaConnection )
+#include "testqgsnmeaconnection.moc"

--- a/tests/src/core/testqgsnmeaconnection.cpp
+++ b/tests/src/core/testqgsnmeaconnection.cpp
@@ -33,7 +33,8 @@ class ReplayNmeaConnection : public QgsNmeaConnection
     {
       mBuffer = new QBuffer();
       setSource( mBuffer );
-      Q_ASSERT( connect() );
+      bool ok = connect();
+      Q_ASSERT( ok );
     }
 
     QgsGpsInformation push( const QString &message )


### PR DESCRIPTION
This logic was present in both the core GPS connection class AND the GPS information widget, so I've removed the duplicate code from the information widget and cleaned this up.

Also adds a new test framework for NMEA message handling