### PR TITLE
[settings] add new type for variant map: QgsSettingsEntryVariantMap

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -158,6 +158,9 @@ QgsSettingsEntryBase.String.__doc__ = "String"
 QgsSettingsEntryBase.StringList = Qgis.SettingsType.StringList
 QgsSettingsEntryBase.StringList.is_monkey_patched = True
 QgsSettingsEntryBase.StringList.__doc__ = "List of strings"
+QgsSettingsEntryBase.VariantMap = Qgis.SettingsType.VariantMap
+QgsSettingsEntryBase.VariantMap.is_monkey_patched = True
+QgsSettingsEntryBase.VariantMap.__doc__ = "Map of strings"
 QgsSettingsEntryBase.Bool = Qgis.SettingsType.Bool
 QgsSettingsEntryBase.Bool.is_monkey_patched = True
 QgsSettingsEntryBase.Bool.__doc__ = "Boolean"
@@ -173,7 +176,7 @@ QgsSettingsEntryBase.EnumFlag.__doc__ = "Enum or Flag"
 QgsSettingsEntryBase.Color = Qgis.SettingsType.Color
 QgsSettingsEntryBase.Color.is_monkey_patched = True
 QgsSettingsEntryBase.Color.__doc__ = "Color"
-Qgis.SettingsType.__doc__ = 'Types of settings entries\n\n.. versionadded:: 3.26\n\n' + '* ``Variant``: ' + Qgis.SettingsType.Variant.__doc__ + '\n' + '* ``String``: ' + Qgis.SettingsType.String.__doc__ + '\n' + '* ``StringList``: ' + Qgis.SettingsType.StringList.__doc__ + '\n' + '* ``Bool``: ' + Qgis.SettingsType.Bool.__doc__ + '\n' + '* ``Integer``: ' + Qgis.SettingsType.Integer.__doc__ + '\n' + '* ``Double``: ' + Qgis.SettingsType.Double.__doc__ + '\n' + '* ``EnumFlag``: ' + Qgis.SettingsType.EnumFlag.__doc__ + '\n' + '* ``Color``: ' + Qgis.SettingsType.Color.__doc__
+Qgis.SettingsType.__doc__ = 'Types of settings entries\n\n.. versionadded:: 3.26\n\n' + '* ``Variant``: ' + Qgis.SettingsType.Variant.__doc__ + '\n' + '* ``String``: ' + Qgis.SettingsType.String.__doc__ + '\n' + '* ``StringList``: ' + Qgis.SettingsType.StringList.__doc__ + '\n' + '* ``VariantMap``: ' + Qgis.SettingsType.VariantMap.__doc__ + '\n' + '* ``Bool``: ' + Qgis.SettingsType.Bool.__doc__ + '\n' + '* ``Integer``: ' + Qgis.SettingsType.Integer.__doc__ + '\n' + '* ``Double``: ' + Qgis.SettingsType.Double.__doc__ + '\n' + '* ``EnumFlag``: ' + Qgis.SettingsType.EnumFlag.__doc__ + '\n' + '* ``Color``: ' + Qgis.SettingsType.Color.__doc__
 # --
 Qgis.SettingsType.baseClass = Qgis
 # monkey patching scoped based enum

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -153,6 +153,7 @@ The development version
       Variant,
       String,
       StringList,
+      VariantMap,
       Bool,
       Integer,
       Double,

--- a/python/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -91,6 +91,8 @@ to validate set values and provide more accurate settings description for the gu
       sipType = sipType_QgsSettingsEntryString;
     else if ( dynamic_cast< QgsSettingsEntryStringList * >( sipCpp ) )
       sipType = sipType_QgsSettingsEntryStringList;
+    else if ( dynamic_cast< QgsSettingsEntryVariantMap * >( sipCpp ) )
+      sipType = sipType_QgsSettingsEntryVariantMap;
     else if ( dynamic_cast< QgsSettingsEntryBool * >( sipCpp ) )
       sipType = sipType_QgsSettingsEntryBool;
     else if ( dynamic_cast< QgsSettingsEntryInteger * >( sipCpp ) )

--- a/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -578,7 +578,7 @@ class QgsSettingsEntryVariantMap : QgsSettingsEntryByReferenceQVariantMapBase
 
 A string list settings entry.
 
-.. versionadded:: 3.20
+.. versionadded:: 3.30
 %End
 
 %TypeHeaderCode

--- a/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -569,6 +569,68 @@ The ``options`` arguments specifies the options for the settings entry.
 
 };
 
+
+typedef QgsSettingsEntryByReference<QVariantMap> QgsSettingsEntryByReferenceQVariantMapBase;
+
+class QgsSettingsEntryVariantMap : QgsSettingsEntryByReferenceQVariantMapBase
+{
+%Docstring(signature="appended")
+
+A string list settings entry.
+
+.. versionadded:: 3.20
+%End
+
+%TypeHeaderCode
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsentry.h"
+typedef QgsSettingsEntryByReference<QVariantMap> QgsSettingsEntryByReferenceQVariantMapBase;
+%End
+  public:
+
+  private:
+    QgsSettingsEntryVariantMap( const QString &key,
+                                const QString &section,
+                                const QVariantMap &defaultValue = QVariantMap(),
+                                const QString &description = QString(),
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() );
+%Docstring
+Constructor for QgsSettingsEntryVariantMap.
+
+The ``key`` argument specifies the final part of the settings key.
+The ``section`` argument specifies the section.
+The ``defaultValue`` argument specifies the default value for the settings entry.
+The ``description`` argument specifies a description for the settings entry.
+The ``options`` arguments specifies the options for the settings entry.
+%End
+  public:
+
+    QgsSettingsEntryVariantMap( const QString &key,
+                                const QString &pluginName,
+                                const QVariantMap &defaultValue = QVariantMap(),
+                                const QString &description = QString(),
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() );
+%Docstring
+Constructor for :py:class:`QgsSettingsEntryStringMap`.
+This constructor is intended to be used from plugins.
+
+The ``key`` argument specifies the key of the settings.
+The ``pluginName`` argument is inserted in the key after the section.
+The ``defaultValue`` argument specifies the default value for the settings entry.
+The ``description`` argument specifies a description for the settings entry.
+The ``options`` arguments specifies the options for the settings entry.
+%End
+%MethodCode
+    sipCpp = new sipQgsSettingsEntryVariantMap( QgsSettingsEntryVariantMap( *a0, QStringLiteral( "plugins/%1" ).arg( *a1 ), *a2, *a3, *a4 ) );
+%End
+
+    virtual Qgis::SettingsType settingsType() const;
+
+  private:
+    virtual QVariantMap convertFromVariant( const QVariant &value ) const;
+
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -232,6 +232,7 @@ class CORE_EXPORT Qgis
       Variant, //!< Generic variant
       String, //!< String
       StringList, //!< List of strings
+      VariantMap, //!< Map of strings
       Bool, //!< Boolean
       Integer, //!< Integer
       Double, //!< Double precision number

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -106,9 +106,6 @@ bool QgsSettingsEntryGroup::hasDynamicKey() const
 }
 
 
-/*--------------*/
-
-
 QString QgsSettingsEntryBase::key( const QString &dynamicKeyPart ) const
 {
   return key( dynamicKeyPartToList( dynamicKeyPart ) );

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -106,6 +106,9 @@ bool QgsSettingsEntryGroup::hasDynamicKey() const
 }
 
 
+/*--------------*/
+
+
 QString QgsSettingsEntryBase::key( const QString &dynamicKeyPart ) const
 {
   return key( dynamicKeyPartToList( dynamicKeyPart ) );

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -110,6 +110,8 @@ class CORE_EXPORT QgsSettingsEntryBase
       sipType = sipType_QgsSettingsEntryString;
     else if ( dynamic_cast< QgsSettingsEntryStringList * >( sipCpp ) )
       sipType = sipType_QgsSettingsEntryStringList;
+    else if ( dynamic_cast< QgsSettingsEntryVariantMap * >( sipCpp ) )
+      sipType = sipType_QgsSettingsEntryVariantMap;
     else if ( dynamic_cast< QgsSettingsEntryBool * >( sipCpp ) )
       sipType = sipType_QgsSettingsEntryBool;
     else if ( dynamic_cast< QgsSettingsEntryInteger * >( sipCpp ) )

--- a/src/core/settings/qgssettingsentryimpl.cpp
+++ b/src/core/settings/qgssettingsentryimpl.cpp
@@ -226,3 +226,12 @@ Qgis::SettingsType QgsSettingsEntryColor::settingsType() const
   return Qgis::SettingsType::Color;
 }
 
+QVariantMap QgsSettingsEntryVariantMap::convertFromVariant( const QVariant &value ) const
+{
+  return value.value<QVariantMap>();
+}
+
+Qgis::SettingsType QgsSettingsEntryVariantMap::settingsType() const
+{
+  return Qgis::SettingsType::VariantMap;
+}

--- a/src/core/settings/qgssettingsentryimpl.h
+++ b/src/core/settings/qgssettingsentryimpl.h
@@ -559,11 +559,11 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryByReference<QCo
 };
 
 /**
- * \class QgsSettingsEntryStringMap
+ * \class QgsSettingsEntryVariantMap
  * \ingroup core
  *
  * \brief A string list settings entry.
- * \since QGIS 3.20
+ * \since QGIS 3.30
  */
 class CORE_EXPORT QgsSettingsEntryVariantMap : public QgsSettingsEntryByReference<QVariantMap>
 {

--- a/src/core/settings/qgssettingsentryimpl.h
+++ b/src/core/settings/qgssettingsentryimpl.h
@@ -558,4 +558,62 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryByReference<QCo
 
 };
 
+/**
+ * \class QgsSettingsEntryStringMap
+ * \ingroup core
+ *
+ * \brief A string list settings entry.
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsSettingsEntryVariantMap : public QgsSettingsEntryByReference<QVariantMap>
+{
+  public:
+
+    /**
+     * Constructor for QgsSettingsEntryVariantMap.
+     *
+     * The \a key argument specifies the final part of the settings key.
+     * The \a section argument specifies the section.
+     * The \a defaultValue argument specifies the default value for the settings entry.
+     * The \a description argument specifies a description for the settings entry.
+     * The \a options arguments specifies the options for the settings entry.
+     */
+    QgsSettingsEntryVariantMap( const QString &key,
+                                const QString &section,
+                                const QVariantMap &defaultValue = QVariantMap(),
+                                const QString &description = QString(),
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_MAKE_PRIVATE
+  : QgsSettingsEntryByReference( key, section, defaultValue, description, options )
+    {
+    }
+
+#ifdef SIP_RUN
+
+    /**
+     * Constructor for QgsSettingsEntryStringMap.
+     * This constructor is intended to be used from plugins.
+     *
+     * The \a key argument specifies the key of the settings.
+     * The \a pluginName argument is inserted in the key after the section.
+     * The \a defaultValue argument specifies the default value for the settings entry.
+     * The \a description argument specifies a description for the settings entry.
+     * The \a options arguments specifies the options for the settings entry.
+     */
+    QgsSettingsEntryVariantMap( const QString &key,
+                                const QString &pluginName,
+                                const QVariantMap &defaultValue = QVariantMap(),
+                                const QString &description = QString(),
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() );
+    % MethodCode
+    sipCpp = new sipQgsSettingsEntryVariantMap( QgsSettingsEntryVariantMap( *a0, QStringLiteral( "plugins/%1" ).arg( *a1 ), *a2, *a3, *a4 ) );
+    % End
+#endif
+
+    virtual Qgis::SettingsType settingsType() const override;
+
+  private:
+    QVariantMap convertFromVariant( const QVariant &value ) const override SIP_FORCE;
+
+};
+
 #endif // QGSSETTINGSENTRYIMPL_H

--- a/tests/src/python/test_qgssettingsentry.py
+++ b/tests/src/python/test_qgssettingsentry.py
@@ -11,9 +11,10 @@ the Free Software Foundation; either version 2 of the License, or
 """
 
 from qgis import core as qgis_core
-from qgis.core import Qgis, QgsSettings, QgsSettingsEntryVariant, QgsSettingsEntryString, QgsSettingsEntryStringList, QgsSettingsEntryBool, QgsSettingsEntryInteger, QgsSettingsEntryDouble, QgsSettingsEntryEnumFlag, QgsUnitTypes, QgsMapLayerProxyModel, QgsSettingsEntryGroup
+from qgis.core import Qgis, QgsSettings, QgsSettingsEntryVariant, QgsSettingsEntryString, QgsSettingsEntryStringList, QgsSettingsEntryBool, QgsSettingsEntryInteger, QgsSettingsEntryDouble, QgsSettingsEntryEnumFlag, QgsUnitTypes, QgsMapLayerProxyModel, QgsSettingsEntryVariantMap, QgsSettingsEntryGroup
 from qgis.testing import start_app, unittest
 
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 
 __author__ = 'Damiano Lombardi'
@@ -36,7 +37,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_base(self):
         settingsKey = "settingsEntryBase/variantValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -88,7 +89,8 @@ class TestQgsSettingsEntry(unittest.TestCase):
             'QgsSettingsEntryInteger': 1,
             'QgsSettingsEntryString': 'Hello',
             'QgsSettingsEntryStringList': [],
-            'QgsSettingsEntryVariant': 1
+            'QgsSettingsEntryVariant': 1,
+            'QgsSettingsEntryVariantMap': {},
         }
         self.assertEqual(settings_types, list(hardcoded_types.keys()))
         for setting_type, default_value in hardcoded_types.items():
@@ -100,7 +102,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_base_default_value_override(self):
         settingsKey = "settingsEntryBase/defaultValueOverride/variantValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -167,7 +169,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_variant(self):
         settingsKey = "settingsEntryVariant/variantValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -189,7 +191,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_string(self):
         settingsKey = "settingsEntryString/stringValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -211,7 +213,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_stringlist(self):
         settingsKey = "settingsEntryStringList/stringListValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -231,9 +233,27 @@ class TestQgsSettingsEntry(unittest.TestCase):
         # Settings type
         self.assertEqual(settingsEntryStringList.settingsType(), Qgis.SettingsType.StringList)
 
+    def test_settings_entry_variantmap(self):
+        settingsKey = "settingsEntryVariantMap/varriantMapValue"
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
+
+        # Make sure settings does not exists
+        QgsSettings().remove(settingsKeyComplete)
+
+        defaultValue = {"key0": "value0"}
+        settingsEntryVariantMap = QgsSettingsEntryVariantMap(settingsKey, self.pluginName, defaultValue)
+        self.assertEqual(settingsEntryVariantMap.value(), defaultValue)
+
+        newValue = {"number": 123, "text": "hi there", "color": QColor(Qt.yellow)}
+        settingsEntryVariantMap.setValue(newValue)
+        self.assertEqual(newValue, settingsEntryVariantMap.value())
+
+        # Settings type
+        self.assertEqual(settingsEntryVariantMap.settingsType(), Qgis.SettingsType.VariantMap)
+
     def test_settings_entry_bool(self):
         settingsKey = "settingsEntryBool/boolValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -255,7 +275,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_integer(self):
         settingsKey = "settingsEntryInteger/integerValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -283,7 +303,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_double(self):
         settingsKey = "settingsEntryDouble/doubleValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -311,7 +331,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_enum(self):
         settingsKey = "settingsEntryEnum/enumValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         # Make sure settings does not exists
         QgsSettings().remove(settingsKeyComplete)
@@ -355,7 +375,7 @@ class TestQgsSettingsEntry(unittest.TestCase):
 
     def test_settings_entry_flag(self):
         settingsKey = "settingsEntryFlag/flagValue"
-        settingsKeyComplete = "plugins/{}/{}".format(self.pluginName, settingsKey)
+        settingsKeyComplete = f"plugins/{self.pluginName}/{settingsKey}"
 
         pointAndLine = QgsMapLayerProxyModel.Filters(QgsMapLayerProxyModel.PointLayer | QgsMapLayerProxyModel.LineLayer)
         pointAndPolygon = QgsMapLayerProxyModel.Filters(QgsMapLayerProxyModel.PointLayer | QgsMapLayerProxyModel.PolygonLayer)


### PR DESCRIPTION
this introduce a new type of setting as a variant map
this is helpful to store things with undefined list of keys, such as http-headers