### PR TITLE
[processing] Raster layer unique values output should use longlong for pixel count field

### DIFF
--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -113,7 +113,7 @@ QVariantMap QgsRasterLayerUniqueValuesReportAlgorithm::processAlgorithm( const Q
   {
     QgsFields outFields;
     outFields.append( QgsField( QStringLiteral( "value" ), QVariant::Double, QString(), 20, 8 ) );
-    outFields.append( QgsField( QStringLiteral( "count" ), QVariant::Int, QString(), 20 ) );
+    outFields.append( QgsField( QStringLiteral( "count" ), QVariant::LongLong, QString(), 20 ) );
     outFields.append( QgsField( areaUnit.replace( QStringLiteral( "²" ), QStringLiteral( "2" ) ), QVariant::Double, QString(), 20, 8 ) );
     sink.reset( parameterAsSink( parameters, QStringLiteral( "OUTPUT_TABLE" ), context, tableDest, outFields, QgsWkbTypes::NoGeometry, QgsCoordinateReferenceSystem() ) );
     if ( !sink )


### PR DESCRIPTION
otherwise values can be too large for plain integer fields when outputting to eg geopackage and ran on a very large raster
