### PR TITLE
Add methods for creating/updating/deleting relationship to QgsAbstractDatabaseProviderConnection

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -358,6 +358,8 @@ This information is calculated from the geometry columns types.
       RenameField,
       RetrieveRelationships,
       AddRelationship,
+      UpdateRelationship,
+      DeleteRelationship,
     };
     typedef QFlags<QgsAbstractDatabaseProviderConnection::Capability> Capabilities;
 
@@ -802,6 +804,24 @@ forms the left (or "parent" / "referenced") side of the relationship are retriev
     virtual void addRelationship( const QgsWeakRelation &relationship ) const throw( QgsProviderConnectionException );
 %Docstring
 Adds a new field ``relationship`` to the database.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+
+.. versionadded:: 3.30
+%End
+
+    virtual void updateRelationship( const QgsWeakRelation &relationship ) const throw( QgsProviderConnectionException );
+%Docstring
+Updates an existing ``relationship`` in the database.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+
+.. versionadded:: 3.30
+%End
+
+    virtual void deleteRelationship( const QgsWeakRelation &relationship ) const throw( QgsProviderConnectionException );
+%Docstring
+Deletes an existing ``relationship`` in the database.
 
 :raises QgsProviderConnectionException: if any errors are encountered.
 

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -357,6 +357,7 @@ This information is calculated from the geometry columns types.
       AddFieldDomain,
       RenameField,
       RetrieveRelationships,
+      AddRelationship,
     };
     typedef QFlags<QgsAbstractDatabaseProviderConnection::Capability> Capabilities;
 
@@ -796,6 +797,15 @@ forms the left (or "parent" / "referenced") side of the relationship are retriev
 :raises QgsProviderConnectionException: if any errors are encountered.
 
 .. versionadded:: 3.28
+%End
+
+    virtual void addRelationship( const QgsWeakRelation &relationship ) const throw( QgsProviderConnectionException );
+%Docstring
+Adds a new field ``relationship`` to the database.
+
+:raises QgsProviderConnectionException: if any errors are encountered.
+
+.. versionadded:: 3.30
 %End
 
     virtual QgsProviderSqlQueryBuilder *queryBuilder() const /Factory/;

--- a/python/core/auto_generated/qgsweakrelation.sip.in
+++ b/python/core/auto_generated/qgsweakrelation.sip.in
@@ -44,6 +44,23 @@ and cannot be translated to :py:class:`QgsRelations` or respected in QGIS relati
 Default constructor for an invalid relation.
 %End
 
+    QgsWeakRelation( const QString &relationId,
+                     const QString &relationName,
+                     const Qgis::RelationshipStrength strength,
+                     const QString &referencingLayerId,
+                     const QString &referencingLayerName,
+                     const QString &referencingLayerSource,
+                     const QString &referencingLayerProviderKey,
+                     const QString &referencedLayerId,
+                     const QString &referencedLayerName,
+                     const QString &referencedLayerSource,
+                     const QString &referencedLayerProviderKey
+                   );
+%Docstring
+Creates a QgsWeakRelation.
+
+.. versionadded:: 3.30
+%End
 
     QList< QgsRelation > resolvedRelations( const QgsProject *project ) const;
 %Docstring

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -1016,7 +1016,7 @@ void QgsOgrProviderConnection::addRelationship( const QgsWeakRelation &relations
     throw QgsProviderConnectionException( QObject::tr( "There was an error opening the dataset %1!" ).arg( uri() ) );
   }
 #else
-  Q_UNUSED( tableName )
+  Q_UNUSED( relationship )
   throw QgsProviderConnectionException( QObject::tr( "Adding relationships for datasets requires GDAL 3.6 or later" ) );
 #endif
 }
@@ -1061,7 +1061,7 @@ void QgsOgrProviderConnection::updateRelationship( const QgsWeakRelation &relati
     throw QgsProviderConnectionException( QObject::tr( "There was an error opening the dataset %1!" ).arg( uri() ) );
   }
 #else
-  Q_UNUSED( tableName )
+  Q_UNUSED( relationship )
   throw QgsProviderConnectionException( QObject::tr( "Updating relationships for datasets requires GDAL 3.6 or later" ) );
 #endif
 }
@@ -1091,7 +1091,7 @@ void QgsOgrProviderConnection::deleteRelationship( const QgsWeakRelation &relati
     throw QgsProviderConnectionException( QObject::tr( "There was an error opening the dataset %1!" ).arg( uri() ) );
   }
 #else
-  Q_UNUSED( tableName )
+  Q_UNUSED( relationship )
   throw QgsProviderConnectionException( QObject::tr( "Deleting relationships for datasets requires GDAL 3.6 or later" ) );
 #endif
 }

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -27,7 +27,6 @@
 #include "qgsdbquerylog.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsweakrelation.h"
-#include "qgsgdalutils.h"
 
 #include <QTextCodec>
 #include <QRegularExpression>
@@ -832,7 +831,7 @@ void QgsOgrProviderConnection::addFieldDomain( const QgsFieldDomain &domain, con
       if ( !GDALDatasetAddFieldDomain( hDS.get(), ogrDomain, &failureReason ) )
       {
         OGR_FldDomain_Destroy( ogrDomain );
-        QString error( failureReason );
+        const QString error( failureReason );
         CPLFree( failureReason );
         throw QgsProviderConnectionException( QObject::tr( "Could not create field domain: %1" ).arg( error ) );
       }
@@ -1004,7 +1003,7 @@ void QgsOgrProviderConnection::addRelationship( const QgsWeakRelation &relations
     char *failureReason = nullptr;
     if ( !GDALDatasetAddRelationship( hDS.get(), relationH.get(), &failureReason ) )
     {
-      QString error( failureReason );
+      const QString error( failureReason );
       CPLFree( failureReason );
       throw QgsProviderConnectionException( QObject::tr( "Could not create relationship: %1" ).arg( error ) );
     }
@@ -1049,7 +1048,7 @@ void QgsOgrProviderConnection::updateRelationship( const QgsWeakRelation &relati
     char *failureReason = nullptr;
     if ( !GDALDatasetUpdateRelationship( hDS.get(), relationH.get(), &failureReason ) )
     {
-      QString error( failureReason );
+      const QString error( failureReason );
       CPLFree( failureReason );
       throw QgsProviderConnectionException( QObject::tr( "Could not update relationship: %1" ).arg( error ) );
     }
@@ -1079,7 +1078,7 @@ void QgsOgrProviderConnection::deleteRelationship( const QgsWeakRelation &relati
     char *failureReason = nullptr;
     if ( !GDALDatasetDeleteRelationship( hDS.get(), relationshipName.toLocal8Bit().constData(), &failureReason ) )
     {
-      QString error( failureReason );
+      const QString error( failureReason );
       CPLFree( failureReason );
       throw QgsProviderConnectionException( QObject::tr( "Could not delete relationship: %1" ).arg( error ) );
     }

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -27,6 +27,9 @@
 #include "qgsdbquerylog.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsweakrelation.h"
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,4,0)
+#include "qgsgdalutils.h"
+#endif
 
 #include <QTextCodec>
 #include <QRegularExpression>

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -91,6 +91,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     QList< QgsWeakRelation > relationships( const QString &schema = QString(), const QString &tableName = QString() ) const override;
+    void addRelationship( const QgsWeakRelation &relationship ) const override;
 
   protected:
 

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -92,6 +92,8 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     QList< QgsWeakRelation > relationships( const QString &schema = QString(), const QString &tableName = QString() ) const override;
     void addRelationship( const QgsWeakRelation &relationship ) const override;
+    void updateRelationship( const QgsWeakRelation &relationship ) const override;
+    void deleteRelationship( const QgsWeakRelation &relationship ) const override;
 
   protected:
 

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1345,6 +1345,16 @@ void QgsAbstractDatabaseProviderConnection::addRelationship( const QgsWeakRelati
   checkCapability( Capability::AddRelationship );
 }
 
+void QgsAbstractDatabaseProviderConnection::updateRelationship( const QgsWeakRelation & ) const
+{
+  checkCapability( Capability::UpdateRelationship );
+}
+
+void QgsAbstractDatabaseProviderConnection::deleteRelationship( const QgsWeakRelation & ) const
+{
+  checkCapability( Capability::DeleteRelationship );
+}
+
 QString QgsAbstractDatabaseProviderConnection::TableProperty::defaultName() const
 {
   QString n = mTableName;

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1340,6 +1340,11 @@ QList< QgsWeakRelation > QgsAbstractDatabaseProviderConnection::relationships( c
   return {};
 }
 
+void QgsAbstractDatabaseProviderConnection::addRelationship( const QgsWeakRelation & ) const
+{
+  checkCapability( Capability::AddRelationship );
+}
+
 QString QgsAbstractDatabaseProviderConnection::TableProperty::defaultName() const
 {
   QString n = mTableName;

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -510,6 +510,8 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
       RenameField = 1 << 26,                          //!< Can rename existing fields via renameField() (since QGIS 3.28)
       RetrieveRelationships = 1 << 27,                //!< Can retrieve relationships from the database (since QGIS 3.28)
       AddRelationship = 1 << 28,                      //!< Can add new relationships to the database via addRelationship() (since QGIS 3.30)
+      UpdateRelationship = 1 << 29,                   //!< Can update existing relationships in the database via updateRelationship() (since QGIS 3.30)
+      DeleteRelationship = 1 << 30,                   //!< Can delete existing relationships from the database via deleteRelationship() (since QGIS 3.30)
     };
     Q_ENUM( Capability )
     Q_DECLARE_FLAGS( Capabilities, Capability )
@@ -915,6 +917,22 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \since QGIS 3.30
      */
     virtual void addRelationship( const QgsWeakRelation &relationship ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
+     * Updates an existing \a relationship in the database.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered.
+     * \since QGIS 3.30
+     */
+    virtual void updateRelationship( const QgsWeakRelation &relationship ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
+     * Deletes an existing \a relationship in the database.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered.
+     * \since QGIS 3.30
+     */
+    virtual void deleteRelationship( const QgsWeakRelation &relationship ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns a SQL query builder for the connection, which provides an interface for provider-specific creation of SQL queries.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -509,6 +509,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
       AddFieldDomain = 1 << 25,                       //!< Can add new field domains to the database via addFieldDomain() (since QGIS 3.26)
       RenameField = 1 << 26,                          //!< Can rename existing fields via renameField() (since QGIS 3.28)
       RetrieveRelationships = 1 << 27,                //!< Can retrieve relationships from the database (since QGIS 3.28)
+      AddRelationship = 1 << 28,                      //!< Can add new relationships to the database via addRelationship() (since QGIS 3.30)
     };
     Q_ENUM( Capability )
     Q_DECLARE_FLAGS( Capabilities, Capability )
@@ -906,6 +907,14 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \since QGIS 3.28
      */
     virtual QList< QgsWeakRelation > relationships( const QString &schema = QString(), const QString &tableName = QString() ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
+     * Adds a new field \a relationship to the database.
+     *
+     * \throws QgsProviderConnectionException if any errors are encountered.
+     * \since QGIS 3.30
+     */
+    virtual void addRelationship( const QgsWeakRelation &relationship ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns a SQL query builder for the connection, which provides an interface for provider-specific creation of SQL queries.

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -21,7 +21,6 @@
 #include "qgslinestring.h"
 #include "qgsmultipoint.h"
 #include "qgsmultilinestring.h"
-#include "qgsogrprovider.h"
 #include "qgslinesymbollayer.h"
 #include "qgspolygon.h"
 #include "qgsmultipolygon.h"
@@ -38,6 +37,10 @@
 #include "qgsfielddomain.h"
 #include "qgsfontmanager.h"
 #include "qgsvariantutils.h"
+#include "qgsweakrelation.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
+#include "qgsogrproviderutils.h"
 
 #include <QTextCodec>
 #include <QUuid>
@@ -102,6 +105,13 @@ void gdal::GDALWarpOptionsDeleter::operator()( GDALWarpOptions *options ) const
 {
   GDALDestroyWarpOptions( options );
 }
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+void gdal::GDALRelationshipDeleter::operator()( GDALRelationshipH relationship ) const
+{
+  GDALDestroyRelationship( relationship );
+}
+#endif
 
 QVariant QgsOgrUtils::OGRFieldtoVariant( const OGRField *value, OGRFieldType type )
 {
@@ -2199,4 +2209,288 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
   return res;
 }
 
+#endif
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+QgsWeakRelation QgsOgrUtils::convertRelationship( GDALRelationshipH relationship, const QString &datasetUri )
+{
+  QgsProviderMetadata *ogrProviderMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
+  const QVariantMap datasetUriParts = ogrProviderMetadata->decodeUri( datasetUri );
+
+  const QString leftTableName( GDALRelationshipGetLeftTableName( relationship ) );
+
+  QVariantMap leftTableUriParts = datasetUriParts;
+  leftTableUriParts.insert( QStringLiteral( "layerName" ), leftTableName );
+  const QString leftTableSource = ogrProviderMetadata->encodeUri( leftTableUriParts );
+
+  const QString rightTableName( GDALRelationshipGetRightTableName( relationship ) );
+  QVariantMap rightTableUriParts = datasetUriParts;
+  rightTableUriParts.insert( QStringLiteral( "layerName" ), rightTableName );
+  const QString rightTableSource = ogrProviderMetadata->encodeUri( rightTableUriParts );
+
+  const QString mappingTableName( GDALRelationshipGetMappingTableName( relationship ) );
+  QString mappingTableSource;
+  if ( !mappingTableName.isEmpty() )
+  {
+    QVariantMap mappingTableUriParts = datasetUriParts;
+    mappingTableUriParts.insert( QStringLiteral( "layerName" ), mappingTableName );
+    mappingTableSource = ogrProviderMetadata->encodeUri( mappingTableUriParts );
+  }
+
+  const QString relationshipName( GDALRelationshipGetName( relationship ) );
+
+  char **cslLeftTableFieldNames = GDALRelationshipGetLeftTableFields( relationship );
+  const QStringList leftTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslLeftTableFieldNames );
+  CSLDestroy( cslLeftTableFieldNames );
+
+  char **cslRightTableFieldNames = GDALRelationshipGetRightTableFields( relationship );
+  const QStringList rightTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslRightTableFieldNames );
+  CSLDestroy( cslRightTableFieldNames );
+
+  char **cslLeftMappingTableFieldNames = GDALRelationshipGetLeftMappingTableFields( relationship );
+  const QStringList leftMappingTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslLeftMappingTableFieldNames );
+  CSLDestroy( cslLeftMappingTableFieldNames );
+
+  char **cslRightMappingTableFieldNames = GDALRelationshipGetRightMappingTableFields( relationship );
+  const QStringList rightMappingTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslRightMappingTableFieldNames );
+  CSLDestroy( cslRightMappingTableFieldNames );
+
+  const QString forwardPathLabel( GDALRelationshipGetForwardPathLabel( relationship ) );
+  const QString backwardPathLabel( GDALRelationshipGetBackwardPathLabel( relationship ) );
+  const QString relatedTableType( GDALRelationshipGetRelatedTableType( relationship ) );
+
+  const GDALRelationshipType relationshipType = GDALRelationshipGetType( relationship );
+  Qgis::RelationshipStrength strength = Qgis::RelationshipStrength::Association;
+  switch ( relationshipType )
+  {
+    case GRT_COMPOSITE:
+      strength = Qgis::RelationshipStrength::Composition;
+      break;
+
+    case GRT_ASSOCIATION:
+      strength = Qgis::RelationshipStrength::Association;
+      break;
+
+    case GRT_AGGREGATION:
+      QgsLogger::warning( "Aggregation relationships are not supported, treating as association instead" );
+      break;
+  }
+
+  const GDALRelationshipCardinality eCardinality = GDALRelationshipGetCardinality( relationship );
+  Qgis::RelationshipCardinality cardinality = Qgis::RelationshipCardinality::OneToOne;
+  switch ( eCardinality )
+  {
+    case GRC_ONE_TO_ONE:
+      cardinality = Qgis::RelationshipCardinality::OneToOne;
+      break;
+    case GRC_ONE_TO_MANY:
+      cardinality = Qgis::RelationshipCardinality::OneToMany;
+      break;
+    case GRC_MANY_TO_ONE:
+      cardinality = Qgis::RelationshipCardinality::ManyToOne;
+      break;
+    case GRC_MANY_TO_MANY:
+      cardinality = Qgis::RelationshipCardinality::ManyToMany;
+      break;
+  }
+
+  switch ( cardinality )
+  {
+    case Qgis::RelationshipCardinality::OneToOne:
+    case Qgis::RelationshipCardinality::OneToMany:
+    case Qgis::RelationshipCardinality::ManyToOne:
+    {
+      QgsWeakRelation rel( relationshipName,
+                           relationshipName,
+                           strength,
+                           QString(), QString(), rightTableSource, QStringLiteral( "ogr" ),
+                           QString(), QString(), leftTableSource, QStringLiteral( "ogr" ) );
+      rel.setCardinality( cardinality );
+      rel.setForwardPathLabel( forwardPathLabel );
+      rel.setBackwardPathLabel( backwardPathLabel );
+      rel.setRelatedTableType( relatedTableType );
+      rel.setReferencedLayerFields( leftTableFieldNames );
+      rel.setReferencingLayerFields( rightTableFieldNames );
+      return rel;
+    }
+
+    case Qgis::RelationshipCardinality::ManyToMany:
+    {
+      QgsWeakRelation rel( relationshipName,
+                           relationshipName,
+                           strength,
+                           QString(), QString(), rightTableSource, QStringLiteral( "ogr" ),
+                           QString(), QString(), leftTableSource, QStringLiteral( "ogr" ) );
+      rel.setCardinality( cardinality );
+      rel.setForwardPathLabel( forwardPathLabel );
+      rel.setBackwardPathLabel( backwardPathLabel );
+      rel.setRelatedTableType( relatedTableType );
+      rel.setMappingTable( QgsVectorLayerRef( QString(), QString(), mappingTableSource, QStringLiteral( "ogr" ) ) );
+      rel.setReferencedLayerFields( leftTableFieldNames );
+      rel.setMappingReferencedLayerFields( leftMappingTableFieldNames );
+      rel.setReferencingLayerFields( rightTableFieldNames );
+      rel.setMappingReferencingLayerFields( rightMappingTableFieldNames );
+      return rel;
+    }
+  }
+  return QgsWeakRelation();
+}
+
+gdal::relationship_unique_ptr QgsOgrUtils::convertRelationship( const QgsWeakRelation &relationship, QString &error )
+{
+  GDALRelationshipCardinality gCardinality = GDALRelationshipCardinality::GRC_ONE_TO_MANY;
+  switch ( relationship.cardinality() )
+  {
+    case Qgis::RelationshipCardinality::OneToOne:
+      gCardinality = GDALRelationshipCardinality::GRC_ONE_TO_ONE;
+      break;
+    case Qgis::RelationshipCardinality::OneToMany:
+      gCardinality = GDALRelationshipCardinality::GRC_ONE_TO_MANY;
+      break;
+    case Qgis::RelationshipCardinality::ManyToOne:
+      gCardinality = GDALRelationshipCardinality::GRC_MANY_TO_ONE;
+      break;
+    case Qgis::RelationshipCardinality::ManyToMany:
+      gCardinality = GDALRelationshipCardinality::GRC_MANY_TO_MANY;
+      break;
+  }
+
+  QgsProviderMetadata *ogrProviderMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
+
+  const QVariantMap leftParts = ogrProviderMetadata->decodeUri( relationship.referencedLayerSource() );
+  const QString leftTableName = leftParts.value( QStringLiteral( "layerName" ) ).toString();
+  if ( leftTableName.isEmpty() )
+  {
+    error = QObject::tr( "Parent table name was not set" );
+    return nullptr;
+  }
+
+  const QVariantMap rightParts = ogrProviderMetadata->decodeUri( relationship.referencingLayerSource() );
+  const QString rightTableName = rightParts.value( QStringLiteral( "layerName" ) ).toString();
+  if ( rightTableName.isEmpty() )
+  {
+    error = QObject::tr( "Child table name was not set" );
+    return nullptr;
+  }
+
+  if ( leftParts.value( QStringLiteral( "path" ) ).toString() != rightParts.value( QStringLiteral( "path" ) ).toString() )
+  {
+    error = QObject::tr( "Parent and child table must be from the same dataset" );
+    return nullptr;
+  }
+
+  QString mappingTableName;
+  if ( !relationship.mappingTableSource().isEmpty() )
+  {
+    const QVariantMap mappingParts = ogrProviderMetadata->decodeUri( relationship.mappingTableSource() );
+    mappingTableName = mappingParts.value( QStringLiteral( "layerName" ) ).toString();
+    if ( leftParts.value( QStringLiteral( "path" ) ).toString() != mappingParts.value( QStringLiteral( "path" ) ).toString() )
+    {
+      error = QObject::tr( "Parent and mapping table must be from the same dataset" );
+      return nullptr;
+    }
+  }
+
+  gdal::relationship_unique_ptr relationH( GDALRelationshipCreate( relationship.name().toLocal8Bit().constData(),
+      leftTableName.toLocal8Bit().constData(),
+      rightTableName.toLocal8Bit().constData(),
+      gCardinality ) );
+
+  // set left table fields
+  const QStringList leftFieldNames = relationship.referencedLayerFields();
+  int count = leftFieldNames.count();
+  char **lst = new char *[count + 1];
+  if ( count > 0 )
+  {
+    int pos = 0;
+    for ( const QString &string : leftFieldNames )
+    {
+      lst[pos] = CPLStrdup( string.toLocal8Bit().constData() );
+      pos++;
+    }
+  }
+  lst[count] = nullptr;
+  GDALRelationshipSetLeftTableFields( relationH.get(), lst );
+  CSLDestroy( lst );
+
+  // set right table fields
+  const QStringList rightFieldNames = relationship.referencingLayerFields();
+  count = rightFieldNames.count();
+  lst = new char *[count + 1];
+  if ( count > 0 )
+  {
+    int pos = 0;
+    for ( const QString &string : rightFieldNames )
+    {
+      lst[pos] = CPLStrdup( string.toLocal8Bit().constData() );
+      pos++;
+    }
+  }
+  lst[count] = nullptr;
+  GDALRelationshipSetRightTableFields( relationH.get(), lst );
+  CSLDestroy( lst );
+
+  if ( !mappingTableName.isEmpty() )
+  {
+    GDALRelationshipSetMappingTableName( relationH.get(), mappingTableName.toLocal8Bit().constData() );
+
+    // set left mapping table fields
+    const QStringList leftFieldNames = relationship.mappingReferencedLayerFields();
+    int count = leftFieldNames.count();
+    char **lst = new char *[count + 1];
+    if ( count > 0 )
+    {
+      int pos = 0;
+      for ( const QString &string : leftFieldNames )
+      {
+        lst[pos] = CPLStrdup( string.toLocal8Bit().constData() );
+        pos++;
+      }
+    }
+    lst[count] = nullptr;
+    GDALRelationshipSetLeftMappingTableFields( relationH.get(), lst );
+    CSLDestroy( lst );
+
+    // set right table fields
+    const QStringList rightFieldNames = relationship.mappingReferencingLayerFields();
+    count = rightFieldNames.count();
+    lst = new char *[count + 1];
+    if ( count > 0 )
+    {
+      int pos = 0;
+      for ( const QString &string : rightFieldNames )
+      {
+        lst[pos] = CPLStrdup( string.toLocal8Bit().constData() );
+        pos++;
+      }
+    }
+    lst[count] = nullptr;
+    GDALRelationshipSetRightMappingTableFields( relationH.get(), lst );
+    CSLDestroy( lst );
+  }
+
+  // set type
+  switch ( relationship.strength() )
+  {
+    case Qgis::RelationshipStrength::Association:
+      GDALRelationshipSetType( relationH.get(), GDALRelationshipType::GRT_ASSOCIATION );
+      break;
+
+    case Qgis::RelationshipStrength::Composition:
+      GDALRelationshipSetType( relationH.get(), GDALRelationshipType::GRT_COMPOSITE );
+      break;
+  }
+
+  // set labels
+  if ( !relationship.forwardPathLabel().isEmpty() )
+    GDALRelationshipSetForwardPathLabel( relationH.get(), relationship.forwardPathLabel().toLocal8Bit().constData() );
+  if ( !relationship.backwardPathLabel().isEmpty() )
+    GDALRelationshipSetBackwardPathLabel( relationH.get(), relationship.backwardPathLabel().toLocal8Bit().constData() );
+
+  // set table type
+  if ( !relationship.relatedTableType().isEmpty() )
+    GDALRelationshipSetRelatedTableType( relationH.get(), relationship.relatedTableType().toLocal8Bit().constData() );
+
+  return relationH;
+}
 #endif

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -32,6 +32,7 @@ class QgsCoordinateReferenceSystem;
 class QgsFieldDomain;
 
 class QTextCodec;
+class QgsWeakRelation;
 
 namespace gdal
 {
@@ -114,6 +115,22 @@ namespace gdal
 
   };
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+
+  /**
+   * Closes and cleanups GDAL relationship.
+   */
+  struct GDALRelationshipDeleter
+  {
+
+    /**
+     * Destroys GDAL \a relationship, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( GDALRelationshipH relationship ) const;
+
+  };
+#endif
+
   /**
    * Scoped OGR data source.
    */
@@ -153,6 +170,14 @@ namespace gdal
    * Scoped GDAL warp options.
    */
   using warp_options_unique_ptr = std::unique_ptr< GDALWarpOptions, GDALWarpOptionsDeleter >;
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+
+  /**
+   * Scoped GDAL relationship.
+   */
+  using relationship_unique_ptr = std::unique_ptr< std::remove_pointer<GDALRelationshipH>::type, GDALRelationshipDeleter >;
+#endif
 }
 
 /**
@@ -426,6 +451,30 @@ class CORE_EXPORT QgsOgrUtils
     static OGRFieldDomainH convertFieldDomain( const QgsFieldDomain *domain );
 #endif
 #endif
+
+#ifndef SIP_RUN
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+
+    /**
+     * Converts an GDAL \a relationship definition to a QgsWeakRelation equivalent.
+     *
+     * \note Requires GDAL >= 3.6
+     * \note Not available in Python bindings
+     * \since QGIS 3.30
+     */
+    static QgsWeakRelation convertRelationship( GDALRelationshipH relationship, const QString &datasetUri );
+
+    /**
+     * Converts a QGIS relation to a GDAL relationship equivalent.
+     *
+     * \note Requires GDAL >= 3.6
+     * \note Not available in Python bindings
+     * \since QGIS 3.30
+     */
+    static gdal::relationship_unique_ptr convertRelationship( const QgsWeakRelation &relation, QString &error );
+#endif
+#endif
+
 };
 
 #endif // QGSOGRUTILS_H

--- a/src/core/qgsweakrelation.h
+++ b/src/core/qgsweakrelation.h
@@ -58,12 +58,10 @@ class CORE_EXPORT QgsWeakRelation
      */
     QgsWeakRelation();
 
-#ifndef SIP_RUN
-
     /**
      * Creates a QgsWeakRelation.
      *
-     * \note Not available in Python bindings.
+     * \since QGIS 3.30
      */
     QgsWeakRelation( const QString &relationId,
                      const QString &relationName,
@@ -77,7 +75,6 @@ class CORE_EXPORT QgsWeakRelation
                      const QString &referencedLayerSource,
                      const QString &referencedLayerProviderKey
                    );
-#endif
 
     /**
      * Resolves a weak relation in the given \a project returning a list of possibly invalid QgsRelations

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -39,6 +39,7 @@
 #include "qgsfontutils.h"
 #include "qgssymbol.h"
 #include "qgsfielddomain.h"
+#include "qgsweakrelation.h"
 
 class TestQgsOgrUtils: public QObject
 {
@@ -76,6 +77,11 @@ class TestQgsOgrUtils: public QObject
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,3,0)
     void testConvertFieldDomain();
     void testConvertToFieldDomain();
+#endif
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+    void testConvertGdalRelationship();
+    void testConvertToGdalRelationship();
 #endif
 
   private:
@@ -1132,6 +1138,204 @@ void TestQgsOgrUtils::testConvertToFieldDomain()
 
 }
 #endif
+
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+void TestQgsOgrUtils::testConvertGdalRelationship()
+{
+  gdal::relationship_unique_ptr relationH( GDALRelationshipCreate( "relation_name",
+      "left_table",
+      "right_table",
+      GDALRelationshipCardinality::GRC_ONE_TO_ONE ) );
+
+  QgsWeakRelation rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.name(), QStringLiteral( "relation_name" ) );
+  QCOMPARE( rel.referencedLayerSource(), QStringLiteral( "/some_data.gdb|layername=left_table" ) );
+  QCOMPARE( rel.referencingLayerSource(), QStringLiteral( "/some_data.gdb|layername=right_table" ) );
+  QCOMPARE( rel.cardinality(), Qgis::RelationshipCardinality::OneToOne );
+
+  relationH.reset( GDALRelationshipCreate( "relation_name",
+                   "left_table",
+                   "right_table",
+                   GDALRelationshipCardinality::GRC_ONE_TO_MANY ) );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.cardinality(), Qgis::RelationshipCardinality::OneToMany );
+
+  relationH.reset( GDALRelationshipCreate( "relation_name",
+                   "left_table",
+                   "right_table",
+                   GDALRelationshipCardinality::GRC_MANY_TO_ONE ) );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.cardinality(), Qgis::RelationshipCardinality::ManyToOne );
+
+  relationH.reset( GDALRelationshipCreate( "relation_name",
+                   "left_table",
+                   "right_table",
+                   GDALRelationshipCardinality::GRC_MANY_TO_MANY ) );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.cardinality(), Qgis::RelationshipCardinality::ManyToMany );
+
+  const char *const fieldsLeft[] {"fielda", "fieldb", nullptr};
+  GDALRelationshipSetLeftTableFields( relationH.get(), fieldsLeft );
+
+  const char *const fieldsRight[] {"fieldc", "fieldd", nullptr};
+  GDALRelationshipSetRightTableFields( relationH.get(), fieldsRight );
+
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.referencedLayerFields(), QStringList() << QStringLiteral( "fielda" ) << QStringLiteral( "fieldb" ) );
+  QCOMPARE( rel.referencingLayerFields(), QStringList() << QStringLiteral( "fieldc" ) << QStringLiteral( "fieldd" ) );
+
+  QCOMPARE( rel.mappingTableSource(), QString() );
+
+  GDALRelationshipSetMappingTableName( relationH.get(), "mapping_table" );
+
+  const char *const mappingFieldsLeft[] {"fieldd", "fielde", nullptr};
+  GDALRelationshipSetLeftMappingTableFields( relationH.get(), mappingFieldsLeft );
+
+  const char *const mappingFieldsRight[] {"fieldf", "fieldg", nullptr};
+  GDALRelationshipSetRightMappingTableFields( relationH.get(), mappingFieldsRight );
+
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.mappingTableSource(), QStringLiteral( "/some_data.gdb|layername=mapping_table" ) );
+  QCOMPARE( rel.referencedLayerFields(), QStringList() << QStringLiteral( "fielda" ) << QStringLiteral( "fieldb" ) );
+  QCOMPARE( rel.referencingLayerFields(), QStringList() << QStringLiteral( "fieldc" ) << QStringLiteral( "fieldd" ) );
+  QCOMPARE( rel.mappingReferencedLayerFields(), QStringList() << QStringLiteral( "fieldd" ) << QStringLiteral( "fielde" ) );
+  QCOMPARE( rel.mappingReferencingLayerFields(), QStringList() << QStringLiteral( "fieldf" ) << QStringLiteral( "fieldg" ) );
+
+  GDALRelationshipSetType( relationH.get(), GRT_COMPOSITE );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.strength(), Qgis::RelationshipStrength::Composition );
+  GDALRelationshipSetType( relationH.get(), GRT_ASSOCIATION );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.strength(), Qgis::RelationshipStrength::Association );
+
+  GDALRelationshipSetForwardPathLabel( relationH.get(), "forward label" );
+  GDALRelationshipSetBackwardPathLabel( relationH.get(), "backward label" );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.forwardPathLabel(), QStringLiteral( "forward label" ) );
+  QCOMPARE( rel.backwardPathLabel(), QStringLiteral( "backward label" ) );
+
+  GDALRelationshipSetRelatedTableType( relationH.get(), "table_type" );
+  rel = QgsOgrUtils::convertRelationship( relationH.get(), QStringLiteral( "/some_data.gdb" ) );
+  QCOMPARE( rel.relatedTableType(), QStringLiteral( "table_type" ) );
+}
+
+void TestQgsOgrUtils::testConvertToGdalRelationship()
+{
+  QgsWeakRelation rel( QStringLiteral( "id" ), QStringLiteral( "name" ),
+                       Qgis::RelationshipStrength::Association,
+                       QStringLiteral( "referencing_layer_id" ),
+                       QStringLiteral( "referencing_layer_name" ),
+                       QStringLiteral( "/some_data.gdb|layername=referencing" ),
+                       QStringLiteral( "ogr" ),
+                       QStringLiteral( "referenced_layer_id" ),
+                       QStringLiteral( "referenced_layer_name" ),
+                       QStringLiteral( "/some_data.gdb|layername=referenced" ),
+                       QStringLiteral( "ogr" ) );
+  rel.setReferencedLayerFields( QStringList() << QStringLiteral( "fielda" ) << QStringLiteral( "fieldb" ) );
+  rel.setReferencingLayerFields( QStringList() << QStringLiteral( "fieldc" ) << QStringLiteral( "fieldd" ) );
+  rel.setCardinality( Qgis::RelationshipCardinality::OneToMany );
+
+  QString error;
+  gdal::relationship_unique_ptr relationH = QgsOgrUtils::convertRelationship( rel, error );
+
+  QCOMPARE( QString( GDALRelationshipGetName( relationH.get() ) ), QStringLiteral( "name" ) );
+  QCOMPARE( QString( GDALRelationshipGetLeftTableName( relationH.get() ) ), QStringLiteral( "referenced" ) );
+  QCOMPARE( QString( GDALRelationshipGetRightTableName( relationH.get() ) ), QStringLiteral( "referencing" ) );
+
+  char **cslLeftTableFieldNames = GDALRelationshipGetLeftTableFields( relationH.get() );
+  const QStringList leftTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslLeftTableFieldNames );
+  CSLDestroy( cslLeftTableFieldNames );
+  QCOMPARE( leftTableFieldNames, QStringList() << QStringLiteral( "fielda" ) << QStringLiteral( "fieldb" ) );
+
+  char **cslRightTableFieldNames = GDALRelationshipGetRightTableFields( relationH.get() );
+  const QStringList rightTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslRightTableFieldNames );
+  CSLDestroy( cslRightTableFieldNames );
+  QCOMPARE( rightTableFieldNames, QStringList() << QStringLiteral( "fieldc" ) << QStringLiteral( "fieldd" ) );
+
+  QCOMPARE( GDALRelationshipGetCardinality( relationH.get() ), GDALRelationshipCardinality::GRC_ONE_TO_MANY );
+  rel.setCardinality( Qgis::RelationshipCardinality::OneToOne );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( GDALRelationshipGetCardinality( relationH.get() ), GDALRelationshipCardinality::GRC_ONE_TO_ONE );
+  rel.setCardinality( Qgis::RelationshipCardinality::ManyToOne );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( GDALRelationshipGetCardinality( relationH.get() ), GDALRelationshipCardinality::GRC_MANY_TO_ONE );
+  rel.setCardinality( Qgis::RelationshipCardinality::ManyToMany );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( GDALRelationshipGetCardinality( relationH.get() ), GDALRelationshipCardinality::GRC_MANY_TO_MANY );
+
+  QCOMPARE( GDALRelationshipGetType( relationH.get() ), GDALRelationshipType::GRT_ASSOCIATION );
+
+  rel = QgsWeakRelation( QStringLiteral( "id" ), QStringLiteral( "name" ),
+                         Qgis::RelationshipStrength::Composition,
+                         QStringLiteral( "referencing_layer_id" ),
+                         QStringLiteral( "referencing_layer_name" ),
+                         QStringLiteral( "/some_data.gdb|layername=referencing" ),
+                         QStringLiteral( "ogr" ),
+                         QStringLiteral( "referenced_layer_id" ),
+                         QStringLiteral( "referenced_layer_name" ),
+                         QStringLiteral( "/some_data.gdb|layername=referenced" ),
+                         QStringLiteral( "ogr" ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( GDALRelationshipGetType( relationH.get() ), GDALRelationshipType::GRT_COMPOSITE );
+
+  rel.setForwardPathLabel( QStringLiteral( "forward" ) );
+  rel.setBackwardPathLabel( QStringLiteral( "backward" ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( QString( GDALRelationshipGetForwardPathLabel( relationH.get() ) ), QStringLiteral( "forward" ) );
+  QCOMPARE( QString( GDALRelationshipGetBackwardPathLabel( relationH.get() ) ), QStringLiteral( "backward" ) );
+
+  rel.setRelatedTableType( QStringLiteral( "table_type" ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( QString( GDALRelationshipGetRelatedTableType( relationH.get() ) ), QStringLiteral( "table_type" ) );
+
+  rel.setMappingTable( QgsVectorLayerRef( QStringLiteral( "mapping_id" ),
+                                          QStringLiteral( "mapping_name" ),
+                                          QStringLiteral( "/some_data.gdb|layername=mapping" ),
+                                          QStringLiteral( "ogr" ) ) );
+  rel.setMappingReferencedLayerFields( QStringList() << QStringLiteral( "fielde" ) << QStringLiteral( "fieldf" ) );
+  rel.setMappingReferencingLayerFields( QStringList() << QStringLiteral( "fieldh" ) << QStringLiteral( "fieldi" ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QCOMPARE( QString( GDALRelationshipGetMappingTableName( relationH.get() ) ), QStringLiteral( "mapping" ) );
+
+  char **cslLeftMappingTableFieldNames = GDALRelationshipGetLeftMappingTableFields( relationH.get() );
+  const QStringList leftMappingTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslLeftMappingTableFieldNames );
+  CSLDestroy( cslLeftMappingTableFieldNames );
+  QCOMPARE( leftMappingTableFieldNames, QStringList() << QStringLiteral( "fielde" ) << QStringLiteral( "fieldf" ) );
+
+  char **cslRightMappingTableFieldNames = GDALRelationshipGetRightMappingTableFields( relationH.get() );
+  const QStringList rightMappingTableFieldNames = QgsOgrUtils::cStringListToQStringList( cslRightMappingTableFieldNames );
+  CSLDestroy( cslRightMappingTableFieldNames );
+  QCOMPARE( rightMappingTableFieldNames, QStringList() << QStringLiteral( "fieldh" ) << QStringLiteral( "fieldi" ) );
+
+  // check that error is raised when tables from different dataset
+  rel.setMappingTable( QgsVectorLayerRef( QStringLiteral( "mapping_id" ),
+                                          QStringLiteral( "mapping_name" ),
+                                          QStringLiteral( "/some_other_data.gdb|layername=mapping" ),
+                                          QStringLiteral( "ogr" ) ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QVERIFY( !relationH.get() );
+  QCOMPARE( error, QStringLiteral( "Parent and mapping table must be from the same dataset" ) );
+  error.clear();
+
+  rel = QgsWeakRelation( QStringLiteral( "id" ), QStringLiteral( "name" ),
+                         Qgis::RelationshipStrength::Composition,
+                         QStringLiteral( "referencing_layer_id" ),
+                         QStringLiteral( "referencing_layer_name" ),
+                         QStringLiteral( "/some_data.gdb|layername=referencing" ),
+                         QStringLiteral( "ogr" ),
+                         QStringLiteral( "referenced_layer_id" ),
+                         QStringLiteral( "referenced_layer_name" ),
+                         QStringLiteral( "/some_other_data.gdb|layername=referenced" ),
+                         QStringLiteral( "ogr" ) );
+  relationH = QgsOgrUtils::convertRelationship( rel, error );
+  QVERIFY( !relationH.get() );
+  QCOMPARE( error, QStringLiteral( "Parent and child table must be from the same dataset" ) );
+  error.clear();
+
+}
+#endif
+
 
 QGSTEST_MAIN( TestQgsOgrUtils )
 #include "testqgsogrutils.moc"

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2968,7 +2968,7 @@ class PyQgsOGRProvider(unittest.TestCase):
 
             # try updating non-existing relationship
             rel2 = QgsWeakRelation('id',
-                                   'dont_exist',
+                                   'nope',
                                    Qgis.RelationshipStrength.Association,
                                    'referencing_id',
                                    'referencing_name',


### PR DESCRIPTION
and implement for OGR provider when built on GDAL >= 3.6 . (GDAL 3.6 supports relationship creation for ESRI FileGeodatabases using the OpenFileGDB driver)