### PR TITLE
Fix XTZ tile resolution settings having no impact on rendering

### DIFF
--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -582,7 +582,6 @@ struct QgsWmtsTileLayer
   QStringList formats;
   QStringList infoFormats;
   QString defaultStyle;
-  int dpi = -1;   //!< DPI of the tile layer (-1 for unknown DPI)
   //! available dimensions (optional, for multi-dimensional data)
   QHash<QString, QgsWmtsDimension> dimensions;
   QHash<QString, QgsWmtsStyle> styles;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -809,10 +809,6 @@ QImage *QgsWmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, in
         return image;
       }
 
-      // if we know both source and output DPI, let's scale the tiles
-      if ( mDpi != -1 && mTileLayer->dpi != -1 )
-        vres *= static_cast<double>( mDpi ) / mTileLayer->dpi;
-
       // find nearest resolution
       tm = mTileMatrixSet->findNearestResolution( vres );
       Q_ASSERT( tm );
@@ -1826,12 +1822,7 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
   if ( parsedUri.hasParam( QStringLiteral( "tilePixelRatio" ) ) )
     tilePixelRatio = parsedUri.param( QStringLiteral( "tilePixelRatio" ) ).toDouble();
 
-  if ( tilePixelRatio != 0 )
-  {
-    // known tile pixel ratio - will be doing auto-scaling of tiles based on output DPI
-    tl.dpi = 96 * tilePixelRatio;  // TODO: is 96 correct base DPI ?
-  }
-  else
+  if ( tilePixelRatio <= 0 )
   {
     // unknown tile pixel ratio - no scaling of tiles based on output DPI
     tilePixelRatio = 1;


### PR DESCRIPTION
## Description

This PR fixes the tile resolution combobox in the new XYZ layer dialog:

![image](https://user-images.githubusercontent.com/1728657/203026441-afbaec45-5682-4bd9-a44b-ef0459fd3764.png)

The DPI handling became unnecessary in-between the initial implementation 4 years ago and now, Nov 2022.

XYZ 'retina' (i.e. 512x512) tiles working out of the box:
![image](https://user-images.githubusercontent.com/1728657/203199683-15fc5412-4679-46e6-bdea-8192bff66630.png)

