### PR TITLE
Remove very old workaround for a closed GDAL ticket preventing use of existing GDAL raster band statistics

### DIFF
--- a/python/core/auto_generated/raster/qgsraster.sip.in
+++ b/python/core/auto_generated/raster/qgsraster.sip.in
@@ -51,13 +51,6 @@ Raster namespace.
       IdentifyFormatFeature,
     };
 
-    enum RasterProgressType
-    {
-      ProgressHistogram,
-      ProgressPyramids,
-      ProgressStatistics
-    };
-
     enum RasterBuildPyramids
     {
       PyramidsFlagNo,

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -89,7 +89,6 @@ const int MAX_CACHE_SIZE = 50;
 
 struct QgsGdalProgress
 {
-  QgsGdalProvider *provider = nullptr;
   QgsRasterBlockFeedback *feedback = nullptr;
 };
 //
@@ -1938,7 +1937,6 @@ QgsRasterHistogram QgsGdalProvider::histogram( int bandNo,
   QgsDebugMsgLevel( QStringLiteral( "xSize() = %1 ySize() = %2 sampleSize = %3 bApproxOK = %4" ).arg( xSize() ).arg( ySize() ).arg( sampleSize ).arg( bApproxOK ), 2 );
 
   QgsGdalProgress myProg;
-  myProg.provider = this;
   myProg.feedback = feedback;
 
 #if 0 // this is the old method
@@ -2183,8 +2181,6 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> &rasterPyr
   {
     //build the pyramid and show progress to console
     QgsGdalProgress myProg;
-    myProg.type = QgsRaster::ProgressPyramids;
-    myProg.provider = this;
     myProg.feedback = feedback;
     myError = GDALBuildOverviews( mGdalBaseDataset, method,
                                   myOverviewLevelsVector.size(), myOverviewLevelsVector.data(),
@@ -2849,7 +2845,6 @@ QgsRasterBandStats QgsGdalProvider::bandStatistics( int bandNo, int stats, const
   double pdfMean;
   double pdfStdDev;
   QgsGdalProgress myProg;
-  myProg.provider = this;
   myProg.feedback = feedback;
 
   // try to fetch the cached stats (bForce=FALSE)

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2868,17 +2868,13 @@ QgsRasterBandStats QgsGdalProvider::bandStatistics( int bandNo, int stats, const
   myProg.feedback = feedback;
 
   // try to fetch the cached stats (bForce=FALSE)
-  // GDALGetRasterStatistics() do not work correctly with bApproxOK=false and bForce=false/true
-  // see above and https://trac.osgeo.org/gdal/ticket/4857
-  // -> Cannot used cached GDAL stats for exact
-
   CPLErr myerval =
-    GDALGetRasterStatistics( myGdalBand, bApproxOK, true, &pdfMin, &pdfMax, &pdfMean, &pdfStdDev );
+    GDALGetRasterStatistics( myGdalBand, bApproxOK, false, &pdfMin, &pdfMax, &pdfMean, &pdfStdDev );
 
   QgsDebugMsgLevel( QStringLiteral( "myerval = %1" ).arg( myerval ), 2 );
 
   // if cached stats are not found, compute them
-  if ( !bApproxOK || CE_None != myerval )
+  if ( CE_None != myerval )
   {
     QgsDebugMsgLevel( QStringLiteral( "Calculating statistics by GDAL" ), 2 );
     myerval = GDALComputeRasterStatistics( myGdalBand, bApproxOK,

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -89,7 +89,6 @@ const int MAX_CACHE_SIZE = 50;
 
 struct QgsGdalProgress
 {
-  int type;
   QgsGdalProvider *provider = nullptr;
   QgsRasterBlockFeedback *feedback = nullptr;
 };
@@ -1939,7 +1938,6 @@ QgsRasterHistogram QgsGdalProvider::histogram( int bandNo,
   QgsDebugMsgLevel( QStringLiteral( "xSize() = %1 ySize() = %2 sampleSize = %3 bApproxOK = %4" ).arg( xSize() ).arg( ySize() ).arg( sampleSize ).arg( bApproxOK ), 2 );
 
   QgsGdalProgress myProg;
-  myProg.type = QgsRaster::ProgressHistogram;
   myProg.provider = this;
   myProg.feedback = feedback;
 
@@ -2851,7 +2849,6 @@ QgsRasterBandStats QgsGdalProvider::bandStatistics( int bandNo, int stats, const
   double pdfMean;
   double pdfStdDev;
   QgsGdalProgress myProg;
-  myProg.type = QgsRaster::ProgressHistogram;
   myProg.provider = this;
   myProg.feedback = feedback;
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -102,27 +102,15 @@ int CPL_STDCALL progressCallback( double dfComplete,
 {
   Q_UNUSED( pszMessage )
 
-  static double sDfLastComplete = -1.0;
-
   QgsGdalProgress *prog = static_cast<QgsGdalProgress *>( pProgressArg );
 
-  if ( sDfLastComplete > dfComplete )
+  if ( QgsRasterBlockFeedback *feedback = prog->feedback )
   {
-    if ( sDfLastComplete >= 1.0 )
-      sDfLastComplete = -1.0;
-    else
-      sDfLastComplete = dfComplete;
-  }
+    feedback->setProgress( dfComplete * 100 );
 
-  if ( std::floor( sDfLastComplete * 10 ) != std::floor( dfComplete * 10 ) )
-  {
-    if ( prog->feedback )
-      prog->feedback->setProgress( dfComplete * 100 );
+    if ( feedback->isCanceled() )
+      return false;
   }
-  sDfLastComplete = dfComplete;
-
-  if ( prog->feedback && prog->feedback->isCanceled() )
-    return false;
 
   return true;
 }

--- a/src/core/raster/qgsraster.h
+++ b/src/core/raster/qgsraster.h
@@ -63,14 +63,6 @@ class CORE_EXPORT QgsRaster
       IdentifyFormatFeature   = 1 << 3, // WMS GML/JSON -> feature
     };
 
-    // Progress types
-    enum RasterProgressType
-    {
-      ProgressHistogram = 0,
-      ProgressPyramids  = 1,
-      ProgressStatistics = 2
-    };
-
     enum RasterBuildPyramids
     {
       PyramidsFlagNo = 0,

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -382,9 +382,9 @@ void TestQgsRasterLayer::checkStats()
   QCOMPARE( myStatistics.minimumValue, 0.0 );
   QCOMPARE( myStatistics.maximumValue, 9.0 );
   QGSCOMPARENEAR( myStatistics.mean, 4.5, 4 * std::numeric_limits<double>::epsilon() );
-  const double stdDev = 2.87228132326901431;
+  const double stdDev = 2.8722813233;
   // TODO: verify why GDAL stdDev is so different from generic (2.88675)
-  QGSCOMPARENEAR( myStatistics.stdDev, stdDev, 0.00000000000001 );
+  QGSCOMPARENEAR( myStatistics.stdDev, stdDev, 0.000001 );
 
   // limited extent
   myStatistics = mpRasterLayer->dataProvider()->bandStatistics( 1,


### PR DESCRIPTION
Without this fix trying to use the "actual" raster value ranges for large datasets is ALWAYS **SUPER** slow, even if those datasets have the stats immediately available (eg in a .aux.xml file)

