### PR TITLE
Fix annoying loss of matrix parameter table values

### DIFF
--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
@@ -51,6 +51,9 @@ QgsProcessingMatrixParameterPanelWidget::QgsProcessingMatrixParameterPanelWidget
   } );
   connect( this, &QgsPanelWidget::panelAccepted, this, [ = ]()
   {
+    // save any current cell edits
+    mTblView->setCurrentIndex( QModelIndex() );
+
     if ( !mWasCanceled )
       emit widgetChanged();
   } );

--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
@@ -43,14 +43,16 @@ QgsProcessingMatrixParameterPanelWidget::QgsProcessingMatrixParameterPanelWidget
   mButtonRemoveAll = new QPushButton( tr( "Remove All" ) );
   mButtonBox->addButton( mButtonRemoveAll, QDialogButtonBox::ActionRole );
 
-  connect( mButtonBox->button( QDialogButtonBox::Ok ), &QPushButton::clicked, this, [ = ]
-  {
-    emit widgetChanged();
-    acceptPanel();
-  } );
+  connect( mButtonBox->button( QDialogButtonBox::Ok ), &QPushButton::clicked, this, &QgsPanelWidget::acceptPanel );
   connect( mButtonBox->button( QDialogButtonBox::Cancel ), &QPushButton::clicked, this, [ = ]
   {
+    mWasCanceled = true;
     acceptPanel();
+  } );
+  connect( this, &QgsPanelWidget::panelAccepted, this, [ = ]()
+  {
+    if ( !mWasCanceled )
+      emit widgetChanged();
   } );
 
   connect( mButtonAdd, &QPushButton::clicked, this, &QgsProcessingMatrixParameterPanelWidget::addRow );

--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.h
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.h
@@ -64,6 +64,7 @@ class GUI_EXPORT QgsProcessingMatrixParameterPanelWidget : public QgsPanelWidget
     QPushButton *mButtonRemoveAll = nullptr;
     const QgsProcessingParameterMatrix *mParam = nullptr;
     QStandardItemModel *mModel = nullptr;
+    bool mWasCanceled = false;
 
     void populateTable( const QVariantList &contents );
 


### PR DESCRIPTION
if back button is pressed in table panel instead of "Ok"

The back button was treated as "cancel", but now the "cancel" only
happens if the user explicitly hits the Cancel button.