### PR TITLE
[Clazy] remove unused-non-trivial-variable

### DIFF
--- a/src/analysis/processing/qgsalgorithmgpsbabeltools.cpp
+++ b/src/analysis/processing/qgsalgorithmgpsbabeltools.cpp
@@ -98,8 +98,6 @@ QgsConvertGpxFeatureTypeAlgorithm *QgsConvertGpxFeatureTypeAlgorithm::createInst
 
 QVariantMap QgsConvertGpxFeatureTypeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
-  const QStringList convertStrings;
-
   const QString inputPath = parameterAsString( parameters, QStringLiteral( "INPUT" ), context );
   const QString outputPath = parameterAsString( parameters, QStringLiteral( "OUTPUT" ), context );
 
@@ -314,8 +312,6 @@ QgsConvertGpsDataAlgorithm *QgsConvertGpsDataAlgorithm::createInstance() const
 
 QVariantMap QgsConvertGpsDataAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
-  const QStringList convertStrings;
-
   const QString inputPath = parameterAsString( parameters, QStringLiteral( "INPUT" ), context );
   const QString outputPath = parameterAsString( parameters, QStringLiteral( "OUTPUT" ), context );
 

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1585,7 +1585,6 @@ void QgsAppLayerHandling::resolveVectorLayerDependencies( QgsVectorLayer *vl, Qg
               // where the dependency was actually loaded but it was found as broken
               // because the source does not match anymore (for instance when loaded
               // from a style definition).
-              QStringList layerUris;
               for ( auto it = QgsProject::instance()->mapLayers().cbegin(); it != QgsProject::instance()->mapLayers().cend(); ++it )
               {
                 if ( it.value()->publicSource() == layerUri )
@@ -1694,4 +1693,3 @@ void QgsAppLayerHandling::onVectorLayerStyleLoaded( QgsVectorLayer *vl, QgsMapLa
     }
   }
 }
-

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1292,8 +1292,11 @@ void QgsOptions::checkPageWidgetNameMap()
   };
   traverseModel( QModelIndex() );
 
-  Q_ASSERT_X( pageNames.count() == pageTitles.count(),  "QgsOptions::checkPageWidgetNameMap()", QStringLiteral( "QgisApp::optionsPagesMap() is outdated, contains too many entries, "
-              " this is often a problem with missing translations for the entries (extra entries: %1)" ).arg( qgsSetJoin( QSet( pageNames.keyBegin(), pageNames.keyEnd() ) - pageTitles.toSet(), QStringLiteral( "," ) ) ).toLocal8Bit().constData() );
+  Q_ASSERT_X( pageNames.count() == pageTitles.count(),  "QgsOptions::checkPageWidgetNameMap()",
+              QStringLiteral( "QgisApp::optionsPagesMap() is outdated, contains too many entries, "
+                              " this is often a problem with missing translations for the entries (extra entries: %1)" ).arg(
+                qgsSetJoin( QSet( pageNames.keyBegin(), pageNames.keyEnd() ) - QSet( pageTitles.constBegin(), pageTitles.constEnd() ),
+                            QStringLiteral( "," ) ) ).toLocal8Bit().constData() );
 
   int page = 0;
   for ( const QString &pageTitle : std::as_const( pageTitles ) )

--- a/src/app/qgsdockablewidgethelper.cpp
+++ b/src/app/qgsdockablewidgethelper.cpp
@@ -89,7 +89,6 @@ void QgsDockableWidgetHelper::writeXml( QDomElement &viewDom )
   viewDom.setAttribute( QStringLiteral( "area" ), mDockArea );
   viewDom.setAttribute( QStringLiteral( "uuid" ), mUuid );
 
-  QStringList tabifiedDocks;
   if ( mDock )
   {
     const QList<QDockWidget * > tabSiblings = mOwnerWindow->tabifiedDockWidgets( mDock );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1621,8 +1621,6 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF *fm, const QSt
   double w = 0.0, h = 0.0, rw = 0.0, rh = 0.0;
   double labelHeight = fm->ascent() + fm->descent(); // ignore +1 for baseline
 
-  QStringList multiLineSplit;
-
   if ( document )
   {
     document->splitLines( wrapchr, evalAutoWrapLength, useMaxLineLengthForAutoWrap );

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -444,7 +444,6 @@ bool QgsLayerMetadata::contains( const QString &searchString ) const
   const QList<QStringList> keyVals { keywords().values() };
   for ( const QStringList &kws : std::as_const( keyVals ) )
   {
-    const QStringList constKws { kws };
     for ( const QString &kw : std::as_const( kws ) )
     {
       if ( kw.contains( searchString, Qt::CaseSensitivity::CaseInsensitive ) )
@@ -480,7 +479,6 @@ bool QgsLayerMetadata::matches( const QVector<QRegularExpression> &searchReList 
     const QList<QStringList> keyVals { keywords().values() };
     for ( const QStringList &kws : std::as_const( keyVals ) )
     {
-      const QStringList constKws { kws };
       for ( const QString &kw : std::as_const( kws ) )
       {
         if ( re.match( kw ).hasMatch() )

--- a/src/core/network/qgsrangerequestcache.cpp
+++ b/src/core/network/qgsrangerequestcache.cpp
@@ -144,7 +144,6 @@ void QgsRangeRequestCache::expire()
 
 QFileInfoList QgsRangeRequestCache::cacheEntries()
 {
-  QStringList list;
   QDir dir( mCacheDir );
   QFileInfoList filesList = dir.entryInfoList( QDir::Filter::Files, QDir::SortFlags() );
   std::sort( filesList.begin(), filesList.end(), []( QFileInfo & f1, QFileInfo & f2 )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1968,7 +1968,6 @@ QStringList QgsProcessingParameters::parameterAsFields( const QgsProcessingParam
   if ( !definition )
     return QStringList();
 
-  const QStringList resultStringList;
   return parameterAsFields( definition, parameters.value( definition->name() ), context );
 }
 
@@ -4335,7 +4334,6 @@ QString QgsProcessingParameterMultipleLayers::asPythonString( const QgsProcessin
 
 QString QgsProcessingParameterMultipleLayers::createFileFilter() const
 {
-  const QStringList exts;
   switch ( mLayerType )
   {
     case QgsProcessing::TypeFile:

--- a/src/core/qgspostgresstringutils.cpp
+++ b/src/core/qgspostgresstringutils.cpp
@@ -74,7 +74,6 @@ QVariantList QgsPostgresStringUtils::parseArray( const QString &string )
   if ( newVal.trimmed().startsWith( '{' ) )
   {
     //it's a multidimensional array
-    QStringList values;
     QString subarray = newVal;
     while ( !subarray.isEmpty() )
     {

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -605,7 +605,6 @@ void QgsStyleModel::setIconGenerator( QgsAbstractStyleEntityIconGenerator *gener
 void QgsStyleModel::onEntityAdded( QgsStyle::StyleEntity type, const QString &name )
 {
   mIconCache[ type ].remove( name );
-  const QStringList oldSymbolNames = mEntityNames[ type ];
   const QStringList newSymbolNames = mStyle->allNames( type );
 
   // find index of newly added symbol
@@ -1066,4 +1065,3 @@ void QgsStyleProxyModel::setEntityFilters( const QList<QgsStyle::StyleEntity> &f
   mEntityFilters = filters;
   invalidateFilter();
 }
-

--- a/src/gui/processing/models/qgsmodelinputreorderwidget.cpp
+++ b/src/gui/processing/models/qgsmodelinputreorderwidget.cpp
@@ -59,7 +59,6 @@ void QgsModelInputReorderWidget::setModel( QgsProcessingModelAlgorithm *model )
 {
   mModel = model;
   mParameters = mModel->orderedParameters();
-  QStringList res;
   mItemModel->clear();
   for ( const QgsProcessingModelParameter &param : std::as_const( mParameters ) )
   {

--- a/src/gui/processing/qgsprocessingaggregatewidgets.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.cpp
@@ -257,7 +257,6 @@ void QgsAggregateMappingModel::setSourceFields( const QgsFields &sourceFields )
   if ( mExpressionContextGenerator )
     mExpressionContextGenerator->setSourceFields( mSourceFields );
 
-  const QStringList usedFields;
   beginResetModel();
   mMapping.clear();
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -332,7 +332,6 @@ void QgsProcessingMultipleInputPanelWidget::addDirectory()
   }
 
   QDirIterator it( dir, nameFilters, QDir::Files | QDir::NoSymLinks | QDir::NoDotAndDotDot, QDirIterator::Subdirectories );
-  QStringList files;
   while ( it.hasNext() )
   {
     const QString fullPath = it.next();

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -4141,7 +4141,6 @@ void QgsProcessingFieldPanelWidget::setValue( const QVariant &value )
 void QgsProcessingFieldPanelWidget::showDialog()
 {
   QVariantList availableOptions;
-  QStringList fieldNames;
   availableOptions.reserve( mFields.size() );
   for ( const QgsField &field : std::as_const( mFields ) )
   {
@@ -6405,7 +6404,6 @@ void QgsProcessingRasterBandPanelWidget::setValue( const QVariant &value )
 void QgsProcessingRasterBandPanelWidget::showDialog()
 {
   QVariantList availableOptions;
-  QStringList fieldNames;
   availableOptions.reserve( mBands.size() );
   for ( int band : std::as_const( mBands ) )
   {

--- a/src/gui/qgsfindfilesbypatternwidget.cpp
+++ b/src/gui/qgsfindfilesbypatternwidget.cpp
@@ -68,7 +68,6 @@ void QgsFindFilesByPatternWidget::find()
     filter << pattern;
 
   QDirIterator it( path, filter, QDir::AllEntries | QDir::NoSymLinks | QDir::NoDotAndDotDot, mRecursiveCheckBox->isChecked() ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags );
-  const QStringList files;
   while ( it.hasNext() )
   {
     const QString fullPath = it.next();

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -2418,8 +2418,6 @@ void QgsStyleManagerDialog::populateGroups()
 
 void QgsStyleManagerDialog::groupChanged( const QModelIndex &index )
 {
-  QStringList groupSymbols;
-
   const QString category = index.data( Qt::UserRole + 1 ).toString();
   sPreviousTag = category;
 
@@ -3009,4 +3007,3 @@ void QgsStyleManagerDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "style_library/style_manager.html" ) );
 }
-

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -214,8 +214,6 @@ void QgsVectorTileLayerProperties::loadStyle()
 {
   const QgsSettings settings;  // where we keep last used filter in persistent state
 
-  QStringList ids, names, descriptions;
-
   QgsMapLayerLoadStyleDialog dlg( mLayer );
 
   if ( dlg.exec() )

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -1147,7 +1147,6 @@ QList<QgsProviderSublayerDetails> QgsMdalProviderMetadata::querySublayers( const
     static std::once_flag initialized;
     std::call_once( initialized, [ = ]( )
     {
-      QStringList meshExtensions;
       QStringList datasetsExtensions;
       QgsMdalProvider::fileMeshExtensions( sExtensions, datasetsExtensions );
       Q_UNUSED( datasetsExtensions )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1737,8 +1737,6 @@ bool QgsPostgresProvider::determinePrimaryKey()
     res = connectionRO()->LoggedPQexec( "QgsPostgresProvider", sql );
     QgsDebugMsgLevel( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ), 2 );
 
-    QStringList log;
-
     // no primary or unique indices found
     if ( res.PQntuples() == 0 )
     {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -251,7 +251,6 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsPostgresProviderConnection
 
 QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QString &sql, bool resolveTypes, QgsFeedback *feedback, std::shared_ptr<QgsPoolPostgresConn> pgconn ) const
 {
-  QStringList columnNames;
   return execSqlPrivate( sql, resolveTypes, feedback, pgconn ).rows();
 }
 

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -2089,8 +2089,6 @@ bool QgsPostgresRasterProvider::determinePrimaryKey()
     res = connectionRO()->PQexec( sql );
     QgsDebugMsgLevel( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ), 4 );
 
-    QStringList log;
-
     // no primary or unique indices found
     if ( res.PQntuples() == 0 )
     {

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1044,7 +1044,6 @@ void QgsWcsProvider::parseServiceException( QDomElement const &e, const QString 
   }
   else
   {
-    const QStringList codes;
     seCode = e.attribute( QStringLiteral( "exceptionCode" ) );
     // UMN Mapserver (6.0.3) has messed/switched 'locator' and 'exceptionCode'
     if ( ! exceptions.contains( seCode ) )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1047,7 +1047,6 @@ QString QgsWMSSourceSelect::connName()
 void QgsWMSSourceSelect::collectSelectedLayers( QStringList &layers, QStringList &styles, QStringList &titles )
 {
   //go through list in layer order tab
-  QStringList selectedLayerList;
   for ( int i = mLayerOrderTreeWidget->topLevelItemCount() - 1; i >= 0; --i )
   {
     layers << mLayerOrderTreeWidget->topLevelItem( i )->text( 0 );

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -203,7 +203,6 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   }
 
   loop.exec();
-  QStringList items = getComboBoxItems( w.mComboBox );
   QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
 
   // set first filter
@@ -725,7 +724,6 @@ void TestQgsRelationReferenceWidget::testSetFilterExpression()
   w.init();
 
   loop.exec();
-  QStringList items = getComboBoxItems( w.mComboBox );
   QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "NULL" ) );
   // in case there is no filter, the number of filtered features will be 4
   QCOMPARE( w.mComboBox->count(), 3 );
@@ -750,8 +748,6 @@ void TestQgsRelationReferenceWidget::testSetFilterExpressionWithOrClause()
   w.setRelation( *mRelation, true );
   w.setFilterExpression( QStringLiteral( " \"raccord\" = 'sleeve' OR FALSE " ) );
   w.init();
-
-  QStringList items = getComboBoxItems( w.mComboBox );
 
   loop.exec();
 


### PR DESCRIPTION
Found when building with Qt6. I don't get why they never popped up when building with Qt5...