### PR TITLE
Add constellation information to QgsGpsInformation and handle GPS fix type across different constellations

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -326,11 +326,9 @@ int nmea_parse_GPGSA( const char *buff, int buff_sz, nmeaGPGSA *pack )
 
   nmea_trace_buff( buff, buff_sz );
 
-  char type;
-
   if ( 18 != nmea_scanf( buff, buff_sz,
                          "$G%CGSA,%C,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%f,%f*",
-                         &( type ), &( pack->fix_mode ), &( pack->fix_type ),
+                         &( pack->pack_type ), &( pack->fix_mode ), &( pack->fix_type ),
                          &( pack->sat_prn[0] ), &( pack->sat_prn[1] ), &( pack->sat_prn[2] ), &( pack->sat_prn[3] ), &( pack->sat_prn[4] ), &( pack->sat_prn[5] ),
                          &( pack->sat_prn[6] ), &( pack->sat_prn[7] ), &( pack->sat_prn[8] ), &( pack->sat_prn[9] ), &( pack->sat_prn[10] ), &( pack->sat_prn[11] ),
                          &( pack->PDOP ), &( pack->HDOP ), &( pack->VDOP ) ) )
@@ -339,7 +337,7 @@ int nmea_parse_GPGSA( const char *buff, int buff_sz, nmeaGPGSA *pack )
     return 0;
   }
 
-  if ( type != 'P' && type != 'N' )
+  if ( pack->pack_type != 'P' && pack->pack_type != 'N' && pack->pack_type != 'L' )
   {
     nmea_error( "G?GSA invalid type " );
     return 0;

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -85,6 +85,7 @@ typedef struct _nmeaGPGSA
   double  PDOP;       //!< Dilution of precision
   double  HDOP;       //!< Horizontal dilution of precision
   double  VDOP;       //!< Vertical dilution of precision
+  char    pack_type;  //!< P=GPS, N=generic, L=GLONASS
 
 } nmeaGPGSA;
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -868,6 +868,18 @@ Qgis.GpsFixStatus.__doc__ = 'GPS fix status.\n\n.. note::\n\n   Prior to QGIS 3.
 # --
 Qgis.GpsFixStatus.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.GnssConstellation.Unknown.__doc__ = "Unknown/other system"
+Qgis.GnssConstellation.Gps.__doc__ = "Global Positioning System (GPS)"
+Qgis.GnssConstellation.Glonass.__doc__ = "Global Navigation Satellite System (GLONASS)"
+Qgis.GnssConstellation.Galileo.__doc__ = "Galileo"
+Qgis.GnssConstellation.BeiDou.__doc__ = "BeiDou"
+Qgis.GnssConstellation.Qzss.__doc__ = "Quasi Zenith Satellite System (QZSS)"
+Qgis.GnssConstellation.Navic.__doc__ = "Indian Regional Navigation Satellite System (IRNSS) / NAVIC"
+Qgis.GnssConstellation.Sbas.__doc__ = "SBAS"
+Qgis.GnssConstellation.__doc__ = 'GNSS constellation\n\n.. versionadded:: 3.30\n\n' + '* ``Unknown``: ' + Qgis.GnssConstellation.Unknown.__doc__ + '\n' + '* ``Gps``: ' + Qgis.GnssConstellation.Gps.__doc__ + '\n' + '* ``Glonass``: ' + Qgis.GnssConstellation.Glonass.__doc__ + '\n' + '* ``Galileo``: ' + Qgis.GnssConstellation.Galileo.__doc__ + '\n' + '* ``BeiDou``: ' + Qgis.GnssConstellation.BeiDou.__doc__ + '\n' + '* ``Qzss``: ' + Qgis.GnssConstellation.Qzss.__doc__ + '\n' + '* ``Navic``: ' + Qgis.GnssConstellation.Navic.__doc__ + '\n' + '* ``Sbas``: ' + Qgis.GnssConstellation.Sbas.__doc__
+# --
+Qgis.GnssConstellation.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.GpsQualityIndicator.Unknown.__doc__ = "Unknown"
 Qgis.GpsQualityIndicator.Invalid.__doc__ = "Invalid"
 Qgis.GpsQualityIndicator.GPS.__doc__ = "Standalone"

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -220,6 +220,13 @@ Returns the status. Possible state are not connected, connected, data received
 Returns the current gps information (lat, lon, etc.)
 %End
 
+    QgsPoint lastValidLocation() const;
+%Docstring
+Returns the last valid location obtained by the device.
+
+.. versionadded:: 3.30
+%End
+
   signals:
 
     void stateChanged( const QgsGpsInformation &info );
@@ -236,6 +243,15 @@ Emitted whenever the GPS device receives a raw NMEA sentence.
     void fixStatusChanged( Qgis::GpsFixStatus status );
 %Docstring
 Emitted when the GPS device fix status is changed.
+
+.. versionadded:: 3.30
+%End
+
+    void positionChanged( const QgsPoint &point );
+%Docstring
+Emitted when the GPS position changes.
+
+This signal is only emitted when the new GPS location is considered valid (see :py:func:`QgsGpsInformation.isValid()`).
 
 .. versionadded:: 3.30
 %End

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -40,9 +40,17 @@ Encapsulates information relating to a GPS satellite.
 
     QChar satType;
 
+    Qgis::GnssConstellation constellation() const;
+%Docstring
+Returns the GNSS constellation associated with the information.
+
+.. versionadded:: 3.30
+%End
+
     bool operator==( const QgsSatelliteInfo &other ) const;
 
     bool operator!=( const QgsSatelliteInfo &other ) const;
+
 };
 
 class QgsGpsInformation
@@ -90,6 +98,24 @@ Encapsulates information relating to a GPS position fix.
 
     int fixType;
 
+    QMap< Qgis::GnssConstellation, Qgis::GpsFixStatus > constellationFixStatus() const;
+%Docstring
+Returns a map of GNSS constellation to fix status.
+
+.. versionadded:: 3.30
+%End
+
+    Qgis::GpsFixStatus bestFixStatus( Qgis::GnssConstellation &constellation /Out/ ) const;
+%Docstring
+Returns the best fix status and corresponding constellation.
+
+
+:return: - best current fix status
+         - constellation: will be set to the constellation with best fix status
+
+.. versionadded:: 3.30
+%End
+
     int quality;
 
     Qgis::GpsQualityIndicator qualityIndicator;
@@ -109,11 +135,12 @@ Returns whether the connection information is valid
 .. versionadded:: 3.10
 %End
 
-    Qgis::GpsFixStatus fixStatus() const;
+ Qgis::GpsFixStatus fixStatus() const /Deprecated/;
 %Docstring
 Returns the fix status
 
-.. versionadded:: 3.10
+.. deprecated::
+  , use :py:func:`~QgsGpsInformation.constellationFixStatus` or :py:func:`~QgsGpsInformation.bestFixStatus` instead.
 %End
 
     QString qualityDescription() const;
@@ -122,6 +149,7 @@ Returns a descriptive string for the signal quality.
 
 .. versionadded:: 3.16
 %End
+
 };
 
 class QgsGpsConnection : QObject

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -580,6 +580,19 @@ The development version
       Fix3D
     };
 
+
+    enum class GnssConstellation
+    {
+      Unknown,
+      Gps,
+      Glonass,
+      Galileo,
+      BeiDou,
+      Qzss,
+      Navic,
+      Sbas,
+    };
+
     enum class GpsQualityIndicator
     {
       Unknown,

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -56,6 +56,11 @@ void QgsAppGpsConnection::setConnection( QgsGpsConnection *connection )
   onConnected( connection );
 }
 
+QgsPoint QgsAppGpsConnection::lastValidLocation() const
+{
+  return mConnection->lastValidLocation();
+}
+
 void QgsAppGpsConnection::connectGps()
 {
   QString port;
@@ -168,6 +173,7 @@ void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )
   connect( mConnection, &QgsGpsConnection::stateChanged, this, &QgsAppGpsConnection::stateChanged );
   connect( mConnection, &QgsGpsConnection::nmeaSentenceReceived, this, &QgsAppGpsConnection::nmeaSentenceReceived );
   connect( mConnection, &QgsGpsConnection::fixStatusChanged, this, &QgsAppGpsConnection::fixStatusChanged );
+  connect( mConnection, &QgsGpsConnection::positionChanged, this, &QgsAppGpsConnection::positionChanged );
 
   Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
   // emit signals so initial fix status is correctly advertised

--- a/src/app/gps/qgsappgpsconnection.h
+++ b/src/app/gps/qgsappgpsconnection.h
@@ -16,6 +16,7 @@
 #define QGSAPPGPSCONNECTION_H
 
 #include "qgis_app.h"
+#include "qgis.h"
 
 #include <QObject>
 class QgsGpsConnection;
@@ -96,6 +97,11 @@ class APP_EXPORT QgsAppGpsConnection : public QObject
      * Emitted when a connection timeout occurs.
      */
     void connectionTimedOut();
+
+    /**
+     * Emitted when the GPS fix status is changed
+     */
+    void fixStatusChanged( Qgis::GpsFixStatus status );
 
     /**
      * Emitted when the state of the associated GPS device changes.

--- a/src/app/gps/qgsappgpsconnection.h
+++ b/src/app/gps/qgsappgpsconnection.h
@@ -59,6 +59,11 @@ class APP_EXPORT QgsAppGpsConnection : public QObject
      */
     void setConnection( QgsGpsConnection *connection );
 
+    /**
+     * Returns the last recorded GPS position.
+     */
+    QgsPoint lastValidLocation() const;
+
   public slots:
 
     /**
@@ -112,6 +117,11 @@ class APP_EXPORT QgsAppGpsConnection : public QObject
      * Emitted when the associated GPS device receives an NMEA sentence.
      */
     void nmeaSentenceReceived( const QString &substring );
+
+    /**
+     * Emitted when the GPS position changes.
+     */
+    void positionChanged( const QgsPoint &point );
 
   private slots:
 

--- a/src/app/gps/qgsappgpsconnection.h
+++ b/src/app/gps/qgsappgpsconnection.h
@@ -19,8 +19,10 @@
 #include "qgis.h"
 
 #include <QObject>
+
 class QgsGpsConnection;
 class QgsGpsInformation;
+class QgsPoint;
 
 /**
  * Manages a single "canonical" GPS connection for use in the QGIS app, eg for displaying GPS

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -663,7 +663,8 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
   QVector<QPointF> data;
 
   // set visual status indicator -- do only on change of state
-  const Qgis::GpsFixStatus fixStatus = info.fixStatus();
+  Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
+  const Qgis::GpsFixStatus fixStatus = info.bestFixStatus( constellation );
   if ( fixStatus != mLastFixStatus )
   {
     setStatusIndicator( fixStatus );

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -200,7 +200,12 @@ void QgsGpsConnection::onStateChanged( const QgsGpsInformation &info )
 {
   if ( info.isValid() )
   {
+    const QgsPoint oldPosition = mLastLocation;
     mLastLocation = QgsPoint( info.longitude, info.latitude, info.elevation );
+    if ( mLastLocation != oldPosition )
+    {
+      emit positionChanged( mLastLocation );
+    }
   }
 
   Qgis::GnssConstellation bestFixConstellation = Qgis::GnssConstellation::Unknown;

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -397,6 +397,13 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Returns the current gps information (lat, lon, etc.)
     QgsGpsInformation currentGPSInformation() const { return mLastGPSInformation; }
 
+    /**
+     * Returns the last valid location obtained by the device.
+     *
+     * \since QGIS 3.30
+     */
+    QgsPoint lastValidLocation() const { return mLastLocation; }
+
   signals:
 
     /**
@@ -417,6 +424,15 @@ class CORE_EXPORT QgsGpsConnection : public QObject
      * \since QGIS 3.30
      */
     void fixStatusChanged( Qgis::GpsFixStatus status );
+
+    /**
+     * Emitted when the GPS position changes.
+     *
+     * This signal is only emitted when the new GPS location is considered valid (see QgsGpsInformation::isValid()).
+     *
+     * \since QGIS 3.30
+     */
+    void positionChanged( const QgsPoint &point );
 
   protected:
     //! Data source (e.g. serial device, socket, file,...)
@@ -444,7 +460,7 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Last fix status
     Qgis::GpsFixStatus mLastFixStatus = Qgis::GpsFixStatus::NoData;
 
-    //! Last recorded location
+    //! Last recorded valid location
     QgsPoint mLastLocation;
 };
 

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -466,14 +466,12 @@ void QgsNmeaConnection::processGsaSentence( const char *data, int len )
         mLastGPSInformation.satellitesUsed += 1;
 
         Qgis::GnssConstellation constellation = Qgis::GnssConstellation::Unknown;
-        if ( result.pack_type == 'L' )
+        if ( result.pack_type == 'L' || result.sat_prn[i] > 64 )
           constellation = Qgis::GnssConstellation::Glonass;
         else if ( result.sat_prn[i] >= 1 && result.sat_prn[i] <= 32 )
           constellation = Qgis::GnssConstellation::Gps;
         else if ( result.sat_prn[i] > 32 && result.sat_prn[i] <= 64 )
           constellation = Qgis::GnssConstellation::Sbas;
-        else if ( result.sat_prn[i] > 64 )
-          constellation = Qgis::GnssConstellation::Glonass;
 
         if ( result.sat_prn[i] > 0 )
         {

--- a/src/core/gps/qgsqtlocationconnection.cpp
+++ b/src/core/gps/qgsqtlocationconnection.cpp
@@ -70,6 +70,19 @@ void QgsQtLocationConnection::parseData()
       mLastGPSInformation.direction = mInfo.attribute( QGeoPositionInfo::Direction );
       mLastGPSInformation.utcDateTime = mInfo.timestamp();
       mLastGPSInformation.fixType = mInfo.coordinate().type() + 1;
+      switch ( mInfo.coordinate().type() )
+      {
+        case QGeoCoordinate::InvalidCoordinate:
+          mLastGPSInformation.mConstellationFixStatus[ Qgis::GnssConstellation::Unknown ] = Qgis::GpsFixStatus::NoFix;
+          break;
+        case QGeoCoordinate::Coordinate2D:
+          mLastGPSInformation.mConstellationFixStatus[ Qgis::GnssConstellation::Unknown ] = Qgis::GpsFixStatus::Fix2D;
+          break;
+        case QGeoCoordinate::Coordinate3D:
+          mLastGPSInformation.mConstellationFixStatus[ Qgis::GnssConstellation::Unknown ] = Qgis::GpsFixStatus::Fix3D;
+          break;
+      }
+
       //< fixType, used for navigation (1 = Fix not available; 2 = 2D; 3 = 3D)
       //< coordinate().type(), returns 0 = Fix not available; 1 = 2D; 2 = 3D)
       mLastGPSInformation.hacc = mInfo.attribute( QGeoPositionInfo::HorizontalAccuracy );   //< Horizontal dilution of precision

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -948,6 +948,25 @@ class CORE_EXPORT Qgis
     };
     Q_ENUM( GpsFixStatus );
 
+
+    /**
+     * GNSS constellation
+     *
+     * \since QGIS 3.30
+     */
+    enum class GnssConstellation
+    {
+      Unknown, //!< Unknown/other system
+      Gps, //!< Global Positioning System (GPS)
+      Glonass, //!< Global Navigation Satellite System (GLONASS)
+      Galileo, //!< Galileo
+      BeiDou, //!< BeiDou
+      Qzss, //!< Quasi Zenith Satellite System (QZSS)
+      Navic, //!< Indian Regional Navigation Satellite System (IRNSS) / NAVIC
+      Sbas, //!< SBAS
+    };
+    Q_ENUM( GnssConstellation );
+
     /**
      * GPS signal quality indicator
      *

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -295,6 +295,7 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QgsInterval>( "QgsInterval" );
     qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
     qRegisterMetaType<QgsPointXY>( "QgsPointXY" );
+    qRegisterMetaType<QgsPoint>( "QgsPoint" );
     qRegisterMetaType<QgsDatumTransform::GridDetails>( "QgsDatumTransform::GridDetails" );
     qRegisterMetaType<QgsDatumTransform::TransformDetails>( "QgsDatumTransform::TransformDetails" );
     qRegisterMetaType<QgsNewsFeedParser::Entry>( "QgsNewsFeedParser::Entry" );


### PR DESCRIPTION
A NMEA sequence of GNGSA sentences may reflect different fix types for satellites associated with different constellations. eg:

$GNGSA,A,3,6,11,12,19,20,25,29,10,20,19,7,10,7.5,5.5,5.1*24
$GNGSA,A,3,11,12,24,25,31,,,,,,,,7.5,5.5,5.1*2A
$GNGSA,A,1,194,195,,,,,,,,,,,7.5,5.5,5.1*29

Currently, only the last fix type is recorded, so QGIS always treats this connection as having no fix and always invalid locations.

Instead, we should handle the fix type per constellation and always use the best fix type across all constellations when determining whether a fix is valid.

