### PR TITLE
Fix bad .qgz project file error handling

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6268,7 +6268,7 @@ bool QgisApp::addProject( const QString &projectFile )
     }
   }
 
-  if ( !usedCustomHandler && !QgsProject::instance()->read( projectFile ) && !QgsZipUtils::isZipFile( projectFile ) )
+  if ( !usedCustomHandler && !QgsProject::instance()->read( projectFile ) )
   {
     QString backupFile = projectFile + "~";
     QString loadBackupPrompt;

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1551,7 +1551,7 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
 
     projectFile.close();
 
-    setError( tr( "%1 for file %2" ).arg( errorString, projectFile.fileName() ) );
+    setError( errorString );
 
     return false;
   }
@@ -3723,7 +3723,7 @@ bool QgsProject::unzip( const QString &filename, Qgis::ProjectReadFlags flags )
   // read the project file
   if ( ! readProjectFile( static_cast<QgsProjectArchive *>( mArchive.get() )->projectFile(), flags ) )
   {
-    setError( tr( "Cannot read unzipped qgs project file" ) );
+    setError( tr( "Cannot read unzipped qgs project file" ) + QStringLiteral( ": " ) + error() );
     return false;
   }
 


### PR DESCRIPTION
This PR fixes three issues:
1. Until now, if a .qgz project file would fail to load, no error message would be shown in QGIS. This goes back all the way to when .qgz support was added (in https://github.com/qgis/QGIS/pull/4845) and it is unclear why showing of error message was disabled for .qgz files (probably the idea was to disable the logic for backup files)
2. On XML reading error, the message had the project file name mentioned twice for no reason
3. For zipped (.qgz) project files, the underlying error message was getting lost - only saying that unzipped project file has failed to load
