### PR TITLE
[Digitizing] convert Z new geom to 25D if needed

### DIFF
--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -261,6 +261,14 @@ bool QgsAbstractGeometry::convertTo( QgsWkbTypes::Type type )
   if ( QgsWkbTypes::flatType( type ) != QgsWkbTypes::flatType( mWkbType ) )
     return false;
 
+  // converts blindly between 25D and Z (and vice versa)
+  if ( QgsWkbTypes::hasZ( type ) && !QgsWkbTypes::hasM( type )
+       && is3D() && !isMeasure() )
+  {
+    mWkbType = type;
+    return true;
+  }
+
   const bool needZ = QgsWkbTypes::hasZ( type );
   const bool needM = QgsWkbTypes::hasM( type );
   if ( !needZ )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1523,6 +1523,13 @@ QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type, do
     newGeom.get()->addMValue( defaultM );
   }
 
+  // need to convert between 25D and Z (and vice versa)
+  if ( QgsWkbTypes::hasZ( type ) && !QgsWkbTypes::hasM( type )
+       && newGeom.constGet()->is3D() && !newGeom.constGet()->isMeasure() )
+  {
+    newGeom.get()->convertTo( type );
+  }
+
   // Multi -> single
   if ( ! QgsWkbTypes::isMultiType( type ) && newGeom.isMultipart( ) )
   {
@@ -4018,4 +4025,3 @@ bool QgsGeometry::Error::hasWhere() const
 {
   return mHasLocation;
 }
-

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -6346,6 +6346,40 @@ class TestQgsGeometry(unittest.TestCase):
                                        QgsWkbTypes.MultiLineString),
                          ['MultiLineString ((1 1, 1 2, 2 2, 1 1),(3 3, 4 3, 4 4, 3 3))'])
 
+        # Test to change from 25D et Z and vice versa
+        geom = QgsGeometry.fromWkt('Point z (1 1 3)')
+        newGeom = geom.coerceToType(QgsWkbTypes.Point25D)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.Point25D)
+        self.assertEqual(newGeom[0].asWkt(2), 'PointZ (1 1 3)')
+        geom = newGeom[0]
+        newGeom = geom.coerceToType(QgsWkbTypes.PointZ)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(newGeom[0].asWkt(2), 'PointZ (1 1 3)')
+
+        geom = QgsGeometry.fromWkt('LineStringZ (1 1 1, 2 2 2, 3 3 3)')
+        newGeom = geom.coerceToType(QgsWkbTypes.LineString25D)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.LineString25D)
+        self.assertEqual(newGeom[0].asWkt(2), 'LineStringZ (1 1 1, 2 2 2, 3 3 3)')
+        geom = newGeom[0]
+        newGeom = geom.coerceToType(QgsWkbTypes.LineStringZ)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.LineStringZ)
+        self.assertEqual(newGeom[0].asWkt(2), 'LineStringZ (1 1 1, 2 2 2, 3 3 3)')
+
+        geom = QgsGeometry.fromWkt('PolygonZ ((1 1 1, 2 2 2, 3 3 3, 1 1 1))')
+        newGeom = geom.coerceToType(QgsWkbTypes.Polygon25D)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.Polygon25D)
+        self.assertEqual(newGeom[0].asWkt(2), 'PolygonZ ((1 1 1, 2 2 2, 3 3 3, 1 1 1))')
+        geom = newGeom[0]
+        newGeom = geom.coerceToType(QgsWkbTypes.PolygonZ)
+        self.assertEqual(len(newGeom), 1)
+        self.assertEqual(newGeom[0].wkbType(), QgsWkbTypes.PolygonZ)
+        self.assertEqual(newGeom[0].asWkt(2), 'PolygonZ ((1 1 1, 2 2 2, 3 3 3, 1 1 1))')
+
     def testTriangularWaves(self):
         """Test triangular waves"""
         self.assertEqual(QgsGeometry.fromWkt('Point (1 1)').triangularWaves(1, 2).asWkt(3), 'Point (1 1)')


### PR DESCRIPTION
Some providers advertise their data as 25D (Oracle for instance) so we need to convert the new created geometry from Z to 25D (LineStringZ to LineString25D for instance)

if not we the following message 

>The digitized geometry type (LineStringZ) does not correspond to the layer geometry type (LineString25D).

**Sponsored by Metropole Européenne de Lille**

