### PR TITLE
[pal] Add api to allow setting the outer bounds for a label feature 

### DIFF
--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -112,6 +112,24 @@ class CORE_EXPORT QgsLabelFeature
     QSizeF size( double angle = 0.0 ) const;
 
     /**
+     * Returns the extreme outer bounds of the label feature, including any surrounding content like
+     * borders or background shapes.
+     *
+     * \see setOuterBounds()
+     * \since QGIS 3.30
+     */
+    QRectF outerBounds() const { return mOuterBounds; }
+
+    /**
+     * Sets the extreme outer \a bounds of the label feature, including any surrounding content like
+     * borders or background shapes.
+     *
+     * \see outerBounds()
+     * \since QGIS 3.30
+     */
+    void setOuterBounds( const QRectF &bounds ) { mOuterBounds = bounds; }
+
+    /**
      * Sets the visual margin for the label feature. The visual margin represents a margin
      * within the label which should not be considered when calculating the positions of candidates
      * for the label feature. It is used in certain label placement modes to adjust the position
@@ -627,6 +645,8 @@ class CORE_EXPORT QgsLabelFeature
     QSizeF mSize;
     //! Width and height of the label when rotated between 45 to 135 and 235 to 315 degrees;
     QSizeF mRotatedSize;
+    //! Extreme outer bounds of the label feature, including any surrounding content like borders or background shapes.
+    QRectF mOuterBounds;
     //! Visual margin of label contents
     QgsMargins mVisualMargin;
     //! Size of associated rendered symbol, if applicable

--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -58,9 +58,19 @@ class CORE_EXPORT QgsLabelFeature
 {
   public:
 
-    //! Create label feature, takes ownership of the geometry instance
+    /**
+     * Constructor for QgsLabelFeature.
+     *
+     * The feature \a id argument links the label feature back to the original layer feature.
+     *
+     * The \a geometry argument specifies the geometry associated with the feature, which is
+     * used by the labeling engine to generate candidate placements for the label. For
+     * a vector layer feature this will generally be the feature's geometry.
+     *
+     * The \a size argument dicates the size of the label's content (e.g. text width and height).
+     */
     QgsLabelFeature( QgsFeatureId id, geos::unique_ptr geometry, QSizeF size );
-    //! Clean up geometry and curved label info (if present)
+
     virtual ~QgsLabelFeature();
 
     //! Identifier of the label (unique within the parent label provider)

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -599,10 +599,10 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
       for ( int blockIndex = 0; blockIndex < blockCount; ++blockIndex )
       {
         const double blockBaseLine = metrics.baselineOffset( blockIndex, Qgis::TextLayoutMode::Labeling );
-        painter->drawLine( QPointF( rect.left(), rect.top()  + blockBaseLine ), QPointF( rect.right(), rect.top() + blockBaseLine ) );
+        painter->drawLine( QPointF( rect.left(), rect.top()  + blockBaseLine ),
+                           QPointF( rect.right(), rect.top() + blockBaseLine ) );
       }
     }
-
 
     painter->restore();
   }

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -569,6 +569,25 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
       painter->drawLine( QPointF( rect.left(), rect.bottom() + bottomMargin ), QPointF( rect.right(), rect.bottom() + bottomMargin ) );
     }
 
+    const QRectF outerBounds = label->getFeaturePart()->feature()->outerBounds();
+    if ( !outerBounds.isNull() )
+    {
+      const QRectF mapOuterBounds = QRectF( label->getX() + outerBounds.left(),
+                                            label->getY() + outerBounds.top(),
+                                            outerBounds.width(), outerBounds.height() );
+
+      QgsPointXY outerBoundsPt1 = xform.transform( mapOuterBounds.left(), mapOuterBounds.top() );
+      QgsPointXY outerBoundsPt2 = xform.transform( mapOuterBounds.right(), mapOuterBounds.bottom() );
+
+      const QRectF outerBoundsPixel( outerBoundsPt1.x() - outPt.x(),
+                                     outerBoundsPt1.y() - outPt.y(),
+                                     outerBoundsPt2.x() - outerBoundsPt1.x(),
+                                     outerBoundsPt2.y() - outerBoundsPt1.y() );
+
+      painter->setPen( QColor( 255, 0, 255, 140 ) );
+      painter->drawRect( outerBoundsPixel );
+    }
+
     if ( QgsTextLabelFeature *textFeature = dynamic_cast< QgsTextLabelFeature * >( label->getFeaturePart()->feature() ) )
     {
       const QgsTextDocumentMetrics &metrics = textFeature->documentMetrics();
@@ -583,6 +602,8 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
         painter->drawLine( QPointF( rect.left(), rect.top()  + blockBaseLine ), QPointF( rect.right(), rect.top() + blockBaseLine ) );
       }
     }
+
+
     painter->restore();
   }
 

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -555,6 +555,20 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
 
     painter->drawRect( rect );
 
+
+    painter->setPen( QColor( 0, 0, 0, 120 ) );
+    const QgsMargins &margins = label->getFeaturePart()->feature()->visualMargin();
+    if ( margins.top() > 0 )
+    {
+      const double topMargin = margins.top() / context.mapToPixel().mapUnitsPerPixel();
+      painter->drawLine( QPointF( rect.left(), rect.top() - topMargin ), QPointF( rect.right(), rect.top() - topMargin ) );
+    }
+    if ( margins.bottom() > 0 )
+    {
+      const double bottomMargin = margins.top() / context.mapToPixel().mapUnitsPerPixel();
+      painter->drawLine( QPointF( rect.left(), rect.bottom() + bottomMargin ), QPointF( rect.right(), rect.bottom() + bottomMargin ) );
+    }
+
     if ( QgsTextLabelFeature *textFeature = dynamic_cast< QgsTextLabelFeature * >( label->getFeaturePart()->feature() ) )
     {
       const QgsTextDocumentMetrics &metrics = textFeature->documentMetrics();

--- a/src/core/pal/costcalculator.cpp
+++ b/src/core/pal/costcalculator.cpp
@@ -16,7 +16,6 @@
 #include "layer.h"
 #include "pal.h"
 #include "feature.h"
-#include "geomfunction.h"
 #include "labelposition.h"
 #include "util.h"
 #include "costcalculator.h"
@@ -40,7 +39,7 @@ void CostCalculator::addObstacleCostPenalty( LabelPosition *lp, FeaturePart *obs
   {
     case GEOS_POINT:
 
-      dist = lp->getDistanceToPoint( obstacle->x[0], obstacle->y[0] );
+      dist = lp->getDistanceToPoint( obstacle->x[0], obstacle->y[0], true );
       if ( dist < 0 )
         n = 2;
       else if ( dist < distlabel )

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -2040,7 +2040,7 @@ std::size_t FeaturePart::createCandidatesOutsidePolygon( std::vector<std::unique
     // here we deviate a little from R&R, and instead of just calculating the centroid distance
     // to centroid of label, we calculate the distance from the centroid to the nearest point on the label
 
-    const double centroidDistance = candidate->getDistanceToPoint( cx, cy );
+    const double centroidDistance = candidate->getDistanceToPoint( cx, cy, false );
     const double centroidCost = centroidDistance / estimateOfMaxPossibleDistanceCentroidToLabel;
     candidate->setCost( centroidCost );
 

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -546,7 +546,7 @@ const GEOSPreparedGeometry *LabelPosition::preparedOuterBoundsGeom() const
 
 double LabelPosition::getDistanceToPoint( double xp, double yp, bool useOuterBounds ) const
 {
-  // this method considers the label's outer bounds
+  // this method may consider the label's outer bounds!
 
   GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
 

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -28,11 +28,10 @@
  */
 
 #include "layer.h"
-#include "pal.h"
 #include "costcalculator.h"
 #include "feature.h"
-#include "geomfunction.h"
 #include "labelposition.h"
+#include "geomfunction.h"
 #include "qgsgeos.h"
 #include "qgsmessagelog.h"
 #include <cmath>
@@ -135,6 +134,8 @@ LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, 
     ymin = std::min( ymin, y[i] );
     ymax = std::max( ymax, y[i] );
   }
+
+  createOuterBoundsGeom();
 }
 
 LabelPosition::LabelPosition( const LabelPosition &other )
@@ -159,50 +160,28 @@ LabelPosition::LabelPosition( const LabelPosition &other )
   quadrant = other.quadrant;
   mHasObstacleConflict = other.mHasObstacleConflict;
   mUpsideDownCharCount = other.mUpsideDownCharCount;
+
+  createOuterBoundsGeom();
 }
 
-bool LabelPosition::isIn( double *bbox )
+LabelPosition::~LabelPosition()
 {
-  int i;
-
-  for ( i = 0; i < 4; i++ )
+  if ( mPreparedOuterBoundsGeos )
   {
-    if ( x[i] >= bbox[0] && x[i] <= bbox[2] &&
-         y[i] >= bbox[1] && y[i] <= bbox[3] )
-      return true;
+    GEOSPreparedGeom_destroy_r( QgsGeos::getGEOSHandler(), mPreparedOuterBoundsGeos );
+    mPreparedOuterBoundsGeos = nullptr;
   }
-
-  if ( mNextPart )
-    return mNextPart->isIn( bbox );
-  else
-    return false;
-}
-
-bool LabelPosition::isIntersect( double *bbox )
-{
-  int i;
-
-  for ( i = 0; i < 4; i++ )
-  {
-    if ( x[i] >= bbox[0] && x[i] <= bbox[2] &&
-         y[i] >= bbox[1] && y[i] <= bbox[3] )
-      return true;
-  }
-
-  if ( mNextPart )
-    return mNextPart->isIntersect( bbox );
-  else
-    return false;
 }
 
 bool LabelPosition::intersects( const GEOSPreparedGeometry *geometry )
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   try
   {
-    if ( GEOSPreparedIntersects_r( QgsGeos::getGEOSHandler(), geometry, mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( QgsGeos::getGEOSHandler(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
     {
       return true;
     }
@@ -223,12 +202,13 @@ bool LabelPosition::intersects( const GEOSPreparedGeometry *geometry )
 
 bool LabelPosition::within( const GEOSPreparedGeometry *geometry )
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   try
   {
-    if ( GEOSPreparedContains_r( QgsGeos::getGEOSHandler(), geometry, mGeos ) != 1 )
+    if ( GEOSPreparedContains_r( QgsGeos::getGEOSHandler(), geometry, mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) != 1 )
     {
       return false;
     }
@@ -247,23 +227,10 @@ bool LabelPosition::within( const GEOSPreparedGeometry *geometry )
   return true;
 }
 
-bool LabelPosition::isInside( double *bbox )
-{
-  for ( int i = 0; i < 4; i++ )
-  {
-    if ( !( x[i] >= bbox[0] && x[i] <= bbox[2] &&
-            y[i] >= bbox[1] && y[i] <= bbox[3] ) )
-      return false;
-  }
-
-  if ( mNextPart )
-    return mNextPart->isInside( bbox );
-  else
-    return true;
-}
-
 bool LabelPosition::isInConflict( const LabelPosition *lp ) const
 {
+  // this method considers the label's outer bounds
+
   if ( this->probFeat == lp->probFeat ) // bugfix #1
     return false; // always overlaping itself !
 
@@ -277,7 +244,36 @@ bool LabelPosition::isInConflict( const LabelPosition *lp ) const
     if ( qgsDoubleNear( alpha, 0 ) && qgsDoubleNear( lp->alpha, 0 ) )
     {
       // simple case -- both candidates are oriented to axis, so shortcut with easy calculation
-      return boundingBoxIntersects( lp );
+      if ( mOuterBoundsGeos )
+      {
+        return outerBoundingBoxIntersects( lp );
+      }
+      else
+      {
+        return boundingBoxIntersects( lp );
+      }
+    }
+    else
+    {
+      // this method considers the label's outer bounds
+      if ( !mOuterBoundsGeos && !mGeos )
+        createGeosGeom();
+
+      GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+      try
+      {
+        const bool result = ( GEOSPreparedIntersects_r( geosctxt, lp->preparedOuterBoundsGeom() ? lp->preparedOuterBoundsGeom() : lp->preparedGeom(),
+                              mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 );
+        return result;
+      }
+      catch ( GEOSException &e )
+      {
+        qWarning( "GEOS exception: %s", e.what() );
+        QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
+        return false;
+      }
+
+      return false;
     }
   }
 
@@ -308,26 +304,73 @@ bool LabelPosition::isInConflictMultiPart( const LabelPosition *lp ) const
   return false;
 }
 
+void LabelPosition::createOuterBoundsGeom()
+{
+  const QRectF outerBounds = getFeaturePart()->feature()->outerBounds();
+  if ( outerBounds.isNull() )
+    return;
+
+  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+
+  const double beta = this->alpha + M_PI_2;
+
+  const double dx1 = std::cos( this->alpha ) * outerBounds.width();
+  const double dy1 = std::sin( this->alpha ) * outerBounds.width();
+
+  const double dx2 = std::cos( beta ) * outerBounds.height();
+  const double dy2 = std::sin( beta ) * outerBounds.height();
+
+  mOuterBoundsX.resize( 5 );
+  mOuterBoundsY.resize( 5 );
+
+  const double x1 = x[0] + outerBounds.left();
+  const double y1 = y[0] + outerBounds.top();
+
+  mOuterBoundsX[0] = x1;
+  mOuterBoundsY[0] = y1;
+
+  mOuterBoundsX[1] = x1 + dx1;
+  mOuterBoundsY[1] = y1 + dy1;
+
+  mOuterBoundsX[2] = x1 + dx1 + dx2;
+  mOuterBoundsY[2] = y1 + dy1 + dy2;
+
+  mOuterBoundsX[3] = x1 + dx2;
+  mOuterBoundsY[3] = y1 + dy2;
+
+  mOuterBoundsX[4] = mOuterBoundsX[0];
+  mOuterBoundsY[4] = mOuterBoundsY[0];
+
+  GEOSCoordSequence *coord = nullptr;
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=10 )
+  // use optimised method if we don't have to force close an open ring
+  coord = GEOSCoordSeq_copyFromArrays_r( geosctxt, mOuterBoundsX.data(), mOuterBoundsY.data(), nullptr, nullptr, 5 );
+#else
+  coord = GEOSCoordSeq_create_r( geosctxt, 5, 2 );
+  for ( int i = 0; i < nbPoints; ++i )
+  {
+    GEOSCoordSeq_setXY_r( geosctxt, coord, i, mOuterBoundsX[i], mOuterBoundsY[i] );
+  }
+#endif
+
+  mOuterBoundsGeos.reset( GEOSGeom_createPolygon_r( geosctxt, GEOSGeom_createLinearRing_r( geosctxt, coord ), nullptr, 0 ) );
+
+  mPreparedOuterBoundsGeos = GEOSPrepare_r( QgsGeos::getGEOSHandler(), mOuterBoundsGeos.get() );
+
+  auto xminmax = std::minmax_element( mOuterBoundsX.begin(), mOuterBoundsX.end() );
+  mOuterBoundsXMin = *xminmax.first;
+  mOuterBoundsXMax = *xminmax.second;
+  auto yminmax = std::minmax_element( mOuterBoundsY.begin(), mOuterBoundsY.end() );
+  mOuterBoundsYMin = *yminmax.first;
+  mOuterBoundsYMax = *yminmax.second;
+}
+
 int LabelPosition::partCount() const
 {
   if ( mNextPart )
     return mNextPart->partCount() + 1;
   else
     return 1;
-}
-
-void LabelPosition::offsetPosition( double xOffset, double yOffset )
-{
-  for ( int i = 0; i < 4; i++ )
-  {
-    x[i] += xOffset;
-    y[i] += yOffset;
-  }
-
-  if ( mNextPart )
-    mNextPart->offsetPosition( xOffset, yOffset );
-
-  invalidateGeos();
 }
 
 int LabelPosition::getId() const
@@ -365,6 +408,7 @@ FeaturePart *LabelPosition::getFeaturePart() const
 
 void LabelPosition::getBoundingBox( double amin[2], double amax[2] ) const
 {
+  // this method considers the label's outer bounds
   if ( mNextPart )
   {
     mNextPart->getBoundingBox( amin, amax );
@@ -378,14 +422,52 @@ void LabelPosition::getBoundingBox( double amin[2], double amax[2] ) const
   }
   for ( int c = 0; c < 4; c++ )
   {
-    if ( x[c] < amin[0] )
-      amin[0] = x[c];
-    if ( x[c] > amax[0] )
-      amax[0] = x[c];
-    if ( y[c] < amin[1] )
-      amin[1] = y[c];
-    if ( y[c] > amax[1] )
-      amax[1] = y[c];
+    if ( mOuterBoundsGeos )
+    {
+      if ( mOuterBoundsX[c] < amin[0] )
+        amin[0] = mOuterBoundsX[c];
+      if ( mOuterBoundsX[c] > amax[0] )
+        amax[0] = mOuterBoundsX[c];
+      if ( mOuterBoundsY[c] < amin[1] )
+        amin[1] = mOuterBoundsY[c];
+      if ( mOuterBoundsY[c] > amax[1] )
+        amax[1] = mOuterBoundsY[c];
+    }
+    else
+    {
+      if ( x[c] < amin[0] )
+        amin[0] = x[c];
+      if ( x[c] > amax[0] )
+        amax[0] = x[c];
+      if ( y[c] < amin[1] )
+        amin[1] = y[c];
+      if ( y[c] > amax[1] )
+        amax[1] = y[c];
+    }
+  }
+}
+
+bool LabelPosition::outerBoundingBoxIntersects( const LabelPosition *other ) const
+{
+  if ( other->mOuterBoundsGeos )
+  {
+    const double x1 = ( mOuterBoundsXMin > other->mOuterBoundsXMin ? mOuterBoundsXMin : other->mOuterBoundsXMin );
+    const double x2 = ( mOuterBoundsXMax < other->mOuterBoundsXMax ? mOuterBoundsXMax : other->mOuterBoundsXMax );
+    if ( x1 > x2 )
+      return false;
+    const double y1 = ( mOuterBoundsYMin > other->mOuterBoundsYMin ? mOuterBoundsYMin : other->mOuterBoundsYMin );
+    const double y2 = ( mOuterBoundsYMax < other->mOuterBoundsYMax ? mOuterBoundsYMax : other->mOuterBoundsYMax );
+    return y1 <= y2;
+  }
+  else
+  {
+    const double x1 = ( mOuterBoundsXMin > other->xmin ? mOuterBoundsXMin : other->xmin );
+    const double x2 = ( mOuterBoundsXMax < other->xmax ? mOuterBoundsXMax : other->xmax );
+    if ( x1 > x2 )
+      return false;
+    const double y1 = ( mOuterBoundsYMin > other->ymin ? mOuterBoundsYMin : other->ymin );
+    const double y2 = ( mOuterBoundsYMax < other->ymax ? mOuterBoundsYMax : other->ymax );
+    return y1 <= y2;
   }
 }
 
@@ -457,18 +539,49 @@ const GEOSPreparedGeometry *LabelPosition::preparedMultiPartGeom() const
   return mMultipartPreparedGeos;
 }
 
-double LabelPosition::getDistanceToPoint( double xp, double yp ) const
+const GEOSPreparedGeometry *LabelPosition::preparedOuterBoundsGeom() const
 {
+  return mPreparedOuterBoundsGeos;
+}
+
+double LabelPosition::getDistanceToPoint( double xp, double yp, bool useOuterBounds ) const
+{
+  // this method considers the label's outer bounds
+
+  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
+
   //first check if inside, if so then distance is -1
   bool contains = false;
   if ( alpha == 0 )
   {
     // easy case -- horizontal label
-    contains = x[0] <= xp && x[1] >= xp && y[0] <= yp && y[2] >= yp;
+    if ( useOuterBounds && mOuterBoundsGeos )
+    {
+      contains = mOuterBoundsX[0] <= xp && mOuterBoundsX[1] >= xp && mOuterBoundsY[0] <= yp && mOuterBoundsY[2] >= yp;
+    }
+    else
+    {
+      contains = x[0] <= xp && x[1] >= xp && y[0] <= yp && y[2] >= yp;
+    }
   }
   else
   {
-    contains = containsPoint( xp, yp );
+    if ( useOuterBounds && mPreparedOuterBoundsGeos )
+    {
+      try
+      {
+        geos::unique_ptr point( GEOSGeom_createPointFromXY_r( geosctxt, xp, yp ) );
+        contains = ( GEOSPreparedContainsProperly_r( geosctxt, mPreparedOuterBoundsGeos, point.get() ) == 1 );
+      }
+      catch ( GEOSException &e )
+      {
+        contains = false;
+      }
+    }
+    else
+    {
+      contains = containsPoint( xp, yp );
+    }
   }
 
   double distance = -1;
@@ -476,25 +589,66 @@ double LabelPosition::getDistanceToPoint( double xp, double yp ) const
   {
     if ( alpha == 0 )
     {
-      const double dx = std::max( std::max( x[0] - xp, 0.0 ), xp - x[1] );
-      const double dy = std::max( std::max( y[0] - yp, 0.0 ), yp - y[2] );
-      distance = std::sqrt( dx * dx + dy * dy );
+      if ( useOuterBounds && mOuterBoundsGeos )
+      {
+        const double dx = std::max( std::max( mOuterBoundsX[0] - xp, 0.0 ), xp - mOuterBoundsX[1] );
+        const double dy = std::max( std::max( mOuterBoundsY[0] - yp, 0.0 ), yp - mOuterBoundsY[2] );
+        distance = std::sqrt( dx * dx + dy * dy );
+      }
+      else
+      {
+        const double dx = std::max( std::max( x[0] - xp, 0.0 ), xp - x[1] );
+        const double dy = std::max( std::max( y[0] - yp, 0.0 ), yp - y[2] );
+        distance = std::sqrt( dx * dx + dy * dy );
+      }
     }
     else
     {
-      distance = std::sqrt( minDistanceToPoint( xp, yp ) );
+      if ( useOuterBounds && mPreparedOuterBoundsGeos )
+      {
+        try
+        {
+          geos::unique_ptr geosPt( GEOSGeom_createPointFromXY_r( geosctxt, xp, yp ) );
+
+          const geos::coord_sequence_unique_ptr nearestCoord( GEOSPreparedNearestPoints_r( geosctxt, mPreparedOuterBoundsGeos, geosPt.get() ) );
+          double nx;
+          double ny;
+          unsigned int nPoints = 0;
+          GEOSCoordSeq_getSize_r( geosctxt, nearestCoord.get(), &nPoints );
+          if ( nPoints == 0 )
+          {
+            distance = -1;
+          }
+          else
+          {
+            ( void )GEOSCoordSeq_getXY_r( geosctxt, nearestCoord.get(), 0, &nx, &ny );
+            distance = GeomFunction::dist_euc2d_sq( xp, yp, nx, ny );
+          }
+        }
+        catch ( GEOSException &e )
+        {
+          qWarning( "GEOS exception: %s", e.what() );
+          QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
+          distance = -1;
+        }
+      }
+      else
+      {
+        distance = std::sqrt( minDistanceToPoint( xp, yp ) );
+      }
     }
   }
 
   if ( mNextPart && distance > 0 )
-    return std::min( distance, mNextPart->getDistanceToPoint( xp, yp ) );
+    return std::min( distance, mNextPart->getDistanceToPoint( xp, yp, useOuterBounds ) );
 
   return distance;
 }
 
 bool LabelPosition::crossesLine( PointSet *line ) const
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   if ( !line->mGeos )
@@ -503,7 +657,7 @@ bool LabelPosition::crossesLine( PointSet *line ) const
   GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
   try
   {
-    if ( GEOSPreparedIntersects_r( geosctxt, line->preparedGeom(), mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( geosctxt, line->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
     {
       return true;
     }
@@ -524,7 +678,8 @@ bool LabelPosition::crossesLine( PointSet *line ) const
 
 bool LabelPosition::crossesBoundary( PointSet *polygon ) const
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   if ( !polygon->mGeos )
@@ -533,8 +688,8 @@ bool LabelPosition::crossesBoundary( PointSet *polygon ) const
   GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
   try
   {
-    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1
-         && GEOSPreparedContains_r( geosctxt, polygon->preparedGeom(), mGeos ) != 1 )
+    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1
+         && GEOSPreparedContains_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) != 1 )
     {
       return true;
     }
@@ -563,7 +718,8 @@ int LabelPosition::polygonIntersectionCost( PointSet *polygon ) const
 
 bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   if ( !polygon->mGeos )
@@ -572,7 +728,7 @@ bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
   GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
   try
   {
-    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
     {
       return true;
     }
@@ -595,7 +751,8 @@ bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
 
 double LabelPosition::polygonIntersectionCostForParts( PointSet *polygon ) const
 {
-  if ( !mGeos )
+  // this method considers the label's outer bounds
+  if ( !mOuterBoundsGeos && !mGeos )
     createGeosGeom();
 
   if ( !polygon->mGeos )
@@ -605,7 +762,7 @@ double LabelPosition::polygonIntersectionCostForParts( PointSet *polygon ) const
   double cost = 0;
   try
   {
-    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 )
     {
       //at least a partial intersection
       cost += 1;

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -97,55 +97,62 @@ namespace pal
       //! Copy constructor
       LabelPosition( const LabelPosition &other );
 
-      /**
-       * \brief Is the labelposition in the bounding-box ? (intersect or inside????)
-       *
-       *\param bbox the bounding-box double[4] = {xmin, ymin, xmax, ymax}
-       */
-      bool isIn( double *bbox );
-
-      /**
-       * \brief Is the labelposition intersect the bounding-box ?
-       *
-       *\param bbox the bounding-box double[4] = {xmin, ymin, xmax, ymax}
-       */
-      bool isIntersect( double *bbox );
+      ~LabelPosition() override;
 
       /**
        * Returns TRUE if the label position intersects a \a geometry.
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
        */
       bool intersects( const GEOSPreparedGeometry *geometry );
 
       /**
        * Returns TRUE if the label position is within a \a geometry.
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
        */
       bool within( const GEOSPreparedGeometry *geometry );
 
       /**
-       * \brief Is the labelposition inside the bounding-box ?
+       * Check whether or not this overlap with another labelPosition.
        *
-       *\param bbox the bounding-box double[4] = {xmin, ymin, xmax, ymax}
-       */
-      bool isInside( double *bbox );
-
-      /**
-       * \brief Check whether or not this overlap with another labelPosition
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
        *
        * \param ls other labelposition
        * \returns TRUE or FALSE
        */
       bool isInConflict( const LabelPosition *ls ) const;
 
-      //! Returns bounding box - amin: xmin,ymin - amax: xmax,ymax
+      /**
+       * Returns bounding box - amin: xmin,ymin - amax: xmax,ymax
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
+       */
       void getBoundingBox( double amin[2], double amax[2] ) const;
 
-      //! Gets distance from this label to a point. If point lies inside, returns negative number.
-      double getDistanceToPoint( double xp, double yp ) const;
+      /**
+       * Returns TRUE if the outer bounding box of this pointset intersects the outer bounding box
+       * of another label position.
+       */
+      bool outerBoundingBoxIntersects( const LabelPosition *other ) const;
 
-      //! Returns TRUE if this label crosses the specified line
+      /**
+       * Gets distance from this label to a point. If point lies inside, returns negative number.
+       */
+      double getDistanceToPoint( double xp, double yp, bool useOuterBounds ) const;
+
+      /**
+       * Returns TRUE if this label crosses the specified line.
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
+       */
       bool crossesLine( PointSet *line ) const;
 
-      //! Returns TRUE if this label crosses the boundary of the specified polygon
+      /**
+       * Returns TRUE if this label crosses the boundary of the specified polygon.
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
+       */
       bool crossesBoundary( PointSet *polygon ) const;
 
       /**
@@ -156,17 +163,15 @@ namespace pal
 
       /**
        * Returns TRUE if any intersection between polygon and position exists.
+       *
+       * \note This method considers the label's outer bounds (see QgsLabelFeature::outerBounds())
       */
       bool intersectsWithPolygon( PointSet *polygon ) const;
-
-      //! Shift the label by specified offset
-      void offsetPosition( double xOffset, double yOffset );
 
       /**
        * Returns the id
        */
       int getId() const;
-
 
       /**
        * Returns the feature corresponding to this labelposition
@@ -319,6 +324,13 @@ namespace pal
       const GEOSPreparedGeometry *preparedMultiPartGeom() const;
 
       /**
+       * Returns the prepared outer boundary geometry.
+       *
+       * \since QGIS 3.30
+       */
+      const GEOSPreparedGeometry *preparedOuterBoundsGeom() const;
+
+      /**
        * Returns the global ID for the candidate, which is unique for a single run of the pal
        * labelling engine.
        *
@@ -372,6 +384,17 @@ namespace pal
       unsigned int mGlobalId = 0;
       std::unique_ptr< LabelPosition > mNextPart;
 
+      std::vector< double > mOuterBoundsX;
+      std::vector< double > mOuterBoundsY;
+
+      double mOuterBoundsXMin = std::numeric_limits<double>::max();
+      double mOuterBoundsXMax = std::numeric_limits<double>::lowest();
+      double mOuterBoundsYMin = std::numeric_limits<double>::max();
+      double mOuterBoundsYMax = std::numeric_limits<double>::lowest();
+
+      geos::unique_ptr mOuterBoundsGeos;
+      const GEOSPreparedGeometry *mPreparedOuterBoundsGeos = nullptr;
+
       double mCost;
       bool mHasObstacleConflict;
       bool mHasHardConflict = false;
@@ -394,6 +417,8 @@ namespace pal
       void createMultiPartGeosGeom() const;
 
       bool isInConflictMultiPart( const LabelPosition *lp ) const;
+
+      void createOuterBoundsGeom();
 
       LabelPosition &operator=( const LabelPosition & ) = delete;
   };

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -138,6 +138,10 @@ namespace pal
 
       /**
        * Gets distance from this label to a point. If point lies inside, returns negative number.
+       *
+       * If \a useOuterBounds is TRUE then the distance will be calculated to the outer bounds
+       * of the label (see QgsLabelFeature::outerBounds()), otherwise it will be calculated
+       * to the label's actual rectangle.
        */
       double getDistanceToPoint( double xp, double yp, bool useOuterBounds ) const;
 


### PR DESCRIPTION
The outer bounds can represent the extreme margins of a label, including
non-text parts like borders or padded backgrounds. During the label
solving the outer bounds will be used when detecting whether
labels are in conflict.