### PR TITLE
Add key dates to layer/project metadata

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2250,3 +2250,11 @@ QgsAction.SubmitUrlMultipart.__doc__ = "POST data to an URL using \"multipart/fo
 Qgis.AttributeActionType.__doc__ = 'Attribute action types.\n\nPrior to QGIS 3.30 this was available as :py:class:`QgsAction`.ActionType\n\n.. versionadded:: 3.30\n\n' + '* ``Generic``: ' + Qgis.AttributeActionType.Generic.__doc__ + '\n' + '* ``GenericPython``: ' + Qgis.AttributeActionType.GenericPython.__doc__ + '\n' + '* ``Mac``: ' + Qgis.AttributeActionType.Mac.__doc__ + '\n' + '* ``Windows``: ' + Qgis.AttributeActionType.Windows.__doc__ + '\n' + '* ``Unix``: ' + Qgis.AttributeActionType.Unix.__doc__ + '\n' + '* ``OpenUrl``: ' + Qgis.AttributeActionType.OpenUrl.__doc__ + '\n' + '* ``SubmitUrlEncoded``: ' + Qgis.AttributeActionType.SubmitUrlEncoded.__doc__ + '\n' + '* ``SubmitUrlMultipart``: ' + Qgis.AttributeActionType.SubmitUrlMultipart.__doc__
 # --
 Qgis.AttributeActionType.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.MetadataDateType.Created.__doc__ = "Date created"
+Qgis.MetadataDateType.Published.__doc__ = "Date published"
+Qgis.MetadataDateType.Revised.__doc__ = "Date revised"
+Qgis.MetadataDateType.Superseded.__doc__ = "Date superseded"
+Qgis.MetadataDateType.__doc__ = 'Date types for metadata.\n\n.. versionadded:: 3.30\n\n' + '* ``Created``: ' + Qgis.MetadataDateType.Created.__doc__ + '\n' + '* ``Published``: ' + Qgis.MetadataDateType.Published.__doc__ + '\n' + '* ``Revised``: ' + Qgis.MetadataDateType.Revised.__doc__ + '\n' + '* ``Superseded``: ' + Qgis.MetadataDateType.Superseded.__doc__
+# --
+Qgis.MetadataDateType.baseClass = Qgis

--- a/python/core/auto_generated/metadata/qgsabstractmetadatabase.sip.in
+++ b/python/core/auto_generated/metadata/qgsabstractmetadatabase.sip.in
@@ -401,6 +401,24 @@ Adds an individual ``link`` to the existing links.
 .. seealso:: :py:func:`setLinks`
 %End
 
+    QDateTime dateTime( Qgis::MetadataDateType type ) const;
+%Docstring
+Returns the date for the specified date ``type``.
+
+.. seealso:: :py:func:`setDateTime`
+
+.. versionadded:: 3.30
+%End
+
+    void setDateTime( Qgis::MetadataDateType type, QDateTime date );
+%Docstring
+Sets a date value for the specified date ``type``.
+
+.. seealso:: :py:func:`dateTime`
+
+.. versionadded:: 3.30
+%End
+
     virtual bool readMetadataXml( const QDomElement &metadataElement );
 %Docstring
 Sets state from DOM document.
@@ -443,6 +461,7 @@ Constructor for QgsAbstractMetadataBase.
 
 QgsAbstractMetadataBase cannot be instantiated directly, it must be subclassed.
 %End
+
 
 
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1486,6 +1486,14 @@ The development version
       SubmitUrlMultipart,
     };
 
+    enum class MetadataDateType
+    {
+      Created,
+      Published,
+      Revised,
+      Superseded,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/resources/qgis-base-metadata.xml
+++ b/resources/qgis-base-metadata.xml
@@ -13,6 +13,12 @@
         <keyword>kw1</keyword>
         <keyword>kw2</keyword>
     </keywords>
+    <dates>
+        <date type="Created" value="2020-01-01T12:13:14" />
+        <date type="Superseded" value="2020-01-02T12:13:14" />
+        <date type="Published" value="2020-01-03T12:13:14" />
+        <date type="Revised" value="2020-01-04T12:13:14" />
+    </dates>
     <contact>
         <name>John Smith</name>
         <organization>ACME</organization>

--- a/resources/qgis-base-metadata.xsd
+++ b/resources/qgis-base-metadata.xsd
@@ -66,7 +66,7 @@
 					<xs:documentation>Set of descriptive keywords associated with a given resource.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="dates" type="rm:datesType">
+			<xs:element name="dates" type="rm:datesType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Set of key dates associated with a given resource.</xs:documentation>
 				</xs:annotation>
@@ -148,7 +148,7 @@
 	</xs:complexType>
 	<xs:complexType name="datesType">
 		<xs:sequence>
-			<xs:element name="date" maxOccurs="unbounded" type="rm:dateType">
+			<xs:element name="date" minOccurs="0" maxOccurs="unbounded" type="rm:dateType">
 				<xs:annotation>
 					<xs:documentation>A date associated with a resource.</xs:documentation>
 				</xs:annotation>

--- a/resources/qgis-base-metadata.xsd
+++ b/resources/qgis-base-metadata.xsd
@@ -66,6 +66,11 @@
 					<xs:documentation>Set of descriptive keywords associated with a given resource.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="dates" type="rm:datesType">
+				<xs:annotation>
+					<xs:documentation>Set of key dates associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="contact" type="rm:contactType" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Contact person/entity associated with a given resource.</xs:documentation>
@@ -101,6 +106,25 @@
 				<xs:documentation>Reference (URI/URL preferred) to a codelist or vocabulary associated with keyword list.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="datesType">
+		<xs:sequence>
+			<xs:element name="date" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A dates associated with a resource.</xs:documentation>
+				</xs:annotation>
+				<xs:attribute name="type" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>Date type, valid values are Created, Published, Revised, Superseded.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="value" type="xs:dateTime">
+					<xs:annotation>
+						<xs:documentation>Associated datetime value.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:element>
+		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="contactType">
 		<xs:sequence>

--- a/resources/qgis-base-metadata.xsd
+++ b/resources/qgis-base-metadata.xsd
@@ -107,22 +107,51 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
+	<xs:simpleType name="dateDescriptor" final="restriction">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Created">
+				<xs:annotation>
+					<xs:documentation>Date resource was created.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Published">
+				<xs:annotation>
+					<xs:documentation>Date resource was first published.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Revised">
+				<xs:annotation>
+					<xs:documentation>Date resource was most recently revised.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Superseded">
+				<xs:annotation>
+					<xs:documentation>Date resource was superseded.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:attributeGroup name="dateAttrs">
+		<xs:attribute name="type" type="rm:dateDescriptor" use="required">
+			<xs:annotation>
+				<xs:documentation>Date type.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="value" type="xs:dateTime" use="required">
+			<xs:annotation>
+				<xs:documentation>Associated datetime value.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:complexType name="dateType">
+		<xs:attributeGroup ref="rm:dateAttrs"/>
+	</xs:complexType>
 	<xs:complexType name="datesType">
 		<xs:sequence>
-			<xs:element name="date" maxOccurs="unbounded">
+			<xs:element name="date" maxOccurs="unbounded" type="rm:dateType">
 				<xs:annotation>
-					<xs:documentation>A dates associated with a resource.</xs:documentation>
+					<xs:documentation>A date associated with a resource.</xs:documentation>
 				</xs:annotation>
-				<xs:attribute name="type" type="xs:string">
-					<xs:annotation>
-						<xs:documentation>Date type, valid values are Created, Published, Revised, Superseded.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:attribute name="value" type="xs:dateTime">
-					<xs:annotation>
-						<xs:documentation>Associated datetime value.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>

--- a/src/core/metadata/qgsabstractmetadatabase.h
+++ b/src/core/metadata/qgsabstractmetadatabase.h
@@ -20,6 +20,7 @@
 
 #include "qgis_sip.h"
 #include "qgis_core.h"
+#include "qgis.h"
 #include <QMap>
 #include <QString>
 #include <QMetaType>
@@ -503,6 +504,22 @@ class CORE_EXPORT QgsAbstractMetadataBase
     void addLink( const QgsAbstractMetadataBase::Link &link );
 
     /**
+     * Returns the date for the specified date \a type.
+     *
+     * \see setDateTime()
+     * \since QGIS 3.30
+     */
+    QDateTime dateTime( Qgis::MetadataDateType type ) const;
+
+    /**
+     * Sets a date value for the specified date \a type.
+     *
+     * \see dateTime()
+     * \since QGIS 3.30
+     */
+    void setDateTime( Qgis::MetadataDateType type, QDateTime date );
+
+    /**
      * Sets state from DOM document.
      *
      * \param metadataElement The DOM element corresponding to ``resourceMetadata'' tag
@@ -571,6 +588,9 @@ class CORE_EXPORT QgsAbstractMetadataBase
     QgsAbstractMetadataBase::ContactList mContacts;
 
     QgsAbstractMetadataBase::LinkList mLinks;
+
+    //! Metadata dates
+    QMap< Qgis::MetadataDateType, QDateTime > mDates;
 
     /*
      * IMPORTANT!!!!!!

--- a/src/core/metadata/qgsmetadatautils.cpp
+++ b/src/core/metadata/qgsmetadatautils.cpp
@@ -43,6 +43,39 @@ QgsLayerMetadata QgsMetadataUtils::convertFromEsri( const QDomDocument &document
   if ( metadata.identifier().isEmpty()  && !title.isEmpty() )
     metadata.setIdentifier( title );
 
+  const QDomElement citationDatesElement = idCitation.firstChildElement( QStringLiteral( "date" ) ).toElement();
+  if ( !citationDatesElement.isNull() )
+  {
+    {
+      const QDomElement createDateElement = citationDatesElement.firstChildElement( QStringLiteral( "createDate" ) ).toElement();
+      if ( !createDateElement.isNull() )
+      {
+        metadata.setDateTime( Qgis::MetadataDateType::Created, QDateTime::fromString( createDateElement.text(), Qt::ISODate ) );
+      }
+    }
+    {
+      const QDomElement pubDateElement = citationDatesElement.firstChildElement( QStringLiteral( "pubDate" ) ).toElement();
+      if ( !pubDateElement.isNull() )
+      {
+        metadata.setDateTime( Qgis::MetadataDateType::Published, QDateTime::fromString( pubDateElement.text(), Qt::ISODate ) );
+      }
+    }
+    {
+      const QDomElement reviseDateElement = citationDatesElement.firstChildElement( QStringLiteral( "reviseDate" ) ).toElement();
+      if ( !reviseDateElement.isNull() )
+      {
+        metadata.setDateTime( Qgis::MetadataDateType::Revised, QDateTime::fromString( reviseDateElement.text(), Qt::ISODate ) );
+      }
+    }
+    {
+      const QDomElement supersededDateElement = citationDatesElement.firstChildElement( QStringLiteral( "supersDate" ) ).toElement();
+      if ( !supersededDateElement.isNull() )
+      {
+        metadata.setDateTime( Qgis::MetadataDateType::Superseded, QDateTime::fromString( supersededDateElement.text(), Qt::ISODate ) );
+      }
+    }
+  }
+
   // abstract
   const QDomElement idAbs = dataIdInfo.firstChildElement( QStringLiteral( "idAbs" ) );
   const QString abstractPlainText = QTextDocumentFragment::fromHtml( idAbs.text() ).toPlainText();

--- a/src/core/metadata/qgsprojectmetadata.cpp
+++ b/src/core/metadata/qgsprojectmetadata.cpp
@@ -29,9 +29,13 @@ bool QgsProjectMetadata::readMetadataXml( const QDomElement &metadataElement )
   mnl = metadataElement.namedItem( QStringLiteral( "author" ) );
   mAuthor = mnl.toElement().text();
 
-  // creation datetime
-  mnl = metadataElement.namedItem( QStringLiteral( "creation" ) );
-  mCreationDateTime = QDateTime::fromString( mnl.toElement().text(), Qt::ISODate );
+  if ( !mDates.contains( Qgis::MetadataDateType::Created ) )
+  {
+    // creation datetime -- old format
+    mnl = metadataElement.namedItem( QStringLiteral( "creation" ) );
+    const QDateTime creationDateTime = QDateTime::fromString( mnl.toElement().text(), Qt::ISODate );
+    mDates.insert( Qgis::MetadataDateType::Created, creationDateTime );
+  }
 
   return true;
 }
@@ -48,7 +52,7 @@ bool QgsProjectMetadata::writeMetadataXml( QDomElement &metadataElement, QDomDoc
 
   // creation datetime
   QDomElement creation = document.createElement( QStringLiteral( "creation" ) );
-  const QDomText creationText = document.createTextNode( mCreationDateTime.toString( Qt::ISODate ) );
+  const QDomText creationText = document.createTextNode( mDates.value( Qgis::MetadataDateType::Created ).toString( Qt::ISODate ) );
   creation.appendChild( creationText );
   metadataElement.appendChild( creation );
 
@@ -63,17 +67,13 @@ void QgsProjectMetadata::combine( const QgsAbstractMetadataBase *other )
   {
     if ( !otherProjectMetadata->author().isEmpty() )
       mAuthor = otherProjectMetadata->author();
-
-    if ( otherProjectMetadata->creationDateTime().isValid() )
-      mCreationDateTime = otherProjectMetadata->creationDateTime();
   }
 }
 
 bool QgsProjectMetadata::operator==( const QgsProjectMetadata &metadataOther )  const
 {
   return equals( metadataOther ) &&
-         mAuthor == metadataOther.mAuthor &&
-         mCreationDateTime == metadataOther.mCreationDateTime ;
+         mAuthor == metadataOther.mAuthor;
 }
 
 QgsProjectMetadata *QgsProjectMetadata::clone() const
@@ -93,10 +93,10 @@ void QgsProjectMetadata::setAuthor( const QString &author )
 
 QDateTime QgsProjectMetadata::creationDateTime() const
 {
-  return mCreationDateTime;
+  return mDates.value( Qgis::MetadataDateType::Created );
 }
 
 void QgsProjectMetadata::setCreationDateTime( const QDateTime &creationDateTime )
 {
-  mCreationDateTime = creationDateTime;
+  mDates[ Qgis::MetadataDateType::Created ] = creationDateTime;
 }

--- a/src/core/metadata/qgsprojectmetadata.h
+++ b/src/core/metadata/qgsprojectmetadata.h
@@ -103,8 +103,6 @@ class CORE_EXPORT QgsProjectMetadata : public QgsAbstractMetadataBase
 
     QString mAuthor;
 
-    QDateTime mCreationDateTime;
-
     /*
      * IMPORTANT!!!!!!
      *

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2582,6 +2582,20 @@ class CORE_EXPORT Qgis
     Q_ENUM( AttributeActionType )
 
     /**
+     * Date types for metadata.
+     *
+     * \since QGIS 3.30
+     */
+    enum class MetadataDateType
+    {
+      Created, //!< Date created
+      Published, //!< Date published
+      Revised, //!< Date revised
+      Superseded, //!< Date superseded
+    };
+    Q_ENUM( MetadataDateType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -83,6 +83,19 @@ QgsMetadataWidget::QgsMetadataWidget( QWidget *parent, QgsMapLayer *layer )
   mHistoryModel = new QStringListModel( listHistory );
   listHistory->setModel( mHistoryModel );
 
+  for ( QgsDateTimeEdit *w :
+        {
+          mCreationDateTimeEdit,
+          mCreationDateTimeEdit2,
+          mPublishedDateTimeEdit,
+          mRevisedDateTimeEdit,
+          mSupersededDateTimeEdit
+        } )
+  {
+    w->setAllowNull( true );
+    w->setNullRepresentation( tr( "Not set" ) );
+  }
+
   // Connect signals and slots
   connect( tabWidget, &QTabWidget::currentChanged, this, &QgsMetadataWidget::updatePanel );
   connect( btnAutoSource, &QPushButton::clicked, this, &QgsMetadataWidget::fillSourceFromLayer );
@@ -147,6 +160,23 @@ void QgsMetadataWidget::setMode( QgsMetadataWidget::Mode mode )
       tabWidget->removeTab( 4 );
       tabWidget->removeTab( 3 );
       btnAutoSource->setEnabled( true );
+
+      // these two widgets should be kept in sync
+      connect( mCreationDateTimeEdit, &QDateTimeEdit::dateTimeChanged, this, [ = ]( const QDateTime & value )
+      {
+        if ( value.isValid() )
+          mCreationDateTimeEdit2->setDateTime( value );
+        else if ( mCreationDateTimeEdit2->dateTime().isValid() )
+          mCreationDateTimeEdit2->clear();
+      } );
+      connect( mCreationDateTimeEdit2, &QDateTimeEdit::dateTimeChanged, this, [ = ]( const QDateTime & value )
+      {
+        if ( value.isValid() )
+          mCreationDateTimeEdit->setDateTime( value );
+        else if ( mCreationDateTimeEdit->dateTime().isValid() )
+          mCreationDateTimeEdit->clear();
+      } );
+
       break;
   }
 
@@ -583,7 +613,6 @@ void QgsMetadataWidget::setUiFromMetadata()
   else if ( QgsProjectMetadata *projectMetadata = dynamic_cast< QgsProjectMetadata * >( mMetadata.get() ) )
   {
     mLineEditAuthor->setText( projectMetadata->author() );
-    mCreationDateTimeEdit->setDateTime( projectMetadata->creationDateTime() );
   }
 
   // Contacts
@@ -635,6 +664,27 @@ void QgsMetadataWidget::setUiFromMetadata()
 
   // History
   mHistoryModel->setStringList( mMetadata->history() );
+
+  // dates
+  if ( mMetadata->dateTime( Qgis::MetadataDateType::Created ).isValid() )
+    mCreationDateTimeEdit2->setDateTime( mMetadata->dateTime( Qgis::MetadataDateType::Created ) );
+  else
+    mCreationDateTimeEdit2->clear();
+
+  if ( mMetadata->dateTime( Qgis::MetadataDateType::Published ).isValid() )
+    mPublishedDateTimeEdit->setDateTime( mMetadata->dateTime( Qgis::MetadataDateType::Published ) );
+  else
+    mPublishedDateTimeEdit->clear();
+
+  if ( mMetadata->dateTime( Qgis::MetadataDateType::Revised ).isValid() )
+    mRevisedDateTimeEdit->setDateTime( mMetadata->dateTime( Qgis::MetadataDateType::Revised ) );
+  else
+    mRevisedDateTimeEdit->clear();
+
+  if ( mMetadata->dateTime( Qgis::MetadataDateType::Superseded ).isValid() )
+    mSupersededDateTimeEdit->setDateTime( mMetadata->dateTime( Qgis::MetadataDateType::Superseded ) );
+  else
+    mSupersededDateTimeEdit->clear();
 }
 
 void QgsMetadataWidget::saveMetadata( QgsAbstractMetadataBase *metadata )
@@ -718,7 +768,6 @@ void QgsMetadataWidget::saveMetadata( QgsAbstractMetadataBase *metadata )
     {
       QgsProjectMetadata *projectMetadata = static_cast< QgsProjectMetadata * >( metadata );
       projectMetadata->setAuthor( mLineEditAuthor->text() );
-      projectMetadata->setCreationDateTime( mCreationDateTimeEdit->dateTime() );
       break;
     }
   }
@@ -770,6 +819,12 @@ void QgsMetadataWidget::saveMetadata( QgsAbstractMetadataBase *metadata )
 
   // History
   metadata->setHistory( mHistoryModel->stringList() );
+
+  // dates
+  metadata->setDateTime( Qgis::MetadataDateType::Created, mCreationDateTimeEdit2->dateTime() );
+  metadata->setDateTime( Qgis::MetadataDateType::Published, mPublishedDateTimeEdit->dateTime() );
+  metadata->setDateTime( Qgis::MetadataDateType::Revised, mRevisedDateTimeEdit->dateTime() );
+  metadata->setDateTime( Qgis::MetadataDateType::Superseded, mSupersededDateTimeEdit->dateTime() );
 }
 
 bool QgsMetadataWidget::checkMetadata()

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -68,7 +68,7 @@
             <x>0</x>
             <y>0</y>
             <width>786</width>
-            <height>670</height>
+            <height>687</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -205,7 +205,7 @@
                </widget>
               </item>
               <item row="2" column="1">
-               <widget class="QDateTimeEdit" name="mCreationDateTimeEdit">
+               <widget class="QgsDateTimeEdit" name="mCreationDateTimeEdit">
                 <property name="displayFormat">
                  <string>yyyy-MM-dd HH:mm:ss</string>
                 </property>
@@ -669,7 +669,7 @@
             <x>0</x>
             <y>0</y>
             <width>800</width>
-            <height>637</height>
+            <height>636</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1075,7 +1075,7 @@
               <x>0</x>
               <y>0</y>
               <width>778</width>
-              <height>592</height>
+              <height>590</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
@@ -1404,6 +1404,95 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_17">
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Key Dates</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="1">
+           <widget class="QgsDateTimeEdit" name="mCreationDateTimeEdit2">
+            <property name="displayFormat">
+             <string>yyyy-MM-dd HH:mm:ss</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QgsDateTimeEdit" name="mPublishedDateTimeEdit">
+            <property name="displayFormat">
+             <string>yyyy-MM-dd HH:mm:ss</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="toolTip">
+             <string>Returns the human readable name of the resource, typically displayed in search results.</string>
+            </property>
+            <property name="text">
+             <string>Revised</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsDateTimeEdit" name="mRevisedDateTimeEdit">
+            <property name="displayFormat">
+             <string>yyyy-MM-dd HH:mm:ss</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="toolTip">
+             <string>Returns the human readable name of the resource, typically displayed in search results.</string>
+            </property>
+            <property name="text">
+             <string>Published</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsDateTimeEdit" name="mSupersededDateTimeEdit">
+            <property name="displayFormat">
+             <string>yyyy-MM-dd HH:mm:ss</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="toolTip">
+             <string>Returns the human readable name of the resource, typically displayed in search results.</string>
+            </property>
+            <property name="text">
+             <string>Created</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_30">
+            <property name="toolTip">
+             <string>Returns the human readable name of the resource, typically displayed in search results.</string>
+            </property>
+            <property name="text">
+             <string>Superseded</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="mLabelHistory">
          <property name="text">
           <string notr="true">Label text set in qgsmetadatawidget.cpp</string>
@@ -1567,12 +1656,17 @@
   <tabstop>btnAddLink</tabstop>
   <tabstop>btnRemoveLink</tabstop>
   <tabstop>tabLinks</tabstop>
+  <tabstop>mCreationDateTimeEdit2</tabstop>
+  <tabstop>mPublishedDateTimeEdit</tabstop>
+  <tabstop>mRevisedDateTimeEdit</tabstop>
+  <tabstop>mSupersededDateTimeEdit</tabstop>
   <tabstop>btnAddHistory</tabstop>
   <tabstop>btnRemoveHistory</tabstop>
   <tabstop>listHistory</tabstop>
   <tabstop>resultsCheckMetadata</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/tests/src/python/test_qgsmetadatabase.py
+++ b/tests/src/python/test_qgsmetadatabase.py
@@ -21,7 +21,8 @@ from qgis.core import (QgsAbstractMetadataBase,
                        QgsVectorLayer,
                        QgsNativeMetadataBaseValidator,
                        QgsBox3d,
-                       QgsDateTimeRange)
+                       QgsDateTimeRange,
+                       Qgis)
 from qgis.PyQt.QtCore import (QDate,
                               QTime,
                               QDateTime)
@@ -66,6 +67,16 @@ class TestQgsMetadataBase(unittest.TestCase):
         self.assertEqual(m.history(), ['accidentally deleted some features'])
         m.addHistoryItem('panicked and deleted more')
         self.assertEqual(m.history(), ['accidentally deleted some features', 'panicked and deleted more'])
+
+        m.setDateTime(Qgis.MetadataDateType.Published, QDateTime(QDate(2022, 1, 2), QTime(12, 13, 14)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published), QDateTime(QDate(2022, 1, 2), QTime(12, 13, 14)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created),
+                         QDateTime())
+        m.setDateTime(Qgis.MetadataDateType.Created,
+                      QDateTime(QDate(2020, 1, 2), QTime(12, 13, 14)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published), QDateTime(QDate(2022, 1, 2), QTime(12, 13, 14)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created),
+                         QDateTime(QDate(2020, 1, 2), QTime(12, 13, 14)))
 
     def testEquality(self):
         a = QgsAbstractMetadataBase.Address()
@@ -342,6 +353,14 @@ class TestQgsMetadataBase(unittest.TestCase):
 
         m.setLinks([l, l2, l3])
 
+        m.setDateTime(Qgis.MetadataDateType.Created, QDateTime(QDate(2020, 1, 2), QTime(11, 12, 13)))
+        m.setDateTime(Qgis.MetadataDateType.Published,
+                      QDateTime(QDate(2020, 1, 3), QTime(11, 12, 13)))
+        m.setDateTime(Qgis.MetadataDateType.Revised,
+                      QDateTime(QDate(2020, 1, 4), QTime(11, 12, 13)))
+        m.setDateTime(Qgis.MetadataDateType.Superseded,
+                      QDateTime(QDate(2020, 1, 5), QTime(11, 12, 13)))
+
         return m
 
     def checkExpectedMetadata(self, m):
@@ -387,6 +406,14 @@ class TestQgsMetadataBase(unittest.TestCase):
         self.assertEqual(m.links()[2].format, 'ESRI Shapefile')
         self.assertEqual(m.links()[2].mimeType, 'application/gzip')
         self.assertEqual(m.links()[2].size, '283676')
+
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created), QDateTime(QDate(2020, 1, 2), QTime(11, 12, 13)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published),
+                         QDateTime(QDate(2020, 1, 3), QTime(11, 12, 13)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime(QDate(2020, 1, 4), QTime(11, 12, 13)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 5), QTime(11, 12, 13)))
 
     def testStandard(self):
         m = self.createTestMetadata()
@@ -622,6 +649,19 @@ class TestQgsMetadataBase(unittest.TestCase):
         m2.setLinks([QgsAbstractMetadataBase.Link('l2'), QgsAbstractMetadataBase.Link('ll2')])
         m1.combine(m2)
         self.assertEqual(m1.links(), [QgsAbstractMetadataBase.Link('l2'), QgsAbstractMetadataBase.Link('ll2')])
+
+        m1.setDateTime(Qgis.MetadataDateType.Created, QDateTime(QDate(2020, 1, 2), QTime(1, 2, 3)))
+        m1.setDateTime(Qgis.MetadataDateType.Revised, QDateTime(QDate(2020, 1, 3), QTime(1, 2, 3)))
+
+        m2.setDateTime(Qgis.MetadataDateType.Revised, QDateTime(QDate(2020, 1, 4), QTime(1, 2, 3)))
+        m2.setDateTime(Qgis.MetadataDateType.Superseded, QDateTime(QDate(2020, 1, 5), QTime(1, 2, 3)))
+        m1.combine(m2)
+
+        self.assertEqual(m1.dateTime(Qgis.MetadataDateType.Created), QDateTime(QDate(2020, 1, 2), QTime(1, 2, 3)))
+        self.assertEqual(m1.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime(QDate(2020, 1, 4), QTime(1, 2, 3)))
+        self.assertEqual(m1.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 5), QTime(1, 2, 3)))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsmetadatautils.py
+++ b/tests/src/python/test_qgsmetadatautils.py
@@ -13,7 +13,8 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 from qgis.PyQt.QtCore import QDateTime
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
-    QgsMetadataUtils
+    QgsMetadataUtils,
+    Qgis
 )
 from qgis.testing import (start_app,
                           unittest,
@@ -51,6 +52,11 @@ class TestPyQgsMetadataUtils(unittest.TestCase):
         self.assertEqual(metadata.extent().spatialExtents()[0].bounds.yMinimum(), -29.177948)
         self.assertEqual(metadata.extent().spatialExtents()[0].bounds.yMaximum(), -9.373145)
         self.assertEqual(metadata.extent().spatialExtents()[0].extentCrs.authid(), 'EPSG:4283')
+
+        self.assertEqual(metadata.dateTime(Qgis.MetadataDateType.Created), QDateTime(2022, 11, 1, 0, 0))
+        self.assertEqual(metadata.dateTime(Qgis.MetadataDateType.Published), QDateTime(2016, 6, 28, 0, 0))
+        self.assertEqual(metadata.dateTime(Qgis.MetadataDateType.Revised), QDateTime(2022, 11, 5, 0, 0))
+        self.assertEqual(metadata.dateTime(Qgis.MetadataDateType.Superseded), QDateTime(2022, 11, 12, 0, 0))
 
         self.assertEqual(metadata.licenses(), ['This material is licensed under a CC4'])
         self.assertEqual(metadata.rights(), ['The State of Queensland (Department of Natural Resources and Mines)',

--- a/tests/src/python/test_qgsmetadatawidget.py
+++ b/tests/src/python/test_qgsmetadatawidget.py
@@ -16,7 +16,8 @@ import qgis  # NOQA
 
 from qgis.PyQt.QtXml import QDomDocument
 
-from qgis.core import (QgsCoordinateReferenceSystem,
+from qgis.core import (Qgis,
+                       QgsCoordinateReferenceSystem,
                        QgsAbstractMetadataBase,
                        QgsLayerMetadata,
                        QgsProjectMetadata,
@@ -113,6 +114,12 @@ class TestQgsMetadataWidget(unittest.TestCase):
 
         m.setLinks([l, l2, l3])
 
+        m.setDateTime(Qgis.MetadataDateType.Published, QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        m.setDateTime(Qgis.MetadataDateType.Revised,
+                      QDateTime(QDate(2020, 1, 3), QTime(3, 4, 5)))
+        m.setDateTime(Qgis.MetadataDateType.Superseded,
+                      QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
         # set widget metadata
         w.setMetadata(m)
         self.assertEqual(w.mode(), QgsMetadataWidget.LayerMetadata)
@@ -175,6 +182,86 @@ class TestQgsMetadataWidget(unittest.TestCase):
         self.assertEqual(m.links()[2].format, 'ESRI Shapefile')
         self.assertEqual(m.links()[2].mimeType, 'application/gzip')
         self.assertEqual(m.links()[2].size, '283676')
+
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published), QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime(QDate(2020, 1, 3), QTime(3, 4, 5)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+    def testDates(self):
+        """
+        Test date handling
+        """
+        w = QgsMetadataWidget()
+
+        m = QgsLayerMetadata()
+
+        m.setDateTime(Qgis.MetadataDateType.Created,
+                      QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        m.setDateTime(Qgis.MetadataDateType.Superseded,
+                      QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+        # set widget metadata
+        w.setMetadata(m)
+
+        m = w.metadata()
+
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created),
+                         QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+        # with project metadata
+        w = QgsMetadataWidget()
+
+        m = QgsProjectMetadata()
+
+        m.setDateTime(Qgis.MetadataDateType.Created,
+                      QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        m.setDateTime(Qgis.MetadataDateType.Superseded,
+                      QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+        # set widget metadata
+        w.setMetadata(m)
+
+        m = w.metadata()
+
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created),
+                         QDateTime(QDate(2020, 1, 2), QTime(3, 4, 5)))
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+        w = QgsMetadataWidget()
+
+        m = QgsProjectMetadata()
+
+        m.setDateTime(Qgis.MetadataDateType.Created,
+                      QDateTime())
+        m.setDateTime(Qgis.MetadataDateType.Superseded,
+                      QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
+
+        # set widget metadata
+        w.setMetadata(m)
+
+        m = w.metadata()
+
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Created),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Published),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Revised),
+                         QDateTime())
+        self.assertEqual(m.dateTime(Qgis.MetadataDateType.Superseded),
+                         QDateTime(QDate(2020, 1, 4), QTime(3, 4, 5)))
 
     def testProjectMode(self):
         """

--- a/tests/testdata/esri_metadata.xml
+++ b/tests/testdata/esri_metadata.xml
@@ -141,6 +141,10 @@
       <resTitle Sync="FALSE">Baseline roads and tracks Queensland</resTitle>
       <date>
         <pubDate>2016-06-28T00:00:00</pubDate>
+        <createDate>2022-11-01T00:00:00</createDate>
+        <reviseDate>2022-11-05T00:00:00</reviseDate>
+        <deprecDate>2022-11-29T00:00:00</deprecDate>
+        <supersDate>2022-11-12T00:00:00</supersDate>
       </date>
       <citRespParty>
         <rpIndName>DNRM, NR, LSI, ED</rpIndName>


### PR DESCRIPTION
This adds the following fields to the QGIS layer/project metadata standard:

- Date created
- Date published
- Date revised
- Date superseded

(Previously the layer metadata had no date fields, and project metadata had only the created date field)
