### PR TITLE
Add SLD export context

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -180,6 +180,21 @@ Qgis.SettingsType.__doc__ = 'Types of settings entries\n\n.. versionadded:: 3.26
 # --
 Qgis.SettingsType.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.SldExportOption.NoOptions.__doc__ = "Default SLD export"
+Qgis.SldExportOption.Svg.__doc__ = "Export complex styles to separate SVG files for better compatibility with OGC servers"
+Qgis.SldExportOption.__doc__ = 'SLD export options\n\n.. versionadded:: 3.30\n\n' + '* ``NoOptions``: ' + Qgis.SldExportOption.NoOptions.__doc__ + '\n' + '* ``Svg``: ' + Qgis.SldExportOption.Svg.__doc__
+# --
+Qgis.SldExportOption.baseClass = Qgis
+Qgis.SldExportOptions.baseClass = Qgis
+SldExportOptions = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.SldExportVendorExtension.NoVendorExtension.__doc__ = "No vendor extensions"
+Qgis.SldExportVendorExtension.GeoServerVendorExtension.__doc__ = "Use GeoServer vendor extensions when required"
+Qgis.SldExportVendorExtension.DeegreeVendorExtension.__doc__ = "Use Deegree vendor extensions when required"
+Qgis.SldExportVendorExtension.__doc__ = 'SLD export vendor extensions, allow the use of vendor extensions when exporting to SLD.\n\n.. versionadded:: 3.30\n\n' + '* ``NoVendorExtension``: ' + Qgis.SldExportVendorExtension.NoVendorExtension.__doc__ + '\n' + '* ``GeoServerVendorExtension``: ' + Qgis.SldExportVendorExtension.GeoServerVendorExtension.__doc__ + '\n' + '* ``DeegreeVendorExtension``: ' + Qgis.SldExportVendorExtension.DeegreeVendorExtension.__doc__
+# --
+Qgis.SldExportVendorExtension.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.SettingsOption.SaveFormerValue.__doc__ = ""
 Qgis.SettingsOption.SaveEnumFlagAsInt.__doc__ = ""
 Qgis.SettingsOption.__doc__ = 'Settings options\n\n.. versionadded:: 3.26\n\n' + '* ``SaveFormerValue``: ' + Qgis.SettingsOption.SaveFormerValue.__doc__ + '\n' + '* ``SaveEnumFlagAsInt``: ' + Qgis.SettingsOption.SaveEnumFlagAsInt.__doc__

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -161,6 +161,22 @@ The development version
       Color
     };
 
+    enum class SldExportOption
+    {
+      NoOptions,
+      Svg,
+    };
+    typedef QFlags<Qgis::SldExportOption> SldExportOptions;
+
+
+    enum class SldExportVendorExtension
+    {
+      NoVendorExtension,
+      GeoServerVendorExtension,
+      DeegreeVendorExtension,
+    };
+
+
     enum class SettingsOption
     {
       SaveFormerValue,

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -982,6 +982,18 @@ Export the properties of this layer as SLD style in a QDomDocument
                  during the execution of writeSymbology
 %End
 
+    virtual void exportSldStyleV2( QDomDocument &doc, QString &errorMsg, const QgsSldExportContext &exportContext ) const;
+%Docstring
+Export the properties of this layer as SLD style in a QDomDocument
+
+:param doc: the target QDomDocument
+:param errorMsg: this QString will be initialized on error
+                 during the execution of writeSymbology
+:param exportContext: SLD export context
+
+.. versionadded:: 3.30
+%End
+
     virtual QString saveDefaultStyle( bool &resultFlag /Out/, StyleCategories categories );
 %Docstring
 Save the properties of this layer as the default style
@@ -1039,6 +1051,24 @@ Saves the properties of this layer to an SLD format file.
                    the SLD file could not be generated
 
 :return: a string with any status or error messages
+
+.. seealso:: :py:func:`loadSldStyle`
+
+.. seealso:: :py:func:`saveSldStyleV2`
+%End
+
+    virtual QString saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const;
+%Docstring
+Saves the properties of this layer to an SLD format file.
+
+:param uri: uri of destination for exported SLD file.
+:param resultFlag: a reference to a flag that will be set to ``False`` if
+                   the SLD file could not be generated
+:param exportContext: SLD export context
+
+:return: a string with any status or error messages
+
+.. versionadded:: 3.30
 
 .. seealso:: :py:func:`loadSldStyle`
 %End

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1068,9 +1068,9 @@ Saves the properties of this layer to an SLD format file.
 
 :return: a string with any status or error messages
 
-.. versionadded:: 3.30
-
 .. seealso:: :py:func:`loadSldStyle`
+
+.. versionadded:: 3.30
 %End
 
     virtual QString loadSldStyle( const QString &uri, bool &resultFlag );

--- a/python/core/auto_generated/qgssldexportcontext.sip.in
+++ b/python/core/auto_generated/qgssldexportcontext.sip.in
@@ -1,0 +1,54 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssldexportcontext.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+class QgsSldExportContext
+{
+%Docstring(signature="appended")
+/ingroup core
+/brief The :py:class:`QgsSldExportContext` class holds SLD export options and other information related to SLD export of a QGIS layer style.
+
+/since QGIS 3.30
+%End
+
+%TypeHeaderCode
+#include "qgssldexportcontext.h"
+%End
+  public:
+
+    QgsSldExportContext();
+    ~QgsSldExportContext();
+    QgsSldExportContext( const QgsSldExportContext &other );
+
+    QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
+%Docstring
+/brief Create a new QgsSldExportContext
+/param options SLD export options
+/param vendorExtension SLD export vendor extension
+/param filePath SLD export file path
+%End
+
+    Qgis::SldExportOptions exportOptions() const;
+    void setExportOptions( const Qgis::SldExportOptions &exportOptions );
+
+    Qgis::SldExportVendorExtension vendorExtensions() const;
+    void setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions );
+
+    QString exportFilePath() const;
+    void setExportFilePath( const QString &exportFilePath );
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssldexportcontext.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgssldexportcontext.sip.in
+++ b/python/core/auto_generated/qgssldexportcontext.sip.in
@@ -10,10 +10,9 @@
 class QgsSldExportContext
 {
 %Docstring(signature="appended")
-/ingroup core
-/brief The :py:class:`QgsSldExportContext` class holds SLD export options and other information related to SLD export of a QGIS layer style.
+The :py:class:`QgsSldExportContext` class holds SLD export options and other information related to SLD export of a QGIS layer style.
 
-/since QGIS 3.30
+.. versionadded:: 3.30
 %End
 
 %TypeHeaderCode
@@ -22,8 +21,17 @@ class QgsSldExportContext
   public:
 
     QgsSldExportContext();
+%Docstring
+Constructs a default SLD export context
+%End
+
     ~QgsSldExportContext();
+
     QgsSldExportContext( const QgsSldExportContext &other );
+%Docstring
+Constructs a copy of SLD export context ``other``
+%End
+
 
     QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
 %Docstring
@@ -34,13 +42,34 @@ class QgsSldExportContext
 %End
 
     Qgis::SldExportOptions exportOptions() const;
+%Docstring
+Returns the export options
+%End
+
     void setExportOptions( const Qgis::SldExportOptions &exportOptions );
+%Docstring
+Set export options to ``exportOptions``
+%End
 
     Qgis::SldExportVendorExtension vendorExtensions() const;
-    void setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions );
+%Docstring
+Returns the vendor extension enabled for the SLD export
+%End
+
+    void setVendorExtension( const Qgis::SldExportVendorExtension &vendorExtension );
+%Docstring
+Sets the vendor extensions to ``vendorExtension``
+%End
 
     QString exportFilePath() const;
+%Docstring
+Returns the export file path for the SLD
+%End
+
     void setExportFilePath( const QString &exportFilePath );
+%Docstring
+Sets the export file path for the SLD to ``exportFilePath``
+%End
 
 };
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -166,6 +166,7 @@
 %Include auto_generated/qgsselectioncontext.sip
 %Include auto_generated/qgssimplifymethod.sip
 %Include auto_generated/qgssingleitemmodel.sip
+%Include auto_generated/qgssldexportcontext.sip
 %Include auto_generated/qgssnappingconfig.sip
 %Include auto_generated/qgssnappingutils.sip
 %Include auto_generated/qgsspatialindex.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -498,6 +498,7 @@ set(QGIS_CORE_SRCS
   qgsshapegenerator.cpp
   qgssimplifymethod.cpp
   qgssingleitemmodel.cpp
+  qgssldexportcontext.cpp
   qgssnappingutils.cpp
   qgsspatialindex.cpp
   qgsspatialindexkdbush.cpp
@@ -1177,6 +1178,7 @@ set(QGIS_CORE_HDRS
   qgsshapegenerator.h
   qgssimplifymethod.h
   qgssingleitemmodel.h
+  qgssldexportcontext.h
   qgssnappingconfig.h
   qgssnappingutils.h
   qgsspatialindex.h

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -41,6 +41,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsmaplayerelevationproperties.h"
+#include "qgsmaplayerstyle.h"
 #include "qgsvectorlayerrenderer.h"
 #include "qgsrendereditemresults.h"
 #include "qgsmaskpaintdevice.h"

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -242,6 +242,34 @@ class CORE_EXPORT Qgis
     Q_ENUM( SettingsType )
 
     /**
+     * \brief SLD export options
+     *
+     * \since QGIS 3.30
+     */
+    enum class SldExportOption : int
+    {
+      NoOptions = 0,                      //!< Default SLD export
+      Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
+    };
+    Q_ENUM( SldExportOption )
+    Q_DECLARE_FLAGS( SldExportOptions, SldExportOption )
+    Q_FLAG( SldExportOptions )
+
+    /**
+     * \brief SLD export vendor extensions, allow the use of vendor extensions when exporting to SLD.
+     *
+     * \since QGIS 3.30
+     */
+    enum class SldExportVendorExtension : int
+    {
+      NoVendorExtension = 0,             //!< No vendor extensions
+      GeoServerVendorExtension = 1 << 1, //!< Use GeoServer vendor extensions when required
+      DeegreeVendorExtension = 1 << 2,   //!< Use Deegree vendor extensions when required
+    };
+    Q_ENUM( SldExportVendorExtension )
+
+
+    /**
      * Settings options
      * \since QGIS 3.26
      */

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1168,8 +1168,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \param exportContext SLD export context
      * \returns a string with any status or error messages
      *
-     * \since QGIS 3.30
      * \see loadSldStyle()
+     * \since QGIS 3.30
      */
     virtual QString saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const;
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -37,7 +37,6 @@
 #include "qgsmaplayerdependency.h"
 #include "qgslayermetadata.h"
 #include "qgsmaplayerserverproperties.h"
-#include "qgsmaplayerstyle.h"
 #include "qgsreadwritecontext.h"
 #include "qgsdataprovider.h"
 #include "qgis.h"
@@ -52,6 +51,7 @@ class QgsProject;
 class QgsStyleEntityVisitorInterface;
 class QgsMapLayerTemporalProperties;
 class QgsMapLayerElevationProperties;
+class QgsSldExportContext;
 
 class QDomDocument;
 class QKeyEvent;
@@ -1099,6 +1099,16 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg ) const;
 
     /**
+     * Export the properties of this layer as SLD style in a QDomDocument
+     * \param doc the target QDomDocument
+     * \param errorMsg this QString will be initialized on error
+     *                 during the execution of writeSymbology
+     * \param exportContext SLD export context
+     * \since QGIS 3.30
+     */
+    virtual void exportSldStyleV2( QDomDocument &doc, QString &errorMsg, const QgsSldExportContext &exportContext ) const;
+
+    /**
      * Save the properties of this layer as the default style
      * (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
@@ -1146,8 +1156,22 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * the SLD file could not be generated
      * \returns a string with any status or error messages
      * \see loadSldStyle()
+     * \see saveSldStyleV2()
      */
     virtual QString saveSldStyle( const QString &uri, bool &resultFlag ) const;
+
+    /**
+     * Saves the properties of this layer to an SLD format file.
+     * \param uri uri of destination for exported SLD file.
+     * \param resultFlag a reference to a flag that will be set to FALSE if
+     *        the SLD file could not be generated
+     * \param exportContext SLD export context
+     * \returns a string with any status or error messages
+     *
+     * \since QGIS 3.30
+     * \see loadSldStyle()
+     */
+    virtual QString saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const;
 
     /**
      * Attempts to style the layer using the formatting from an SLD type file.

--- a/src/core/qgssldexportcontext.cpp
+++ b/src/core/qgssldexportcontext.cpp
@@ -38,9 +38,9 @@ Qgis::SldExportVendorExtension QgsSldExportContext::vendorExtensions() const
   return mVendorExtensions;
 }
 
-void QgsSldExportContext::setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions )
+void QgsSldExportContext::setVendorExtension( const Qgis::SldExportVendorExtension &vendorExtension )
 {
-  mVendorExtensions = vendorExtensions;
+  mVendorExtensions = vendorExtension;
 }
 
 QString QgsSldExportContext::exportFilePath() const

--- a/src/core/qgssldexportcontext.cpp
+++ b/src/core/qgssldexportcontext.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+  qgssldexportcontext.cpp - QgsSldExportContext
+
+ ---------------------
+ begin                : 21.12.2022
+ copyright            : (C) 2022 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgssldexportcontext.h"
+
+QgsSldExportContext::QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath )
+  : mExportOptions( options )
+  , mVendorExtensions( vendorExtension )
+  , mExportFilePath( filePath )
+{
+
+}
+
+Qgis::SldExportOptions QgsSldExportContext::exportOptions() const
+{
+  return mExportOptions;
+}
+
+void QgsSldExportContext::setExportOptions( const Qgis::SldExportOptions &exportOptions )
+{
+  mExportOptions = exportOptions;
+}
+
+Qgis::SldExportVendorExtension QgsSldExportContext::vendorExtensions() const
+{
+  return mVendorExtensions;
+}
+
+void QgsSldExportContext::setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions )
+{
+  mVendorExtensions = vendorExtensions;
+}
+
+QString QgsSldExportContext::exportFilePath() const
+{
+  return mExportFilePath;
+}
+
+void QgsSldExportContext::setExportFilePath( const QString &exportFilePath )
+{
+  mExportFilePath = exportFilePath;
+}

--- a/src/core/qgssldexportcontext.h
+++ b/src/core/qgssldexportcontext.h
@@ -20,18 +20,30 @@
 #include "qgis_core.h"
 
 /**
- * /ingroup core
- * /brief The QgsSldExportContext class holds SLD export options and other information related to SLD export of a QGIS layer style.
+ * \ingroup core
+ * \brief The QgsSldExportContext class holds SLD export options and other information related to SLD export of a QGIS layer style.
  *
- * /since QGIS 3.30
+ * \since QGIS 3.30
  */
 class CORE_EXPORT QgsSldExportContext
 {
   public:
 
+    /**
+     * Constructs a default SLD export context
+     */
     QgsSldExportContext() = default;
+
     ~QgsSldExportContext() = default;
+
+    /**
+     * Constructs a copy of SLD export context \a other
+     */
     QgsSldExportContext( const QgsSldExportContext &other ) = default;
+
+    /**
+     * Copy the values of \a other into the SLD export context
+     */
     QgsSldExportContext &operator=( const QgsSldExportContext &other ) = default;
 
     /**
@@ -42,13 +54,34 @@ class CORE_EXPORT QgsSldExportContext
      */
     QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
 
+    /**
+     * Returns the export options
+     */
     Qgis::SldExportOptions exportOptions() const;
+
+    /**
+     * Set export options to \a exportOptions
+     */
     void setExportOptions( const Qgis::SldExportOptions &exportOptions );
 
+    /**
+     * Returns the vendor extension enabled for the SLD export
+     */
     Qgis::SldExportVendorExtension vendorExtensions() const;
-    void setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions );
 
+    /**
+     * Sets the vendor extensions to \a vendorExtension
+     */
+    void setVendorExtension( const Qgis::SldExportVendorExtension &vendorExtension );
+
+    /**
+     * Returns the export file path for the SLD
+     */
     QString exportFilePath() const;
+
+    /**
+     * Sets the export file path for the SLD to \a exportFilePath
+     */
     void setExportFilePath( const QString &exportFilePath );
 
   private:

--- a/src/core/qgssldexportcontext.h
+++ b/src/core/qgssldexportcontext.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+  qgssldexportcontext.h - QgsSldExportContext
+
+ ---------------------
+ begin                : 21.12.2022
+ copyright            : (C) 2022 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSSLDEXPORTCONTEXT_H
+#define QGSSLDEXPORTCONTEXT_H
+
+#include "qgis.h"
+#include "qgis_core.h"
+
+/**
+ * /ingroup core
+ * /brief The QgsSldExportContext class holds SLD export options and other information related to SLD export of a QGIS layer style.
+ *
+ * /since QGIS 3.30
+ */
+class CORE_EXPORT QgsSldExportContext
+{
+  public:
+
+    QgsSldExportContext() = default;
+    ~QgsSldExportContext() = default;
+    QgsSldExportContext( const QgsSldExportContext &other ) = default;
+    QgsSldExportContext &operator=( const QgsSldExportContext &other ) = default;
+
+    /**
+     * /brief Create a new QgsSldExportContext
+     * /param options SLD export options
+     * /param vendorExtension SLD export vendor extension
+     * /param filePath SLD export file path
+     */
+    QgsSldExportContext( const Qgis::SldExportOptions &options, const Qgis::SldExportVendorExtension &vendorExtension, const QString &filePath );
+
+    Qgis::SldExportOptions exportOptions() const;
+    void setExportOptions( const Qgis::SldExportOptions &exportOptions );
+
+    Qgis::SldExportVendorExtension vendorExtensions() const;
+    void setVendorExtensions( const Qgis::SldExportVendorExtension &vendorExtensions );
+
+    QString exportFilePath() const;
+    void setExportFilePath( const QString &exportFilePath );
+
+  private:
+
+    Qgis::SldExportOptions mExportOptions = Qgis::SldExportOption::NoOptions;
+    Qgis::SldExportVendorExtension mVendorExtensions = Qgis::SldExportVendorExtension::NoVendorExtension;
+    QString mExportFilePath;
+
+};
+
+Q_DECLARE_METATYPE( QgsSldExportContext );
+
+#endif // QGSSLDEXPORTCONTEXT_H


### PR DESCRIPTION
This is the first part of a few SLD export enhancements, it introduces a SLD export context that holds a few options for the SLD export process.

The final goal is to be able to export more complex styles to SLD, by using a combination of SVG symbols export and vendor extensions (initially for GeoServer and Deegree, but the API is open for additional vendor extensions).

The existing SLD export API and behavior will not be changed, but the new V2 API will allow for a more granular configuration of the SLD export process.


