### PR TITLE
Fix build debian

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -108,6 +108,10 @@ if (WITH_GUI)
   )
 endif()
 
+if (WITH_PDAL)
+  include_directories(SYSTEM "${PDAL_INCLUDE_DIR}")
+endif()
+
 if(NOT ENABLE_TESTS)
   set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} TESTS)
 endif()

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -12,6 +12,10 @@ if(HAVE_OPENCL)
     include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
 endif()
 
+if (WITH_PDAL)
+    include_directories(SYSTEM "${PDAL_INCLUDE_DIR}")
+endif()
+
 #############################################################
 # Tests:
 


### PR DESCRIPTION
## Description

Fix build on debian with PDAL.
Very new to `qgis`: not sure this is the best fix, but, reporting what fixed the build at my side (on debian).

```
>> export LIB_DIR="/path/to/PDAL/local"
>> mkdir build; cd build
>> cmake -DWITH_PDAL=ON ..
```