### PR TITLE
Elevation profiling against online terrain-related backport

### DIFF
--- a/src/core/raster/qgsrasterlayerprofilegenerator.cpp
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.cpp
@@ -189,14 +189,13 @@ bool QgsRasterLayerProfileGenerator::generateProfile( const QgsProfileGeneration
                                          subRegionLeft,
                                          subRegionTop ) : transformedCurve->boundingBox();
 
-  if ( mRasterProvider->xSize() == 0 || mRasterProvider->ySize() == 0 )
+  const bool zeroXYSize = mRasterProvider->xSize() == 0 || mRasterProvider->ySize() == 0;
+  if ( zeroXYSize )
   {
-    // e.g. XYZ tile source -- this is a rough hack for https://github.com/qgis/QGIS/issues/48806, which results
-    // in pretty poor curves ;)
     const double curveLengthInPixels = sourceCurve->length() / context.mapUnitsPerDistancePixel();
     const double conversionFactor = curveLengthInPixels / transformedCurve->length();
-    subRegionWidth = 2 * conversionFactor * rasterSubRegion.width();
-    subRegionHeight = 2 * conversionFactor * rasterSubRegion.height();
+    subRegionWidth = static_cast< int >( std::floor( rasterSubRegion.width() * conversionFactor ) );
+    subRegionHeight = static_cast< int >( std::floor( rasterSubRegion.height() * conversionFactor ) );
   }
 
   // iterate over the raster blocks, throwing away any which don't intersect the profile curve
@@ -248,8 +247,17 @@ bool QgsRasterLayerProfileGenerator::generateProfile( const QgsProfileGeneration
         // convert point to a pixel and sample, if it's in this block
         if ( blockExtent.contains( *it ) )
         {
-          const int row = std::clamp( static_cast< int >( std::round( ( blockExtent.yMaximum() - it->y() ) / mRasterUnitsPerPixelY ) ), 0, blockRows - 1 );
-          const int col = std::clamp( static_cast< int >( std::round( ( it->x() - blockExtent.xMinimum() ) / mRasterUnitsPerPixelX ) ),  0, blockColumns - 1 );
+          int row, col;
+          if ( zeroXYSize )
+          {
+            row = std::clamp( static_cast< int >( std::round( ( blockExtent.yMaximum() - it->y() ) * blockRows / blockExtent.height() ) ), 0, blockRows - 1 );
+            col = std::clamp( static_cast< int >( std::round( ( it->x() - blockExtent.xMinimum() ) * blockColumns / blockExtent.width() ) ), 0, blockColumns - 1 );
+          }
+          else
+          {
+            row = std::clamp( static_cast< int >( std::round( ( blockExtent.yMaximum() - it->y() ) / mRasterUnitsPerPixelY ) ), 0, blockRows - 1 );
+            col = std::clamp( static_cast< int >( std::round( ( it->x() - blockExtent.xMinimum() ) / mRasterUnitsPerPixelX ) ),  0, blockColumns - 1 );
+          }
           double val = block->valueAndNoData( row, col, isNoData );
           if ( !isNoData )
           {

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -292,6 +292,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
     int bandCount() const override;
     QString htmlMetadata() override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
+    double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;
     QString lastErrorFormat() override;

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -167,6 +167,23 @@ class TestQgsWmsProvider: public QgsTest
       QVERIFY( imageCheck( "mbtiles_1", mapSettings ) );
     }
 
+    void testMBTilesSample()
+    {
+      QString dataDir( TEST_DATA_DIR );
+      QUrlQuery uq;
+      uq.addQueryItem( "type", "mbtiles" );
+      uq.addQueryItem( "interpretation", "maptilerterrain" );
+      uq.addQueryItem( "url", QUrl::fromLocalFile( dataDir + "/isle_of_man.mbtiles" ).toString() );
+
+      QgsRasterLayer layer( uq.toString(), "isle_of_man", "wms" );
+      QVERIFY( layer.isValid() );
+
+      bool ok = false;
+      const double value = layer.dataProvider()->sample( QgsPointXY( -496419, 7213350 ), 1, &ok );
+      QVERIFY( ok );
+      QCOMPARE( value, 1167617.375 );
+    }
+
     void testDpiDependentData()
     {
       QString dataDir( TEST_DATA_DIR );


### PR DESCRIPTION
## Description

These two backported fixes together unlock elevation profiling against "online" terrain for 3.28 LTR. 

@nyalldawson , as discussed.