### PR TITLE
[QgsQuick] Add moveTo animation to qgsquick map canvas

### DIFF
--- a/src/quickgui/CMakeLists.txt
+++ b/src/quickgui/CMakeLists.txt
@@ -5,6 +5,7 @@ set(QGIS_QUICK_GUI_MOC_HDRS
   qgsquickmapcanvasmap.h
   qgsquickmapsettings.h
   qgsquickmaptransform.h
+  qgsquickutils.h
 )
 
 set(QGIS_QUICK_GUI_SRC
@@ -12,6 +13,7 @@ set(QGIS_QUICK_GUI_SRC
   qgsquickmapcanvasmap.cpp
   qgsquickmapsettings.cpp
   qgsquickmaptransform.cpp
+  qgsquickutils.cpp
 )
 
 include_directories(

--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -55,9 +55,6 @@ Item {
   //! This signal is emitted independently of double tap / click
   signal clicked(var point)
 
-  //! This signal is only emitted if there is no double tap/click coming after a short delay
-//  signal confirmedClicked(var point) // TODO: ideally get rid of this one
-
   //! Signal emitted when user holds pointer on map
   signal longPressed(var point)
 
@@ -103,6 +100,32 @@ Item {
     mapCanvasWrapper.refresh()
   }
 
+  /**
+   * Animates movement of map canvas from oldPos to newPos.
+   *
+   * oldPos and newPos need to be in device pixels.
+   */
+  function moveTo( newPos )
+  {
+    freeze('moveTo')
+
+    let newPosMapCRS = mapCanvasWrapper.mapSettings.screenToCoordinate( newPos )
+    let oldPosMapCRS = mapCanvasWrapper.mapSettings.center
+
+    // Disable animation until initial position is set
+    jumpAnimator.enabled = false
+
+    jumpAnimator.px = oldPosMapCRS.x
+    jumpAnimator.py = oldPosMapCRS.y
+
+    jumpAnimator.enabled = true
+
+    jumpAnimator.px = newPosMapCRS.x
+    jumpAnimator.py = newPosMapCRS.y
+
+    unfreeze('moveTo')
+  }
+
   QgsQuick.MapCanvasMap {
     id: mapCanvasWrapper
 
@@ -112,6 +135,40 @@ Item {
     property var __freezecount: ({})
 
     freeze: false
+  }
+
+  Item {
+    id: jumpAnimator
+
+    property double px: 0
+    property double py: 0
+
+    Behavior on py {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    Behavior on px {
+      SmoothedAnimation {
+        duration: 200
+        reversingMode: SmoothedAnimation.Immediate
+      }
+      enabled: jumpAnimator.enabled
+    }
+
+    onPxChanged: {
+      if ( enabled ) {
+        mapCanvasWrapper.mapSettings.setCenter( utils.toQgsPoint( Qt.point( px, py ) ) )
+      }
+    }
+    onPyChanged: {
+      if ( enabled ) {
+        mapCanvasWrapper.mapSettings.setCenter( utils.toQgsPoint( Qt.point( px, py ) ) )
+      }
+    }
   }
 
   // Mouse, stylus and other pointer devices handler
@@ -330,7 +387,7 @@ Item {
     target: null
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByItems
 
-    onWheel: {
+    onWheel: function( event ) {
       if (event.angleDelta.y > 0)
       {
         zoomIn(point.position)
@@ -342,5 +399,9 @@ Item {
 
       userInteractedWithMap()
     }
+  }
+
+  QgsQuick.QgsQuickUtils {
+    id: utils
   }
 }

--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -101,9 +101,9 @@ Item {
   }
 
   /**
-   * Animates movement of map canvas from oldPos to newPos.
+   * Animates movement of map canvas from the current center to newPos.
    *
-   * oldPos and newPos need to be in device pixels.
+   * newPos need to be in device pixels.
    */
   function moveTo( newPos )
   {
@@ -161,12 +161,13 @@ Item {
 
     onPxChanged: {
       if ( enabled ) {
-        mapCanvasWrapper.mapSettings.setCenter( utils.toQgsPoint( Qt.point( px, py ) ) )
+        mapCanvasWrapper.mapSettings.center = utils.toQgsPoint( Qt.point( px, py ) )
       }
     }
+
     onPyChanged: {
       if ( enabled ) {
-        mapCanvasWrapper.mapSettings.setCenter( utils.toQgsPoint( Qt.point( px, py ) ) )
+        mapCanvasWrapper.mapSettings.center = utils.toQgsPoint( Qt.point( px, py ) )
       }
     }
   }

--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -161,13 +161,13 @@ Item {
 
     onPxChanged: {
       if ( enabled ) {
-        mapCanvasWrapper.mapSettings.center = utils.toQgsPoint( Qt.point( px, py ) )
+        mapCanvasWrapper.mapSettings.center = QgsQuick.Utils.toQgsPoint( Qt.point( px, py ) )
       }
     }
 
     onPyChanged: {
       if ( enabled ) {
-        mapCanvasWrapper.mapSettings.center = utils.toQgsPoint( Qt.point( px, py ) )
+        mapCanvasWrapper.mapSettings.center = QgsQuick.Utils.toQgsPoint( Qt.point( px, py ) )
       }
     }
   }
@@ -400,9 +400,5 @@ Item {
 
       userInteractedWithMap()
     }
-  }
-
-  QgsQuick.QgsQuickUtils {
-    id: utils
   }
 }

--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -103,7 +103,7 @@ Item {
   /**
    * Animates movement of map canvas from the current center to newPos.
    *
-   * newPos need to be in device pixels.
+   * newPos needs to be in device pixels.
    */
   function moveTo( newPos )
   {

--- a/src/quickgui/plugin/qgsquickplugin.cpp
+++ b/src/quickgui/plugin/qgsquickplugin.cpp
@@ -68,4 +68,5 @@ void QgsQuickPlugin::registerTypes( const char *uri )
   qmlRegisterType< QgsVectorLayer >( uri, 0, 1, "VectorLayer" );
 
   qmlRegisterSingletonType< QgsQuickUtils >( uri, 0, 1, "Utils", _utilsProvider );
+
 }

--- a/src/quickgui/plugin/qgsquickplugin.cpp
+++ b/src/quickgui/plugin/qgsquickplugin.cpp
@@ -35,6 +35,14 @@
 #include "qgsquickmapsettings.h"
 #include "qgsquickmaptransform.h"
 #include "qgsquickplugin.h"
+#include "qgsquickutils.h"
+
+static QObject *_utilsProvider( QQmlEngine *engine, QJSEngine *scriptEngine )
+{
+  Q_UNUSED( engine )
+  Q_UNUSED( scriptEngine )
+  return new QgsQuickUtils();  // the object will be owned by QML engine and destroyed by the engine on exit
+}
 
 void QgsQuickPlugin::registerTypes( const char *uri )
 {
@@ -58,4 +66,6 @@ void QgsQuickPlugin::registerTypes( const char *uri )
   qmlRegisterType< QgsQuickMapSettings >( uri, 0, 1, "MapSettings" );
   qmlRegisterType< QgsQuickMapTransform >( uri, 0, 1, "MapTransform" );
   qmlRegisterType< QgsVectorLayer >( uri, 0, 1, "VectorLayer" );
+
+  qmlRegisterSingletonType< QgsQuickUtils >( uri, 0, 1, "Utils", _utilsProvider );
 }

--- a/src/quickgui/plugin/qgsquickplugin.cpp
+++ b/src/quickgui/plugin/qgsquickplugin.cpp
@@ -37,7 +37,7 @@
 #include "qgsquickplugin.h"
 #include "qgsquickutils.h"
 
-static QObject *_utilsProvider( QQmlEngine *engine, QJSEngine *scriptEngine )
+static QObject *buildUtilsSingleton( QQmlEngine *engine, QJSEngine *scriptEngine )
 {
   Q_UNUSED( engine )
   Q_UNUSED( scriptEngine )
@@ -67,6 +67,6 @@ void QgsQuickPlugin::registerTypes( const char *uri )
   qmlRegisterType< QgsQuickMapTransform >( uri, 0, 1, "MapTransform" );
   qmlRegisterType< QgsVectorLayer >( uri, 0, 1, "VectorLayer" );
 
-  qmlRegisterSingletonType< QgsQuickUtils >( uri, 0, 1, "Utils", _utilsProvider );
+  qmlRegisterSingletonType< QgsQuickUtils >( uri, 0, 1, "Utils", buildUtilsSingleton );
 
 }

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -1,0 +1,26 @@
+/***************************************************************************
+  qgsquickutils.cpp
+  --------------------------------------
+  Date                 : 7.11.2022
+  Copyright            : (C) 2022 by Tomas Mizera
+  Email                : tomas.mizera (at) lutraconsulting.co.uk
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsquickutils.h"
+
+QgsQuickUtils::QgsQuickUtils( QObject *parent )
+  : QObject( parent )
+{
+}
+
+QgsPoint QgsQuickUtils::toQgsPoint( const QPointF &point )
+{
+  return QgsPoint( point );
+}

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -29,7 +29,7 @@
  * \brief The QgsQuickUtils class serves as a utility class for common operations
  * needed either from QML or cpp.
  *
- * \note use in qml as a singleton, registered as "Utils", e.g. QgsQuick.Utils.<function>
+ * \note use in qml as a singleton, registered as "Utils", e.g. QgsQuick.Utils.toQgsPoint
  *
  * \since QGIS 3.30
  */

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -31,7 +31,7 @@
  *
  * \since QGIS 3.30
  */
-class QgsQuickUtils : public QObject
+class QUICK_EXPORT QgsQuickUtils : public QObject
 {
     Q_OBJECT
 

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -37,6 +37,7 @@ class QUICK_EXPORT QgsQuickUtils : public QObject
 
   public:
 
+    //! Creates new QgsQuickUtils - this class is meant to serve as a QML singleton
     explicit QgsQuickUtils( QObject *parent = nullptr );
     ~QgsQuickUtils() = default;
 

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -44,7 +44,7 @@ class QgsQuickUtils : public QObject
      * Helper function to convert QPointF to QgsPoint without any transformations.
      * Useful for converting these values in QML.
      */
-    Q_INVOKABLE QgsPoint toQgsPoint( const QPointF &point );
+    Q_INVOKABLE static QgsPoint toQgsPoint( const QPointF &point );
 };
 
 #endif // QGSQUICKUTILS_H

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+  qgsquickutils.cpp
+  --------------------------------------
+  Date                 : 7.11.2022
+  Copyright            : (C) 2022 by Tomas Mizera
+  Email                : tomas.mizera (at) lutraconsulting.co.uk
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSQUICKUTILS_H
+#define QGSQUICKUTILS_H
+
+#include <QObject>
+#include <qglobal.h>
+
+#include "qgspoint.h"
+
+class QgsQuickUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    explicit QgsQuickUtils( QObject *parent = nullptr );
+    ~QgsQuickUtils() = default;
+
+    /**
+     * Helper function to convert QPointF to QgsPoint without any transformations.
+     * Useful for converting these values in QML.
+     */
+    Q_INVOKABLE QgsPoint toQgsPoint( const QPointF &point );
+};
+
+#endif // QGSQUICKUTILS_H

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -21,6 +21,16 @@
 
 #include "qgspoint.h"
 
+/**
+ * \ingroup quick
+ *
+ * \brief The QgsQuickUtils class serves as a utility class for common operations
+ * needed either from QML or cpp.
+ *
+ * \note QML Type: QgsQuickUtils
+ *
+ * \since QGIS 3.30
+ */
 class QgsQuickUtils : public QObject
 {
     Q_OBJECT

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -19,6 +19,8 @@
 #include <QObject>
 #include <qglobal.h>
 
+#include "qgis_quick.h"
+
 #include "qgspoint.h"
 
 /**
@@ -27,7 +29,7 @@
  * \brief The QgsQuickUtils class serves as a utility class for common operations
  * needed either from QML or cpp.
  *
- * \note QML Type: QgsQuickUtils
+ * \note use in qml as a singleton, registered as "Utils", e.g. QgsQuick.Utils.<function>
  *
  * \since QGIS 3.30
  */


### PR DESCRIPTION
This is a follow-up PR to https://github.com/qgis/QGIS/pull/50271 as that one was closed because of inactivity (Sorry for that @nirvn and thanks for the review!).

PR adds animation to interactively move the map canvas and addresses comments from the previous PR.
It also adds a new utils class to be used from QML (it could be a singleton in the future if we use it in multiple places). 

This is how it looks in Mergin Maps 🙂 

https://user-images.githubusercontent.com/22449698/200290559-56a67f64-360f-4e0d-bede-8a98ebb79e07.mp4

