### PR TITLE
[layouts] Support non-printer layout exports when QPrinter not available

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -269,6 +269,7 @@ Constructor for PrintExportSettings
 
     };
 
+
     ExportResult print( QPrinter &printer, const QgsLayoutExporter::PrintExportSettings &settings );
 %Docstring
 Prints the layout to a ``printer``, using the specified export ``settings``.
@@ -287,7 +288,6 @@ Returns a result code indicating whether the export was successful or an
 error was encountered. If an error was obtained then ``error`` will be set
 to the error description.
 %End
-
 
     struct SvgExportSettings
     {
@@ -422,7 +422,6 @@ Subclasses can override this method to customize page file naming.
 %End
 
 };
-
 
 
 

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -15,8 +15,6 @@
  ***************************************************************************/
 
 #include "qgslayoutexporter.h"
-#ifndef QT_NO_PRINTER
-
 #include "qgslayout.h"
 #include "qgslayoutitemmap.h"
 #include "qgslayoutpagecollection.h"
@@ -29,6 +27,7 @@
 #include "qgslinestring.h"
 #include "qgsmessagelog.h"
 #include "qgslabelingresults.h"
+
 #include <QImageWriter>
 #include <QSize>
 #include <QSvgGenerator>
@@ -527,6 +526,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToImage( QgsAbstractLay
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &filePath, const QgsLayoutExporter::PdfExportSettings &s )
 {
+#ifndef QT_NO_PRINTER
   if ( !mLayout || mLayout->pageCollection()->pageCount() == 0 )
     return PrintError;
 
@@ -713,10 +713,14 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   }
   captureLabelingResults();
   return result;
+#else
+  return PrintError;
+#endif
 }
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayoutIterator *iterator, const QString &fileName, const QgsLayoutExporter::PdfExportSettings &s, QString &error, QgsFeedback *feedback )
 {
+#ifndef QT_NO_PRINTER
   error.clear();
 
   if ( !iterator->beginRender() )
@@ -807,10 +811,14 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayou
 
   iterator->endRender();
   return Success;
+#else
+  return PrintError;
+#endif
 }
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdfs( QgsAbstractLayoutIterator *iterator, const QString &baseFilePath, const QgsLayoutExporter::PdfExportSettings &settings, QString &error, QgsFeedback *feedback )
 {
+#ifndef QT_NO_PRINTER
   error.clear();
 
   if ( !iterator->beginRender() )
@@ -856,8 +864,12 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdfs( QgsAbstractLayo
 
   iterator->endRender();
   return Success;
+#else
+  return PrintError;
+#endif
 }
 
+#ifndef QT_NO_PRINTER
 QgsLayoutExporter::ExportResult QgsLayoutExporter::print( QPrinter &printer, const QgsLayoutExporter::PrintExportSettings &s )
 {
   if ( !mLayout )
@@ -977,6 +989,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::print( QgsAbstractLayoutItera
   iterator->endRender();
   return Success;
 }
+#endif // QT_NO_PRINTER
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( const QString &filePath, const QgsLayoutExporter::SvgExportSettings &s )
 {
@@ -1215,6 +1228,7 @@ QMap<QString, QgsLabelingResults *> QgsLayoutExporter::takeLabelingResults()
   return res;
 }
 
+#ifndef QT_NO_PRINTER
 void QgsLayoutExporter::preparePrintAsPdf( QgsLayout *layout, QPrinter &printer, const QString &filePath )
 {
   QFileInfo fi( filePath );
@@ -1342,6 +1356,7 @@ void QgsLayoutExporter::updatePrinterPageSize( QgsLayout *layout, QPrinter &prin
   printer.setFullPage( true );
   printer.setPageMargins( QMarginsF( 0, 0, 0, 0 ) );
 }
+#endif // QT_NO_PRINTER
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::renderToLayeredSvg( const SvgExportSettings &settings, double width, double height, int page, const QRectF &bounds, const QString &filename, unsigned int svgLayerId, const QString &layerName, QDomDocument &svg, QDomNode &svgDocRoot, bool includeMetadata ) const
 {
@@ -2095,5 +2110,3 @@ bool QgsLayoutExporter::saveImage( const QImage &image, const QString &imageFile
   }
   return w.write( image );
 }
-
-#endif // ! QT_NO_PRINTER

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -29,6 +29,7 @@
 
 #ifndef QT_NO_PRINTER
 #include <QPrinter>
+#endif
 
 class QgsLayout;
 class QPainter;
@@ -459,6 +460,8 @@ class CORE_EXPORT QgsLayoutExporter
 
     };
 
+#ifndef QT_NO_PRINTER
+
     /**
      * Prints the layout to a \a printer, using the specified export \a settings.
      *
@@ -477,7 +480,7 @@ class CORE_EXPORT QgsLayoutExporter
     static ExportResult print( QgsAbstractLayoutIterator *iterator, QPrinter &printer,
                                const QgsLayoutExporter::PrintExportSettings &settings,
                                QString &error SIP_OUT, QgsFeedback *feedback = nullptr );
-
+#endif
 
     //! Contains settings relating to exporting layouts to SVG
     struct SvgExportSettings
@@ -718,6 +721,8 @@ class CORE_EXPORT QgsLayoutExporter
     //! Write a world file
     void writeWorldFile( const QString &fileName, double a, double b, double c, double d, double e, double f ) const;
 
+#ifndef QT_NO_PRINTER
+
     /**
      * Prepare a \a printer for printing a layout as a PDF, to the destination \a filePath.
      */
@@ -741,6 +746,7 @@ class CORE_EXPORT QgsLayoutExporter
     ExportResult printPrivate( QPrinter &printer, QPainter &painter, bool startNewPage = false, double dpi = -1, bool rasterize = false );
 
     static void updatePrinterPageSize( QgsLayout *layout, QPrinter &printer, int page );
+#endif
 
     ExportResult renderToLayeredSvg( const SvgExportSettings &settings, double width, double height, int page, const QRectF &bounds,
                                      const QString &filename, unsigned int svgLayerId, const QString &layerName,
@@ -758,8 +764,6 @@ class CORE_EXPORT QgsLayoutExporter
     friend class TestQgsLayoutExporter;
 
 };
-
-#endif // ! QT_NO_PRINTER
 
 #endif //QGSLAYOUTEXPORTER_H
 


### PR DESCRIPTION
## Description

This PR revisits a commit merged 4 years ago that completely disabled layout exports for iOS to employ a slightly more surgical approach and only disable exports relying on QPrinter (namely PDF exports and prints to printer hardware). This allows for iOS to do image exports of print layout and atlases.

Tested in QField, works like a charm. 