### PR TITLE
Fix qgsdialog.cpp to use addLayout

### DIFF
--- a/src/gui/qgsdialog.cpp
+++ b/src/gui/qgsdialog.cpp
@@ -28,7 +28,7 @@ QgsDialog::QgsDialog( QWidget *parent, Qt::WindowFlags fl,
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
 
   // layout
-  QLayout *layout = nullptr;
+  QBoxLayout *layout = nullptr;
   if ( orientation == Qt::Horizontal )
     layout = new QVBoxLayout();
   else

--- a/src/gui/qgsdialog.cpp
+++ b/src/gui/qgsdialog.cpp
@@ -34,7 +34,7 @@ QgsDialog::QgsDialog( QWidget *parent, Qt::WindowFlags fl,
   else
     layout = new QHBoxLayout();
   mLayout = new QVBoxLayout();
-  layout->addItem( mLayout );
+  layout->addLayout( mLayout );
   layout->addWidget( mButtonBox );
   setLayout( layout );
 }


### PR DESCRIPTION
It seems that addLayout should be used when adding another layout to a layout.

If fixed, the code below will display QLineEdit correctly:

dlg = QgsDialog()
layout = dlg.layout()
layout.addWidget(QLineEdit())
dlg.exec()
