### PR TITLE
Don't show a empty geometry field when expanding aspatial GPKG tables in browser

### DIFF
--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -535,7 +535,7 @@ QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const 
     }
     // Append name of the geometry column, the data provider does not expose this information so we need an extra query:/
     const QString sql = QStringLiteral( "SELECT g.column_name "
-                                        "FROM gpkg_contents c LEFT JOIN gpkg_geometry_columns g ON (c.table_name = g.table_name) "
+                                        "FROM gpkg_contents c CROSS JOIN gpkg_geometry_columns g ON (c.table_name = g.table_name) "
                                         "WHERE c.table_name = %1" ).arg( QgsSqliteUtils::quotedString( table ) );
     try
     {

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -158,6 +158,13 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         self.assertIn(table_info.primaryKeyColumns()[0], fields.names())
         self.assertEqual(fields.names(), ['fid', 'id', 'typ', 'name', 'ortsrat', 'id_long', 'geom'])
 
+        # aspatial table
+        fields = conn.fields('', 'myNewAspatialTable')
+        table_info = conn.table('', 'myNewAspatialTable')
+        self.assertFalse(table_info.geometryColumn())
+        self.assertIn(table_info.primaryKeyColumns()[0], fields.names())
+        self.assertEqual(fields.names(), ['fid'])
+
     @unittest.skipIf(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(3, 5, 0), "GDAL 3.5 required")
     def test_gpkg_field_domain_names(self):
         """


### PR DESCRIPTION
Avoids this:
![image](https://user-images.githubusercontent.com/1829991/204196576-abface60-c1b2-42e4-b8c7-c465cdc9c5a9.png)


(from https://github.com/qgis/QGIS/pull/49504#issuecomment-1313871043 )
