### PR TITLE
use completeBaseName to make copc copy

### DIFF
--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -79,7 +79,7 @@ static QString _outEptDir( const QString &filename )
 {
   const QFileInfo fi( filename );
   const QDir directory = fi.absoluteDir();
-  const QString outputDir = QStringLiteral( "%1/ept_%2" ).arg( directory.absolutePath() ).arg( fi.baseName() );
+  const QString outputDir = QStringLiteral( "%1/ept_%2" ).arg( directory.absolutePath() ).arg( fi.completeBaseName() );
   return outputDir;
 }
 
@@ -87,7 +87,7 @@ static QString _outCopcFile( const QString &filename )
 {
   const QFileInfo fi( filename );
   const QDir directory = fi.absoluteDir();
-  const QString outputFile = QStringLiteral( "%1/%2.copc.laz" ).arg( directory.absolutePath() ).arg( fi.baseName() );
+  const QString outputFile = QStringLiteral( "%1/%2.copc.laz" ).arg( directory.absolutePath() ).arg( fi.completeBaseName() );
   return outputFile;
 }
 


### PR DESCRIPTION
## Description

The auxiliary copc file created when a LAS/LAZ file is opened is using `baseName()` that takes the string until the "first" dot. This PR replaces it with `completeBaseName()`  that takes the string until the "last" dot. That makes that a file that is `cloud.point.1.laz` is copied into `cloud.point.1.cocp.laz` instead of `cloud.cocp.laz` that can be problematic.
Actually if you open later another file like `cloud.point.2.laz` it did not work properly.

See https://doc.qt.io/qt-5/qfileinfo.html#completeBaseName for more info.

This bugfix is interesting to be backported.

