### PR TITLE
[AttributeTable] Lazy load widget information for attributes

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -337,10 +337,15 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
 
     QgsFields mFields;
     QgsAttributeList mAttributes;
-    QVector<QgsEditorWidgetFactory *> mWidgetFactories;
-    QVector<QgsFieldFormatter *> mFieldFormatters;
-    QVector<QVariant> mAttributeWidgetCaches;
-    QVector<QVariantMap> mWidgetConfigs;
+
+    struct WidgetData
+    {
+      QgsFieldFormatter *fieldFormatter = nullptr;
+      QVariant cache;
+      QVariantMap config;
+      bool loaded = false;
+    };
+    mutable QVector<WidgetData> mWidgetDatas;
 
     QHash<QgsFeatureId, int> mIdRowMap;
     QHash<int, QgsFeatureId> mRowIdMap;
@@ -349,9 +354,14 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     mutable QgsExpressionContext mExpressionContext;
 
     /**
+     * Returns widget information for \a column index
+     */
+    const WidgetData &getWidgetData( int column ) const;
+
+    /**
       * Gets mFieldCount, mAttributes
       */
-    virtual void loadAttributes();
+    void loadAttributes();
 
     /**
      * Load feature fid into local cache (mFeat)


### PR DESCRIPTION
Load field formatter only when needed, for instance, don't load field formatter when:
- the column is hidden in attribute table
- Feature form use attribute table model to access cache and print the feature display expression

It really improves things when field formatter is relation reference.

It's a partial fix for https://github.com/qgis/QGIS/issues/47797

**Sponsored by National Land Survey of Finland, City of Tampere and Gispo Ltd**