### PR TITLE
Fix labeling positions are reversed on certain negative offsets on builds based on GEOS >= 3.11

### DIFF
--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -589,15 +589,17 @@ void PointSet::offsetCurveByDistance( double distance )
       newGeos = std::move( longestPartClone );
     }
 
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<11
     if ( distance < 0 )
     {
-      // geos reverses the direction of offset curves with negative distances -- we don't want that!
+      // geos < 3.11 reverses the direction of offset curves with negative distances -- we don't want that!
       geos::unique_ptr reversed( GEOSReverse_r( geosctxt, newGeos.get() ) );
       if ( !reversed )
         return;
 
       newGeos = std::move( reversed );
     }
+#endif
 
     const int newNbPoints = GEOSGeomGetNumPoints_r( geosctxt, newGeos.get() );
     const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( geosctxt, newGeos.get() );


### PR DESCRIPTION
Refs #49234

This is covered by a LOT of tests -- however none of our current CI infrastructure uses GEOS > 3.10. I've tested manually on Fedora 37 using GEOS 3.11 and can confirm that the tests which previously failed are now passing.

This is a regression, so should skip the queued branch.
