### PR TITLE
Remove the 'stale' label upon unstaling with commits

### DIFF
--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,6 +1,6 @@
 name: Remove Labels
 
-on: [issue_comment]
+on: [issue_comment, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
~~If I correctly understood the [actions/stale description](https://github.com/actions/stale#close-stale-issues-and-prs) and particularly the [labels-to-remove-when-unstale](https://github.com/actions/stale#labels-to-remove-when-unstale) option, this should be enough to trigger removal of the label for PR and issue. We shouldn't need a specific unstale.yml action. Or did I overlook something?~~
Fixes #50822