### PR TITLE
[WFS] Improve support of layers with unknown geometry type with Deegree servers

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2309,6 +2309,23 @@ not change the geometry.
 :return: ``True`` in case of success and ``False`` else
 %End
 
+    bool convertToCurvedMultiType();
+%Docstring
+Converts a geometry into a multitype geometry of curve kind (when there
+is a corresponding curve type).
+e.g. a polygon into a multisurface geometry with one polygon,
+a multipolygon into a multisurface, a linestring into a multicurve
+geometry with one linestring, or a multilinestring into a multicurve.
+If it is already a multipart curve geometry, it will return ``True`` and
+not change the geometry. It will also return ``True`` and do nothing if
+the current geometry is a multipoint or a geometry collection. A single
+point will be transformed to a multipoint.
+
+:return: ``True`` in case of success and ``False`` else
+
+.. versionadded:: 3.30
+%End
+
     bool convertToSingleType();
 %Docstring
 Converts multi type geometry into single type geometry

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -396,6 +396,16 @@ The optional ``feedback`` argument can be used to provide cancellation support f
 .. versionadded:: 3.22
 %End
 
+    virtual QString suggestGroupNameForUri( const QString &uri ) const;
+%Docstring
+Returns a name that can be used as a group name for sublayers got from
+the specified ``uri``.
+
+The default implementation returns an empty string.
+
+.. versionadded:: 3.30
+%End
+
     virtual QgsDataProvider *createProvider( const QString &uri,
         const QgsDataProvider::ProviderOptions &options,
         QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) /Factory/;

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -398,7 +398,7 @@ The optional ``feedback`` argument can be used to provide cancellation support f
 
     virtual QString suggestGroupNameForUri( const QString &uri ) const;
 %Docstring
-Returns a name that can be used as a group name for sublayers got from
+Returns a name that can be used as a group name for sublayers retrieved from
 the specified ``uri``.
 
 The default implementation returns an empty string.

--- a/python/core/auto_generated/providers/qgsprovidersublayertask.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidersublayertask.sip.in
@@ -41,6 +41,14 @@ Constructor for QgsProviderSublayerTask, which retrieves sublayer details for th
 specified ``uri``.
 %End
 
+    QgsProviderSublayerTask( const QString &uri, const QString &providerKey, bool includeSystemTables = false );
+%Docstring
+Constructor for QgsProviderSublayerTask, which retrieves sublayer details for the
+specified ``uri``, restricted to a particular provider.
+
+.. versionadded:: 3.30
+%End
+
     ~QgsProviderSublayerTask();
 
     QList<QgsProviderSublayerDetails> results() const;

--- a/python/gui/auto_generated/qgsprovidersublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgsprovidersublayersdialog.sip.in
@@ -56,6 +56,7 @@ Dialog for selecting provider sublayers.
   public:
 
     QgsProviderSublayersDialog( const QString &uri,
+                                const QString &providerKey,
                                 const QString &filePath,
                                 const QList< QgsProviderSublayerDetails> initialDetails = QList< QgsProviderSublayerDetails>(),
                                 const QList< QgsMapLayerType > &acceptableTypes = QList< QgsMapLayerType >(),
@@ -85,6 +86,11 @@ Returns the list of selected non-layer items (e.g. embedded QGIS project items).
     QString groupName() const;
 %Docstring
 Returns an appropriate name for the layer group.
+%End
+
+    void setGroupName( const QString &groupNameIn );
+%Docstring
+Sets an appropriate name for the layer group.
 %End
 
   signals:

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -728,8 +728,11 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
     }
     else
     {
-      if ( layerName != baseName && !layerName.isEmpty() && !baseName.isEmpty() )
+      if ( layerName != baseName && !layerName.isEmpty() && !baseName.isEmpty() &&
+           !layerName.startsWith( baseName ) )
+      {
         layer->setName( QStringLiteral( "%1 — %2" ).arg( baseName, layerName ) );
+      }
       else if ( !layerName.isEmpty() )
         layer->setName( layerName );
       else if ( !baseName.isEmpty() )

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -324,7 +324,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addOgrVectorLayers( const QStringLis
           case SublayerHandling::AskUser:
           {
             // prompt user for sublayers
-            QgsProviderSublayersDialog dlg( uri, path, sublayers, {QgsMapLayerType::VectorLayer}, QgisApp::instance() );
+            QgsProviderSublayersDialog dlg( uri, QString(), path, sublayers, {QgsMapLayerType::VectorLayer}, QgisApp::instance() );
 
             if ( dlg.exec() )
               sublayers = dlg.selectedLayers();
@@ -534,7 +534,7 @@ bool QgsAppLayerHandling::askUserForZipItemLayers( const QString &path, const QL
       case SublayerHandling::AskUser:
       {
         // prompt user for sublayers
-        QgsProviderSublayersDialog dlg( path, path, sublayers, acceptableTypes, QgisApp::instance() );
+        QgsProviderSublayersDialog dlg( path, QString(), path, sublayers, acceptableTypes, QgisApp::instance() );
 
         if ( dlg.exec() )
           sublayers = dlg.selectedLayers();
@@ -936,7 +936,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
         case SublayerHandling::AskUser:
         {
           // prompt user for sublayers
-          QgsProviderSublayersDialog dlg( fileName, fileName, sublayers, {}, QgisApp::instance() );
+          QgsProviderSublayersDialog dlg( fileName, QString(), fileName, sublayers, {}, QgisApp::instance() );
           dlg.setNonLayerItems( nonLayerItems );
 
           if ( dlg.exec() )
@@ -1373,7 +1373,7 @@ T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &ur
       {
         case SublayerHandling::AskUser:
         {
-          QgsProviderSublayersDialog dlg( updatedUri, path, sublayers, {type}, QgisApp::instance() );
+          QgsProviderSublayersDialog dlg( updatedUri, providerKey, path, sublayers, {type}, QgisApp::instance() );
           QString groupName = providerMetadata->suggestGroupNameForUri( uri );
           if ( !groupName.isEmpty() )
             dlg.setGroupName( groupName );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1523,6 +1523,12 @@ QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type, do
     newGeom.get()->addMValue( defaultM );
   }
 
+  // Straight -> curve
+  if ( QgsWkbTypes::isCurvedType( type ) && !QgsWkbTypes::isCurvedType( newGeom.wkbType() ) )
+  {
+    newGeom.convertToCurvedMultiType();
+  }
+
   // Multi -> single
   if ( ! QgsWkbTypes::isMultiType( type ) && newGeom.isMultipart( ) )
   {
@@ -1587,6 +1593,52 @@ bool QgsGeometry::convertToMultiType()
   // and replace it with the multi geometry.
   // TADA! a clone free conversion in some cases
   d->geometry = std::move( geom );
+  return true;
+}
+
+bool QgsGeometry::convertToCurvedMultiType()
+{
+  if ( !d->geometry )
+  {
+    return false;
+  }
+
+  switch ( QgsWkbTypes::flatType( d->geometry->wkbType() ) )
+  {
+    case QgsWkbTypes::MultiPoint:
+    case QgsWkbTypes::MultiCurve:
+    case QgsWkbTypes::MultiSurface:
+    case QgsWkbTypes::GeometryCollection:
+    {
+      return true;
+    }
+    default:
+      break;
+  }
+
+  std::unique_ptr< QgsAbstractGeometry >geom = QgsGeometryFactory::geomFromWkbType( QgsWkbTypes::curveType( QgsWkbTypes::multiType( d->geometry->wkbType() ) ) );
+  QgsGeometryCollection *multiGeom = qgsgeometry_cast<QgsGeometryCollection *>( geom.get() );
+  if ( !multiGeom )
+  {
+    return false;
+  }
+
+  QgsGeometryCollection *sourceMultiGeom = qgsgeometry_cast<QgsGeometryCollection *>( d->geometry.get() );
+  if ( sourceMultiGeom )
+  {
+    for ( int i = 0; i < sourceMultiGeom->numGeometries(); ++i )
+    {
+      if ( !multiGeom->addGeometry( sourceMultiGeom->geometryN( i )->clone() ) )
+        return false;
+    }
+  }
+  else
+  {
+    if ( !multiGeom->addGeometry( d->geometry->clone() ) )
+      return false;
+  }
+
+  reset( std::move( geom ) );
   return true;
 }
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2377,6 +2377,23 @@ class CORE_EXPORT QgsGeometry
     bool convertToMultiType();
 
     /**
+     * Converts a geometry into a multitype geometry of curve kind (when there
+     * is a corresponding curve type).
+     * e.g. a polygon into a multisurface geometry with one polygon,
+     * a multipolygon into a multisurface, a linestring into a multicurve
+     * geometry with one linestring, or a multilinestring into a multicurve.
+     * If it is already a multipart curve geometry, it will return TRUE and
+     * not change the geometry. It will also return TRUE and do nothing if
+     * the current geometry is a multipoint or a geometry collection. A single
+     * point will be transformed to a multipoint.
+     *
+     * \returns TRUE in case of success and FALSE else
+     *
+     * \since QGIS 3.30
+     */
+    bool convertToCurvedMultiType();
+
+    /**
      * Converts multi type geometry into single type geometry
      * e.g. a multipolygon into a polygon geometry. Only the first part of the
      * multi geometry will be retained.

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -77,6 +77,11 @@ QString QgsProviderMetadata::library() const
   return mLibrary;
 }
 
+QString QgsProviderMetadata::suggestGroupNameForUri( const QString & /*uri*/ ) const
+{
+  return QString();
+}
+
 QgsProviderMetadata::CreateDataProviderFunction QgsProviderMetadata::createFunction() const
 {
   return mCreateFunction;

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -458,7 +458,7 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     virtual QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const;
 
     /**
-     * Returns a name that can be used as a group name for sublayers got from
+     * Returns a name that can be used as a group name for sublayers retrieved from
      * the specified \a uri.
      *
      * The default implementation returns an empty string.

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -458,6 +458,16 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     virtual QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const;
 
     /**
+     * Returns a name that can be used as a group name for sublayers got from
+     * the specified \a uri.
+     *
+     * The default implementation returns an empty string.
+     *
+     * \since QGIS 3.30
+    */
+    virtual QString suggestGroupNameForUri( const QString &uri ) const;
+
+    /**
      * Class factory to return a pointer to a newly created QgsDataProvider object
      *
      * \param uri the datasource uri

--- a/src/core/providers/qgsprovidersublayertask.h
+++ b/src/core/providers/qgsprovidersublayertask.h
@@ -55,6 +55,14 @@ class CORE_EXPORT QgsProviderSublayerTask : public QgsTask
      */
     QgsProviderSublayerTask( const QString &uri, bool includeSystemTables = false );
 
+    /**
+     * Constructor for QgsProviderSublayerTask, which retrieves sublayer details for the
+     * specified \a uri, restricted to a particular provider.
+     *
+     * \since QGIS 3.30
+     */
+    QgsProviderSublayerTask( const QString &uri, const QString &providerKey, bool includeSystemTables = false );
+
     ~QgsProviderSublayerTask() override;
 
     /**
@@ -71,6 +79,8 @@ class CORE_EXPORT QgsProviderSublayerTask : public QgsTask
   private:
 
     QString mUri;
+
+    QString mProviderKey;
 
     bool mIncludeSystemTables = false;
 

--- a/src/gui/qgsprovidersublayersdialog.cpp
+++ b/src/gui/qgsprovidersublayersdialog.cpp
@@ -111,21 +111,31 @@ void QgsProviderSublayerDialogModel::setGeometryTypesResolved( bool resolved )
   emit dataChanged( index( 0, 0 ), index( rowCount( QModelIndex() ), columnCount() ) );
 }
 
-QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, const QString &filePath, const QList<QgsProviderSublayerDetails> initialDetails, const QList<QgsMapLayerType> &acceptableTypes, QWidget *parent, Qt::WindowFlags fl )
+QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, const QString &filePathIn, const QList<QgsProviderSublayerDetails> initialDetails, const QList<QgsMapLayerType> &acceptableTypes, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
 {
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
-  const QFileInfo fileInfo( filePath );
-  mFilePath = ( fileInfo.isFile() || fileInfo.isDir() ) && fileInfo.exists() ? filePath : QString();
-  const QString fileName = !mFilePath.isEmpty() ? QgsProviderUtils::suggestLayerNameFromFilePath( mFilePath ) : QString();
+  const QFileInfo fileInfo( filePathIn );
+  const QString filePath = ( fileInfo.isFile() || fileInfo.isDir() ) && fileInfo.exists() ? filePathIn : QString();
+  const QString fileName = !filePath.isEmpty() ? QgsProviderUtils::suggestLayerNameFromFilePath( filePath ) : QString();
+
+  if ( !fileName.isEmpty() )
+  {
+    mGroupName = fileName;
+    const QgsSettings settings;
+    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+    {
+      mGroupName = QgsMapLayer::formatLayerName( mGroupName );
+    }
+  }
 
   setWindowTitle( fileName.isEmpty() ? tr( "Select Items to Add" ) : QStringLiteral( "%1 | %2" ).arg( tr( "Select Items to Add" ), fileName ) );
 
   mLblFilePath->setText( QStringLiteral( "<a href=\"%1\">%2</a>" )
-                         .arg( QUrl::fromLocalFile( mFilePath ).toString(), QDir::toNativeSeparators( QFileInfo( mFilePath ).canonicalFilePath() ) ) );
-  mLblFilePath->setVisible( !mFilePath.isEmpty() );
+                         .arg( QUrl::fromLocalFile( filePath ).toString(), QDir::toNativeSeparators( QFileInfo( filePath ).canonicalFilePath() ) ) );
+  mLblFilePath->setVisible( !filePath.isEmpty() );
   mLblFilePath->setWordWrap( true );
   mLblFilePath->setTextInteractionFlags( Qt::TextBrowserInteraction );
   connect( mLblFilePath, &QLabel::linkActivated, this, [ = ]( const QString & link )
@@ -149,6 +159,7 @@ QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, cons
   const QgsSettings settings;
   const bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), false ).toBool();
   mCbxAddToGroup->setChecked( addToGroup );
+  mCbxAddToGroup->setVisible( !fileName.isEmpty() );
 
   // resize columns
   const QByteArray ba = settings.value( "/Windows/SubLayers/headerState" ).toByteArray();
@@ -262,19 +273,23 @@ QList<QgsProviderSublayerModel::NonLayerItem> QgsProviderSublayersDialog::select
   return selectedItems;
 }
 
+void QgsProviderSublayersDialog::setGroupName( const QString &groupNameIn )
+{
+  mGroupName = groupNameIn;
+  const QgsSettings settings;
+  if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+  {
+    mGroupName = QgsMapLayer::formatLayerName( mGroupName );
+  }
+
+  mCbxAddToGroup->setVisible( !mGroupName.isEmpty() );
+}
+
 QString QgsProviderSublayersDialog::groupName() const
 {
   if ( !mCbxAddToGroup->isChecked() )
     return QString();
-
-  QString res = QgsProviderUtils::suggestLayerNameFromFilePath( mFilePath );
-
-  const QgsSettings settings;
-  if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-  {
-    res = QgsMapLayer::formatLayerName( res );
-  }
-  return res;
+  return mGroupName;
 }
 
 void QgsProviderSublayersDialog::treeSelectionChanged( const QItemSelection &selected, const QItemSelection & )

--- a/src/gui/qgsprovidersublayersdialog.cpp
+++ b/src/gui/qgsprovidersublayersdialog.cpp
@@ -123,12 +123,7 @@ QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, cons
 
   if ( !fileName.isEmpty() )
   {
-    mGroupName = fileName;
-    const QgsSettings settings;
-    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-    {
-      mGroupName = QgsMapLayer::formatLayerName( mGroupName );
-    }
+    setGroupName( fileName );
   }
 
   setWindowTitle( fileName.isEmpty() ? tr( "Select Items to Add" ) : QStringLiteral( "%1 | %2" ).arg( tr( "Select Items to Add" ), fileName ) );

--- a/src/gui/qgsprovidersublayersdialog.cpp
+++ b/src/gui/qgsprovidersublayersdialog.cpp
@@ -111,7 +111,7 @@ void QgsProviderSublayerDialogModel::setGeometryTypesResolved( bool resolved )
   emit dataChanged( index( 0, 0 ), index( rowCount( QModelIndex() ), columnCount() ) );
 }
 
-QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, const QString &filePathIn, const QList<QgsProviderSublayerDetails> initialDetails, const QList<QgsMapLayerType> &acceptableTypes, QWidget *parent, Qt::WindowFlags fl )
+QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, const QString &providerKey, const QString &filePathIn, const QList<QgsProviderSublayerDetails> initialDetails, const QList<QgsMapLayerType> &acceptableTypes, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
 {
   setupUi( this );
@@ -177,7 +177,7 @@ QgsProviderSublayersDialog::QgsProviderSublayersDialog( const QString &uri, cons
   if ( QgsProviderUtils::sublayerDetailsAreIncomplete( initialDetails ) )
   {
     // initial details are incomplete, so fire up a task in the background to fully populate the model...
-    mTask = new QgsProviderSublayerTask( uri, true );
+    mTask = new QgsProviderSublayerTask( uri, providerKey, true );
     connect( mTask.data(), &QgsProviderSublayerTask::taskCompleted, this, [ = ]
     {
       QList< QgsProviderSublayerDetails > res = mTask->results();

--- a/src/gui/qgsprovidersublayersdialog.h
+++ b/src/gui/qgsprovidersublayersdialog.h
@@ -78,6 +78,7 @@ class GUI_EXPORT QgsProviderSublayersDialog : public QDialog, private Ui::QgsPro
      * Constructor.
      */
     QgsProviderSublayersDialog( const QString &uri,
+                                const QString &providerKey,
                                 const QString &filePath,
                                 const QList< QgsProviderSublayerDetails> initialDetails = QList< QgsProviderSublayerDetails>(),
                                 const QList< QgsMapLayerType > &acceptableTypes = QList< QgsMapLayerType >(),

--- a/src/gui/qgsprovidersublayersdialog.h
+++ b/src/gui/qgsprovidersublayersdialog.h
@@ -106,6 +106,11 @@ class GUI_EXPORT QgsProviderSublayersDialog : public QDialog, private Ui::QgsPro
      */
     QString groupName() const;
 
+    /**
+     * Sets an appropriate name for the layer group.
+     */
+    void setGroupName( const QString &groupNameIn );
+
   signals:
 
     /**
@@ -122,7 +127,7 @@ class GUI_EXPORT QgsProviderSublayersDialog : public QDialog, private Ui::QgsPro
     QgsProviderSublayerDialogModel *mModel = nullptr;
     QgsProviderSublayerProxyModel *mProxyModel = nullptr;
     QPointer< QgsProviderSublayerTask > mTask;
-    QString mFilePath;
+    QString mGroupName;
     bool mBlockSelectionChanges = false;
 
 };

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -5,9 +5,11 @@
 set(WFS_SRCS
   ${CMAKE_SOURCE_DIR}/external/nlohmann/json.hpp
   qgswfsprovider.cpp
+  qgswfsprovidermetadata.cpp
   qgswfscapabilities.cpp
   qgswfsdataitems.cpp
   qgswfsfeatureiterator.cpp
+  qgswfsgetfeature.cpp
   qgswfsrequest.cpp
   qgswfsconnection.cpp
   qgswfsdatasourceuri.cpp

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -22,11 +22,44 @@
 #include "qgsapplication.h"
 #include "qgsvariantutils.h"
 
+#include <QCache>
 #include <QEventLoop>
 #include <QNetworkCacheMetaData>
 #include <QCryptographicHash> // just for testing file:// fake_qgis_http_endpoint hack
 #include <QFuture>
 #include <QtConcurrent>
+
+static QMutex gMemoryCacheMmutex;
+static QCache<QUrl, std::pair<QDateTime, QByteArray>> gCache( 10 * 1024 * 1024 );
+
+static QByteArray getFromMemoryCache( const QUrl &url )
+{
+  QMutexLocker lock( &gMemoryCacheMmutex );
+  const std::pair<QDateTime, QByteArray> *entry = gCache.object( url );
+  if ( entry )
+  {
+    QgsSettings s;
+    const int delayOfCachingInSecs = s.value( QStringLiteral( "qgis/wfsMemoryCacheDelay" ), 60 ).toInt();
+    if ( entry->first.secsTo( QDateTime::currentDateTime() ) < delayOfCachingInSecs )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Reusing cached response from memory cache for %1" ).arg( url.toString() ), 4 );
+      return entry->second;
+    }
+  }
+  return QByteArray();
+}
+
+static void insertIntoMemoryCache( const QUrl &url, const QByteArray &response )
+{
+  QMutexLocker lock( &gMemoryCacheMmutex );
+  if ( response.size() <= gCache.maxCost() )
+  {
+    std::pair<QDateTime, QByteArray> *entry = new std::pair<QDateTime, QByteArray>();
+    entry->first = QDateTime::currentDateTime();
+    entry->second = response;
+    gCache.insert( url, entry, response.size() );
+  }
+}
 
 QgsBaseNetworkRequest::QgsBaseNetworkRequest( const QgsAuthorizationSettings &auth, const QString &translatedComponent )
   : mAuth( auth )
@@ -57,6 +90,17 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
   mErrorCode = QgsBaseNetworkRequest::NoError;
   mForceRefresh = forceRefresh;
   mResponse.clear();
+
+  if ( synchronous )
+  {
+    mResponse = getFromMemoryCache( url );
+    if ( !mResponse.isEmpty() )
+    {
+      emit downloadProgress( mResponse.size(), mResponse.size() );
+      emit downloadFinished();
+      return true;
+    }
+  }
 
   QUrl modifiedUrl( url );
 
@@ -254,7 +298,31 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
   {
     downloaderFunction();
   }
-  return success && mErrorMessage.isEmpty();
+
+  if ( !success || !mErrorMessage.isEmpty() )
+  {
+    return false;
+  }
+
+  if ( synchronous )
+  {
+    // Insert response of requests GetCapabilities, DescribeFeatureType or GetFeature
+    // with a COUNT=1 into a short-lived memory cache, as they are emitted
+    // repeatedly in interactive scenarios when adding a WFS layer.
+    QString urlString = url.toString();
+    if ( urlString.contains( QStringLiteral( "REQUEST=GetCapabilities" ) ) ||
+         urlString.contains( QStringLiteral( "REQUEST=DescribeFeatureType" ) ) ||
+         ( urlString.contains( QStringLiteral( "REQUEST=GetFeature" ) ) && urlString.contains( QStringLiteral( "COUNT=1" ) ) ) )
+    {
+      QgsSettings s;
+      if ( s.value( QStringLiteral( "qgis/wfsMemoryCacheAllowed" ), true ).toBool() )
+      {
+        insertIntoMemoryCache( url, mResponse );
+      }
+    }
+  }
+
+  return true;
 }
 
 bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data )

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -41,7 +41,7 @@ QgsWfsCapabilities::QgsWfsCapabilities( const QString &uri, const QgsDataProvide
   connect( this, &QgsWfsRequest::downloadFinished, this, &QgsWfsCapabilities::capabilitiesReplyFinished, Qt::DirectConnection );
 }
 
-bool QgsWfsCapabilities::requestCapabilities( bool synchronous, bool forceRefresh )
+QUrl QgsWfsCapabilities::requestUrl() const
 {
   QUrl url( mUri.baseURL( ) );
   QUrlQuery query( url );
@@ -55,7 +55,12 @@ bool QgsWfsCapabilities::requestCapabilities( bool synchronous, bool forceRefres
     query.addQueryItem( QStringLiteral( "VERSION" ), version );
 
   url.setQuery( query );
-  if ( !sendGET( url, QString(), synchronous, forceRefresh ) )
+  return url;
+}
+
+bool QgsWfsCapabilities::requestCapabilities( bool synchronous, bool forceRefresh )
+{
+  if ( !sendGET( requestUrl(), QString(), synchronous, forceRefresh ) )
   {
     emit gotCapabilities();
     return false;

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -119,6 +119,36 @@ QString QgsWfsCapabilities::Capabilities::getNamespaceParameterValue( const QStr
   return QString();
 }
 
+bool QgsWfsCapabilities::Capabilities::supportsGeometryTypeFilters() const
+{
+  // Detect servers, such as Deegree, that expose additional filter functions
+  // to test if a geometry is a (multi)point, (multi)curve or (multi)surface
+  // This can be used to figure out which geometry types are present in layers
+  // that describe a generic geometry type.
+  bool hasIsPoint = false;
+  bool hasIsCurve = false;
+  bool hasIsSurface = false;
+  for ( const auto &function : functionList )
+  {
+    if ( function.minArgs == 1 && function.maxArgs == 1 )
+    {
+      if ( function.name == QLatin1String( "IsPoint" ) )
+      {
+        hasIsPoint = true;
+      }
+      else if ( function.name == QLatin1String( "IsCurve" ) )
+      {
+        hasIsCurve = true;
+      }
+      else if ( function.name == QLatin1String( "IsSurface" ) )
+      {
+        hasIsSurface = true;
+      }
+    }
+  }
+  return hasIsPoint && hasIsCurve && hasIsSurface;
+}
+
 class CPLXMLTreeUniquePointer
 {
   public:

--- a/src/providers/wfs/qgswfscapabilities.h
+++ b/src/providers/wfs/qgswfscapabilities.h
@@ -29,6 +29,9 @@ class QgsWfsCapabilities : public QgsWfsRequest
   public:
     explicit QgsWfsCapabilities( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
+    //! returns request URL
+    QUrl requestUrl() const;
+
     //! start network connection to get capabilities
     bool requestCapabilities( bool synchronous, bool forceRefresh );
 

--- a/src/providers/wfs/qgswfscapabilities.h
+++ b/src/providers/wfs/qgswfscapabilities.h
@@ -110,6 +110,9 @@ class QgsWfsCapabilities : public QgsWfsRequest
       QString addPrefixIfNeeded( const QString &name ) const;
       QString getNamespaceForTypename( const QString &name ) const;
       QString getNamespaceParameterValue( const QString &WFSVersion, const QString &typeName ) const;
+
+      //! Returns whether the server supports IsPoint, IsCurve and IsSurface functions
+      bool supportsGeometryTypeFilters() const;
     };
 
     //! Application level error

--- a/src/providers/wfs/qgswfsconstants.cpp
+++ b/src/providers/wfs/qgswfsconstants.cpp
@@ -42,6 +42,7 @@ const QString QgsWFSConstants::URI_PARAM_PAGING_ENABLED( "pagingEnabled" );
 const QString QgsWFSConstants::URI_PARAM_PAGE_SIZE( "pageSize" );
 const QString QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES( "preferCoordinatesForWfsT11" );
 const QString QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE( "skipInitialGetFeature" );
+const QString QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER( QStringLiteral( "geometryTypeFilter" ) );
 
 const QString QgsWFSConstants::VERSION_AUTO( QStringLiteral( "auto" ) );
 

--- a/src/providers/wfs/qgswfsconstants.h
+++ b/src/providers/wfs/qgswfsconstants.h
@@ -50,6 +50,7 @@ struct QgsWFSConstants
   static const QString URI_PARAM_PAGE_SIZE;
   static const QString URI_PARAM_WFST_1_1_PREFER_COORDINATES;
   static const QString URI_PARAM_SKIP_INITIAL_GET_FEATURE;
+  static const QString URI_PARAM_GEOMETRY_TYPE_FILTER;
 
   //
   static const QString VERSION_AUTO;

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -172,7 +172,8 @@ QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const
     QgsWFSConstants::URI_PARAM_PAGING_ENABLED,
     QgsWFSConstants::URI_PARAM_PAGE_SIZE,
     QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES,
-    QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE
+    QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE,
+    QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER,
   };
 
   QSet<QString> l_unknownParamKeys;
@@ -353,6 +354,16 @@ void QgsWFSDataSourceURI::setFilter( const QString &filter )
   {
     mURI.setParam( QgsWFSConstants::URI_PARAM_FILTER, filter );
   }
+}
+
+bool QgsWFSDataSourceURI::hasGeometryTypeFilter() const
+{
+  return mURI.hasParam( QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER );
+}
+
+QgsWkbTypes::Type QgsWFSDataSourceURI::geometryTypeFilter() const
+{
+  return QgsWkbTypes::parseType( mURI.param( QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER ) );
 }
 
 QString QgsWFSDataSourceURI::sql() const

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -28,7 +28,9 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
 
   // Compatibility with QGIS < 2.16 layer URI of the format
   // http://example.com/?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=x&SRSNAME=y&username=foo&password=
-  if ( !mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) )
+  if ( !mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) &&
+       ( uri.startsWith( QLatin1String( "http://" ) ) ||
+         uri.startsWith( QLatin1String( "https://" ) ) ) )
   {
     mDeprecatedURI = true;
     static const QSet<QString> sFilter
@@ -102,7 +104,7 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
     if ( !bbox.isEmpty() )
       mURI.setParam( QgsWFSConstants::URI_PARAM_RESTRICT_TO_REQUEST_BBOX, QStringLiteral( "1" ) );
   }
-  else
+  else if ( mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) )
   {
     QUrl url( mURI.param( QgsWFSConstants::URI_PARAM_URL ) );
     QUrlQuery query( url );
@@ -147,6 +149,12 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
     mAuth.mPassword = mURI.password();
     mAuth.mAuthCfg = mURI.authConfigId();
   }
+}
+
+bool QgsWFSDataSourceURI::isValid() const
+{
+  return mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) &&
+         mURI.hasParam( QgsWFSConstants::URI_PARAM_TYPENAME );
 }
 
 QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -87,6 +87,12 @@ class QgsWFSDataSourceURI
     //! Sets OGC filter xml or a QGIS expression
     void setFilter( const QString &filterIn );
 
+    //! Returns whether there is a geometry type filter.
+    bool hasGeometryTypeFilter() const;
+
+    //! Gets the geometry type filter.
+    QgsWkbTypes::Type geometryTypeFilter() const;
+
     //! Gets SQL query
     QString sql() const;
 

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -42,6 +42,9 @@ class QgsWFSDataSourceURI
 
     explicit QgsWFSDataSourceURI( const QString &uri );
 
+    //! Returns whether the URI is a valid one
+    bool isValid() const;
+
     //! Returns the URI, optionally with the authentication configuration expanded
     QString uri( bool expandAuthConfig = false ) const;
 

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -174,14 +174,14 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
     query.addQueryItem( QStringLiteral( "SRSNAME" ), srsName );
   }
 
-  const QgsRectangle &rect = mShared->currentRect();
-
   // In case we must issue a BBOX and we have a filter, we must combine
   // both as a single filter, as both BBOX and FILTER aren't supported together
-  if ( ( !rect.isNull() && !mShared->mWFSFilter.isEmpty() )
-       || ( !mShared->mServerExpression.isEmpty() && !mShared->mWFSFilter.isEmpty() )
-       || ( !rect.isNull() && !mShared->mServerExpression.isEmpty() )
-     )
+  std::vector<QString> filters;
+  if ( !mShared->mServerExpression.isEmpty() )
+    filters.push_back( mShared->mServerExpression );
+
+  const QgsRectangle &rect = mShared->currentRect();
+  if ( !rect.isNull() && ( !mShared->mWFSFilter.isEmpty() || !mShared->mServerExpression.isEmpty() || !mShared->mWFSGeometryTypeFilter.isEmpty() ) )
   {
     QgsOgcUtils::GMLVersion gmlVersion;
     QgsOgcUtils::FilterVersion filterVersion;
@@ -203,95 +203,37 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
       gmlVersion = QgsOgcUtils::GML_3_2_1;
       filterVersion = QgsOgcUtils::FILTER_FES_2_0;
     }
-
-    QDomDocument bboxDoc;
-    QDomDocument filterDoc;
-    QDomDocument expressionDoc;
-
     QString geometryAttribute( mShared->mGeometryAttribute );
     if ( mShared->mLayerPropertiesList.size() > 1 )
       geometryAttribute = mShared->mURI.typeName() + "/" + geometryAttribute;
 
-    QDomNode bboxNode;
-    QDomNode filterNode;
-    QDomNode expressionNode;
 
-    QDomDocument envelopeFilterDoc;
+    double minx = rect.xMinimum();
+    double miny = rect.yMinimum();
+    double maxx = rect.xMaximum();
+    double maxy = rect.yMaximum();
+    QString filterBbox( QStringLiteral( "intersects_bbox($geometry, geomFromWKT('LINESTRING(%1 %2,%3 %4)'))" ).
+                        arg( minx ).arg( miny ).arg( maxx ).arg( maxy ) );
+    QgsExpression bboxExp( filterBbox );
+    QDomDocument bboxDoc;
+    QDomElement bboxElem = QgsOgcUtils::expressionToOgcFilter( bboxExp, bboxDoc,
+                           gmlVersion, filterVersion,
+                           mShared->mLayerPropertiesList.size() == 1 ? mShared->mLayerPropertiesList[0].mNamespacePrefix : QString(),
+                           mShared->mLayerPropertiesList.size() == 1 ? mShared->mLayerPropertiesList[0].mNamespaceURI : QString(),
+                           geometryAttribute, mShared->srsName(),
+                           honourAxisOrientation, mShared->mURI.invertAxisOrientation() );
+    bboxDoc.appendChild( bboxElem );
 
-    //having a filter
-    if ( !mShared->mWFSFilter.isEmpty() )
-    {
-      ( void )filterDoc.setContent( mShared->mWFSFilter, true );
-      filterNode = filterDoc.firstChildElement().firstChildElement();
-      filterNode = filterDoc.firstChildElement().removeChild( filterNode );
-      envelopeFilterDoc = filterDoc;
-    }
+    filters.push_back( bboxDoc.toString() );
+  }
+  if ( !mShared->mWFSFilter.isEmpty() )
+    filters.push_back( mShared->mWFSFilter );
+  if ( !mShared->mWFSGeometryTypeFilter.isEmpty() )
+    filters.push_back( mShared->mWFSGeometryTypeFilter );
 
-    //having an expression
-    if ( !mShared->mServerExpression.isEmpty() )
-    {
-      ( void )expressionDoc.setContent( mShared->mServerExpression, true );
-      expressionNode = expressionDoc.firstChildElement().firstChildElement();
-      expressionNode = expressionDoc.firstChildElement().removeChild( expressionNode );
-      envelopeFilterDoc = expressionDoc;
-    }
-
-    //having a bbox
-    if ( !rect.isNull() )
-    {
-      double minx = rect.xMinimum();
-      double miny = rect.yMinimum();
-      double maxx = rect.xMaximum();
-      double maxy = rect.yMaximum();
-      QString filterBbox( QStringLiteral( "intersects_bbox($geometry, geomFromWKT('LINESTRING(%1 %2,%3 %4)'))" ).
-                          arg( minx ).arg( miny ).arg( maxx ).arg( maxy ) );
-      QgsExpression bboxExp( filterBbox );
-      QDomElement bboxElem = QgsOgcUtils::expressionToOgcFilter( bboxExp, bboxDoc,
-                             gmlVersion, filterVersion,
-                             mShared->mLayerPropertiesList.size() == 1 ? mShared->mLayerPropertiesList[0].mNamespacePrefix : QString(),
-                             mShared->mLayerPropertiesList.size() == 1 ? mShared->mLayerPropertiesList[0].mNamespaceURI : QString(),
-                             geometryAttribute, mShared->srsName(),
-                             honourAxisOrientation, mShared->mURI.invertAxisOrientation() );
-      bboxDoc.appendChild( bboxElem );
-
-      bboxNode = bboxElem.firstChildElement();
-      bboxNode = bboxElem.removeChild( bboxNode );
-      envelopeFilterDoc = bboxDoc;
-    }
-
-    QDomElement andElem = envelopeFilterDoc.createElement( ( filterVersion == QgsOgcUtils::FILTER_FES_2_0 ) ? "fes:And" : "ogc:And" );
-    if ( !expressionNode.isNull() )
-      andElem.appendChild( expressionNode );
-    if ( !bboxNode.isNull() )
-      andElem.appendChild( bboxNode );
-    if ( !filterNode.isNull() )
-      andElem.appendChild( filterNode );
-
-    envelopeFilterDoc.firstChildElement().appendChild( andElem );
-
-    if ( mShared->mLayerPropertiesList.size() == 1 &&
-         envelopeFilterDoc.firstChildElement().hasAttribute( QStringLiteral( "xmlns:" ) + mShared->mLayerPropertiesList[0].mNamespacePrefix ) )
-    {
-      // nothing to do
-    }
-    else
-    {
-      // add xmls:PREFIX=URI attributes to top element
-      QSet<QString> setNamespaceURI;
-      for ( const QgsOgcUtils::LayerProperties &props : std::as_const( mShared->mLayerPropertiesList ) )
-      {
-        if ( !props.mNamespacePrefix.isEmpty() && !props.mNamespaceURI.isEmpty() &&
-             !setNamespaceURI.contains( props.mNamespaceURI ) )
-        {
-          setNamespaceURI.insert( props.mNamespaceURI );
-          QDomAttr attr = envelopeFilterDoc.createAttribute( QStringLiteral( "xmlns:" ) + props.mNamespacePrefix );
-          attr.setValue( props.mNamespaceURI );
-          envelopeFilterDoc.firstChildElement().setAttributeNode( attr );
-        }
-      }
-    }
-
-    query.addQueryItem( QStringLiteral( "FILTER" ), sanitizeFilter( envelopeFilterDoc.toString() ) );
+  if ( filters.size() >= 2 )
+  {
+    query.addQueryItem( QStringLiteral( "FILTER" ), sanitizeFilter( mShared->combineWFSFilters( filters ) ) );
   }
   else if ( !rect.isNull() )
   {
@@ -338,6 +280,11 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   {
     query.addQueryItem( QStringLiteral( "FILTER" ), sanitizeFilter( mShared->mServerExpression ) );
   }
+  else if ( !mShared->mWFSGeometryTypeFilter.isEmpty() )
+  {
+    query.addQueryItem( QStringLiteral( "FILTER" ), sanitizeFilter( mShared->mWFSGeometryTypeFilter ) );
+  }
+
 
   if ( !mShared->mSortBy.isEmpty() && !forHits )
   {
@@ -741,6 +688,13 @@ void QgsWFSFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFeat
               }
               f.setGeometry( QgsGeometry( newGC ) );
             }
+          }
+          else if ( f.hasGeometry() && !mShared->mWFSGeometryTypeFilter.isEmpty() &&
+                    QgsWkbTypes::flatType( f.geometry().wkbType() ) != mShared->mWKBType )
+          {
+            QgsGeometry g = f.geometry();
+            g.convertToCurvedMultiType();
+            f.setGeometry( g );
           }
 
           featureList.push_back( QgsFeatureUniqueIdPair( f, gmlId ) );

--- a/src/providers/wfs/qgswfsgetfeature.cpp
+++ b/src/providers/wfs/qgswfsgetfeature.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+    qgswfsgetfeature.cpp
+    ---------------------
+    begin                : November 2022
+    copyright            : (C) 2022 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswfsgetfeature.h"
+#include "qgsmessagelog.h"
+#include <QUrlQuery>
+
+QgsWFSGetFeature::QgsWFSGetFeature( QgsWFSDataSourceURI &uri )
+  : QgsWfsRequest( uri )
+{
+}
+
+bool QgsWFSGetFeature::request( bool synchronous, const QString &WFSVersion,
+                                const QString &typeName, const QString &filter, bool hitsOnly, const QgsWfsCapabilities::Capabilities &caps )
+{
+  QUrl url( mUri.requestUrl( QStringLiteral( "GetFeature" ) ) );
+  QUrlQuery query( url );
+  query.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
+
+  const QString namespaceValue( caps.getNamespaceParameterValue( WFSVersion, typeName ) );
+
+  if ( WFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+  {
+    query.addQueryItem( QStringLiteral( "TYPENAMES" ), typeName );
+    if ( !namespaceValue.isEmpty() )
+    {
+      query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
+    }
+  }
+  else
+  {
+    query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+  }
+
+  if ( !namespaceValue.isEmpty() )
+  {
+    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+  }
+
+  if ( !filter.isEmpty() )
+  {
+    query.addQueryItem( QStringLiteral( "FILTER" ), filter );
+  }
+
+  if ( hitsOnly )
+  {
+    query.addQueryItem( QStringLiteral( "RESULTTYPE" ), "hits" );
+  }
+
+  url.setQuery( query );
+  return sendGET( url, QString(), synchronous, /*forceRefresh=*/ true, /* cache=*/ false );
+}
+
+QString QgsWFSGetFeature::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Download of feature type failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/qgswfsgetfeature.h
+++ b/src/providers/wfs/qgswfsgetfeature.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgswfsgetfeature.h
+    ---------------------
+    begin                : November 2022
+    copyright            : (C) 2022 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSWFSGETFEATURE_H
+#define QGSWFSGETFEATURE_H
+
+#include "qgswfsrequest.h"
+#include "qgswfscapabilities.h"
+
+//! Manages the QgsWFSGetFeature request
+class QgsWFSGetFeature : public QgsWfsRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsWFSGetFeature( QgsWFSDataSourceURI &uri );
+
+    //! Issue the request
+    bool request( bool synchronous,
+                  const QString &WFSVersion,
+                  const QString &typeName,
+                  const QString &filter,
+                  bool hitsOnly,
+                  const QgsWfsCapabilities::Capabilities &caps );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSWFSGETFEATURE_H

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -245,10 +245,17 @@ void QgsWFSProvider::issueInitialGetFeature()
   }
   // For WFS >= 1.1, by default, issue a GetFeature on one feature to check
   // if gml:description, gml:identifier, gml:name attributes are
-  // present (unless mShared->mURI.skipInitialGetFeature() returns false)
+  // present (unless mShared->mURI.skipInitialGetFeature() returns false),
+  // unless gmlId, gmlName, gmlDescription fields are found (some servers use
+  // that hack since gml:description/identifier/name attributes might be
+  // missed by clients...).
   // Another reason to issue it if we do not known the exact geometry type
   // from describeFeatureType()
-  else if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) )
+  else if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) &&
+            ( mShared->mWKBType == QgsWkbTypes::Unknown ||
+              mShared->mFields.indexOf( QLatin1String( "gmlId" ) ) < 0 ||
+              mShared->mFields.indexOf( QLatin1String( "gmlName" ) ) < 0 ||
+              mShared->mFields.indexOf( QLatin1String( "gmlDescription" ) ) < 0 ) )
   {
     // Try to see if gml:description, gml:identifier, gml:name attributes are
     // present. So insert them temporarily in mShared->mFields so that the

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -129,6 +129,18 @@ class QgsWFSProvider final: public QgsVectorDataProvider
 
     void handlePostCloneOperations( QgsVectorDataProvider *source ) override;
 
+    static QgsWfsCapabilities::Capabilities getCachedCapabilities( const QString &uri );
+    static QString buildFilterByGeometryType( const QgsWfsCapabilities::Capabilities &caps,
+        const QString &geometryElement,
+        const QString &function );
+    static QString buildIsNullGeometryFilter( const QgsWfsCapabilities::Capabilities &caps,
+        const QString &geometryElement );
+    static QString buildGeometryCollectionFilter( const QgsWfsCapabilities::Capabilities &caps,
+        const QString &geometryElement );
+
+    //! Perform an initial GetFeature request with a 1-feature limit.
+    void issueInitialGetFeature();
+
   private slots:
 
     void featureReceivedAnalyzeOneFeature( QVector<QgsFeatureUniqueIdPair> );
@@ -227,17 +239,6 @@ class QgsWFSProvider final: public QgsVectorDataProvider
     QString convertToXML( const QVariant &value );
 
     bool processSQL( const QString &sqlString, QString &errorMsg, QString &warningMsg );
-};
-
-class QgsWfsProviderMetadata final: public QgsProviderMetadata
-{
-    Q_OBJECT
-  public:
-    QgsWfsProviderMetadata();
-    QIcon icon() const override;
-    QList<QgsDataItemProvider *> dataItemProviders() const override;
-    QgsWFSProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
-    QList< QgsMapLayerType > supportedLayerTypes() const override;
 };
 
 

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -194,6 +194,8 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
     return res;
 
   QgsWFSDataSourceURI wfsUri( uri );
+  if ( !wfsUri.isValid() )
+    return res;
 
   QgsWfsCapabilities::Capabilities caps = QgsWFSProvider::getCachedCapabilities( uri );
   if ( caps.version.isEmpty() )

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -290,7 +290,10 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
       timerForHits.setSingleShot( true );
       timerForHits.start();
       connect( &timerForHits, &QTimer::timeout, &loop, &QEventLoop::quit );
-      connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+      if ( feedback )
+      {
+        connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+      }
       loop.exec( QEventLoop::ExcludeUserInputEvents );
       // Make sure to terminate requests in this thread, to avoid potential
       // crash in main thread when "requests" goes out of scope.

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -272,6 +272,10 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
         connect( thisRequest, &QgsWfsRequest::downloadFinished, thisRequest, downloadFinishedLambda );
       }
       QgsSettings s;
+      if ( !s.contains( QStringLiteral( "qgis/wfsGetFeatureGeometryTypesTimeout" ) ) )
+      {
+        s.setValue( QStringLiteral( "qgis/wfsGetFeatureGeometryTypesTimeout" ), 2.0 );
+      }
       const double timeout = s.value( QStringLiteral( "qgis/wfsGetFeatureGeometryTypesTimeout" ), 2.0 ).toDouble();
       timerForHits.setInterval( static_cast<int>( timeout * 1000 ) );
       timerForHits.setSingleShot( true );

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -349,7 +349,7 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
         details.setType( QgsMapLayerType::VectorLayer );
         details.setProviderKey( QgsWFSProvider::WFS_PROVIDER_KEY );
         details.setUri( uri + QStringLiteral( " " ) + QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER + QStringLiteral( "='" ) + QgsWkbTypes::displayString( tuple.wkbType ) + QStringLiteral( "'" ) );
-        details.setName( QgsWkbTypes::translatedDisplayString( tuple.wkbType ) );
+        details.setName( wfsUri.typeName() + QStringLiteral( " " ) + QgsWkbTypes::translatedDisplayString( tuple.wkbType ) );
         details.setWkbType( tuple.wkbType );
         if ( countsAllValid )
           details.setFeatureCount( featureCounts[tuple.index] );

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -179,6 +179,13 @@ QString QgsWFSProvider::buildGeometryCollectionFilter( const QgsWfsCapabilities:
   return doc.toString();
 }
 
+QString QgsWfsProviderMetadata::suggestGroupNameForUri( const QString &uri ) const
+{
+  QgsWFSDataSourceURI wfsUri( uri );
+  return wfsUri.typeName();
+}
+
+
 QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags, QgsFeedback *feedback ) const
 {
   QList<QgsProviderSublayerDetails> res;

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -161,7 +161,7 @@ QString QgsWFSProvider::buildGeometryCollectionFilter( const QgsWfsCapabilities:
   for ( const QString &function : { QStringLiteral( "IsPoint" ), QStringLiteral( "IsCurve" ), QStringLiteral( "IsSurface" ) } )
   {
     QDomElement propertyIsEqualToElem = doc.createElement( filterPrefix + QStringLiteral( ":PropertyIsEqualTo" ) );
-    filterElem.appendChild( propertyIsEqualToElem );
+    andElem.appendChild( propertyIsEqualToElem );
     QDomElement functionElem = doc.createElement( filterPrefix + QStringLiteral( ":Function" ) );
     propertyIsEqualToElem.appendChild( functionElem );
     QDomAttr attrFunctionName = doc.createAttribute( QStringLiteral( "name" ) );

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -1,0 +1,367 @@
+/***************************************************************************
+                              qgswfsprovidermetadata.cpp
+                              -------------------
+  begin                : November 2022
+  copyright            : (C) 2006 by Marco Hugentobler
+                         (C) 2016-2022 by Even Rouault
+  email                : marco dot hugentobler at karto dot baug dot ethz dot ch
+                         even.rouault at spatialys.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgis.h"
+#include "qgsfeedback.h"
+#include "qgsogcutils.h"
+#include "qgsoapifprovider.h"
+#include "qgswfsdataitems.h"
+#include "qgsprovidersublayerdetails.h"
+#include "qgswfsconstants.h"
+#include "qgswfsprovider.h"
+#include "qgswfsprovidermetadata.h"
+#include "qgswfscapabilities.h"
+#include "qgswfsgetfeature.h"
+#include "qgswfsshareddata.h"
+#include "qgssettings.h"
+
+#include <QDomDocument>
+#include <QMessageBox>
+#include <QDomNodeList>
+#include <QFile>
+#include <QIcon>
+#include <QUrl>
+#include <QTimer>
+
+QgsDataProvider *QgsWfsProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
+{
+  Q_UNUSED( flags );
+  return new QgsWFSProvider( uri, options );
+}
+
+QList<QgsMapLayerType> QgsWfsProviderMetadata::supportedLayerTypes() const
+{
+  return { QgsMapLayerType::VectorLayer };
+}
+
+QList<QgsDataItemProvider *> QgsWfsProviderMetadata::dataItemProviders() const
+{
+  QList<QgsDataItemProvider *> providers;
+  providers << new QgsWfsDataItemProvider;
+  return providers;
+}
+
+QgsProviderMetadata::ProviderMetadataCapabilities QgsWfsProviderMetadata::capabilities() const
+{
+  return QuerySublayers;
+}
+
+QString QgsWFSProvider::buildFilterByGeometryType( const QgsWfsCapabilities::Capabilities &caps,
+    const QString &geometryElement,
+    const QString &function )
+{
+  /* Generate something like:
+   <fes:Filter xmlns="http://www.opengis.net/fes/2.0">
+    <fes:PropertyIsEqualTo>
+      <fes:Function name="IsPoint">
+        <fes:ValueReference>xplan:geltungsbereich</fes:ValueReference>
+      </fes:Function>
+      <fes:Literal>false</fes:Literal>
+    </fes:PropertyIsEqualTo>
+  </fes:Filter>
+  */
+
+  QDomDocument doc;
+  QDomElement filterElem =
+    ( caps.version.startsWith( QStringLiteral( "2.0" ) ) ) ?
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/fes/2.0" ), QStringLiteral( "fes:Filter" ) ) :
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/ogc" ), QStringLiteral( "ogc:Filter" ) ) ;
+  doc.appendChild( filterElem );
+  QString filterPrefix( caps.version.startsWith( "2.0" ) ? QStringLiteral( "fes" ) : QStringLiteral( "ogc" ) );
+  QDomElement propertyIsEqualToElem = doc.createElement( filterPrefix + QStringLiteral( ":PropertyIsEqualTo" ) );
+  filterElem.appendChild( propertyIsEqualToElem );
+  QDomElement functionElem = doc.createElement( filterPrefix + QStringLiteral( ":Function" ) );
+  propertyIsEqualToElem.appendChild( functionElem );
+  QDomAttr attrFunctionName = doc.createAttribute( QStringLiteral( "name" ) );
+  attrFunctionName.setValue( function );
+  functionElem.setAttributeNode( attrFunctionName );
+  QDomElement valueReferenceElem = doc.createElement(
+                                     ( caps.version.startsWith( "2.0" ) ) ? filterPrefix + QStringLiteral( ":ValueReference" ) : filterPrefix + QStringLiteral( ":PropertyName" ) );
+  functionElem.appendChild( valueReferenceElem );
+  valueReferenceElem.appendChild( doc.createTextNode( geometryElement ) );
+  QDomElement literalElem = doc.createElement( filterPrefix + QStringLiteral( ":Literal" ) );
+  propertyIsEqualToElem.appendChild( literalElem );
+  literalElem.appendChild( doc.createTextNode( QStringLiteral( "true" ) ) );
+
+  return doc.toString();
+}
+
+QString QgsWFSProvider::buildIsNullGeometryFilter( const QgsWfsCapabilities::Capabilities &caps,
+    const QString &geometryElement )
+{
+  /* Generate something like:
+   <fes:Filter xmlns="http://www.opengis.net/fes/2.0">
+    <fes:PropertyIsNull>
+        <fes:ValueReference>xplan:geltungsbereich</fes:ValueReference>
+    </fes:PropertyIsNull>
+  </fes:Filter>
+  */
+
+  QDomDocument doc;
+  QDomElement filterElem =
+    ( caps.version.startsWith( QStringLiteral( "2.0" ) ) ) ?
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/fes/2.0" ), QStringLiteral( "fes:Filter" ) ) :
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/ogc" ), QStringLiteral( "ogc:Filter" ) ) ;
+  doc.appendChild( filterElem );
+  QString filterPrefix( caps.version.startsWith( "2.0" ) ? QStringLiteral( "fes" ) : QStringLiteral( "ogc" ) );
+  QDomElement propertyIsNullElem = doc.createElement( filterPrefix + QStringLiteral( ":PropertyIsNull" ) );
+  filterElem.appendChild( propertyIsNullElem );
+  QDomElement valueReferenceElem = doc.createElement(
+                                     ( caps.version.startsWith( "2.0" ) ) ? filterPrefix + QStringLiteral( ":ValueReference" ) : filterPrefix + QStringLiteral( ":PropertyName" ) );
+  propertyIsNullElem.appendChild( valueReferenceElem );
+  valueReferenceElem.appendChild( doc.createTextNode( geometryElement ) );
+
+  return doc.toString();
+}
+
+QString QgsWFSProvider::buildGeometryCollectionFilter( const QgsWfsCapabilities::Capabilities &caps,
+    const QString &geometryElement )
+{
+  QDomDocument doc;
+  QDomElement filterElem =
+    ( caps.version.startsWith( QStringLiteral( "2.0" ) ) ) ?
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/fes/2.0" ), QStringLiteral( "fes:Filter" ) ) :
+    doc.createElementNS( QStringLiteral( "http://www.opengis.net/ogc" ), QStringLiteral( "ogc:Filter" ) ) ;
+  doc.appendChild( filterElem );
+  QString filterPrefix( caps.version.startsWith( "2.0" ) ? QStringLiteral( "fes" ) : QStringLiteral( "ogc" ) );
+
+  QDomElement andElem = doc.createElement( filterPrefix + QStringLiteral( ":And" ) );
+  filterElem.appendChild( andElem );
+
+  {
+
+    QDomElement notElem = doc.createElement( filterPrefix + QStringLiteral( ":Not" ) );
+    andElem.appendChild( notElem );
+
+    QDomElement propertyIsNullElem = doc.createElement( filterPrefix + QStringLiteral( ":PropertyIsNull" ) );
+    notElem.appendChild( propertyIsNullElem );
+    QDomElement valueReferenceElem = doc.createElement(
+                                       ( caps.version.startsWith( "2.0" ) ) ? filterPrefix + QStringLiteral( ":ValueReference" ) : filterPrefix + QStringLiteral( ":PropertyName" ) );
+    propertyIsNullElem.appendChild( valueReferenceElem );
+    valueReferenceElem.appendChild( doc.createTextNode( geometryElement ) );
+
+  }
+
+  for ( const QString &function : { QStringLiteral( "IsPoint" ), QStringLiteral( "IsCurve" ), QStringLiteral( "IsSurface" ) } )
+  {
+    QDomElement propertyIsEqualToElem = doc.createElement( filterPrefix + QStringLiteral( ":PropertyIsEqualTo" ) );
+    filterElem.appendChild( propertyIsEqualToElem );
+    QDomElement functionElem = doc.createElement( filterPrefix + QStringLiteral( ":Function" ) );
+    propertyIsEqualToElem.appendChild( functionElem );
+    QDomAttr attrFunctionName = doc.createAttribute( QStringLiteral( "name" ) );
+    attrFunctionName.setValue( function );
+    functionElem.setAttributeNode( attrFunctionName );
+    QDomElement valueReferenceElem = doc.createElement(
+                                       ( caps.version.startsWith( "2.0" ) ) ? filterPrefix + QStringLiteral( ":ValueReference" ) : filterPrefix + QStringLiteral( ":PropertyName" ) );
+    functionElem.appendChild( valueReferenceElem );
+    valueReferenceElem.appendChild( doc.createTextNode( geometryElement ) );
+    QDomElement literalElem = doc.createElement( filterPrefix + QStringLiteral( ":Literal" ) );
+    propertyIsEqualToElem.appendChild( literalElem );
+    literalElem.appendChild( doc.createTextNode( QStringLiteral( "false" ) ) );
+  }
+
+  return doc.toString();
+}
+
+QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags, QgsFeedback *feedback ) const
+{
+  QList<QgsProviderSublayerDetails> res;
+
+  if ( ( flags & Qgis::SublayerQueryFlag::FastScan ) )
+    return res;
+
+  QgsWFSDataSourceURI wfsUri( uri );
+
+  QgsWfsCapabilities::Capabilities caps = QgsWFSProvider::getCachedCapabilities( uri );
+  if ( caps.version.isEmpty() )
+    return res;
+
+  QgsWFSProvider provider(
+    uri + " " + QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE + "='true'",
+    QgsDataProvider::ProviderOptions(), caps );
+  QgsProviderSublayerDetails details;
+  details.setType( QgsMapLayerType::VectorLayer );
+  details.setProviderKey( QgsWFSProvider::WFS_PROVIDER_KEY );
+  details.setUri( uri );
+  details.setName( wfsUri.typeName() );
+  details.setWkbType( provider.wkbType() );
+  res << details;
+
+  if ( wfsUri.hasGeometryTypeFilter() ||
+       !caps.supportsGeometryTypeFilters() )
+  {
+    if ( provider.wkbType() == QgsWkbTypes::Type::Unknown )
+      provider.issueInitialGetFeature();
+    details.setWkbType( provider.wkbType() );
+    return res;
+  }
+
+  if ( provider.wkbType() == QgsWkbTypes::Type::Unknown &&
+       provider.sharedData()->layerProperties().size() == 1 )
+  {
+    std::vector<std::unique_ptr<QgsWFSGetFeature>> requests;
+    std::set<QgsWFSGetFeature *> finishedRequests;
+    constexpr int INDEX_ALL = 0;
+    constexpr int INDEX_NULL = 1;
+    constexpr int INDEX_POINT = 2;
+    constexpr int INDEX_CURVE = 3;
+    constexpr int INDEX_SURFACE = 4;
+    // Order of strings in the list must be consistent with the INDEX_* enumeration above
+    const QStringList filterNames = { QString(), // all features
+                                      QString( "IsNull" ),
+                                      QStringLiteral( "IsPoint" ),
+                                      QStringLiteral( "IsCurve" ),
+                                      QStringLiteral( "IsSurface" )
+                                    };
+
+    const auto downloaderLambda = [ &, feedback]()
+    {
+      QEventLoop loop;
+      QTimer timerForHits;
+      for ( QString function : filterNames )
+      {
+        QString filter;
+        if ( function == QLatin1String( "IsNull" ) )
+        {
+          filter = QgsWFSProvider::buildIsNullGeometryFilter( caps, provider.geometryAttribute() );
+        }
+        else if ( !function.isEmpty() )
+        {
+          filter = QgsWFSProvider::buildFilterByGeometryType( caps,
+                   provider.geometryAttribute(),
+                   function );
+        }
+
+        if ( !provider.sharedData()->WFSFilter().isEmpty() )
+        {
+          filter = provider.sharedData()->combineWFSFilters( {filter, provider.sharedData()->WFSFilter()} );
+        }
+
+        requests.emplace_back( std::make_unique<QgsWFSGetFeature>( wfsUri ) );
+
+        requests.back()->request( /* synchronous = */ false,
+            caps.version,
+            wfsUri.typeName(),
+            filter,
+            /* hitsOnly = */ true,
+            caps );
+
+        QgsWFSGetFeature *thisRequest = requests.back().get();
+        const auto downloadFinishedLambda = [ &, thisRequest]()
+        {
+          finishedRequests.insert( thisRequest );
+          if ( finishedRequests.size() == requests.size() )
+            loop.quit();
+        };
+        connect( thisRequest, &QgsWfsRequest::downloadFinished, thisRequest, downloadFinishedLambda );
+      }
+      QgsSettings s;
+      const double timeout = s.value( QStringLiteral( "qgis/wfsGetFeatureGeometryTypesTimeout" ), 2.0 ).toDouble();
+      timerForHits.setInterval( static_cast<int>( timeout * 1000 ) );
+      timerForHits.setSingleShot( true );
+      timerForHits.start();
+      connect( &timerForHits, &QTimer::timeout, &loop, &QEventLoop::quit );
+      connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+      loop.exec( QEventLoop::ExcludeUserInputEvents );
+
+    };
+
+    std::unique_ptr<_DownloaderThread> downloaderThread =
+      std::make_unique<_DownloaderThread>( downloaderLambda );
+    downloaderThread->start();
+    downloaderThread->wait();
+
+    constexpr int INDEX_GEOMETRYCOLLECTION = 5;
+    std::vector<int64_t> featureCounts( INDEX_GEOMETRYCOLLECTION + 1, -1 );
+    bool countsAllValid = false;
+    if ( finishedRequests.size() == requests.size() )
+    {
+      countsAllValid = true;
+      for ( size_t i = 0; i < requests.size(); ++i )
+      {
+        QByteArray data = requests[i]->response();
+        QgsGmlStreamingParser gmlParser( ( QString() ), ( QString() ), QgsFields() );
+        QString errorMsg;
+        if ( gmlParser.processData( data, true, errorMsg ) )
+        {
+          featureCounts[i] = ( gmlParser.numberMatched() >= 0 ) ? gmlParser.numberMatched() :
+                             gmlParser.numberReturned();
+        }
+        countsAllValid &= featureCounts[i] >= 0;
+      }
+    }
+
+    if ( countsAllValid )
+    {
+      // Deduce numbers of geometry collections from other types
+      featureCounts[INDEX_GEOMETRYCOLLECTION] = featureCounts[INDEX_ALL] -
+          ( featureCounts[INDEX_NULL] + featureCounts[INDEX_POINT] + featureCounts[INDEX_CURVE] + featureCounts[INDEX_SURFACE] );
+    }
+
+    const struct
+    {
+      int index;
+      QgsWkbTypes::Type wkbType;
+    } types[] =
+    {
+      { INDEX_NULL, QgsWkbTypes::NoGeometry },
+      { INDEX_POINT, QgsWkbTypes::MultiPoint },
+      { INDEX_CURVE, QgsWkbTypes::MultiCurve },
+      { INDEX_SURFACE, QgsWkbTypes::MultiSurface },
+      { INDEX_GEOMETRYCOLLECTION, QgsWkbTypes::GeometryCollection },
+    };
+
+    // Create sublayers details
+    res.clear();
+    for ( const auto &tuple : types )
+    {
+      if ( !countsAllValid || featureCounts[tuple.index] > 0 ||
+           ( tuple.wkbType == QgsWkbTypes::NoGeometry && featureCounts[INDEX_ALL] == 0 ) )
+      {
+        QgsProviderSublayerDetails details;
+        details.setType( QgsMapLayerType::VectorLayer );
+        details.setProviderKey( QgsWFSProvider::WFS_PROVIDER_KEY );
+        details.setUri( uri + QStringLiteral( " " ) + QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER + QStringLiteral( "='" ) + QgsWkbTypes::displayString( tuple.wkbType ) + QStringLiteral( "'" ) );
+        details.setName( QgsWkbTypes::translatedDisplayString( tuple.wkbType ) );
+        details.setWkbType( tuple.wkbType );
+        if ( countsAllValid )
+          details.setFeatureCount( featureCounts[tuple.index] );
+        res << details;
+      }
+    }
+
+  }
+  return res;
+}
+
+QgsWfsProviderMetadata::QgsWfsProviderMetadata():
+  QgsProviderMetadata( QgsWFSProvider::WFS_PROVIDER_KEY, QgsWFSProvider::WFS_PROVIDER_DESCRIPTION ) {}
+
+QIcon QgsWfsProviderMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "mIconWfs.svg" ) );
+}
+
+
+#ifndef HAVE_STATIC_PROVIDERS
+QGISEXTERN void *multipleProviderMetadataFactory()
+{
+  return new std::vector<QgsProviderMetadata *> { new QgsWfsProviderMetadata(), new QgsOapifProviderMetadata() };
+}
+#endif

--- a/src/providers/wfs/qgswfsprovidermetadata.cpp
+++ b/src/providers/wfs/qgswfsprovidermetadata.cpp
@@ -290,7 +290,12 @@ QList<QgsProviderSublayerDetails> QgsWfsProviderMetadata::querySublayers( const 
       connect( &timerForHits, &QTimer::timeout, &loop, &QEventLoop::quit );
       connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
       loop.exec( QEventLoop::ExcludeUserInputEvents );
-
+      // Make sure to terminate requests in this thread, to avoid potential
+      // crash in main thread when "requests" goes out of scope.
+      for ( auto &request : requests )
+      {
+        request->abort();
+      }
     };
 
     std::unique_ptr<_DownloaderThread> downloaderThread =

--- a/src/providers/wfs/qgswfsprovidermetadata.h
+++ b/src/providers/wfs/qgswfsprovidermetadata.h
@@ -35,6 +35,7 @@ class QgsWfsProviderMetadata final: public QgsProviderMetadata
     QList< QgsMapLayerType > supportedLayerTypes() const override;
     QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+    QString suggestGroupNameForUri( const QString &uri ) const override;
 };
 
 #endif // QGSWFSPROVIDERMETADATA_H

--- a/src/providers/wfs/qgswfsprovidermetadata.h
+++ b/src/providers/wfs/qgswfsprovidermetadata.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+                              qgswfsprovidermetadata.h
+                              -------------------
+  begin                : November 2022
+  copyright            : (C) 2006 by Marco Hugentobler
+                         (C) 2016-2022 by Even Rouault
+  email                : marco dot hugentobler at karto dot baug dot ethz dot ch
+                         even.rouault at spatialys.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWFSPROVIDERMETADATA_H
+#define QGSWFSPROVIDERMETADATA_H
+
+#include "qgis.h"
+#include "qgsdataprovider.h"
+#include "qgsprovidermetadata.h"
+
+class QgsWfsProviderMetadata final: public QgsProviderMetadata
+{
+    Q_OBJECT
+  public:
+    QgsWfsProviderMetadata();
+    QIcon icon() const override;
+    QList<QgsDataItemProvider *> dataItemProviders() const override;
+    QgsDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
+    QList< QgsMapLayerType > supportedLayerTypes() const override;
+    QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
+    QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+};
+
+#endif // QGSWFSPROVIDERMETADATA_H

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -15,6 +15,7 @@
 
 #include "qgswfsshareddata.h"
 #include "qgswfsutils.h"
+#include "qgswfsprovider.h"
 #include "qgscachedirectorymanager.h"
 #include "qgsogcutils.h"
 #include "qgsexpression.h"
@@ -61,6 +62,7 @@ QgsWFSSharedData *QgsWFSSharedData::clone() const
   copy->mServerPrefersCoordinatesForTransactions_1_1 = mServerPrefersCoordinatesForTransactions_1_1;
   copy->mWKBType = mWKBType;
   copy->mWFSFilter = mWFSFilter;
+  copy->mWFSGeometryTypeFilter = mWFSGeometryTypeFilter;
   copy->mSortBy = mSortBy;
   QgsBackgroundCachedSharedData::copyStateToClone( copy );
 
@@ -212,6 +214,20 @@ bool QgsWFSSharedData::computeFilter( QString &errorMsg )
   return true;
 }
 
+void QgsWFSSharedData::computeGeometryTypeFilter()
+{
+  if ( mWKBType == QgsWkbTypes::NoGeometry )
+    mWFSGeometryTypeFilter = QgsWFSProvider::buildIsNullGeometryFilter( mCaps, mGeometryAttribute );
+  else if ( mWKBType == QgsWkbTypes::MultiPoint )
+    mWFSGeometryTypeFilter = QgsWFSProvider::buildFilterByGeometryType( mCaps, mGeometryAttribute, "IsPoint" );
+  else if ( mWKBType == QgsWkbTypes::MultiCurve )
+    mWFSGeometryTypeFilter = QgsWFSProvider::buildFilterByGeometryType( mCaps, mGeometryAttribute, "IsCurve" );
+  else if ( mWKBType == QgsWkbTypes::MultiSurface )
+    mWFSGeometryTypeFilter = QgsWFSProvider::buildFilterByGeometryType( mCaps, mGeometryAttribute, "IsSurface" );
+  else if ( mWKBType == QgsWkbTypes::GeometryCollection )
+    mWFSGeometryTypeFilter = QgsWFSProvider::buildGeometryCollectionFilter( mCaps, mGeometryAttribute );
+}
+
 void QgsWFSSharedData::pushError( const QString &errorMsg ) const
 {
   QgsMessageLog::logMessage( errorMsg, tr( "WFS" ) );
@@ -264,7 +280,80 @@ QgsRectangle QgsWFSSharedData::getExtentFromSingleFeatureRequest() const
 long long QgsWFSSharedData::getFeatureCountFromServer() const
 {
   QgsWFSFeatureHitsRequest request( mURI );
-  return request.getFeatureCount( mWFSVersion, mWFSFilter, mCaps );
+  return request.getFeatureCount( mWFSVersion, combineWFSFilters( { mWFSFilter, mWFSGeometryTypeFilter} ), mCaps );
+}
+
+QString QgsWFSSharedData::combineWFSFilters( const std::vector<QString> &filters ) const
+{
+  int countNonEmpty = 0;
+  QString nonEmptyFilter;
+  for ( const QString &filter : filters )
+  {
+    if ( !filter.isEmpty() )
+    {
+      countNonEmpty ++;
+      nonEmptyFilter = filter;
+    }
+  }
+  if ( countNonEmpty == 0 )
+    return QString();
+  if ( countNonEmpty == 1 )
+    return nonEmptyFilter;
+
+  std::vector<QDomNode> nodes;
+
+  bool envelopeFilterDocSet = false;
+  QDomDocument envelopeFilterDoc;
+  for ( const QString &filter : filters )
+  {
+    if ( filter.isEmpty() )
+      continue;
+    QDomDocument doc;
+    QDomNode node;
+
+    ( void )doc.setContent( filter, !filter.contains( QStringLiteral( "BBOX" ) ) );
+    node = doc.firstChildElement().firstChildElement();
+    node = doc.firstChildElement().removeChild( node );
+    if ( !envelopeFilterDocSet || filter.contains( QStringLiteral( "BBOX" ) ) )
+    {
+      envelopeFilterDocSet = true;
+      envelopeFilterDoc = doc;
+    }
+
+    nodes.push_back( node );
+  }
+
+  QDomElement andElem = envelopeFilterDoc.createElement( mWFSVersion.startsWith( QLatin1String( "2.0" ) ) ? "fes:And" : "ogc:And" );
+  for ( const auto &node : nodes )
+  {
+    andElem.appendChild( node );
+  }
+  envelopeFilterDoc.firstChildElement().appendChild( andElem );
+
+  if ( mLayerPropertiesList.size() == 1 &&
+       envelopeFilterDoc.firstChildElement().hasAttribute( QStringLiteral( "xmlns:" ) + mLayerPropertiesList[0].mNamespacePrefix ) )
+  {
+    // nothing to do
+  }
+  else
+  {
+    // add xmls:PREFIX=URI attributes to top element
+    QSet<QString> setNamespaceURI;
+    for ( const QgsOgcUtils::LayerProperties &props : std::as_const( mLayerPropertiesList ) )
+    {
+      if ( !props.mNamespacePrefix.isEmpty() && !props.mNamespaceURI.isEmpty() &&
+           !setNamespaceURI.contains( props.mNamespaceURI ) )
+      {
+        setNamespaceURI.insert( props.mNamespaceURI );
+        QDomAttr attr = envelopeFilterDoc.createAttribute( QStringLiteral( "xmlns:" ) + props.mNamespacePrefix );
+        attr.setValue( props.mNamespaceURI );
+        envelopeFilterDoc.firstChildElement().setAttributeNode( attr );
+      }
+    }
+  }
+
+  // fprintf(stderr, "%s\n", envelopeFilterDoc.toString().toStdString().c_str());
+  return envelopeFilterDoc.toString();
 }
 
 void QgsWFSSharedData::getVersionValues( QgsOgcUtils::GMLVersion &gmlVersion, QgsOgcUtils::FilterVersion &filterVersion, bool &honourAxisOrientation ) const

--- a/src/providers/wfs/qgswfsshareddata.h
+++ b/src/providers/wfs/qgswfsshareddata.h
@@ -43,6 +43,9 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
     //! Return provider geometry attribute name
     const QString &geometryAttribute() const { return mGeometryAttribute; }
 
+    //! Return list of layer properties.
+    const QList< QgsOgcUtils::LayerProperties > &layerProperties() const { return mLayerPropertiesList; }
+
     std::unique_ptr<QgsFeatureDownloaderImpl> newFeatureDownloaderImpl( QgsFeatureDownloader *, bool requestFromMainThread ) override;
 
     bool isRestrictedToRequestBBOX() const override;
@@ -53,6 +56,15 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
 
     //! Set a new filter and return the previous one. Only used to temporarily disable filtering when trying to get layer geometry type.
     QString setWFSFilter( const QString &newFilter ) { QString oldFilter = mWFSFilter; mWFSFilter = newFilter; return oldFilter; }
+
+    //! Returns the WFS filter computed by computeFilter()
+    const QString &WFSFilter() const { return mWFSFilter; }
+
+    //! Compute mWFSGeometryTypeFilter
+    void computeGeometryTypeFilter();
+
+    //! Combine several WFS filters together with a And condition
+    QString combineWFSFilters( const std::vector<QString> &filters ) const;
 
     //! Creates a deep copy of this shared data
     QgsWFSSharedData *clone() const;
@@ -107,6 +119,9 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
 
     //! Geometry type of the features in this layer
     QgsWkbTypes::Type mWKBType = QgsWkbTypes::Unknown;
+
+    //! Geometry type filter to ensure geometries returned by the layer are of type mWKBType.
+    QString mWFSGeometryTypeFilter;
 
     //! Create GML parser
     QgsGmlStreamingParser *createParser() const;

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -5823,6 +5823,7 @@ Can't recognize service requested.
 
         self.assertEqual(sublayers[0].uri(), uri + " geometryTypeFilter='NoGeometry'")
         self.assertEqual(sublayers[0].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[0].name(), "my:typename " + QgsWkbTypes.translatedDisplayString(QgsWkbTypes.NoGeometry))
         self.assertEqual(sublayers[0].providerKey(), "WFS")
         self.assertEqual(sublayers[0].wkbType(), QgsWkbTypes.NoGeometry)
         self.assertEqual(sublayers[0].featureCount(), 2)

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -25,6 +25,7 @@ os.environ['QT_HASH_SEED'] = '1'
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QObject, QDateTime, QEventLoop
 
 from qgis.core import (
+    Qgis,
     QgsWkbTypes,
     QgsVectorLayer,
     QgsFeature,
@@ -38,13 +39,16 @@ from qgis.core import (
     QgsExpression,
     QgsExpressionContextUtils,
     QgsExpressionContext,
-    QgsExpressionContextScope
+    QgsExpressionContextScope,
+    QgsMapLayerType,
+    QgsProviderRegistry
 )
+
 from qgis.testing import (start_app,
                           unittest
                           )
 from providertestbase import ProviderTestCase
-from utilities import unitTestDataPath
+from utilities import compareWkt, unitTestDataPath
 
 TEST_DATA_DIR = unitTestDataPath()
 
@@ -658,8 +662,9 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </gml:featureMember>
 </wfs:FeatureCollection>""".encode('UTF-8'))
 
+        uri = "url='http://" + endpoint + "' typename='my:typename' version='1.0.0' restrictToRequestBBOX=1"
         vl = QgsVectorLayer(
-            "url='http://" + endpoint + "' typename='my:typename' version='1.0.0' restrictToRequestBBOX=1", 'test',
+            uri, 'test',
             'WFS')
 
         extent = QgsRectangle(400000.0, 5400000.0, 450000.0, 5500000.0)
@@ -676,6 +681,18 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         request = QgsFeatureRequest().setLimit(1)
         values = [(f.id(), f['INTFIELD']) for f in vl.getFeatures(request)]
         self.assertEqual(values[0][1], 100)
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('wfs')
+
+        sublayers = metadata.querySublayers(uri, Qgis.SublayerQueryFlag.FastScan)
+        self.assertEqual(len(sublayers), 0)
+
+        sublayers = metadata.querySublayers(uri)
+        self.assertEqual(len(sublayers), 1)
+        self.assertEqual(sublayers[0].uri(), uri)
+        self.assertEqual(sublayers[0].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[0].providerKey(), "WFS")
+        self.assertEqual(sublayers[0].wkbType(), vl.wkbType())
 
         # Unexpected foo parameter key
         with MessageLogger('WFS') as logger:
@@ -3082,7 +3099,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
     def testWFS20TransactionsDisabled(self):
         """Test WFS 2.0 Transaction disabled"""
 
-        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_WFS_2.0_transaction'
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_WFS_2.0_transaction_disabled'
 
         with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?ACCEPTVERSIONS=2.0.0,1.1.0,1.0.0'),
                   'wb') as f:
@@ -3143,7 +3160,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
     def testWFS20TransactionsEnabled(self):
         """Test WFS 2.0 Transaction enabled"""
 
-        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_WFS_2.0_transaction'
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_WFS_2.0_transaction_enabled'
 
         with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?ACCEPTVERSIONS=2.0.0,1.1.0,1.0.0'),
                   'wb') as f:
@@ -3437,7 +3454,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         request = QgsFeatureRequest().setFilterRect(extent)
 
         with open(sanitize(endpoint,
-                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:my="http://my">
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&FILTER=<fes:Filter xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:my="http://my" xmlns:fes="http://www.opengis.net/fes/2.0">
  <fes:And>
   <fes:BBOX>
    <fes:ValueReference>my:geometryProperty</fes:ValueReference>
@@ -3476,7 +3493,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         # is included in the filter
         vl.setSubsetString('intfield = 2')
         with open(sanitize(endpoint,
-                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:my="http://my">
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&FILTER=<fes:Filter xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:my="http://my" xmlns:fes="http://www.opengis.net/fes/2.0">
  <fes:And>
   <fes:BBOX>
    <fes:ValueReference>my:geometryProperty</fes:ValueReference>
@@ -3698,7 +3715,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         request.setFilterExpression("intersects( $geometry, geometry(var('parent')))")
 
         with open(sanitize(endpoint,
-                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml/3.2">
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
  <fes:And>
   <fes:Intersects xmlns:fes="http://www.opengis.net/fes/2.0">
    <fes:ValueReference>geometryProperty</fes:ValueReference>
@@ -5620,6 +5637,508 @@ Can't recognize service requested.
 
         values = [f['intfield'] for f in vl.getFeatures()]
         self.assertEqual(values, [1])
+
+    def _createBaseFilesForTestsDeegreeServerWithUnknownGeometryType(self, endpoint):
+
+        # Cf https://xplanung.freiburg.de/xplansyn-wfs/services/xplansynwfs?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0
+        with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?VERSION=2.0.0'), 'wb') as f:
+            f.write("""
+<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
+  <OperationsMetadata>
+    <Operation name="GetFeature">
+      <Constraint name="CountDefault">
+        <NoValues/>
+        <DefaultValue>1</DefaultValue>
+      </Constraint>
+    </Operation>
+    <Constraint name="ImplementsResultPaging">
+      <NoValues/>
+      <DefaultValue>TRUE</DefaultValue>
+    </Constraint>
+  </OperationsMetadata>
+  <FeatureTypeList>
+    <FeatureType>
+      <Name>my:typename</Name>
+      <Title>Title</Title>
+      <Abstract>Abstract</Abstract>
+      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
+      <WGS84BoundingBox>
+        <LowerCorner>-71.123 66.33</LowerCorner>
+        <UpperCorner>-65.32 78.3</UpperCorner>
+      </WGS84BoundingBox>
+    </FeatureType>
+  </FeatureTypeList>
+  <fes:Filter_Capabilities>
+    <fes:Functions>
+      <fes:Function name="IsCurve">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsPoint">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml="http://www.opengis.net/gml">gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsPoint">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsSurface">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml="http://www.opengis.net/gml">gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsSurface">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+    </fes:Functions>
+  </fes:Filter_Capabilities>
+</wfs:WFS_Capabilities>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&TYPENAME=my:typename'),
+                  'wb') as f:
+            f.write("""
+<xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
+  <xsd:import namespace="http://www.opengis.net/gml"/>
+  <xsd:complexType name="typenameType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="intfield" nillable="true" type="xsd:int"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geometry" nillable="true" type="gml:GeometryPropertyType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="typename" substitutionGroup="gml:_Feature" type="my:typenameType"/>
+</xsd:schema>
+""".encode('UTF-8'))
+
+    def testDeegreeServerWithUnknownGeometryType(self):
+        """ https://github.com/qgis/QGIS/issues/49328 """
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_layer_unknown_geometry_type'
+
+        self._createBaseFilesForTestsDeegreeServerWithUnknownGeometryType(endpoint)
+
+        with open(sanitize(endpoint,
+                           '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&RESULTTYPE=hits'), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="20" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsNull>
+  <fes:ValueReference>geometry</fes:ValueReference>
+ </fes:PropertyIsNull>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="2" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="3" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsCurve">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="4" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsSurface">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="5" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        uri = "url='http://" + endpoint + "' typename='my:typename' version='2.0.0'"
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('wfs')
+        sublayers = metadata.querySublayers(uri)
+        self.assertEqual(len(sublayers), 5)
+
+        self.assertEqual(sublayers[0].uri(), uri + " geometryTypeFilter='NoGeometry'")
+        self.assertEqual(sublayers[0].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[0].providerKey(), "WFS")
+        self.assertEqual(sublayers[0].wkbType(), QgsWkbTypes.NoGeometry)
+        self.assertEqual(sublayers[0].featureCount(), 2)
+
+        self.assertEqual(sublayers[1].uri(), uri + " geometryTypeFilter='MultiPoint'")
+        self.assertEqual(sublayers[1].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[1].providerKey(), "WFS")
+        self.assertEqual(sublayers[1].wkbType(), QgsWkbTypes.MultiPoint)
+        self.assertEqual(sublayers[1].featureCount(), 3)
+
+        self.assertEqual(sublayers[2].uri(), uri + " geometryTypeFilter='MultiCurve'")
+        self.assertEqual(sublayers[2].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[2].providerKey(), "WFS")
+        self.assertEqual(sublayers[2].wkbType(), QgsWkbTypes.MultiCurve)
+        self.assertEqual(sublayers[2].featureCount(), 4)
+
+        self.assertEqual(sublayers[3].uri(), uri + " geometryTypeFilter='MultiSurface'")
+        self.assertEqual(sublayers[3].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[3].providerKey(), "WFS")
+        self.assertEqual(sublayers[3].wkbType(), QgsWkbTypes.MultiSurface)
+        self.assertEqual(sublayers[3].featureCount(), 5)
+
+        self.assertEqual(sublayers[4].uri(), uri + " geometryTypeFilter='GeometryCollection'")
+        self.assertEqual(sublayers[4].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[4].providerKey(), "WFS")
+        self.assertEqual(sublayers[4].wkbType(), QgsWkbTypes.GeometryCollection)
+        self.assertEqual(sublayers[4].featureCount(), 20 - (2 + 3 + 4 + 5))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+"""), 'wb') as f:
+            f.write("""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my">
+  <wfs:member>
+    <my:typename gml:id="typename.0">
+      <my:intfield>1</my:intfield>
+      <my:geometry><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometry>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        # Test NoGeometry layer
+        vl = QgsVectorLayer(sublayers[0].uri(), 'test', 'WFS')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), QgsWkbTypes.NoGeometry)
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&STARTINDEX=0&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsNull>
+  <fes:ValueReference>geometry</fes:ValueReference>
+ </fes:PropertyIsNull>
+</fes:Filter>
+"""), 'wb') as f:
+            f.write("""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my">
+  <wfs:member>
+    <my:typename gml:id="typename.0">
+      <my:intfield>0</my:intfield>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        got_f = [f for f in vl.getFeatures()]
+        geom = got_f[0].geometry()
+        self.assertTrue(geom.isNull())
+
+        self.assertEqual(vl.featureCount(), sublayers[0].featureCount())
+
+        # Test MultiPoint layer
+        vl = QgsVectorLayer(sublayers[1].uri(), 'test', 'WFS')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), QgsWkbTypes.MultiPoint)
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&STARTINDEX=0&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+"""), 'wb') as f:
+            f.write("""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my">
+  <wfs:member>
+    <my:typename gml:id="typename.0">
+      <my:intfield>1</my:intfield>
+      <my:geometry><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometry>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        got_f = [f for f in vl.getFeatures()]
+        geom = got_f[0].geometry()
+        assert compareWkt('MultiPoint((-65.32 78.3))', geom.asWkt()), geom.asWkt()
+
+        self.assertEqual(vl.featureCount(), sublayers[1].featureCount())
+
+        # Test GeometryCollection layer
+        vl = QgsVectorLayer(sublayers[4].uri(), 'test', 'WFS')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), QgsWkbTypes.GeometryCollection)
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&STARTINDEX=0&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:And>
+  <fes:Not>
+   <fes:PropertyIsNull>
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:PropertyIsNull>
+  </fes:Not>
+ </fes:And>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsCurve">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsSurface">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+"""), 'wb') as f:
+            f.write("""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my">
+  <wfs:member>
+    <my:typename gml:id="typename.1">
+      <my:intfield>2</my:intfield>
+      <my:geometry><gml:MultiGeometry gml:id="geomcollection.geom.0"><gml:geometryMember><gml:Point gml:id="geomcollection.geom.0.0"><gml:pos>0 1</gml:pos></gml:Point></gml:geometryMember><gml:geometryMember><gml:LineString gml:id="geomcollection.geom.0.1"><gml:posList>2 3 4 5</gml:posList></gml:LineString></gml:geometryMember></gml:MultiGeometry></my:geometry>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        got_f = [f for f in vl.getFeatures()]
+        geom = got_f[0].geometry()
+        assert compareWkt('GeometryCollection (Point (0 1),LineString (2 3, 4 5))', geom.asWkt()), geom.asWkt()
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:And>
+  <fes:Not>
+   <fes:PropertyIsNull>
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:PropertyIsNull>
+  </fes:Not>
+ </fes:And>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsCurve">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsSurface">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>false</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="100" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        self.assertEqual(vl.featureCount(), 100)
+
+    def testDeegreeServerWithUnknownGeometryTypeOnlyCurve(self):
+        """ https://github.com/qgis/QGIS/issues/49328 """
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_layer_unknown_geometry_type_only_curve'
+
+        self._createBaseFilesForTestsDeegreeServerWithUnknownGeometryType(endpoint)
+
+        with open(sanitize(endpoint,
+                           '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&RESULTTYPE=hits'), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="20" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsNull>
+  <fes:ValueReference>geometry</fes:ValueReference>
+ </fes:PropertyIsNull>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="0" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsPoint">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="0" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsCurve">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="20" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsEqualTo>
+  <fes:Function name="IsSurface">
+   <fes:ValueReference>geometry</fes:ValueReference>
+  </fes:Function>
+  <fes:Literal>true</fes:Literal>
+ </fes:PropertyIsEqualTo>
+</fes:Filter>
+&RESULTTYPE=hits"""), 'wb') as f:
+            f.write("""<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="0" numberReturned="0" timeStamp="2016-03-25T14:51:48.998Z">
+</wfs:FeatureCollection>""".encode('UTF-8'))
+
+        uri = "url='http://" + endpoint + "' typename='my:typename' version='2.0.0'"
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('wfs')
+        sublayers = metadata.querySublayers(uri)
+        self.assertEqual(len(sublayers), 1)
+
+        self.assertEqual(sublayers[0].uri(), uri + " geometryTypeFilter='MultiCurve'")
+        self.assertEqual(sublayers[0].type(), QgsMapLayerType.VectorLayer)
+        self.assertEqual(sublayers[0].providerKey(), "WFS")
+        self.assertEqual(sublayers[0].wkbType(), QgsWkbTypes.MultiCurve)
+        self.assertEqual(sublayers[0].featureCount(), 20)
+
+    def testDeegreeServerWithUnknownGeometryTypeErrorSituation(self):
+        """ https://github.com/qgis/QGIS/issues/49328 """
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_layer_unknown_geometry_type_error_situation'
+
+        self._createBaseFilesForTestsDeegreeServerWithUnknownGeometryType(endpoint)
+
+        uri = "url='http://" + endpoint + "' typename='my:typename' version='2.0.0'"
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('wfs')
+
+        sublayers = metadata.querySublayers(uri)
+
+        self.assertEqual(len(sublayers), 5)
+        self.assertEqual(sublayers[0].featureCount(), -1)
+        self.assertEqual(sublayers[1].featureCount(), -1)
+        self.assertEqual(sublayers[2].featureCount(), -1)
+        self.assertEqual(sublayers[3].featureCount(), -1)
+        self.assertEqual(sublayers[4].featureCount(), -1)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -5818,6 +5818,10 @@ Can't recognize service requested.
         uri = "url='http://" + endpoint + "' typename='my:typename' version='2.0.0'"
 
         metadata = QgsProviderRegistry.instance().providerMetadata('wfs')
+
+        sublayers = metadata.querySublayers("invalid")
+        self.assertEqual(len(sublayers), 0)
+
         sublayers = metadata.querySublayers(uri)
         self.assertEqual(len(sublayers), 5)
 

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -5956,25 +5956,25 @@ Can't recognize service requested.
     <fes:ValueReference>geometry</fes:ValueReference>
    </fes:PropertyIsNull>
   </fes:Not>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsPoint">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsCurve">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsSurface">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
  </fes:And>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsPoint">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsCurve">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsSurface">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
 </fes:Filter>
 """), 'wb') as f:
             f.write("""
@@ -6002,25 +6002,25 @@ Can't recognize service requested.
     <fes:ValueReference>geometry</fes:ValueReference>
    </fes:PropertyIsNull>
   </fes:Not>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsPoint">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsCurve">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
+  <fes:PropertyIsEqualTo>
+   <fes:Function name="IsSurface">
+    <fes:ValueReference>geometry</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal>false</fes:Literal>
+  </fes:PropertyIsEqualTo>
  </fes:And>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsPoint">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsCurve">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
- <fes:PropertyIsEqualTo>
-  <fes:Function name="IsSurface">
-   <fes:ValueReference>geometry</fes:ValueReference>
-  </fes:Function>
-  <fes:Literal>false</fes:Literal>
- </fes:PropertyIsEqualTo>
 </fes:Filter>
 &RESULTTYPE=hits"""), 'wb') as f:
             f.write("""<wfs:FeatureCollection

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -2867,6 +2867,85 @@ class TestQgsGeometry(unittest.TestCase):
         assert compareWkt(expWkt, wkt), "testConvertToMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
             expWkt, wkt)
 
+    def testConvertToCurvedMultiType(self):
+        """ Test converting geometries to multi curve type """
+        point = QgsGeometry.fromWkt('Point (1 2)')
+        assert point.convertToCurvedMultiType()
+        expWkt = 'MultiPoint ((1 2))'
+        wkt = point.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiPoint
+        assert point.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        multipoint = QgsGeometry.fromWkt('MultiPoint ((1 2))')
+        assert multipoint.convertToCurvedMultiType()
+        expWkt = 'MultiPoint ((1 2))'
+        wkt = multipoint.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiPoint
+        assert multipoint.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        line = QgsGeometry.fromWkt('LineString (1 0, 2 0)')
+        assert line.convertToCurvedMultiType()
+        expWkt = 'MultiCurve (LineString (1 0, 2 0))'
+        wkt = line.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiCurve
+        assert line.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        circular = QgsGeometry.fromWkt('CircularString (0 0, 1 1, 2 0)')
+        assert circular.convertToCurvedMultiType()
+        expWkt = 'MultiCurve (CircularString (0 0, 1 1, 2 0))'
+        wkt = circular.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiCurve
+        assert circular.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        multiline = QgsGeometry.fromWkt('MultiLineString ((1 0, 2 0))')
+        assert multiline.convertToCurvedMultiType()
+        expWkt = 'MultiCurve (LineString (1 0, 2 0))'
+        wkt = multiline.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiCurve
+        assert multiline.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        poly = QgsGeometry.fromWkt('Polygon ((1 0, 2 0, 2 1, 1 1, 1 0))')
+        assert poly.convertToCurvedMultiType()
+        expWkt = 'MultiSurface (Polygon((1 0, 2 0, 2 1, 1 1, 1 0)))'
+        wkt = poly.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiSurface
+        assert poly.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
+        multipoly = QgsGeometry.fromWkt('MultiPolygon (((1 0, 2 0, 2 1, 1 1, 1 0)))')
+        assert multipoly.convertToCurvedMultiType()
+        expWkt = 'MultiSurface ( Polygon((1 0, 2 0, 2 1, 1 1, 1 0)))'
+        wkt = multipoly.asWkt()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+        # test conversion of MultiSurface
+        assert multipoly.convertToCurvedMultiType()
+        assert compareWkt(expWkt, wkt), "testConvertToCurvedMultiType failed: mismatch Expected:\n%s\nGot:\n%s\n" % (
+            expWkt, wkt)
+
     def testConvertToSingleType(self):
         """ Test converting geometries to single type """
         point = QgsGeometry.fromWkt('MultiPoint ((1 2),(2 3))')
@@ -6345,6 +6424,11 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(coerce_to_wkt('MultiPolygon (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))',
                                        QgsWkbTypes.MultiLineString),
                          ['MultiLineString ((1 1, 1 2, 2 2, 1 1),(3 3, 4 3, 4 4, 3 3))'])
+
+        # Straight to curve
+        self.assertEqual(coerce_to_wkt('LineString (0 0,1 1)',
+                                       QgsWkbTypes.MultiCurve),
+                         ['MultiCurve (LineString (0 0, 1 1))'])
 
     def testTriangularWaves(self):
         """Test triangular waves"""


### PR DESCRIPTION
or any server implementing IsPoint, IsCurve and IsSurface filtering functions.
    
When such a layer is added to the project, the Select Items to Add
dialog box used for example for OGR vector layers with unknown geometry
type is displayed, enabling the user to select one or several layers
among ones of NoGeometry/MultiPoint/MultiCurve/MultiSurface/GeometryCollection
types.

![image](https://user-images.githubusercontent.com/1192433/206298574-33a67922-e0c5-4a8b-ae2e-b90923399c22.png)

Fixes #49328

Funded by QGIS-DE user group (QGIS Anwendergruppe Deutschland e.V.)
