### PR TITLE
[Feature] Add x_at, y_at, z_at, m_at expression functions

### DIFF
--- a/resources/function_help/json/$x
+++ b/resources/function_help/json/$x
@@ -2,7 +2,7 @@
   "name": "$x",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns the x coordinate of the current point feature. If the feature is a multipoint feature, then the x-coordinate of the first point will be returned.",
+  "description": "Returns the x coordinate of the current point feature. If the feature is a multipoint feature, then the x-coordinate of the first point will be returned. <b>WARNING: This function is deprecated. It is recommended to use the replacement x() function with @geometry variable instead.</b>",
   "examples": [{
     "expression": "$x",
     "returns": "42"

--- a/resources/function_help/json/$x_at
+++ b/resources/function_help/json/$x_at
@@ -2,7 +2,7 @@
   "name": "$x_at",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Retrieves a x coordinate of the current feature's geometry.",
+  "description": "Retrieves a x coordinate of the current feature's geometry. <b>WARNING: This function is deprecated. It is recommended to use the replacement x_at function with @geometry variable instead.</b>",
   "arguments": [{
     "arg": "i",
     "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"

--- a/resources/function_help/json/$x_at
+++ b/resources/function_help/json/$x_at
@@ -4,8 +4,8 @@
   "groups": ["GeometryGroup"],
   "description": "Retrieves a x coordinate of the current feature's geometry. <b>WARNING: This function is deprecated. It is recommended to use the replacement x_at function with @geometry variable instead.</b>",
   "arguments": [{
-    "arg": "i",
-    "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"
+    "arg": "vertex",
+    "description": "index of the vertex of the current geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{
     "expression": "$x_at(1)",

--- a/resources/function_help/json/$y
+++ b/resources/function_help/json/$y
@@ -2,7 +2,7 @@
   "name": "$y",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns the y coordinate of the current point feature. If the feature is a multipoint feature, then the y-coordinate of the first point will be returned.",
+  "description": "Returns the y coordinate of the current point feature. If the feature is a multipoint feature, then the y-coordinate of the first point will be returned. <b>WARNING: This function is deprecated. It is recommended to use the replacement y() function with @geometry variable instead.</b>",
   "examples": [{
     "expression": "$y",
     "returns": "42"

--- a/resources/function_help/json/$y_at
+++ b/resources/function_help/json/$y_at
@@ -2,7 +2,7 @@
   "name": "$y_at",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Retrieves a y coordinate of the current feature's geometry.",
+  "description": "Retrieves a y coordinate of the current feature's geometry. <b>WARNING: This function is deprecated. It is recommended to use the replacement y_at function with @geometry variable instead.</b>",
   "arguments": [{
     "arg": "i",
     "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"

--- a/resources/function_help/json/$y_at
+++ b/resources/function_help/json/$y_at
@@ -4,8 +4,8 @@
   "groups": ["GeometryGroup"],
   "description": "Retrieves a y coordinate of the current feature's geometry. <b>WARNING: This function is deprecated. It is recommended to use the replacement y_at function with @geometry variable instead.</b>",
   "arguments": [{
-    "arg": "i",
-    "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"
+    "arg": "vertex",
+    "description": "index of the vertex of the current geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{
     "expression": "$y_at(1)",

--- a/resources/function_help/json/$z
+++ b/resources/function_help/json/$z
@@ -2,7 +2,7 @@
   "name": "$z",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns the z value of the current point feature if it is 3D. If the feature is a multipoint feature, then the z value of the first point will be returned.",
+  "description": "Returns the z value of the current point feature if it is 3D. If the feature is a multipoint feature, then the z value of the first point will be returned. <b>WARNING: This function is deprecated. It is recommended to use the replacement z() function with @geometry variable instead.</b>",
   "examples": [{
     "expression": "$z",
     "returns": "123"

--- a/resources/function_help/json/m_at
+++ b/resources/function_help/json/m_at
@@ -7,7 +7,7 @@
     "arg": "geometry",
     "description": "geometry object"
   }, {
-    "arg": "i",
+    "arg": "vertex",
     "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{

--- a/resources/function_help/json/m_at
+++ b/resources/function_help/json/m_at
@@ -1,0 +1,18 @@
+{
+  "name": "m_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a m coordinate of the geometry, or NULL if the geometry has no m value.",
+  "arguments": [{
+    "arg": "geometry",
+    "description": "geometry object"
+  }, {
+    "arg": "i",
+    "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "m_at(geom_from_wkt('LineStringZM(0 0 0 0, 10 10 0 5, 10 10 0 0)'), 1)",
+    "returns": "5"
+  }],
+  "tags": ["retrieves", "coordinate", "measure"]
+}

--- a/resources/function_help/json/x_at
+++ b/resources/function_help/json/x_at
@@ -7,7 +7,7 @@
     "arg": "geometry",
     "description": "geometry object"
   }, {
-    "arg": "i",
+    "arg": "vertex",
     "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{

--- a/resources/function_help/json/x_at
+++ b/resources/function_help/json/x_at
@@ -1,0 +1,18 @@
+{
+  "name": "x_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a x coordinate of the geometry.",
+  "arguments": [{
+    "arg": "geometry",
+    "description": "geometry object"
+  }, {
+    "arg": "i",
+    "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "x_at( geom_from_wkt( 'POINT(4 5)' ), 0 )",
+    "returns": "4"
+  }],
+  "tags": ["retrieves", "coordinate"]
+}

--- a/resources/function_help/json/y_at
+++ b/resources/function_help/json/y_at
@@ -7,7 +7,7 @@
     "arg": "geometry",
     "description": "geometry object"
   }, {
-    "arg": "i",
+    "arg": "vertex",
     "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{

--- a/resources/function_help/json/y_at
+++ b/resources/function_help/json/y_at
@@ -1,0 +1,18 @@
+{
+  "name": "y_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a y coordinate of the geometry.",
+  "arguments": [{
+    "arg": "geometry",
+    "description": "geometry object"
+  }, {
+    "arg": "i",
+    "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "y_at( geom_from_wkt( 'POINT(4 5)' ), 0 )",
+    "returns": "5"
+  }],
+  "tags": ["retrieves", "coordinate"]
+}

--- a/resources/function_help/json/z_at
+++ b/resources/function_help/json/z_at
@@ -7,7 +7,7 @@
     "arg": "geometry",
     "description": "geometry object"
   }, {
-    "arg": "i",
+    "arg": "vertex",
     "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
   }],
   "examples": [{

--- a/resources/function_help/json/z_at
+++ b/resources/function_help/json/z_at
@@ -1,0 +1,18 @@
+{
+  "name": "z_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a z coordinate of the geometry, or NULL if the geometry has no z value.",
+  "arguments": [{
+    "arg": "geometry",
+    "description": "geometry object"
+  }, {
+    "arg": "i",
+    "description": "index of the vertex of the geometry (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "z_at(geom_from_wkt('LineStringZ(0 0 0, 10 10 5, 10 10 0)'), 1)",
+    "returns": "5"
+  }],
+  "tags": ["retrieves", "coordinate", "3D"]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -8113,17 +8113,17 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       QgsExpressionFunction::Parameter( QStringLiteral( "keep_collapsed" ), true, false )
     }, fcnGeomMakeValid, QStringLiteral( "GeometryGroup" ) );
 
-    functions << new QgsStaticExpressionFunction( QStringLiteral( "x_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ), true ) << QgsExpressionFunction::Parameter( QStringLiteral( "i" ), true ), fcnXat, QStringLiteral( "GeometryGroup" ) );
-    functions << new QgsStaticExpressionFunction( QStringLiteral( "y_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ), true ) << QgsExpressionFunction::Parameter( QStringLiteral( "i" ), true ), fcnYat, QStringLiteral( "GeometryGroup" ) );
-    functions << new QgsStaticExpressionFunction( QStringLiteral( "z_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "i" ), true ), fcnZat, QStringLiteral( "GeometryGroup" ) );
-    functions << new QgsStaticExpressionFunction( QStringLiteral( "m_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "i" ), true ), fcnMat, QStringLiteral( "GeometryGroup" ) );
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "x_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ), true ) << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ), true ), fcnXat, QStringLiteral( "GeometryGroup" ) );
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "y_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ), true ) << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ), true ), fcnYat, QStringLiteral( "GeometryGroup" ) );
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "z_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ), true ), fcnZat, QStringLiteral( "GeometryGroup" ) );
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "m_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ), true ), fcnMat, QStringLiteral( "GeometryGroup" ) );
 
-    QgsStaticExpressionFunction *xAtFunc = new QgsStaticExpressionFunction( QStringLiteral( "$x_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "i" ) ), fcnOldXat, QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>(), false, QStringList() << QStringLiteral( "xat" ) );
+    QgsStaticExpressionFunction *xAtFunc = new QgsStaticExpressionFunction( QStringLiteral( "$x_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ) ), fcnOldXat, QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>(), false, QStringList() << QStringLiteral( "xat" ) );
     xAtFunc->setIsStatic( false );
     functions << xAtFunc;
 
 
-    QgsStaticExpressionFunction *yAtFunc = new QgsStaticExpressionFunction( QStringLiteral( "$y_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "i" ) ), fcnOldYat, QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>(), false, QStringList() << QStringLiteral( "yat" ) );
+    QgsStaticExpressionFunction *yAtFunc = new QgsStaticExpressionFunction( QStringLiteral( "$y_at" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "vertex" ) ), fcnOldYat, QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>(), false, QStringList() << QStringLiteral( "yat" ) );
     yAtFunc->setIsStatic( false );
     functions << yAtFunc;
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3800,9 +3800,9 @@ static QVariant fcnOldXat( const QVariantList &values, const QgsExpressionContex
 {
   FEAT_FROM_CONTEXT( context, feature )
   const QgsGeometry geom = feature.geometry();
-  int idx = QgsExpressionUtils::getNativeIntValue( values.at( 0 ), parent );
+  const int idx = QgsExpressionUtils::getNativeIntValue( values.at( 0 ), parent );
 
-  QVariant v = pointAt( geom, idx, parent );
+  const QVariant v = pointAt( geom, idx, parent );
 
   if ( !v.isNull() )
     return QVariant( v.value<QgsPoint>().x() );
@@ -3811,23 +3811,24 @@ static QVariant fcnOldXat( const QVariantList &values, const QgsExpressionContex
 }
 static QVariant fcnXat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
-  if ( values.at( 1 ).isNull() || values.at( 0 ).isNull() ) // the case where the alias x_at function is called like a $ function (x_at(i))
+  if ( values.at( 1 ).isNull() && !values.at( 0 ).isNull() ) // the case where the alias x_at function is called like a $ function (x_at(i))
   {
     return fcnOldXat( values, f, parent, node );
   }
-  else if ( values.at( 0 ).isNull() && !values.at( 1 ).isNull() ) // same as above with x_at(i:=0) (this values is at the second position)
+  else if ( values.at( 0 ).isNull() && !values.at( 1 ).isNull() ) // same as above with x_at(i:=0) (vertex value is at the second position)
   {
     return fcnOldXat( QVariantList() << values[1], f, parent, node );
   }
 
-  QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ); // Should be one or 0 ???
+  const QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
   {
     return QVariant();
   }
 
-  QVariant v = pointAt( geom, vertexNumber, parent );
+  const int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+
+  const QVariant v = pointAt( geom, vertexNumber, parent );
   if ( !v.isNull() )
     return QVariant( v.value<QgsPoint>().x() );
   else
@@ -3839,9 +3840,9 @@ static QVariant fcnOldYat( const QVariantList &values, const QgsExpressionContex
 {
   FEAT_FROM_CONTEXT( context, feature )
   const QgsGeometry geom = feature.geometry();
-  int idx = QgsExpressionUtils::getNativeIntValue( values.at( 0 ), parent );
+  const int idx = QgsExpressionUtils::getNativeIntValue( values.at( 0 ), parent );
 
-  QVariant v = pointAt( geom, idx, parent );
+  const QVariant v = pointAt( geom, idx, parent );
 
   if ( !v.isNull() )
     return QVariant( v.value<QgsPoint>().y() );
@@ -3850,23 +3851,24 @@ static QVariant fcnOldYat( const QVariantList &values, const QgsExpressionContex
 }
 static QVariant fcnYat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
-  if ( values.at( 1 ).isNull() ) // the case where the alias y_at function is called like a $ function (y_at(i))
+  if ( values.at( 1 ).isNull() && !values.at( 0 ).isNull() ) // the case where the alias y_at function is called like a $ function (y_at(i))
   {
     return fcnOldYat( values, f, parent, node );
   }
-  else if ( values.at( 0 ).isNull() && !values.at( 1 ).isNull() ) // same as above with x_at(i:=0) (this values is at the second position)
+  else if ( values.at( 0 ).isNull() && !values.at( 1 ).isNull() ) // same as above with x_at(i:=0) (vertex value is at the second position)
   {
     return fcnOldYat( QVariantList() << values[1], f, parent, node );
   }
 
-  QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
   {
     return QVariant();
   }
 
-  QVariant v = pointAt( geom, vertexNumber, parent );
+  const int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+
+  const QVariant v = pointAt( geom, vertexNumber, parent );
   if ( !v.isNull() )
     return QVariant( v.value<QgsPoint>().y() );
   else
@@ -3875,14 +3877,15 @@ static QVariant fcnYat( const QVariantList &values, const QgsExpressionContext *
 
 static QVariant fcnZat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
   {
     return QVariant();
   }
 
-  QVariant v = pointAt( geom, vertexNumber, parent );
+  const int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+
+  const QVariant v = pointAt( geom, vertexNumber, parent );
   if ( !v.isNull() && v.value<QgsPoint>().is3D() )
     return QVariant( v.value<QgsPoint>().z() );
   else
@@ -3891,14 +3894,15 @@ static QVariant fcnZat( const QVariantList &values, const QgsExpressionContext *
 
 static QVariant fcnMat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
   {
     return QVariant();
   }
 
-  QVariant v = pointAt( geom, vertexNumber, parent );
+  const int vertexNumber = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+
+  const QVariant v = pointAt( geom, vertexNumber, parent );
   if ( !v.isNull() && v.value<QgsPoint>().isMeasure() )
     return QVariant( v.value<QgsPoint>().m() );
   else

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -99,6 +99,8 @@ QString QgsExpressionNode::NodeList::cleanNamedNodeName( const QString &name )
     cleaned = QStringLiteral( "geometry1" );
   else if ( cleaned == QLatin1String( "geometry b" ) )
     cleaned = QStringLiteral( "geometry2" );
+  else if ( cleaned == QLatin1String( "i" ) )
+    cleaned = QStringLiteral( "vertex" );
 
   return cleaned;
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3233,20 +3233,50 @@ class TestQgsExpression: public QObject
 
     void eval_geometry_calc()
     {
-      QgsPolylineXY polyline, polygon_ring;
-      QgsPolyline polylineZ;
-      polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
-      polylineZ << QgsPoint( 0, 0, 0 ) << QgsPoint( 3, 0, 4 );
+      QgsPolylineXY polygon_ring;
       polygon_ring << QgsPointXY( 2, 1 ) << QgsPointXY( 10, 1 ) << QgsPointXY( 10, 6 ) << QgsPointXY( 2, 6 ) << QgsPointXY( 2, 1 );
-      QgsPolygonXY polygon;
-      polygon << polygon_ring;
-      QgsFeature fPolygon, fPolyline, fPolylineZ;
-      QgsGeometry polylineGeom = QgsGeometry::fromPolylineXY( polyline );
-      fPolyline.setGeometry( polylineGeom );
-      QgsGeometry polylineZGeom = QgsGeometry::fromPolyline( polylineZ );
-      fPolylineZ.setGeometry( polylineZGeom );
-      QgsGeometry polygonGeom = QgsGeometry::fromPolygonXY( polygon );
+      QgsPolygonXY polygonXY;
+      polygonXY << polygon_ring;
+      QgsGeometry polygonGeom = QgsGeometry::fromPolygonXY( polygonXY );
+      QgsFeature fPolygon;
       fPolygon.setGeometry( polygonGeom );
+
+      QgsPolylineXY polyline;
+      polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
+      QgsGeometry polylineGeom = QgsGeometry::fromPolylineXY( polyline );
+      QgsFeature fPolyline;
+      fPolyline.setGeometry( polylineGeom );
+
+      QgsPolyline polylineZ;
+      polylineZ << QgsPoint( 0, 0, 0 ) << QgsPoint( 3, 0, 4 );
+      QgsGeometry polylineZGeom = QgsGeometry::fromPolyline( polylineZ );
+      QgsFeature fPolylineZ;
+      fPolylineZ.setGeometry( polylineZGeom );
+
+      QgsPolyline polylineM;
+      polylineM << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 0 ) << QgsPoint( QgsWkbTypes::PointM, 3, 0, 0, 8 );
+      QgsGeometry polylineMGeom = QgsGeometry::fromPolyline( polylineM );
+      QgsFeature fPolylineM;
+      fPolylineM.setGeometry( polylineMGeom );
+
+      QgsPolyline polylineZM;
+      polylineZM << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 0, 0 ) << QgsPoint( QgsWkbTypes::PointZM, 3, 0, 4, 8 );
+      QgsGeometry polylineZMGeom = QgsGeometry::fromPolyline( polylineZM );
+      QgsFeature fPolylineZM;
+      fPolylineZM.setGeometry( polylineZMGeom );
+
+      QgsMultiLineString mls;
+      QgsLineString part;
+      part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 10, 10 )
+                      << QgsPoint( QgsWkbTypes::PointZM, 20, 20, 20, 20 ) );
+      mls.addGeometry( part.clone() );
+      part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 30, 30, 30, 30 )
+                      << QgsPoint( QgsWkbTypes::PointZM, 40, 40, 40, 40 ) );
+      mls.addGeometry( part.clone() );
+      QgsGeometry multiStringZMGeom;
+      multiStringZMGeom.set( mls.clone() );
+      QgsFeature fMultiLineStringZM;
+      fMultiLineStringZM.setGeometry( multiStringZMGeom );
 
       QgsExpressionContext context;
 
@@ -3266,58 +3296,173 @@ class TestQgsExpression: public QObject
       QCOMPARE( vPerimeter.toDouble(), 26. );
 
       QgsExpression deprecatedExpXAt( QStringLiteral( "$x_at(1)" ) );
+      QgsExpression expXAt( QStringLiteral( "x_at(@geometry, 1)" ) );
       context.setFeature( fPolygon );
       QVariant xAt = deprecatedExpXAt.evaluate( &context );
+      QCOMPARE( xAt.toDouble(), 10.0 );
+      xAt = expXAt.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 10.0 );
       context.setFeature( fPolyline );
       xAt = deprecatedExpXAt.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 10.0 );
+      xAt = expXAt.evaluate( &context );
+      QCOMPARE( xAt.toDouble(), 10.0 );
 
       QgsExpression deprecatedExpXAtNeg( QStringLiteral( "$x_at(-2)" ) );
+      QgsExpression expXAtNeg( QStringLiteral( "x_at(@geometry, -2)" ) );
       context.setFeature( fPolygon );
       xAt = deprecatedExpXAtNeg.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 2.0 );
+      xAt = expXAtNeg.evaluate( &context );
+      QCOMPARE( xAt.toDouble(), 2.0 );
 
       QgsExpression deprecatedExpYAt( QStringLiteral( "$y_at(2)" ) );
+      QgsExpression expYAt( QStringLiteral( "y_at(@geometry, 2)" ) );
       context.setFeature( fPolygon );
       QVariant yAt = deprecatedExpYAt.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
+      yAt = expYAt.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 6.0 );
       QgsExpression deprecatedExpYAt2( QStringLiteral( "$y_at(1)" ) );
+      QgsExpression expYAt2( QStringLiteral( "y_at(@geometry, 1)" ) );
       context.setFeature( fPolyline );
       yAt = deprecatedExpYAt2.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 0.0 );
 
       QgsExpression deprecatedExpYAtNeg( QStringLiteral( "$y_at(-2)" ) );
+      QgsExpression expYAtNeg( QStringLiteral( "y_at(@geometry, -2)" ) );
       context.setFeature( fPolygon );
       yAt = deprecatedExpYAtNeg.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
+      yAt = expYAtNeg.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 6.0 );
 
-      QgsExpression expXAt( QStringLiteral( "x_at(1)" ) );
+      QgsExpression deprecatedAliasexpXAt( QStringLiteral( "x_at(1)" ) );
       context.setFeature( fPolygon );
-      xAt = expXAt.evaluate( &context );
+      xAt = deprecatedAliasexpXAt.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 10.0 );
+      QgsExpression deprecatedAliasexpXAt2( QStringLiteral( "x_at(1)" ) );
       context.setFeature( fPolyline );
-      xAt = expXAt.evaluate( &context );
+      xAt = deprecatedAliasexpXAt2.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 10.0 );
 
-      QgsExpression expXAtNeg( QStringLiteral( "x_at(-2)" ) );
+      QgsExpression deprecatedAliasexpYAt( QStringLiteral( "y_at(1)" ) );
+      context.setFeature( fPolygon );
+      yAt = deprecatedAliasexpYAt.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 1.0 );
+      QgsExpression deprecatedAliasexpYAt2( QStringLiteral( "y_at(1)" ) );
+      context.setFeature( fPolyline );
+      yAt = deprecatedAliasexpYAt2.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 0.0 );
+
+      // with a ZM geometry
+      expXAt = QgsExpression( QStringLiteral( "x_at(@geometry, 2)" ) );
+      context.setFeature( fMultiLineStringZM );
+      xAt = expXAt.evaluate( &context );
+      QCOMPARE( xAt.toDouble(), 30.0 );
+
+      QgsExpression expXAtNeg2( QStringLiteral( "x_at(@geometry, -2)" ) );
       context.setFeature( fPolygon );
       xAt = expXAtNeg.evaluate( &context );
       QCOMPARE( xAt.toDouble(), 2.0 );
 
-      QgsExpression expYAt( QStringLiteral( "y_at(2)" ) );
+      QgsExpression expYAt3( QStringLiteral( "y_at(@geometry, 2)" ) );
       context.setFeature( fPolygon );
       yAt = expYAt.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
-      QgsExpression expYAt2( QStringLiteral( "$y_at(1)" ) );
+      QgsExpression expYAt4( QStringLiteral( "y_at(@geometry, 1)" ) );
       context.setFeature( fPolyline );
       yAt = expYAt2.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 0.0 );
 
-      QgsExpression expYAtNeg( QStringLiteral( "y_at(-2)" ) );
+      // with a ZM geometry
+      expYAt2 = QgsExpression( QStringLiteral( "y_at(@geometry, 2)" ) );
+      context.setFeature( fMultiLineStringZM );
+      yAt = expYAt2.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 30.0 );
+
+      QgsExpression expYAtNeg2( QStringLiteral( "y_at(@geometry, -2)" ) );
       context.setFeature( fPolygon );
-      yAt = expYAtNeg.evaluate( &context );
+      yAt = expYAtNeg2.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
+
+      // Test z_at
+
+      // a basic case
+      QgsExpression expZAt( QStringLiteral( "z_at(@geometry, 1)" ) );
+      context.setFeature( fPolylineZ );
+      QVariant zAt = expZAt.evaluate( &context );
+      QCOMPARE( zAt.toDouble(), 4.0 );
+
+      // with a negative range
+      expZAt = QgsExpression( QStringLiteral( "z_at(@geometry, -1)" ) );
+      context.setFeature( fPolylineZ );
+      zAt = expZAt.evaluate( &context );
+      QCOMPARE( zAt.toDouble(), 4.0 );
+
+      // with an index out of range
+      expZAt = QgsExpression( QStringLiteral( "z_at(@geometry, 3)" ) );
+      // even with a no Z geometry, an eval error should be raised.
+      context.setFeature( fPolyline );
+      zAt = expZAt.evaluate( &context );
+      QVERIFY( expZAt.hasEvalError() );
+
+      // with a geom with no Z
+      expZAt = QgsExpression( QStringLiteral( "z_at(@geometry, 1)" ) );
+      context.setFeature( fPolyline );
+      zAt = expZAt.evaluate( &context );
+      QVERIFY( zAt.isNull() );
+
+      // with a geom with no Z but with M
+      expZAt = QStringLiteral( "z_at(@geometry, 1)" );
+      context.setFeature( fPolylineM );
+      zAt = expZAt.evaluate( &context );
+      QVERIFY( zAt.isNull() );
+
+      // with a multi geom
+      expZAt = QStringLiteral( "z_at(@geometry, 2)" );
+      context.setFeature( fMultiLineStringZM );
+      zAt = expZAt.evaluate( &context );
+      QCOMPARE( zAt.toDouble(), 30.0 );
+
+      // Test m_at
+
+      // a basic case
+      QgsExpression expMAt( QStringLiteral( "m_at(@geometry, 1)" ) );
+      context.setFeature( fPolylineM );
+      QVariant mAt = expMAt.evaluate( &context );
+      QCOMPARE( mAt.toDouble(), 8.0 );
+
+      // with a negative range
+      expMAt = QgsExpression( QStringLiteral( "m_at(@geometry, -1)" ) );
+      context.setFeature( fPolylineM );
+      mAt = expMAt.evaluate( &context );
+      QCOMPARE( mAt.toDouble(), 8.0 );
+
+      // with an index out of range
+      expMAt = QgsExpression( QStringLiteral( "m_at(@geometry, 3)" ) );
+      // even with a no M geometry, an eval error should be raised.
+      context.setFeature( fPolyline );
+      mAt = expMAt.evaluate( &context );
+      QVERIFY( expMAt.hasEvalError() );
+
+      // with a geom with no M
+      expMAt = QgsExpression( QStringLiteral( "m_at(@geometry, 1)" ) );
+      context.setFeature( fPolyline );
+      mAt = expMAt.evaluate( &context );
+      QVERIFY( mAt.isNull() );
+
+      // with a geom with no M but with Z
+      expMAt = QStringLiteral( "m_at(@geometry, 1)" );
+      context.setFeature( fPolylineZ );
+      mAt = expMAt.evaluate( &context );
+      QVERIFY( mAt.isNull() );
+
+      // with a multi geom
+      expMAt = QStringLiteral( "m_at(@geometry, 3)" );
+      context.setFeature( fMultiLineStringZM );
+      mAt = expMAt.evaluate( &context );
+      QCOMPARE( mAt.toDouble(), 40.0 );
 
       QgsExpression exp4( QStringLiteral( "bounds_width($geometry)" ) );
       context.setFeature( fPolygon );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3386,6 +3386,18 @@ class TestQgsExpression: public QObject
       yAt = expYAtNeg2.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
 
+      // test with named parameter
+      QgsExpression expYAtWithI( QStringLiteral( "x_at(@geometry, i:=1)" ) );
+      context.setFeature( fPolygon );
+      yAt = expYAtWithI.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 10.0 );
+
+      QgsExpression expYAtWithVertex( QStringLiteral( "x_at(@geometry, vertex:=1)" ) );
+      context.setFeature( fPolygon );
+      yAt = expYAtWithVertex.evaluate( &context );
+      QCOMPARE( yAt.toDouble(), 10.0 );
+
+
       // Test z_at
 
       // a basic case


### PR DESCRIPTION
## Description

Supersedes #49765

Initially, the expressions `$m`, `$z_at` and `$m_at` were to be added. However, the $functions are deprecated (and therefore none should be added).

I wanted to add `z_at` and `m_at` (without the $) as well as `x_at` and `y_at` for the sake of consistency. Except that, big problem, `x_at` and `y_at` already exist as aliases for `$x_at` and `$y_at`. Not wanting to be in a situation where these expressions below coexist:
```
$x_at(i)
$y_at(i)
x_at(i) # alias, undocumented
y_at(i) # alias, undocumented
z_at(geometry, i)
m_at(geometry, i)
```
This PR proposes a solution so that `x_at` and `y_at` have like 2 signatures (to both migrate to functions without $ and without creating a breaking change). So with this PR, there are:
```
$x_at(i)
$y_at(i)
x_at(i) # alias of $x_at(), still undocumented
y_at(i) # alias of $y_at(), still undocumented
x_at(geometry, i)
y_at(geometry, i)
z_at(geometry, i)
m_at(geometry, i)
```

There are also others aliases like `xat` et `yat`. This PR doesn't modify their behavior.

The user help for the `$x`, `$y`, `$z`, `$x_at` and `$y_at` expressions has been modified to inform the user to prefer the version without $.

Founded by: Métropole Européenne de Lille, cc @Jean-Roc