### PR TITLE
When undo/redoing changes in QgsVectorLayer, ensure triggerRepaint signal is emitted

### DIFF
--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -58,6 +58,7 @@ void QgsVectorLayerEditBuffer::undoIndexChanged( int index )
 
   QgsDebugMsgLevel( QStringLiteral( "undo index changed %1" ).arg( index ), 4 );
   Q_UNUSED( index )
+  L->triggerRepaint();
   emit layerModified();
 }
 
@@ -167,9 +168,12 @@ bool QgsVectorLayerEditBuffer::addFeatures( QgsFeatureList &features )
   mBlockModifiedSignals--;
 
   if ( anyAdded )
+  {
     emit layerModified();
+    L->triggerRepaint();
+    L->updateExtents();
+  }
 
-  L->updateExtents();
   return result;
 }
 
@@ -220,6 +224,7 @@ bool QgsVectorLayerEditBuffer::deleteFeatures( const QgsFeatureIds &fids )
     ok = deleteFeature( fid ) && ok;
 
   mBlockModifiedSignals--;
+  L->triggerRepaint();
   emit layerModified();
 
   return ok;
@@ -267,6 +272,7 @@ bool QgsVectorLayerEditBuffer::changeAttributeValues( QgsFeatureId fid, const Qg
   }
 
   mBlockModifiedSignals--;
+  L->triggerRepaint();
   emit layerModified();
 
   return success;

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -217,8 +217,9 @@ class TestLayerDependencies(unittest.TestCase):
 
         # repaintRequested is called on commit changes on point
         # so it is on depending line
-        self.assertEqual(len(spy_lines_repaint_requested), 1)
-        self.assertEqual(len(spy_points_repaint_requested), 1)
+        # (ideally only one repaintRequested signal is fired, but it's harmless to fire multiple ones)
+        self.assertGreaterEqual(len(spy_lines_repaint_requested), 2)
+        self.assertGreaterEqual(len(spy_points_repaint_requested), 2)
 
     def test_circular_dependencies_with_1_layer(self):
 
@@ -249,7 +250,8 @@ class TestLayerDependencies(unittest.TestCase):
         self.assertEqual(len(spy_lines_data_changed), 4)
 
         # repaintRequested is called only once on commit changes on line
-        self.assertEqual(len(spy_lines_repaint_requested), 1)
+        # (ideally only one repaintRequested signal is fired, but it's harmless to fire multiple ones)
+        self.assertGreaterEqual(len(spy_lines_repaint_requested), 2)
 
     def test_layerDefinitionRewriteId(self):
         tmpfile = os.path.join(tempfile.tempdir, "test.qlr")

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -273,12 +273,15 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer = createLayerWithOnePoint()
         layer.startEditing()
 
+        repaint_spy = QSignalSpy(layer.repaintRequested)
+
         self.assertEqual(layer.undoStack().count(), 0)
         self.assertEqual(layer.undoStack().index(), 0)
         f = QgsFeature()
         f.setAttributes(["test", 123])
         f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(100, 200)))
         self.assertTrue(layer.addFeatures([f]))
+        self.assertEqual(len(repaint_spy), 1)
         self.assertEqual(layer.undoStack().count(), 1)
         self.assertEqual(layer.undoStack().index(), 1)
         self.assertEqual(layer.featureCount(), 2)
@@ -287,40 +290,51 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertEqual(layer.undoStack().count(), 1)
         self.assertEqual(layer.undoStack().index(), 0)
         self.assertEqual(layer.featureCount(), 1)
+        self.assertEqual(len(repaint_spy), 2)
 
         layer.undoStack().redo()
         self.assertEqual(layer.undoStack().count(), 1)
         self.assertEqual(layer.undoStack().index(), 1)
         self.assertEqual(layer.featureCount(), 2)
+        self.assertEqual(len(repaint_spy), 3)
 
         # macro commands
         layer.beginEditCommand("Test command 1")
         self.assertTrue(layer.addFeatures([f]))
+        self.assertEqual(len(repaint_spy), 4)
         self.assertTrue(layer.addFeatures([f]))
+        self.assertEqual(len(repaint_spy), 5)
         layer.endEditCommand()
         self.assertEqual(layer.undoStack().count(), 2)
         self.assertEqual(layer.undoStack().index(), 2)
         self.assertEqual(layer.featureCount(), 4)
+        self.assertEqual(len(repaint_spy), 6)
 
         layer.undoStack().undo()
         self.assertEqual(layer.undoStack().count(), 2)
         self.assertEqual(layer.undoStack().index(), 1)
         self.assertEqual(layer.featureCount(), 2)
+        self.assertEqual(len(repaint_spy), 7)
 
         layer.undoStack().redo()
         self.assertEqual(layer.undoStack().count(), 2)
         self.assertEqual(layer.undoStack().index(), 2)
         self.assertEqual(layer.featureCount(), 4)
+        self.assertEqual(len(repaint_spy), 8)
 
         # throw away a macro command
         layer.beginEditCommand("Test command 1")
         self.assertTrue(layer.addFeatures([f]))
+        self.assertEqual(len(repaint_spy), 9)
         self.assertTrue(layer.addFeatures([f]))
+        self.assertEqual(len(repaint_spy), 10)
         self.assertEqual(layer.featureCount(), 6)
+        prev_repaint_count = len(repaint_spy)
         layer.destroyEditCommand()
         self.assertEqual(layer.undoStack().count(), 2)
         self.assertEqual(layer.undoStack().index(), 2)
         self.assertEqual(layer.featureCount(), 4)
+        self.assertGreaterEqual(len(repaint_spy), prev_repaint_count)
 
     def testSetDataSource(self):
         """
@@ -615,9 +629,11 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         checkBefore()
 
         spy = QSignalSpy(layer.layerModified)
+        repaint_spy = QSignalSpy(layer.repaintRequested)
 
         # try to add feature without editing mode
         self.assertFalse(layer.addFeature(feat))
+        self.assertEqual(len(repaint_spy), 0)
 
         # add feature
         layer.startEditing()
@@ -625,6 +641,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         # try adding feature with incorrect number of fields
         bad_feature = QgsFeature()
         self.assertFalse(layer.addFeature(bad_feature))
+        self.assertEqual(len(repaint_spy), 0)
 
         self.assertEqual(len(spy), 0)
 
@@ -632,6 +649,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertTrue(layer.addFeature(feat))
 
         self.assertEqual(len(spy), 1)
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
         self.assertEqual(layer.dataProvider().featureCount(), 0)
@@ -640,11 +658,13 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer.undoStack().undo()
         checkBefore()
         self.assertEqual(len(spy), 2)
+        self.assertEqual(len(repaint_spy), 2)
 
         layer.undoStack().redo()
         checkAfter()
 
         self.assertEqual(len(spy), 3)
+        self.assertEqual(len(repaint_spy), 3)
 
         self.assertTrue(layer.commitChanges())
 
@@ -692,17 +712,20 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer.startEditing()
 
         spy = QSignalSpy(layer.layerModified)
+        repaint_spy = QSignalSpy(layer.repaintRequested)
 
         # try adding feature with incorrect number of fields
         bad_feature = QgsFeature()
         self.assertFalse(layer.addFeatures([bad_feature]))
 
         self.assertEqual(len(spy), 0)
+        self.assertEqual(len(repaint_spy), 0)
 
         # add good features
         self.assertTrue(layer.addFeatures([feat1, feat2]))
 
         self.assertEqual(len(spy), 1)
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
         self.assertEqual(layer.dataProvider().featureCount(), 0)
@@ -711,13 +734,17 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer.undoStack().undo()
 
         self.assertEqual(len(spy), 2)
+        self.assertEqual(len(repaint_spy), 2)
         layer.undoStack().undo()
         self.assertEqual(len(spy), 3)
+        self.assertEqual(len(repaint_spy), 3)
         checkBefore()
         layer.undoStack().redo()
         self.assertEqual(len(spy), 4)
+        self.assertEqual(len(repaint_spy), 4)
         layer.undoStack().redo()
         self.assertEqual(len(spy), 5)
+        self.assertEqual(len(repaint_spy), 5)
         checkAfter()
 
         self.assertTrue(layer.commitChanges())
@@ -759,17 +786,20 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         checkBefore()
 
         spy = QSignalSpy(layer.layerModified)
+        repaint_spy = QSignalSpy(layer.repaintRequested)
 
         # try to delete feature without editing mode
         self.assertFalse(layer.deleteFeature(fid))
 
         self.assertEqual(len(spy), 0)
+        self.assertEqual(len(repaint_spy), 0)
 
         # delete feature
         layer.startEditing()
         self.assertTrue(layer.deleteFeature(fid))
 
         self.assertEqual(len(spy), 1)
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
 
@@ -779,9 +809,11 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         # now try undo/redo
         layer.undoStack().undo()
         self.assertEqual(len(spy), 2)
+        self.assertEqual(len(repaint_spy), 2)
         checkBefore()
         layer.undoStack().redo()
         self.assertEqual(len(spy), 3)
+        self.assertEqual(len(repaint_spy), 3)
         checkAfter()
 
         self.assertEqual(layer.dataProvider().featureCount(), 1)
@@ -859,30 +891,37 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         fid1, fid2, fid3, fid4, fid5 = checkBefore()
 
         spy = QSignalSpy(layer.layerModified)
+        repaint_spy = QSignalSpy(layer.repaintRequested)
 
         # try to delete features without editing mode
         self.assertFalse(layer.deleteFeatures([fid1, fid2]))
 
         self.assertEqual(len(spy), 0)
+        self.assertEqual(len(repaint_spy), 0)
 
         # delete features
         layer.startEditing()
         self.assertTrue(layer.deleteFeatures([fid1, fid3]))
 
         self.assertEqual(len(spy), 1)
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
 
         # now try undo/redo
         layer.undoStack().undo()
         self.assertEqual(len(spy), 2)
+        self.assertEqual(len(repaint_spy), 2)
         layer.undoStack().undo()
         self.assertEqual(len(spy), 3)
+        self.assertEqual(len(repaint_spy), 3)
         checkBefore()
         layer.undoStack().redo()
         self.assertEqual(len(spy), 4)
+        self.assertEqual(len(repaint_spy), 4)
         layer.undoStack().redo()
         self.assertEqual(len(spy), 5)
+        self.assertEqual(len(repaint_spy), 5)
         checkAfter()
 
         self.assertEqual(layer.dataProvider().featureCount(), 5)
@@ -1006,20 +1045,26 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
 
         checkBefore()
 
+        repaint_spy = QSignalSpy(layer.repaintRequested)
+
         # try to change attribute without editing mode
         self.assertFalse(layer.changeAttributeValue(fid, 0, "good"))
+        self.assertEqual(len(repaint_spy), 0)
 
         # change attribute
         layer.startEditing()
         self.assertTrue(layer.changeAttributeValue(fid, 0, "good"))
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
 
         # now try undo/redo
         layer.undoStack().undo()
         checkBefore()
+        self.assertEqual(len(repaint_spy), 2)
         layer.undoStack().redo()
         checkAfter()
+        self.assertEqual(len(repaint_spy), 3)
 
         self.assertTrue(layer.commitChanges())
         checkAfter()
@@ -1049,30 +1094,37 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         checkBefore()
 
         spy = QSignalSpy(layer.layerModified)
+        repaint_spy = QSignalSpy(layer.repaintRequested)
 
         # try to change attribute without editing mode
         self.assertFalse(layer.changeAttributeValues(fid, {0: "good", 1: 100}))
 
         self.assertEqual(len(spy), 0)
+        self.assertEqual(len(repaint_spy), 0)
 
         # change attribute
         layer.startEditing()
         self.assertTrue(layer.changeAttributeValues(fid, {0: "good", 1: 100}))
 
         self.assertEqual(len(spy), 1)
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
 
         # now try undo/redo
         layer.undoStack().undo()
         self.assertEqual(len(spy), 2)
+        self.assertEqual(len(repaint_spy), 2)
         layer.undoStack().undo()
         self.assertEqual(len(spy), 3)
+        self.assertEqual(len(repaint_spy), 3)
         checkBefore()
         layer.undoStack().redo()
         self.assertEqual(len(spy), 4)
+        self.assertEqual(len(repaint_spy), 4)
         layer.undoStack().redo()
         self.assertEqual(len(spy), 5)
+        self.assertEqual(len(repaint_spy), 5)
         checkAfter()
 
         self.assertTrue(layer.commitChanges())
@@ -1153,6 +1205,8 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         # try to change geometry without editing mode
         self.assertFalse(layer.changeGeometry(fid, QgsGeometry.fromPointXY(QgsPointXY(300, 400))))
 
+        repaint_spy = QSignalSpy(layer.repaintRequested)
+
         checkBefore()
 
         # change geometry
@@ -1160,13 +1214,16 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer.beginEditCommand("ChangeGeometry")
         self.assertTrue(layer.changeGeometry(fid, QgsGeometry.fromPointXY(QgsPointXY(300, 400))))
         layer.endEditCommand()
+        self.assertEqual(len(repaint_spy), 1)
 
         checkAfter()
 
         # now try undo/redo
         layer.undoStack().undo()
+        self.assertEqual(len(repaint_spy), 2)
         checkBefore()
         layer.undoStack().redo()
+        self.assertEqual(len(repaint_spy), 3)
         checkAfter()
 
         self.assertTrue(layer.commitChanges())
@@ -1267,15 +1324,20 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
 
         layer.startEditing()
 
+        repaint_spy = QSignalSpy(layer.repaintRequested)
+
         # no matching feature
         f = QgsFeature(1123)
         self.assertFalse(layer.updateFeature(f))
+        self.assertEqual(len(repaint_spy), 0)
 
         # change geometry and attributes
         f = features[0]
         f.setAttributes(['new', 321])
         f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(-200, -200)))
         self.assertTrue(layer.updateFeature(f))
+        self.assertGreaterEqual(len(repaint_spy), 1)
+        prev_spy_count = len(repaint_spy)
 
         new_feature = next(layer.getFeatures(QgsFeatureRequest(f.id())))
         self.assertEqual(new_feature.attributes(), ['new', 321])
@@ -1286,11 +1348,15 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         f6.setAttributes(["test6", 555])
         self.assertTrue(layer.dataProvider().addFeatures([f6]))
         features = [f for f in layer.getFeatures()]
+        self.assertGreaterEqual(len(repaint_spy), prev_spy_count)
+        prev_spy_count = len(repaint_spy)
 
         # update feature with no geometry -> have geometry
         f = features[-1]
         f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(-350, -250)))
         self.assertTrue(layer.updateFeature(f))
+        self.assertGreaterEqual(len(repaint_spy), prev_spy_count)
+        prev_spy_count = len(repaint_spy)
         new_feature = next(layer.getFeatures(QgsFeatureRequest(f.id())))
         self.assertEqual(new_feature.attributes(), ['test6', 555])
         self.assertTrue(new_feature.hasGeometry())
@@ -1300,6 +1366,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         f = features[1]
         f.clearGeometry()
         self.assertTrue(layer.updateFeature(f))
+        self.assertGreaterEqual(len(repaint_spy), prev_spy_count)
         new_feature = next(layer.getFeatures(QgsFeatureRequest(f.id())))
         self.assertEqual(new_feature.attributes(), ['test2', 457])
         self.assertFalse(new_feature.hasGeometry())


### PR DESCRIPTION
 so that layer is redrawn in **all** map canvases
