### PR TITLE
[vector] Do not enable embedded feature symbology when loading KML datasets through the KML driver

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2848,7 +2848,8 @@ void QgsOgrProvider::computeCapabilities()
       ability |= TransactionSupport;
     }
 
-    if ( GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FEATURE_STYLES, nullptr ) != nullptr )
+    // GDAL KML driver doesn't support reading feature style, skip metadata check until GDAL can separate reading/writing capability
+    if ( mGDALDriverName != QLatin1String( "KML" ) && GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FEATURE_STYLES, nullptr ) != nullptr )
     {
       ability |= FeatureSymbology;
       ability |= CreateRenderer;


### PR DESCRIPTION
## Description

@nyalldawson , the GDAL KML driver embedded symbology support is not really good / functional, let's not use it there. LIBKML driver works like a charm.

Discovered while people were reporting KML polygons not showing in QField (when it fact it was just KML not respecting the symbology and instead creating fill-less black outline polygons).