### PR TITLE
Add track distance and distance from start of track to GPS information panel/toolbar

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -905,7 +905,9 @@ Qgis.GpsInformationComponent.Location.__doc__ = "2D location (latitude/longitude
 Qgis.GpsInformationComponent.Altitude.__doc__ = "Altitude/elevation above or below the mean sea level"
 Qgis.GpsInformationComponent.GroundSpeed.__doc__ = "Ground speed"
 Qgis.GpsInformationComponent.Bearing.__doc__ = "Bearing measured in degrees clockwise from true north to the direction of travel"
-Qgis.GpsInformationComponent.__doc__ = 'GPS information component.\n\n.. versionadded:: 3.30\n\n' + '* ``Location``: ' + Qgis.GpsInformationComponent.Location.__doc__ + '\n' + '* ``Altitude``: ' + Qgis.GpsInformationComponent.Altitude.__doc__ + '\n' + '* ``GroundSpeed``: ' + Qgis.GpsInformationComponent.GroundSpeed.__doc__ + '\n' + '* ``Bearing``: ' + Qgis.GpsInformationComponent.Bearing.__doc__
+Qgis.GpsInformationComponent.TotalTrackLength.__doc__ = "Total distance of current GPS track (available from QGIS app library only)"
+Qgis.GpsInformationComponent.TrackDistanceFromStart.__doc__ = "Direct distance from first vertex in current GPS track to last vertex (available from QGIS app library only)"
+Qgis.GpsInformationComponent.__doc__ = 'GPS information component.\n\n.. versionadded:: 3.30\n\n' + '* ``Location``: ' + Qgis.GpsInformationComponent.Location.__doc__ + '\n' + '* ``Altitude``: ' + Qgis.GpsInformationComponent.Altitude.__doc__ + '\n' + '* ``GroundSpeed``: ' + Qgis.GpsInformationComponent.GroundSpeed.__doc__ + '\n' + '* ``Bearing``: ' + Qgis.GpsInformationComponent.Bearing.__doc__ + '\n' + '* ``TotalTrackLength``: ' + Qgis.GpsInformationComponent.TotalTrackLength.__doc__ + '\n' + '* ``TrackDistanceFromStart``: ' + Qgis.GpsInformationComponent.TrackDistanceFromStart.__doc__
 # --
 Qgis.GpsInformationComponent.baseClass = Qgis
 Qgis.GpsInformationComponents.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -620,6 +620,8 @@ The development version
       Altitude,
       GroundSpeed,
       Bearing,
+      TotalTrackLength,
+      TrackDistanceFromStart,
     };
 
     typedef QFlags<Qgis::GpsInformationComponent> GpsInformationComponents;

--- a/src/app/gps/qgsappgpsdigitizing.cpp
+++ b/src/app/gps/qgsappgpsdigitizing.cpp
@@ -109,7 +109,7 @@ double QgsAppGpsDigitizing::totalTrackLength() const
   return mDa.measureLine( points );
 }
 
-double QgsAppGpsDigitizing::trackDirectLength() const
+double QgsAppGpsDigitizing::trackDistanceFromStart() const
 {
   if ( mCaptureListWgs84.empty() )
     return 0;

--- a/src/app/gps/qgsappgpsdigitizing.cpp
+++ b/src/app/gps/qgsappgpsdigitizing.cpp
@@ -117,6 +117,11 @@ double QgsAppGpsDigitizing::trackDirectLength() const
   return mDa.measureLine( { QgsPointXY( mCaptureListWgs84.constFirst() ), QgsPointXY( mCaptureListWgs84.constLast() )} );
 }
 
+const QgsDistanceArea &QgsAppGpsDigitizing::distanceArea() const
+{
+  return mDa;
+}
+
 void QgsAppGpsDigitizing::addVertex()
 {
   if ( !mRubberBand )
@@ -622,6 +627,7 @@ void QgsAppGpsDigitizing::updateDistanceArea()
 {
   mDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
   mDa.setSourceCrs( mWgs84CRS, QgsProject::instance()->transformContext() );
+  emit distanceAreaChanged();
 }
 
 void QgsAppGpsDigitizing::createRubberBand()

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -50,6 +50,20 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
     QgsAppGpsDigitizing( QgsAppGpsConnection *connection, QgsMapCanvas *canvas, QObject *parent = nullptr );
     ~QgsAppGpsDigitizing() override;
 
+    /**
+     * Returns the total length of the current digitized track (in meters).
+     *
+     * The returned length is calculated using ellipsoidal calculations.
+     */
+    double totalTrackLength() const;
+
+    /**
+     * Returns the direct length from the first vertex in the track to the last (in meters).
+     *
+     * The returned length is calculated using ellipsoidal calculations.
+     */
+    double trackDirectLength() const;
+
   public slots:
     void addVertex();
     void resetTrack();
@@ -63,6 +77,11 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
      * Emitted whenever the current track changes from being empty to non-empty or vice versa.
      */
     void trackIsEmptyChanged( bool isEmpty );
+
+    /**
+     * Emitted whenever the recorded track is changed.
+     */
+    void trackChanged();
 
   private slots:
     void gpsSettingsChanged();
@@ -78,6 +97,8 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
 
     void startLogging();
     void stopLogging();
+
+    void updateDistanceArea();
 
   private:
     void createRubberBand();
@@ -118,6 +139,8 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
 
     std::unique_ptr< QFile > mLogFile;
     QTextStream mLogFileTextStream;
+
+    QgsDistanceArea mDa;
 
     friend class TestQgsGpsIntegration;
 };

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -62,7 +62,7 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
      *
      * The returned length is calculated using ellipsoidal calculations.
      */
-    double trackDirectLength() const;
+    double trackDistanceFromStart() const;
 
     /**
      * Returns the distance area calculator used to calculate track lengths.

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -64,6 +64,11 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
      */
     double trackDirectLength() const;
 
+    /**
+     * Returns the distance area calculator used to calculate track lengths.
+     */
+    const QgsDistanceArea &distanceArea() const;
+
   public slots:
     void addVertex();
     void resetTrack();
@@ -82,6 +87,11 @@ class APP_EXPORT QgsAppGpsDigitizing: public QObject
      * Emitted whenever the recorded track is changed.
      */
     void trackChanged();
+
+    /**
+     * Emitted whenever the distance area used to calculate track distances is changed.
+     */
+    void distanceAreaChanged();
 
   private slots:
     void gpsSettingsChanged();

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -296,7 +296,7 @@ void QgsGpsInformationWidget::gpsConnected()
 void QgsGpsInformationWidget::updateTrackInformation()
 {
   const double totalTrackLength = mDigitizing->totalTrackLength();
-  const double directTrackLength = mDigitizing->trackDirectLength();
+  const double directTrackLength = mDigitizing->trackDistanceFromStart();
 
   const QgsSettings settings;
   const bool keepBaseUnit = settings.value( QStringLiteral( "qgis/measure/keepbaseunit" ), true ).toBool();

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -36,6 +36,7 @@ class QextSerialPort;
 class QgsAppGpsConnection;
 class QgsGpsInformation;
 class QgsMapCanvas;
+class QgsAppGpsDigitizing;
 
 /**
  * A dock widget that displays information from a GPS device and
@@ -47,7 +48,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     Q_OBJECT
   public:
 
-    QgsGpsInformationWidget( QgsAppGpsConnection *connection, QgsMapCanvas *mapCanvas, QWidget *parent = nullptr );
+    QgsGpsInformationWidget( QgsAppGpsConnection *connection, QgsMapCanvas *mapCanvas, QgsAppGpsDigitizing *digitizing = nullptr, QWidget *parent = nullptr );
     ~QgsGpsInformationWidget() override;
 
   private slots:
@@ -64,6 +65,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     void gpsConnecting();
     void gpsDisconnected();
     void gpsConnected();
+    void updateTrackInformation();
 
   private:
 
@@ -72,6 +74,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
 
     QgsAppGpsConnection *mConnection = nullptr;
     QPointer< QgsMapCanvas > mMapCanvas;
+    QgsAppGpsDigitizing *mDigitizing = nullptr;
 
     QwtPlot *mPlot = nullptr;
     QwtPlotCurve *mCurve = nullptr;

--- a/src/app/gps/qgsgpstoolbar.h
+++ b/src/app/gps/qgsgpstoolbar.h
@@ -28,7 +28,7 @@ class QLabel;
 class QgsVectorLayer;
 class QgsMapLayerProxyModel;
 class QToolButton;
-
+class QgsAppGpsDigitizing;
 
 
 class QgsGpsToolBar : public QToolBar
@@ -42,6 +42,8 @@ class QgsGpsToolBar : public QToolBar
     QgsGpsToolBar( QgsAppGpsConnection *connection, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
     QAction *showInfoAction() { return mShowInfoAction; }
+
+    void setGpsDigitizing( QgsAppGpsDigitizing *digitizing );
 
   signals:
 
@@ -66,6 +68,8 @@ class QgsGpsToolBar : public QToolBar
 
     QgsAppGpsConnection *mConnection = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
+    QPointer< QgsAppGpsDigitizing > mDigitizing;
+
     QAction *mConnectAction = nullptr;
     QAction *mRecenterAction = nullptr;
     QAction *mShowInfoAction = nullptr;

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -36,8 +36,6 @@
 #include "qgslayertreenode.h"
 #include "qgslayertree.h"
 #include "qgslayertreeview.h"
-#include "qgslayertreemodel.h"
-#include "qgslayertreeutils.h"
 #include "qgsgui.h"
 #include "qgsmbtiles.h"
 #include "qgsmessagelog.h"

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1420,7 +1420,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::nmeaLogFileChanged, mGpsDigitizing, &QgsAppGpsDigitizing::setNmeaLogFile );
   connect( mGpsDigitizing, &QgsAppGpsDigitizing::trackIsEmptyChanged, mGpsToolBar, [ = ]( bool isEmpty ) { mGpsToolBar->setResetTrackButtonEnabled( !isEmpty ); } );
 
-  mpGpsWidget = new QgsGpsInformationWidget( mGpsConnection, mMapCanvas );
+  mpGpsWidget = new QgsGpsInformationWidget( mGpsConnection, mMapCanvas, mGpsDigitizing );
   QgsPanelWidgetStack *gpsStack = new QgsPanelWidgetStack();
   gpsStack->setMainPanel( mpGpsWidget );
   mpGpsWidget->setDockMode( true );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1407,6 +1407,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( mGpsToolBar, &QgsGpsToolBar::addVertexClicked, mGpsDigitizing, &QgsAppGpsDigitizing::addVertex );
   connect( mGpsToolBar, &QgsGpsToolBar::resetFeatureClicked, mGpsDigitizing, &QgsAppGpsDigitizing::resetTrack );
 
+  mGpsToolBar->setGpsDigitizing( mGpsDigitizing );
+
   mGpsCanvasBridge = new QgsGpsCanvasBridge( mGpsConnection, mMapCanvas );
   mGpsCanvasBridge->setLocationMarkerVisible( mGpsSettingsMenu->locationMarkerVisible() );
   mGpsCanvasBridge->setBearingLineVisible( mGpsSettingsMenu->bearingLineVisible() );

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -140,6 +140,10 @@ QVariant QgsGpsInformation::componentValue( Qgis::GpsInformationComponent compon
       return speed;
     case Qgis::GpsInformationComponent::Bearing:
       return std::isnan( direction ) ? QVariant() : direction;
+
+    case Qgis::GpsInformationComponent::TotalTrackLength:
+    case Qgis::GpsInformationComponent::TrackDistanceFromStart:
+      return QVariant(); // not available
   }
   BUILTIN_UNREACHABLE
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1011,6 +1011,8 @@ class CORE_EXPORT Qgis
       Altitude = 1 << 1, //!< Altitude/elevation above or below the mean sea level
       GroundSpeed = 1 << 2, //!< Ground speed
       Bearing = 1 << 3, //!< Bearing measured in degrees clockwise from true north to the direction of travel
+      TotalTrackLength = 1 << 4, //!< Total distance of current GPS track (available from QGIS app library only)
+      TrackDistanceFromStart = 1 << 5, //!< Direct distance from first vertex in current GPS track to last vertex (available from QGIS app library only)
     };
 
     /**

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -111,20 +111,77 @@
              <property name="spacing">
               <number>2</number>
              </property>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="mTxtLatitude">
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_13">
                <property name="toolTip">
-                <string>latitude of position fix (degrees)</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Difference between WGS-84 earth ellipsoid and mean sea level.  -=geoid is below WGS-84 ellipsoid&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Geoidal separation</string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="1">
+              <widget class="QLineEdit" name="mTxt3Dacc"/>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLineEdit" name="mTxtAltitudeDiff"/>
+             </item>
+             <item row="17" column="0">
+              <widget class="QLabel" name="mLblFixMode">
+               <property name="text">
+                <string>Mode</string>
+               </property>
+              </widget>
+             </item>
+             <item row="20" column="1">
+              <widget class="QLineEdit" name="mTxtStatus">
+               <property name="toolTip">
+                <string>position fix status: Valid or Invalid</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="10" column="0">
-              <widget class="QLabel" name="mLblHdop">
+             <item row="18" column="1">
+              <widget class="QLineEdit" name="mTxtFixType">
+               <property name="toolTip">
+                <string>position fix dimensions: 2D, 3D or No fix</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="0">
+              <widget class="QLabel" name="mLblVdop">
                <property name="text">
-                <string>HDOP</string>
+                <string>VDOP</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QLineEdit" name="mTxtSpeed">
+               <property name="toolTip">
+                <string>speed over ground</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="18" column="0">
+              <widget class="QLabel" name="mLblFixType">
+               <property name="text">
+                <string>Dimensions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="0">
+              <widget class="QLabel" name="mLblQuality">
+               <property name="text">
+                <string>Quality</string>
                </property>
               </widget>
              </item>
@@ -138,10 +195,30 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
-              <widget class="QLineEdit" name="mTxtAltitude">
+             <item row="7" column="0">
+              <widget class="QLabel" name="mLblSpeed">
                <property name="toolTip">
-                <string>antenna altitude with respect to geoid (mean sea level)</string>
+                <string/>
+               </property>
+               <property name="text">
+                <string>Speed</string>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="1">
+              <widget class="QLineEdit" name="mTxtDirection">
+               <property name="toolTip">
+                <string>track direction (degrees)</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="mTxtLongitude">
+               <property name="toolTip">
+                <string>longitude of position fix (degrees)</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
@@ -164,48 +241,8 @@
                </property>
               </spacer>
              </item>
-             <item row="17" column="0">
-              <widget class="QLabel" name="mLblFixMode">
-               <property name="text">
-                <string>Mode</string>
-               </property>
-              </widget>
-             </item>
-             <item row="13" column="1">
-              <widget class="QLineEdit" name="mTxtHacc"/>
-             </item>
-             <item row="6" column="1">
-              <spacer name="verticalSpacer_5">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>6</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="mLblSpeed">
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="text">
-                <string>Speed</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="mLblAltitude">
-               <property name="text">
-                <string>Altitude</string>
-               </property>
-              </widget>
+             <item row="14" column="1">
+              <widget class="QLineEdit" name="mTxtVacc"/>
              </item>
              <item row="1" column="0">
               <widget class="QLabel" name="mLblLongitude">
@@ -214,179 +251,15 @@
                </property>
               </widget>
              </item>
-             <item row="17" column="1">
-              <widget class="QLineEdit" name="mTxtFixMode">
-               <property name="toolTip">
-                <string>GPS receiver configuration 2D/3D mode: Automatic or Manual</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="mLblLatitude">
+             <item row="13" column="0">
+              <widget class="QLabel" name="mLblHacc">
                <property name="text">
-                <string>Latitude</string>
+                <string>H accuracy</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="mLblUtcTime">
-               <property name="text">
-                <string>Time of fix</string>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="0">
-              <widget class="QLabel" name="mLblVacc">
-               <property name="text">
-                <string>V accuracy</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <spacer name="verticalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>6</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="18" column="0">
-              <widget class="QLabel" name="mLblFixType">
-               <property name="text">
-                <string>Dimensions</string>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="1">
-              <widget class="QLineEdit" name="mTxtSpeed">
-               <property name="toolTip">
-                <string>speed over ground</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="0">
-              <widget class="QLabel" name="mLblVdop">
-               <property name="text">
-                <string>VDOP</string>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="0">
-              <widget class="QLabel" name="mLbl3Dacc">
-               <property name="text">
-                <string>3D accuracy</string>
-               </property>
-              </widget>
-             </item>
-             <item row="18" column="1">
-              <widget class="QLineEdit" name="mTxtFixType">
-               <property name="toolTip">
-                <string>position fix dimensions: 2D, 3D or No fix</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="19" column="1">
-              <widget class="QLineEdit" name="mTxtQuality">
-               <property name="toolTip">
-                <string>Positioning quality indicator (NMEA GGA or comparable sentence)</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="20" column="0">
-              <widget class="QLabel" name="mLblStatus">
-               <property name="text">
-                <string>Status</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QLineEdit" name="mTxtDateTime">
-               <property name="toolTip">
-                <string>date/time of position fix (UTC)</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="1">
-              <widget class="QLineEdit" name="mTxt3Dacc"/>
-             </item>
-             <item row="14" column="1">
-              <widget class="QLineEdit" name="mTxtVacc"/>
-             </item>
-             <item row="21" column="1">
-              <widget class="QLineEdit" name="mTxtSatellitesUsed">
-               <property name="toolTip">
-                <string>number of satellites used in the position fix</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="19" column="0">
-              <widget class="QLabel" name="mLblQuality">
-               <property name="text">
-                <string>Quality</string>
-               </property>
-              </widget>
-             </item>
-             <item row="20" column="1">
-              <widget class="QLineEdit" name="mTxtStatus">
-               <property name="toolTip">
-                <string>position fix status: Valid or Invalid</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="1">
-              <widget class="QLineEdit" name="mTxtDirection">
-               <property name="toolTip">
-                <string>track direction (degrees)</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="0">
-              <widget class="QLabel" name="mLblDirection">
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="text">
-                <string>Direction</string>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="1">
-              <spacer name="verticalSpacer_4">
+             <item row="6" column="1">
+              <spacer name="verticalSpacer_5">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
                </property>
@@ -408,6 +281,16 @@
                </property>
               </widget>
              </item>
+             <item row="21" column="1">
+              <widget class="QLineEdit" name="mTxtSatellitesUsed">
+               <property name="toolTip">
+                <string>number of satellites used in the position fix</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
              <item row="11" column="1">
               <widget class="QLineEdit" name="mTxtVdop">
                <property name="toolTip">
@@ -418,20 +301,123 @@
                </property>
               </widget>
              </item>
-             <item row="12" column="0">
-              <widget class="QLabel" name="mLblPdop">
-               <property name="text">
-                <string>PDOP</string>
-               </property>
-              </widget>
+             <item row="13" column="1">
+              <widget class="QLineEdit" name="mTxtHacc"/>
              </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="mTxtLongitude">
+             <item row="2" column="1">
+              <widget class="QLineEdit" name="mTxtAltitude">
                <property name="toolTip">
-                <string>longitude of position fix (degrees)</string>
+                <string>antenna altitude with respect to geoid (mean sea level)</string>
                </property>
                <property name="readOnly">
                 <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="22" column="1">
+              <spacer name="verticalSpacer_10">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>6</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="10" column="0">
+              <widget class="QLabel" name="mLblHdop">
+               <property name="text">
+                <string>HDOP</string>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="0">
+              <widget class="QLabel" name="mLblVacc">
+               <property name="text">
+                <string>V accuracy</string>
+               </property>
+              </widget>
+             </item>
+             <item row="19" column="1">
+              <widget class="QLineEdit" name="mTxtQuality">
+               <property name="toolTip">
+                <string>Positioning quality indicator (NMEA GGA or comparable sentence)</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="mLblUtcTime">
+               <property name="text">
+                <string>Time of fix</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="mTxtLatitude">
+               <property name="toolTip">
+                <string>latitude of position fix (degrees)</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="0">
+              <widget class="QLabel" name="mLblDirection">
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="text">
+                <string>Direction</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="mLblAltitude">
+               <property name="text">
+                <string>Altitude</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="1">
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>6</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="23" column="1">
+              <widget class="QLineEdit" name="mTxtTotalTrackLength">
+               <property name="toolTip">
+                <string>Total length of current GPS track</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="mLblLatitude">
+               <property name="text">
+                <string>Latitude</string>
                </property>
               </widget>
              </item>
@@ -445,25 +431,89 @@
                </property>
               </widget>
              </item>
-             <item row="13" column="0">
-              <widget class="QLabel" name="mLblHacc">
+             <item row="12" column="0">
+              <widget class="QLabel" name="mLblPdop">
                <property name="text">
-                <string>H accuracy</string>
+                <string>PDOP</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_13">
+             <item row="20" column="0">
+              <widget class="QLabel" name="mLblStatus">
+               <property name="text">
+                <string>Status</string>
+               </property>
+              </widget>
+             </item>
+             <item row="17" column="1">
+              <widget class="QLineEdit" name="mTxtFixMode">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Difference between WGS-84 earth ellipsoid and mean sea level.  -=geoid is below WGS-84 ellipsoid&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>GPS receiver configuration 2D/3D mode: Automatic or Manual</string>
                </property>
-               <property name="text">
-                <string>Geoidal separation</string>
+               <property name="readOnly">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QLineEdit" name="mTxtAltitudeDiff"/>
+             <item row="15" column="0">
+              <widget class="QLabel" name="mLbl3Dacc">
+               <property name="text">
+                <string>3D accuracy</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QLineEdit" name="mTxtDateTime">
+               <property name="toolTip">
+                <string>date/time of position fix (UTC)</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <spacer name="verticalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>6</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="23" column="0">
+              <widget class="QLabel" name="mLblSatellitesUsed_3">
+               <property name="text">
+                <string>Total track length</string>
+               </property>
+              </widget>
+             </item>
+             <item row="24" column="0">
+              <widget class="QLabel" name="mLblSatellitesUsed_4">
+               <property name="text">
+                <string>Distance from start of track</string>
+               </property>
+              </widget>
+             </item>
+             <item row="24" column="1">
+              <widget class="QLineEdit" name="mTxtDirectTrackLength">
+               <property name="toolTip">
+                <string>Direct distance from first vertex in GPS track to last vertex</string>
+               </property>
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -706,6 +756,27 @@ gray = no data
   <tabstop>mTxtQuality</tabstop>
   <tabstop>mTxtStatus</tabstop>
   <tabstop>mTxtSatellitesUsed</tabstop>
+  <tabstop>mTxtTotalTrackLength</tabstop>
+  <tabstop>mTxtDirectTrackLength</tabstop>
+  <tabstop>mBtnPopupOptions</tabstop>
+  <tabstop>mTxtLatitude_2</tabstop>
+  <tabstop>mTxtPdop_2</tabstop>
+  <tabstop>mTxtAltitude_2</tabstop>
+  <tabstop>mTxtHacc_2</tabstop>
+  <tabstop>mTxtFixMode_2</tabstop>
+  <tabstop>mTxtSpeed_2</tabstop>
+  <tabstop>mTxtFixType_2</tabstop>
+  <tabstop>mTxtQuality_2</tabstop>
+  <tabstop>mTxtDateTime_2</tabstop>
+  <tabstop>mTxt3Dacc_2</tabstop>
+  <tabstop>mTxtVacc_2</tabstop>
+  <tabstop>mTxtSatellitesUsed_2</tabstop>
+  <tabstop>mTxtStatus_2</tabstop>
+  <tabstop>mTxtDirection_2</tabstop>
+  <tabstop>mTxtVdop_2</tabstop>
+  <tabstop>mTxtLongitude_2</tabstop>
+  <tabstop>mTxtHdop_2</tabstop>
+  <tabstop>mTxtAltitudeDiff_2</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/tests/src/app/testqgsgpsintegration.cpp
+++ b/tests/src/app/testqgsgpsintegration.cpp
@@ -462,7 +462,7 @@ void TestQgsGpsIntegration::testTrackDistance()
   QCOMPARE( spy.count(), 1 );
 
   QCOMPARE( gpsDigitizing.totalTrackLength(), 0 );
-  QCOMPARE( gpsDigitizing.trackDirectLength(), 0 );
+  QCOMPARE( gpsDigitizing.trackDistanceFromStart(), 0 );
 
   info.latitude = 46;
   info.longitude = 100;
@@ -474,11 +474,11 @@ void TestQgsGpsIntegration::testTrackDistance()
   QgsProject::instance()->setCrs( QgsCoordinateReferenceSystem( "EPSG:3857" ) );
   QCOMPARE( QgsProject::instance()->ellipsoid(), QStringLiteral( "NONE" ) );
   QGSCOMPARENEAR( gpsDigitizing.totalTrackLength(), 1, 0.01 );
-  QGSCOMPARENEAR( gpsDigitizing.trackDirectLength(), 1, 0.01 );
+  QGSCOMPARENEAR( gpsDigitizing.trackDistanceFromStart(), 1, 0.01 );
   QgsProject::instance()->setEllipsoid( QStringLiteral( "EPSG:7030" ) );
   QCOMPARE( QgsProject::instance()->ellipsoid(), QStringLiteral( "EPSG:7030" ) );
   QGSCOMPARENEAR( gpsDigitizing.totalTrackLength(), 111141.548, 1 );
-  QGSCOMPARENEAR( gpsDigitizing.trackDirectLength(), 111141.548, 1 );
+  QGSCOMPARENEAR( gpsDigitizing.trackDistanceFromStart(), 111141.548, 1 );
 
   info.latitude = 46;
   info.longitude = 101;
@@ -487,7 +487,7 @@ void TestQgsGpsIntegration::testTrackDistance()
   gpsDigitizing.addVertex();
   QCOMPARE( spy.count(), 3 );
   QGSCOMPARENEAR( gpsDigitizing.totalTrackLength(), 188604.338, 1 );
-  QGSCOMPARENEAR( gpsDigitizing.trackDirectLength(), 135869.0912, 1 );
+  QGSCOMPARENEAR( gpsDigitizing.trackDistanceFromStart(), 135869.0912, 1 );
 
   gpsDigitizing.resetTrack();
   QCOMPARE( spy.count(), 4 );


### PR DESCRIPTION
This PR adds the current total track length and distance from start of track to the GPS information panel, and also as a (not-on-by-default) option to show in the GPS toolbar information label.

Sponsored by NIWA