### PR TITLE
Show digitized point location on map while add feature attributes dialog is open 

### DIFF
--- a/python/gui/auto_generated/qgshighlight.sip.in
+++ b/python/gui/auto_generated/qgshighlight.sip.in
@@ -143,6 +143,13 @@ Returns the layer for which this highlight has been created.
     virtual void updatePosition();
 
 
+    void applyDefaultStyle();
+%Docstring
+Applies the default style from the user settings to the highlight.
+
+.. versionadded:: 3.30
+%End
+
   protected:
     virtual void paint( QPainter *p );
 

--- a/python/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/gui/auto_generated/qgsidentifymenu.sip.in
@@ -161,11 +161,12 @@ exec
 :param pos: the position where the menu will be executed
 %End
 
-    static void styleHighlight( QgsHighlight *highlight );
+ static void styleHighlight( QgsHighlight *highlight ) /Deprecated/;
 %Docstring
 Applies style from the settings to the highlight
 
-.. versionadded:: 3.8
+.. deprecated::
+   Use :py:func:`QgsHighlight.applyDefaultStyle()` instead.
 %End
 
   protected:

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -138,6 +138,8 @@ convenient method to clean members
 Returns the rubberBand currently owned by this map tool and
 transfers ownership to the caller.
 
+May be ``None``.
+
 .. versionadded:: 3.8
 %End
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -167,7 +167,7 @@ bool QgsFeatureAction::editFeature( bool showModal )
   return true;
 }
 
-bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, QgsExpressionContextScope *scope SIP_TRANSFER, bool hideParent )
+bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, std::unique_ptr< QgsExpressionContextScope > scope, bool hideParent )
 {
   if ( !mLayer || !mLayer->isEditable() )
     return false;
@@ -197,7 +197,7 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
   // values and field constraints
   QgsExpressionContext context = mLayer->createExpressionContext();
   if ( scope )
-    context.appendScope( scope );
+    context.appendScope( scope.release() );
 
   const QgsFeature newFeature = QgsVectorLayerUtils::createFeature( mLayer, mFeature->geometry(), initialAttributeValues,
                                 &context );

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -167,7 +167,7 @@ bool QgsFeatureAction::editFeature( bool showModal )
   return true;
 }
 
-bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, std::unique_ptr< QgsExpressionContextScope > scope, bool hideParent )
+bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, std::unique_ptr< QgsExpressionContextScope > scope, bool hideParent, std::unique_ptr<QgsHighlight> highlight )
 {
   if ( !mLayer || !mLayer->isEditable() )
     return false;
@@ -260,6 +260,8 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
     dialog->setEditCommandMessage( text() );
     if ( scope )
       dialog->setExtraContextScope( new QgsExpressionContextScope( *scope ) );
+    if ( highlight )
+      dialog->setHighlight( highlight.release() );
 
     connect( dialog->attributeForm(), &QgsAttributeForm::featureSaved, this, &QgsFeatureAction::onFeatureSaved );
 

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -38,11 +38,6 @@ class APP_EXPORT QgsFeatureAction : public QAction
   public:
     QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, QUuid actionId = QUuid(), int defaultAttr = -1, QObject *parent = nullptr );
 
-  public slots:
-    void execute();
-    bool viewFeatureForm( QgsHighlight *h = nullptr );
-    bool editFeature( bool showModal = true );
-
     /**
      * Add a new feature to the layer.
      * Will set the default values to recently used or provider defaults based on settings
@@ -55,7 +50,15 @@ class APP_EXPORT QgsFeatureAction : public QAction
      *
      * \returns TRUE if feature was added if showModal is true. If showModal is FALSE, returns TRUE in every case
      */
-    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true, QgsExpressionContextScope *scope = nullptr, bool hideParent = false );
+    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(),
+                     bool showModal = true,
+                     std::unique_ptr<QgsExpressionContextScope >scope = std::unique_ptr< QgsExpressionContextScope >(),
+                     bool hideParent = false );
+
+  public slots:
+    void execute();
+    bool viewFeatureForm( QgsHighlight *h = nullptr );
+    bool editFeature( bool showModal = true );
 
     /**
      * Sets whether to force suppression of the attribute form popup after creating a new feature.

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -24,10 +24,10 @@
 #include <QAction>
 #include <QUuid>
 #include "qgis_app.h"
+#include "qgshighlight.h"
 
 class QgsIdentifyResultsDialog;
 class QgsVectorLayer;
-class QgsHighlight;
 class QgsAttributeDialog;
 class QgsExpressionContextScope;
 
@@ -47,13 +47,15 @@ class APP_EXPORT QgsFeatureAction : public QAction
      * \param scope              Scope of the expression
      * \param showModal          If the used dialog should be modal or not
      * \param hideParent         If the parent widget should be hidden, when the used dialog is opened
+     * \param highlight          Optional canvas highlight for feature
      *
      * \returns TRUE if feature was added if showModal is true. If showModal is FALSE, returns TRUE in every case
      */
     bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(),
                      bool showModal = true,
                      std::unique_ptr<QgsExpressionContextScope >scope = std::unique_ptr< QgsExpressionContextScope >(),
-                     bool hideParent = false );
+                     bool hideParent = false,
+                     std::unique_ptr<QgsHighlight> highlight = std::unique_ptr<QgsHighlight>() );
 
   public slots:
     void execute();

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -2151,7 +2151,7 @@ void QgsIdentifyResultsDialog::highlightFeature( QTreeWidgetItem *item )
     highlight->setWidth( 2 );
   }
 
-  QgsIdentifyMenu::styleHighlight( highlight );
+  highlight->applyDefaultStyle();
   highlight->show();
   mHighlights.insert( featItem, highlight );
 }

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -56,11 +56,11 @@ QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mo
 bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, const QgsFeature &f, bool showModal )
 {
   QgsFeature feat( f );
-  QgsExpressionContextScope *scope = QgsExpressionContextUtils::mapToolCaptureScope( snappingMatches() );
+  std::unique_ptr< QgsExpressionContextScope > scope( QgsExpressionContextUtils::mapToolCaptureScope( snappingMatches() ) );
   QgsFeatureAction *action = new QgsFeatureAction( tr( "add feature" ), feat, vlayer, QUuid(), -1, this );
   if ( QgsRubberBand *rb = takeRubberBand() )
     connect( action, &QgsFeatureAction::addFeatureFinished, rb, &QgsRubberBand::deleteLater );
-  const bool res = action->addFeature( QgsAttributeMap(), showModal, scope );
+  const bool res = action->addFeature( QgsAttributeMap(), showModal, std::move( scope ) );
   if ( showModal )
     delete action;
   return res;

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -57,6 +57,8 @@ std::unique_ptr<QgsHighlight> QgsMapToolAddFeature::createHighlight( QgsVectorLa
 {
   std::unique_ptr< QgsHighlight > highlight = std::make_unique< QgsHighlight >( mCanvas, f.geometry(), layer );
   highlight->applyDefaultStyle();
+  highlight->mPointSizeRadiusMM = 1.0;
+  highlight->mPointSymbol = QgsHighlight::PointSymbol::Circle;
   return highlight;
 };
 

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -53,14 +53,33 @@ QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mo
 {
 }
 
+std::unique_ptr<QgsHighlight> QgsMapToolAddFeature::createHighlight( QgsVectorLayer *layer, const QgsFeature &f )
+{
+  std::unique_ptr< QgsHighlight > highlight = std::make_unique< QgsHighlight >( mCanvas, f.geometry(), layer );
+  highlight->applyDefaultStyle();
+  return highlight;
+};
+
 bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, const QgsFeature &f, bool showModal )
 {
   QgsFeature feat( f );
   std::unique_ptr< QgsExpressionContextScope > scope( QgsExpressionContextUtils::mapToolCaptureScope( snappingMatches() ) );
   QgsFeatureAction *action = new QgsFeatureAction( tr( "add feature" ), feat, vlayer, QUuid(), -1, this );
+
+  std::unique_ptr< QgsHighlight > highlight;
   if ( QgsRubberBand *rb = takeRubberBand() )
+  {
     connect( action, &QgsFeatureAction::addFeatureFinished, rb, &QgsRubberBand::deleteLater );
-  const bool res = action->addFeature( QgsAttributeMap(), showModal, std::move( scope ) );
+  }
+  else
+  {
+    // if we didn't get a rubber band, then create manually a highlight for the geometry. This ensures
+    // that tools which don't create a rubber band (ie those which digitize single points) still have
+    // a visible way of representing the captured geometry
+    highlight = createHighlight( vlayer, f );
+  }
+
+  const bool res = action->addFeature( QgsAttributeMap(), showModal, std::move( scope ), false, std::move( highlight ) );
   if ( showModal )
     delete action;
   return res;

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -16,6 +16,8 @@
 #include "qgsmaptooldigitizefeature.h"
 #include "qgis_app.h"
 
+class QgsHighlight;
+
 //! This tool adds new point/line/polygon features to already existing vector layers
 class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolDigitizeFeature
 {
@@ -38,6 +40,12 @@ class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolDigitizeFeature
   private:
 
     bool addFeature( QgsVectorLayer *vlayer, const QgsFeature &f, bool showModal = true );
+
+    /**
+     * Creates a highlight corresponding to the captured geometry map tool and transfers
+     * ownership to the caller.
+     */
+    std::unique_ptr< QgsHighlight > createHighlight( QgsVectorLayer *layer, const QgsFeature &f );
 
     /**
      * Check if CaptureMode matches layer type. Default is TRUE.

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -799,7 +799,7 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highlightAllFeatures()
       if ( !geom.isEmpty() )
       {
         QgsHighlight *hl = new QgsHighlight( mCanvas, geom, mVectorLayer );
-        styleHighlight( hl );
+        hl->applyDefaultStyle();
         mHighlight.append( hl );
         count++;
       }
@@ -821,24 +821,9 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::highlightOneFeature( Qg
   if ( !geom.isEmpty() )
   {
     QgsHighlight *hl = new QgsHighlight( mCanvas, geom, mVectorLayer );
-    styleHighlight( hl );
+    hl->applyDefaultStyle();
     mHighlight.append( hl );
   }
-}
-
-void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::styleHighlight( QgsHighlight *highlight )
-{
-  QgsSettings settings;
-  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-  int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
-  double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
-  double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
-
-  highlight->setColor( color ); // sets also fill with default alpha
-  color.setAlpha( alpha );
-  highlight->setFillColor( color ); // sets fill with alpha
-  highlight->setBuffer( buffer );
-  highlight->setMinWidth( minWidth );
 }
 
 QgsFeatureIds QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::filterIds( const QgsFeatureIds &ids,

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -171,8 +171,6 @@ namespace QgsMapToolSelectUtils
 
       void startFeatureSearch();
 
-      void styleHighlight( QgsHighlight *highlight );
-
       QString textForChooseAll( qint64 featureCount = -1 ) const;
       QString textForChooseOneMenu() const;
       void populateChooseOneMenu( const QgsFeatureIds &ids );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -43,7 +43,6 @@
 #include "qgsfeaturelistcombobox.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturefiltermodel.h"
-#include "qgsidentifymenu.h"
 #include "qgsvectorlayerutils.h"
 
 
@@ -584,7 +583,7 @@ void QgsRelationReferenceWidget::highlightFeature( QgsFeature f, CanvasExtent ca
   // highlight
   deleteHighlight();
   mHighlight = new QgsHighlight( mCanvas, f, mReferencedLayer );
-  QgsIdentifyMenu::styleHighlight( mHighlight );
+  mHighlight->applyDefaultStyle();
   mHighlight->show();
 
   QTimer *timer = new QTimer( this );

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -306,6 +306,21 @@ void QgsHighlight::updatePosition()
   updateRect();
 }
 
+void QgsHighlight::applyDefaultStyle()
+{
+  const QgsSettings settings;
+  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
+  const int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
+  const double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
+  const double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
+
+  setColor( color ); // sets also fill with default alpha
+  color.setAlpha( alpha );
+  setFillColor( color ); // sets fill with alpha
+  setBuffer( buffer );
+  setMinWidth( minWidth );
+}
+
 void QgsHighlight::paint( QPainter *p )
 {
   if ( mFeature.hasGeometry() )

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -414,9 +414,9 @@ void QgsHighlight::paint( QPainter *p )
         setRenderContextVariables( p, mRenderContext );
 
         // default to 1.5 mm radius square points
-        double pointSizeRadius = 1.5;
+        double pointSizeRadius = mPointSizeRadiusMM;
         QgsUnitTypes::RenderUnit sizeUnit = QgsUnitTypes::RenderMillimeters;
-        PointSymbol symbol = Square;
+        PointSymbol symbol = mPointSymbol;
 
         // but for point clouds, use actual sizes (+a little margin!)
         if ( QgsPointCloudLayer *pcLayer = qobject_cast<QgsPointCloudLayer *>( mLayer ) )

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -217,6 +217,11 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
     double mBuffer = 0; // line / stroke buffer in pixels
     double mMinWidth = 0; // line / stroke minimum width in pixels
     QgsRenderContext mRenderContext;
+
+    // we don't want to make PointSymbol public for now, so just grant access selectively via a friend
+    friend class QgsMapToolAddFeature;
+    double mPointSizeRadiusMM = 1.5;
+    PointSymbol mPointSymbol = PointSymbol::Square;
 };
 
 #endif

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -172,6 +172,13 @@ class GUI_EXPORT QgsHighlight : public QgsMapCanvasItem
 
     void updatePosition() override;
 
+    /**
+     * Applies the default style from the user settings to the highlight.
+     *
+     * \since QGIS 3.30
+     */
+    void applyDefaultStyle();
+
   protected:
     void paint( QPainter *p ) override;
 

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -673,7 +673,7 @@ void QgsIdentifyMenu::handleMenuHover()
       continue;
 
     QgsHighlight *hl = new QgsHighlight( mCanvas, result.mFeature.geometry(), vl );
-    styleHighlight( hl );
+    hl->applyDefaultStyle();
     mRubberBands.append( hl );
     connect( vl, &QObject::destroyed, this, &QgsIdentifyMenu::layerDestroyed );
   }
@@ -681,17 +681,7 @@ void QgsIdentifyMenu::handleMenuHover()
 
 void QgsIdentifyMenu::styleHighlight( QgsHighlight *highlight )
 {
-  const QgsSettings settings;
-  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-  const int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
-  const double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
-  const double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
-
-  highlight->setColor( color ); // sets also fill with default alpha
-  color.setAlpha( alpha );
-  highlight->setFillColor( color ); // sets fill with alpha
-  highlight->setBuffer( buffer );
-  highlight->setMinWidth( minWidth );
+  highlight->applyDefaultStyle();
 }
 
 void QgsIdentifyMenu::deleteRubberBands()

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -177,9 +177,9 @@ class GUI_EXPORT QgsIdentifyMenu : public QMenu
     /**
      * Applies style from the settings to the highlight
      *
-     * \since QGIS 3.8
+     * \deprecated Use QgsHighlight::applyDefaultStyle() instead.
      */
-    static void styleHighlight( QgsHighlight *highlight );
+    Q_DECL_DEPRECATED static void styleHighlight( QgsHighlight *highlight ) SIP_DEPRECATED;
 
   protected:
     void closeEvent( QCloseEvent *e ) override;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -155,6 +155,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * Returns the rubberBand currently owned by this map tool and
      * transfers ownership to the caller.
      *
+     * May be NULLPTR.
+     *
      * \since QGIS 3.8
      */
     QgsRubberBand *takeRubberBand() SIP_FACTORY;


### PR DESCRIPTION
When digitizing points, ensure that we show a visible marker on the canvas at the digitized point while the attribute dialog is open

This matches the behavior we see for lines/polygons, where the digitized geometry stays visible on the map until the user either accepts the attribute dialog and adds the feature or cancels it.
Previously, the clicked point would disappear and the user would have no way of knowing where it was prior to accepting the form and actually creating the feature.

Fixes an annoying UX papercut.