### PR TITLE
Make raster paletted renderer classify function thread safe

### DIFF
--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -22,7 +22,6 @@
 #include "qgscolordialog.h"
 #include "qgssettings.h"
 #include "qgsproject.h"
-#include "qgscolorrampshaderwidget.h"
 #include "qgscolorrampimpl.h"
 #include "qgslocaleawarenumericlineeditdelegate.h"
 
@@ -840,7 +839,7 @@ void QgsPalettedRendererModel::deleteAll()
 //
 
 QgsPalettedRendererClassGatherer::QgsPalettedRendererClassGatherer( QgsRasterLayer *layer, int bandNumber, const QgsPalettedRasterRenderer::ClassData &existingClasses, QgsColorRamp *ramp )
-  : mLayer( layer )
+  : mProvider( ( layer && layer->dataProvider() ) ? layer->dataProvider()->clone() : nullptr )
   , mBandNumber( bandNumber )
   , mRamp( ramp )
   , mClasses( existingClasses )
@@ -855,28 +854,31 @@ void QgsPalettedRendererClassGatherer::run()
   mFeedback = new QgsRasterBlockFeedback();
   connect( mFeedback, &QgsRasterBlockFeedback::progressChanged, this, &QgsPalettedRendererClassGatherer::progressChanged );
 
-  QgsPalettedRasterRenderer::ClassData newClasses = QgsPalettedRasterRenderer::classDataFromRaster( mLayer->dataProvider(), mBandNumber, mRamp.get(), mFeedback );
-
-  // combine existing classes with new classes
-  QgsPalettedRasterRenderer::ClassData::iterator classIt = newClasses.begin();
-  emit progressChanged( 0 );
-  qlonglong i = 0;
-  for ( ; classIt != newClasses.end(); ++classIt )
+  if ( mProvider )
   {
-    // check if existing classes contains this same class
-    for ( const QgsPalettedRasterRenderer::Class &existingClass : std::as_const( mClasses ) )
+    QgsPalettedRasterRenderer::ClassData newClasses = QgsPalettedRasterRenderer::classDataFromRaster( mProvider.get(), mBandNumber, mRamp.get(), mFeedback );
+
+    // combine existing classes with new classes
+    QgsPalettedRasterRenderer::ClassData::iterator classIt = newClasses.begin();
+    emit progressChanged( 0 );
+    qlonglong i = 0;
+    for ( ; classIt != newClasses.end(); ++classIt )
     {
-      if ( existingClass.value == classIt->value )
+      // check if existing classes contains this same class
+      for ( const QgsPalettedRasterRenderer::Class &existingClass : std::as_const( mClasses ) )
       {
-        classIt->color = existingClass.color;
-        classIt->label = existingClass.label;
-        break;
+        if ( existingClass.value == classIt->value )
+        {
+          classIt->color = existingClass.color;
+          classIt->label = existingClass.label;
+          break;
+        }
       }
+      i ++;
+      emit progressChanged( 100 * ( i / static_cast<float>( newClasses.count() ) ) );
     }
-    i ++;
-    emit progressChanged( 100 * ( i / static_cast<float>( newClasses.count() ) ) );
+    mClasses = newClasses;
   }
-  mClasses = newClasses;
 
   // be overly cautious - it's *possible* stop() might be called between deleting mFeedback and nulling it
   mFeedbackMutex.lock();

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -875,7 +875,7 @@ void QgsPalettedRendererClassGatherer::run()
         }
       }
       i ++;
-      emit progressChanged( 100 * ( i / static_cast<float>( newClasses.count() ) ) );
+      emit progressChanged( 100 * ( static_cast< double >( i ) / static_cast<double>( newClasses.count() ) ) );
     }
     mClasses = newClasses;
   }

--- a/src/gui/raster/qgspalettedrendererwidget.h
+++ b/src/gui/raster/qgspalettedrendererwidget.h
@@ -23,7 +23,6 @@
 #include "qgspalettedrasterrenderer.h"
 #include "qgscolorschemelist.h"
 #include "qgsrasterlayer.h"
-#include "qgsrasterdataprovider.h"
 #include "ui_qgspalettedrendererwidgetbase.h"
 #include "qgis_gui.h"
 
@@ -81,7 +80,7 @@ class QgsPalettedRendererClassGatherer: public QThread
 
   private:
 
-    QgsRasterLayer *mLayer = nullptr;
+    std::unique_ptr< QgsRasterDataProvider > mProvider;
     int mBandNumber;
     std::unique_ptr< QgsColorRamp > mRamp;
     QString mSubstring;


### PR DESCRIPTION
In addition to making this correctly thread safe, also avoids a temporary UI hang during the classification if the layer rendering is triggered before the classification finishes.
