### PR TITLE
[OGR provider] Avoid console error related to gpkg_metadata_reference table

### DIFF
--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -405,6 +405,12 @@ QList<QgsLayerMetadataProviderResult> QgsGeoPackageProviderConnection::searchLay
   {
     try
     {
+      // first check if metadata tables/extension exists
+      if ( executeSql( QStringLiteral( "SELECT name FROM sqlite_master WHERE name='gpkg_metadata' AND type='table'" ), nullptr ).isEmpty() )
+      {
+        return results;
+      }
+
       const QString searchQuery { QStringLiteral( R"SQL(
       SELECT
         ref.table_name, md.metadata, gc.geometry_type_name

--- a/tests/src/python/test_qgslayermetadataprovider_python.py
+++ b/tests/src/python/test_qgslayermetadataprovider_python.py
@@ -122,8 +122,9 @@ class TestPythonLayerMetadataProvider(unittest.TestCase):
 
         super().setUp()
         srcpath = os.path.join(TEST_DATA_DIR, 'provider')
-        shutil.copy(os.path.join(srcpath, 'geopackage.gpkg'), temp_path)
         self.conn = os.path.join(temp_path, 'geopackage.gpkg')
+        # Create a truncated file so that we get an exception later
+        open(self.conn, "wb").write(open(os.path.join(srcpath, 'geopackage.gpkg'), "rb").read(8192))
 
         shutil.copy(os.path.join(srcpath, 'spatialite.db'), temp_path)
         self.conn_sl = os.path.join(temp_path, 'spatialite.db')


### PR DESCRIPTION
When opening the 'Open Vector Layer' dialog box in a directory with a .gpkg without the optional metadata tables, the following error was emitted on the console:
```
ERROR 1: In ExecuteSQL(): sqlite3_prepare_v2(
      SELECT
        ref.table_name, md.metadata, gc.geometry_type_name
      FROM
        gpkg_metadata_reference AS ref
      JOIN
        gpkg_metadata AS md ON md.id = ref.md_file_id
      LEFT JOIN
        gpkg_geometry_columns AS gc ON gc.table_name = ref.table_name
      WHERE
        md.md_standard_uri = 'http://mrcc.com/qgis.dtd'
        AND ref.reference_scope = 'table'
        AND md.md_scope = 'dataset'
      ):
  no such table: gpkg_metadata_reference
```
