### PR TITLE
Raster maptips

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -200,6 +200,16 @@ a map tool capture like add feature.
 .. versionadded:: 3.0
 %End
 
+    static QgsExpressionContextScope *mapLayerPositionScope( const QgsPointXY &position ) /Factory/;
+%Docstring
+Sets the expression context variables which are available for expressions triggered by moving the mouse over a feature
+of the currently selected layer.
+
+:param position: map coordinates of the currente pointer position in the CRS of the layer which triggered the action.
+
+.. versionadded:: 3.30
+%End
+
     static QgsExpressionContextScope *updateSymbolScope( const QgsSymbol *symbol, QgsExpressionContextScope *symbolScope = 0 );
 %Docstring
 Updates a symbol scope related to a :py:class:`QgsSymbol` to an expression context.

--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -205,7 +205,7 @@ a map tool capture like add feature.
 Sets the expression context variables which are available for expressions triggered by moving the mouse over a feature
 of the currently selected layer.
 
-:param position: map coordinates of the currente pointer position in the CRS of the layer which triggered the action.
+:param position: map coordinates of the current pointer position in the CRS of the layer which triggered the action.
 
 .. versionadded:: 3.30
 %End

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1518,7 +1518,7 @@ It may also contain embedded expressions.
 
    this method was only available for vector layers since QGIS 3.0
 
-.. versionadded:: 3.0
+.. versionadded:: 3.30
 %End
 
     void setMapTipTemplate( const QString &mapTipTemplate );
@@ -1877,9 +1877,13 @@ Emitted when modifications has been done on layer
 
     void mapTipTemplateChanged();
 %Docstring
-Emitted when the map tip changes
+Emitted when the map tip template changes
 
-.. versionadded:: 3.0
+.. note::
+
+   this method was only available for vector layers since QGIS 3.0
+
+.. versionadded:: 3.30
 %End
 
   protected:

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1508,6 +1508,33 @@ Set placeholder image for legend. If the string is empty, a generated legend wil
 .. versionadded:: 3.22
 %End
 
+    QString mapTipTemplate() const;
+%Docstring
+The mapTip is a pretty, html representation for feature information.
+
+It may also contain embedded expressions.
+
+.. note::
+
+   this method was only available for vector layers since QGIS 3.0
+
+.. versionadded:: 3.0
+%End
+
+    void setMapTipTemplate( const QString &mapTipTemplate );
+%Docstring
+The mapTip is a pretty, html representation for feature information.
+
+It may also contain embedded expressions.
+
+.. note::
+
+   this method was only available for vector layers since QGIS 3.0
+
+.. versionadded:: 3.30
+%End
+
+
   public slots:
 
     void setMinimumScale( double scale );
@@ -1846,6 +1873,13 @@ Emitted when edited changes have been successfully written to the data provider.
 Emitted when modifications has been done on layer
 
 .. versionadded:: 3.22
+%End
+
+    void mapTipTemplateChanged();
+%Docstring
+Emitted when the map tip changes
+
+.. versionadded:: 3.0
 %End
 
   protected:

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -448,6 +448,24 @@ to be drawn outside the data extent.
     virtual QgsMapLayerElevationProperties *elevationProperties();
 
 
+    QString mapTipTemplate() const;
+%Docstring
+The mapTip is a pretty, html representation for feature information.
+
+It may also contain embedded expressions.
+
+.. versionadded:: 3.30
+%End
+
+    void setMapTipTemplate( const QString &mapTip );
+%Docstring
+The mapTip is a pretty, html representation for feature information.
+
+It may also contain embedded expressions.
+
+.. versionadded:: 3.30
+%End
+
   public slots:
     void showStatusMessage( const QString &message );
 
@@ -466,6 +484,14 @@ Emitted when the layer's subset string has changed.
 
 .. versionadded:: 3.12
 %End
+
+    void mapTipTemplateChanged();
+%Docstring
+Emitted when the map tip changes
+
+.. versionadded:: 3.30
+%End
+
 
 
   protected:

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -448,24 +448,6 @@ to be drawn outside the data extent.
     virtual QgsMapLayerElevationProperties *elevationProperties();
 
 
-    QString mapTipTemplate() const;
-%Docstring
-The mapTip is a pretty, html representation for feature information.
-
-It may also contain embedded expressions.
-
-.. versionadded:: 3.30
-%End
-
-    void setMapTipTemplate( const QString &mapTip );
-%Docstring
-The mapTip is a pretty, html representation for feature information.
-
-It may also contain embedded expressions.
-
-.. versionadded:: 3.30
-%End
-
   public slots:
     void showStatusMessage( const QString &message );
 
@@ -484,15 +466,6 @@ Emitted when the layer's subset string has changed.
 
 .. versionadded:: 3.12
 %End
-
-    void mapTipTemplateChanged();
-%Docstring
-Emitted when the map tip changes
-
-.. versionadded:: 3.30
-%End
-
-
 
   protected:
     virtual bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -2571,24 +2571,6 @@ Sets the attribute table configuration object.
 This defines the appearance of the attribute table.
 %End
 
-    QString mapTipTemplate() const;
-%Docstring
-The mapTip is a pretty, html representation for feature information.
-
-It may also contain embedded expressions.
-
-.. versionadded:: 3.0
-%End
-
-    void setMapTipTemplate( const QString &mapTipTemplate );
-%Docstring
-The mapTip is a pretty, html representation for feature information.
-
-It may also contain embedded expressions.
-
-.. versionadded:: 3.0
-%End
-
     virtual QgsExpressionContext createExpressionContext() const ${SIP_FINAL};
 
 
@@ -2984,13 +2966,6 @@ to this signal and update the element accordingly.
 :param element: The XML element where you can add additional style information to.
 :param doc: The XML document that you can use to create new XML nodes.
 :param errorMessage: Write error messages into this string.
-%End
-
-    void mapTipTemplateChanged();
-%Docstring
-Emitted when the map tip changes
-
-.. versionadded:: 3.0
 %End
 
     void displayExpressionChanged();

--- a/resources/function_help/json/map_to_html_dl
+++ b/resources/function_help/json/map_to_html_dl
@@ -1,0 +1,15 @@
+{
+  "name": "map_to_html_dl",
+  "type": "function",
+  "groups": ["Maps"],
+  "description": "Merge map elements into a HTML definition list string.",
+  "arguments": [{
+    "arg": "map",
+    "description": "the input map"
+  }],
+  "examples": [{
+    "expression": "map_to_html_dl(map('qgis','rocks'))",
+    "returns": "<dl><dt>qgis</dt><dd>rocks</dd></dl>"
+  }],
+  "tags": ["formatted", "map", "html"]
+}

--- a/resources/function_help/json/map_to_html_table
+++ b/resources/function_help/json/map_to_html_table
@@ -1,0 +1,15 @@
+{
+  "name": "map_to_html_table",
+  "type": "function",
+  "groups": ["Maps"],
+  "description": "Merge map elements into a HTML table string.",
+  "arguments": [{
+    "arg": "map",
+    "description": "the input map"
+  }],
+  "examples": [{
+    "expression": "map_to_html_table(map('qgis','rocks'))",
+    "returns": "<table><thead><th>qgis</th></thead><tbody><tr><td>rocks</td></tr></tbody></table>"
+  }],
+  "tags": ["formatted", "map", "html"]
+}

--- a/resources/function_help/json/raster_attributes
+++ b/resources/function_help/json/raster_attributes
@@ -2,13 +2,13 @@
   "name": "raster_attributes",
   "type": "function",
   "groups": ["Rasters"],
-  "description": "Returns a map with the fields names as keys and the raster attribute table values as values from the attribute table entry that matches the given raster value .",
+  "description": "Returns a map with the fields names as keys and the raster attribute table values as values from the attribute table entry that matches the given raster value.",
   "arguments": [{
     "arg": "layer",
     "description": "the name or id of a raster layer"
   }, {
     "arg": "band",
-    "description": "the band number to sample the value from and for the associated attribute table lookup. "
+    "description": "the band number for the associated attribute table lookup."
   }, {
     "arg": "value",
     "description": "raster value"

--- a/resources/function_help/json/raster_attributes
+++ b/resources/function_help/json/raster_attributes
@@ -1,0 +1,21 @@
+{
+  "name": "raster_attributes",
+  "type": "function",
+  "groups": ["Rasters"],
+  "description": "Returns a map with the fields names as keys and the raster attribute table values as values from the attribute table entry that matches the given raster value .",
+  "arguments": [{
+    "arg": "layer",
+    "description": "the name or id of a raster layer"
+  }, {
+    "arg": "band",
+    "description": "the band number to sample the value from and for the associated attribute table lookup."
+  }, {
+    "arg": "value",
+    "description": "raster value"
+  }],
+  "examples": [{
+    "expression": "raster_attributes('vegetation', 1, raster_value('vegetation', 1, make_point(1,1)))",
+    "returns": "{'class': 'Vegetated', 'subclass': 'Trees'}"
+  }],
+  "tags": ["provider", "point", "raster", "found", "attributes"]
+}

--- a/resources/function_help/json/raster_attributes
+++ b/resources/function_help/json/raster_attributes
@@ -8,7 +8,7 @@
     "description": "the name or id of a raster layer"
   }, {
     "arg": "band",
-    "description": "the band number to sample the value from and for the associated attribute table lookup."
+    "description": "the band number to sample the value from and for the associated attribute table lookup. "
   }, {
     "arg": "value",
     "description": "raster value"

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14412,23 +14412,15 @@ void QgisApp::removeMapToolMessage()
 void QgisApp::showMapTip()
 {
   // Only show maptips if the mouse is still over the map canvas when timer is triggered
-  if ( mMapCanvas->underMouse() )
+  if ( mMapTipsVisible && mMapCanvas->underMouse() )
   {
     QPoint myPointerPos = mMapCanvas->mouseLastXY();
 
     //  Make sure there is an active layer before proceeding
     QgsMapLayer *mypLayer = mMapCanvas->currentLayer();
-    if ( mypLayer )
+    if ( mypLayer && !mypLayer->mapTipTemplate().isEmpty() )
     {
-      // only process vector and raster layers
-      if ( mypLayer->type() == QgsMapLayerType::VectorLayer || mypLayer->type() == QgsMapLayerType::RasterLayer )
-      {
-        // Show the maptip if the maptips button is depressed
-        if ( mMapTipsVisible )
-        {
-          mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
-        }
-      }
+      mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
     }
   }
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14420,8 +14420,8 @@ void QgisApp::showMapTip()
     QgsMapLayer *mypLayer = mMapCanvas->currentLayer();
     if ( mypLayer )
     {
-      // only process vector layers
-      if ( mypLayer->type() == QgsMapLayerType::VectorLayer )
+      // only process vector and raster layers
+      if ( mypLayer->type() == QgsMapLayerType::VectorLayer || mypLayer->type() == QgsMapLayerType::RasterLayer )
       {
         // Show the maptip if the maptips button is depressed
         if ( mMapTipsVisible )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -826,6 +826,7 @@ void QgsExpression::initVariableHelp()
 
   // map canvas item variables
   sVariableHelpTexts()->insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the current layers's geographical coordinates." ) );
 
   // legend canvas item variables
   sVariableHelpTexts()->insert( QStringLiteral( "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -538,7 +538,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapToolCaptureScope( const
 QgsExpressionContextScope *QgsExpressionContextUtils::mapLayerPositionScope( const QgsPointXY &position )
 {
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Map Layer Position" ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_position" ), QVariant::fromValue( QgsGeometry::fromPointXY( position ) ) ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_cursor_point" ), QVariant::fromValue( QgsGeometry::fromPointXY( position ) ) ) );
   return scope;
 }
 

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -535,6 +535,13 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapToolCaptureScope( const
   return scope;
 }
 
+QgsExpressionContextScope *QgsExpressionContextUtils::mapLayerPositionScope( const QgsPointXY &position )
+{
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Map Layer Position" ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_position" ), QVariant::fromValue( QgsGeometry::fromPointXY( position ) ) ) );
+  return scope;
+}
+
 QgsExpressionContextScope *QgsExpressionContextUtils::updateSymbolScope( const QgsSymbol *symbol, QgsExpressionContextScope *symbolScope )
 {
   if ( !symbolScope )

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsExpressionContextUtils
     /**
      * Sets the expression context variables which are available for expressions triggered by moving the mouse over a feature
      * of the currently selected layer.
-     * \param position map coordinates of the currente pointer position in the CRS of the layer which triggered the action.
+     * \param position map coordinates of the current pointer position in the CRS of the layer which triggered the action.
      *
      * \since QGIS 3.30
      */

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -189,6 +189,15 @@ class CORE_EXPORT QgsExpressionContextUtils
     static QgsExpressionContextScope *mapToolCaptureScope( const QList<QgsPointLocator::Match> &matches ) SIP_FACTORY;
 
     /**
+     * Sets the expression context variables which are available for expressions triggered by moving the mouse over a feature
+     * of the currently selected layer.
+     * \param position map coordinates of the currente pointer position in the CRS of the layer which triggered the action.
+     *
+     * \since QGIS 3.30
+     */
+    static QgsExpressionContextScope *mapLayerPositionScope( const QgsPointXY &position ) SIP_FACTORY;
+
+    /**
      * Updates a symbol scope related to a QgsSymbol to an expression context.
      * \param symbol symbol to extract properties from
      * \param symbolScope pointer to an existing scope to update

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1706,7 +1706,7 @@ static QVariant fcnRasterAttributes( const QVariantList &values, const QgsExpres
     return QVariant();
   }
 
-  int bandNb = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const int bandNb = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
   if ( bandNb < 1 || bandNb > layer->bandCount() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `raster_attributes` requires a valid raster band number." ) );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1810,8 +1810,8 @@ static QVariant fcnMapToHtmlTable( const QVariantList &values, const QgsExpressi
 
   for ( auto it = dict.cbegin(); it != dict.cend(); ++it )
   {
-    headers.push_back( it.key() );
-    cells.push_back( it.value().toString( ) );
+    headers.push_back( it.key().toHtmlEscaped() );
+    cells.push_back( it.value().toString( ).toHtmlEscaped() );
   }
 
   return table.arg( headers.join( QStringLiteral( "</th><th>" ) ), cells.join( QStringLiteral( "</td><td>" ) ) );
@@ -1843,7 +1843,7 @@ static QVariant fcnMapToHtmlDefinitionList( const QVariantList &values, const Qg
 
   for ( auto it = dict.cbegin(); it != dict.cend(); ++it )
   {
-    rows.append( QStringLiteral( "<dt>%1</dt><dd>%2</dd>" ).arg( it.key(), it.value().toString() ) );
+    rows.append( QStringLiteral( "<dt>%1</dt><dd>%2</dd>" ).arg( it.key().toHtmlEscaped(), it.value().toString().toHtmlEscaped() ) );
   }
 
   return table.arg( rows );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -816,6 +816,20 @@ void QgsMapLayer::writeStyleManager( QDomNode &layerNode, QDomDocument &doc ) co
   }
 }
 
+QString QgsMapLayer::mapTipTemplate() const
+{
+  return mMapTipTemplate;
+}
+
+void QgsMapLayer::setMapTipTemplate( const QString &mapTip )
+{
+  if ( mMapTipTemplate == mapTip )
+    return;
+
+  mMapTipTemplate = mapTip;
+  emit mapTipTemplateChanged();
+}
+
 bool QgsMapLayer::isValid() const
 {
   return mValid;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1530,7 +1530,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * It may also contain embedded expressions.
      *
      * \note this method was only available for vector layers since QGIS 3.0
-     * \since QGIS 3.0
+     * \since QGIS 3.30
      */
     QString mapTipTemplate() const;
 
@@ -1830,9 +1830,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void layerModified();
 
     /**
-     * Emitted when the map tip changes
+     * Emitted when the map tip template changes
      *
-     * \since QGIS 3.0
+     * \note this method was only available for vector layers since QGIS 3.0
+     * \since QGIS 3.30
      */
     void mapTipTemplateChanged();
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -80,6 +80,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_PROPERTY( QgsMapLayerType type READ type CONSTANT )
     Q_PROPERTY( bool isValid READ isValid NOTIFY isValidChanged )
     Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
+    Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
@@ -1523,6 +1524,27 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void setLegendPlaceholderImage( const QString &imgPath ) { mLegendPlaceholderImage = imgPath; }
 
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * \note this method was only available for vector layers since QGIS 3.0
+     * \since QGIS 3.0
+     */
+    QString mapTipTemplate() const;
+
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * \note this method was only available for vector layers since QGIS 3.0
+     * \since QGIS 3.30
+     */
+    void setMapTipTemplate( const QString &mapTipTemplate );
+
+
   public slots:
 
     /**
@@ -1806,6 +1828,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.22 in the QgsMapLayer base class
      */
     void layerModified();
+
+    /**
+     * Emitted when the map tip changes
+     *
+     * \since QGIS 3.0
+     */
+    void mapTipTemplateChanged();
 
   private slots:
 
@@ -2126,6 +2155,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Path to placeholder image for layer legend. If the string is empty, a generated legend is shown
     QString mLegendPlaceholderImage;
+
+    //! Maptip template
+    QString mMapTipTemplate;
 
     friend class QgsVectorLayer;
     friend class TestQgsMapLayer;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1213,6 +1213,21 @@ QgsMapLayerElevationProperties *QgsRasterLayer::elevationProperties()
   return mElevationProperties;
 }
 
+QString QgsRasterLayer::mapTipTemplate() const
+{
+  return mMapTipTemplate;
+}
+
+void QgsRasterLayer::setMapTipTemplate( const QString &mapTip )
+{
+  if ( mMapTipTemplate == mapTip )
+    return;
+
+  mMapTipTemplate = mapTip;
+  emit mapTipTemplateChanged();
+
+}
+
 void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm, QgsRasterMinMaxOrigin::Limits limits, const QgsRectangle &extent, int sampleSize, bool generateLookupTableFlag )
 {
   setContrastEnhancement( algorithm,

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -76,6 +76,9 @@ typedef QList < QPair< QString, QColor > > QgsLegendColorList;
 class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfileSource
 {
     Q_OBJECT
+
+    Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
+
   public:
 
     //! \brief Default sample size (number of pixels) for estimated statistics/histogram calculation
@@ -491,6 +494,24 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
     QgsMapLayerTemporalProperties *temporalProperties() override;
     QgsMapLayerElevationProperties *elevationProperties() override;
 
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * \since QGIS 3.30
+     */
+    QString mapTipTemplate() const;
+
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * \since QGIS 3.30
+     */
+    void setMapTipTemplate( const QString &mapTip );
+
   public slots:
     void showStatusMessage( const QString &message );
 
@@ -508,6 +529,14 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
      * \since QGIS 3.12
      */
     void subsetStringChanged();
+
+    /**
+     * Emitted when the map tip changes
+     *
+     * \since QGIS 3.30
+     */
+    void mapTipTemplateChanged();
+
 
 
   protected:
@@ -608,6 +637,8 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
 
     QDomDocument mOriginalStyleDocument;
     QDomElement mOriginalStyleElement;
+
+    QString mMapTipTemplate;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -494,24 +494,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
     QgsMapLayerTemporalProperties *temporalProperties() override;
     QgsMapLayerElevationProperties *elevationProperties() override;
 
-    /**
-     * The mapTip is a pretty, html representation for feature information.
-     *
-     * It may also contain embedded expressions.
-     *
-     * \since QGIS 3.30
-     */
-    QString mapTipTemplate() const;
-
-    /**
-     * The mapTip is a pretty, html representation for feature information.
-     *
-     * It may also contain embedded expressions.
-     *
-     * \since QGIS 3.30
-     */
-    void setMapTipTemplate( const QString &mapTip );
-
   public slots:
     void showStatusMessage( const QString &message );
 
@@ -529,15 +511,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
      * \since QGIS 3.12
      */
     void subsetStringChanged();
-
-    /**
-     * Emitted when the map tip changes
-     *
-     * \since QGIS 3.30
-     */
-    void mapTipTemplateChanged();
-
-
 
   protected:
     bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories ) override;
@@ -638,7 +611,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
     QDomDocument mOriginalStyleDocument;
     QDomElement mOriginalStyleElement;
 
-    QString mMapTipTemplate;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -77,8 +77,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer, public QgsAbstractProfile
 {
     Q_OBJECT
 
-    Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
-
   public:
 
     //! \brief Default sample size (number of pixels) for estimated statistics/histogram calculation

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5189,20 +5189,6 @@ void QgsVectorLayer::setEditFormConfig( const QgsEditFormConfig &editFormConfig 
   emit editFormConfigChanged();
 }
 
-QString QgsVectorLayer::mapTipTemplate() const
-{
-  return mMapTipTemplate;
-}
-
-void QgsVectorLayer::setMapTipTemplate( const QString &mapTip )
-{
-  if ( mMapTipTemplate == mapTip )
-    return;
-
-  mMapTipTemplate = mapTip;
-  emit mapTipTemplateChanged();
-}
-
 QgsAttributeTableConfig QgsVectorLayer::attributeTableConfig() const
 {
   QgsAttributeTableConfig config = mAttributeTableConfig;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -394,7 +394,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     Q_PROPERTY( QString subsetString READ subsetString WRITE setSubsetString NOTIFY subsetStringChanged )
     Q_PROPERTY( QString displayExpression READ displayExpression WRITE setDisplayExpression NOTIFY displayExpressionChanged )
-    Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
     Q_PROPERTY( bool supportsEditing READ supportsEditing NOTIFY supportsEditingChanged )
@@ -2364,24 +2363,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig &attributeTableConfig );
 
-    /**
-     * The mapTip is a pretty, html representation for feature information.
-     *
-     * It may also contain embedded expressions.
-     *
-     * \since QGIS 3.0
-     */
-    QString mapTipTemplate() const;
-
-    /**
-     * The mapTip is a pretty, html representation for feature information.
-     *
-     * It may also contain embedded expressions.
-     *
-     * \since QGIS 3.0
-     */
-    void setMapTipTemplate( const QString &mapTipTemplate );
-
     QgsExpressionContext createExpressionContext() const FINAL;
 
     QgsExpressionContextScope *createExpressionContextScope() const FINAL SIP_FACTORY;
@@ -2777,13 +2758,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void writeCustomSymbology( QDomElement &element, QDomDocument &doc, QString &errorMessage ) const;
 
     /**
-     * Emitted when the map tip changes
-     *
-     * \since QGIS 3.0
-     */
-    void mapTipTemplateChanged();
-
-    /**
      * Emitted when the display expression changes
      *
      * \since QGIS 3.0
@@ -2909,8 +2883,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! The preview expression used to generate a human readable preview string for features
     QString mDisplayExpression;
-
-    QString mMapTipTemplate;
 
     //! The user-defined actions that are accessed from the Identify Results dialog box
     QgsActionManager *mActions = nullptr;

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -251,6 +251,7 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vlayer ) );
   context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+  context.appendScope( QgsExpressionContextUtils::mapLayerPositionScope( r.center() ) );
 
   const QString canvasFilter = QgsMapCanvasUtils::filterForLayer( mapCanvas, vlayer );
   if ( canvasFilter ==  QLatin1String( "FALSE" ) )

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -17,6 +17,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmaptool.h"
 #include "qgsvectorlayer.h"
+#include "qgsrasterlayer.h"
 #include "qgsexpression.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
@@ -311,6 +312,31 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
     renderer->stopRender( renderCtx );
 
   return tipString;
+}
+
+QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, QgsMapCanvas *mapCanvas )
+{
+  QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer );
+  if ( !rlayer )
+    return QString();
+
+  if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) )
+  {
+    return QString();
+  }
+
+  const QgsPointXY mappedPosition { mapCanvas->mapSettings().mapToLayerCoordinates( layer, mapPosition ) };
+
+  if ( ! layer->extent().contains( mappedPosition ) )
+  {
+    return QString( );
+  }
+
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+  context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+
+  const QString mapTip = rlayer->mapTipTemplate();
+
 }
 
 void QgsMapTip::applyFontSettings()

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -234,7 +234,8 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
   if ( !vlayer || !vlayer->isSpatial() )
     return QString();
 
-  if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) )
+  if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) ||
+       ( mapCanvas->mapSettings().isTemporal() && !layer->temporalProperties()->isVisibleInTemporalRange( mapCanvas->temporalRange() ) ) )
   {
     return QString();
   }
@@ -334,7 +335,8 @@ QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, Qgs
   if ( !rlayer )
     return QString();
 
-  if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) )
+  if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) ||
+       ( mapCanvas->mapSettings().isTemporal() && !layer->temporalProperties()->isVisibleInTemporalRange( mapCanvas->temporalRange() ) ) )
   {
     return QString();
   }

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -82,51 +82,53 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   QString tipText, lastTipText, tipHtml, bodyStyle, containerStyle,
           backgroundColor, strokeColor, textColor;
 
-  delete mWidget;
-  mWidget = new QWidget( pMapCanvas );
-  mWidget->setContentsMargins( MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE );
-  mWebView = new QgsWebView( mWidget );
+  if ( ! mWidget )
+  {
+    mWidget = new QWidget( pMapCanvas );
+    mWidget->setContentsMargins( MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE );
+    mWebView = new QgsWebView( mWidget );
 
 
 #if WITH_QTWEBKIT
-  mWebView->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
-  mWebView->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
-  connect( mWebView, &QWebView::linkClicked, this, &QgsMapTip::onLinkClicked );
-  connect( mWebView, &QWebView::loadFinished, this, [ = ]( bool ) { resizeContent(); } );
+    mWebView->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
+    mWebView->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
+    connect( mWebView, &QWebView::linkClicked, this, &QgsMapTip::onLinkClicked );
+    connect( mWebView, &QWebView::loadFinished, this, [ = ]( bool ) { resizeContent(); } );
 #endif
 
-  mWebView->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
-  mWebView->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
-  mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
+    mWebView->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
+    mWebView->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
+    mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
 
-  // Disable scrollbars, avoid random resizing issues
-  mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
-  mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
+    // Disable scrollbars, avoid random resizing issues
+    mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
+    mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
 
-  QHBoxLayout *layout = new QHBoxLayout;
-  layout->setContentsMargins( 0, 0, 0, 0 );
-  layout->addWidget( mWebView );
+    QHBoxLayout *layout = new QHBoxLayout;
+    layout->setContentsMargins( 0, 0, 0, 0 );
+    layout->addWidget( mWebView );
 
-  mWidget->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
-  mWidget->setLayout( layout );
+    mWidget->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+    mWidget->setLayout( layout );
 
-  // Assure the map tip is never larger than half the map canvas
-  const int MAX_WIDTH = pMapCanvas->geometry().width() / 2;
-  const int MAX_HEIGHT = pMapCanvas->geometry().height() / 2;
-  mWidget->setMaximumSize( MAX_WIDTH, MAX_HEIGHT );
+    // Assure the map tip is never larger than half the map canvas
+    const int MAX_WIDTH = pMapCanvas->geometry().width() / 2;
+    const int MAX_HEIGHT = pMapCanvas->geometry().height() / 2;
+    mWidget->setMaximumSize( MAX_WIDTH, MAX_HEIGHT );
 
-  // Start with 0 size,
-  // The content will automatically make it grow up to MaximumSize
-  mWidget->resize( 0, 0 );
+    // Start with 0 size,
+    // The content will automatically make it grow up to MaximumSize
+    mWidget->resize( 0, 0 );
 
-  backgroundColor = mWidget->palette().base().color().name();
-  strokeColor = mWidget->palette().shadow().color().name();
-  textColor = mWidget->palette().text().color().name();
-  mWidget->setStyleSheet( QString(
-                            ".QWidget{"
-                            "border: 1px solid %1;"
-                            "background-color: %2;}" ).arg(
-                            strokeColor, backgroundColor ) );
+    backgroundColor = mWidget->palette().base().color().name();
+    strokeColor = mWidget->palette().shadow().color().name();
+    textColor = mWidget->palette().text().color().name();
+    mWidget->setStyleSheet( QString(
+                              ".QWidget{"
+                              "border: 1px solid %1;"
+                              "background-color: %2;}" ).arg(
+                              strokeColor, backgroundColor ) );
+  }
 
   // Only supported layer types here:
   switch ( pLayer->type() )
@@ -184,11 +186,11 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   }
 
   mWidget->move( pixelPosition.x() + cursorOffset, pixelPosition.y() );
-
   mWebView->setHtml( tipHtml );
   lastTipText = tipText;
 
   mWidget->show();
+
 }
 
 void QgsMapTip::resizeContent()
@@ -343,12 +345,17 @@ QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, Qgs
     return QString( );
   }
 
-  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
-  context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
-  context.appendScope( QgsExpressionContextUtils::mapLayerPositionScope( mappedPosition ) );
+  QString tipText { rlayer->mapTipTemplate() };
 
-  const QString mapTip = rlayer->mapTipTemplate();
-  return mapTip;
+  if ( ! tipText.isEmpty() )
+  {
+    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+    context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+    context.appendScope( QgsExpressionContextUtils::mapLayerPositionScope( mappedPosition ) );
+    tipText = QgsExpression::replaceExpressionText( tipText, &context );
+  }
+
+  return tipText;
 }
 
 void QgsMapTip::applyFontSettings()

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -128,7 +128,18 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
                             "background-color: %2;}" ).arg(
                             strokeColor, backgroundColor ) );
 
-  tipText = fetchFeature( pLayer, mapPosition, pMapCanvas );
+  // Only supported layer types here:
+  switch ( pLayer->type() )
+  {
+    case QgsMapLayerType::VectorLayer:
+      tipText = fetchFeature( pLayer, mapPosition, pMapCanvas );
+      break;
+    case QgsMapLayerType::RasterLayer:
+      tipText = fetchRaster( pLayer, mapPosition, pMapCanvas );
+      break;
+    default:
+      break;
+  }
 
   mMapTipVisible = !tipText.isEmpty();
   if ( !mMapTipVisible )
@@ -334,9 +345,10 @@ QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, Qgs
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
   context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+  context.appendScope( QgsExpressionContextUtils::mapLayerPositionScope( mappedPosition ) );
 
   const QString mapTip = rlayer->mapTipTemplate();
-
+  return mapTip;
 }
 
 void QgsMapTip::applyFontSettings()

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -97,6 +97,11 @@ class GUI_EXPORT QgsMapTip : public QWidget
                           QgsPointXY &mapPosition,
                           QgsMapCanvas *mapCanvas );
 
+    // Sample the raster and get the maptip text
+    QString fetchRaster( QgsMapLayer *layer,
+                         QgsPointXY &mapPosition,
+                         QgsMapCanvas *mapCanvas );
+
     QString replaceText(
       QString displayText, QgsVectorLayer *layer, QgsFeature &feat );
 

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -205,6 +205,15 @@
          </item>
          <item>
           <property name="text">
+           <string>Display</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/display.svg</normaloff>:/images/themes/default/propertyicons/display.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Attribute Tables</string>
           </property>
           <property name="toolTip">
@@ -1450,6 +1459,110 @@ p, li { white-space: pre-wrap; }
            </item>
           </layout>
          </widget>
+         <widget class="QWidget" name="mOptsPage_Display">
+          <layout class="QVBoxLayout" name="verticalLayout_25">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QWidget" name="scrollArea_10" native="true">
+             <property name="widgetResizable" stdset="0">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_101">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QGroupBox" name="groupBox_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>HTML Map Tip</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_81">
+                 <item row="1" column="2">
+                  <widget class="QPushButton" name="mInsertExpressionButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>Inserts the selected field or expression into the map tip</string>
+                   </property>
+                   <property name="text">
+                    <string>Insert</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0" colspan="3">
+                  <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>100</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="2">
+                  <widget class="QgsExpressionLineEdit" name="mMapTipExpressionWidget" native="true">
+                   <property name="focusPolicy">
+                    <enum>Qt::StrongFocus</enum>
+                   </property>
+                   <property name="toolTip">
+                    <string>The valid attribute names for this layer</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0" colspan="3">
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
          <widget class="QWidget" name="mOptsPage_RasterAttributeTable">
           <layout class="QVBoxLayout" name="verticalLayout_rat">
            <property name="leftMargin">
@@ -1470,7 +1583,7 @@ p, li { white-space: pre-wrap; }
               <item>
                <widget class="QLabel" name="mRasterAttributeTableLabel">
                 <property name="text">
-                 <string>There are no raster attribute tables associated with this data source. 
+                 <string>There are no raster attribute tables associated with this data source.
 
 If the current symbology can be converted to an attribute table you can create a new attribute table using the context menu available in the layer tree or the button below.
 
@@ -1954,18 +2067,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -1999,6 +2100,23 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsCodeEditorHTML</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorhtml.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
@@ -2007,6 +2125,12 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsfilecontentsourcelineedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -363,7 +363,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>11</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>239</width>
+                <height>480</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -733,8 +733,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>110</width>
+                <height>87</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1345,8 +1345,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>679</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1547,8 +1547,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>689</width>
-                <height>665</height>
+                <width>493</width>
+                <height>473</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -2106,8 +2106,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>343</width>
-                <height>800</height>
+                <width>263</width>
+                <height>713</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2709,6 +2709,8 @@
   <tabstop>mButtonRemoveWmsDimension</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
MapTips were only available for vector layers, by moving the maptips API from `QgsVectorLayer` to `QgsMapLayer` it becomes possible to implement maptips for other layer types.

This PR adds the implementation for raster layers and a few expression functions and utilities to make it useful:

- `map_to_html_table`: converts a map (key value pair data structure) to an HTML table
- `map_to_html_dl`: converts a map (key value pair data structure) to an HTML definition list
- `raster_attributes`: creates a map with the fields names as keys and the raster attribute table values as values from the attribute table entry that matches the given raster value
- a new "Map Layer Position" expression scope that defines a variable `@layer_cursor_point` with the layer coordinates (in layer's CRS) under the mouse position


An expression that shows raster attributes in a maptip could look like this:

![raster_maptips_config](https://user-images.githubusercontent.com/142164/201292695-1401e69c-ff37-4c13-9170-3a5345dfba85.png)

Which renders:

![raster_maptips](https://user-images.githubusercontent.com/142164/201292488-6fecc4d4-7b63-4f90-80ec-609c34fd1624.png)

Funded by: NOAA OCS Hydrography

