### PR TITLE
Add option to store selected GPS component in geometry M values

### DIFF
--- a/python/core/auto_generated/gps/qgsgpslogger.sip.in
+++ b/python/core/auto_generated/gps/qgsgpslogger.sip.in
@@ -27,6 +27,8 @@ from incoming GPS location points.
 %End
   public:
 
+
+
     QgsGpsLogger( QgsGpsConnection *connection, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsGpsLogger with the specified ``parent`` object.
@@ -122,6 +124,11 @@ handling.
     double lastElevation() const;
 %Docstring
 Returns the last recorded elevation the device.
+%End
+
+    double lastMValue() const;
+%Docstring
+Returns the last recorded value corresponding to the QgsGpsLogger.settingsGpsMValueComponent setting.
 %End
 
     void resetTrack();

--- a/src/app/gps/qgsappgpslogging.cpp
+++ b/src/app/gps/qgsappgpslogging.cpp
@@ -334,7 +334,7 @@ bool QgsAppGpsLogging::createOrUpdateLogDatabase()
 
       const Qgis::VectorExportResult result = ogrMetadata->createEmptyLayer( mGpkgLogFile,
                                               pointFields,
-                                              QgsWkbTypes::PointZ,
+                                              QgsGpsLogger::settingsGpsStoreAttributeInMValues.value() ? QgsWkbTypes::PointZM : QgsWkbTypes::PointZ,
                                               QgsCoordinateReferenceSystem( "EPSG:4326" ),
                                               false, unusedMap, error, &options );
       if ( result != Qgis::VectorExportResult::Success )
@@ -374,7 +374,7 @@ bool QgsAppGpsLogging::createOrUpdateLogDatabase()
 
       const Qgis::VectorExportResult result = ogrMetadata->createEmptyLayer( mGpkgLogFile,
                                               tracksFields,
-                                              QgsWkbTypes::LineStringZ,
+                                              QgsGpsLogger::settingsGpsStoreAttributeInMValues.value() ? QgsWkbTypes::LineStringZM : QgsWkbTypes::LineStringZ,
                                               QgsCoordinateReferenceSystem( "EPSG:4326" ),
                                               false, unusedMap, error, &options );
       if ( result != Qgis::VectorExportResult::Success )

--- a/src/app/options/qgsgpsoptions.cpp
+++ b/src/app/options/qgsgpsoptions.cpp
@@ -131,6 +131,20 @@ QgsGpsOptionsWidget::QgsGpsOptionsWidget( QWidget *parent )
   mCboAcquisitionInterval->setValidator( mAcquisitionIntValidator );
   mCboDistanceThreshold->setValidator( mDistanceThresholdValidator );
 
+  mComboMValueAttribute->addItem( tr( "Do not Store M Values" ) );
+  mComboMValueAttribute->addItem( tr( "Timestamp (Milliseconds Since Epoch)" ), QVariant::fromValue( Qgis::GpsInformationComponent::Timestamp ) );
+  mComboMValueAttribute->addItem( tr( "Ground Speed" ), QVariant::fromValue( Qgis::GpsInformationComponent::GroundSpeed ) );
+  mComboMValueAttribute->addItem( tr( "Bearing" ), QVariant::fromValue( Qgis::GpsInformationComponent::Bearing ) );
+  mComboMValueAttribute->addItem( tr( "Altitude (Geoid)" ), QVariant::fromValue( Qgis::GpsInformationComponent::EllipsoidAltitude ) );
+  mComboMValueAttribute->addItem( tr( "Altitude (WGS-84 Ellipsoid)" ), QVariant::fromValue( Qgis::GpsInformationComponent::Altitude ) );
+  mComboMValueAttribute->addItem( tr( "PDOP" ), QVariant::fromValue( Qgis::GpsInformationComponent::Pdop ) );
+  mComboMValueAttribute->addItem( tr( "HDOP" ), QVariant::fromValue( Qgis::GpsInformationComponent::Hdop ) );
+  mComboMValueAttribute->addItem( tr( "VDOP" ), QVariant::fromValue( Qgis::GpsInformationComponent::Vdop ) );
+  mComboMValueAttribute->addItem( tr( "Horizontal Accuracy" ), QVariant::fromValue( Qgis::GpsInformationComponent::HorizontalAccuracy ) );
+  mComboMValueAttribute->addItem( tr( "Vertical Accuracy" ), QVariant::fromValue( Qgis::GpsInformationComponent::VerticalAccuracy ) );
+  mComboMValueAttribute->addItem( tr( "Accuracy (3D RMS)" ), QVariant::fromValue( Qgis::GpsInformationComponent::HvAccuracy ) );
+  mComboMValueAttribute->addItem( tr( "Satellites Used" ), QVariant::fromValue( Qgis::GpsInformationComponent::SatellitesUsed ) );
+  mComboMValueAttribute->setCurrentIndex( 0 );
 
   Qgis::GpsConnectionType connectionType = Qgis::GpsConnectionType::Automatic;
   QString gpsdHost;
@@ -163,6 +177,11 @@ QgsGpsOptionsWidget::QgsGpsOptionsWidget( QWidget *parent )
     timeSpec = QgsGpsConnection::settingsGpsTimeStampSpecification.value();
     timeZone = QgsGpsConnection::settingsGpsTimeStampTimeZone.value();
     offsetFromUtc = static_cast< int >( QgsGpsConnection::settingsGpsTimeStampOffsetFromUtc.value() );
+
+    if ( QgsGpsLogger::settingsGpsStoreAttributeInMValues.value() )
+    {
+      mComboMValueAttribute->setCurrentIndex( mComboMValueAttribute->findData( QVariant::fromValue( QgsGpsLogger::settingsGpsMValueComponent.value() ) ) );
+    }
   }
   else
   {
@@ -354,6 +373,16 @@ void QgsGpsOptionsWidget::apply()
   QgsGpsConnection::settingGpsApplyLeapSecondsCorrection.setValue( mCbxLeapSeconds->isChecked() );
   QgsGpsConnection::settingGpsLeapSeconds.setValue( mLeapSeconds->value() );
   QgsGpsConnection::settingsGpsTimeStampOffsetFromUtc.setValue( mOffsetFromUtc->value() );
+
+  if ( !mComboMValueAttribute->currentData().isValid() )
+  {
+    QgsGpsLogger::settingsGpsStoreAttributeInMValues.setValue( false );
+  }
+  else
+  {
+    QgsGpsLogger::settingsGpsStoreAttributeInMValues.setValue( true );
+    QgsGpsLogger::settingsGpsMValueComponent.setValue( mComboMValueAttribute->currentData().value< Qgis::GpsInformationComponent >() );
+  }
 }
 
 void QgsGpsOptionsWidget::refreshDevices()

--- a/src/core/gps/qgsgpslogger.cpp
+++ b/src/core/gps/qgsgpslogger.cpp
@@ -364,7 +364,7 @@ void QgsGpsLogger::gpsStateChanged( const QgsGpsInformation &info )
       }
 
       case Qgis::GpsInformationComponent::Timestamp:
-        mLastMValue = info.utcDateTime.toMSecsSinceEpoch();
+        mLastMValue = static_cast< double >( info.utcDateTime.toMSecsSinceEpoch() );
         break;
 
       case Qgis::GpsInformationComponent::Location:

--- a/src/core/gps/qgsgpslogger.h
+++ b/src/core/gps/qgsgpslogger.h
@@ -23,6 +23,8 @@
 #include "qgsdistancearea.h"
 #include "qgscoordinatetransformcontext.h"
 #include "qgswkbtypes.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsentryenumflag.h"
 
 #include <QObject>
 #include <QPointer>
@@ -49,6 +51,12 @@ class CORE_EXPORT QgsGpsLogger : public QObject
     Q_OBJECT
 
   public:
+
+    //! Settings entry for whether storing GPS attributes as geometry M values should be enabled
+    static const inline QgsSettingsEntryBool settingsGpsStoreAttributeInMValues = QgsSettingsEntryBool( QStringLiteral( "store-attribute-in-m-values" ), QgsSettings::Prefix::GPS, false, QStringLiteral( "Whether GPS attributes should be stored in geometry m values" ) ) SIP_SKIP;
+
+    //! Settings entry dictating which GPS attribute should be stored in geometry M values
+    static const inline QgsSettingsEntryEnumFlag<Qgis::GpsInformationComponent> settingsGpsMValueComponent = QgsSettingsEntryEnumFlag<Qgis::GpsInformationComponent>( QStringLiteral( "m-value-attribute" ), QgsSettings::Prefix::GPS, Qgis::GpsInformationComponent::Timestamp, QStringLiteral( "Which GPS attribute should be stored in geometry m values" ) ) SIP_SKIP;
 
     /**
      * Constructor for QgsGpsLogger with the specified \a parent object.
@@ -146,6 +154,11 @@ class CORE_EXPORT QgsGpsLogger : public QObject
      * Returns the last recorded elevation the device.
      */
     double lastElevation() const;
+
+    /**
+     * Returns the last recorded value corresponding to the QgsGpsLogger::settingsGpsMValueComponent setting.
+     */
+    double lastMValue() const;
 
     /**
      * Resets the current track, discarding all recorded points.
@@ -272,6 +285,9 @@ class CORE_EXPORT QgsGpsLogger : public QObject
     int mOffsetFromUtc = 0;
 
     bool mAutomaticallyAddTrackVertices = true;
+    bool mStoreAttributeInMValues = false;
+    Qgis::GpsInformationComponent mMValueComponent = Qgis::GpsInformationComponent::Timestamp;
+    double mLastMValue = std::numeric_limits<double>::quiet_NaN();
 
     friend class TestQgsGpsIntegration;
 

--- a/src/core/gps/qgsvectorlayergpslogger.cpp
+++ b/src/core/gps/qgsvectorlayergpslogger.cpp
@@ -107,6 +107,15 @@ void QgsVectorLayerGpsLogger::endCurrentTrack()
       QgsDebugMsg( QStringLiteral( "Error transforming GPS track" ) );
     }
 
+    if ( geometry.constGet()->is3D() && !QgsWkbTypes::hasZ( mTracksLayer->wkbType() ) )
+    {
+      geometry.get()->dropZValue();
+    }
+    if ( geometry.constGet()->isMeasure() && !QgsWkbTypes::hasM( mTracksLayer->wkbType() ) )
+    {
+      geometry.get()->dropMValue();
+    }
+
     QgsAttributeMap attributes;
 
     for ( auto it = mDestinationFields.constBegin(); it != mDestinationFields.constEnd(); ++it )
@@ -186,7 +195,16 @@ void QgsVectorLayerGpsLogger::gpsStateChanged( const QgsGpsInformation &info )
   {
     // record point
     const QgsPointXY newPosition = lastPosition();
-    QgsGeometry geometry( new QgsPoint( newPosition.x(), newPosition.y(), lastElevation() ) );
+    QgsGeometry geometry( new QgsPoint( newPosition.x(), newPosition.y(), lastElevation(), lastMValue() ) );
+
+    if ( geometry.constGet()->is3D() && !QgsWkbTypes::hasZ( mPointsLayer->wkbType() ) )
+    {
+      geometry.get()->dropZValue();
+    }
+    if ( geometry.constGet()->isMeasure() && !QgsWkbTypes::hasM( mPointsLayer->wkbType() ) )
+    {
+      geometry.get()->dropMValue();
+    }
 
     try
     {

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -29,6 +29,7 @@
 #include "qgsogrdbconnection.h"
 #include "qgsfontmanager.h"
 #include "qgsgpsconnection.h"
+#include "qgsgpslogger.h"
 
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
@@ -129,6 +130,9 @@ QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampSpecification );
   addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampTimeZone );
   addSettingsEntry( &QgsGpsConnection::settingsGpsTimeStampOffsetFromUtc );
+
+  addSettingsEntry( &QgsGpsLogger::settingsGpsStoreAttributeInMValues );
+  addSettingsEntry( &QgsGpsLogger::settingsGpsMValueComponent );
 }
 
 QgsSettingsRegistryCore::~QgsSettingsRegistryCore()

--- a/src/ui/qgsgpsoptionswidgetbase.ui
+++ b/src/ui/qgsgpsoptionswidgetbase.ui
@@ -262,6 +262,25 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Geometry Options</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,2">
+          <item row="0" column="1">
+           <widget class="QComboBox" name="mComboMValueAttribute"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Store in M values</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
          <property name="title">
           <string>GPS Location Marker</string>
@@ -567,17 +586,18 @@
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mRadAutodetect</tabstop>
   <tabstop>mRadInternal</tabstop>
+  <tabstop>mRadSerialDevice</tabstop>
   <tabstop>mCboDevices</tabstop>
   <tabstop>mBtnRefreshDevices</tabstop>
-  <tabstop>mRadAutodetect</tabstop>
-  <tabstop>mGpsdDevice</tabstop>
+  <tabstop>mRadGpsd</tabstop>
   <tabstop>mGpsdHost</tabstop>
   <tabstop>mSpinGpsdPort</tabstop>
-  <tabstop>mRadGpsd</tabstop>
-  <tabstop>mRadSerialDevice</tabstop>
-  <tabstop>mCboDistanceThreshold</tabstop>
+  <tabstop>mGpsdDevice</tabstop>
   <tabstop>mCboAcquisitionInterval</tabstop>
+  <tabstop>mCboDistanceThreshold</tabstop>
+  <tabstop>mComboMValueAttribute</tabstop>
   <tabstop>mGpsMarkerSymbolButton</tabstop>
   <tabstop>mCheckRotateLocationMarker</tabstop>
   <tabstop>mBearingLineStyleButton</tabstop>


### PR DESCRIPTION
This new setting, available from the GPS settings panel, allows users to opt into creating geometries with M values from the inbuilt GPS logging tools. This applies to both features digitized from GPS logs and from the new "Log to 
Geopackage/Spatialite" functionality.

Options include storing timestamps (as ms since epoch), ground speed, altitudes, bearings, and accuracy components as m values.

Sponsored by NIWA