### PR TITLE
Write common properties of annotation layers to project file

### DIFF
--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -440,9 +440,12 @@ bool QgsAnnotationLayer::writeXml( QDomNode &layer_node, QDomDocument &doc, cons
   return writeSymbology( layer_node, doc, errorMsg, context );
 }
 
-bool QgsAnnotationLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString &, const QgsReadWriteContext &, QgsMapLayer::StyleCategories categories ) const
+bool QgsAnnotationLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString &, const QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  QDomElement layerElement = node.toElement();
+  writeCommonStyle( layerElement, doc, context, categories );
 
   // add the layer opacity
   if ( categories.testFlag( Rendering ) )
@@ -470,9 +473,12 @@ bool QgsAnnotationLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QStr
   return true;
 }
 
-bool QgsAnnotationLayer::readSymbology( const QDomNode &node, QString &, QgsReadWriteContext &, QgsMapLayer::StyleCategories categories )
+bool QgsAnnotationLayer::readSymbology( const QDomNode &node, QString &, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  const QDomElement layerElement = node.toElement();
+  readCommonStyle( layerElement, context, categories );
 
   if ( categories.testFlag( Rendering ) )
   {

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -44,7 +44,8 @@ from qgis.core import (QgsMapSettings,
                        QgsAnnotationItemEditOperationMoveNode,
                        QgsVertexId,
                        QgsPointXY,
-                       Qgis
+                       Qgis,
+                       QgsLayerNotesUtils
                        )
 from qgis.testing import start_app, unittest
 
@@ -198,6 +199,9 @@ class TestQgsAnnotationLayer(unittest.TestCase):
         self.assertTrue(layer.isValid())
 
         layer.setCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        layer.setScaleBasedVisibility(True)
+        QgsLayerNotesUtils.setLayerNotes(layer, 'test layer notes')
+
         polygon_item_id = layer.addItem(QgsAnnotationPolygonItem(
             QgsPolygon(QgsLineString([QgsPoint(12, 13), QgsPoint(14, 13), QgsPoint(14, 15), QgsPoint(12, 13)]))))
         linestring_item_id = layer.addItem(
@@ -210,6 +214,8 @@ class TestQgsAnnotationLayer(unittest.TestCase):
         layer2 = QgsAnnotationLayer('test2', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
         self.assertTrue(layer2.readLayerXml(elem, QgsReadWriteContext()))
         self.assertEqual(layer2.crs().authid(), 'EPSG:4326')
+        self.assertTrue(layer2.hasScaleBasedVisibility())
+        self.assertEqual(QgsLayerNotesUtils.layerNotes(layer2), 'test layer notes')
 
         self.assertEqual(len(layer2.items()), 3)
         self.assertIsInstance(layer2.items()[polygon_item_id], QgsAnnotationPolygonItem)


### PR DESCRIPTION

fixes #47463

Currently functionalities such as scale based rendering and layer notes don't work on annotation layers although the respective UI options exist ever since annotation layers were introduced. 
This is due to the fact that the required entries (e.g. `hasScaleBasedVisibilityFlag`, `minScale`, `maxScale`, etc.) are not written to the project file. This PR aims to solve this issue.
