### PR TITLE
When undo/redoing changes in QgsVectorLayer, ensure triggerRepaint signal is emitted  (3.22 backport)

### DIFF
--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -216,8 +216,9 @@ class TestLayerDependencies(unittest.TestCase):
 
         # repaintRequested is called on commit changes on point
         # so it is on depending line
-        self.assertEqual(len(spy_lines_repaint_requested), 1)
-        self.assertEqual(len(spy_points_repaint_requested), 1)
+        # (ideally only one repaintRequested signal is fired, but it's harmless to fire multiple ones)
+        self.assertGreaterEqual(len(spy_lines_repaint_requested), 2)
+        self.assertGreaterEqual(len(spy_points_repaint_requested), 2)
 
     def test_circular_dependencies_with_1_layer(self):
 
@@ -248,7 +249,8 @@ class TestLayerDependencies(unittest.TestCase):
         self.assertEqual(len(spy_lines_data_changed), 4)
 
         # repaintRequested is called only once on commit changes on line
-        self.assertEqual(len(spy_lines_repaint_requested), 1)
+        # (ideally only one repaintRequested signal is fired, but it's harmless to fire multiple ones)
+        self.assertGreaterEqual(len(spy_lines_repaint_requested), 2)
 
     def test_layerDefinitionRewriteId(self):
         tmpfile = os.path.join(tempfile.tempdir, "test.qlr")


### PR DESCRIPTION
so that layer is redrawn in **all** map canvases

Manual backport of https://github.com/qgis/QGIS/pull/51094