### PR TITLE
fix(3d): fix typo and bug in qgs3dutils and QgsAbstract3DEngine

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -60,6 +60,7 @@ QImage Qgs3DUtils::captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene
   {
     if ( scene->sceneState() == Qgs3DMapScene::Ready )
     {
+      engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
       engine.requestCaptureImage();
     }
   };
@@ -105,7 +106,8 @@ QImage Qgs3DUtils::captureSceneDepthBuffer( QgsAbstract3DEngine &engine, Qgs3DMa
   {
     if ( scene->sceneState() == Qgs3DMapScene::Ready )
     {
-      engine.requestCaptureImage();
+      engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
+      engine.requestDepthBufferCapture();
     }
   };
 
@@ -115,7 +117,7 @@ QImage Qgs3DUtils::captureSceneDepthBuffer( QgsAbstract3DEngine &engine, Qgs3DMa
     evLoop.quit();
   };
 
-  QMetaObject::Connection conn1 = QObject::connect( &engine, &QgsAbstract3DEngine::imageCaptured, saveImageFcn );
+  QMetaObject::Connection conn1 = QObject::connect( &engine, &QgsAbstract3DEngine::depthBufferCaptured, saveImageFcn );
   QMetaObject::Connection conn2;
 
   if ( scene->sceneState() == Qgs3DMapScene::Ready )

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -30,12 +30,10 @@ void QgsAbstract3DEngine::requestCaptureImage()
 {
   Qt3DRender::QRenderCaptureReply *captureReply;
   captureReply = mFrameGraph->renderCapture()->requestCapture();
-  // We need to change render policy to RenderPolicy::Always, since otherwise render capture node won't work
-  this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::Always );
+
   connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
   {
     emit imageCaptured( captureReply->image() );
-    this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
     captureReply->deleteLater();
   } );
 }
@@ -44,12 +42,10 @@ void QgsAbstract3DEngine::requestDepthBufferCapture()
 {
   Qt3DRender::QRenderCaptureReply *captureReply;
   captureReply = mFrameGraph->depthRenderCapture()->requestCapture();
-  // We need to change render policy to RenderPolicy::Always, since otherwise render capture node won't work
-  this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::Always );
+
   connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
   {
     emit depthBufferCaptured( captureReply->image() );
-    this->renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
     captureReply->deleteLater();
   } );
 }


### PR DESCRIPTION
* fix captureSceneDepthBuffer by adjusting bad copy/paste from captureSceneImage
* fix bug: sometimes some tiles are re-computed while capturing and so are disabled
* remove useless RenderPolicy in QgsAbstract3DEngine

