### PR TITLE
Remove SIP_SKIP on hasCheckedStateInfo and setHasCheckedStateInfo

### DIFF
--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -117,10 +117,6 @@ and thus whether :py:func:`~MapThemeRecord.expandedGroupNodes` and expandedLegen
 Returns whether information about checked/unchecked state of groups has been recorded
 and thus whether :py:func:`~MapThemeRecord.checkedGroupNodes` is valid.
 
-.. note::
-
-   Not available in Python bindings
-
 .. versionadded:: 3.10.1
 %End
         void setHasExpandedStateInfo( bool hasInfo );
@@ -133,10 +129,6 @@ Sets whether the map theme contains valid expanded/collapsed state of nodes
         void setHasCheckedStateInfo( bool hasInfo );
 %Docstring
 Sets whether the map theme contains valid checked/unchecked state of group nodes
-
-.. note::
-
-   Not available in Python bindings
 
 .. versionadded:: 3.10.1
 %End

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -112,6 +112,17 @@ and thus whether :py:func:`~MapThemeRecord.expandedGroupNodes` and expandedLegen
 .. versionadded:: 3.2
 %End
 
+        bool hasCheckedStateInfo() const;
+%Docstring
+Returns whether information about checked/unchecked state of groups has been recorded
+and thus whether :py:func:`~MapThemeRecord.checkedGroupNodes` is valid.
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.10.1
+%End
         void setHasExpandedStateInfo( bool hasInfo );
 %Docstring
 Sets whether the map theme contains valid expanded/collapsed state of nodes
@@ -119,6 +130,16 @@ Sets whether the map theme contains valid expanded/collapsed state of nodes
 .. versionadded:: 3.2
 %End
 
+        void setHasCheckedStateInfo( bool hasInfo );
+%Docstring
+Sets whether the map theme contains valid checked/unchecked state of group nodes
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.10.1
+%End
         QSet<QString> expandedGroupNodes() const;
 %Docstring
 Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -163,7 +163,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
          * \note Not available in Python bindings
          * \since QGIS 3.10.1
          */
-        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; } SIP_SKIP;
+        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; };
 
         /**
          * Sets whether the map theme contains valid expanded/collapsed state of nodes
@@ -176,7 +176,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
          * \note Not available in Python bindings
          * \since QGIS 3.10.1
          */
-        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; } SIP_SKIP;
+        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; };
 
         /**
          * Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -160,7 +160,6 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         /**
          * Returns whether information about checked/unchecked state of groups has been recorded
          * and thus whether checkedGroupNodes() is valid.
-         * \note Not available in Python bindings
          * \since QGIS 3.10.1
          */
         bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; };
@@ -173,7 +172,6 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
         /**
          * Sets whether the map theme contains valid checked/unchecked state of group nodes
-         * \note Not available in Python bindings
          * \since QGIS 3.10.1
          */
         void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; };


### PR DESCRIPTION
## Description
Besides `QgsMapThemeCollection::MapThemeRecord::validLayerRecords` (where I don't see a need in the API) those methods where the missing bit in the API to configure a full map theme.

```py
map_theme_record = QgsMapThemeCollection.MapThemeRecord()
map_theme_record.setHasCheckedStateInfo(True)
map_theme_record.setCheckedGroupNodes(["Small Group", "Another Group"])
project.mapThemeCollection().insert("Fancy New Theme", map_theme_record)
```

