### PR TITLE
Fix source select dialog does not add new pages for providers registered after QGIS startup

### DIFF
--- a/python/gui/auto_generated/qgssourceselectproviderregistry.sip.in
+++ b/python/gui/auto_generated/qgssourceselectproviderregistry.sip.in
@@ -9,8 +9,7 @@
 
 
 
-
-class QgsSourceSelectProviderRegistry
+class QgsSourceSelectProviderRegistry : QObject
 {
 %Docstring(signature="appended")
 This class keeps a list of source select providers that may add items to the :py:class:`QgsDataSourceManagerDialog`
@@ -78,6 +77,22 @@ Gets select widget from provider with ``name``
 The function is replacement of  :py:func:`QgsProviderRegistry.createSelectionWidget()` from QGIS 3.8
 
 .. versionadded:: 3.10
+%End
+
+  signals:
+
+    void providerAdded( const QString &name );
+%Docstring
+Emitted whenever a provider is added to the registry.
+
+.. versionadded:: 3.30
+%End
+
+    void providerRemoved( const QString &name );
+%Docstring
+Emitted whenever a provider is removed from the registry.
+
+.. versionadded:: 3.30
 %End
 
   private:

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -59,7 +59,8 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserGuiModel *brow
   mBrowserWidget = new QgsBrowserDockWidget( QStringLiteral( "Browser" ), mBrowserModel, this );
   mBrowserWidget->setFeatures( QDockWidget::NoDockWidgetFeatures );
   ui->mOptionsStackedWidget->addWidget( mBrowserWidget );
-  mPageNames.append( QStringLiteral( "browser" ) );
+  mPageProviderKeys.append( QStringLiteral( "browser" ) );
+  mPageProviderNames.append( QStringLiteral( "browser" ) );
 
   // Forward all browser signals
   connect( mBrowserWidget, &QgsBrowserDockWidget::handleDropUriList, this, &QgsDataSourceManagerDialog::handleDropUriList );
@@ -77,8 +78,27 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserGuiModel *brow
       QgsMessageLog::logMessage( tr( "Cannot get %1 select dialog from source select provider %2." ).arg( provider->name(), provider->providerKey() ), QStringLiteral( "DataSourceManager" ), Qgis::MessageLevel::Critical );
       continue;
     }
-    addProviderDialog( dlg, provider->providerKey(), provider->text(), provider->icon( ), provider->toolTip( ) );
+    addProviderDialog( dlg, provider->providerKey(), provider->name(), provider->text(), provider->icon( ), provider->toolTip( ) );
   }
+
+  connect( QgsGui::sourceSelectProviderRegistry(), &QgsSourceSelectProviderRegistry::providerAdded, this, [ = ]( const QString & name )
+  {
+    if ( QgsSourceSelectProvider *provider = QgsGui::sourceSelectProviderRegistry()->providerByName( name ) )
+    {
+      QgsAbstractDataSourceWidget *dlg = provider->createDataSourceWidget( this );
+      if ( !dlg )
+      {
+        QgsMessageLog::logMessage( tr( "Cannot get %1 select dialog from source select provider %2." ).arg( provider->name(), provider->providerKey() ), QStringLiteral( "DataSourceManager" ), Qgis::MessageLevel::Critical );
+        return;
+      }
+      addProviderDialog( dlg, provider->providerKey(), provider->name(), provider->text(), provider->icon( ), provider->toolTip( ) );
+    }
+  } );
+
+  connect( QgsGui::sourceSelectProviderRegistry(), &QgsSourceSelectProviderRegistry::providerRemoved, this, [ = ]( const QString & name )
+  {
+    removeProviderDialog( name );
+  } );
 
   restoreOptionsBaseUi( tr( "Data Source Manager" ) );
 }
@@ -90,7 +110,8 @@ QgsDataSourceManagerDialog::~QgsDataSourceManagerDialog()
 
 void QgsDataSourceManagerDialog::openPage( const QString &pageName )
 {
-  const int pageIdx = mPageNames.indexOf( pageName );
+  // TODO -- this is actually using provider keys, not provider names!
+  const int pageIdx = mPageProviderKeys.indexOf( pageName );
   if ( pageIdx != -1 )
   {
     QTimer::singleShot( 0, this, [ = ] { setCurrentPage( pageIdx ); } );
@@ -161,11 +182,13 @@ void QgsDataSourceManagerDialog::vectorLayersAdded( const QStringList &layerQStr
   emit addVectorLayers( layerQStringList, enc, dataSourceType );
 }
 
-void QgsDataSourceManagerDialog::addProviderDialog( QgsAbstractDataSourceWidget *dlg, const QString &providerKey, const QString &providerName, const QIcon &icon, const QString &toolTip )
+void QgsDataSourceManagerDialog::addProviderDialog( QgsAbstractDataSourceWidget *dlg, const QString &providerKey, const QString &providerName, const QString &text, const QIcon &icon, const QString &toolTip )
 {
-  mPageNames.append( providerKey );
+  mPageProviderKeys.append( providerKey );
+  mPageProviderNames.append( providerName );
   ui->mOptionsStackedWidget->addWidget( dlg );
-  QListWidgetItem *layerItem = new QListWidgetItem( providerName, ui->mOptionsListWidget );
+  QListWidgetItem *layerItem = new QListWidgetItem( text, ui->mOptionsListWidget );
+  layerItem->setData( Qt::UserRole, providerName );
   layerItem->setToolTip( toolTip.isEmpty() ? tr( "Add %1 layer" ).arg( providerName ) : toolTip );
   layerItem->setIcon( icon );
   // Set crs and extent from canvas
@@ -178,6 +201,18 @@ void QgsDataSourceManagerDialog::addProviderDialog( QgsAbstractDataSourceWidget 
   connect( dlg, &QgsAbstractDataSourceWidget::rejected, this, &QgsDataSourceManagerDialog::reject );
   connect( dlg, &QgsAbstractDataSourceWidget::accepted, this, &QgsDataSourceManagerDialog::accept );
   makeConnections( dlg, providerKey );
+}
+
+void QgsDataSourceManagerDialog::removeProviderDialog( const QString &providerName )
+{
+  const int pageIdx = mPageProviderNames.indexOf( providerName );
+  if ( pageIdx != -1 )
+  {
+    ui->mOptionsStackedWidget->removeWidget( ui->mOptionsStackedWidget->widget( pageIdx ) );
+    mPageProviderKeys.removeAt( pageIdx );
+    mPageProviderNames.removeAt( pageIdx );
+    ui->mOptionsListWidget->removeItemWidget( ui->mOptionsListWidget->item( pageIdx ) );
+  }
 }
 
 void QgsDataSourceManagerDialog::makeConnections( QgsAbstractDataSourceWidget *dlg, const QString &providerKey )

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -175,13 +175,15 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     void providerDialogsRefreshRequested();
 
   private:
-    void addProviderDialog( QgsAbstractDataSourceWidget *dlg, const QString &providerKey, const QString &providerName, const QIcon &icon, const QString &toolTip = QString() );
+    void addProviderDialog( QgsAbstractDataSourceWidget *dlg, const QString &providerKey, const QString &providerName, const QString &text, const QIcon &icon, const QString &toolTip = QString() );
+    void removeProviderDialog( const QString &providerName );
     void makeConnections( QgsAbstractDataSourceWidget *dlg, const QString &providerKey );
     Ui::QgsDataSourceManagerDialog *ui = nullptr;
     QgsBrowserDockWidget *mBrowserWidget = nullptr;
     QgsLayerMetadataSearchWidget *mLayerMetadataSearchWidget = nullptr;
     int mPreviousRow;
-    QStringList mPageNames;
+    QStringList mPageProviderKeys;
+    QStringList mPageProviderNames;
     // Map canvas
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;

--- a/src/gui/qgssourceselectproviderregistry.cpp
+++ b/src/gui/qgssourceselectproviderregistry.cpp
@@ -38,14 +38,18 @@ void QgsSourceSelectProviderRegistry::addProvider( QgsSourceSelectProvider *prov
   {
     return first->ordering() < second->ordering();
   } );
+
+  emit providerAdded( provider->name() );
 }
 
 bool QgsSourceSelectProviderRegistry::removeProvider( QgsSourceSelectProvider *provider )
 {
+  const QString name = provider ? provider->name() : QString();
   const int index = mProviders.indexOf( provider );
   if ( index >= 0 )
   {
     delete mProviders.takeAt( index );
+    emit providerRemoved( name );
     return true;
   }
   return false;

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -17,8 +17,7 @@
 #define QGSSOURCESELECTPROVIDERREGISTRY_H
 
 #include <QList>
-#include <QWidget>
-
+#include <QObject>
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 
@@ -38,8 +37,10 @@ class QgsAbstractDataSourceWidget;
  *
  * \since QGIS 3.0
  */
-class GUI_EXPORT QgsSourceSelectProviderRegistry
+class GUI_EXPORT QgsSourceSelectProviderRegistry : public QObject
 {
+    Q_OBJECT
+
   public:
 
     QgsSourceSelectProviderRegistry();
@@ -88,6 +89,22 @@ class GUI_EXPORT QgsSourceSelectProviderRegistry
       Qt::WindowFlags fl,
       QgsProviderRegistry::WidgetMode widgetMode
     );
+
+  signals:
+
+    /**
+     * Emitted whenever a provider is added to the registry.
+     *
+     * \since QGIS 3.30
+     */
+    void providerAdded( const QString &name );
+
+    /**
+     * Emitted whenever a provider is removed from the registry.
+     *
+     * \since QGIS 3.30
+     */
+    void providerRemoved( const QString &name );
 
   private:
 #ifdef SIP_RUN


### PR DESCRIPTION
 (eg when enabling a new plugin), and also ensure pages are correctly removed when providers are removed

