### PR TITLE
Refresh GPS Information Panel widget - Timeout connection error! 

### DIFF
--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -183,8 +183,6 @@ void QgsAppGpsConnection::onTimeOut()
 
   QgisApp::instance()->statusBarIface()->clearMessage();
   showGpsConnectFailureWarning( tr( "TIMEOUT - Failed to connect to GPS device." ) );
-
-  QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
 }
 
 void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )

--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -178,12 +178,7 @@ void QgsAppGpsConnection::disconnectGps()
 
 void QgsAppGpsConnection::onTimeOut()
 {
-  std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );
-  mConnection = nullptr;
-
-  emit disconnected();
-  emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
-  emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
+  disconnectGps();
   emit connectionTimedOut();
 
   QgisApp::instance()->statusBarIface()->clearMessage();

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -269,12 +269,17 @@ void QgsGpsInformationWidget::gpsConnecting()
   mTxtLatitude->clear();
   mTxtLongitude->clear();
   mTxtAltitude->clear();
+  mTxtAltitudeDiff->clear();
+  mTxtAltitudeEllipsoid->clear();
   mTxtDateTime->clear();
   mTxtSpeed->clear();
   mTxtDirection->clear();
   mTxtHdop->clear();
   mTxtVdop->clear();
   mTxtPdop->clear();
+  mTxtHacc->clear();
+  mTxtVacc->clear();
+  mTxt3Dacc->clear();
   mTxtFixMode->clear();
   mTxtFixType->clear();
   mTxtQuality->clear();
@@ -328,6 +333,32 @@ void QgsGpsInformationWidget::updateTrackInformation()
 
 void QgsGpsInformationWidget::gpsDisconnected()
 {
+  // clear position page fields to give better indication that something happened (or didn't happen)
+  mTxtLatitude->clear();
+  mTxtLongitude->clear();
+  mTxtAltitude->clear();
+  mTxtAltitudeDiff->clear();
+  mTxtAltitudeEllipsoid->clear();
+  mTxtDateTime->clear();
+  mTxtSpeed->clear();
+  mTxtDirection->clear();
+  mTxtHdop->clear();
+  mTxtVdop->clear();
+  mTxtPdop->clear();
+  mTxtHacc->clear();
+  mTxtVacc->clear();
+  mTxt3Dacc->clear();
+  mTxtFixMode->clear();
+  mTxtFixType->clear();
+  mTxtQuality->clear();
+  mTxtSatellitesUsed->clear();
+  mTxtStatus->clear();
+  
+  // Clear Plot Signal data
+  QVector<QPointF> data;
+  mCurve->setSamples( data );
+  mPlot->replot();
+
   mGPSPlainTextEdit->appendPlainText( tr( "Disconnected…" ) );
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -353,7 +353,7 @@ void QgsGpsInformationWidget::gpsDisconnected()
   mTxtQuality->clear();
   mTxtSatellitesUsed->clear();
   mTxtStatus->clear();
-  
+
   // Clear Plot Signal data
   QVector<QPointF> data;
   mCurve->setSamples( data );


### PR DESCRIPTION
My GNSS receiver is having trouble connecting with the new GPS Tools. The TIMEOUT connection error blocked the connection to the GNSS receiver and I had to restart QGis to make a new connection attempt.
This PR refreshes the GPS Information Panel, cancels any values present and closes any active GNSS connection!