### PR TITLE
Include <cmath> as required to use std::fabs

### DIFF
--- a/src/gui/plot/qgsplotrubberband.cpp
+++ b/src/gui/plot/qgsplotrubberband.cpp
@@ -20,7 +20,7 @@
 
 #include <QGraphicsScene>
 #include <QGraphicsRectItem>
-#include <math.h>
+#include <cmath>
 
 QgsPlotRubberBand::QgsPlotRubberBand( QgsPlotCanvas *canvas )
   : mCanvas( canvas )


### PR DESCRIPTION
Previously, math.h was included instead, but this is C++ code.   The C++ standards say that cmath is required to use std::fabs.

I have built 3.28.1 with this change under NetBSD 9 amd64, in a pkgsrc environment, and after installing the package everything seems to work.  Without the change, the compiler objected to use of std::fabs.

This change should be backported to 3.28.

