### PR TITLE
Speed up selection of objects in TopoGeometry  layers

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -63,6 +63,8 @@ class QgsPostgresFeatureSource final: public QgsAbstractFeatureSource
      * connection has since been destroyed. */
     QgsPostgresConn *mTransactionConnection = nullptr;
 
+    QgsPostgresProvider::TopoLayerInfo mTopoLayerInfo;
+
     friend class QgsPostgresFeatureIterator;
     friend class QgsPostgresExpressionCompiler;
 };

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -432,6 +432,14 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     {
       QString topologyName;
       long    layerId;
+      int     layerLevel;
+      enum TopoFeatureType
+      {
+        Puntal = 1,
+        Lineal = 2,
+        Polygonal = 3,
+        Mixed = 4
+      } featureType;
     };
 
     TopoLayerInfo mTopoLayerInfo;


### PR DESCRIPTION
This is aimed at using spatial indexes on primitive tables. Only affects non-hierarchical TopoGeometry layers access.
