### PR TITLE
Fix crash when loading raster with RAT with no class data

### DIFF
--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -463,6 +463,9 @@ QgsPalettedRasterRenderer::MultiValueClassData QgsPalettedRasterRenderer::raster
   QgsPalettedRasterRenderer::MultiValueClassData classData;
 
   const QList<QgsRasterAttributeTable::MinMaxClass> minMaxClasses { attributeTable->minMaxClasses( classificationColumn ) };
+  if ( minMaxClasses.empty() )
+    return QgsPalettedRasterRenderer::MultiValueClassData();
+
   for ( const QgsRasterAttributeTable::MinMaxClass &minMaxClass : std::as_const( minMaxClasses ) )
   {
     QVector<QVariant> values;

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1283,7 +1283,6 @@ QList<QgsRasterAttributeTable::MinMaxClass> QgsRasterAttributeTable::minMaxClass
     else
     {
       classificationIndex = fieldUsages.indexOf( Qgis::RasterAttributeTableFieldUsage::Generic );
-      Q_ASSERT( classificationIndex >= 0 );
     }
   }
   else if ( classificationIndex >= mFields.count( ) )

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1478,7 +1478,6 @@ QgsGradientColorRamp QgsRasterAttributeTable::colorRamp( QStringList &labels, co
 
 QgsRasterRenderer *QgsRasterAttributeTable::createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn )
 {
-
   if ( ! provider )
   {
     return nullptr;
@@ -1494,6 +1493,9 @@ QgsRasterRenderer *QgsRasterAttributeTable::createRenderer( QgsRasterDataProvide
       ramp.reset( new QgsRandomColorRamp() );
     }
     const QgsPalettedRasterRenderer::MultiValueClassData classes = QgsPalettedRasterRenderer::rasterAttributeTableToClassData( this, classificationColumn, ramp.get() );
+    if ( classes.isEmpty() )
+      return nullptr;
+
     renderer = std::make_unique<QgsPalettedRasterRenderer>( provider,
                bandNumber,
                classes );

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1286,7 +1286,7 @@ QList<QgsRasterAttributeTable::MinMaxClass> QgsRasterAttributeTable::minMaxClass
     }
     else
     {
-      classificationIndex = fieldUsages.indexOf( Qgis::RasterAttributeTableFieldUsage::MinMax );
+      classificationIndex = minMaxIndex;
     }
   }
   else if ( classificationIndex >= mFields.count( ) )

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1280,9 +1280,13 @@ QList<QgsRasterAttributeTable::MinMaxClass> QgsRasterAttributeTable::minMaxClass
     {
       classificationIndex = fieldUsages.indexOf( Qgis::RasterAttributeTableFieldUsage::Name );
     }
-    else
+    else if ( fieldUsages.contains( Qgis::RasterAttributeTableFieldUsage::Generic ) )
     {
       classificationIndex = fieldUsages.indexOf( Qgis::RasterAttributeTableFieldUsage::Generic );
+    }
+    else
+    {
+      classificationIndex = fieldUsages.indexOf( Qgis::RasterAttributeTableFieldUsage::MinMax );
     }
   }
   else if ( classificationIndex >= mFields.count( ) )


### PR DESCRIPTION
Found when testing with rasters found in the wild
