### PR TITLE
[QgsQuick] Qt6 updates

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -401,7 +401,6 @@ void QgsQuickMapCanvasMap::geometryChange( const QRectF &newGeometry, const QRec
 {
   QQuickItem::geometryChange( newGeometry, oldGeometry );
 #endif
-  QQuickItem::geometryChanged( newGeometry, oldGeometry );
   if ( newGeometry.size() != oldGeometry.size() )
   {
     mMapSettings->setOutputSize( newGeometry.size().toSize() );

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -20,7 +20,6 @@
 #include "qgsmaplayer.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmessagelog.h"
-#include "qgsproject.h"
 #include "qgsprojectviewsettings.h"
 
 QgsQuickMapSettings::QgsQuickMapSettings( QObject *parent )

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -18,7 +18,6 @@
 #include "qgsquickmapsettings.h"
 
 #include "qgsmaplayer.h"
-#include "qgsmaplayerstylemanager.h"
 #include "qgsmessagelog.h"
 #include "qgsprojectviewsettings.h"
 

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -23,7 +23,6 @@
 #include "qgscoordinatetransformcontext.h"
 #include "qgsmaplayer.h"
 #include "qgsmapsettings.h"
-#include "qgsmapthemecollection.h"
 #include "qgspoint.h"
 #include "qgsrectangle.h"
 #include "qgsproject.h"

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -26,8 +26,7 @@
 #include "qgsmapthemecollection.h"
 #include "qgspoint.h"
 #include "qgsrectangle.h"
-
-class QgsProject;
+#include "qgsproject.h"
 
 /**
  * \ingroup quick

--- a/src/quickgui/qgsquickmaptransform.cpp
+++ b/src/quickgui/qgsquickmaptransform.cpp
@@ -14,7 +14,6 @@
  ***************************************************************************/
 
 #include "qgsquickmaptransform.h"
-#include "qgsquickmapsettings.h"
 
 void QgsQuickMapTransform::applyTo( QMatrix4x4 *matrix ) const
 {

--- a/src/quickgui/qgsquickmaptransform.h
+++ b/src/quickgui/qgsquickmaptransform.h
@@ -20,8 +20,7 @@
 #include <QMatrix4x4>
 
 #include "qgis_quick.h"
-
-class QgsQuickMapSettings;
+#include "qgsquickmapsettings.h"
 
 /**
  * \ingroup quick


### PR DESCRIPTION
There were quite a few issues with qgsquick map canvas when building with Qt6:
 - forward declaration no longer works when the type is used in Q_PROPERTY (see https://www.qt.io/blog/whats-new-in-qmetatype-qvariant#:~:text=QMetaObject%3A%3AinvokeMethod.-,QMetaType,-knows%20your%20properties)
 - https://github.com/qgis/QGIS/commit/f55b838d4c8f0bbb16045db10be4f44136b16701 failed to remove the `QQuickItem::geometryChanged` call that was outside of the `ifdef` - could not build the code with Qt 6.3.2

PR also removes unused imports