### PR TITLE
Harmonize documentation of Python expression function decorator

### DIFF
--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -48,11 +48,24 @@ def register_function(function, arg_count, group, usesgeometry=False,
 
     Eval errors can be raised using parent.setEvalErrorString("Error message")
 
-    :param function:
-    :param arg_count:
-    :param group:
-    :param usesgeometry:
-    :param handlesnull: Needs to be set to True if this function does not always return NULL if any parameter is NULL. Default False.
+    :param function: Function to be registered.
+    :param arg_count: Defines the number of arguments. With args="auto" the number of
+                    arguments will automatically be extracted from the signature. With
+                    args=-1, any number of arguments are accepted. Note that two
+                    arguments, feature and parent, are always automatically passed.
+                    Defaults to "auto".
+    :param group: The expression group to which this expression should be added.
+                    Defaults to "custom".
+    :param usesgeometry: Defines if this expression requires the geometry (i.e.
+                    feature.geometry()). Defaults to False.
+    :param referenced_columns: A list of attribute names that are required to run this
+                    function. QgsFeatureRequest.ALL_ATTRIBUTES can be used to indicate all
+                    attributes. Potentially used by the expression engine and providers to
+                    efficiently limit requests to the specified column(s).
+                    Defaults to [QgsFeatureRequest.ALL_ATTRIBUTES].
+    :param handlesnull: Defines if this expression has custom handling for NULL values.
+                    If False, the result will always be NULL if any parameter is NULL.
+                    Defaults to False.
     :return:
     """
 
@@ -141,18 +154,23 @@ def qgsfunction(args='auto', group='custom', **kwargs):
     r"""
     Decorator function used to define a user expression function.
 
-    :param args: Number of parameters, set to 'auto' to accept a variable length of parameters.
-    :param group: The expression group to which this expression should be added.
+    :param args: Defines the number of arguments. With ``'auto'`` the number of arguments will automatically
+                be extracted from the signature. With ``-1``, any number of arguments are accepted. Note
+                that two arguments, feature and parent, are always automatically passed. Defaults to ``"auto"``.
+    :param group: The expression group to which this expression should be added. Defaults to ``"custom"``.
     :param \**kwargs:
         See below
 
     :Keyword Arguments:
-        * *referenced_columns* (``list``) --
-          An array of field names on which this expression works. Can be set to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. By default empty.
         * *usesgeometry* (``bool``) --
-          Defines if this expression requires the geometry. By default False.
+            Defines if this expression requires the geometry (i.e. ``feature.geometry()``). Defaults to False.
+        * *referenced_columns* (``list``) --
+            A list of attribute names that are required to run this function. ``QgsFeatureRequest.ALL_ATTRIBUTES``
+            can be used to indicate all attributes. Potentially used by the expression engine and providers to
+            efficiently limit requests to the specified column(s). Defaults to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``.
         * *handlesnull* (``bool``) --
-          Defines if this expression has custom handling for NULL values. If False, the result will always be NULL as soon as any parameter is NULL. False by default.
+            Defines if this expression has custom handling for NULL values. If False, the result will always be
+            NULL if any parameter is NULL. Defaults to False.
 
     Example:
       @qgsfunction(2, 'test'):

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -226,18 +226,22 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
  The @qgsfunction decorator accepts the following arguments:\n\
 \n\
 \n\
- : param args: Defines the number of arguments. With ``args = 'auto'`` the number of\n\
-               arguments will automatically be extracted from the signature.\n\
-               With ``args = -1``, any number of arguments are accepted.\n\
- : param group: The name of the group under which this expression function will\n\
-                be listed.\n\
- : param handlesnull: Set this to True if your function has custom handling for NULL values.\n\
-                     If False, the result will always be NULL as soon as any parameter is NULL.\n\
-                     Defaults to False.\n\
- : param usesgeometry : Set this to True if your function requires access to\n\
-                        feature.geometry(). Defaults to False.\n\
- : param referenced_columns: An array of attribute names that are required to run\n\
-                             this function. Defaults to [QgsFeatureRequest.ALL_ATTRIBUTES].\n\
+ : param args: Defines the number of arguments. With ``args='auto'`` the number of\n\
+              arguments will automatically be extracted from the signature.\n\
+              With ``args=-1``, any number of arguments are accepted.\n\
+              Note that two arguments, feature and parent, are always automatically passed.\n\
+              Defaults to ``'auto'``.\n\
+ : param group: The expression group to which this expression should be added.\n\
+              Defaults to ``'custom'``.\n\
+ : param usesgeometry : Defines if this expression requires the geometry (i.e. feature.geometry()).\n\
+              Defaults to False.\n\
+ : param referenced_columns: A list of attribute names that are required to run this function.\n\
+              ``QgsFeatureRequest.ALL_ATTRIBUTES`` can be used to indicate all attributes.\n\
+              Potentially used by the expression engine and providers to efficiently limit\n\
+              requests to the specified column(s). Defaults to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``.\n\
+ : param handlesnull: Defines if this expression has custom handling for NULL values.\n\
+              If False, the result will always be NULL if any parameter is NULL.\n\
+              Defaults to False.\n\
      \"\"\"" ) );
 }
 


### PR DESCRIPTION
## Description

There were several slightly different versions of how the parameters of the Python expression function decorator were explained. I tried to harmonize them and at the same add some more detail about `referenced_columns` (finally https://github.com/qgis/QGIS/issues/46161, thanks again @m-kuhn).

I identified the following places:
- The yellow help text in the expression editor dialog:
  - https://github.com/qgis/QGIS/blob/ec51684f06fcd9695d436c819f80d1e9d5acba00/src/gui/qgsexpressionbuilderwidget.cpp#L210
- The `qgsfunction` decorator and the `register_function` function:
  - https://github.com/qgis/QGIS/blob/914dccbd5b74d5e9b5cccba23d0bdf4757f73e61/python/core/additions/qgsfunction.py#L29
  - https://github.com/qgis/QGIS/blob/914dccbd5b74d5e9b5cccba23d0bdf4757f73e61/python/core/additions/qgsfunction.py#L140
- The docs
  - https://github.com/qgis/QGIS-Documentation/blob/master/docs/user_manual/expressions/expression.rst
  - Handled in https://github.com/qgis/QGIS-Documentation/pull/7905

- Order taken from `register_function`'s parameter list
- Added SOME missing parameters' docs in `register_function`
- Tried to abide to markup and indentation of the surrounding code

To be honest, I have no idea why double-backtick markup is used in the text that gets shown in the inline help in the expression editor dialog. To me personally single-backticks would feel more natural.

Strong scrutiny by people involved in this code would be appreciated. I don't want to worsen any understanding of people!

I did compile QGIS which these changes:
![inline](https://user-images.githubusercontent.com/7661092/205303795-3db69016-4bbe-4ea8-bae3-55805e5532e8.png)

It would be nice to also harmonize docs of the other parameters around this, `feature`, `parent` and `context`, but I don't have the time to do that right now.

Fixes #46161