### PR TITLE
[wms] Implement specific sample implementation for tiled layers with relevant data types

### DIFF
--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -292,6 +292,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
     int bandCount() const override;
     QString htmlMetadata() override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
+    double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;
     QString lastErrorFormat() override;

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -167,6 +167,23 @@ class TestQgsWmsProvider: public QgsTest
       QVERIFY( imageCheck( "mbtiles_1", mapSettings ) );
     }
 
+    void testMBTilesSample()
+    {
+      QString dataDir( TEST_DATA_DIR );
+      QUrlQuery uq;
+      uq.addQueryItem( "type", "mbtiles" );
+      uq.addQueryItem( "interpretation", "maptilerterrain" );
+      uq.addQueryItem( "url", QUrl::fromLocalFile( dataDir + "/isle_of_man.mbtiles" ).toString() );
+
+      QgsRasterLayer layer( uq.toString(), "isle_of_man", "wms" );
+      QVERIFY( layer.isValid() );
+
+      bool ok = false;
+      const double value = layer.dataProvider()->sample( QgsPointXY( -496419, 7213350 ), 1, &ok );
+      QVERIFY( ok );
+      QCOMPARE( value, 1167617.375 );
+    }
+
     void testDpiDependentData()
     {
       QString dataDir( TEST_DATA_DIR );


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/50669 by implementing a QgsWmsProvider::sample function for tiled layers with relevant data types (i.e. not RGB).

It also unlocks the raster_value() expression function against XYZ layers such as mapzen global elevation, which means users can drape geometries against it which is _nice_.