### PR TITLE
Correctly render ordered list in maplayerrenderer API docs - take 2

### DIFF
--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -27,13 +27,10 @@ Qt containers and various Qt classes use implicit sharing.
 
 The scenario will be:
 
-#. renderer job (doing preparation in the GUI thread) calls
-  :py:func:`QgsMapLayer.createMapRenderer()` and gets instance of this class.
-  The instance is initialized at that point and should not need
-  additional calls to :py:class:`QgsVectorLayer`.
-#. renderer job (still in GUI thread) stores the renderer for later use.
-#. renderer job (in worker thread) calls :py:func:`QgsMapLayerRenderer.render()`
-#. renderer job (again in GUI thread) will check :py:func:`~errors` and report them
+1. renderer job (doing preparation in the GUI thread) calls :py:func:`QgsMapLayer.createMapRenderer()` and gets instance of this class. The instance is initialized at that point and should not need additional calls to :py:class:`QgsVectorLayer`.
+2. renderer job (still in GUI thread) stores the renderer for later use.
+3. renderer job (in worker thread) calls :py:func:`QgsMapLayerRenderer.render()`
+4. renderer job (again in GUI thread) will check :py:func:`~errors` and report them
 
 .. versionadded:: 2.4
 %End

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -41,13 +41,10 @@ class QgsRenderedItemDetails;
  *
  * The scenario will be:
  *
- * #. renderer job (doing preparation in the GUI thread) calls
- *    QgsMapLayer::createMapRenderer() and gets instance of this class.
- *    The instance is initialized at that point and should not need
- *    additional calls to QgsVectorLayer.
- * #. renderer job (still in GUI thread) stores the renderer for later use.
- * #. renderer job (in worker thread) calls QgsMapLayerRenderer::render()
- * #. renderer job (again in GUI thread) will check errors() and report them
+ * 1. renderer job (doing preparation in the GUI thread) calls QgsMapLayer::createMapRenderer() and gets instance of this class. The instance is initialized at that point and should not need additional calls to QgsVectorLayer.
+ * 2. renderer job (still in GUI thread) stores the renderer for later use.
+ * 3. renderer job (in worker thread) calls QgsMapLayerRenderer::render()
+ * 4. renderer job (again in GUI thread) will check errors() and report them
  *
  * \since QGIS 2.4
  */


### PR DESCRIPTION
#50960 improved the [c++](https://api.qgis.org/api/classQgsMapLayerRenderer.html) and [pyqgis](https://qgis.org/pyqgis/master/core/QgsMapLayerRenderer.html#module-QgsMapLayerRenderer) docs rendering but still not the best. After [some reading](https://www.doxygen.nl/manual/lists.html), it looks like:
1. the proper ordered list formatting for c++ docs is to use 1., 2.,... (I'm not confident in the output I get with -# format)
2. the scripts/prepare_commit is failing to do multiline list item proper formatting to sip > so the long text of the first item is now one lined (for safety)