### PR TITLE
Add debugging setting to show label metrics when rendering labels

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1385,6 +1385,49 @@ QgsRenderContext.TextFormatAlwaysText.__doc__ = "Always render text as text obje
 Qgis.TextRenderFormat.__doc__ = 'Options for rendering text.\n\n.. versionadded:: 3.22\n\n' + '* ``TextFormatAlwaysOutlines``: ' + Qgis.TextRenderFormat.AlwaysOutlines.__doc__ + '\n' + '* ``TextFormatAlwaysText``: ' + Qgis.TextRenderFormat.AlwaysText.__doc__
 # --
 Qgis.TextRenderFormat.baseClass = Qgis
+QgsLabelingEngineSettings.Flag = Qgis.LabelingFlag
+# monkey patching scoped based enum
+QgsLabelingEngineSettings.UseAllLabels = Qgis.LabelingFlag.UseAllLabels
+QgsLabelingEngineSettings.UseAllLabels.is_monkey_patched = True
+QgsLabelingEngineSettings.UseAllLabels.__doc__ = "Whether to draw all labels even if there would be collisions"
+QgsLabelingEngineSettings.UsePartialCandidates = Qgis.LabelingFlag.UsePartialCandidates
+QgsLabelingEngineSettings.UsePartialCandidates.is_monkey_patched = True
+QgsLabelingEngineSettings.UsePartialCandidates.__doc__ = "Whether to use also label candidates that are partially outside of the map view"
+QgsLabelingEngineSettings.RenderOutlineLabels = Qgis.LabelingFlag.RenderOutlineLabels
+QgsLabelingEngineSettings.RenderOutlineLabels.is_monkey_patched = True
+QgsLabelingEngineSettings.RenderOutlineLabels.__doc__ = "Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead."
+QgsLabelingEngineSettings.DrawLabelRectOnly = Qgis.LabelingFlag.DrawLabelRectOnly
+QgsLabelingEngineSettings.DrawLabelRectOnly.is_monkey_patched = True
+QgsLabelingEngineSettings.DrawLabelRectOnly.__doc__ = "Whether to only draw the label rect and not the actual label text (used for unit tests)"
+QgsLabelingEngineSettings.DrawCandidates = Qgis.LabelingFlag.DrawCandidates
+QgsLabelingEngineSettings.DrawCandidates.is_monkey_patched = True
+QgsLabelingEngineSettings.DrawCandidates.__doc__ = "Whether to draw rectangles of generated candidates (good for debugging)"
+QgsLabelingEngineSettings.DrawUnplacedLabels = Qgis.LabelingFlag.DrawUnplacedLabels
+QgsLabelingEngineSettings.DrawUnplacedLabels.is_monkey_patched = True
+QgsLabelingEngineSettings.DrawUnplacedLabels.__doc__ = "Whether to render unplaced labels as an indicator/warning for users"
+QgsLabelingEngineSettings.CollectUnplacedLabels = Qgis.LabelingFlag.CollectUnplacedLabels
+QgsLabelingEngineSettings.CollectUnplacedLabels.is_monkey_patched = True
+QgsLabelingEngineSettings.CollectUnplacedLabels.__doc__ = "Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered). Since QGIS 3.20"
+QgsLabelingEngineSettings.DrawLabelMetrics = Qgis.LabelingFlag.DrawLabelMetrics
+QgsLabelingEngineSettings.DrawLabelMetrics.is_monkey_patched = True
+QgsLabelingEngineSettings.DrawLabelMetrics.__doc__ = "Whether to render label metric guides (for debugging). Since QGIS 3.30"
+Qgis.LabelingFlag.__doc__ = 'Various flags that affect drawing and placement of labels.\n\nPrior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.Flag\n\n.. versionadded:: 3.30\n\n' + '* ``UseAllLabels``: ' + Qgis.LabelingFlag.UseAllLabels.__doc__ + '\n' + '* ``UsePartialCandidates``: ' + Qgis.LabelingFlag.UsePartialCandidates.__doc__ + '\n' + '* ``RenderOutlineLabels``: ' + Qgis.LabelingFlag.RenderOutlineLabels.__doc__ + '\n' + '* ``DrawLabelRectOnly``: ' + Qgis.LabelingFlag.DrawLabelRectOnly.__doc__ + '\n' + '* ``DrawCandidates``: ' + Qgis.LabelingFlag.DrawCandidates.__doc__ + '\n' + '* ``DrawUnplacedLabels``: ' + Qgis.LabelingFlag.DrawUnplacedLabels.__doc__ + '\n' + '* ``CollectUnplacedLabels``: ' + Qgis.LabelingFlag.CollectUnplacedLabels.__doc__ + '\n' + '* ``DrawLabelMetrics``: ' + Qgis.LabelingFlag.DrawLabelMetrics.__doc__
+# --
+Qgis.LabelingFlag.baseClass = Qgis
+QgsLabelingEngineSettings.Flags = Qgis.LabelingFlags
+Qgis.LabelingFlags.baseClass = Qgis
+LabelingFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+QgsLabelingEngineSettings.PlacementEngineVersion = Qgis.LabelPlacementEngineVersion
+# monkey patching scoped based enum
+QgsLabelingEngineSettings.PlacementEngineVersion1 = Qgis.LabelPlacementEngineVersion.Version1
+QgsLabelingEngineSettings.PlacementEngineVersion1.is_monkey_patched = True
+QgsLabelingEngineSettings.PlacementEngineVersion1.__doc__ = "Version 1, matches placement from QGIS <= 3.10.1"
+QgsLabelingEngineSettings.PlacementEngineVersion2 = Qgis.LabelPlacementEngineVersion.Version2
+QgsLabelingEngineSettings.PlacementEngineVersion2.is_monkey_patched = True
+QgsLabelingEngineSettings.PlacementEngineVersion2.__doc__ = "Version 2 (default for new projects since QGIS 3.12)"
+Qgis.LabelPlacementEngineVersion.__doc__ = 'Labeling placement engine version.\n\nPrior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.PlacementEngineVersion\n\n.. versionadded:: 3.30\n\n' + '* ``PlacementEngineVersion1``: ' + Qgis.LabelPlacementEngineVersion.Version1.__doc__ + '\n' + '* ``PlacementEngineVersion2``: ' + Qgis.LabelPlacementEngineVersion.Version2.__doc__
+# --
+Qgis.LabelPlacementEngineVersion.baseClass = Qgis
 QgsTextFormat.TextOrientation = Qgis.TextOrientation
 # monkey patching scoped based enum
 QgsTextFormat.HorizontalOrientation = Qgis.TextOrientation.Horizontal

--- a/python/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
+++ b/python/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
@@ -20,19 +20,6 @@ Stores global configuration for labeling engine
 #include "qgslabelingenginesettings.h"
 %End
   public:
-    enum Flag
-    {
-      UseAllLabels,
-      UsePartialCandidates,
-      // TODO QGIS 4.0: remove
-      RenderOutlineLabels,
-      DrawLabelRectOnly,
-      DrawCandidates,
-      DrawUnplacedLabels,
-      CollectUnplacedLabels,
-    };
-    typedef QFlags<QgsLabelingEngineSettings::Flag> Flags;
-
 
 
     enum Search
@@ -44,12 +31,6 @@ Stores global configuration for labeling engine
       Falp
     };
 
-    enum PlacementEngineVersion
-    {
-      PlacementEngineVersion1,
-      PlacementEngineVersion2,
-    };
-
     QgsLabelingEngineSettings();
 
     void clear();
@@ -57,19 +38,19 @@ Stores global configuration for labeling engine
 Returns the configuration to the defaults
 %End
 
-    void setFlags( Flags flags );
+    void setFlags( Qgis::LabelingFlags flags );
 %Docstring
 Sets flags of the labeling engine
 %End
-    Flags flags() const;
+    Qgis::LabelingFlags flags() const;
 %Docstring
 Gets flags of the labeling engine
 %End
-    bool testFlag( Flag f ) const;
+    bool testFlag( Qgis::LabelingFlag f ) const;
 %Docstring
 Test whether a particular flag is enabled
 %End
-    void setFlag( Flag f, bool enabled = true );
+    void setFlag( Qgis::LabelingFlag f, bool enabled = true );
 %Docstring
 Sets whether a particual flag is enabled
 %End
@@ -188,7 +169,7 @@ Sets the ``color`` to use when rendering unplaced labels.
 .. versionadded:: 3.10
 %End
 
-    PlacementEngineVersion placementVersion() const;
+    Qgis::LabelPlacementEngineVersion placementVersion() const;
 %Docstring
 Returns the placement engine version, which dictates how the label placement problem is solved.
 
@@ -197,7 +178,7 @@ Returns the placement engine version, which dictates how the label placement pro
 .. versionadded:: 3.10.2
 %End
 
-    void setPlacementVersion( PlacementEngineVersion version );
+    void setPlacementVersion( Qgis::LabelPlacementEngineVersion version );
 %Docstring
 Sets the placement engine ``version``, which dictates how the label placement problem is solved.
 
@@ -207,9 +188,6 @@ Sets the placement engine ``version``, which dictates how the label placement pr
 %End
 
 };
-
-QFlags<QgsLabelingEngineSettings::Flag> operator|(QgsLabelingEngineSettings::Flag f1, QFlags<QgsLabelingEngineSettings::Flag> f2);
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -921,6 +921,28 @@ The development version
       AlwaysText,
     };
 
+    enum class LabelingFlag
+      {
+      UseAllLabels,
+      UsePartialCandidates,
+      // TODO QGIS 4.0: remove
+      RenderOutlineLabels,
+      DrawLabelRectOnly,
+      DrawCandidates,
+      DrawUnplacedLabels,
+      CollectUnplacedLabels,
+      DrawLabelMetrics,
+    };
+
+    typedef QFlags<Qgis::LabelingFlag> LabelingFlags;
+
+
+    enum class LabelPlacementEngineVersion
+      {
+      Version1,
+      Version2,
+    };
+
     enum class TextOrientation
       {
       Horizontal,
@@ -1510,6 +1532,8 @@ QFlags<Qgis::RasterTemporalCapabilityFlag> operator|(Qgis::RasterTemporalCapabil
 QFlags<Qgis::SelectionFlag> operator|(Qgis::SelectionFlag f1, QFlags<Qgis::SelectionFlag> f2);
 
 QFlags<Qgis::RasterRendererFlag> operator|(Qgis::RasterRendererFlag f1, QFlags<Qgis::RasterRendererFlag> f2);
+
+QFlags<Qgis::LabelingFlag> operator|(Qgis::LabelingFlag f1, QFlags<Qgis::LabelingFlag> f2);
 
 
 

--- a/src/analysis/processing/qgsalgorithmextractlabels.cpp
+++ b/src/analysis/processing/qgsalgorithmextractlabels.cpp
@@ -601,8 +601,8 @@ bool QgsExtractLabelsAlgorithm::prepareAlgorithm( const QVariantMap &parameters,
 
   bool includeUnplaced = parameterAsBoolean( parameters, QStringLiteral( "INCLUDE_UNPLACED" ), context );
   mLabelSettings = context.project()->labelingEngineSettings();
-  mLabelSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, includeUnplaced );
-  mLabelSettings.setFlag( QgsLabelingEngineSettings::CollectUnplacedLabels, includeUnplaced );
+  mLabelSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, includeUnplaced );
+  mLabelSettings.setFlag( Qgis::LabelingFlag::CollectUnplacedLabels, includeUnplaced );
 
   return true;
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3040,13 +3040,13 @@ void QgisApp::createActions()
   connect( mActionShowUnplacedLabels, &QAction::toggled, this, [ = ]( bool active )
   {
     QgsLabelingEngineSettings engineSettings = QgsProject::instance()->labelingEngineSettings();
-    engineSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, active );
+    engineSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, active );
     QgsProject::instance()->setLabelingEngineSettings( engineSettings );
     refreshMapCanvas( true );
   } );
   connect( QgsProject::instance(), &QgsProject::labelingEngineSettingsChanged, this, [ = ]
   {
-    whileBlocking( mActionShowUnplacedLabels )->setChecked( QgsProject::instance()->labelingEngineSettings().testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
+    whileBlocking( mActionShowUnplacedLabels )->setChecked( QgsProject::instance()->labelingEngineSettings().testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
   } );
   connect( mActionPinLabels, &QAction::triggered, this, &QgisApp::pinLabels );
   connect( mActionShowHideLabels, &QAction::triggered, this, &QgisApp::showHideLabels );

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -265,7 +265,7 @@ void QgsLabelingEngine::registerLabels( QgsRenderContext &context )
   mPal->setMaximumLineCandidatesPerMapUnit( settings.maximumLineCandidatesPerCm() / context.convertToMapUnits( 10, QgsUnitTypes::RenderMillimeters ) );
   mPal->setMaximumPolygonCandidatesPerMapUnitSquared( settings.maximumPolygonCandidatesPerCmSquared() / std::pow( context.convertToMapUnits( 10, QgsUnitTypes::RenderMillimeters ), 2 ) );
 
-  mPal->setShowPartialLabels( settings.testFlag( QgsLabelingEngineSettings::UsePartialCandidates ) );
+  mPal->setShowPartialLabels( settings.testFlag( Qgis::LabelingFlag::UsePartialCandidates ) );
   mPal->setPlacementVersion( settings.placementVersion() );
 
   // for each provider: get labels and register them in PAL
@@ -318,7 +318,7 @@ void QgsLabelingEngine::solve( QgsRenderContext &context )
     mapBoundaryGeom = mapBoundaryGeom.difference( region.geometry );
   }
 
-  if ( settings.flags() & QgsLabelingEngineSettings::DrawCandidates )
+  if ( settings.flags() & Qgis::LabelingFlag::DrawCandidates )
   {
     // draw map boundary
     QgsFeature f;
@@ -382,7 +382,7 @@ void QgsLabelingEngine::solve( QgsRenderContext &context )
   // this is done before actual solution of the problem
   // before number of candidates gets reduced
   // TODO mCandidates.clear();
-  if ( settings.testFlag( QgsLabelingEngineSettings::DrawCandidates ) && mProblem )
+  if ( settings.testFlag( Qgis::LabelingFlag::DrawCandidates ) && mProblem )
   {
     painter->setBrush( Qt::NoBrush );
     for ( int i = 0; i < static_cast< int >( mProblem->featureCount() ); i++ )
@@ -398,8 +398,9 @@ void QgsLabelingEngine::solve( QgsRenderContext &context )
 
   // find the solution
   mLabels = mPal->solveProblem( mProblem.get(), context,
-                                settings.testFlag( QgsLabelingEngineSettings::UseAllLabels ),
-                                settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) || settings.testFlag( QgsLabelingEngineSettings::CollectUnplacedLabels ) ? &mUnlabeled : nullptr );
+                                settings.testFlag( Qgis::LabelingFlag::UseAllLabels ),
+                                settings.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels )
+                                || settings.testFlag( Qgis::LabelingFlag::CollectUnplacedLabels ) ? &mUnlabeled : nullptr );
 
   // sort labels
   std::sort( mLabels.begin(), mLabels.end(), QgsLabelSorter( mMapSettings ) );
@@ -490,7 +491,7 @@ void QgsLabelingEngine::drawLabels( QgsRenderContext &context, const QString &la
   }
 
   // draw unplaced labels. These are always rendered on top
-  if ( settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) || settings.testFlag( QgsLabelingEngineSettings::CollectUnplacedLabels ) )
+  if ( settings.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) || settings.testFlag( Qgis::LabelingFlag::CollectUnplacedLabels ) )
   {
     for ( pal::LabelPosition *label : std::as_const( mUnlabeled ) )
     {

--- a/src/core/labeling/qgslabelingengine.h
+++ b/src/core/labeling/qgslabelingengine.h
@@ -21,7 +21,6 @@
 #include "qgis_core.h"
 #include "qgsmapsettings.h"
 
-#include "qgslabelingenginesettings.h"
 #include "qgslabeling.h"
 #include "qgsfeedback.h"
 #include "qgslabelobstaclesettings.h"
@@ -29,6 +28,7 @@
 class QgsLabelingEngine;
 class QgsLabelingResults;
 class QgsLabelFeature;
+class QgsLabelingEngineSettings;
 
 namespace pal
 {
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsAbstractLabelProvider
      *
      * The default behavior is to draw nothing for these labels.
      *
-     * \note This method is only used if the QgsLabelingEngineSettings::DrawUnplacedLabels flag
+     * \note This method is only used if the Qgis::Qgis::LabelingFlag::DrawUnplacedLabels flag
      * is set on the labeling engine.
      *
      * \since QGIS 3.10

--- a/src/core/labeling/qgslabelingenginesettings.cpp
+++ b/src/core/labeling/qgslabelingenginesettings.cpp
@@ -19,7 +19,6 @@
 #include "qgssymbollayerutils.h"
 
 QgsLabelingEngineSettings::QgsLabelingEngineSettings()
-  : mFlags( UsePartialCandidates )
 {
 }
 
@@ -35,12 +34,13 @@ void QgsLabelingEngineSettings::readSettingsFromProject( QgsProject *prj )
   mMaxLineCandidatesPerCm = prj->readDoubleEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLinePerCM" ), 5, &saved );
   mMaxPolygonCandidatesPerCmSquared = prj->readDoubleEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygonPerCM" ), 2.5, &saved );
 
-  mFlags = Flags();
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) ) mFlags |= DrawCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) ) mFlags |= DrawLabelRectOnly;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) ) mFlags |= UseAllLabels;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) ) mFlags |= UsePartialCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), false, &saved ) ) mFlags |= DrawUnplacedLabels;
+  mFlags = Qgis::LabelingFlags();
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) ) mFlags |= Qgis::LabelingFlag::DrawCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) ) mFlags |= Qgis::LabelingFlag::DrawLabelRectOnly;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) ) mFlags |= Qgis::LabelingFlag::UseAllLabels;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) ) mFlags |= Qgis::LabelingFlag::UsePartialCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), false, &saved ) ) mFlags |= Qgis::LabelingFlag::DrawUnplacedLabels;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawLabelMetrics" ), false, &saved ) ) mFlags |= Qgis::LabelingFlag::DrawLabelMetrics;
 
   mDefaultTextRenderFormat = Qgis::TextRenderFormat::AlwaysOutlines;
   // if users have disabled the older PAL "DrawOutlineLabels" setting, respect that
@@ -53,7 +53,7 @@ void QgsLabelingEngineSettings::readSettingsFromProject( QgsProject *prj )
 
   mUnplacedLabelColor = QgsSymbolLayerUtils::decodeColor( prj->readEntry( QStringLiteral( "PAL" ), QStringLiteral( "/UnplacedColor" ), QStringLiteral( "#ff0000" ) ) );
 
-  mPlacementVersion = static_cast< PlacementEngineVersion >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), static_cast< int >( PlacementEngineVersion1 ) ) );
+  mPlacementVersion = static_cast< Qgis::LabelPlacementEngineVersion >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), static_cast< int >( Qgis::LabelPlacementEngineVersion::Version1 ) ) );
 }
 
 void QgsLabelingEngineSettings::writeSettingsToProject( QgsProject *project )
@@ -62,17 +62,18 @@ void QgsLabelingEngineSettings::writeSettingsToProject( QgsProject *project )
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLinePerCM" ), mMaxLineCandidatesPerCm );
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygonPerCM" ), mMaxPolygonCandidatesPerCmSquared );
 
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( DrawCandidates ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( DrawLabelRectOnly ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), mFlags.testFlag( DrawUnplacedLabels ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( UseAllLabels ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( UsePartialCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( Qgis::LabelingFlag::DrawCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( Qgis::LabelingFlag::DrawLabelRectOnly ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), mFlags.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( Qgis::LabelingFlag::UseAllLabels ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( Qgis::LabelingFlag::UsePartialCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawLabelMetrics" ), mFlags.testFlag( Qgis::LabelingFlag::DrawLabelMetrics ) );
 
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/TextFormat" ), static_cast< int >( mDefaultTextRenderFormat ) );
 
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/UnplacedColor" ), QgsSymbolLayerUtils::encodeColor( mUnplacedLabelColor ) );
 
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), mPlacementVersion );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), static_cast< int >( mPlacementVersion ) );
 }
 
 QColor QgsLabelingEngineSettings::unplacedLabelColor() const
@@ -85,12 +86,12 @@ void QgsLabelingEngineSettings::setUnplacedLabelColor( const QColor &unplacedLab
   mUnplacedLabelColor = unplacedLabelColor;
 }
 
-QgsLabelingEngineSettings::PlacementEngineVersion QgsLabelingEngineSettings::placementVersion() const
+Qgis::LabelPlacementEngineVersion QgsLabelingEngineSettings::placementVersion() const
 {
   return mPlacementVersion;
 }
 
-void QgsLabelingEngineSettings::setPlacementVersion( PlacementEngineVersion placementVersion )
+void QgsLabelingEngineSettings::setPlacementVersion( Qgis::LabelPlacementEngineVersion placementVersion )
 {
   mPlacementVersion = placementVersion;
 }

--- a/src/core/labeling/qgslabelingenginesettings.h
+++ b/src/core/labeling/qgslabelingenginesettings.h
@@ -18,7 +18,6 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgis.h"
-#include <QFlags>
 #include <QColor>
 
 class QgsProject;
@@ -31,19 +30,6 @@ class QgsProject;
 class CORE_EXPORT QgsLabelingEngineSettings
 {
   public:
-    //! Various flags that affect drawing and placement of labels
-    enum Flag
-    {
-      UseAllLabels          = 1 << 1,  //!< Whether to draw all labels even if there would be collisions
-      UsePartialCandidates  = 1 << 2,  //!< Whether to use also label candidates that are partially outside of the map view
-      // TODO QGIS 4.0: remove
-      RenderOutlineLabels   = 1 << 3,  //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
-      DrawLabelRectOnly     = 1 << 4,  //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
-      DrawCandidates        = 1 << 5,  //!< Whether to draw rectangles of generated candidates (good for debugging)
-      DrawUnplacedLabels    = 1 << 6,  //!< Whether to render unplaced labels as an indicator/warning for users
-      CollectUnplacedLabels = 1 << 7,  //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered). Since QGIS 3.20
-    };
-    Q_DECLARE_FLAGS( Flags, Flag )
 
     // TODO QGIS 4 - remove
 
@@ -60,30 +46,19 @@ class CORE_EXPORT QgsLabelingEngineSettings
       Falp
     };
 
-    /**
-     * Placement engine version.
-     *
-     * \since QGIS 3.10.2
-     */
-    enum PlacementEngineVersion
-    {
-      PlacementEngineVersion1, //!< Version 1, matches placement from QGIS <= 3.10.1
-      PlacementEngineVersion2, //!< Version 2 (default for new projects since QGIS 3.12)
-    };
-
     QgsLabelingEngineSettings();
 
     //! Returns the configuration to the defaults
     void clear();
 
     //! Sets flags of the labeling engine
-    void setFlags( Flags flags ) { mFlags = flags; }
+    void setFlags( Qgis::LabelingFlags flags ) { mFlags = flags; }
     //! Gets flags of the labeling engine
-    Flags flags() const { return mFlags; }
+    Qgis::LabelingFlags flags() const { return mFlags; }
     //! Test whether a particular flag is enabled
-    bool testFlag( Flag f ) const { return mFlags.testFlag( f ); }
+    bool testFlag( Qgis::LabelingFlag f ) const { return mFlags.testFlag( f ); }
     //! Sets whether a particual flag is enabled
-    void setFlag( Flag f, bool enabled = true ) { if ( enabled ) mFlags |= f; else mFlags &= ~f; }
+    void setFlag( Qgis::LabelingFlag f, bool enabled = true ) { if ( enabled ) mFlags |= f; else mFlags &= ~static_cast< int >( f ); }
 
     /**
      * Returns the maximum number of line label candidate positions per centimeter.
@@ -204,7 +179,7 @@ class CORE_EXPORT QgsLabelingEngineSettings
      * \see setPlacementVersion()
      * \since QGIS 3.10.2
      */
-    PlacementEngineVersion placementVersion() const;
+    Qgis::LabelPlacementEngineVersion placementVersion() const;
 
     /**
      * Sets the placement engine \a version, which dictates how the label placement problem is solved.
@@ -212,11 +187,11 @@ class CORE_EXPORT QgsLabelingEngineSettings
      * \see placementVersion()
      * \since QGIS 3.10.2
      */
-    void setPlacementVersion( PlacementEngineVersion version );
+    void setPlacementVersion( Qgis::LabelPlacementEngineVersion version );
 
   private:
     //! Flags
-    Flags mFlags;
+    Qgis::LabelingFlags mFlags = Qgis::LabelingFlag::UsePartialCandidates;
     //! search method to use for removal collisions between labels
     Search mSearchMethod = Chain;
 
@@ -226,12 +201,10 @@ class CORE_EXPORT QgsLabelingEngineSettings
 
     QColor mUnplacedLabelColor = QColor( 255, 0, 0 );
 
-    PlacementEngineVersion mPlacementVersion = PlacementEngineVersion2;
+    Qgis::LabelPlacementEngineVersion mPlacementVersion = Qgis::LabelPlacementEngineVersion::Version2;
 
     Qgis::TextRenderFormat mDefaultTextRenderFormat = Qgis::TextRenderFormat::AlwaysOutlines;
 
 };
-
-Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLabelingEngineSettings::Flags )
 
 #endif // QGSLABELINGENGINESETTINGS_H

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1547,9 +1547,9 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   QgsLabelingEngineSettings labelSettings = mLayout->project()->labelingEngineSettings();
 
   // override project "show partial labels" setting with this map's setting
-  labelSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, mMapFlags & ShowPartialLabels );
-  labelSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, mMapFlags & ShowUnplacedLabels );
-  labelSettings.setFlag( QgsLabelingEngineSettings::CollectUnplacedLabels, true );
+  labelSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, mMapFlags & ShowPartialLabels );
+  labelSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, mMapFlags & ShowUnplacedLabels );
+  labelSettings.setFlag( Qgis::LabelingFlag::CollectUnplacedLabels, true );
   jobMapSettings.setLabelingEngineSettings( labelSettings );
 
   // override the default text render format inherited from the labeling engine settings using the layout's render context setting

--- a/src/core/pal/costcalculator.cpp
+++ b/src/core/pal/costcalculator.cpp
@@ -85,10 +85,10 @@ void CostCalculator::addObstacleCostPenalty( LabelPosition *lp, FeaturePart *obs
 
   switch ( pal->placementVersion() )
   {
-    case QgsLabelingEngineSettings::PlacementEngineVersion1:
+    case Qgis::LabelPlacementEngineVersion::Version1:
       break;
 
-    case QgsLabelingEngineSettings::PlacementEngineVersion2:
+    case Qgis::LabelPlacementEngineVersion::Version2:
     {
       // obstacle factor is from 0 -> 2, label priority is from 1 -> 0. argh!
       const double priority = 2 * ( 1 - lp->feature->calculatePriority() );

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -389,10 +389,10 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
       {
         switch ( mPlacementVersion )
         {
-          case QgsLabelingEngineSettings::PlacementEngineVersion1:
+          case Qgis::LabelPlacementEngineVersion::Version1:
             break;
 
-          case QgsLabelingEngineSettings::PlacementEngineVersion2:
+          case Qgis::LabelPlacementEngineVersion::Version2:
           {
             // v2 placement rips out candidates where the candidate cost is too high when compared to
             // their inactive cost
@@ -636,12 +636,12 @@ void Pal::setShowPartialLabels( bool show )
   this->mShowPartialLabels = show;
 }
 
-QgsLabelingEngineSettings::PlacementEngineVersion Pal::placementVersion() const
+Qgis::LabelPlacementEngineVersion Pal::placementVersion() const
 {
   return mPlacementVersion;
 }
 
-void Pal::setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion placementVersion )
+void Pal::setPlacementVersion( Qgis::LabelPlacementEngineVersion placementVersion )
 {
   mPlacementVersion = placementVersion;
 }

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -36,7 +36,6 @@
 #include "qgis_core.h"
 #include "qgsgeometry.h"
 #include "qgsgeos.h"
-#include "qgslabelingenginesettings.h"
 #include <QList>
 #include <iostream>
 #include <ctime>
@@ -195,14 +194,14 @@ namespace pal
        *
        * \see setPlacementVersion()
        */
-      QgsLabelingEngineSettings::PlacementEngineVersion placementVersion() const;
+      Qgis::LabelPlacementEngineVersion placementVersion() const;
 
       /**
        * Sets the placement engine \a version, which dictates how the label placement problem is solved.
        *
        * \see placementVersion()
        */
-      void setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion placementVersion );
+      void setPlacementVersion( Qgis::LabelPlacementEngineVersion placementVersion );
 
       /**
        * Returns the global candidates limit for point features, or 0 if no global limit is in effect.
@@ -278,7 +277,7 @@ namespace pal
       int mGlobalCandidatesLimitLine = 0;
       int mGlobalCandidatesLimitPolygon = 0;
 
-      QgsLabelingEngineSettings::PlacementEngineVersion mPlacementVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
+      Qgis::LabelPlacementEngineVersion mPlacementVersion = Qgis::LabelPlacementEngineVersion::Version2;
 
       //! Callback that may be called from PAL to check whether the job has not been canceled in meanwhile
       FnIsCanceled fnIsCanceled = nullptr;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1522,6 +1522,51 @@ class CORE_EXPORT Qgis
     Q_ENUM( TextRenderFormat )
 
     /**
+     * Various flags that affect drawing and placement of labels.
+     *
+     * Prior to QGIS 3.30 this was available as QgsLabelingEngineSettings::Flag
+     *
+     * \since QGIS 3.30
+     */
+    enum class LabelingFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, Flag ) : int
+      {
+      UseAllLabels          = 1 << 1, //!< Whether to draw all labels even if there would be collisions
+      UsePartialCandidates  = 1 << 2, //!< Whether to use also label candidates that are partially outside of the map view
+      // TODO QGIS 4.0: remove
+      RenderOutlineLabels   = 1 << 3, //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
+      DrawLabelRectOnly     = 1 << 4, //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
+      DrawCandidates        = 1 << 5, //!< Whether to draw rectangles of generated candidates (good for debugging)
+      DrawUnplacedLabels    = 1 << 6, //!< Whether to render unplaced labels as an indicator/warning for users
+      CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered). Since QGIS 3.20
+      DrawLabelMetrics      = 1 << 8, //!< Whether to render label metric guides (for debugging). Since QGIS 3.30
+    };
+    Q_ENUM( LabelingFlag )
+
+    /**
+     * Flags that affect drawing and placement of labels.
+     *
+     * Prior to QGIS 3.30 this was available as QgsLabelingEngineSettings::Flags
+     *
+     * \since QGIS 3.30
+     */
+    Q_DECLARE_FLAGS( LabelingFlags, LabelingFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsLabelingEngineSettings, Flags )
+    Q_FLAG( LabelingFlags )
+
+    /**
+     * Labeling placement engine version.
+     *
+     * Prior to QGIS 3.30 this was available as QgsLabelingEngineSettings::PlacementEngineVersion
+     *
+     * \since QGIS 3.30
+     */
+    enum class LabelPlacementEngineVersion SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, PlacementEngineVersion ) : int
+      {
+      Version1 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion1 ), //!< Version 1, matches placement from QGIS <= 3.10.1
+      Version2 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion2 ), //!< Version 2 (default for new projects since QGIS 3.12)
+    };
+    Q_ENUM( LabelPlacementEngineVersion )
+
+    /**
      * Text orientations.
      *
      * \note Prior to QGIS 3.28 this was available as QgsTextFormat::TextOrientation
@@ -2525,6 +2570,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::CoordinateTransformationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::RasterTemporalCapabilityFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SelectionFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::RasterRendererFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::LabelingFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/gui/labeling/qgslabelengineconfigdialog.h
+++ b/src/gui/labeling/qgslabelengineconfigdialog.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsLabelEngineConfigWidget : public QgsPanelWidget, private Ui:
     QgsMessageBar *mMessageBar = nullptr;
     QMenu *mWidgetMenu = nullptr;
 
-    QgsLabelingEngineSettings::PlacementEngineVersion mPreviousEngineVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
+    Qgis::LabelPlacementEngineVersion mPreviousEngineVersion = Qgis::LabelPlacementEngineVersion::Version2;
 };
 
 /**

--- a/src/ui/labeling/qgslabelengineconfigdialog.ui
+++ b/src/ui/labeling/qgslabelengineconfigdialog.ui
@@ -118,13 +118,10 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
-     <item row="0" column="1" colspan="2">
-      <widget class="QComboBox" name="mTextRenderFormatComboBox">
-       <property name="sizeAdjustPolicy">
-        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-       </property>
-       <property name="minimumContentsLength">
-        <number>8</number>
+     <item row="1" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowPartialsLabels">
+       <property name="text">
+        <string>Allow truncated labels on edges of map</string>
        </property>
       </widget>
      </item>
@@ -132,6 +129,22 @@
       <widget class="QCheckBox" name="chkShowCandidates">
        <property name="text">
         <string>Show candidates (for debugging)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowAllLabels">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="inputMethodHints">
+        <set>Qt::ImhNone</set>
+       </property>
+       <property name="text">
+        <string>Show all labels for all layers (i.e. including collisions)</string>
        </property>
       </widget>
      </item>
@@ -174,19 +187,30 @@
        </item>
       </layout>
      </item>
-     <item row="2" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowAllLabels">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+     <item row="7" column="1" colspan="2">
+      <widget class="QComboBox" name="mPlacementVersionComboBox">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
        </property>
-       <property name="inputMethodHints">
-        <set>Qt::ImhNone</set>
+       <property name="minimumContentsLength">
+        <number>8</number>
        </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="2">
+      <widget class="QComboBox" name="mTextRenderFormatComboBox">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+       </property>
+       <property name="minimumContentsLength">
+        <number>8</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_7">
        <property name="text">
-        <string>Show all labels for all layers (i.e. including collisions)</string>
+        <string>Project labeling version</string>
        </property>
       </widget>
      </item>
@@ -204,27 +228,10 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowPartialsLabels">
+     <item row="6" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowMetrics">
        <property name="text">
-        <string>Allow truncated labels on edges of map</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Project labeling version</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1" colspan="2">
-      <widget class="QComboBox" name="mPlacementVersionComboBox">
-       <property name="sizeAdjustPolicy">
-        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-       </property>
-       <property name="minimumContentsLength">
-        <number>8</number>
+        <string>Show label metrics (for debugging)</string>
        </property>
       </widget>
      </item>
@@ -273,6 +280,8 @@
   <tabstop>chkShowUnplaced</tabstop>
   <tabstop>mUnplacedColorButton</tabstop>
   <tabstop>chkShowCandidates</tabstop>
+  <tabstop>chkShowMetrics</tabstop>
+  <tabstop>mPlacementVersionComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -181,20 +181,20 @@ void TestQgsLabelingEngine::testEngineSettings()
   QgsLabelingEngineSettings settings;
 
   // default for new projects should be placement engine v2
-  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion2 );
+  QCOMPARE( settings.placementVersion(), Qgis::LabelPlacementEngineVersion::Version2 );
 
   settings.setDefaultTextRenderFormat( Qgis::TextRenderFormat::AlwaysText );
   QCOMPARE( settings.defaultTextRenderFormat(), Qgis::TextRenderFormat::AlwaysText );
   settings.setDefaultTextRenderFormat( Qgis::TextRenderFormat::AlwaysOutlines );
   QCOMPARE( settings.defaultTextRenderFormat(), Qgis::TextRenderFormat::AlwaysOutlines );
 
-  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion1 );
-  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  settings.setPlacementVersion( Qgis::LabelPlacementEngineVersion::Version1 );
+  QCOMPARE( settings.placementVersion(), Qgis::LabelPlacementEngineVersion::Version1 );
 
-  settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
-  QVERIFY( settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
-  settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, false );
-  QVERIFY( !settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
+  settings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, true );
+  QVERIFY( settings.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
+  settings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, false );
+  QVERIFY( !settings.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
 
   settings.setUnplacedLabelColor( QColor( 0, 255, 0 ) );
   QCOMPARE( settings.unplacedLabelColor().name(), QStringLiteral( "#00ff00" ) );
@@ -202,23 +202,23 @@ void TestQgsLabelingEngine::testEngineSettings()
   // reading from project
   QgsProject p;
   settings.setDefaultTextRenderFormat( Qgis::TextRenderFormat::AlwaysText );
-  settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
+  settings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, true );
   settings.setUnplacedLabelColor( QColor( 0, 255, 0 ) );
-  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  settings.setPlacementVersion( Qgis::LabelPlacementEngineVersion::Version1 );
   settings.writeSettingsToProject( &p );
   QgsLabelingEngineSettings settings2;
   settings2.readSettingsFromProject( &p );
   QCOMPARE( settings2.defaultTextRenderFormat(), Qgis::TextRenderFormat::AlwaysText );
-  QVERIFY( settings2.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
+  QVERIFY( settings2.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
   QCOMPARE( settings2.unplacedLabelColor().name(), QStringLiteral( "#00ff00" ) );
 
   settings.setDefaultTextRenderFormat( Qgis::TextRenderFormat::AlwaysOutlines );
-  settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, false );
+  settings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, false );
   settings.writeSettingsToProject( &p );
   settings2.readSettingsFromProject( &p );
   QCOMPARE( settings2.defaultTextRenderFormat(), Qgis::TextRenderFormat::AlwaysOutlines );
-  QVERIFY( !settings2.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
-  QCOMPARE( settings2.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  QVERIFY( !settings2.testFlag( Qgis::LabelingFlag::DrawUnplacedLabels ) );
+  QCOMPARE( settings2.placementVersion(), Qgis::LabelPlacementEngineVersion::Version1 );
 
   // test that older setting is still respected as a fallback
   QgsProject p2;
@@ -234,7 +234,7 @@ void TestQgsLabelingEngine::testEngineSettings()
   // when opening an older project, labeling engine version should be 1
   p2.removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ) );
   settings3.readSettingsFromProject( &p2 );
-  QCOMPARE( settings3.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  QCOMPARE( settings3.placementVersion(), Qgis::LabelPlacementEngineVersion::Version1 );
 }
 
 void TestQgsLabelingEngine::testScaledFont()
@@ -280,7 +280,7 @@ void TestQgsLabelingEngine::setDefaultLabelParams( QgsPalLayerSettings &settings
 QgsLabelingEngineSettings TestQgsLabelingEngine::createLabelEngineSettings()
 {
   QgsLabelingEngineSettings settings;
-  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion2 );
+  settings.setPlacementVersion( Qgis::LabelPlacementEngineVersion::Version2 );
   return settings;
 }
 
@@ -997,8 +997,8 @@ void TestQgsLabelingEngine::testRotateHidePartial()
   mapSettings.setRotation( 45 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1068,8 +1068,8 @@ void TestQgsLabelingEngine::testParallelLabelSmallFeature()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1137,8 +1137,8 @@ void TestQgsLabelingEngine::testAllowDegradedPlacements()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1232,8 +1232,8 @@ void TestQgsLabelingEngine::testOverlapHandling()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1395,8 +1395,8 @@ void TestQgsLabelingEngine::testAllowOverlapsIgnoresObstacles()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1479,9 +1479,9 @@ void TestQgsLabelingEngine::testAdjacentParts()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1534,9 +1534,9 @@ void TestQgsLabelingEngine::testTouchingParts()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1601,9 +1601,9 @@ void TestQgsLabelingEngine::testMergingLinesWithForks()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1668,9 +1668,9 @@ void TestQgsLabelingEngine::testMergingLinesWithMinimumSize()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1722,8 +1722,8 @@ void TestQgsLabelingEngine::testCurvedLabelsHtmlFormatting()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1778,8 +1778,8 @@ void TestQgsLabelingEngine::testPointLabelHtmlFormatting()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1833,9 +1833,9 @@ void TestQgsLabelingEngine::testCurvedLabelsWithTinySegments()
   mapSettings.setFlag( Qgis::MapSettingsFlag::UseRenderingOptimization, false );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1889,9 +1889,9 @@ void TestQgsLabelingEngine::testCurvedLabelCorrectLinePlacement()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -1953,9 +1953,9 @@ void TestQgsLabelingEngine::testCurvedLabelNegativeDistance()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2006,9 +2006,9 @@ void TestQgsLabelingEngine::testCurvedLabelOnSmallLineNearCenter()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2058,9 +2058,9 @@ void TestQgsLabelingEngine::testCurvedLabelLineOrientationAbove()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2123,9 +2123,9 @@ void TestQgsLabelingEngine::testCurvedLabelLineOrientationBelow()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2192,9 +2192,9 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownAbove()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2260,9 +2260,9 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownBelow()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2329,7 +2329,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownAbovePositiveOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2397,7 +2397,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownAboveNegativeOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2464,7 +2464,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownLeftPositiveOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2532,7 +2532,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownLeftNegativeOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2599,7 +2599,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownRightPositiveOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2667,7 +2667,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownRightNegativeOffset()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2733,7 +2733,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintAbove()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2799,7 +2799,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintBelow()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2866,7 +2866,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintAbovePositiveOffse
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -2934,7 +2934,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintAboveNegativeOffse
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3001,7 +3001,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintLeftPositiveOffset
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3069,7 +3069,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintLeftNegativeOffset
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3136,7 +3136,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintRightPositiveOffse
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3204,7 +3204,7 @@ void TestQgsLabelingEngine::testCurvedLabelAllowUpsideDownHintRightNegativeOffse
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3268,10 +3268,10 @@ void TestQgsLabelingEngine::testRepeatDistanceWithSmallLine()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3322,9 +3322,9 @@ void TestQgsLabelingEngine::testParallelPlacementPreferAbove()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3383,8 +3383,8 @@ void TestQgsLabelingEngine::testLabelBoundary()
   mapSettings.setLabelBoundaryGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon((3 1, 12 1, 12 9, 3 9, 3 1),(8 4, 10 4, 10 7, 8 7, 8 4))" ) ) );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3455,9 +3455,9 @@ void TestQgsLabelingEngine::testLabelBlockingRegion()
   mapSettings.setLabelBlockingRegions( regions );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3534,9 +3534,9 @@ void TestQgsLabelingEngine::testLabelRotationWithReprojection()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3660,8 +3660,8 @@ void TestQgsLabelingEngine::drawUnplaced()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, true );
   engineSettings.setUnplacedLabelColor( QColor( 255, 0, 255 ) );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
@@ -3723,9 +3723,9 @@ void TestQgsLabelingEngine::labelingResults()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -3794,7 +3794,7 @@ void TestQgsLabelingEngine::labelingResults()
   settings.priority = 1;
   vl3->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl3->setLabelsEnabled( true );
-  engineSettings.setFlag( QgsLabelingEngineSettings::CollectUnplacedLabels, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::CollectUnplacedLabels, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob jobB( mapSettings );
@@ -3928,9 +3928,9 @@ void TestQgsLabelingEngine::labelingResultsCurved()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4057,9 +4057,9 @@ void TestQgsLabelingEngine::labelingResultsWithCallouts()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4488,9 +4488,9 @@ void TestQgsLabelingEngine::curvedOverrun()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4564,9 +4564,9 @@ void TestQgsLabelingEngine::parallelOverrun()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4643,9 +4643,9 @@ void TestQgsLabelingEngine::testDataDefinedLabelAllParts()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4936,8 +4936,8 @@ void TestQgsLabelingEngine::testMapUnitLetterSpacing()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -4990,8 +4990,8 @@ void TestQgsLabelingEngine::testMapUnitWordSpacing()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5043,8 +5043,8 @@ void TestQgsLabelingEngine::testLineHeightAbsolute()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5118,8 +5118,8 @@ void TestQgsLabelingEngine::testClipping()
   mapSettings.addClippingRegion( region2 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  //engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  //engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5180,9 +5180,9 @@ void TestQgsLabelingEngine::testLineAnchorParallel()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5244,9 +5244,9 @@ void TestQgsLabelingEngine::testLineAnchorParallelConstraints()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5442,9 +5442,9 @@ void TestQgsLabelingEngine::testLineAnchorDataDefinedType()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5509,9 +5509,9 @@ void TestQgsLabelingEngine::testLineAnchorCurved()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5594,9 +5594,9 @@ void TestQgsLabelingEngine::testLineAnchorCurvedConstraints()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5795,9 +5795,9 @@ void TestQgsLabelingEngine::testLineAnchorCurvedOverrun()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5865,9 +5865,9 @@ void TestQgsLabelingEngine::testLineAnchorCurvedStrictAllUpsideDown()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5920,9 +5920,9 @@ void TestQgsLabelingEngine::testLineAnchorHorizontal()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -5993,9 +5993,9 @@ void TestQgsLabelingEngine::testLineAnchorHorizontalConstraints()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -6076,9 +6076,9 @@ void TestQgsLabelingEngine::testLineAnchorClipping()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UsePartialCandidates, false );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );
@@ -6137,10 +6137,10 @@ void TestQgsLabelingEngine::testShowAllLabelsWhenALabelHasNoCandidates()
   mapSettings.setOutputDpi( 96 );
 
   QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
-  engineSettings.setFlag( QgsLabelingEngineSettings::UseAllLabels, true );
-  engineSettings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
-  // engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawLabelRectOnly, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::UseAllLabels, true );
+  engineSettings.setFlag( Qgis::LabelingFlag::DrawUnplacedLabels, true );
+  // engineSettings.setFlag( Qgis::LabelingFlag::DrawCandidates, true );
   mapSettings.setLabelingEngineSettings( engineSettings );
 
   QgsMapRendererSequentialJob job( mapSettings );


### PR DESCRIPTION
Shows the text bounds of the label in red and baselines in blue. Designed for debugging purposes only.

Also move label engine enums to Qgis, promote to enum class
