### PR TITLE
Add an explicit "Offset from UTC" option for storing GPS feature timestamps

### DIFF
--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -193,6 +193,7 @@ Abstract base class for connection to a GPS device
 
 
 
+
     QgsGpsConnection( QIODevice *dev /Transfer/ );
 %Docstring
 Constructor

--- a/src/app/gps/qgsappgpsdigitizing.cpp
+++ b/src/app/gps/qgsappgpsdigitizing.cpp
@@ -428,6 +428,7 @@ void QgsAppGpsDigitizing::gpsSettingsChanged()
     mLeapSeconds = static_cast< int >( QgsGpsConnection::settingGpsLeapSeconds.value() );
     mTimeStampSpec = QgsGpsConnection::settingsGpsTimeStampSpecification.value();
     mTimeZone = QgsGpsConnection::settingsGpsTimeStampTimeZone.value();
+    mOffsetFromUtc = static_cast< int >( QgsGpsConnection::settingsGpsTimeStampOffsetFromUtc.value() );
   }
   else
   {
@@ -656,7 +657,9 @@ QVariant QgsAppGpsDigitizing::timestamp( QgsVectorLayer *vlayer, int idx )
       time = time.addSecs( mLeapSeconds );
     }
     // Desired format
-    time = time.toTimeSpec( mTimeStampSpec );
+    if ( mTimeStampSpec != Qt::TimeSpec::OffsetFromUTC )
+      time = time.toTimeSpec( mTimeStampSpec );
+
     if ( mTimeStampSpec == Qt::TimeSpec::TimeZone )
     {
       // Get timezone from the combo
@@ -669,6 +672,10 @@ QVariant QgsAppGpsDigitizing::timestamp( QgsVectorLayer *vlayer, int idx )
     else if ( mTimeStampSpec == Qt::TimeSpec::LocalTime )
     {
       time = time.toLocalTime();
+    }
+    else if ( mTimeStampSpec == Qt::TimeSpec::OffsetFromUTC )
+    {
+      time = time.toOffsetFromUtc( mOffsetFromUtc );
     }
     else if ( mTimeStampSpec == Qt::TimeSpec::UTC )
     {

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -120,6 +120,7 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
     int mLeapSeconds = 0;
     Qt::TimeSpec mTimeStampSpec = Qt::TimeSpec::LocalTime;
     QString mTimeZone;
+    int mOffsetFromUtc = 0;
 
     //! Temporary storage of preferred fields
     QMap<QString, QString> mPreferredTimestampFields;

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -389,6 +389,9 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Settings entry GPS time stamp time zone
     static const inline QgsSettingsEntryString settingsGpsTimeStampTimeZone = QgsSettingsEntryString( QStringLiteral( "timestamp-time-zone" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "GPS time stamp time zone" ) ) SIP_SKIP;
 
+    //! Settings entry GPS time offset from UTC in seconds
+    static const inline QgsSettingsEntryInteger settingsGpsTimeStampOffsetFromUtc = QgsSettingsEntryInteger( QStringLiteral( "timestamp-offset-from-utc" ), QgsSettings::Prefix::GPS, 0, QStringLiteral( "GPS time stamp offset from UTC (in seconds)" ) ) SIP_SKIP;
+
     /**
      * Constructor
      * \param dev input device for the connection (e.g. serial device). The class takes ownership of the object

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -128,6 +128,7 @@ QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   addSettingsEntry( &QgsGpsConnection::settingGpsLeapSeconds );
   addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampSpecification );
   addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampTimeZone );
+  addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampOffsetFromUtc );
 }
 
 QgsSettingsRegistryCore::~QgsSettingsRegistryCore()

--- a/src/ui/qgsgpsoptionswidgetbase.ui
+++ b/src/ui/qgsgpsoptionswidgetbase.ui
@@ -47,9 +47,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-137</y>
+        <y>-157</y>
         <width>676</width>
-        <height>898</height>
+        <height>931</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -479,7 +479,7 @@
           <item row="2" column="1">
            <widget class="QComboBox" name="mCboTimeZones"/>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="mCbxLeapSeconds">
             <property name="toolTip">
              <string>Apply leap seconds correction by adding the seconds to GPS timestamp</string>
@@ -489,8 +489,28 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QgsSpinBox" name="mLeapSeconds"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="mLblOffsetFromUtc">
+            <property name="text">
+             <string>Offset from UTC</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsSpinBox" name="mOffsetFromUtc">
+            <property name="suffix">
+             <string> seconds</string>
+            </property>
+            <property name="minimum">
+             <number>-86400</number>
+            </property>
+            <property name="maximum">
+             <number>86400</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -545,6 +565,32 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mRadInternal</tabstop>
+  <tabstop>mCboDevices</tabstop>
+  <tabstop>mBtnRefreshDevices</tabstop>
+  <tabstop>mRadAutodetect</tabstop>
+  <tabstop>mGpsdDevice</tabstop>
+  <tabstop>mGpsdHost</tabstop>
+  <tabstop>mSpinGpsdPort</tabstop>
+  <tabstop>mRadGpsd</tabstop>
+  <tabstop>mRadSerialDevice</tabstop>
+  <tabstop>mCboDistanceThreshold</tabstop>
+  <tabstop>mCboAcquisitionInterval</tabstop>
+  <tabstop>mGpsMarkerSymbolButton</tabstop>
+  <tabstop>mCheckRotateLocationMarker</tabstop>
+  <tabstop>mBearingLineStyleButton</tabstop>
+  <tabstop>mTravelBearingCheckBox</tabstop>
+  <tabstop>mTrackLineStyleButton</tabstop>
+  <tabstop>mSpinMapExtentMultiplier</tabstop>
+  <tabstop>mSpinMapRotateInterval</tabstop>
+  <tabstop>mCboTimestampFormat</tabstop>
+  <tabstop>mCboTimeZones</tabstop>
+  <tabstop>mOffsetFromUtc</tabstop>
+  <tabstop>mCbxLeapSeconds</tabstop>
+  <tabstop>mLeapSeconds</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
This option allows users to manually enter a desired offset from UTC for storing GPS time stamps. This allows for full flexibility for users who need to account for daylight savings offsets or other complex time zone issues.

Sponsored by NIWA

