### PR TITLE
Fix papercut leading to loss of fields in various "new *** layer" dialogs

### DIFF
--- a/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
@@ -65,6 +65,9 @@ Returns attributes for the new layer.
 .. versionadded:: 3.14
 %End
 
+    virtual void accept();
+
+
 };
 
 /************************************************************************

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -336,6 +336,33 @@ void QgsNewSpatialiteLayerDialog::buttonBox_rejected()
 
 bool QgsNewSpatialiteLayerDialog::apply()
 {
+  if ( !mNameEdit->text().trimmed().isEmpty() )
+  {
+    const QString currentFieldName = mNameEdit->text();
+    bool currentFound = false;
+    QTreeWidgetItemIterator it( mAttributeView );
+    while ( *it )
+    {
+      QTreeWidgetItem *item = *it;
+      if ( item->text( 0 ) == currentFieldName )
+      {
+        currentFound = true;
+        break;
+      }
+      ++it;
+    }
+
+    if ( !currentFound )
+    {
+      if ( QMessageBox::question( this, windowTitle(),
+                                  tr( "The field “%1” has not been added to the fields list. Are you sure you want to proceed and discard this field?" ).arg( currentFieldName ),
+                                  QMessageBox::Ok | QMessageBox::Cancel ) != QMessageBox::Ok )
+      {
+        return false;
+      }
+    }
+  }
+
   const QgsDataSourceUri dbUri = mDatabaseComboBox->currentConnectionUri();
   const QString dbPath = dbUri.database();
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -269,6 +269,33 @@ void QgsNewGeoPackageLayerDialog::buttonBox_rejected()
 
 bool QgsNewGeoPackageLayerDialog::apply()
 {
+  if ( !mFieldNameEdit->text().trimmed().isEmpty() )
+  {
+    const QString currentFieldName = mFieldNameEdit->text();
+    bool currentFound = false;
+    QTreeWidgetItemIterator it( mAttributeView );
+    while ( *it )
+    {
+      QTreeWidgetItem *item = *it;
+      if ( item->text( 0 ) == currentFieldName )
+      {
+        currentFound = true;
+        break;
+      }
+      ++it;
+    }
+
+    if ( !currentFound )
+    {
+      if ( QMessageBox::question( this, windowTitle(),
+                                  tr( "The field “%1” has not been added to the fields list. Are you sure you want to proceed and discard this field?" ).arg( currentFieldName ),
+                                  QMessageBox::Ok | QMessageBox::Cancel ) != QMessageBox::Ok )
+      {
+        return false;
+      }
+    }
+  }
+
   QString fileName( mDatabase->filePath() );
   if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
     fileName += QLatin1String( ".gpkg" );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -34,6 +34,7 @@
 #include <QComboBox>
 #include <QUuid>
 #include <QFileDialog>
+#include <QMessageBox>
 
 QgsVectorLayer *QgsNewMemoryLayerDialog::runAndCreateLayer( QWidget *parent, const QgsCoordinateReferenceSystem &defaultCrs )
 {
@@ -113,7 +114,10 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   connect( mAttributeView, &QTreeWidget::itemSelectionChanged, this, &QgsNewMemoryLayerDialog::selectionChanged );
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewMemoryLayerDialog::mRemoveAttributeButton_clicked );
+
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsNewMemoryLayerDialog::showHelp );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsNewMemoryLayerDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsNewMemoryLayerDialog::reject );
 
   mNameLineEdit->selectAll();
   mNameLineEdit->setFocus();
@@ -301,6 +305,25 @@ QgsFields QgsNewMemoryLayerDialog::fields() const
   }
 
   return fields;
+}
+
+void QgsNewMemoryLayerDialog::accept()
+{
+  if ( !mFieldNameEdit->text().trimmed().isEmpty() )
+  {
+    const QString currentFieldName = mFieldNameEdit->text();
+    if ( fields().lookupField( currentFieldName ) == -1 )
+    {
+      if ( QMessageBox::question( this, tr( "New Temporary Scratch Layer" ),
+                                  tr( "The field “%1” has not been added to the fields list. Are you sure you want to proceed and discard this field?" ).arg( currentFieldName ),
+                                  QMessageBox::Ok | QMessageBox::Cancel ) != QMessageBox::Ok )
+      {
+        return;
+      }
+    }
+  }
+
+  QDialog::accept();
 }
 
 void QgsNewMemoryLayerDialog::mAddAttributeButton_clicked()

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -74,6 +74,8 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
      */
     QgsFields fields() const;
 
+    void accept() override;
+
   private:
 
     QString mCrsId;

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -307,6 +307,33 @@ void QgsNewVectorLayerDialog::updateExtension()
 
 void QgsNewVectorLayerDialog::accept()
 {
+  if ( !mNameEdit->text().trimmed().isEmpty() )
+  {
+    const QString currentFieldName = mNameEdit->text();
+    bool currentFound = false;
+    QTreeWidgetItemIterator it( mAttributeView );
+    while ( *it )
+    {
+      QTreeWidgetItem *item = *it;
+      if ( item->text( 0 ) == currentFieldName )
+      {
+        currentFound = true;
+        break;
+      }
+      ++it;
+    }
+
+    if ( !currentFound )
+    {
+      if ( QMessageBox::question( this, windowTitle(),
+                                  tr( "The field “%1” has not been added to the fields list. Are you sure you want to proceed and discard this field?" ).arg( currentFieldName ),
+                                  QMessageBox::Ok | QMessageBox::Cancel ) != QMessageBox::Ok )
+      {
+        return;
+      }
+    }
+  }
+
   updateExtension();
 
   if ( QFile::exists( filename() ) && QMessageBox::warning( this, tr( "New ShapeFile Layer" ), tr( "The layer already exists. Are you sure you want to overwrite the existing file?" ),

--- a/src/ui/qgsnewmemorylayerdialogbase.ui
+++ b/src/ui/qgsnewmemorylayerdialogbase.ui
@@ -265,39 +265,7 @@
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>QgsNewMemoryLayerDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>349</x>
-     <y>400</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>387</x>
-     <y>304</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsNewMemoryLayerDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>275</x>
-     <y>400</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>242</x>
-     <y>308</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
In various "new *** layer" dialogs, show a warning when the user accepts the dialog but has entered a field name in the new field box without adding it to the fields list

Avoids a papercut where a user thinks that just entering the name of a field alone is sufficient to create that field in the resultant table

(I still frequently do this!!)