### PR TITLE
[Lint] QgsMeshDatasetGroupStore: make mExtraDatasets a non-pointer member

### DIFF
--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -698,7 +698,7 @@ bool QgsMeshExtraDatasetStore::hasTemporalCapabilities() const
   return mTemporalCapabilities->hasTemporalCapabilities();
 }
 
-quint64 QgsMeshExtraDatasetStore::datasetRelativeTime( QgsMeshDatasetIndex index ) const
+qint64 QgsMeshExtraDatasetStore::datasetRelativeTime( QgsMeshDatasetIndex index ) const
 {
   return mTemporalCapabilities->datasetTime( index );
 }

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -39,12 +39,11 @@ int QgsMeshDatasetGroupStore::datasetGroupCount() const
 
 int QgsMeshDatasetGroupStore::extraDatasetGroupCount() const
 {
-  return mExtraDatasets->datasetGroupCount();
+  return mExtraDatasets.datasetGroupCount();
 }
 
 QgsMeshDatasetGroupStore::QgsMeshDatasetGroupStore( QgsMeshLayer *layer ):
   mLayer( layer ),
-  mExtraDatasets( new QgsMeshExtraDatasetStore ),
   mDatasetGroupTreeRootItem( new QgsMeshDatasetGroupTreeItem )
 {}
 
@@ -63,15 +62,12 @@ void QgsMeshDatasetGroupStore::setPersistentProvider( QgsMeshDataProvider *provi
   removeUnregisteredItemFromTree();
 
   //Once everything is in place, initialize the extra dataset groups
-  if ( mExtraDatasets )
-  {
-    const int groupCount = mExtraDatasets->datasetGroupCount();
-    for ( int i = 0; i < groupCount; ++i )
-      if ( mExtraDatasets->datasetGroup( i ) )
-        mExtraDatasets->datasetGroup( i )->initialize();
-  }
+  const int groupCount = mExtraDatasets.datasetGroupCount();
+  for ( int i = 0; i < groupCount; ++i )
+    if ( mExtraDatasets.datasetGroup( i ) )
+      mExtraDatasets.datasetGroup( i )->initialize();
 
-  mExtraDatasets->updateTemporalCapabilities();
+  mExtraDatasets.updateTemporalCapabilities();
 
   connect( mPersistentProvider, &QgsMeshDataProvider::datasetGroupsAdded, this, &QgsMeshDatasetGroupStore::onPersistentDatasetAdded );
 }
@@ -90,7 +86,7 @@ bool QgsMeshDatasetGroupStore::addPersistentDatasets( const QString &path )
 
 bool QgsMeshDatasetGroupStore::addDatasetGroup( QgsMeshDatasetGroup *group )
 {
-  if ( !mExtraDatasets && !mLayer )
+  if ( !mLayer )
     return false;
 
   switch ( group->dataType() )
@@ -112,8 +108,8 @@ bool QgsMeshDatasetGroupStore::addDatasetGroup( QgsMeshDatasetGroup *group )
       break;
   }
 
-  int nativeIndex = mExtraDatasets->addDatasetGroup( group );
-  int groupIndex = registerDatasetGroup( DatasetGroup{mExtraDatasets.get(), nativeIndex} );
+  int nativeIndex = mExtraDatasets.addDatasetGroup( group );
+  int groupIndex = registerDatasetGroup( DatasetGroup{&mExtraDatasets, nativeIndex} );
 
   if ( groupIndex == -1 )
     return false;
@@ -270,8 +266,8 @@ qint64 QgsMeshDatasetGroupStore::datasetRelativeTime( const QgsMeshDatasetIndex 
 
   if ( group.first == mPersistentProvider )
     return mPersistentProvider->temporalCapabilities()->datasetTime( nativeIndex );
-  else if ( group.first == mExtraDatasets.get() )
-    return mExtraDatasets->datasetRelativeTime( nativeIndex );
+  else if ( group.first == &mExtraDatasets )
+    return mExtraDatasets.datasetRelativeTime( nativeIndex );
 
   return INVALID_MESHLAYER_TIME;
 
@@ -280,7 +276,7 @@ qint64 QgsMeshDatasetGroupStore::datasetRelativeTime( const QgsMeshDatasetIndex 
 bool QgsMeshDatasetGroupStore::hasTemporalCapabilities() const
 {
   return ( mPersistentProvider && mPersistentProvider->temporalCapabilities()->hasTemporalCapabilities() ) ||
-         ( mExtraDatasets && mExtraDatasets->hasTemporalCapabilities() );
+         ( mExtraDatasets.hasTemporalCapabilities() );
 }
 
 QDomElement QgsMeshDatasetGroupStore::writeXml( QDomDocument &doc, const QgsReadWriteContext &context )
@@ -300,12 +296,12 @@ QDomElement QgsMeshDatasetGroupStore::writeXml( QDomDocument &doc, const QgsRead
       elemDataset.setAttribute( QStringLiteral( "source-type" ), QStringLiteral( "persitent-provider" ) );
       elemDataset.setAttribute( QStringLiteral( "source-index" ), it.value().second );
     }
-    else if ( it.value().first == mExtraDatasets.get() )
+    else if ( it.value().first == &mExtraDatasets )
     {
       QgsMeshDatasetGroupTreeItem *item = mDatasetGroupTreeRootItem->childFromDatasetGroupIndex( it.key() );
       if ( item )
       {
-        elemDataset = mExtraDatasets->writeXml( it.value().second, doc, context );
+        elemDataset = mExtraDatasets.writeXml( it.value().second, doc, context );
         if ( !elemDataset.isNull() )
           elemDataset.setAttribute( QStringLiteral( "global-index" ), it.key() );
       }
@@ -345,7 +341,7 @@ void QgsMeshDatasetGroupStore::readXml( const QDomElement &storeElem, const QgsR
     }
     else if ( sourceType == QLatin1String( "virtual" ) )
     {
-      QgsMeshDatasetSourceInterface *source = mExtraDatasets.get();
+      QgsMeshDatasetSourceInterface *source = &mExtraDatasets;
       QString name = datasetElem.attribute( QStringLiteral( "name" ) );
       QString formula = datasetElem.attribute( QStringLiteral( "formula" ) );
       qint64 startTime = datasetElem.attribute( QStringLiteral( "start-time" ) ).toLongLong();
@@ -353,7 +349,7 @@ void QgsMeshDatasetGroupStore::readXml( const QDomElement &storeElem, const QgsR
 
       QgsMeshDatasetGroup *dsg = new QgsMeshVirtualDatasetGroup( name, formula, mLayer, startTime, endTime );
       extraDatasetGroups[globalIndex] = dsg;
-      int sourceIndex = mExtraDatasets->addDatasetGroup( dsg );
+      int sourceIndex = mExtraDatasets.addDatasetGroup( dsg );
 
       mRegistery[globalIndex] = DatasetGroup{source, sourceIndex};
     }
@@ -523,20 +519,20 @@ void QgsMeshDatasetGroupStore::eraseDatasetGroup( const QgsMeshDatasetGroupStore
 {
   if ( group.first == mPersistentProvider )
     return; //removing persistent dataset group from the store is not allowed
-  else if ( group.first == mExtraDatasets.get() )
+  else if ( group.first == &mExtraDatasets )
     eraseExtraDataset( group.second );
 }
 
 void QgsMeshDatasetGroupStore::eraseExtraDataset( int indexInExtraStore )
 {
-  mExtraDatasets->removeDatasetGroup( indexInExtraStore );
+  mExtraDatasets.removeDatasetGroup( indexInExtraStore );
 
   //search dataset with index greater than indexInExtraStore and decrement it
   QMap < int, DatasetGroup>::iterator it = mRegistery.begin();
   while ( it != mRegistery.end() )
   {
     int localIndex = it.value().second;
-    if ( it.value().first == mExtraDatasets.get() && localIndex > indexInExtraStore )
+    if ( it.value().first == &mExtraDatasets && localIndex > indexInExtraStore )
       it->second = localIndex - 1;
     ++it;
   }
@@ -628,10 +624,10 @@ void QgsMeshDatasetGroupStore::syncItemToDatasetGroup( int groupIndex )
     if ( item )
       item->setPersistentDatasetGroup( meta.uri() );
   }
-  else if ( group.first == mExtraDatasets.get() )
+  else if ( group.first == &mExtraDatasets )
   {
     if ( item )
-      item->setDatasetGroup( mExtraDatasets->datasetGroup( group.second ) );
+      item->setDatasetGroup( mExtraDatasets.datasetGroup( group.second ) );
   }
 }
 
@@ -702,7 +698,7 @@ bool QgsMeshExtraDatasetStore::hasTemporalCapabilities() const
   return mTemporalCapabilities->hasTemporalCapabilities();
 }
 
-quint64 QgsMeshExtraDatasetStore::datasetRelativeTime( QgsMeshDatasetIndex index )
+quint64 QgsMeshExtraDatasetStore::datasetRelativeTime( QgsMeshDatasetIndex index ) const
 {
   return mTemporalCapabilities->datasetTime( index );
 }

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -47,7 +47,7 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
     bool hasTemporalCapabilities() const;
 
     //! Returns the relative times of the dataset index with \a index, returned value in milliseconds
-    quint64 datasetRelativeTime( QgsMeshDatasetIndex index );
+    quint64 datasetRelativeTime( QgsMeshDatasetIndex index ) const;
 
     //! Returns information related to the dataset group with \a groupIndex
     QString description( int groupIndex ) const;
@@ -237,7 +237,7 @@ class QgsMeshDatasetGroupStore: public QObject
   private:
     QgsMeshLayer *mLayer = nullptr;
     QgsMeshDataProvider *mPersistentProvider = nullptr;
-    std::unique_ptr<QgsMeshExtraDatasetStore> mExtraDatasets;
+    QgsMeshExtraDatasetStore mExtraDatasets;
     QMap < int, DatasetGroup> mRegistery;
     QList<int> mPersistentExtraDatasetGroupIndexes;
     QMap<QString, int> mGroupNameToGlobalIndex;

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -47,7 +47,7 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
     bool hasTemporalCapabilities() const;
 
     //! Returns the relative times of the dataset index with \a index, returned value in milliseconds
-    quint64 datasetRelativeTime( QgsMeshDatasetIndex index ) const;
+    qint64 datasetRelativeTime( QgsMeshDatasetIndex index ) const;
 
     //! Returns information related to the dataset group with \a groupIndex
     QString description( int groupIndex ) const;


### PR DESCRIPTION
There's no need to make it a std::unique_ptr<> given it is always allocated in the constructor, and never assigned to another value. This removes a useless check for mExtraDatasets != nullptr.

Spotted by cppcheck
