### PR TITLE
[AttributeTable] Create attributes widget only when needed

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -106,8 +106,18 @@ int QgsAttributeTableModel::extraColumns() const
 
 void QgsAttributeTableModel::setExtraColumns( int extraColumns )
 {
-  mExtraColumns = extraColumns;
-  loadAttributes();
+  if ( extraColumns > mExtraColumns )
+  {
+    beginInsertColumns( QModelIndex(), mFieldCount + mExtraColumns, mFieldCount + extraColumns - 1 );
+    mExtraColumns = extraColumns;
+    endInsertColumns();
+  }
+  else if ( extraColumns < mExtraColumns )
+  {
+    beginRemoveColumns( QModelIndex(), mFieldCount + extraColumns, mFieldCount + mExtraColumns - 1 );
+    mExtraColumns = extraColumns;
+    endRemoveColumns();
+  }
 }
 
 void QgsAttributeTableModel::featuresDeleted( const QgsFeatureIds &fids )
@@ -403,10 +413,15 @@ void QgsAttributeTableModel::loadAttributes()
     return;
   }
 
+  const QgsFields &fields = mLayer->fields();
+  if ( mFields == fields )
+    return;
+
+  mFields = fields;
+
   bool ins = false, rm = false;
 
   QgsAttributeList attributes;
-  const QgsFields &fields = mLayer->fields();
 
   mWidgetFactories.clear();
   mAttributeWidgetCaches.clear();

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -413,7 +413,7 @@ void QgsAttributeTableModel::loadAttributes()
     return;
   }
 
-  const QgsFields &fields = mLayer->fields();
+  const QgsFields fields = mLayer->fields();
   if ( mFields == fields )
     return;
 

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -335,6 +335,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
 
     mutable QgsFeature mFeat;
 
+    QgsFields mFields;
     QgsAttributeList mAttributes;
     QVector<QgsEditorWidgetFactory *> mWidgetFactories;
     QVector<QgsFieldFormatter *> mFieldFormatters;

--- a/tests/src/python/test_qgsattributetablemodel.py
+++ b/tests/src/python/test_qgsattributetablemodel.py
@@ -15,6 +15,7 @@ import os
 
 from qgis.gui import (
     QgsAttributeTableModel,
+    QgsEditorWidgetFactory,
     QgsGui
 )
 from qgis.core import (
@@ -32,7 +33,7 @@ from qgis.core import (
     QgsFields,
     QgsWkbTypes,
 )
-from qgis.PyQt.QtCore import Qt, QTemporaryDir, QVariant
+from qgis.PyQt.QtCore import Qt, QTemporaryDir, QVariant, QSortFilterProxyModel
 from qgis.PyQt.QtGui import QColor
 from qgis.testing import (start_app,
                           unittest
@@ -220,6 +221,111 @@ class TestQgsAttributeTableModel(unittest.TestCase):
         self.assertTrue(vl.rollBack())
         self.assertEqual(len([f for f in vl.getFeatures()]), 1)
         self.assertEqual(am.rowCount(), 1)
+
+    def testExtraColumns(self):
+        """
+        Test that models handles correctly extra columns
+        and that attribute loading is done only when needed
+        """
+
+        # to track down whether or not we have created widget regarding the field
+        widgetLoaded = 0
+
+        class TestEditorWidgetFactory(QgsEditorWidgetFactory):
+
+            def __init__(self):
+                super().__init__("test")
+
+            def create(self, vl, fieldIdx, editor, parent):
+                return None
+
+            def configWidget(self, vl, fieldIdx, parent):
+                return None
+
+            def fieldScore(self, vl, fieldIdx):
+                nonlocal widgetLoaded
+                widgetLoaded += 1
+                return 0
+
+        QgsGui.editorWidgetRegistry().registerWidget("testWidget", TestEditorWidgetFactory())
+
+        # to track down if column have been inserted or removed
+        colsInserted = 0
+        colsRemoved = 0
+
+        def onColsInserted(parent, first, last):
+            nonlocal colsInserted
+            colsInserted = last - first + 1
+
+        def onColsRemoved(parent, first, last):
+            nonlocal colsRemoved
+            colsRemoved = last - first + 1
+
+        self.am.columnsInserted.connect(onColsInserted)
+        self.am.columnsRemoved.connect(onColsRemoved)
+
+        # to check our extra column is working
+        class TestFilterModel(QSortFilterProxyModel):
+
+            def __init__(self):
+                super().__init__()
+
+            def data(self, index, role):
+                if role == Qt.DisplayRole and index.column() > 1:
+                    return f"extra_{index.column()}"
+
+                return super().data(index, role)
+
+        fm = TestFilterModel()
+        fm.setSourceModel(self.am)
+
+        self.assertEqual(fm.data(fm.index(2, 0), Qt.DisplayRole), "test")
+        self.assertEqual(fm.data(fm.index(2, 1), Qt.DisplayRole), "2")
+        self.assertEqual(fm.data(fm.index(2, 2), Qt.DisplayRole), None)
+
+        # only one column inserted, no widget loaded
+        self.am.setExtraColumns(1)
+        self.assertEqual(widgetLoaded, 0)
+        self.assertEqual(colsInserted, 1)
+        colsInserted = 0
+        self.assertEqual(colsRemoved, 0)
+
+        self.assertEqual(fm.data(fm.index(2, 0), Qt.DisplayRole), "test")
+        self.assertEqual(fm.data(fm.index(2, 1), Qt.DisplayRole), "2")
+        self.assertEqual(fm.data(fm.index(2, 2), Qt.DisplayRole), "extra_2")
+
+        # only one column removed, no widget loaded
+        self.am.setExtraColumns(0)
+        self.assertEqual(widgetLoaded, 0)
+        self.assertEqual(colsInserted, 0)
+        self.assertEqual(colsRemoved, 1)
+        colsRemoved = 0
+
+        self.assertEqual(fm.data(fm.index(2, 0), Qt.DisplayRole), "test")
+        self.assertEqual(fm.data(fm.index(2, 1), Qt.DisplayRole), "2")
+        self.assertEqual(fm.data(fm.index(2, 2), Qt.DisplayRole), None)
+
+        # nothing has changed, nothing should happened
+        self.am.loadLayer()
+        self.assertEqual(widgetLoaded, 0)
+        self.assertEqual(colsInserted, 0)
+        self.assertEqual(colsRemoved, 0)
+
+        # add field, widget are reloaded
+        self.layer.addExpressionField("'newfield_' || \"fldtxt\"", QgsField("newfield", QVariant.String))
+        self.assertEqual(widgetLoaded, 3)
+        self.assertEqual(colsInserted, 1)
+        self.assertEqual(colsRemoved, 0)
+        colsInserted = 0
+        widgetLoaded = 0
+
+        # remove field, widget are loaded again
+        self.layer.removeExpressionField(2)
+        self.assertEqual(widgetLoaded, 2)
+        self.assertEqual(colsInserted, 0)
+        self.assertEqual(colsRemoved, 1)
+        colsRemoved = 0
+        widgetLoaded = 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When displaying the attribute table, attribute field formatters widgets creation is done 3 times:
- In constructor
- When setExtraColumn() is called
- When loadLayer() is called

And each time, a possibly Postgres request is sent (when there is a relation reference widget for instance). 

This PR limits to only one creation and so divide the loading time by 3. It's a partial fix for #47797

**Sponsored by National Land Survey of Finland, City of Tampere and Gispo Ltd**



