### PR TITLE
Don't emit layerModified for every atomic change made during a bulk operation to the vector layer edit buffer

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -331,6 +331,7 @@ Updates an index in an attribute map to a new value (for updates of changed attr
 
 
 
+
 };
 
 /************************************************************************

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3447,14 +3447,7 @@ bool QgsVectorLayer::deleteFeatures( const QgsFeatureIds &fids, QgsVectorLayer::
   }
   else
   {
-    if ( mEditBuffer )
-    {
-      res = mEditBuffer->deleteFeatures( fids );
-    }
-    else
-    {
-      res = false;
-    }
+    res = mEditBuffer && mEditBuffer->deleteFeatures( fids );
   }
 
   if ( res )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3153,9 +3153,12 @@ bool QgsVectorLayer::changeAttributeValues( QgsFeatureId fid, const QgsAttribute
     result = mJoinBuffer->changeAttributeValues( fid, newValuesJoin, oldValuesJoin );
   }
 
-  if ( ! newValuesNotJoin.isEmpty() && mEditBuffer && mDataProvider )
+  if ( ! newValuesNotJoin.isEmpty() )
   {
-    result &= mEditBuffer->changeAttributeValues( fid, newValuesNotJoin, oldValues );
+    if ( mEditBuffer && mDataProvider )
+      result &= mEditBuffer->changeAttributeValues( fid, newValuesNotJoin, oldValues );
+    else
+      result = false;
   }
 
   if ( result && !skipDefaultValues && !mDefaultValueOnUpdateFields.isEmpty() )

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -330,6 +330,8 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     QgsVectorLayerEditBufferGroup *mEditBufferGroup = nullptr;
 
+    int mBlockModifiedSignals = 0;
+
     friend class QgsGrassProvider; //GRASS provider totally abuses the edit buffer
 
   private:


### PR DESCRIPTION
Eg Instead of emitting layerModified for every individual feature in a call to QgsVectorLayer::addFeatures, we defer the signal and emit it only once after adding all the features.

This avoids a lot of expensive, unnecessary work which is triggered by the signal
