### PR TITLE
Refresh GPS Information Panel widget - Timeout connection error!

### DIFF
--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -148,6 +148,7 @@ void QgsAppGpsConnection::connectGps()
   emit statusChanged( Qgis::GpsConnectionStatus::Connecting );
   emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
 
+  QgisApp::instance()->statusBarIface()->clearMessage();
   showStatusBarMessage( tr( "Connecting to GPS device %1…" ).arg( port ) );
 
   QgsGpsDetector *detector = new QgsGpsDetector( port );
@@ -168,6 +169,7 @@ void QgsAppGpsConnection::disconnectGps()
     emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
     emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
 
+    QgisApp::instance()->statusBarIface()->clearMessage();
     showStatusBarMessage( tr( "Disconnected from GPS device." ) );
 
     QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
@@ -176,12 +178,18 @@ void QgsAppGpsConnection::disconnectGps()
 
 void QgsAppGpsConnection::onTimeOut()
 {
+  std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );
   mConnection = nullptr;
-  emit connectionTimedOut();
+  
+  emit disconnected();
   emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
+  emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
+  emit connectionTimedOut();
 
   QgisApp::instance()->statusBarIface()->clearMessage();
-  showGpsConnectFailureWarning( tr( "Failed to connect to GPS device." ) );
+  showGpsConnectFailureWarning( tr( "TIMEOUT - Failed to connect to GPS device." ) );
+
+  QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
 }
 
 void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -180,7 +180,7 @@ void QgsAppGpsConnection::onTimeOut()
 {
   std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );
   mConnection = nullptr;
-  
+
   emit disconnected();
   emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
   emit fixStatusChanged( Qgis::GpsFixStatus::NoData );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -286,7 +286,6 @@ void QgsGpsInformationWidget::gpsConnecting()
   mTxtQuality->clear();
   mTxtSatellitesUsed->clear();
   mTxtStatus->clear();
-  
   mGPSPlainTextEdit->appendPlainText( tr( "Connecting…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -359,7 +359,7 @@ void QgsGpsInformationWidget::gpsDisconnected()
   QVector<QPointF> data;
   mCurve->setSamples( data );
   mPlot->replot();
-
+  
   mGPSPlainTextEdit->appendPlainText( tr( "Disconnected…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -82,22 +82,23 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsAppGpsConnection *connectio
   //
   mPlot = new QwtPlot( mpHistogramWidget );
   mPlot->setAutoReplot( false );   // plot on demand
-  //mpPlot->setTitle(QObject::tr("Signal Status"));
-  //mpPlot->insertLegend(new QwtLegend(), QwtPlot::BottomLegend);
+  //mPlot->setTitle(QObject::tr("Signal dB Value"));
+  //mPlot->insertLegend(new QwtLegend(), QwtPlot::BottomLegend);
   // Set axis titles
-  //mpPlot->setAxisTitle(QwtPlot::xBottom, QObject::tr("Satellite"));
-  //mpPlot->setAxisTitle(QwtPlot::yLeft, QObject::tr("Value"));
+  //mPlot->setAxisTitle(QwtPlot::xBottom, QObject::tr("Satellite"));
+  //mPlot->setAxisTitle(QwtPlot::yLeft, QObject::tr("dB Value"));
   mPlot->setAxisScale( QwtPlot::xBottom, 0, 20 );
-  mPlot->setAxisScale( QwtPlot::yLeft, 0, 100 );  // max is 50dB SNR, I believe - SLM
+  mPlot->setAxisScale( QwtPlot::yLeft, 0, 60 );  // max is 50dB SNR, I believe - SLM
   // add a grid
-  //QwtPlotGrid * mypGrid = new QwtPlotGrid();
-  //mypGrid->attach( mpPlot );
-  //display satellites first
+  QwtPlotGrid * mypGrid = new QwtPlotGrid();
+  mGrid->enableX (false);
+  mypGrid->attach( mpPlot );
+  // display satellites first
   mCurve = new QwtPlotCurve();
   mCurve->setRenderHint( QwtPlotItem::RenderAntialiased );
   mCurve->setPen( QPen( Qt::blue ) );
   mCurve->setBrush( QBrush( Qt::blue ) );
-  mPlot->enableAxis( QwtPlot::yLeft, false );
+  mPlot->enableAxis( QwtPlot::yLeft, true );
   mPlot->enableAxis( QwtPlot::xBottom, false );
   mCurve->attach( mPlot );
   //ensure all children get removed
@@ -269,12 +270,17 @@ void QgsGpsInformationWidget::gpsConnecting()
   mTxtLatitude->clear();
   mTxtLongitude->clear();
   mTxtAltitude->clear();
+  mTxtAltitudeDiff->clear();
+  mTxtAltitudeEllipsoid->clear();
   mTxtDateTime->clear();
   mTxtSpeed->clear();
   mTxtDirection->clear();
   mTxtHdop->clear();
   mTxtVdop->clear();
   mTxtPdop->clear();
+  mTxtHacc->clear();
+  mTxtVacc->clear();
+  mTxt3Dacc->clear();
   mTxtFixMode->clear();
   mTxtFixType->clear();
   mTxtQuality->clear();
@@ -328,6 +334,27 @@ void QgsGpsInformationWidget::updateTrackInformation()
 
 void QgsGpsInformationWidget::gpsDisconnected()
 {
+  // clear position page fields to give better indication that something happened (or didn't happen)
+  mTxtLatitude->clear();
+  mTxtLongitude->clear();
+  mTxtAltitude->clear();
+  mTxtAltitudeDiff->clear();
+  mTxtAltitudeEllipsoid->clear();
+  mTxtDateTime->clear();
+  mTxtSpeed->clear();
+  mTxtDirection->clear();
+  mTxtHdop->clear();
+  mTxtVdop->clear();
+  mTxtPdop->clear();
+  mTxtHacc->clear();
+  mTxtVacc->clear();
+  mTxt3Dacc->clear();
+  mTxtFixMode->clear();
+  mTxtFixType->clear();
+  mTxtQuality->clear();
+  mTxtSatellitesUsed->clear();
+  mTxtStatus->clear();
+
   mGPSPlainTextEdit->appendPlainText( tr( "Disconnected…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -354,6 +354,11 @@ void QgsGpsInformationWidget::gpsDisconnected()
   mTxtQuality->clear();
   mTxtSatellitesUsed->clear();
   mTxtStatus->clear();
+  
+  // Clear Plot Signal data
+  QVector<QPointF> data;
+  mCurve->setSamples( data );
+  mPlot->replot();
 
   mGPSPlainTextEdit->appendPlainText( tr( "Disconnected…" ) );
 }

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -90,9 +90,9 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsAppGpsConnection *connectio
   mPlot->setAxisScale( QwtPlot::xBottom, 0, 20 );
   mPlot->setAxisScale( QwtPlot::yLeft, 0, 60 );  // max is 50dB SNR, I believe - SLM
   // add a grid
-  QwtPlotGrid * mypGrid = new QwtPlotGrid();
+  QwtPlotGrid * mGrid = new QwtPlotGrid();
   mGrid->enableX (false);
-  mypGrid->attach( mpPlot );
+  mGrid->attach( mPlot );
   // display satellites first
   mCurve = new QwtPlotCurve();
   mCurve->setRenderHint( QwtPlotItem::RenderAntialiased );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -354,12 +354,10 @@ void QgsGpsInformationWidget::gpsDisconnected()
   mTxtQuality->clear();
   mTxtSatellitesUsed->clear();
   mTxtStatus->clear();
-  
-  // Clear Plot Signal data
+  // clear plot signal data
   QVector<QPointF> data;
   mCurve->setSamples( data );
   mPlot->replot();
-  
   mGPSPlainTextEdit->appendPlainText( tr( "Disconnected…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -91,7 +91,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsAppGpsConnection *connectio
   mPlot->setAxisScale( QwtPlot::yLeft, 0, 60 );  // max is 50dB SNR, I believe - SLM
   // add a grid
   QwtPlotGrid * mGrid = new QwtPlotGrid();
-  mGrid->enableX (false);
+  mGrid->enableX ( false );
   mGrid->attach( mPlot );
   // display satellites first
   mCurve = new QwtPlotCurve();

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -286,7 +286,7 @@ void QgsGpsInformationWidget::gpsConnecting()
   mTxtQuality->clear();
   mTxtSatellitesUsed->clear();
   mTxtStatus->clear();
-
+  
   mGPSPlainTextEdit->appendPlainText( tr( "Connecting…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -90,7 +90,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsAppGpsConnection *connectio
   mPlot->setAxisScale( QwtPlot::xBottom, 0, 20 );
   mPlot->setAxisScale( QwtPlot::yLeft, 0, 60 );  // max is 50dB SNR, I believe - SLM
   // add a grid
-  QwtPlotGrid * mGrid = new QwtPlotGrid();
+  QwtPlotGrid *mGrid = new QwtPlotGrid();
   mGrid->enableX ( false );
   mGrid->attach( mPlot );
   // display satellites first

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -91,7 +91,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsAppGpsConnection *connectio
   mPlot->setAxisScale( QwtPlot::yLeft, 0, 60 );  // max is 50dB SNR, I believe - SLM
   // add a grid
   QwtPlotGrid *mGrid = new QwtPlotGrid();
-  mGrid->enableX ( false );
+  mGrid->enableX( false );
   mGrid->attach( mPlot );
   // display satellites first
   mCurve = new QwtPlotCurve();

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -440,6 +440,8 @@ void QgsNmeaConnection::processVtgSentence( const char *data, int len )
   nmeaGPVTG result;
   if ( nmea_parse_GPVTG( data, len, &result ) )
   {
+    if ( !std::isnan( result.dir ) )
+      mLastGPSInformation.direction = result.dir;
     mLastGPSInformation.speed = result.spk;
   }
 }


### PR DESCRIPTION
My GNSS receiver is having trouble connecting with the new GPS Tools. The TIMEOUT connection error blocked the connection to the GNSS receiver and I had to restart QGis to make a new connection attempt.
This PR refreshes the GPS Information Panel, cancels any values present and closes any active GNSS connection!
Further minor updates.

Hi @nyalldawson
I would like to send you my feedback for the new GPS Tools!
I state immediately that not knowing the specifics of the GPS Tools lender, you can safely consider my observations null and void:

1) the Z coordinate of points does NOT use the height of the ellipsoid but uses the height (geoid) which is an approximate NMEA value that does not take into account the Undulation Model of Local Geoid.
**Conversions to Geoid Height always start from Ellipsoid Height!**
I think it's more correct to use Ellipsoidal Height for Z coordinate when saving a single point to current layer or storing a navigation track! (of course I would do it in LOG file).

2) function: LOG TO GEOPACKAGE/SPATIALITE... : Layer: GPS_POINT
a) I get double/triple points with the same timestamp even though my GNSS receiver is set to 1Hz (1 point per second)!!!!
b) I would add to the LOG: the QUALITY field: it is a very important parameter in a topographic survey.
c) It would be nice (not essential) to have the number of satellites in use for each constellation in the table.

3) I would add in Setting (and in LOG table): POLE_HEIGHT field: generally in surveys the GNSS receiver is mounted on a pole.
Consequently the Z values must take into account the new parameter!

One thing I would definitely do is modernize the names of the instruments, abandoning the old wording GPS and replacing it with GNSS.

If my remarks conflict with the GPS Tools lender's specifications,
consider void what I wrote above!

Always grateful for your amazing work!!
See you soon!
Thank you