### PR TITLE
Nominatim locator: add viewbox parameter only if bounds are finite

### DIFF
--- a/src/core/geocoding/qgsnominatimgeocoder.cpp
+++ b/src/core/geocoding/qgsnominatimgeocoder.cpp
@@ -150,7 +150,7 @@ QUrl QgsNominatimGeocoder::requestUrl( const QString &address, const QgsRectangl
   QUrlQuery query;
   query.addQueryItem( QStringLiteral( "format" ), QStringLiteral( "json" ) );
   query.addQueryItem( QStringLiteral( "addressdetails" ), QStringLiteral( "1" ) );
-  if ( !bounds.isNull() )
+  if ( !bounds.isNull() && bounds.isFinite() )
   {
     query.addQueryItem( QStringLiteral( "viewbox" ), QStringLiteral( "%1,%2,%3,%4" ).arg( bounds.xMinimum() )
                         .arg( bounds.yMinimum() )

--- a/tests/src/python/test_qgsnominatimgeocoder.py
+++ b/tests/src/python/test_qgsnominatimgeocoder.py
@@ -78,6 +78,9 @@ class TestQgsNominatimGeocoder(unittest.TestCase):
         self.assertEqual(geocoder.requestUrl('20 green st, twaddlingham', QgsRectangle(3, 5, 6, 8)).toString(),
                          'https://nominatim.qgis.org/search?format=json&addressdetails=1&viewbox=3,5,6,8&q=20 green st, twaddlingham')
 
+        self.assertEqual(geocoder.requestUrl('20 green st, twaddlingham', QgsRectangle(float('-inf'), float('-inf'), float('inf'), float('inf'))).toString(),
+                         'https://nominatim.qgis.org/search?format=json&addressdetails=1&q=20 green st, twaddlingham')
+
         geocoder = QgsNominatimGeocoder(countryCodes='ca,km', endpoint='https://my.server/search')
         self.assertEqual(geocoder.requestUrl('20 green st, twaddlingham', QgsRectangle(3, 5, 6, 8)).toString(),
                          'https://my.server/search?format=json&addressdetails=1&viewbox=3,5,6,8&countrycodes=ca,km&q=20 green st, twaddlingham')


### PR DESCRIPTION
fixes qgis#50807

Query string parameter `viewbox` is optional.

From https://nominatim.org/release-docs/latest/api/Search/ 

> The preferred area to find search results. 

So we are good not using it when bounds are `Inf`. 
