### PR TITLE
Fix WMS layers cannot be identified on QGIS

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1089,7 +1089,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
         value = QgsStringUtils::insertLinks( value );
         value.prepend( QStringLiteral( "<pre style=\"font-family: monospace;\">" ) ).append( QStringLiteral( "</pre>" ) );
       }
-      attrItem->setHtml( value );
+      attrItem->setContent( value.toUtf8(), QStringLiteral( "text/html" ) );
     }
     else
     {


### PR DESCRIPTION
This is an attempt to fix a regression of #23519, which was likely introduced in 0acc056.