### PR TITLE
Ensure that dataChanged signal is raised for DisplayRole in QgsAttributeTableModel when a feature attribute is changed

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -367,7 +367,11 @@ void QgsAttributeTableModel::attributeValueChanged( QgsFeatureId fid, int idx, c
   if ( mFeatureRequest.filterType() == QgsFeatureRequest::FilterNone )
   {
     if ( loadFeatureAtId( fid ) )
-      setData( index( idToRow( fid ), fieldCol( idx ) ), value, Qt::EditRole );
+    {
+      const QModelIndex modelIndex = index( idToRow( fid ), fieldCol( idx ) );
+      setData( modelIndex, value, Qt::EditRole );
+      emit dataChanged( modelIndex, modelIndex, QVector<int>() << Qt::DisplayRole );
+    }
   }
   else
   {
@@ -383,7 +387,9 @@ void QgsAttributeTableModel::attributeValueChanged( QgsFeatureId fid, int idx, c
         else
         {
           // Update representation
-          setData( index( idToRow( fid ), fieldCol( idx ) ), value, Qt::EditRole );
+          const QModelIndex modelIndex = index( idToRow( fid ), fieldCol( idx ) );
+          setData( modelIndex, value, Qt::EditRole );
+          emit dataChanged( modelIndex, modelIndex, QVector<int>() << Qt::DisplayRole );
         }
       }
       else

--- a/tests/src/python/test_qgsattributetablemodel.py
+++ b/tests/src/python/test_qgsattributetablemodel.py
@@ -32,9 +32,12 @@ from qgis.core import (
     QgsField,
     QgsFields,
     QgsWkbTypes,
+    QgsFeatureRequest
 )
 from qgis.PyQt.QtCore import Qt, QTemporaryDir, QVariant, QSortFilterProxyModel
 from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtTest import QSignalSpy
+
 from qgis.testing import (start_app,
                           unittest
                           )
@@ -117,7 +120,19 @@ class TestQgsAttributeTableModel(unittest.TestCase):
 
         # change attribute value for a feature and commit
         self.layer.startEditing()
+
+        spy = QSignalSpy(self.am.dataChanged)
+
         self.layer.changeAttributeValue(fid, field_idx, new_value)
+
+        # ensure that dataChanged signal was raised
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1][0].row(), model_index.row())
+        self.assertEqual(spy[-1][0].column(), field_idx)
+        self.assertEqual(spy[-1][1].row(), model_index.row())
+        self.assertEqual(spy[-1][1].column(), field_idx)
+        self.assertEqual(spy[-1][2], [Qt.DisplayRole])
+
         self.layer.commitChanges()
 
         # check the feature in layer is good
@@ -127,6 +142,51 @@ class TestQgsAttributeTableModel(unittest.TestCase):
         # get the same feature from model and layer
         model_index = self.am.idToIndex(fid)
         feature_model = self.am.feature(model_index)
+
+        # check that index from layer and model are sync
+        self.assertEqual(feature.attribute(field_idx), feature_model.attribute(field_idx))
+
+    def testEditWithFilter(self):
+        fid = 2
+        field_idx = 1
+        new_value = 334
+
+        # get the same feature from model and layer
+        feature = self.layer.getFeature(fid)
+        am = QgsAttributeTableModel(self.cache)
+        am.setRequest(QgsFeatureRequest().setFilterFid(fid))
+        am.loadLayer()
+
+        model_index = am.idToIndex(fid)
+        feature_model = am.feature(model_index)
+
+        # check that feature from layer and model are sync
+        self.assertEqual(feature.attribute(field_idx), feature_model.attribute(field_idx))
+
+        # change attribute value for a feature and commit
+        self.layer.startEditing()
+
+        spy = QSignalSpy(am.dataChanged)
+
+        self.layer.changeAttributeValue(fid, field_idx, new_value)
+
+        # ensure that dataChanged signal was raised
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1][0].row(), model_index.row())
+        self.assertEqual(spy[-1][0].column(), field_idx)
+        self.assertEqual(spy[-1][1].row(), model_index.row())
+        self.assertEqual(spy[-1][1].column(), field_idx)
+        self.assertEqual(spy[-1][2], [Qt.DisplayRole])
+
+        self.layer.commitChanges()
+
+        # check the feature in layer is good
+        feature = self.layer.getFeature(fid)
+        self.assertEqual(feature.attribute(field_idx), new_value)
+
+        # get the same feature from model and layer
+        model_index = am.idToIndex(fid)
+        feature_model = am.feature(model_index)
 
         # check that index from layer and model are sync
         self.assertEqual(feature.attribute(field_idx), feature_model.attribute(field_idx))


### PR DESCRIPTION
Otherwise the attribute table will show the outdated value until it is repainted
