### PR TITLE
[processing] Don't load default style when creating a memory sink

### DIFF
--- a/python/core/auto_generated/providers/memory/qgsmemoryproviderutils.sip.in
+++ b/python/core/auto_generated/providers/memory/qgsmemoryproviderutils.sip.in
@@ -26,7 +26,8 @@ Utility functions for use with the memory vector data provider.
     static QgsVectorLayer *createMemoryLayer( const QString &name,
         const QgsFields &fields,
         QgsWkbTypes::Type geometryType = QgsWkbTypes::NoGeometry,
-        const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Factory/;
+        const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
+        bool loadDefaultStyle = true ) /Factory/;
 %Docstring
 Creates a new memory layer using the specified parameters. The caller takes responsibility
 for deleting the newly created layer.
@@ -35,6 +36,7 @@ for deleting the newly created layer.
 :param fields: fields for layer
 :param geometryType: optional layer geometry type
 :param crs: optional layer CRS for layers with geometry
+:param loadDefaultStyle: optional load default style toggle
 %End
 };
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -808,7 +808,7 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
       destination = QStringLiteral( "output" );
 
     // memory provider cannot be used with QgsVectorLayerImport - so create layer manually
-    std::unique_ptr< QgsVectorLayer > layer( QgsMemoryProviderUtils::createMemoryLayer( destination, fields, geometryType, crs ) );
+    std::unique_ptr< QgsVectorLayer > layer( QgsMemoryProviderUtils::createMemoryLayer( destination, fields, geometryType, crs, false ) );
     if ( !layer || !layer->isValid() )
     {
       throw QgsProcessingException( QObject::tr( "Could not create memory layer" ) );

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -60,7 +60,7 @@ QString memoryLayerFieldType( QVariant::Type type )
   return QStringLiteral( "string" );
 }
 
-QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, const QgsFields &fields, QgsWkbTypes::Type geometryType, const QgsCoordinateReferenceSystem &crs )
+QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, const QgsFields &fields, QgsWkbTypes::Type geometryType, const QgsCoordinateReferenceSystem &crs, bool loadDefaultStyle )
 {
   QString geomType = QgsWkbTypes::displayString( geometryType );
   if ( geomType.isNull() )
@@ -86,5 +86,6 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   const QString uri = geomType + '?' + parts.join( '&' );
   QgsVectorLayer::LayerOptions options{ QgsCoordinateTransformContext() };
   options.skipCrsValidation = true;
+  options.loadDefaultStyle = loadDefaultStyle;
   return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ), options );
 }

--- a/src/core/providers/memory/qgsmemoryproviderutils.h
+++ b/src/core/providers/memory/qgsmemoryproviderutils.h
@@ -45,11 +45,13 @@ class CORE_EXPORT QgsMemoryProviderUtils
      * \param fields fields for layer
      * \param geometryType optional layer geometry type
      * \param crs optional layer CRS for layers with geometry
+     * \param loadDefaultStyle optional load default style toggle
      */
     static QgsVectorLayer *createMemoryLayer( const QString &name,
         const QgsFields &fields,
         QgsWkbTypes::Type geometryType = QgsWkbTypes::NoGeometry,
-        const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) SIP_FACTORY;
+        const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
+        bool loadDefaultStyle = true ) SIP_FACTORY;
 };
 
 #endif // QGSMEMORYPROVIDERUTILS_H


### PR DESCRIPTION
## Description

Because loading default styles has a bunch of QgsProject::instance calls.