### PR TITLE
Adjust OAPIF subsection title for a better display in PyQGIS docs

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -143,8 +143,8 @@ attribute operators, “BBOX, Disjoint, Intersects, Touches, Crosses, Contains, 
 spatial binary operators and the QGIS local “geomFromWKT, geomFromGML”
 geometry constructor functions.
 
-OGC API - Features data provider (oapif)
-~~~~~~~~-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+OGC API Features data provider (oapif)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Used to access data provided by a OGC API - Features server.
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -203,7 +203,7 @@ typedef QSet<int> QgsAttributeIds;
  * spatial binary operators and the QGIS local “geomFromWKT, geomFromGML”
  * geometry constructor functions.
  *
- * \subsection oapif OGC API - Features data provider (oapif)
+ * \subsection oapif OGC API Features data provider (oapif)
  *
  * Used to access data provided by a OGC API - Features server.
  *


### PR DESCRIPTION
Sections and subsections are now ([3.28](https://qgis.org/pyqgis/3.28/core/QgsVectorLayer.html#module-QgsVectorLayer) vs [3.26](https://qgis.org/pyqgis/3.26/core/QgsVectorLayer.html#module-QgsVectorLayer)) correctly displayed in QgsVectorLayer PyQGIS documentation, except oapif one due to `-` character failing to translate as underline correctly. Let's then slightly adjust the title. _I don't think there is any other occurrence that would make a regex fix worthy (and I don't know where I'd need to look at anyway)_