### PR TITLE
Raster Attribute Table GUI enhancements/fixes

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -28,7 +28,7 @@ methods to handle data from QGIS and to import/export a Raster Attribute Table f
     class UsageInformation
 {
 %Docstring(signature="appended")
-The UsageInformation struct represents information about a field usage.
+The UsageInformation class represents information about a field usage.
 
 .. versionadded:: 3.30
 %End
@@ -58,7 +58,7 @@ The UsageInformation struct represents information about a field usage.
     class Field
 {
 %Docstring(signature="appended")
-The Field struct represents a Raster Attribute Table field, including its name, usage and type.
+The Field class represents a Raster Attribute Table field, including its name, usage and type.
 
 .. versionadded:: 3.30
 %End
@@ -91,7 +91,7 @@ Returns ``True`` if the field carries a color ramp component information (RedMin
     class MinMaxClass
 {
 %Docstring(signature="appended")
-The Field struct represents a Raster Attribute Table classification entry for a thematic Raster Attribute Table.
+The Field class represents a Raster Attribute Table classification entry for a thematic Raster Attribute Table.
 
 .. versionadded:: 3.30
 %End

--- a/src/core/raster/qgsrasterattributetable.h
+++ b/src/core/raster/qgsrasterattributetable.h
@@ -19,7 +19,6 @@
 #include "qgsfields.h"
 #include "qgsfeature.h"
 #include "qgis_core.h"
-#include "gdal.h"
 #include "qgis_sip.h"
 #include "qgis.h"
 #include "qgscolorrampimpl.h"
@@ -50,7 +49,7 @@ class CORE_EXPORT QgsRasterAttributeTable
 
     /**
      * \ingroup core
-     * \brief The UsageInformation struct represents information about a field usage.
+     * \brief The UsageInformation class represents information about a field usage.
      * \since QGIS 3.30
      */
     class CORE_EXPORT UsageInformation
@@ -84,7 +83,7 @@ class CORE_EXPORT QgsRasterAttributeTable
 
     /**
      * \ingroup core
-     * \brief The Field struct represents a Raster Attribute Table field, including its name, usage and type.
+     * \brief The Field class represents a Raster Attribute Table field, including its name, usage and type.
      * \since QGIS 3.30
      */
     class CORE_EXPORT Field
@@ -114,7 +113,7 @@ class CORE_EXPORT QgsRasterAttributeTable
 
     /**
      * \ingroup core
-     * \brief The Field struct represents a Raster Attribute Table classification entry for a thematic Raster Attribute Table.
+     * \brief The Field class represents a Raster Attribute Table classification entry for a thematic Raster Attribute Table.
      * \since QGIS 3.30
      */
     class CORE_EXPORT MinMaxClass

--- a/src/gui/raster/qgsrasterattributetableaddcolumndialog.cpp
+++ b/src/gui/raster/qgsrasterattributetableaddcolumndialog.cpp
@@ -15,7 +15,6 @@
  ***************************************************************************/
 #include "qgsrasterattributetableaddcolumndialog.h"
 #include "qgsrasterattributetable.h"
-#include "qgsfield.h"
 #include "qgsgui.h"
 
 #include <QPushButton>
@@ -35,10 +34,10 @@ QgsRasterAttributeTableAddColumnDialog::QgsRasterAttributeTableAddColumnDialog( 
   connect( mColor, &QRadioButton::toggled, this, [ = ]( bool ) { updateDialog(); } );
   connect( mUsage, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int ) { updateDialog(); } );
 
-  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::String ), tr( "String" ), QVariant::String );
-  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::Int ), tr( "Integer" ), QVariant::Int );
-  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::LongLong ), tr( "Long Integer" ), QVariant::LongLong );
-  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::Double ), tr( "Double" ), QVariant::Double );
+  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::String ), tr( "String" ), static_cast<int>( QVariant::Type::String ) );
+  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::Int ), tr( "Integer" ), static_cast<int>( QVariant::Type::Int ) );
+  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::LongLong ), tr( "Long Integer" ), static_cast<int>( QVariant::Type::LongLong ) );
+  mDataType->addItem( QgsFields::iconForFieldType( QVariant::Type::Double ), tr( "Double" ), static_cast<int>( QVariant::Type::Double ) );
   mStandardColumn->setChecked( true );
 
   updateDialog();
@@ -96,9 +95,6 @@ void QgsRasterAttributeTableAddColumnDialog::updateDialog()
   const bool canAddMinMax { !hasMinMax &&mAttributeTable->type() == Qgis::RasterAttributeTableType::Thematic };
   const bool canAddMinAndMax { !hasMinAndMax &&mAttributeTable->type() == Qgis::RasterAttributeTableType::Athematic };
 
-  bool canAddColor { true };
-  bool canAddRamp { true };
-
   if ( mAttributeTable->hasColor() || mAttributeTable->hasRamp() )
   {
     mColor->setChecked( false );
@@ -106,15 +102,12 @@ void QgsRasterAttributeTableAddColumnDialog::updateDialog()
     mRamp->setChecked( false );
     mRamp->setEnabled( false );
     mStandardColumn->setChecked( true );
-    canAddColor = false;
-    canAddRamp = false;
   }
   else if ( mAttributeTable->type() == Qgis::RasterAttributeTableType::Thematic )
   {
     mColor->setEnabled( true );
     mRamp->setChecked( false );
     mRamp->setEnabled( false );
-    canAddRamp = false;
   }
   else
   {
@@ -161,8 +154,8 @@ void QgsRasterAttributeTableAddColumnDialog::updateDialog()
       if ( ( it.key() == Qgis::RasterAttributeTableFieldUsage::MinMax && ! canAddMinMax ) ||
            ( it.key() == Qgis::RasterAttributeTableFieldUsage::Min && ! canAddMinAndMax ) ||
            ( it.key() == Qgis::RasterAttributeTableFieldUsage::Max && ! canAddMinAndMax ) ||
-           ( it.value().isColor && ! canAddColor ) ||
-           ( it.value().isRamp && ! canAddRamp ) )
+           ( it.value().isColor ) ||
+           ( it.value().isRamp ) )
       {
         continue;
       }

--- a/src/gui/raster/qgsrasterattributetablemodel.cpp
+++ b/src/gui/raster/qgsrasterattributetablemodel.cpp
@@ -72,7 +72,7 @@ QString QgsRasterAttributeTableModel::headerTooltip( const int section ) const
   }
 
   const QString fieldName { hNames.at( section ) };
-  const bool isColor { hasColor() && section == hNames.count( ) - 1 };
+  const bool isColor { hasColor() && section == hNames.count( ) - 1 };  // *NOPAD*
 
   if ( isColor )
   {
@@ -330,7 +330,7 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
   if ( mRat && index.isValid() && index.row() < rowCount( QModelIndex() ) && index.column() < columnCount( QModelIndex() ) )
   {
     const QString fieldName { headerNames().at( index.column() ) };
-    const bool isColorOrRamp { ( hasColor() || hasRamp() ) && index.column() == columnCount( QModelIndex() ) - 1 };
+    const bool isColorOrRamp { ( hasColor() || hasRamp() ) && index.column() == columnCount( QModelIndex() ) - 1 }; // *NOPAD*
     bool ok;
     const QgsRasterAttributeTable::Field field { mRat->fieldByName( fieldName, &ok ) };
     if ( ! isColorOrRamp && ! ok )

--- a/src/gui/raster/qgsrasterattributetablemodel.cpp
+++ b/src/gui/raster/qgsrasterattributetablemodel.cpp
@@ -72,7 +72,7 @@ QString QgsRasterAttributeTableModel::headerTooltip( const int section ) const
   }
 
   const QString fieldName { hNames.at( section ) };
-  const bool isColor { hasColor() &&section == hNames.count( ) - 1 };
+  const bool isColor { hasColor() && section == hNames.count( ) - 1 };
 
   if ( isColor )
   {
@@ -330,7 +330,7 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
   if ( mRat && index.isValid() && index.row() < rowCount( QModelIndex() ) && index.column() < columnCount( QModelIndex() ) )
   {
     const QString fieldName { headerNames().at( index.column() ) };
-    const bool isColorOrRamp { ( hasColor() || hasRamp() ) &&index.column() == columnCount( QModelIndex() ) - 1 };
+    const bool isColorOrRamp { ( hasColor() || hasRamp() ) && index.column() == columnCount( QModelIndex() ) - 1 };
     bool ok;
     const QgsRasterAttributeTable::Field field { mRat->fieldByName( fieldName, &ok ) };
     if ( ! isColorOrRamp && ! ok )

--- a/src/gui/raster/qgsrasterattributetablemodel.cpp
+++ b/src/gui/raster/qgsrasterattributetablemodel.cpp
@@ -72,7 +72,7 @@ QString QgsRasterAttributeTableModel::headerTooltip( const int section ) const
   }
 
   const QString fieldName { hNames.at( section ) };
-  const bool isColor { section == hNames.count( ) - 1 };
+  const bool isColor { hasColor() &&section == hNames.count( ) - 1 };
 
   if ( isColor )
   {
@@ -330,14 +330,14 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
   if ( mRat && index.isValid() && index.row() < rowCount( QModelIndex() ) && index.column() < columnCount( QModelIndex() ) )
   {
     const QString fieldName { headerNames().at( index.column() ) };
-    const bool isColorOrRamp { index.column() == columnCount( QModelIndex() ) - 1 };
+    const bool isColorOrRamp { ( hasColor() || hasRamp() ) &&index.column() == columnCount( QModelIndex() ) - 1 };
     bool ok;
     const QgsRasterAttributeTable::Field field { mRat->fieldByName( fieldName, &ok ) };
     if ( ! isColorOrRamp && ! ok )
     {
       return QVariant();
     }
-    if ( hasColor() && isColorOrRamp )
+    if ( isColorOrRamp && hasColor() )
     {
       switch ( role )
       {
@@ -357,7 +357,7 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
           return QVariant();
       }
     }
-    else if ( hasRamp() && isColorOrRamp )
+    else if ( isColorOrRamp && hasRamp() )
     {
       switch ( role )
       {
@@ -383,11 +383,11 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
           return QVariant();
       }
     }
-    else if ( ! isColorOrRamp && role == Qt::ItemDataRole::TextAlignmentRole && field.type != QVariant::String )
+    else if ( role == Qt::ItemDataRole::TextAlignmentRole && field.type != QVariant::String )
     {
       return QVariant( Qt::AlignmentFlag::AlignRight | Qt::AlignmentFlag::AlignVCenter );
     }
-    else if ( role == Qt::ItemDataRole::ToolTipRole && ( field.isColor() || field.isRamp() ) )
+    else if ( role == Qt::ItemDataRole::ToolTipRole && ( isColorOrRamp ) )
     {
       return tr( "This data is part of a color definition: click on '%1' column to edit." ).arg( ratColorHeaderName() );
     }
@@ -395,7 +395,7 @@ QVariant QgsRasterAttributeTableModel::data( const QModelIndex &index, int role 
     {
       return mRat->data().at( index.row() ).at( index.column() );
     }
-    else if ( role == Qt::ItemDataRole::FontRole && ( field.isColor() || field.isRamp() ) )
+    else if ( role == Qt::ItemDataRole::FontRole && ( isColorOrRamp ) )
     {
       QFont font;
       font.setItalic( true );

--- a/src/gui/raster/qgsrasterattributetablewidget.h
+++ b/src/gui/raster/qgsrasterattributetablewidget.h
@@ -21,6 +21,7 @@
 #include "qgsrasterattributetablemodel.h"
 #include "qgscolorrampimpl.h"
 #include "qgspanelwidget.h"
+#include "qgslocaleawarenumericlineeditdelegate.h"
 
 #include <QWidget>
 #include <QStyledItemDelegate>
@@ -97,6 +98,23 @@ class ColorRampAlphaDelegate: public ColorRampDelegate
     // QAbstractItemDelegate interface
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
 };
+
+
+class LocalizedDoubleDelegate: public QgsLocaleAwareNumericLineEditDelegate
+{
+
+    Q_OBJECT
+
+  public:
+
+    LocalizedDoubleDelegate( QWidget *parent = nullptr ): QgsLocaleAwareNumericLineEditDelegate( Qgis::DataType::Float64, parent ) {};
+
+    // QStyledItemDelegate interface
+    QString displayText( const QVariant &value, const QLocale &locale ) const override;
+};
+
+
+
 #endif
 ///@endcond private
 


### PR DESCRIPTION
Fixes #51200 and more small GUI/UX related glitches:

- locale aware double input (consistent behavior with the vector attr table and the widgets)
- locale aware double formatting (same logic of the vector fields of type double)
- right-alignment of double fields
- wrong tooltip for last column
