### PR TITLE
symbols: rename material to material settings

### DIFF
--- a/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
@@ -107,12 +107,12 @@ Returns whether the renderer will render data with simple lines (otherwise it us
 Sets whether the renderer will render data with simple lines (otherwise it uses buffer)
 %End
 
-    QgsAbstractMaterialSettings *material() const;
+    QgsAbstractMaterialSettings *materialSettings() const;
 %Docstring
-Returns material used for shading of the symbol
+Returns material settings used for shading of the symbol
 %End
 
-    void setMaterial( QgsAbstractMaterialSettings *material /Transfer/ );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings /Transfer/ );
 %Docstring
 Sets the ``material`` settings used for shading of the symbol.
 

--- a/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -69,12 +69,12 @@ Returns method that determines altitude (whether to clamp to feature to terrain)
 Sets method that determines altitude (whether to clamp to feature to terrain)
 %End
 
-    QgsAbstractMaterialSettings *material() const;
+    QgsAbstractMaterialSettings *materialSettings() const;
 %Docstring
-Returns material used for shading of the symbol
+Returns material settings used for shading of the symbol
 %End
 
-    void setMaterial( QgsAbstractMaterialSettings *material /Transfer/ );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings /Transfer/ );
 %Docstring
 Sets the ``material`` settings used for shading of the symbol.
 

--- a/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
@@ -90,12 +90,12 @@ Returns extrusion height (in map units)
 Sets extrusion height (in map units)
 %End
 
-    QgsAbstractMaterialSettings *material() const;
+    QgsAbstractMaterialSettings *materialSettings() const;
 %Docstring
-Returns material used for shading of the symbol
+Returns material settings used for shading of the symbol
 %End
 
-    void setMaterial( QgsAbstractMaterialSettings *material /Transfer/ );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings /Transfer/ );
 %Docstring
 Sets the ``material`` settings used for shading of the symbol.
 

--- a/src/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/3d/materials/qgsgoochmaterialsettings.cpp
@@ -206,8 +206,7 @@ void QgsGoochMaterialSettings::applyDataDefinedToGeometry( Qt3DQGeometry *geomet
   warmAttribute->setByteStride( 12 * sizeof( unsigned char ) );
   warmAttribute->setByteOffset( 3 * sizeof( unsigned char ) );
   warmAttribute->setCount( vertexCount );
-  geometry->addAttribute( warmAttribute
-                        );
+  geometry->addAttribute( warmAttribute );
 
   Qt3DQAttribute *coolAttribute = new Qt3DQAttribute( geometry );
   coolAttribute->setName( QStringLiteral( "dataDefinedCoolColor" ) );

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -23,7 +23,7 @@
 #include "qgsvectorlayerelevationproperties.h"
 
 QgsLine3DSymbol::QgsLine3DSymbol()
-  : mMaterial( std::make_unique< QgsPhongMaterialSettings >() )
+  : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
 {
 
 }
@@ -39,7 +39,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbol::clone() const
   result->mHeight = mHeight;
   result->mExtrusionHeight = mExtrusionHeight;
   result->mRenderAsSimpleLines = mRenderAsSimpleLines;
-  result->mMaterial.reset( mMaterial->clone() );
+  result->mMaterialSettings.reset( mMaterialSettings->clone() );
   copyBaseSettings( result.get() );
   return result.release();
 }
@@ -59,9 +59,9 @@ void QgsLine3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &co
   elemDataProperties.setAttribute( QStringLiteral( "width" ), mWidth );
   elem.appendChild( elemDataProperties );
 
-  elem.setAttribute( QStringLiteral( "material_type" ), mMaterial->type() );
+  elem.setAttribute( QStringLiteral( "material_type" ), mMaterialSettings->type() );
   QDomElement elemMaterial = doc.createElement( QStringLiteral( "material" ) );
-  mMaterial->writeXml( elemMaterial, context );
+  mMaterialSettings->writeXml( elemMaterial, context );
   elem.appendChild( elemMaterial );
 }
 
@@ -79,23 +79,23 @@ void QgsLine3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
 
   const QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
   const QString materialType = elem.attribute( QStringLiteral( "material_type" ), QStringLiteral( "phong" ) );
-  mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
-  if ( !mMaterial )
-    mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
-  mMaterial->readXml( elemMaterial, context );
+  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  if ( !mMaterialSettings )
+    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
+  mMaterialSettings->readXml( elemMaterial, context );
 }
 
 QgsAbstractMaterialSettings *QgsLine3DSymbol::material() const
 {
-  return mMaterial.get();
+  return mMaterialSettings.get();
 }
 
 void QgsLine3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
 {
-  if ( material == mMaterial.get() )
+  if ( material == mMaterialSettings.get() )
     return;
 
-  mMaterial.reset( material );
+  mMaterialSettings.reset( material );
 }
 
 QList<QgsWkbTypes::GeometryType> QgsLine3DSymbol::compatibleGeometryTypes() const

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -85,17 +85,17 @@ void QgsLine3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   mMaterialSettings->readXml( elemMaterial, context );
 }
 
-QgsAbstractMaterialSettings *QgsLine3DSymbol::material() const
+QgsAbstractMaterialSettings *QgsLine3DSymbol::materialSettings() const
 {
   return mMaterialSettings.get();
 }
 
-void QgsLine3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
+void QgsLine3DSymbol::setMaterialSettings( QgsAbstractMaterialSettings *materialSettings )
 {
-  if ( material == mMaterialSettings.get() )
+  if ( materialSettings == mMaterialSettings.get() )
     return;
 
-  mMaterialSettings.reset( material );
+  mMaterialSettings.reset( materialSettings );
 }
 
 QList<QgsWkbTypes::GeometryType> QgsLine3DSymbol::compatibleGeometryTypes() const
@@ -133,7 +133,7 @@ bool QgsLine3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::
     {
       Qgs3DExportObject *object = exporter->processGeometryRenderer( r, objectNamePrefix );
       if ( object == nullptr ) continue;
-      object->setupMaterial( material() );
+      object->setupMaterial( materialSettings() );
       exporter->mObjects.push_back( object );
     }
     return renderers.size() != 0;

--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -110,7 +110,7 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
     float mHeight = 0.0f;           //!< Base height of polygons
     float mExtrusionHeight = 0.0f;  //!< How much to extrude (0 means no walls)
     bool mRenderAsSimpleLines = false;   //!< Whether to render data with simple lines (otherwise it uses buffer)
-    std::unique_ptr< QgsAbstractMaterialSettings > mMaterial;  //!< Defines appearance of objects
+    std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings;  //!< Defines appearance of objects
 };
 
 

--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -84,15 +84,15 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
     //! Sets whether the renderer will render data with simple lines (otherwise it uses buffer)
     void setRenderAsSimpleLines( bool enabled ) { mRenderAsSimpleLines = enabled; }
 
-    //! Returns material used for shading of the symbol
-    QgsAbstractMaterialSettings *material() const;
+    //! Returns material settings used for shading of the symbol
+    QgsAbstractMaterialSettings *materialSettings() const;
 
     /**
      * Sets the \a material settings used for shading of the symbol.
      *
      * Ownership of \a material is transferred to the symbol.
      */
-    void setMaterial( QgsAbstractMaterialSettings *material SIP_TRANSFER );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings SIP_TRANSFER );
 
     /**
      * Exports the geometries contained within the hierarchy of entity.

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -96,7 +96,7 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &context,
 {
   Q_UNUSED( attributeNames )
 
-  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->material() );
+  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->materialSettings() );
 
   outNormal.tessellator.reset( new QgsTessellator( context.map().origin().x(), context.map().origin().y(), true,
                                false, false, false, texturedMaterialSettings ? texturedMaterialSettings->requiresTextureCoordinates() : false,
@@ -196,13 +196,13 @@ void QgsBufferedLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, cons
   QgsMaterialContext materialContext;
   materialContext.setIsSelected( selected );
   materialContext.setSelectionColor( context.map().selectionColor() );
-  Qt3DRender::QMaterial *mat = mSymbol->material()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
+  Qt3DRender::QMaterial *mat = mSymbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
 
   // extract vertex buffer data from tessellator
   const QByteArray data( ( const char * )out.tessellator->data().constData(), out.tessellator->data().count() * sizeof( float ) );
   const int nVerts = data.count() / out.tessellator->stride();
 
-  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->material() );
+  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->materialSettings() );
 
   QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry( true, false, false,
       texturedMaterialSettings ? texturedMaterialSettings->requiresTextureCoordinates() : false );
@@ -314,7 +314,7 @@ void QgsSimpleLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const 
   QgsMaterialContext materialContext;
   materialContext.setIsSelected( selected );
   materialContext.setSelectionColor( context.map().selectionColor() );
-  Qt3DRender::QMaterial *mat = mSymbol->material()->toMaterial( QgsMaterialSettingsRenderingTechnique::Lines, materialContext );
+  Qt3DRender::QMaterial *mat = mSymbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Lines, materialContext );
 
   // geometry renderer
 
@@ -436,7 +436,7 @@ void QgsThickLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Q
   QgsMaterialContext materialContext;
   materialContext.setIsSelected( selected );
   materialContext.setSelectionColor( context.map().selectionColor() );
-  Qt3DRender::QMaterial *mat = mSymbol->material()->toMaterial( QgsMaterialSettingsRenderingTechnique::Lines, materialContext );
+  Qt3DRender::QMaterial *mat = mSymbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Lines, materialContext );
   if ( !mat )
   {
     const QgsSimpleLineMaterialSettings defaultMaterial;

--- a/src/3d/symbols/qgsmesh3dsymbol.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol.cpp
@@ -19,7 +19,7 @@
 #include "qgsphongmaterialsettings.h"
 
 QgsMesh3DSymbol::QgsMesh3DSymbol()
-  : mMaterial( std::make_unique< QgsPhongMaterialSettings >() )
+  : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
 {
 
 }
@@ -32,7 +32,7 @@ QgsMesh3DSymbol *QgsMesh3DSymbol::clone() const
 
   result->mAltClamping = mAltClamping;
   result->mHeight = mHeight;
-  result->mMaterial.reset( mMaterial->clone() );
+  result->mMaterialSettings.reset( mMaterialSettings->clone() );
   result->mAddBackFaces = mAddBackFaces;
   result->mEnabled = mEnabled;
   result->mSmoothedTriangles = mSmoothedTriangles;
@@ -67,7 +67,7 @@ void QgsMesh3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &co
   elem.appendChild( elemDataProperties );
 
   QDomElement elemMaterial = doc.createElement( QStringLiteral( "material" ) );
-  mMaterial->writeXml( elemMaterial, context );
+  mMaterialSettings->writeXml( elemMaterial, context );
   elem.appendChild( elemMaterial );
 
   //Advanced symbol
@@ -105,7 +105,7 @@ void QgsMesh3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   mAddBackFaces = elemDataProperties.attribute( QStringLiteral( "add-back-faces" ) ).toInt();
 
   const QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
-  mMaterial->readXml( elemMaterial, context );
+  mMaterialSettings->readXml( elemMaterial, context );
 
   //Advanced symbol
   const QDomElement elemAdvancedSettings = elem.firstChildElement( QStringLiteral( "advanced-settings" ) );
@@ -295,13 +295,13 @@ void QgsMesh3DSymbol::setEnabled( bool enabled )
 
 QgsAbstractMaterialSettings *QgsMesh3DSymbol::material() const
 {
-  return mMaterial.get();
+  return mMaterialSettings.get();
 }
 
 void QgsMesh3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
 {
-  if ( material == mMaterial.get() )
+  if ( material == mMaterialSettings.get() )
     return;
 
-  mMaterial.reset( material );
+  mMaterialSettings.reset( material );
 }

--- a/src/3d/symbols/qgsmesh3dsymbol.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol.cpp
@@ -293,15 +293,15 @@ void QgsMesh3DSymbol::setEnabled( bool enabled )
 }
 
 
-QgsAbstractMaterialSettings *QgsMesh3DSymbol::material() const
+QgsAbstractMaterialSettings *QgsMesh3DSymbol::materialSettings() const
 {
   return mMaterialSettings.get();
 }
 
-void QgsMesh3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
+void QgsMesh3DSymbol::setMaterialSettings( QgsAbstractMaterialSettings *materialSettings )
 {
-  if ( material == mMaterialSettings.get() )
+  if ( materialSettings == mMaterialSettings.get() )
     return;
 
-  mMaterialSettings.reset( material );
+  mMaterialSettings.reset( materialSettings );
 }

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -106,15 +106,15 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
     //! Sets height (altitude) of the symbol (in map units)
     void setHeight( float height ) { mHeight = height; }
 
-    //! Returns material used for shading of the symbol
-    QgsAbstractMaterialSettings *material() const;
+    //! Returns material settings used for shading of the symbol
+    QgsAbstractMaterialSettings *materialSettings() const;
 
     /**
      * Sets the \a material settings used for shading of the symbol.
      *
      * Ownership of \a material is transferred to the symbol.
      */
-    void setMaterial( QgsAbstractMaterialSettings *material SIP_TRANSFER );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings SIP_TRANSFER );
 
     /**
      * Returns whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -347,7 +347,7 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
     //! how to handle altitude of vector features
     Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
     float mHeight = 0.0f;           //!< Base height of triangles
-    std::unique_ptr< QgsAbstractMaterialSettings > mMaterial;  //!< Defines appearance of objects
+    std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings;  //!< Defines appearance of objects
     bool mAddBackFaces = false;
 
     bool mEnabled = true;

--- a/src/3d/symbols/qgsmesh3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol_p.cpp
@@ -66,7 +66,7 @@ QgsMesh3DSymbolEntity::QgsMesh3DSymbolEntity( const Qgs3DMapSettings &map,
 Qt3DRender::QMaterial *QgsMesh3DSymbolEntity::material( const QgsMesh3DSymbol &symbol ) const
 {
   const QgsMaterialContext context;
-  Qt3DRender::QMaterial *material = symbol.material()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, context );
+  Qt3DRender::QMaterial *material = symbol.materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, context );
 
   // front/back side culling
   const auto techniques = material->effect()->techniques();
@@ -136,7 +136,7 @@ Qt3DRender::QGeometryRenderer *QgsMesh3DSymbolEntityNode::renderer( const Qgs3DM
   // call QgsTessellatedPolygonGeometry to
   // use symbol settings for back faces, normals, etc
 
-  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( symbol.material() );
+  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( symbol.materialSettings() );
 
   mGeometry = new QgsTessellatedPolygonGeometry( true, false, symbol.addBackFaces(), texturedMaterialSettings ? texturedMaterialSettings->requiresTextureCoordinates() : false );
   const QList<float> extrusionHeightPerPolygon;

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -38,14 +38,14 @@ QgsAbstract3DSymbol *QgsPoint3DSymbol::create()
 }
 
 QgsPoint3DSymbol::QgsPoint3DSymbol()
-  : mMaterial( std::make_unique< QgsPhongMaterialSettings >() )
+  : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
 {
   setBillboardSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ) ) );
 }
 
 QgsPoint3DSymbol::QgsPoint3DSymbol( const QgsPoint3DSymbol &other )
   : mAltClamping( other.altitudeClamping() )
-  , mMaterial( other.material() ? other.material()->clone() : nullptr )
+  , mMaterialSettings( other.material() ? other.material()->clone() : nullptr )
   , mShape( other.shape() )
   , mShapeProperties( other.shapeProperties() )
   , mTransform( other.transform() )
@@ -64,9 +64,9 @@ void QgsPoint3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &c
   elemDataProperties.setAttribute( QStringLiteral( "alt-clamping" ), Qgs3DUtils::altClampingToString( mAltClamping ) );
   elem.appendChild( elemDataProperties );
 
-  elem.setAttribute( QStringLiteral( "material_type" ), mMaterial->type() );
+  elem.setAttribute( QStringLiteral( "material_type" ), mMaterialSettings->type() );
   QDomElement elemMaterial = doc.createElement( QStringLiteral( "material" ) );
-  mMaterial->writeXml( elemMaterial, context );
+  mMaterialSettings->writeXml( elemMaterial, context );
   elem.appendChild( elemMaterial );
 
   elem.setAttribute( QStringLiteral( "shape" ), shapeToString( mShape ) );
@@ -97,10 +97,10 @@ void QgsPoint3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteConte
 
   const QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
   const QString materialType = elem.attribute( QStringLiteral( "material_type" ), QStringLiteral( "phong" ) );
-  mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
-  if ( !mMaterial )
-    mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
-  mMaterial->readXml( elemMaterial, context );
+  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  if ( !mMaterialSettings )
+    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
+  mMaterialSettings->readXml( elemMaterial, context );
 
   mShape = shapeFromString( elem.attribute( QStringLiteral( "shape" ) ) );
 
@@ -179,15 +179,15 @@ QMatrix4x4 QgsPoint3DSymbol::billboardTransform() const
 
 QgsAbstractMaterialSettings *QgsPoint3DSymbol::material() const
 {
-  return mMaterial.get();
+  return mMaterialSettings.get();
 }
 
 void QgsPoint3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
 {
-  if ( material == mMaterial.get() )
+  if ( material == mMaterialSettings.get() )
     return;
 
-  mMaterial.reset( material );
+  mMaterialSettings.reset( material );
 }
 
 bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -45,7 +45,7 @@ QgsPoint3DSymbol::QgsPoint3DSymbol()
 
 QgsPoint3DSymbol::QgsPoint3DSymbol( const QgsPoint3DSymbol &other )
   : mAltClamping( other.altitudeClamping() )
-  , mMaterialSettings( other.material() ? other.material()->clone() : nullptr )
+  , mMaterialSettings( other.materialSettings() ? other.materialSettings()->clone() : nullptr )
   , mShape( other.shape() )
   , mShapeProperties( other.shapeProperties() )
   , mTransform( other.transform() )
@@ -177,17 +177,17 @@ QMatrix4x4 QgsPoint3DSymbol::billboardTransform() const
   return billboardTransformMatrix;
 }
 
-QgsAbstractMaterialSettings *QgsPoint3DSymbol::material() const
+QgsAbstractMaterialSettings *QgsPoint3DSymbol::materialSettings() const
 {
   return mMaterialSettings.get();
 }
 
-void QgsPoint3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
+void QgsPoint3DSymbol::setMaterialSettings( QgsAbstractMaterialSettings *materialSettings )
 {
-  if ( material == mMaterialSettings.get() )
+  if ( materialSettings == mMaterialSettings.get() )
     return;
 
-  mMaterialSettings.reset( material );
+  mMaterialSettings.reset( materialSettings );
 }
 
 bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const
@@ -201,7 +201,7 @@ bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore:
       for ( Qgs3DExportObject *obj : objects )
       {
         obj->setSmoothEdges( exporter->smoothEdges() );
-        obj->setupMaterial( material() );
+        obj->setupMaterial( materialSettings() );
       }
       exporter->mObjects << objects;
     }
@@ -213,7 +213,7 @@ bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore:
         Qgs3DExportObject *object = exporter->processGeometryRenderer( mesh, objectNamePrefix );
         if ( object == nullptr ) continue;
         object->setSmoothEdges( exporter->smoothEdges() );
-        object->setupMaterial( material() );
+        object->setupMaterial( materialSettings() );
         exporter->mObjects << object;
       }
     }
@@ -233,7 +233,7 @@ bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore:
     const QVector<Qgs3DExportObject *> objects = exporter->processInstancedPointGeometry( entity, objectNamePrefix );
     for ( Qgs3DExportObject *obj : objects )
     {
-      obj->setupMaterial( material() );
+      obj->setupMaterial( materialSettings() );
       exporter->mObjects << obj;
     }
     return true;

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -66,15 +66,15 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     //! Sets method that determines altitude (whether to clamp to feature to terrain)
     void setAltitudeClamping( Qgis::AltitudeClamping altClamping ) { mAltClamping = altClamping; }
 
-    //! Returns material used for shading of the symbol
-    QgsAbstractMaterialSettings *material() const;
+    //! Returns material settings used for shading of the symbol
+    QgsAbstractMaterialSettings *materialSettings() const;
 
     /**
      * Sets the \a material settings used for shading of the symbol.
      *
      * Ownership of \a material is transferred to the symbol.
      */
-    void setMaterial( QgsAbstractMaterialSettings *material SIP_TRANSFER );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings SIP_TRANSFER );
 
     //! 3D shape types supported by the symbol
     enum Shape

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -127,7 +127,7 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     //! how to handle altitude of vector features
     Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Relative;
 
-    std::unique_ptr< QgsAbstractMaterialSettings> mMaterial;  //!< Defines appearance of objects
+    std::unique_ptr< QgsAbstractMaterialSettings> mMaterialSettings;  //!< Defines appearance of objects
     Shape mShape = Cylinder;  //!< What kind of shape to use
     QVariantMap mShapeProperties;  //!< Key-value dictionary of shape's properties (different keys for each shape)
     QMatrix4x4 mTransform;  //!< Transform of individual instanced models

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -217,7 +217,7 @@ Qt3DRender::QMaterial *QgsInstancedPoint3DSymbolHandler::material( const QgsPoin
   effect->addParameter( paramInst );
   effect->addParameter( paramInstNormal );
 
-  symbol->material()->addParametersToEffect( effect );
+  symbol->materialSettings()->addParametersToEffect( effect );
 
   Qt3DRender::QMaterial *material = new Qt3DRender::QMaterial;
   material->setEffect( effect );
@@ -421,7 +421,7 @@ void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const 
   {
     //  "overwriteMaterial" is a legacy setting indicating that non-embedded material should be used
     if ( mSymbol->shapeProperties()[QStringLiteral( "overwriteMaterial" )].toBool()
-         || ( mSymbol->material() && mSymbol->material()->type() != QLatin1String( "null" ) ) )
+         || ( mSymbol->materialSettings() && mSymbol->materialSettings()->type() != QLatin1String( "null" ) ) )
     {
       addMeshEntities( context.map(), out.positions, mSymbol.get(), parent, false );
     }
@@ -469,7 +469,7 @@ void QgsModelPoint3DSymbolHandler::addMeshEntities( const Qgs3DMapSettings &map,
   QgsMaterialContext materialContext;
   materialContext.setIsSelected( are_selected );
   materialContext.setSelectionColor( map.selectionColor() );
-  Qt3DRender::QMaterial *mat = symbol->material()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
+  Qt3DRender::QMaterial *mat = symbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
 
   // get nodes
   for ( const QVector3D &position : positions )

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -155,17 +155,17 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbol::create()
   return new QgsPolygon3DSymbol();
 }
 
-QgsAbstractMaterialSettings *QgsPolygon3DSymbol::material() const
+QgsAbstractMaterialSettings *QgsPolygon3DSymbol::materialSettings() const
 {
   return mMaterialSettings.get();
 }
 
-void QgsPolygon3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
+void QgsPolygon3DSymbol::setMaterialSettings( QgsAbstractMaterialSettings *materialSettings )
 {
-  if ( material == mMaterialSettings.get() )
+  if ( materialSettings == mMaterialSettings.get() )
     return;
 
-  mMaterialSettings.reset( material );
+  mMaterialSettings.reset( materialSettings );
 }
 
 bool QgsPolygon3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -26,7 +26,7 @@
 #include "qgsvectorlayer.h"
 
 QgsPolygon3DSymbol::QgsPolygon3DSymbol()
-  : mMaterial( std::make_unique< QgsPhongMaterialSettings >() )
+  : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
 {
 
 }
@@ -40,7 +40,7 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbol::clone() const
   result->mAltBinding = mAltBinding;
   result->mHeight = mHeight;
   result->mExtrusionHeight = mExtrusionHeight;
-  result->mMaterial.reset( mMaterial->clone() );
+  result->mMaterialSettings.reset( mMaterialSettings->clone() );
   result->mCullingMode = mCullingMode;
   result->mInvertNormals = mInvertNormals;
   result->mAddBackFaces = mAddBackFaces;
@@ -69,9 +69,9 @@ void QgsPolygon3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext 
   elemDataProperties.setAttribute( QStringLiteral( "rendered-facade" ), mRenderedFacade );
   elem.appendChild( elemDataProperties );
 
-  elem.setAttribute( QStringLiteral( "material_type" ), mMaterial->type() );
+  elem.setAttribute( QStringLiteral( "material_type" ), mMaterialSettings->type() );
   QDomElement elemMaterial = doc.createElement( QStringLiteral( "material" ) );
-  mMaterial->writeXml( elemMaterial, context );
+  mMaterialSettings->writeXml( elemMaterial, context );
   elem.appendChild( elemMaterial );
 
   QDomElement elemDDP = doc.createElement( QStringLiteral( "data-defined-properties" ) );
@@ -101,10 +101,10 @@ void QgsPolygon3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteCon
 
   const QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
   const QString materialType = elem.attribute( QStringLiteral( "material_type" ), QStringLiteral( "phong" ) );
-  mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
-  if ( !mMaterial )
-    mMaterial.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
-  mMaterial->readXml( elemMaterial, context );
+  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  if ( !mMaterialSettings )
+    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( QStringLiteral( "phong" ) ) );
+  mMaterialSettings->readXml( elemMaterial, context );
 
   const QDomElement elemDDP = elem.firstChildElement( QStringLiteral( "data-defined-properties" ) );
   if ( !elemDDP.isNull() )
@@ -157,15 +157,15 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbol::create()
 
 QgsAbstractMaterialSettings *QgsPolygon3DSymbol::material() const
 {
-  return mMaterial.get();
+  return mMaterialSettings.get();
 }
 
 void QgsPolygon3DSymbol::setMaterial( QgsAbstractMaterialSettings *material )
 {
-  if ( material == mMaterial.get() )
+  if ( material == mMaterialSettings.get() )
     return;
 
-  mMaterial.reset( material );
+  mMaterialSettings.reset( material );
 }
 
 bool QgsPolygon3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -76,15 +76,15 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
     //! Sets extrusion height (in map units)
     void setExtrusionHeight( float extrusionHeight ) { mExtrusionHeight = extrusionHeight; }
 
-    //! Returns material used for shading of the symbol
-    QgsAbstractMaterialSettings *material() const;
+    //! Returns material settings used for shading of the symbol
+    QgsAbstractMaterialSettings *materialSettings() const;
 
     /**
      * Sets the \a material settings used for shading of the symbol.
      *
      * Ownership of \a material is transferred to the symbol.
      */
-    void setMaterial( QgsAbstractMaterialSettings *material SIP_TRANSFER );
+    void setMaterialSettings( QgsAbstractMaterialSettings *materialSettings SIP_TRANSFER );
 
     //! Returns front/back culling mode
     Qgs3DTypes::CullingMode cullingMode() const { return mCullingMode; }

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -171,7 +171,7 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
 
     float mHeight = 0.0f;           //!< Base height of polygons
     float mExtrusionHeight = 0.0f;  //!< How much to extrude (0 means no walls)
-    std::unique_ptr< QgsAbstractMaterialSettings > mMaterial; //!< Defines appearance of objects
+    std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings; //!< Defines appearance of objects
     Qgs3DTypes::CullingMode mCullingMode = Qgs3DTypes::NoCulling;  //!< Front/back culling mode
     bool mInvertNormals = false;
     bool mAddBackFaces = false;

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -91,7 +91,7 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   outEdges.withAdjacency = true;
   outEdges.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), 0, &context.map() );
 
-  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->material() );
+  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->materialSettings() );
 
   outNormal.tessellator.reset( new QgsTessellator( context.map().origin().x(), context.map().origin().y(), true, mSymbol->invertNormals(), mSymbol->addBackFaces(), false,
                                texturedMaterialSettings && texturedMaterialSettings->requiresTextureCoordinates(),
@@ -105,7 +105,7 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
 
   QSet<QString> attrs = mSymbol->dataDefinedProperties().referencedFields( context.expressionContext() );
   attributeNames.unite( attrs );
-  attrs = mSymbol->material()->dataDefinedProperties().referencedFields( context.expressionContext() );
+  attrs = mSymbol->materialSettings()->dataDefinedProperties().referencedFields( context.expressionContext() );
   attributeNames.unite( attrs );
   return true;
 }
@@ -144,13 +144,13 @@ void QgsPolygon3DSymbolHandler::processPolygon( QgsPolygon *polyClone, QgsFeatur
   out.tessellator->addPolygon( *polyClone, extrusionHeight );
   delete polyClone;
 
-  if ( mSymbol->material()->dataDefinedProperties().hasActiveProperties() )
+  if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
     processMaterialDatadefined( out.tessellator->dataVerticesCount() - oldVerticesCount, context.expressionContext(), out );
 }
 
 void QgsPolygon3DSymbolHandler::processMaterialDatadefined( uint verticesCount, const QgsExpressionContext &context, QgsPolygon3DSymbolHandler::PolygonData &out )
 {
-  const QByteArray bytes = mSymbol->material()->dataDefinedVertexColorsAsByte( context );
+  const QByteArray bytes = mSymbol->materialSettings()->dataDefinedVertexColorsAsByte( context );
   out.materialDataDefined.append( bytes.repeated( verticesCount ) );
 }
 
@@ -258,13 +258,13 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
   const QByteArray data( ( const char * )out.tessellator->data().constData(), out.tessellator->data().count() * sizeof( float ) );
   const int nVerts = data.count() / out.tessellator->stride();
 
-  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->material() );
+  const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast< const QgsPhongTexturedMaterialSettings * >( mSymbol->materialSettings() );
 
   QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry( true, mSymbol->invertNormals(), mSymbol->addBackFaces(),
       texturedMaterialSettings && texturedMaterialSettings->requiresTextureCoordinates() );
   geometry->setData( data, nVerts, out.triangleIndexFids, out.triangleIndexStartingIndices );
-  if ( mSymbol->material()->dataDefinedProperties().hasActiveProperties() )
-    mSymbol->material()->applyDataDefinedToGeometry( geometry, nVerts, out.materialDataDefined );
+  if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
+    mSymbol->materialSettings()->applyDataDefinedToGeometry( geometry, nVerts, out.materialDataDefined );
 
   Qt3DRender::QGeometryRenderer *renderer = new Qt3DRender::QGeometryRenderer;
   renderer->setGeometry( geometry );
@@ -316,8 +316,8 @@ Qt3DRender::QMaterial *QgsPolygon3DSymbolHandler::material( const QgsPolygon3DSy
   materialContext.setIsSelected( isSelected );
   materialContext.setSelectionColor( context.map().selectionColor() );
 
-  const bool dataDefined = mSymbol->material()->dataDefinedProperties().hasActiveProperties();
-  Qt3DRender::QMaterial *material = symbol->material()->toMaterial( dataDefined ?
+  const bool dataDefined = mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties();
+  Qt3DRender::QMaterial *material = symbol->materialSettings()->toMaterial( dataDefined ?
                                     QgsMaterialSettingsRenderingTechnique::TrianglesDataDefined : QgsMaterialSettingsRenderingTechnique::Triangles,
                                     materialContext );
   applyCullingMode( symbol->cullingMode(), material );

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -64,7 +64,7 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVec
   cboAltClamping->setCurrentIndex( cboAltClamping->findData( static_cast< int >( lineSymbol->altitudeClamping() ) ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( lineSymbol->altitudeBinding() ) );
   chkSimpleLines->setChecked( lineSymbol->renderAsSimpleLines() );
-  widgetMaterial->setSettings( lineSymbol->material(), layer );
+  widgetMaterial->setSettings( lineSymbol->materialSettings(), layer );
   widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? QgsMaterialSettingsRenderingTechnique::Lines
                                 : QgsMaterialSettingsRenderingTechnique::Triangles );
   updateGuiState();
@@ -79,7 +79,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbolWidget::symbol()
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentData().toInt() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );
   sym->setRenderAsSimpleLines( chkSimpleLines->isChecked() );
-  sym->setMaterial( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings() );
   return sym.release();
 }
 
@@ -121,4 +121,3 @@ void QgsLine3DSymbolWidget::simple3DLinesToggled( bool active )
     }
   }
 }
-

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -130,8 +130,8 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
       lineEditModel->setSource( vm[QStringLiteral( "model" )].toString() );
       // "overwriteMaterial" is a legacy setting indicating that non-null material should be used
       forceNullMaterial = ( vm.contains( QStringLiteral( "overwriteMaterial" ) ) && !vm[QStringLiteral( "overwriteMaterial" )].toBool() )
-                          || !pointSymbol->material()
-                          || pointSymbol->material()->type() == QLatin1String( "null" );
+                          || !pointSymbol->materialSettings()
+                          || pointSymbol->materialSettings()->type() == QLatin1String( "null" );
       technique = QgsMaterialSettingsRenderingTechnique::TrianglesFromModel;
       break;
     }
@@ -144,7 +144,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
       break;
   }
 
-  widgetMaterial->setSettings( pointSymbol->material(), layer );
+  widgetMaterial->setSettings( pointSymbol->materialSettings(), layer );
   widgetMaterial->setTechnique( technique );
 
   if ( forceNullMaterial )
@@ -230,7 +230,7 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
   sym->setShape( static_cast<QgsPoint3DSymbol::Shape>( cboShape->itemData( cboShape->currentIndex() ).toInt() ) );
   sym->setShapeProperties( vm );
-  sym->setMaterial( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings() );
   sym->setTransform( tr );
   return sym.release();
 }

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -68,7 +68,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
   chkAddBackFaces->setChecked( polygonSymbol->addBackFaces() );
   chkInvertNormals->setChecked( polygonSymbol->invertNormals() );
 
-  widgetMaterial->setSettings( polygonSymbol->material(), layer );
+  widgetMaterial->setSettings( polygonSymbol->materialSettings(), layer );
 
   btnHeightDD->init( QgsAbstract3DSymbol::PropertyHeight, polygonSymbol->dataDefinedProperties(), QgsAbstract3DSymbol::propertyDefinitions(), layer, true );
   btnExtrusionDD->init( QgsAbstract3DSymbol::PropertyExtrusionHeight, polygonSymbol->dataDefinedProperties(), QgsAbstract3DSymbol::propertyDefinitions(), layer, true );
@@ -89,7 +89,7 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
   sym->setRenderedFacade( cboRenderedFacade->currentIndex() );
   sym->setAddBackFaces( chkAddBackFaces->isChecked() );
   sym->setInvertNormals( chkInvertNormals->isChecked() );
-  sym->setMaterial( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings() );
 
   QgsPropertyCollection ddp;
   ddp.setProperty( QgsAbstract3DSymbol::PropertyHeight, btnHeightDD->toProperty() );

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -1121,9 +1121,9 @@ void TestQgs3DRendering::testInstancedRendering()
   QVariantMap vmSphere;
   vmSphere[QStringLiteral( "radius" )] = 80.0f;
   sphere3DSymbol->setShapeProperties( vmSphere );
-  QgsPhongMaterialSettings material;
-  material.setAmbient( Qt::gray );
-  sphere3DSymbol->setMaterial( material.clone() );
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::gray );
+  sphere3DSymbol->setMaterialSettings( materialSettings.clone() );
 
   layerPointsZ->setRenderer3D( new QgsVectorLayer3DRenderer( sphere3DSymbol ) );
 
@@ -1157,7 +1157,7 @@ void TestQgs3DRendering::testInstancedRendering()
   vmCylinder[QStringLiteral( "radius" )] = 20.0f;
   vmCylinder[QStringLiteral( "length" )] = 200.0f;
   cylinder3DSymbol->setShapeProperties( vmCylinder );
-  cylinder3DSymbol->setMaterial( material.clone() );
+  cylinder3DSymbol->setMaterialSettings( materialSettings.clone() );
 
   layerPointsZ->setRenderer3D( new QgsVectorLayer3DRenderer( cylinder3DSymbol ) );
 

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -594,9 +594,9 @@ void TestQgs3DRendering::testLineRendering()
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setRenderAsSimpleLines( true );
   lineSymbol->setWidth( 10 );
-  QgsSimpleLineMaterialSettings mat;
-  mat.setAmbient( Qt::red );
-  lineSymbol->setMaterial( mat.clone() );
+  QgsSimpleLineMaterialSettings matSettings;
+  matSettings.setAmbient( Qt::red );
+  lineSymbol->setMaterialSettings( matSettings.clone() );
   layerLines->setRenderer3D( new QgsVectorLayer3DRenderer( lineSymbol ) );
 
   QVector<QgsPoint> pts;
@@ -653,9 +653,9 @@ void TestQgs3DRendering::testLineRenderingCurved()
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setRenderAsSimpleLines( true );
   lineSymbol->setWidth( 10 );
-  QgsSimpleLineMaterialSettings mat;
-  mat.setAmbient( Qt::red );
-  lineSymbol->setMaterial( mat.clone() );
+  QgsSimpleLineMaterialSettings matSettings;
+  matSettings.setAmbient( Qt::red );
+  lineSymbol->setMaterialSettings( matSettings.clone() );
   layerLines->setRenderer3D( new QgsVectorLayer3DRenderer( lineSymbol ) );
 
   QVector<QgsPoint> pts;
@@ -711,9 +711,9 @@ void TestQgs3DRendering::testBufferedLineRendering()
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setWidth( 10 );
   lineSymbol->setExtrusionHeight( 30 );
-  QgsPhongMaterialSettings mat;
-  mat.setAmbient( Qt::red );
-  lineSymbol->setMaterial( mat.clone() );
+  QgsPhongMaterialSettings matSettings;
+  matSettings.setAmbient( Qt::red );
+  lineSymbol->setMaterialSettings( matSettings.clone() );
   layerLines->setRenderer3D( new QgsVectorLayer3DRenderer( lineSymbol ) );
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
@@ -760,9 +760,9 @@ void TestQgs3DRendering::testBufferedLineRenderingWidth()
   lineSymbol->setWidth( 20 );
   lineSymbol->setExtrusionHeight( 30 );
   lineSymbol->setHeight( 10 );
-  QgsPhongMaterialSettings mat;
-  mat.setAmbient( Qt::red );
-  lineSymbol->setMaterial( mat.clone() );
+  QgsPhongMaterialSettings matSettings;
+  matSettings.setAmbient( Qt::red );
+  lineSymbol->setMaterialSettings( matSettings.clone() );
   layerLines->setRenderer3D( new QgsVectorLayer3DRenderer( lineSymbol ) );
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;
@@ -1252,9 +1252,9 @@ void TestQgs3DRendering::testEpsg4978LineRendering()
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setRenderAsSimpleLines( true );
   lineSymbol->setWidth( 2 );
-  QgsSimpleLineMaterialSettings mat;
-  mat.setAmbient( Qt::red );
-  lineSymbol->setMaterial( mat.clone() );
+  QgsSimpleLineMaterialSettings matSettings;
+  matSettings.setAmbient( Qt::red );
+  lineSymbol->setMaterialSettings( matSettings.clone() );
   layerLines->setRenderer3D( new QgsVectorLayer3DRenderer( lineSymbol ) );
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -132,10 +132,10 @@ void TestQgs3DRendering::initTestCase()
   // so we do not get some possible artifacts
   mLayerBuildings->setRenderer( nullptr );
 
-  QgsPhongMaterialSettings material;
-  material.setAmbient( Qt::lightGray );
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
-  symbol3d->setMaterial( material.clone() );
+  symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
   QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbol3d );
   mLayerBuildings->setRenderer3D( renderer3d );
@@ -416,7 +416,7 @@ void TestQgs3DRendering::testExtrudedPolygons()
   materialSettings.setAmbient( Qt::lightGray );
   materialSettings.setOpacity( 0.5f );
   QgsPolygon3DSymbol *symbol3dOpacity = new QgsPolygon3DSymbol;
-  symbol3dOpacity->setMaterial( materialSettings.clone() );
+  symbol3dOpacity->setMaterialSettings( materialSettings.clone() );
   symbol3dOpacity->setExtrusionHeight( 10.f );
   QgsVectorLayer3DRenderer *renderer3dOpacity = new QgsVectorLayer3DRenderer( symbol3dOpacity );
   mLayerBuildings->setRenderer3D( renderer3dOpacity );
@@ -440,11 +440,11 @@ void TestQgs3DRendering::testExtrudedPolygonsDataDefined()
   propertyColection.setProperty( QgsAbstractMaterialSettings::Diffuse, diffuseColor );
   propertyColection.setProperty( QgsAbstractMaterialSettings::Ambient, ambientColor );
   propertyColection.setProperty( QgsAbstractMaterialSettings::Specular, specularColor );
-  QgsPhongMaterialSettings material;
-  material.setDataDefinedProperties( propertyColection );
-  material.setAmbient( Qt::red );
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setDataDefinedProperties( propertyColection );
+  materialSettings.setAmbient( Qt::red );
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
-  symbol3d->setMaterial( material.clone() );
+  symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
   QgsVectorLayer3DRenderer *renderer3d = new QgsVectorLayer3DRenderer( symbol3d );
   mLayerBuildings->setRenderer3D( renderer3d );
@@ -510,7 +510,7 @@ void TestQgs3DRendering::testExtrudedPolygonsGoochShading()
   materialSettings.setAlpha( 0.2f );
   materialSettings.setBeta( 0.6f );
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
-  symbol3d->setMaterial( materialSettings.clone() );
+  symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
   QgsVectorLayer3DRenderer *renderer3dOpacity = new QgsVectorLayer3DRenderer( symbol3d );
   mLayerBuildings->setRenderer3D( renderer3dOpacity );
@@ -537,10 +537,10 @@ void TestQgs3DRendering::testPolygonsEdges()
   map->setCrs( mProject->crs() );
   map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
 
-  QgsPhongMaterialSettings material;
-  material.setAmbient( Qt::lightGray );
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
-  symbol3d->setMaterial( material.clone() );
+  symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
   symbol3d->setHeight( 20.f );
   symbol3d->setEdgesEnabled( true );
@@ -981,16 +981,16 @@ void TestQgs3DRendering::testMeshSimplified()
 
 void TestQgs3DRendering::testRuleBasedRenderer()
 {
-  QgsPhongMaterialSettings material;
-  material.setAmbient( Qt::lightGray );
+  QgsPhongMaterialSettings materialSettings;
+  materialSettings.setAmbient( Qt::lightGray );
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
-  symbol3d->setMaterial( material.clone() );
+  symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
 
-  QgsPhongMaterialSettings material2;
-  material2.setAmbient( Qt::red );
+  QgsPhongMaterialSettings materialSettings2;
+  materialSettings2.setAmbient( Qt::red );
   QgsPolygon3DSymbol *symbol3d2 = new QgsPolygon3DSymbol;
-  symbol3d2->setMaterial( material2.clone() );
+  symbol3d2->setMaterialSettings( materialSettings2.clone() );
   symbol3d2->setExtrusionHeight( 10.f );
 
   QgsRuleBased3DRenderer::Rule *root = new QgsRuleBased3DRenderer::Rule( nullptr );


### PR DESCRIPTION
`mMaterial` is not a material but an attribute to handle material
settings. Renaming it makes it easier to understand its usage.

cc @wonder-sk @benoitdm-oslandia 