### PR TITLE
[RelationEditor] Don't recreate QgsDualView when only request has changed

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -618,8 +618,8 @@ void QgsRelationEditorWidget::updateUiSingleEdit()
 
   mStackedWidget->setCurrentWidget( mDualView );
 
-  const QgsFeatureRequest request = mRelation.getRelatedFeaturesRequest( mFeatureList.first() );
-
+  QgsFeatureRequest request = mRelation.getRelatedFeaturesRequest( mFeatureList.first() );
+  QgsVectorLayer *layer = nullptr;
   if ( mNmRelation.isValid() )
   {
     QgsFeatureIterator it = mRelation.referencingLayer()->getFeatures( request );
@@ -635,11 +635,26 @@ void QgsRelationEditorWidget::updateUiSingleEdit()
     QgsFeatureRequest nmRequest;
     nmRequest.setFilterExpression( filters.join( QLatin1String( " OR " ) ) );
 
-    initDualView( mNmRelation.referencedLayer(), nmRequest );
+    request = nmRequest;
+    layer = mNmRelation.referencedLayer();
   }
   else if ( mRelation.referencingLayer() )
   {
-    initDualView( mRelation.referencingLayer(), request );
+    layer = mRelation.referencingLayer();
+  }
+
+  if ( !layer )
+    return;
+
+  // don't recreate all the widget from scratch if only the request has changed
+  if ( !mDualView->masterModel() || layer != mDualView->masterModel()->layer() )
+  {
+    initDualView( layer, request );
+  }
+  else
+  {
+    mDualView->setRequest( request );
+    mDualView->masterModel()->loadLayer();
   }
 }
 

--- a/tests/src/gui/testqgsrelationeditorwidget.cpp
+++ b/tests/src/gui/testqgsrelationeditorwidget.cpp
@@ -23,6 +23,7 @@
 #include <qgsrelationeditorwidget.h>
 #include <qgsrelationmanager.h>
 #include <qgsrelationreferencewidget.h>
+#include <qgstrackedvectorlayertools.h>
 
 #include <QTreeWidgetItem>
 
@@ -40,6 +41,7 @@ class TestQgsRelationEditorWidget : public QObject
 
     void testMultiEdit1N();
     void testMultiEditNM();
+    void testUpdateUi();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -281,6 +283,73 @@ void TestQgsRelationEditorWidget::testMultiEditNM()
             << QStringLiteral( "Layer2-11" )
             << QStringLiteral( "Layer2-11" ) );
 
+}
+
+void TestQgsRelationEditorWidget::testUpdateUi()
+{
+  // Test that we don't recreate all the widget when only the request have been updated
+
+  QgsTrackedVectorLayerTools tools;
+
+  // Init a relation editor widget
+  QgsRelationEditorWidget relationEditorWidget( ( QVariantMap() ) );
+  relationEditorWidget.setRelations( *mRelation, QgsRelation() );
+  QgsAttributeEditorContext context;
+  context.setVectorLayerTools( &tools );
+  relationEditorWidget.setEditorContext( context );
+
+  QVERIFY( !relationEditorWidget.multiEditModeActive() );
+
+  relationEditorWidget.setVisible( true );
+
+  QgsFeature feat = mLayer2->getFeature( 1 );
+  QVERIFY( feat.isValid() );
+  relationEditorWidget.setFeature( feat );
+
+  QVERIFY( relationEditorWidget.mDualView );
+
+  QPointer<QAbstractItemModel> model = relationEditorWidget.mDualView->masterModel();
+  QVERIFY( model );
+
+  QCOMPARE( model->rowCount(), 1 );
+  QCOMPARE( model->data( model->index( 0, 0 ) ), 0 );
+
+  feat = mLayer2->getFeature( 2 );
+  QVERIFY( feat.isValid() );
+  relationEditorWidget.setFeature( feat );
+
+  // model hasn't changed (old one has not being destroyed)
+  QVERIFY( model );
+  QCOMPARE( model->rowCount(), 1 );
+  QCOMPARE( model->data( model->index( 0, 0 ) ), 1 );
+
+  // Now try with NM relations
+  relationEditorWidget.setRelations( *mRelationNM, *mRelation1N );
+  // model has not been destroyed (mLayer1 is still the displayed layer)
+  QVERIFY( model );
+
+  feat = mLayer2->getFeature( 1 );
+  QVERIFY( feat.isValid() );
+  relationEditorWidget.setFeature( feat );
+
+  // model not destroyed, set request only
+  QCOMPARE( model->rowCount(), 1 );
+  QCOMPARE( model->data( model->index( 0, 0 ) ), 0 );
+
+  relationEditorWidget.setRelations( *mRelation1N, *mRelationNM );
+  // model has been destroyed (mLayer2 is now the displayed layer)
+  QVERIFY( !model );
+  model = relationEditorWidget.mDualView->masterModel();
+
+  feat = mLayer1->getFeature( 1 );
+  QVERIFY( feat.isValid() );
+  relationEditorWidget.setFeature( feat );
+
+  // model not destroyed, set request only
+  QVERIFY( model );
+  QCOMPARE( model->rowCount(), 2 );
+  QCOMPARE( model->data( model->index( 0, 0 ) ), 10 );
+  QCOMPARE( model->data( model->index( 1, 0 ) ), 11 );
 }
 
 QGSTEST_MAIN( TestQgsRelationEditorWidget )


### PR DESCRIPTION
It avoids to recreate attributetablemodel and so, field formatters that could trigger Postgres requests.

For instance with sample project attached in #47797, and with also #50986 we can switch from one feature to another in less than one second, instead of 14s before.

**Sponsored by National Land Survey of Finland, City of Tampere and Gispo Ltd**