### PR TITLE
[OGR provider] Fix opening /vsizip//path/to/my.zip/my.gpkg files

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -992,6 +992,7 @@ GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUp
   bool bIsGpkg = QFileInfo( filePath ).suffix().compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0;
   const bool bIsLocalGpkg = bIsGpkg &&
                             IsLocalFile( filePath ) &&
+                            !filePath.startsWith( "/vsizip/" ) &&
                             !CPLGetConfigOption( "OGR_SQLITE_JOURNAL", nullptr ) &&
                             QgsSettings().value( QStringLiteral( "qgis/walForSqlite3" ), true ).toBool();
 


### PR DESCRIPTION
This actually works around an issue in current GDAL versions (addressed upstream per https://github.com/OSGeo/gdal/pull/6895) where the NOLOCK=YES open option does not work with /vsizip/ files
