### PR TITLE
[attribute form] Allow users to clear a customized group background color

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -44,6 +44,7 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mVisibilityExpressionWidget->setLayer( layer );
   mVisibilityExpressionWidget->setExpression( itemData.visibilityExpression()->expression() );
   mColumnCountSpinBox->setValue( itemData.columnCount() );
+  mBackgroundColorButton->setShowNull( true );
   mBackgroundColorButton->setColor( itemData.backgroundColor() );
   mCollapsedCheckBox->setChecked( itemData.collapsed() );
   mCollapsedCheckBox->setEnabled( itemData.showAsGroupBox() );


### PR DESCRIPTION
## Description

Because sometimes we make questionable choices and need a way to go back to normal:
![image](https://user-images.githubusercontent.com/1728657/200158631-d819713f-35e1-4b40-91d9-553d7dce91de.png)

