### PR TITLE
Use daemon property instead of setDaemon()

### DIFF
--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -4987,7 +4987,7 @@ java.io.IOExceptionCannot do natural order without a primary key, please add it 
 </wfs:FeatureCollection>"""))
 
         httpd_thread = threading.Thread(target=httpd.serve_forever)
-        httpd_thread.setDaemon(True)
+        httpd_thread.daemon = True
         httpd_thread.start()
 
         vl = QgsVectorLayer("url='http://localhost:{}' typename='my:typename' version='1.0.0'".format(port), 'test',

--- a/tests/src/python/test_qgseditformconfig.py
+++ b/tests/src/python/test_qgseditformconfig.py
@@ -44,7 +44,7 @@ class TestQgsEditFormConfig(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def createLayer(self):

--- a/tests/src/python/test_qgsimagecache.py
+++ b/tests/src/python/test_qgsimagecache.py
@@ -47,7 +47,7 @@ class TestQgsImageCache(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def setUp(self):

--- a/tests/src/python/test_qgslayoutpicture.py
+++ b/tests/src/python/test_qgslayoutpicture.py
@@ -50,7 +50,7 @@ class TestQgsLayoutPicture(unittest.TestCase, LayoutItemTestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def __init__(self, methodName):

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -55,7 +55,7 @@ class TestQgsNetworkAccessManager(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def test_request_preprocessor(self):

--- a/tests/src/python/test_qgsnetworkcontentfetcher.py
+++ b/tests/src/python/test_qgsnetworkcontentfetcher.py
@@ -40,7 +40,7 @@ class TestQgsNetworkContentFetcher(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def __init__(self, methodName):

--- a/tests/src/python/test_qgsnetworkcontentfetcherregistry.py
+++ b/tests/src/python/test_qgsnetworkcontentfetcherregistry.py
@@ -40,7 +40,7 @@ class TestQgsNetworkContentFetcherTask(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def __init__(self, methodName):

--- a/tests/src/python/test_qgsnetworkcontentfetchertask.py
+++ b/tests/src/python/test_qgsnetworkcontentfetchertask.py
@@ -41,7 +41,7 @@ class TestQgsNetworkContentFetcherTask(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def __init__(self, methodName):

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -1344,7 +1344,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         port = httpd.server_address[1]
 
         httpd_thread = threading.Thread(target=httpd.serve_forever)
-        httpd_thread.setDaemon(True)
+        httpd_thread.daemon = True
         httpd_thread.start()
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({

--- a/tests/src/python/test_qgssvgcache.py
+++ b/tests/src/python/test_qgssvgcache.py
@@ -47,7 +47,7 @@ class TestQgsSvgCache(unittest.TestCase):
         cls.port = cls.httpd.server_address[1]
 
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
-        cls.httpd_thread.setDaemon(True)
+        cls.httpd_thread.daemon = True
         cls.httpd_thread.start()
 
     def setUp(self):


### PR DESCRIPTION
`SetDaemon()` is deprecated since Python 3.10:

- https://docs.python.org/3/library/threading.html#threading.Thread.daemon 
- https://docs.python.org/3/library/threading.html#threading.Thread.setDaemon

