### PR TITLE
Add option to directly log GPS points and tracks to a Geopackage or Spatialite db

### DIFF
--- a/python/core/auto_generated/gps/qgsvectorlayergpslogger.sip.in
+++ b/python/core/auto_generated/gps/qgsvectorlayergpslogger.sip.in
@@ -32,6 +32,28 @@ The logger will automatically record GPS information from the specified ``connec
 
     ~QgsVectorLayerGpsLogger();
 
+    bool writeToEditBuffer() const;
+%Docstring
+Returns ``True`` if the logger will use the vector layer edit buffer for the destination layers.
+
+If ``False`` then the features will be written directly to the destination layer's data providers.
+
+The default behavior is to use the edit buffer.
+
+.. seealso:: :py:func:`setWriteToEditBuffer`
+%End
+
+    void setWriteToEditBuffer( bool buffer );
+%Docstring
+Sets whether the logger will use the vector layer edit buffer for the destination layers.
+
+If ``buffer`` is ``False`` then the features will be written directly to the destination layer's data providers.
+
+The default behavior is to use the edit buffer.
+
+.. seealso:: :py:func:`writeToEditBuffer`
+%End
+
     void setPointsLayer( QgsVectorLayer *layer );
 %Docstring
 Sets the ``layer`` in which recorded GPS points should be stored.

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -266,6 +266,7 @@ set(QGIS_APP_SRCS
 
   gps/qgsappgpsconnection.cpp
   gps/qgsappgpsdigitizing.cpp
+  gps/qgsappgpslogging.cpp
   gps/qgsappgpssettingsmenu.cpp
   gps/qgsgpsbearingitem.cpp
   gps/qgsgpscanvasbridge.cpp

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -160,8 +160,8 @@ void QgsAppGpsConnection::disconnectGps()
 {
   if ( mConnection )
   {
-    QgsApplication::gpsConnectionRegistry()->unregisterConnection( mConnection );
-    delete mConnection;
+    // we don't actually delete the connection until everything has had time to respond to the cleanup signals
+    std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );
     mConnection = nullptr;
 
     emit disconnected();
@@ -169,6 +169,8 @@ void QgsAppGpsConnection::disconnectGps()
     emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
 
     showStatusBarMessage( tr( "Disconnected from GPS device." ) );
+
+    QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
   }
 }
 

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -23,15 +23,12 @@
 #include "qgssettingsentryimpl.h"
 #include "qgsgpslogger.h"
 
-#include <QTextStream>
-
 class QgsAppGpsConnection;
 class QgsMapCanvas;
 class QgsRubberBand;
 class QgsPoint;
 class QgsGpsInformation;
 class QgsVectorLayer;
-class QFile;
 
 class APP_EXPORT QgsAppGpsDigitizing: public QgsGpsLogger
 {
@@ -41,17 +38,11 @@ class APP_EXPORT QgsAppGpsDigitizing: public QgsGpsLogger
 
     static const inline QgsSettingsEntryString settingTrackLineSymbol = QgsSettingsEntryString( QStringLiteral( "track-line-symbol" ), QgsSettings::Prefix::GPS, QStringLiteral( "<symbol alpha=\"1\" name=\"gps-track-symbol\" force_rhr=\"0\" clip_to_extent=\"1\" type=\"line\"><layer enabled=\"1\" pass=\"0\" locked=\"0\" class=\"SimpleLine\"><Option type=\"Map\"><Option name=\"line_color\" type=\"QString\" value=\"219,30,42,255\"/><Option name=\"line_style\" type=\"QString\" value=\"solid\"/><Option name=\"line_width\" type=\"QString\" value=\"0.4\"/></Option></layer></symbol>" ), QStringLiteral( "Line symbol to use for GPS track line" ), Qgis::SettingsOptions(), 0 );
 
-    static const inline QgsSettingsEntryString settingLastLogFolder = QgsSettingsEntryString( QStringLiteral( "last-log-folder" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used folder for GPS log files" ) );
-    static const inline QgsSettingsEntryString settingLastGpkgLog = QgsSettingsEntryString( QStringLiteral( "last-gpkg-log" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used Geopackage/Spatialite file for logging GPS locations" ) );
-
     QgsAppGpsDigitizing( QgsAppGpsConnection *connection, QgsMapCanvas *canvas, QObject *parent = nullptr );
     ~QgsAppGpsDigitizing() override;
 
   public slots:
     void createFeature();
-    void setNmeaLogFile( const QString &filename );
-    void setNmeaLoggingEnabled( bool enabled );
-
     void createVertexAtCurrentLocation();
 
   private slots:
@@ -63,11 +54,6 @@ class APP_EXPORT QgsAppGpsDigitizing: public QgsGpsLogger
     void gpsConnected();
     void gpsDisconnected();
 
-    void logNmeaSentence( const QString &nmeaString ); // added to handle 'raw' data
-
-    void startLogging();
-    void stopLogging();
-
   private:
     void createRubberBand();
     QVariant timestamp( QgsVectorLayer *vlayer, int idx );
@@ -78,12 +64,6 @@ class APP_EXPORT QgsAppGpsDigitizing: public QgsGpsLogger
     QgsRubberBand *mRubberBand = nullptr;
 
     QgsCoordinateTransform mCanvasToWgs84Transform;
-
-    QString mNmeaLogFile;
-    bool mEnableNmeaLogging = false;
-
-    std::unique_ptr< QFile > mLogFile;
-    QTextStream mLogFileTextStream;
 
     friend class TestQgsGpsIntegration;
 };

--- a/src/app/gps/qgsappgpsdigitizing.h
+++ b/src/app/gps/qgsappgpsdigitizing.h
@@ -42,6 +42,7 @@ class APP_EXPORT QgsAppGpsDigitizing: public QgsGpsLogger
     static const inline QgsSettingsEntryString settingTrackLineSymbol = QgsSettingsEntryString( QStringLiteral( "track-line-symbol" ), QgsSettings::Prefix::GPS, QStringLiteral( "<symbol alpha=\"1\" name=\"gps-track-symbol\" force_rhr=\"0\" clip_to_extent=\"1\" type=\"line\"><layer enabled=\"1\" pass=\"0\" locked=\"0\" class=\"SimpleLine\"><Option type=\"Map\"><Option name=\"line_color\" type=\"QString\" value=\"219,30,42,255\"/><Option name=\"line_style\" type=\"QString\" value=\"solid\"/><Option name=\"line_width\" type=\"QString\" value=\"0.4\"/></Option></layer></symbol>" ), QStringLiteral( "Line symbol to use for GPS track line" ), Qgis::SettingsOptions(), 0 );
 
     static const inline QgsSettingsEntryString settingLastLogFolder = QgsSettingsEntryString( QStringLiteral( "last-log-folder" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used folder for GPS log files" ) );
+    static const inline QgsSettingsEntryString settingLastGpkgLog = QgsSettingsEntryString( QStringLiteral( "last-gpkg-log" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used Geopackage/Spatialite file for logging GPS locations" ) );
 
     QgsAppGpsDigitizing( QgsAppGpsConnection *connection, QgsMapCanvas *canvas, QObject *parent = nullptr );
     ~QgsAppGpsDigitizing() override;

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -51,14 +51,14 @@ void QgsAppGpsLogging::setNmeaLogFile( const QString &filename )
 {
   if ( mLogFile )
   {
-    stopLogging();
+    stopNmeaLogging();
   }
 
   mNmeaLogFile = filename;
 
   if ( mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
   {
-    startLogging();
+    startNmeaLogging();
   }
 }
 
@@ -69,14 +69,14 @@ void QgsAppGpsLogging::setNmeaLoggingEnabled( bool enabled )
 
   if ( mLogFile && !enabled )
   {
-    stopLogging();
+    stopNmeaLogging();
   }
 
   mEnableNmeaLogging = enabled;
 
   if ( mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
   {
-    startLogging();
+    startNmeaLogging();
   }
 }
 
@@ -90,14 +90,14 @@ void QgsAppGpsLogging::gpsConnected()
 {
   if ( !mLogFile && mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
   {
-    startLogging();
+    startNmeaLogging();
   }
   setConnection( mConnection->connection() );
 }
 
 void QgsAppGpsLogging::gpsDisconnected()
 {
-  stopLogging();
+  stopNmeaLogging();
   setConnection( nullptr );
 }
 
@@ -109,7 +109,7 @@ void QgsAppGpsLogging::logNmeaSentence( const QString &nmeaString )
   }
 }
 
-void QgsAppGpsLogging::startLogging()
+void QgsAppGpsLogging::startNmeaLogging()
 {
   if ( !mLogFile )
   {
@@ -134,7 +134,7 @@ void QgsAppGpsLogging::startLogging()
   }
 }
 
-void QgsAppGpsLogging::stopLogging()
+void QgsAppGpsLogging::stopNmeaLogging()
 {
   if ( mLogFile && mLogFile->isOpen() )
   {

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -181,7 +181,10 @@ void QgsAppGpsLogging::startNmeaLogging()
     mLogFileTextStream.setDevice( mLogFile.get() );
 
     // crude way to separate chunks - use when manually editing file - NMEA parsers should discard
-    mLogFileTextStream << "====" << "\r\n";
+    if ( mLogFile->size() > 0 )
+    {
+      mLogFileTextStream << "====" << "\r\n";
+    }
 
     connect( mConnection, &QgsAppGpsConnection::nmeaSentenceReceived, this, &QgsAppGpsLogging::logNmeaSentence ); // added to handle raw data
   }

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -1,0 +1,146 @@
+/***************************************************************************
+    qgsappgpslogging.cpp
+    -------------------
+    begin                : October 2022
+    copyright            : (C) 2022 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsappgpslogging.h"
+#include "qgsgui.h"
+#include "qgisapp.h"
+#include "qgsmessagebar.h"
+#include "qgsgpsconnection.h"
+#include "qgsappgpsconnection.h"
+
+QgsAppGpsLogging::QgsAppGpsLogging( QgsAppGpsConnection *connection, QObject *parent )
+  : QgsGpsLogger( nullptr, parent )
+  , mConnection( connection )
+{
+  connect( QgsProject::instance(), &QgsProject::transformContextChanged, this, [ = ]
+  {
+    setTransformContext( QgsProject::instance()->transformContext() );
+  } );
+  setTransformContext( QgsProject::instance()->transformContext() );
+
+  setEllipsoid( QgsProject::instance()->ellipsoid() );
+  connect( QgsProject::instance(), &QgsProject::ellipsoidChanged, this, [ = ]
+  {
+    setEllipsoid( QgsProject::instance()->ellipsoid() );
+  } );
+
+  connect( mConnection, &QgsAppGpsConnection::connected, this, &QgsAppGpsLogging::gpsConnected );
+  connect( mConnection, &QgsAppGpsConnection::disconnected, this, &QgsAppGpsLogging::gpsDisconnected );
+
+  connect( QgsGui::instance(), &QgsGui::optionsChanged, this, &QgsAppGpsLogging::updateGpsSettings );
+  updateGpsSettings();
+}
+
+QgsAppGpsLogging::~QgsAppGpsLogging()
+{
+}
+
+void QgsAppGpsLogging::setNmeaLogFile( const QString &filename )
+{
+  if ( mLogFile )
+  {
+    stopLogging();
+  }
+
+  mNmeaLogFile = filename;
+
+  if ( mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
+  {
+    startLogging();
+  }
+}
+
+void QgsAppGpsLogging::setNmeaLoggingEnabled( bool enabled )
+{
+  if ( enabled == static_cast< bool >( mLogFile ) )
+    return;
+
+  if ( mLogFile && !enabled )
+  {
+    stopLogging();
+  }
+
+  mEnableNmeaLogging = enabled;
+
+  if ( mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
+  {
+    startLogging();
+  }
+}
+
+void QgsAppGpsLogging::setGpkgLogFile( const QString &filename )
+{
+
+}
+
+
+void QgsAppGpsLogging::gpsConnected()
+{
+  if ( !mLogFile && mEnableNmeaLogging && !mNmeaLogFile.isEmpty() )
+  {
+    startLogging();
+  }
+  setConnection( mConnection->connection() );
+}
+
+void QgsAppGpsLogging::gpsDisconnected()
+{
+  stopLogging();
+  setConnection( nullptr );
+}
+
+void QgsAppGpsLogging::logNmeaSentence( const QString &nmeaString )
+{
+  if ( mEnableNmeaLogging && mLogFile && mLogFile->isOpen() )
+  {
+    mLogFileTextStream << nmeaString << "\r\n"; // specifically output CR + LF (NMEA requirement)
+  }
+}
+
+void QgsAppGpsLogging::startLogging()
+{
+  if ( !mLogFile )
+  {
+    mLogFile = std::make_unique< QFile >( mNmeaLogFile );
+  }
+
+  if ( mLogFile->open( QIODevice::Append ) )  // open in binary and explicitly output CR + LF per NMEA
+  {
+    mLogFileTextStream.setDevice( mLogFile.get() );
+
+    // crude way to separate chunks - use when manually editing file - NMEA parsers should discard
+    mLogFileTextStream << "====" << "\r\n";
+
+    connect( mConnection, &QgsAppGpsConnection::nmeaSentenceReceived, this, &QgsAppGpsLogging::logNmeaSentence ); // added to handle raw data
+  }
+  else  // error opening file
+  {
+    mLogFile.reset();
+
+    // need to indicate why - this just reports that an error occurred
+    QgisApp::instance()->messageBar()->pushCritical( QString(), tr( "Error opening log file." ) );
+  }
+}
+
+void QgsAppGpsLogging::stopLogging()
+{
+  if ( mLogFile && mLogFile->isOpen() )
+  {
+    disconnect( mConnection, &QgsAppGpsConnection::nmeaSentenceReceived, this, &QgsAppGpsLogging::logNmeaSentence );
+    mLogFile->close();
+    mLogFile.reset();
+  }
+}
+

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -19,32 +19,67 @@
 #include "qgsmessagebar.h"
 #include "qgsgpsconnection.h"
 #include "qgsappgpsconnection.h"
+#include "qgsvectorlayergpslogger.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
+
+const std::vector< std::tuple< Qgis::GpsInformationComponent, std::tuple< QVariant::Type, QString >>> QgsAppGpsLogging::sPointFields
+{
+  { Qgis::GpsInformationComponent::Timestamp, { QVariant::DateTime, QStringLiteral( "timestamp" )}},
+  { Qgis::GpsInformationComponent::Altitude, { QVariant::Double, QStringLiteral( "altitude" )}},
+  { Qgis::GpsInformationComponent::GroundSpeed, { QVariant::Double, QStringLiteral( "ground_speed" )}},
+  { Qgis::GpsInformationComponent::Bearing, { QVariant::Double, QStringLiteral( "bearing" )}},
+  { Qgis::GpsInformationComponent::Pdop, { QVariant::Double, QStringLiteral( "pdop" )}},
+  { Qgis::GpsInformationComponent::Hdop, { QVariant::Double, QStringLiteral( "hdop" )}},
+  { Qgis::GpsInformationComponent::Vdop, { QVariant::Double, QStringLiteral( "vdop" )}},
+  { Qgis::GpsInformationComponent::HorizontalAccuracy, { QVariant::Double, QStringLiteral( "horizontal_accuracy" )}},
+  { Qgis::GpsInformationComponent::VerticalAccuracy, { QVariant::Double, QStringLiteral( "vertical_accuracy" )}},
+  { Qgis::GpsInformationComponent::HvAccuracy, { QVariant::Double, QStringLiteral( "hv_accuracy" )}},
+  { Qgis::GpsInformationComponent::SatellitesUsed, { QVariant::Double, QStringLiteral( "satellites_used" )}},
+  { Qgis::GpsInformationComponent::TrackDistanceSinceLastPoint, { QVariant::Double, QStringLiteral( "distance_since_previous" )}},
+  { Qgis::GpsInformationComponent::TrackTimeSinceLastPoint, { QVariant::Double, QStringLiteral( "time_since_previous" )}},
+};
+
+const std::vector< std::tuple< Qgis::GpsInformationComponent, std::tuple< QVariant::Type, QString >>> QgsAppGpsLogging::sTrackFields
+{
+  { Qgis::GpsInformationComponent::TrackStartTime, { QVariant::DateTime, QStringLiteral( "start_time" )}},
+  { Qgis::GpsInformationComponent::TrackEndTime, { QVariant::DateTime, QStringLiteral( "end_time" )}},
+  { Qgis::GpsInformationComponent::TotalTrackLength, { QVariant::Double, QStringLiteral( "track_length" )}},
+  { Qgis::GpsInformationComponent::TrackDistanceFromStart, { QVariant::Double, QStringLiteral( "distance_from_start" )}},
+};
+
 
 QgsAppGpsLogging::QgsAppGpsLogging( QgsAppGpsConnection *connection, QObject *parent )
-  : QgsGpsLogger( nullptr, parent )
+  : QObject( parent )
   , mConnection( connection )
 {
   connect( QgsProject::instance(), &QgsProject::transformContextChanged, this, [ = ]
   {
-    setTransformContext( QgsProject::instance()->transformContext() );
+    if ( mGpkgLogger )
+      mGpkgLogger->setTransformContext( QgsProject::instance()->transformContext() );
   } );
-  setTransformContext( QgsProject::instance()->transformContext() );
-
-  setEllipsoid( QgsProject::instance()->ellipsoid() );
   connect( QgsProject::instance(), &QgsProject::ellipsoidChanged, this, [ = ]
   {
-    setEllipsoid( QgsProject::instance()->ellipsoid() );
+    if ( mGpkgLogger )
+      mGpkgLogger->setEllipsoid( QgsProject::instance()->ellipsoid() );
   } );
 
   connect( mConnection, &QgsAppGpsConnection::connected, this, &QgsAppGpsLogging::gpsConnected );
   connect( mConnection, &QgsAppGpsConnection::disconnected, this, &QgsAppGpsLogging::gpsDisconnected );
 
-  connect( QgsGui::instance(), &QgsGui::optionsChanged, this, &QgsAppGpsLogging::updateGpsSettings );
-  updateGpsSettings();
+  connect( QgsGui::instance(), &QgsGui::optionsChanged, this, [ = ]
+  {
+    if ( mGpkgLogger )
+      mGpkgLogger->updateGpsSettings();
+  } );
 }
 
 QgsAppGpsLogging::~QgsAppGpsLogging()
 {
+  if ( mGpkgLogger )
+  {
+    mGpkgLogger->endCurrentTrack();
+  }
 }
 
 void QgsAppGpsLogging::setNmeaLogFile( const QString &filename )
@@ -82,9 +117,27 @@ void QgsAppGpsLogging::setNmeaLoggingEnabled( bool enabled )
 
 void QgsAppGpsLogging::setGpkgLogFile( const QString &filename )
 {
+  mGpkgLogFile = filename;
+  if ( filename.isEmpty() )
+  {
+    // stop logging
+    if ( mGpkgLogger )
+    {
+      mGpkgLogger->endCurrentTrack();
+      mGpkgLogger.reset();
 
+      QgisApp::instance()->messageBar()->pushInfo( QString(), tr( "GPS logging stopped" ) );
+    }
+  }
+  else
+  {
+    if ( !createOrUpdateLogDatabase() )
+      return;
+    createGpkgLogger();
+
+    QgisApp::instance()->messageBar()->pushInfo( QString(), tr( "Saving GPS log to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( mGpkgLogFile ).toString(), QDir::toNativeSeparators( mGpkgLogFile ) ) );
+  }
 }
-
 
 void QgsAppGpsLogging::gpsConnected()
 {
@@ -92,13 +145,20 @@ void QgsAppGpsLogging::gpsConnected()
   {
     startNmeaLogging();
   }
-  setConnection( mConnection->connection() );
+  if ( mGpkgLogger )
+  {
+    mGpkgLogger->setConnection( mConnection->connection() );
+  }
 }
 
 void QgsAppGpsLogging::gpsDisconnected()
 {
   stopNmeaLogging();
-  setConnection( nullptr );
+  if ( mGpkgLogger )
+  {
+    mGpkgLogger->endCurrentTrack();
+    mGpkgLogger->setConnection( nullptr );
+  }
 }
 
 void QgsAppGpsLogging::logNmeaSentence( const QString &nmeaString )
@@ -142,5 +202,186 @@ void QgsAppGpsLogging::stopNmeaLogging()
     mLogFile->close();
     mLogFile.reset();
   }
+}
+
+void QgsAppGpsLogging::createGpkgLogger()
+{
+  mGpkgLogger = std::make_unique< QgsVectorLayerGpsLogger >( mConnection->connection() );
+  mGpkgLogger->setTransformContext( QgsProject::instance()->transformContext() );
+  mGpkgLogger->setEllipsoid( QgsProject::instance()->ellipsoid() );
+  mGpkgLogger->updateGpsSettings();
+  // write direct to data provider, just in case the QGIS session is closed unexpectedly (because the laptop
+  // battery ran out that is, not because we want to protect against QGIS crashes ;)
+  mGpkgLogger->setWriteToEditBuffer( false );
+
+  QVariantMap uriParts;
+  uriParts.insert( QStringLiteral( "path" ), mGpkgLogFile );
+  uriParts.insert( QStringLiteral( "layerName" ), QStringLiteral( "gps_points" ) );
+
+  mGpkgPointsLayer = std::make_unique< QgsVectorLayer >( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "ogr" ), uriParts ) );
+  if ( mGpkgPointsLayer->isValid() )
+  {
+    for ( const auto &it : sPointFields )
+    {
+      Qgis::GpsInformationComponent component;
+      std::tuple< QVariant::Type, QString > fieldTypeToName;
+      QVariant::Type fieldType;
+      QString fieldName;
+      std::tie( component, fieldTypeToName ) = it;
+      std::tie( fieldType, fieldName ) = fieldTypeToName;
+
+      const int fieldIndex = mGpkgPointsLayer->fields().lookupField( fieldName );
+      if ( fieldIndex >= 0 )
+      {
+        mGpkgLogger->setDestinationField( component, fieldName );
+      }
+    }
+    mGpkgLogger->setPointsLayer( mGpkgPointsLayer.get() );
+  }
+  else
+  {
+    QgisApp::instance()->messageBar()->pushCritical( tr( "Log GPS Tracks" ), tr( "Could not load gps_points layer" ) );
+    emit gpkgLoggingFailed();
+    mGpkgPointsLayer.reset();
+    return;
+  }
+
+  uriParts.insert( QStringLiteral( "layerName" ), QStringLiteral( "gps_tracks" ) );
+  mGpkgTracksLayer = std::make_unique< QgsVectorLayer >( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "ogr" ), uriParts ) );
+  if ( mGpkgTracksLayer->isValid() )
+  {
+    for ( const auto &it : sTrackFields )
+    {
+      Qgis::GpsInformationComponent component;
+      std::tuple< QVariant::Type, QString > fieldTypeToName;
+      QVariant::Type fieldType;
+      QString fieldName;
+      std::tie( component, fieldTypeToName ) = it;
+      std::tie( fieldType, fieldName ) = fieldTypeToName;
+
+      const int fieldIndex = mGpkgTracksLayer->fields().lookupField( fieldName );
+      if ( fieldIndex >= 0 )
+      {
+        mGpkgLogger->setDestinationField( component, fieldName );
+      }
+    }
+    mGpkgLogger->setTracksLayer( mGpkgTracksLayer.get() );
+  }
+  else
+  {
+    QgisApp::instance()->messageBar()->pushCritical( tr( "Log GPS Tracks" ), tr( "Could not load gps_tracks layer" ) );
+    emit gpkgLoggingFailed();
+    mGpkgTracksLayer.reset();
+    return;
+  }
+
+}
+
+bool QgsAppGpsLogging::createOrUpdateLogDatabase()
+{
+  const QFileInfo fi( mGpkgLogFile );
+
+  if ( QgsProviderMetadata *ogrMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) )
+  {
+    QString error;
+
+    // if database doesn't already exist, create it
+    bool newFile = false;
+    if ( !QFile::exists( mGpkgLogFile ) )
+    {
+      if ( ! ogrMetadata->createDatabase( mGpkgLogFile, error ) )
+      {
+        QgisApp::instance()->messageBar()->pushCritical( tr( "Create GPS Log" ), tr( "Database creation failed: %1" ).arg( error ) );
+        emit gpkgLoggingFailed();
+        return false;
+      }
+      newFile = true;
+    }
+
+    // does gps_points layer already exist?
+    bool createPointLayer = true;
+    if ( !newFile )
+    {
+      std::unique_ptr< QgsVectorLayer > testLayer = std::make_unique< QgsVectorLayer>( ogrMetadata->encodeUri( {{QStringLiteral( "path" ), mGpkgLogFile }, {QStringLiteral( "layerName" ), QStringLiteral( "gps_points" )}} ), QString(), QStringLiteral( "ogr" ) );
+      if ( testLayer->isValid() )
+      {
+        createPointLayer = false;
+      }
+    }
+
+    QMap< int, int > unusedMap;
+    QVariantMap options;
+    options.insert( QStringLiteral( "driverName" ), QgsVectorFileWriter::driverForExtension( fi.suffix() ) );
+    options.insert( QStringLiteral( "update" ), true );
+    options.insert( QStringLiteral( "layerName" ), QStringLiteral( "gps_points" ) );
+    if ( createPointLayer )
+    {
+      QgsFields pointFields;
+      for ( const auto &it : sPointFields )
+      {
+        Qgis::GpsInformationComponent component;
+        std::tuple< QVariant::Type, QString > fieldTypeToName;
+        QVariant::Type fieldType;
+        QString fieldName;
+        std::tie( component, fieldTypeToName ) = it;
+        std::tie( fieldType, fieldName ) = fieldTypeToName;
+        pointFields.append( QgsField( fieldName, fieldType ) );
+      }
+
+      const Qgis::VectorExportResult result = ogrMetadata->createEmptyLayer( mGpkgLogFile,
+                                              pointFields,
+                                              QgsWkbTypes::PointZ,
+                                              QgsCoordinateReferenceSystem( "EPSG:4326" ),
+                                              false, unusedMap, error, &options );
+      if ( result != Qgis::VectorExportResult::Success )
+      {
+        QgisApp::instance()->messageBar()->pushCritical( tr( "Create GPS Log" ), tr( "Database creation failed: %1" ).arg( error ) );
+        emit gpkgLoggingFailed();
+        return false;
+      }
+    }
+
+    options.insert( QStringLiteral( "layerName" ), QStringLiteral( "gps_tracks" ) );
+
+    // does gps_tracks layer already exist?
+    bool createTracksLayer = true;
+    if ( !newFile )
+    {
+      std::unique_ptr< QgsVectorLayer > testLayer = std::make_unique< QgsVectorLayer>( ogrMetadata->encodeUri( {{QStringLiteral( "path" ), mGpkgLogFile }, {QStringLiteral( "layerName" ), QStringLiteral( "gps_tracks" )}} ), QString(), QStringLiteral( "ogr" ) );
+      if ( testLayer->isValid() )
+      {
+        createTracksLayer = false;
+      }
+    }
+
+    if ( createTracksLayer )
+    {
+      QgsFields tracksFields;
+      for ( const auto &it : sTrackFields )
+      {
+        Qgis::GpsInformationComponent component;
+        std::tuple< QVariant::Type, QString > fieldTypeToName;
+        QVariant::Type fieldType;
+        QString fieldName;
+        std::tie( component, fieldTypeToName ) = it;
+        std::tie( fieldType, fieldName ) = fieldTypeToName;
+        tracksFields.append( QgsField( fieldName, fieldType ) );
+      }
+
+      const Qgis::VectorExportResult result = ogrMetadata->createEmptyLayer( mGpkgLogFile,
+                                              tracksFields,
+                                              QgsWkbTypes::LineStringZ,
+                                              QgsCoordinateReferenceSystem( "EPSG:4326" ),
+                                              false, unusedMap, error, &options );
+      if ( result != Qgis::VectorExportResult::Success )
+      {
+        QgisApp::instance()->messageBar()->pushCritical( tr( "Create GPS Log" ), tr( "Database creation failed: %1" ).arg( error ) );
+        emit gpkgLoggingFailed();
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 

--- a/src/app/gps/qgsappgpslogging.h
+++ b/src/app/gps/qgsappgpslogging.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+    qgsappgpslogging.h
+    -------------------
+    begin                : October 2022
+    copyright            : (C) 2022 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAPPGPSLOGGING_H
+#define QGSAPPGPSLOGGING_H
+
+#include <QObject>
+
+#include "qgis_app.h"
+#include "qgssettingsentryimpl.h"
+#include "qgsgpslogger.h"
+
+#include <QTextStream>
+
+class QgsAppGpsConnection;
+class QFile;
+
+class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
+{
+    Q_OBJECT
+
+  public:
+
+    static const inline QgsSettingsEntryString settingLastLogFolder = QgsSettingsEntryString( QStringLiteral( "last-log-folder" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used folder for GPS log files" ) );
+    static const inline QgsSettingsEntryString settingLastGpkgLog = QgsSettingsEntryString( QStringLiteral( "last-gpkg-log" ), QgsSettings::Prefix::GPS, QString(), QStringLiteral( "Last used Geopackage/Spatialite file for logging GPS locations" ) );
+
+    QgsAppGpsLogging( QgsAppGpsConnection *connection, QObject *parent = nullptr );
+    ~QgsAppGpsLogging() override;
+
+  public slots:
+    void setNmeaLogFile( const QString &filename );
+    void setNmeaLoggingEnabled( bool enabled );
+    void setGpkgLogFile( const QString &filename );
+
+  private slots:
+
+    void gpsConnected();
+    void gpsDisconnected();
+
+    void logNmeaSentence( const QString &nmeaString ); // added to handle 'raw' data
+
+    void startLogging();
+    void stopLogging();
+
+  private:
+    QgsAppGpsConnection *mConnection = nullptr;
+
+    QString mNmeaLogFile;
+    bool mEnableNmeaLogging = false;
+
+    std::unique_ptr< QFile > mLogFile;
+    QTextStream mLogFileTextStream;
+};
+
+#endif // QGSAPPGPSLOGGING_H

--- a/src/app/gps/qgsappgpslogging.h
+++ b/src/app/gps/qgsappgpslogging.h
@@ -20,14 +20,15 @@
 
 #include "qgis_app.h"
 #include "qgssettingsentryimpl.h"
-#include "qgsgpslogger.h"
 
 #include <QTextStream>
 
 class QgsAppGpsConnection;
+class QgsVectorLayerGpsLogger;
 class QFile;
+class QgsVectorLayer;
 
-class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
+class APP_EXPORT QgsAppGpsLogging: public QObject
 {
     Q_OBJECT
 
@@ -44,6 +45,10 @@ class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
     void setNmeaLoggingEnabled( bool enabled );
     void setGpkgLogFile( const QString &filename );
 
+  signals:
+
+    void gpkgLoggingFailed();
+
   private slots:
 
     void gpsConnected();
@@ -55,6 +60,12 @@ class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
     void stopNmeaLogging();
 
   private:
+
+    void createGpkgLogger();
+    bool createOrUpdateLogDatabase();
+    void createGpkgLogDatabase();
+    void createSpatialiteLogDatabase();
+
     QgsAppGpsConnection *mConnection = nullptr;
 
     QString mNmeaLogFile;
@@ -62,6 +73,15 @@ class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
 
     std::unique_ptr< QFile > mLogFile;
     QTextStream mLogFileTextStream;
+
+    QString mGpkgLogFile;
+    std::unique_ptr< QgsVectorLayerGpsLogger > mGpkgLogger;
+    std::unique_ptr< QgsVectorLayer > mGpkgPointsLayer;
+    std::unique_ptr< QgsVectorLayer > mGpkgTracksLayer;
+
+    static const std::vector< std::tuple< Qgis::GpsInformationComponent, std::tuple< QVariant::Type, QString >>> sPointFields;
+    static const std::vector< std::tuple< Qgis::GpsInformationComponent, std::tuple< QVariant::Type, QString >>> sTrackFields;
+
 };
 
 #endif // QGSAPPGPSLOGGING_H

--- a/src/app/gps/qgsappgpslogging.h
+++ b/src/app/gps/qgsappgpslogging.h
@@ -51,8 +51,8 @@ class APP_EXPORT QgsAppGpsLogging: public QgsGpsLogger
 
     void logNmeaSentence( const QString &nmeaString ); // added to handle 'raw' data
 
-    void startLogging();
-    void stopLogging();
+    void startNmeaLogging();
+    void stopNmeaLogging();
 
   private:
     QgsAppGpsConnection *mConnection = nullptr;

--- a/src/app/gps/qgsappgpssettingsmenu.cpp
+++ b/src/app/gps/qgsappgpssettingsmenu.cpp
@@ -327,6 +327,11 @@ Qgis::MapRecenteringMode QgsAppGpsSettingsMenu::mapCenteringMode() const
   }
 }
 
+void QgsAppGpsSettingsMenu::onGpkgLoggingFailed()
+{
+  mActionGpkgLog->setChecked( false );
+}
+
 void QgsAppGpsSettingsMenu::timeStampMenuAboutToShow()
 {
   mFieldProxyModel->sourceFieldModel()->setLayer( QgsProject::instance()->gpsSettings()->destinationLayer() );

--- a/src/app/gps/qgsappgpssettingsmenu.cpp
+++ b/src/app/gps/qgsappgpssettingsmenu.cpp
@@ -220,6 +220,39 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
 
   addSeparator();
 
+  mActionGpkgLog = new QAction( "Log to GeoPackage/Spatialite…" );
+  mActionGpkgLog->setCheckable( true );
+  connect( mActionGpkgLog, &QAction::toggled, this, [ = ]( bool checked )
+  {
+    if ( checked )
+    {
+      const QString lastGpkgLog = QgsAppGpsDigitizing::settingLastGpkgLog.value();
+      const QString initialPath = lastGpkgLog.isEmpty() ? QDir::homePath() : lastGpkgLog;
+
+      QString selectedFilter;
+      QString fileName = QFileDialog::getSaveFileName( this, tr( "GPS Log File" ), initialPath,
+                         tr( "GeoPackage" ) + " (*.gpkg *.GPKG);;" + tr( "SpatiaLite" ) + " (*.sqlite *.db *.sqlite3 *.db3 *.s3db);;",
+                         &selectedFilter, QFileDialog::Option::DontConfirmOverwrite );
+      if ( fileName.isEmpty() )
+      {
+        mActionGpkgLog->setChecked( false );
+        emit gpkgLogDestinationChanged( QString() );
+        return;
+      }
+
+
+      fileName = QgsFileUtils::addExtensionFromFilter( fileName, selectedFilter );
+      QgsAppGpsDigitizing::settingLastGpkgLog.setValue( fileName );
+
+      emit gpkgLogDestinationChanged( fileName );
+    }
+    else
+    {
+      emit gpkgLogDestinationChanged( QString() );
+    }
+  } );
+  addAction( mActionGpkgLog );
+
   mActionNmeaLog = new QAction( "Log NMEA Sentences…" );
   mActionNmeaLog->setCheckable( true );
   connect( mActionNmeaLog, &QAction::toggled, this, [ = ]( bool checked )
@@ -249,6 +282,8 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
     }
   } );
   addAction( mActionNmeaLog );
+
+  addSeparator();
 
   QAction *settingsAction = new QAction( tr( "GPS Settings…" ), this );
   settingsAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOptions.svg" ) ) );

--- a/src/app/gps/qgsappgpssettingsmenu.cpp
+++ b/src/app/gps/qgsappgpssettingsmenu.cpp
@@ -24,6 +24,7 @@
 #include "qgsappgpsdigitizing.h"
 #include "qgsproject.h"
 #include "qgsprojectgpssettings.h"
+#include "qgsappgpslogging.h"
 
 #include <QRadioButton>
 #include <QButtonGroup>
@@ -226,7 +227,7 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
   {
     if ( checked )
     {
-      const QString lastGpkgLog = QgsAppGpsDigitizing::settingLastGpkgLog.value();
+      const QString lastGpkgLog = QgsAppGpsLogging::settingLastGpkgLog.value();
       const QString initialPath = lastGpkgLog.isEmpty() ? QDir::homePath() : lastGpkgLog;
 
       QString selectedFilter;
@@ -240,9 +241,8 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
         return;
       }
 
-
       fileName = QgsFileUtils::addExtensionFromFilter( fileName, selectedFilter );
-      QgsAppGpsDigitizing::settingLastGpkgLog.setValue( fileName );
+      QgsAppGpsLogging::settingLastGpkgLog.setValue( fileName );
 
       emit gpkgLogDestinationChanged( fileName );
     }
@@ -259,7 +259,7 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
   {
     if ( checked )
     {
-      const QString lastLogFolder = QgsAppGpsDigitizing::settingLastLogFolder.value();
+      const QString lastLogFolder = QgsAppGpsLogging::settingLastLogFolder.value();
       const QString initialFolder = lastLogFolder.isEmpty() ? QDir::homePath() : lastLogFolder;
 
       QString fileName = QFileDialog::getSaveFileName( this, tr( "GPS Log File" ), initialFolder, tr( "NMEA files" ) + " (*.nmea)" );
@@ -271,7 +271,7 @@ QgsAppGpsSettingsMenu::QgsAppGpsSettingsMenu( QWidget *parent )
       }
 
       fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, { QStringLiteral( "nmea" ) } );
-      QgsAppGpsDigitizing::settingLastLogFolder.setValue( QFileInfo( fileName ).absolutePath() );
+      QgsAppGpsLogging::settingLastLogFolder.setValue( QFileInfo( fileName ).absolutePath() );
 
       emit nmeaLogFileChanged( fileName );
       emit enableNmeaLog( true );

--- a/src/app/gps/qgsappgpssettingsmenu.h
+++ b/src/app/gps/qgsappgpssettingsmenu.h
@@ -57,6 +57,10 @@ class APP_EXPORT QgsAppGpsSettingsMenu : public QMenu
     bool rotateMap() const;
     Qgis::MapRecenteringMode mapCenteringMode() const;
 
+  public slots:
+
+    void onGpkgLoggingFailed();
+
   signals:
 
     void locationMarkerToggled( bool visible );

--- a/src/app/gps/qgsappgpssettingsmenu.h
+++ b/src/app/gps/qgsappgpssettingsmenu.h
@@ -64,6 +64,7 @@ class APP_EXPORT QgsAppGpsSettingsMenu : public QMenu
     void rotateMapToggled( bool enabled );
     void mapCenteringModeChanged( Qgis::MapRecenteringMode mode );
     void enableNmeaLog( bool enabled );
+    void gpkgLogDestinationChanged( const QString &path );
     void nmeaLogFileChanged( const QString &filename );
 
   private slots:
@@ -77,6 +78,7 @@ class APP_EXPORT QgsAppGpsSettingsMenu : public QMenu
     QAction *mRotateMapAction = nullptr;
     QAction *mAutoAddTrackVerticesAction = nullptr;
     QAction *mAutoSaveAddedFeatureAction = nullptr;
+    QAction *mActionGpkgLog = nullptr;
     QAction *mActionNmeaLog = nullptr;
 
     QRadioButton *mRadioAlwaysRecenter = nullptr;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -252,6 +252,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsgpsinformationwidget.h"
 #include "qgsappgpsconnection.h"
 #include "qgsappgpsdigitizing.h"
+#include "qgsappgpslogging.h"
 #include "qgsappgpssettingsmenu.h"
 #include "qgsgpstoolbar.h"
 #include "qgsgpscanvasbridge.h"
@@ -1408,6 +1409,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( mGpsToolBar, &QgsGpsToolBar::addVertexClicked, mGpsDigitizing, &QgsAppGpsDigitizing::createVertexAtCurrentLocation );
   connect( mGpsToolBar, &QgsGpsToolBar::resetFeatureClicked, mGpsDigitizing, &QgsAppGpsDigitizing::resetTrack );
 
+  mGpsLogging = new QgsAppGpsLogging( mGpsConnection, this );
+
   mGpsToolBar->setGpsDigitizing( mGpsDigitizing );
 
   mGpsCanvasBridge = new QgsGpsCanvasBridge( mGpsConnection, mMapCanvas );
@@ -1419,8 +1422,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::bearingLineToggled, mGpsCanvasBridge, &QgsGpsCanvasBridge::setBearingLineVisible );
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::rotateMapToggled, mGpsCanvasBridge, &QgsGpsCanvasBridge::setRotateMap );
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::mapCenteringModeChanged, mGpsCanvasBridge, &QgsGpsCanvasBridge::setMapCenteringMode );
-  connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::enableNmeaLog, mGpsDigitizing, &QgsAppGpsDigitizing::setNmeaLoggingEnabled );
-  connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::nmeaLogFileChanged, mGpsDigitizing, &QgsAppGpsDigitizing::setNmeaLogFile );
+  connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::enableNmeaLog, mGpsLogging, &QgsAppGpsLogging::setNmeaLoggingEnabled );
+  connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::nmeaLogFileChanged, mGpsLogging, &QgsAppGpsLogging::setNmeaLogFile );
+  connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::gpkgLogDestinationChanged, mGpsLogging, &QgsAppGpsLogging::setGpkgLogFile );
   connect( mGpsDigitizing, &QgsAppGpsDigitizing::trackIsEmptyChanged, mGpsToolBar, [ = ]( bool isEmpty ) { mGpsToolBar->setResetTrackButtonEnabled( !isEmpty ); } );
 
   mpGpsWidget = new QgsGpsInformationWidget( mGpsConnection, mMapCanvas, mGpsDigitizing );
@@ -2014,6 +2018,9 @@ QgisApp::~QgisApp()
 
   delete mGpsDigitizing;
   mGpsDigitizing = nullptr;
+
+  delete mGpsLogging;
+  mGpsLogging = nullptr;
 
   delete mGpsConnection;
   mGpsConnection = nullptr;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1425,6 +1425,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::enableNmeaLog, mGpsLogging, &QgsAppGpsLogging::setNmeaLoggingEnabled );
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::nmeaLogFileChanged, mGpsLogging, &QgsAppGpsLogging::setNmeaLogFile );
   connect( mGpsSettingsMenu, &QgsAppGpsSettingsMenu::gpkgLogDestinationChanged, mGpsLogging, &QgsAppGpsLogging::setGpkgLogFile );
+  connect( mGpsLogging, &QgsAppGpsLogging::gpkgLoggingFailed, mGpsSettingsMenu, &QgsAppGpsSettingsMenu::onGpkgLoggingFailed );
   connect( mGpsDigitizing, &QgsAppGpsDigitizing::trackIsEmptyChanged, mGpsToolBar, [ = ]( bool isEmpty ) { mGpsToolBar->setResetTrackButtonEnabled( !isEmpty ); } );
 
   mpGpsWidget = new QgsGpsInformationWidget( mGpsConnection, mMapCanvas, mGpsDigitizing );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -123,6 +123,7 @@ class QgsAdvancedDigitizingDockWidget;
 class QgsGpsInformationWidget;
 class QgsGpsCanvasBridge;
 class QgsAppGpsDigitizing;
+class QgsAppGpsLogging;
 class QgsStatisticalSummaryDockWidget;
 class QgsMapCanvasTracer;
 class QgsTemporalControllerDockWidget;
@@ -2611,6 +2612,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsGpsToolBar *mGpsToolBar = nullptr;
     QgsGpsCanvasBridge *mGpsCanvasBridge = nullptr;
     QgsAppGpsDigitizing *mGpsDigitizing = nullptr;
+    QgsAppGpsLogging *mGpsLogging = nullptr;
 
     QgsMessageBarItem *mLastMapToolMessage = nullptr;
 

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -63,6 +63,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   addSettingsEntry( &QgsIdentifyResultsDialog::settingHideNullValues );
 
   addSettingsEntry( &QgsAppGpsDigitizing::settingLastLogFolder );
+  addSettingsEntry( &QgsAppGpsDigitizing::settingLastGpkgLog );
 
   addSettingsEntry( &QgsGpsCanvasBridge::settingShowBearingLine );
   addSettingsEntry( &QgsGpsCanvasBridge::settingBearingLineSymbol );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -30,6 +30,7 @@
 #include "vertextool/qgsvertexeditor.h"
 #include "elevation/qgselevationprofilewidget.h"
 #include "qgsappgpsdigitizing.h"
+#include "qgsappgpslogging.h"
 #include "qgsgpscanvasbridge.h"
 #include "qgsgpsmarker.h"
 #include "qgsgpstoolbar.h"
@@ -62,8 +63,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
 
   addSettingsEntry( &QgsIdentifyResultsDialog::settingHideNullValues );
 
-  addSettingsEntry( &QgsAppGpsDigitizing::settingLastLogFolder );
-  addSettingsEntry( &QgsAppGpsDigitizing::settingLastGpkgLog );
+  addSettingsEntry( &QgsAppGpsLogging::settingLastLogFolder );
+  addSettingsEntry( &QgsAppGpsLogging::settingLastGpkgLog );
 
   addSettingsEntry( &QgsGpsCanvasBridge::settingShowBearingLine );
   addSettingsEntry( &QgsGpsCanvasBridge::settingBearingLineSymbol );

--- a/src/core/gps/qgsvectorlayergpslogger.cpp
+++ b/src/core/gps/qgsvectorlayergpslogger.cpp
@@ -170,7 +170,10 @@ void QgsVectorLayerGpsLogger::endCurrentTrack()
 
     QgsFeature feature = QgsVectorLayerUtils::createFeature( mTracksLayer, geometry, attributes, &context );
 
-    mTracksLayer->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
+    if ( mUseEditBuffer )
+      mTracksLayer->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
+    else
+      mTracksLayer->dataProvider()->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
   }
   resetTrack();
 }
@@ -255,7 +258,10 @@ void QgsVectorLayerGpsLogger::gpsStateChanged( const QgsGpsInformation &info )
 
     QgsFeature feature = QgsVectorLayerUtils::createFeature( mPointsLayer, geometry, attributes, &context );
 
-    mPointsLayer->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
+    if ( mUseEditBuffer )
+      mPointsLayer->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
+    else
+      mPointsLayer->dataProvider()->addFeature( feature, QgsFeatureSink::Flag::FastInsert );
   }
 }
 

--- a/src/core/gps/qgsvectorlayergpslogger.h
+++ b/src/core/gps/qgsvectorlayergpslogger.h
@@ -48,6 +48,28 @@ class CORE_EXPORT QgsVectorLayerGpsLogger : public QgsGpsLogger
     ~QgsVectorLayerGpsLogger() override;
 
     /**
+     * Returns TRUE if the logger will use the vector layer edit buffer for the destination layers.
+     *
+     * If FALSE then the features will be written directly to the destination layer's data providers.
+     *
+     * The default behavior is to use the edit buffer.
+     *
+     * \see setWriteToEditBuffer()
+     */
+    bool writeToEditBuffer() const { return mUseEditBuffer; }
+
+    /**
+     * Sets whether the logger will use the vector layer edit buffer for the destination layers.
+     *
+     * If \a buffer is FALSE then the features will be written directly to the destination layer's data providers.
+     *
+     * The default behavior is to use the edit buffer.
+     *
+     * \see writeToEditBuffer()
+     */
+    void setWriteToEditBuffer( bool buffer ) { mUseEditBuffer = buffer; }
+
+    /**
      * Sets the \a layer in which recorded GPS points should be stored.
      *
      * \see setTracksLayer()
@@ -137,6 +159,8 @@ class CORE_EXPORT QgsVectorLayerGpsLogger : public QgsGpsLogger
     void gpsStateChanged( const QgsGpsInformation &information );
 
   private:
+
+    bool mUseEditBuffer = true;
 
     QPointer< QgsVectorLayer > mPointsLayer;
     QPointer< QgsVectorLayer > mTracksLayer;


### PR DESCRIPTION
When activated via the GPS toolbar - settings button - "Log to Geopackage/Spatialite" action, the user will be prompted
to select and existing GPKG/spatialite file or enter a new file name. A "gps_points" and "gps_tracks" table will be created in
the file with a predefined structure.

All incoming GPS messages will be logged to the gps_points layer, along with speed/bearing/altitude/accuracy information from the GPS

When the GPS is disconnected (or QGIS closed), the entire recorded GPS track will be added to the gps_tracks table (along with some calculated information like track length, start and end times)

Sponsored by NIWA