### PR TITLE
Make some expression functions more thread safe by running layer related operations on main thread

### DIFF
--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -22,8 +22,6 @@
 #include "qgsprocessingmodelalgorithm.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsmapsettings.h"
-#include "qgssymbollayerutils.h"
-#include "qgslayout.h"
 #include "qgslayoutitem.h"
 #include "qgsexpressionutils.h"
 #include "qgslayoutpagecollection.h"
@@ -959,7 +957,7 @@ QgsExpressionContextUtils::GetLayerVisibility::GetLayerVisibility()
   : QgsScopedExpressionFunction( QStringLiteral( "is_layer_visible" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "id" ) ), QStringLiteral( "General" ) )
 {}
 
-QVariant QgsExpressionContextUtils::GetLayerVisibility::func( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+QVariant QgsExpressionContextUtils::GetLayerVisibility::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( mLayers.isEmpty() )
   {
@@ -967,7 +965,7 @@ QVariant QgsExpressionContextUtils::GetLayerVisibility::func( const QVariantList
   }
 
   bool isVisible = false;
-  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), parent );
+  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), context, parent );
   if ( layer && mLayers.contains( layer ) )
   {
     isVisible = true;

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -34,6 +34,7 @@
 #include "qgsmarkersymbol.h"
 #include "qgstriangularmesh.h"
 #include "qgsvectortileutils.h"
+#include "qgsmeshlayer.h"
 
 QgsExpressionContextScope *QgsExpressionContextUtils::globalScope()
 {
@@ -965,7 +966,9 @@ QVariant QgsExpressionContextUtils::GetLayerVisibility::func( const QVariantList
   }
 
   bool isVisible = false;
+  Q_NOWARN_DEPRECATED_PUSH
   QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), context, parent );
+  Q_NOWARN_DEPRECATED_POP
   if ( layer && mLayers.contains( layer ) )
   {
     isVisible = true;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6174,20 +6174,9 @@ static QVariant fcnDecodeUri( const QVariantList &values, const QgsExpressionCon
   }
 }
 
-static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QString layerIdOrName = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-
-  //try to find a matching layer by name
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerIdOrName ); //search by id first
-  if ( !layer )
-  {
-    QList<QgsMapLayer *> layersByName = QgsProject::instance()->mapLayersByName( layerIdOrName );
-    if ( !layersByName.isEmpty() )
-    {
-      layer = layersByName.at( 0 );
-    }
-  }
+  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), context, parent );
 
   if ( !layer )
     return QVariant();
@@ -6199,7 +6188,7 @@ static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpre
   int band = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
   if ( band < 1 || band > rl->bandCount() )
   {
-    parent->setEvalErrorString( QObject::tr( "Invalid band number %1 for layer %2" ).arg( band ).arg( layerIdOrName ) );
+    parent->setEvalErrorString( QObject::tr( "Invalid band number %1 for layer" ).arg( band ) );
     return QVariant();
   }
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -601,7 +601,11 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
   ENSURE_NO_EVAL_ERROR
   QVariant value = node->eval( parent, context );
   ENSURE_NO_EVAL_ERROR
+
+  // TODO this expression function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( value, context, parent );
+  Q_NOWARN_DEPRECATED_POP
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot find layer with name or ID '%1'" ).arg( value.toString() ) );
@@ -745,7 +749,11 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
   }
 
   // first step - find current layer
+
+  // TODO this expression function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
+  Q_NOWARN_DEPRECATED_POP
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot use relation aggregate function in this context" ) );
@@ -868,7 +876,11 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   }
 
   // first step - find current layer
+
+  // TODO this expression function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
+  Q_NOWARN_DEPRECATED_POP
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot use aggregate function in this context" ) );
@@ -1905,6 +1917,8 @@ static QVariant fcnRepresentAttributes( const QVariantList &values, const QgsExp
   QgsVectorLayer *layer = nullptr;
   QgsFeature feature;
 
+  // TODO this expression function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   if ( values.isEmpty() )
   {
     feature = context->feature();
@@ -1925,6 +1939,7 @@ static QVariant fcnRepresentAttributes( const QVariantList &values, const QgsExp
     parent->setEvalErrorString( QObject::tr( "Function `represent_attributes` requires no more than two parameters. %n given.", nullptr, values.length() ) );
     return QVariant();
   }
+  Q_NOWARN_DEPRECATED_POP
 
   if ( !layer )
   {
@@ -1988,6 +2003,8 @@ static QVariant fcnCoreFeatureMaptipDisplay( const QVariantList &values, const Q
   QgsFeature feature;
   bool evaluate = true;
 
+  // TODO this expression function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   if ( values.isEmpty() )
   {
     feature = context->feature();
@@ -2027,6 +2044,7 @@ static QVariant fcnCoreFeatureMaptipDisplay( const QVariantList &values, const Q
     parent->setEvalErrorString( QObject::tr( "The layer is not valid." ) );
     return QVariant( );
   }
+  Q_NOWARN_DEPRECATED_POP
 
   if ( !feature.isValid() )
   {
@@ -6063,7 +6081,10 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
     }
     else
     {
+      // TODO this function is NOT thread safe
+      Q_NOWARN_DEPRECATED_PUSH
       QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
+      Q_NOWARN_DEPRECATED_POP
 
       const QString cacheValueKey = QStringLiteral( "repvalfcnval:%1:%2:%3" ).arg( layer ? layer->id() : QStringLiteral( "[None]" ), fieldName, value.toString() );
       if ( context->hasCachedValue( cacheValueKey ) )
@@ -7142,7 +7163,10 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 {
 
   const QVariant sourceLayerRef = context->variable( QStringLiteral( "layer" ) ); //used to detect if sourceLayer and targetLayer are the same
+  // TODO this function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   QgsVectorLayer *sourceLayer = QgsExpressionUtils::getVectorLayer( sourceLayerRef, context, parent );
+  Q_NOWARN_DEPRECATED_POP
 
   QgsFeatureRequest request;
   request.setTimeout( 10000 );
@@ -7163,7 +7187,10 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QString subExpString = node->dump();
 
   bool testOnly = ( subExpString == "NULL" );
+  // TODO this function is NOT thread safe
+  Q_NOWARN_DEPRECATED_PUSH
   QgsVectorLayer *targetLayer = QgsExpressionUtils::getVectorLayer( targetLayerValue, context, parent );
+  Q_NOWARN_DEPRECATED_POP
   if ( !targetLayer ) // No layer, no joy
   {
     parent->setEvalErrorString( QObject::tr( "Layer '%1' could not be loaded." ).arg( targetLayerValue.toString() ) );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -601,7 +601,7 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
   ENSURE_NO_EVAL_ERROR
   QVariant value = node->eval( parent, context );
   ENSURE_NO_EVAL_ERROR
-  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( value, parent );
+  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( value, context, parent );
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot find layer with name or ID '%1'" ).arg( value.toString() ) );
@@ -745,7 +745,7 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
   }
 
   // first step - find current layer
-  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot use relation aggregate function in this context" ) );
@@ -868,7 +868,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   }
 
   // first step - find current layer
-  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   if ( !vl )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot use aggregate function in this context" ) );
@@ -1655,9 +1655,9 @@ static QVariant fcnFeatureId( const QVariantList &, const QgsExpressionContext *
   return QVariant( static_cast< int >( f.id() ) );
 }
 
-static QVariant fcnRasterValue( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnRasterValue( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsRasterLayer *layer = QgsExpressionUtils::getRasterLayer( values.at( 0 ), parent );
+  QgsRasterLayer *layer = QgsExpressionUtils::getRasterLayer( values.at( 0 ), context, parent );
   if ( !layer || !layer->dataProvider() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `raster_value` requires a valid raster layer." ) );
@@ -1697,9 +1697,9 @@ static QVariant fcnRasterValue( const QVariantList &values, const QgsExpressionC
   return std::isnan( value ) ? QVariant() : value;
 }
 
-static QVariant fcnRasterAttributes( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnRasterAttributes( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsRasterLayer *layer = QgsExpressionUtils::getRasterLayer( values.at( 0 ), parent );
+  QgsRasterLayer *layer = QgsExpressionUtils::getRasterLayer( values.at( 0 ), context, parent );
   if ( !layer || !layer->dataProvider() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `raster_attributes` requires a valid raster layer." ) );
@@ -1879,16 +1879,16 @@ static QVariant fcnRepresentAttributes( const QVariantList &values, const QgsExp
   if ( values.isEmpty() )
   {
     feature = context->feature();
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   }
   else if ( values.size() == 1 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
   }
   else if ( values.size() == 2 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context,  parent );
     feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
   }
   else
@@ -1962,21 +1962,21 @@ static QVariant fcnCoreFeatureMaptipDisplay( const QVariantList &values, const Q
   if ( values.isEmpty() )
   {
     feature = context->feature();
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   }
   else if ( values.size() == 1 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
   }
   else if ( values.size() == 2 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
   }
   else if ( values.size() == 3 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
     evaluate = values.value( 2 ).toBool();
   }
@@ -2051,16 +2051,16 @@ static QVariant fcnIsSelected( const QVariantList &values, const QgsExpressionCo
   if ( values.isEmpty() )
   {
     feature = context->feature();
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   }
   else if ( values.size() == 1 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
   }
   else if ( values.size() == 2 )
   {
-    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
     feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
   }
   else
@@ -2082,9 +2082,9 @@ static QVariant fcnNumSelected( const QVariantList &values, const QgsExpressionC
   QgsVectorLayer *layer = nullptr;
 
   if ( values.isEmpty() )
-    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
   else if ( values.count() == 1 )
-    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
   else
   {
     parent->setEvalErrorString( QObject::tr( "Function `num_selected` requires no more than one parameter. %n given.", nullptr, values.length() ) );
@@ -2099,7 +2099,7 @@ static QVariant fcnNumSelected( const QVariantList &values, const QgsExpressionC
   return layer->selectedFeatureCount();
 }
 
-static QVariant fcnSqliteFetchAndIncrement( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnSqliteFetchAndIncrement( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   static QMap<QString, qlonglong> counterCache;
   QVariant functionResult;
@@ -2107,7 +2107,7 @@ static QVariant fcnSqliteFetchAndIncrement( const QVariantList &values, const Qg
   std::function<void()> fetchAndIncrementFunc = [ =, &functionResult ]()
   {
     QString database;
-    const QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    const QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
 
     if ( layer )
     {
@@ -2604,9 +2604,9 @@ static QVariant fcnDateTimeFromEpoch( const QVariantList &values, const QgsExpre
   return QVariant( QDateTime::fromMSecsSinceEpoch( millisecs_since_epoch ) );
 }
 
-static QVariant fcnExif( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnExif( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString filepath = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString filepath = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "exif" ) ) );
@@ -2616,9 +2616,9 @@ static QVariant fcnExif( const QVariantList &values, const QgsExpressionContext 
   return !tag.isNull() ? QgsExifTools::readTag( filepath, tag ) : QVariant( QgsExifTools::readTags( filepath ) );
 }
 
-static QVariant fcnExifGeoTag( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnExifGeoTag( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString filepath = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString filepath = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "exif_geotag" ) ) );
@@ -5875,7 +5875,7 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
 static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant result;
-  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), context, parent );
   if ( vl )
   {
     QgsFeatureId fid = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -5900,7 +5900,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
 
-  std::unique_ptr<QgsVectorLayerFeatureSource> featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), parent );
+  std::unique_ptr<QgsVectorLayerFeatureSource> featureSource = QgsExpressionUtils::getFeatureSource( values.at( 0 ), context, parent );
 
   //no layer found
   if ( !featureSource )
@@ -5999,7 +5999,7 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
     }
     else
     {
-      QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+      QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), context, parent );
 
       const QString cacheValueKey = QStringLiteral( "repvalfcnval:%1:%2:%3" ).arg( layer ? layer->id() : QStringLiteral( "[None]" ), fieldName, value.toString() );
       if ( context->hasCachedValue( cacheValueKey ) )
@@ -6041,9 +6041,9 @@ static QVariant fcnMimeType( const QVariantList &values, const QgsExpressionCont
   return db.mimeTypeForData( data.toByteArray() ).name();
 }
 
-static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), parent );
+  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), context, parent );
 
   if ( !layer )
     return QVariant();
@@ -6145,9 +6145,9 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
   return QVariant();
 }
 
-static QVariant fcnDecodeUri( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnDecodeUri( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), parent );
+  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), context, parent );
   if ( !layer )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot find layer %1" ).arg( values.at( 0 ).toString() ) );
@@ -6854,9 +6854,9 @@ static QVariant fcnEnvVar( const QVariantList &values, const QgsExpressionContex
   return QProcessEnvironment::systemEnvironment().value( envVarName );
 }
 
-static QVariant fcnBaseFileName( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnBaseFileName( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "base_file_name" ) ) );
@@ -6865,9 +6865,9 @@ static QVariant fcnBaseFileName( const QVariantList &values, const QgsExpression
   return QFileInfo( file ).completeBaseName();
 }
 
-static QVariant fcnFileSuffix( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnFileSuffix( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "file_suffix" ) ) );
@@ -6876,9 +6876,9 @@ static QVariant fcnFileSuffix( const QVariantList &values, const QgsExpressionCo
   return QFileInfo( file ).completeSuffix();
 }
 
-static QVariant fcnFileExists( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnFileExists( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "file_exists" ) ) );
@@ -6887,9 +6887,9 @@ static QVariant fcnFileExists( const QVariantList &values, const QgsExpressionCo
   return QFileInfo::exists( file );
 }
 
-static QVariant fcnFileName( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnFileName( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "file_name" ) ) );
@@ -6898,9 +6898,9 @@ static QVariant fcnFileName( const QVariantList &values, const QgsExpressionCont
   return QFileInfo( file ).fileName();
 }
 
-static QVariant fcnPathIsFile( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnPathIsFile( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "is_file" ) ) );
@@ -6909,9 +6909,9 @@ static QVariant fcnPathIsFile( const QVariantList &values, const QgsExpressionCo
   return QFileInfo( file ).isFile();
 }
 
-static QVariant fcnPathIsDir( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnPathIsDir( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "is_directory" ) ) );
@@ -6920,9 +6920,9 @@ static QVariant fcnPathIsDir( const QVariantList &values, const QgsExpressionCon
   return QFileInfo( file ).isDir();
 }
 
-static QVariant fcnFilePath( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnFilePath( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "file_path" ) ) );
@@ -6931,9 +6931,9 @@ static QVariant fcnFilePath( const QVariantList &values, const QgsExpressionCont
   return QDir::toNativeSeparators( QFileInfo( file ).path() );
 }
 
-static QVariant fcnFileSize( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnFileSize( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), parent );
+  const QString file = QgsExpressionUtils::getFilePathValue( values.at( 0 ), context, parent );
   if ( parent->hasEvalError() )
   {
     parent->setEvalErrorString( QObject::tr( "Function `%1` requires a value which represents a possible file path" ).arg( QLatin1String( "file_size" ) ) );
@@ -7061,7 +7061,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 {
 
   const QVariant sourceLayerRef = context->variable( QStringLiteral( "layer" ) ); //used to detect if sourceLayer and targetLayer are the same
-  QgsVectorLayer *sourceLayer = QgsExpressionUtils::getVectorLayer( sourceLayerRef, parent );
+  QgsVectorLayer *sourceLayer = QgsExpressionUtils::getVectorLayer( sourceLayerRef, context, parent );
 
   QgsFeatureRequest request;
   request.setTimeout( 10000 );
@@ -7082,7 +7082,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QString subExpString = node->dump();
 
   bool testOnly = ( subExpString == "NULL" );
-  QgsVectorLayer *targetLayer = QgsExpressionUtils::getVectorLayer( targetLayerValue, parent );
+  QgsVectorLayer *targetLayer = QgsExpressionUtils::getVectorLayer( targetLayerValue, context, parent );
   if ( !targetLayer ) // No layer, no joy
   {
     parent->setEvalErrorString( QObject::tr( "Layer '%1' could not be loaded." ).arg( targetLayerValue.toString() ) );

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -51,7 +51,7 @@ QgsGradientColorRamp QgsExpressionUtils::getRamp( const QVariant &value, QgsExpr
   return QgsGradientColorRamp();
 }
 
-QgsMapLayer *QgsExpressionUtils::getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * )
+QgsMapLayer *QgsExpressionUtils::getMapLayer( const QVariant &value, const QgsExpressionContext *, QgsExpression * )
 {
   // First check if we already received a layer pointer
   QgsMapLayer *ml = value.value< QgsWeakMapLayerPointer >().data();

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -82,10 +82,12 @@ QgsMapLayer *QgsExpressionUtils::getMapLayer( const QVariant &value, const QgsEx
     ml = project->mapLayersByName( value.toString() ).value( 0 );
   };
 
+#ifndef __clang_analyzer__
   if ( QThread::currentThread() == qApp->thread() )
     getMapLayerFromProjectInstance();
   else
     QMetaObject::invokeMethod( qApp, getMapLayerFromProjectInstance, Qt::BlockingQueuedConnection );
+#endif
 
   return ml;
 }
@@ -105,10 +107,12 @@ QVariant QgsExpressionUtils::runMapLayerFunctionThreadSafe( const QVariant &valu
   // Anything else risks a crash.
 
   // Note that this is not completely correct -- a layer may have been created on a non-main thread!
+#ifndef __clang_analyzer__
   if ( QThread::currentThread() == qApp->thread() )
     runFunction();
   else
     QMetaObject::invokeMethod( qApp, runFunction, Qt::BlockingQueuedConnection );
+#endif
 
   return res;
 }

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -361,29 +361,7 @@ class CORE_EXPORT QgsExpressionUtils
      */
     static QVariant runMapLayerFunctionThreadSafe( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<QVariant( QgsMapLayer * ) > &function );
 
-    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
-    {
-      std::unique_ptr<QgsVectorLayerFeatureSource> featureSource;
-
-      auto getFeatureSource = [ &value, context, e, &featureSource ]
-      {
-        QgsVectorLayer *layer = getVectorLayer( value, context, e );
-
-        if ( layer )
-        {
-          featureSource.reset( new QgsVectorLayerFeatureSource( layer ) );
-        }
-      };
-
-      // Make sure we only deal with the vector layer on the main thread where it lives.
-      // Anything else risks a crash.
-      if ( QThread::currentThread() == qApp->thread() )
-        getFeatureSource();
-      else
-        QMetaObject::invokeMethod( qApp, getFeatureSource, Qt::BlockingQueuedConnection );
-
-      return featureSource;
-    }
+    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e );
 
     static QgsVectorLayer *getVectorLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
     {

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -359,33 +359,23 @@ class CORE_EXPORT QgsExpressionUtils
      *
      * \since QGIS 3.30
      */
-    static void executeLambdaForMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function< void( QgsMapLayer * )> &function );
+    static void executeLambdaForMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function< void( QgsMapLayer * )> &function, bool &foundLayer );
 
     /**
      * Evaluates a \a value to a map layer, then runs a \a function on the layer in a thread safe way before returning the result of the function.
      *
      * \since QGIS 3.30
      */
-    static QVariant runMapLayerFunctionThreadSafe( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<QVariant( QgsMapLayer * ) > &function );
+    static QVariant runMapLayerFunctionThreadSafe( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<QVariant( QgsMapLayer * ) > &function, bool &foundLayer );
 
     /**
      * Gets a vector layer feature source for a \a value which corresponds to a vector layer, in a thread-safe way.
      */
-    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e );
+    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
 
     static QgsVectorLayer *getVectorLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
     {
       return qobject_cast<QgsVectorLayer *>( getMapLayer( value, context, e ) );
-    }
-
-    static QgsRasterLayer *getRasterLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
-    {
-      return qobject_cast<QgsRasterLayer *>( getMapLayer( value, context, e ) );
-    }
-
-    static QgsMeshLayer *getMeshLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
-    {
-      return qobject_cast<QgsMeshLayer *>( getMapLayer( value, context, e ) );
     }
 
     /**

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -355,12 +355,22 @@ class CORE_EXPORT QgsExpressionUtils
     static QgsMapLayer *getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
 
     /**
+     * Executes a lambda \a function for a \a value which corresponds to a map layer, in a thread-safe way.
+     *
+     * \since QGIS 3.30
+     */
+    static void executeLambdaForMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function< void( QgsMapLayer * )> &function );
+
+    /**
      * Evaluates a \a value to a map layer, then runs a \a function on the layer in a thread safe way before returning the result of the function.
      *
      * \since QGIS 3.30
      */
     static QVariant runMapLayerFunctionThreadSafe( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<QVariant( QgsMapLayer * ) > &function );
 
+    /**
+     * Gets a vector layer feature source for a \a value which corresponds to a vector layer, in a thread-safe way.
+     */
     static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e );
 
     static QgsVectorLayer *getVectorLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -355,7 +355,7 @@ class CORE_EXPORT QgsExpressionUtils
     static QgsMapLayer *getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
 
     /**
-     * Evalutes a \a value to a map layer, then runs a \a function on the layer in a thread safe way before returning the result of the function.
+     * Evaluates a \a value to a map layer, then runs a \a function on the layer in a thread safe way before returning the result of the function.
      *
      * \since QGIS 3.30
      */

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -21,17 +21,15 @@
 
 #include "qgsfeature.h"
 #include "qgsexpression.h"
-#include "qgsvectorlayerfeatureiterator.h"
-#include "qgsrasterlayer.h"
-#include "qgsvectorlayer.h"
-#include "qgsmeshlayer.h"
 #include "qgsvariantutils.h"
+#include "qgsfeaturerequest.h"
 
 #include <QThread>
 #include <QLocale>
 #include <functional>
 
 class QgsGradientColorRamp;
+class QgsVectorLayerFeatureSource;
 
 #define ENSURE_NO_EVAL_ERROR   {  if ( parent->hasEvalError() ) return QVariant(); }
 #define SET_EVAL_ERROR(x)   { parent->setEvalErrorString( x ); return QVariant(); }
@@ -352,7 +350,10 @@ class CORE_EXPORT QgsExpressionUtils
       return nullptr;
     }
 
-    static QgsMapLayer *getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
+    /**
+     * \deprecated Not actually deprecated, but this method is not thread safe -- use with extreme caution only when the thread safety has already been taken care of by the caller!
+     */
+    Q_DECL_DEPRECATED static QgsMapLayer *getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
 
     /**
      * Executes a lambda \a function for a \a value which corresponds to a map layer, in a thread-safe way.
@@ -373,10 +374,10 @@ class CORE_EXPORT QgsExpressionUtils
      */
     static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e, bool &foundLayer );
 
-    static QgsVectorLayer *getVectorLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
-    {
-      return qobject_cast<QgsVectorLayer *>( getMapLayer( value, context, e ) );
-    }
+    /**
+     * \deprecated Not actually deprecated, but this method is not thread safe -- use with extreme caution only when the thread safety has already been taken care of by the caller!
+     */
+    Q_DECL_DEPRECATED static QgsVectorLayer *getVectorLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e );
 
     /**
      * Tries to convert a \a value to a file path.
@@ -477,6 +478,13 @@ class CORE_EXPORT QgsExpressionUtils
      * \since QGIS 3.22
      */
     static std::tuple<QVariant::Type, int> determineResultType( const QString &expression, const QgsVectorLayer *layer, QgsFeatureRequest request = QgsFeatureRequest(), QgsExpressionContext context = QgsExpressionContext(), bool *foundFeatures = nullptr );
+
+  private:
+
+    /**
+     * \warning Only call when thread safety has been taken care of by the caller!
+     */
+    static QgsMapLayer *getMapLayerPrivate( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
 
 };
 

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -29,6 +29,7 @@
 
 #include <QThread>
 #include <QLocale>
+#include <functional>
 
 class QgsGradientColorRamp;
 
@@ -352,6 +353,13 @@ class CORE_EXPORT QgsExpressionUtils
     }
 
     static QgsMapLayer *getMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression * );
+
+    /**
+     * Evalutes a \a value to a map layer, then runs a \a function on the layer in a thread safe way before returning the result of the function.
+     *
+     * \since QGIS 3.30
+     */
+    static QVariant runMapLayerFunctionThreadSafe( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<QVariant( QgsMapLayer * ) > &function );
 
     static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( const QVariant &value, const QgsExpressionContext *context, QgsExpression *e )
     {

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsThreadingUtils
           QSemaphore semaphoreWorkerThreadReady( 1 );
 
           // Acquire both semaphores. We want the main thread and the current thread to be blocked
-          // until it's save to continue.
+          // until it's safe to continue.
           semaphoreMainThreadReady.acquire();
           semaphoreWorkerThreadReady.acquire();
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4580,12 +4580,13 @@ class TestQgsExpression: public QObject
     {
       QgsExpression exp;
       // NULL value
-      QgsMapLayer *res = QgsExpressionUtils::getMapLayer( QVariant(), &exp );
+      QgsExpressionContext context;
+      QgsMapLayer *res = QgsExpressionUtils::getMapLayer( QVariant(), &context, &exp );
       QVERIFY( !res );
       QVERIFY( !exp.hasEvalError() );
 
       // value which CANNOT be a map layer
-      res = QgsExpressionUtils::getMapLayer( QVariant( 5 ), &exp );
+      res = QgsExpressionUtils::getMapLayer( QVariant( 5 ), &context,  &exp );
       QVERIFY( !res );
 #if 0
       // TODO probably **should** raise an eval error for this situation?
@@ -4595,31 +4596,31 @@ class TestQgsExpression: public QObject
       // with weak map layer pointer
       exp = QgsExpression();
       QgsWeakMapLayerPointer weakPointer( mPointsLayer );
-      res = QgsExpressionUtils::getMapLayer( QVariant::fromValue( weakPointer ), &exp );
+      res = QgsExpressionUtils::getMapLayer( QVariant::fromValue( weakPointer ), &context,  &exp );
       QCOMPARE( res, mPointsLayer );
       QVERIFY( !exp.hasEvalError() );
 
       // with raw map layer pointer
       exp = QgsExpression();
-      res = QgsExpressionUtils::getMapLayer( QVariant::fromValue( mPointsLayer ), &exp );
+      res = QgsExpressionUtils::getMapLayer( QVariant::fromValue( mPointsLayer ), &context, &exp );
       QCOMPARE( res, mPointsLayer );
       QVERIFY( !exp.hasEvalError() );
 
       // with layer id
       exp = QgsExpression();
-      res = QgsExpressionUtils::getMapLayer( mPointsLayer->id(), &exp );
+      res = QgsExpressionUtils::getMapLayer( mPointsLayer->id(), &context, &exp );
       QCOMPARE( res, mPointsLayer );
       QVERIFY( !exp.hasEvalError() );
 
       // with layer name
       exp = QgsExpression();
-      res = QgsExpressionUtils::getMapLayer( mPointsLayer->name(), &exp );
+      res = QgsExpressionUtils::getMapLayer( mPointsLayer->name(), &context, &exp );
       QCOMPARE( res, mPointsLayer );
       QVERIFY( !exp.hasEvalError() );
 
       // with string which is neither id or name
       exp = QgsExpression();
-      res = QgsExpressionUtils::getMapLayer( QStringLiteral( "xxxA" ), &exp );
+      res = QgsExpressionUtils::getMapLayer( QStringLiteral( "xxxA" ), &context, &exp );
       QVERIFY( !res );
 #if 0
       // TODO -- probably should flag an error here?
@@ -4630,26 +4631,27 @@ class TestQgsExpression: public QObject
     void testGetFilePathValue()
     {
       QgsExpression exp;
+      QgsExpressionContext context;
       // NULL value
-      QString path = QgsExpressionUtils::getFilePathValue( QVariant(), &exp );
+      QString path = QgsExpressionUtils::getFilePathValue( QVariant(), &context, &exp );
       QVERIFY( path.isEmpty() );
       QVERIFY( !exp.hasEvalError() );
 
       // value which CANNOT be a file path
-      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( QgsGeometry() ), &exp );
+      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( QgsGeometry() ), &context,  &exp );
       QVERIFY( path.isEmpty() );
       QVERIFY( exp.hasEvalError() );
       QCOMPARE( exp.evalErrorString(), QStringLiteral( "Cannot convert value to a file path" ) );
 
       // good value
       exp = QgsExpression();
-      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( QStringLiteral( "/home/me/mine.txt" ) ), &exp );
+      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( QStringLiteral( "/home/me/mine.txt" ) ), &context,  &exp );
       QCOMPARE( path, QStringLiteral( "/home/me/mine.txt" ) );
       QVERIFY( !exp.hasEvalError() );
 
       // with map layer pointer -- should use layer path
       exp = QgsExpression();
-      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( mPointsLayer ), &exp );
+      path = QgsExpressionUtils::getFilePathValue( QVariant::fromValue( mPointsLayer ), &context, &exp );
       QCOMPARE( path, QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/points.shp" ) );
       QVERIFY( !exp.hasEvalError() );
     }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -36,6 +36,7 @@
 #include "qgsvectorlayerutils.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsexpressionutils.h"
+#include "qgsmeshlayer.h"
 #include <geos_c.h>
 
 static void _parseAndEvalExpr( int arg )
@@ -4581,6 +4582,7 @@ class TestQgsExpression: public QObject
       QgsExpression exp;
       // NULL value
       QgsExpressionContext context;
+      Q_NOWARN_DEPRECATED_PUSH
       QgsMapLayer *res = QgsExpressionUtils::getMapLayer( QVariant(), &context, &exp );
       QVERIFY( !res );
       QVERIFY( !exp.hasEvalError() );
@@ -4626,6 +4628,7 @@ class TestQgsExpression: public QObject
       // TODO -- probably should flag an error here?
       QVERIFY( !exp.hasEvalError() );
 #endif
+      Q_NOWARN_DEPRECATED_POP
     }
 
     void testGetFilePathValue()

--- a/tests/src/core/testqgslayoutcontext.cpp
+++ b/tests/src/core/testqgslayoutcontext.cpp
@@ -121,7 +121,7 @@ void TestQgsLayoutContext::layer()
   l.reportContext().setLayer( layer );
   //test that expression context created for layout contains report context layer scope
   const QgsExpressionContext expContext  = l.createExpressionContext();
-  QCOMPARE( QgsExpressionUtils::getVectorLayer( expContext.variable( "layer" ), nullptr ), layer );
+  QCOMPARE( QgsExpressionUtils::getVectorLayer( expContext.variable( "layer" ), &expContext, nullptr ), layer );
 
   delete layer;
 }

--- a/tests/src/core/testqgslayoutcontext.cpp
+++ b/tests/src/core/testqgslayoutcontext.cpp
@@ -121,7 +121,9 @@ void TestQgsLayoutContext::layer()
   l.reportContext().setLayer( layer );
   //test that expression context created for layout contains report context layer scope
   const QgsExpressionContext expContext  = l.createExpressionContext();
+  Q_NOWARN_DEPRECATED_PUSH
   QCOMPARE( QgsExpressionUtils::getVectorLayer( expContext.variable( "layer" ), &expContext, nullptr ), layer );
+  Q_NOWARN_DEPRECATED_POP
 
   delete layer;
 }


### PR DESCRIPTION
This updates some expression functions which access map layers directly to be more thread safe by running the layer related operation on the main thread only, instead of whatever thread the expression is being evaluated under. 

I've only updated a handful of the functions which access layers directly here, but ultimately we should do this for ALL functions.

Also note that I've said "more thread safe" and not "thread safe" because there's still potentially an issue when a layer has been created on the non-main thread. That's a rare situation though, since it's currently *mostly-only possible to access layers from the project instance in expressions.

\* mostly. Nothing is ever easy!



