### PR TITLE
[Oracle] treat 3D geometry as Z geometry, not 25D

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -851,20 +851,20 @@ QgsWkbTypes::Type QgsOracleConn::wkbTypeFromDatabase( int gtype )
     switch ( t )
     {
       case 1:
-        return QgsWkbTypes::Point25D;
+        return QgsWkbTypes::PointZ;
       case 2:
         return QgsWkbTypes::CompoundCurveZ;
       case 3:
-        return QgsWkbTypes::Polygon25D;
+        return QgsWkbTypes::PolygonZ;
       case 4:
         QgsDebugMsg( QStringLiteral( "geometry collection type %1 unsupported" ).arg( gtype ) );
         return QgsWkbTypes::Unknown;
       case 5:
-        return QgsWkbTypes::MultiPoint25D;
+        return QgsWkbTypes::MultiPointZ;
       case 6:
         return QgsWkbTypes::MultiCurveZ;
       case 7:
-        return QgsWkbTypes::MultiPolygon25D;
+        return QgsWkbTypes::MultiPolygonZ;
       default:
         QgsDebugMsg( QStringLiteral( "gtype %1 unsupported" ).arg( gtype ) );
         return QgsWkbTypes::Unknown;

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -240,23 +240,23 @@ QgsVectorLayer *QgsOracleProviderConnection::createSqlVectorLayer( const QgsAbst
               break;
             // 3K...
             case 3001:
-              geomType = QgsWkbTypes::Point25D;
+              geomType = QgsWkbTypes::PointZ;
               break;
             case 3002:
-              geomType = QgsWkbTypes::LineString25D;
+              geomType = QgsWkbTypes::LineStringZ;
               break;
             case 3003:
-              geomType = QgsWkbTypes::Polygon25D;
+              geomType = QgsWkbTypes::PolygonZ;
               break;
             // Note: 3004 is missing
             case 3005:
-              geomType = QgsWkbTypes::MultiPoint25D;
+              geomType = QgsWkbTypes::MultiPointZ;
               break;
             case 3006:
-              geomType = QgsWkbTypes::MultiLineString25D;
+              geomType = QgsWkbTypes::MultiLineStringZ;
               break;
             case 3007:
-              geomType = QgsWkbTypes::MultiPolygon25D;
+              geomType = QgsWkbTypes::MultiPolygonZ;
               break;
             default:
               geomType = QgsWkbTypes::Type::Unknown;

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -1175,7 +1175,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
         testdata = [
             ("POINT", 2, "SDO_GEOMETRY( 2001,5698,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL)", QgsWkbTypes.Point),
-            ("POINTZ", 3, "SDO_GEOMETRY( 3001,5698,SDO_POINT_TYPE(1, 2, 3), NULL, NULL)", QgsWkbTypes.Point25D),
+            ("POINTZ", 3, "SDO_GEOMETRY( 3001,5698,SDO_POINT_TYPE(1, 2, 3), NULL, NULL)", QgsWkbTypes.PointZ),
             # there is difference between line and curve so everything is a compoundcurve to cover both
             # https://docs.oracle.com/database/121/SPATL/sdo_geometry-object-type.htm
             ("LINE", 2, "SDO_GEOMETRY( 2002,5698,NULL, SDO_ELEM_INFO_ARRAY(1,2,1), SDO_ORDINATE_ARRAY(1,2,3,4,5,6))", QgsWkbTypes.CompoundCurve),
@@ -1183,10 +1183,10 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
             ("CURVE", 2, "SDO_GEOMETRY(2002,5698,NULL, SDO_ELEM_INFO_ARRAY(1, 2, 2), SDO_ORDINATE_ARRAY(1, 2, 5, 4, 7, 2.2, 10, .1, 13, 4))", QgsWkbTypes.CompoundCurve),
             ("CURVEZ", 3, "SDO_GEOMETRY(3002,5698,NULL, SDO_ELEM_INFO_ARRAY(1, 2, 2), SDO_ORDINATE_ARRAY(1, 2, 1, 5, 4, 2, 7, 2.2, 3, 10, 0.1, 4, 13, 4, 5))", QgsWkbTypes.CompoundCurveZ),
             ("POLYGON", 2, "SDO_GEOMETRY(2003,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1), SDO_ORDINATE_ARRAY(1, 2, 11, 2, 11, 22, 1, 22, 1, 2))", QgsWkbTypes.Polygon),
-            ("POLYGONZ", 3, "SDO_GEOMETRY(3003,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1), SDO_ORDINATE_ARRAY(1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3))", QgsWkbTypes.Polygon25D),
+            ("POLYGONZ", 3, "SDO_GEOMETRY(3003,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1), SDO_ORDINATE_ARRAY(1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3))", QgsWkbTypes.PolygonZ),
 
             ("MULTIPOINT", 2, "SDO_GEOMETRY( 2005,5698,NULL, sdo_elem_info_array (1,1,1, 3,1,1), sdo_ordinate_array (1,2, 3,4))", QgsWkbTypes.MultiPoint),
-            ("MULTIPOINTZ", 3, "SDO_GEOMETRY( 3005,5698,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6))", QgsWkbTypes.MultiPoint25D),
+            ("MULTIPOINTZ", 3, "SDO_GEOMETRY( 3005,5698,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6))", QgsWkbTypes.MultiPointZ),
             # there is difference between line and curve so everything is a compoundcurve to cover both
             # https://docs.oracle.com/database/121/SPATL/sdo_geometry-object-type.htm
             ("MULTILINE", 2, "SDO_GEOMETRY(2006,5698,NULL, SDO_ELEM_INFO_ARRAY(1,2,1, 5,2,1), SDO_ORDINATE_ARRAY(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))", QgsWkbTypes.MultiCurve),
@@ -1194,7 +1194,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
             ("MULTICURVE", 2, "SDO_GEOMETRY(2006,5698,NULL, SDO_ELEM_INFO_ARRAY(1,2,2, 11,2,2), SDO_ORDINATE_ARRAY(1, 2, 5, 4, 7, 2.2, 10, .1, 13, 4, -11, -3, 5, 7, 10, -1))", QgsWkbTypes.MultiCurve),
             ("MULTICURVEZ", 3, "SDO_GEOMETRY(3006,5698,NULL, SDO_ELEM_INFO_ARRAY(1,2,2, 16,2,2), SDO_ORDINATE_ARRAY(1, 2, 1, 5, 4, 2, 7, 2.2, 3, 10, .1, 4, 13, 4, 5, -11, -3, 6, 5, 7, 8, 10, -1, 9))", QgsWkbTypes.MultiCurveZ),
             ("MULTIPOLYGON", 2, "SDO_GEOMETRY(2007,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1, 11,1003,1, 21,2003,1, 29,2003,1), SDO_ORDINATE_ARRAY(1, 2, 11, 2, 11, 22, 1, 22, 1, 2, 1, 2, 11, 2, 11, 22, 1, 22, 1, 2, 5, 6, 8, 9, 8, 6, 5, 6, 3, 4, 5, 6, 3, 6, 3, 4))", QgsWkbTypes.MultiPolygon),
-            ("MULTIPOLYGONZ", 3, "SDO_GEOMETRY(3007,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1, 16,1003,1, 31,2003,1), SDO_ORDINATE_ARRAY(1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3, 1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3, 5, 6, 1, 8, 9, -1, 8, 6, 2, 5, 6, 1))", QgsWkbTypes.MultiPolygon25D)
+            ("MULTIPOLYGONZ", 3, "SDO_GEOMETRY(3007,5698,NULL, SDO_ELEM_INFO_ARRAY(1,1003,1, 16,1003,1, 31,2003,1), SDO_ORDINATE_ARRAY(1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3, 1, 2, 3, 11, 2, 13, 11, 22, 15, 1, 22, 7, 1, 2, 3, 5, 6, 1, 8, 9, -1, 8, 6, 2, 5, 6, 1))", QgsWkbTypes.MultiPolygonZ)
         ]
 
         for name, dim, geom, wkb_type in testdata:


### PR DESCRIPTION
Supersedes #51069

Advertize 3D geometries as (Multi)PointZ/(Multi)LineStringZ/(Multi)PolygonZ not (Multi)Point25D/(Multi)LineString25D/(Multi)Polygon25D

**Sponsored by Metropole Européenne de Lille**

cc @Jean-Roc 