### PR TITLE
New function "load_layer"

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -388,6 +388,7 @@ Creates a new scope which contains functions relating to mesh layer element ``el
 };
 
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -284,6 +284,7 @@ Returns the node's static cached value. Only valid if :py:func:`~QgsExpressionNo
 .. versionadded:: 3.18
 %End
 
+
     const QgsExpressionNode *effectiveNode() const;
 %Docstring
 Returns a reference to the simplest node which represents this node,

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -947,6 +947,30 @@ Returns the list of layer stores associated with the context.
 .. versionadded:: 3.30
 %End
 
+    void setLoadedLayerStore( QgsMapLayerStore *store );
+%Docstring
+Sets the destination layer ``store`` for any layers loaded during
+expression evaluation.
+
+Ownership of the ``store`` is not transferred to the context, it is the caller's
+responsibility to ensure that the store remains alive for the duration of the
+expression context.
+
+.. seealso:: :py:func:`loadedLayerStore`
+
+.. versionadded:: 3.30
+%End
+
+    QgsMapLayerStore *loadedLayerStore() const;
+%Docstring
+Returns the destination layer store for any layers loaded during
+expression evaluation.
+
+.. seealso:: :py:func:`setLoadedLayerStore`
+
+.. versionadded:: 3.30
+%End
+
     void setFeedback( QgsFeedback *feedback );
 %Docstring
 Attach a ``feedback`` object that can be queried regularly by the expression engine to check

--- a/resources/function_help/json/load_layer
+++ b/resources/function_help/json/load_layer
@@ -1,0 +1,19 @@
+{
+  "name": "load_layer",
+  "type": "function",
+  "groups": ["Map Layers"],
+  "description": "Loads a layer by source URI and provider name.",
+  "arguments": [{
+    "arg": "uri",
+    "description": "layer source URI string"
+  },
+  { 
+    "arg": "provider",
+    "description": "layer data provider name"
+  }],
+  "examples": [{
+    "expression": "layer_property(load_layer('c:/data/roads.shp', 'ogr'), 'feature_count')",
+    "returns": "count of features from the c:/data/roads.shp vector layer"
+  }],
+  "tags": ["layer", "vector", "raster", "mesh", "point", "cloud"]
+}

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -359,6 +359,24 @@ class CORE_EXPORT QgsExpressionContextUtils
 
 };
 
+///@cond PRIVATE
+#ifndef SIP_RUN
+class LoadLayerFunction : public QgsScopedExpressionFunction
+{
+  public:
+    LoadLayerFunction()
+      : QgsScopedExpressionFunction( QStringLiteral( "load_layer" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "uri" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "provider" ) ), QStringLiteral( "Map Layers" ) )
+    {}
+
+    QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * ) override;
+    bool isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+
+    QgsScopedExpressionFunction *clone() const override;
+
+};
+#endif
+///@endcond
+
 #ifndef SIP_RUN
 
 /**

--- a/src/core/expression/qgsexpressionnode.cpp
+++ b/src/core/expression/qgsexpressionnode.cpp
@@ -56,6 +56,12 @@ bool QgsExpressionNode::prepare( QgsExpression *parent, const QgsExpressionConte
   }
 }
 
+void QgsExpressionNode::setCachedStaticValue( const QVariant &value ) const
+{
+  mHasCachedValue = true;
+  mCachedStaticValue = value;
+}
+
 QgsExpressionNode::QgsExpressionNode( const QgsExpressionNode &other )
   : parserFirstLine( other.parserFirstLine )
   , parserFirstColumn( other.parserFirstColumn )

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -334,6 +334,15 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
     QVariant cachedStaticValue() const { return mCachedStaticValue; }
 
     /**
+     * Sets the cached static \a value for the node.
+     *
+     * \note Not available from Python bindings.
+     *
+     * \since QGIS 3.30
+     */
+    void setCachedStaticValue( const QVariant &value ) const SIP_SKIP;
+
+    /**
      * Returns a reference to the simplest node which represents this node,
      * after any compilation optimizations have been applied.
      *

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -31,6 +31,7 @@ QgsProcessingContext::QgsProcessingContext()
       mFeedback->reportError( QObject::tr( "Encountered a transform error when reprojecting feature with id %1." ).arg( feature.id() ) );
   };
   mTransformErrorCallback = callback;
+  mExpressionContext.setLoadedLayerStore( &tempLayerStore );
 }
 
 QgsProcessingContext::~QgsProcessingContext()
@@ -39,6 +40,13 @@ QgsProcessingContext::~QgsProcessingContext()
   {
     delete it.value().postProcessor();
   }
+}
+
+void QgsProcessingContext::setExpressionContext( const QgsExpressionContext &context )
+{
+  mExpressionContext = context;
+  // any layers temporarily loaded by expressions should use the same temporary layer store as this context
+  mExpressionContext.setLoadedLayerStore( &tempLayerStore );
 }
 
 void QgsProcessingContext::setLayersToLoadOnCompletion( const QMap<QString, QgsProcessingContext::LayerDetails> &layers )

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -88,6 +88,7 @@ class CORE_EXPORT QgsProcessingContext
       mProject = other.mProject;
       mTransformContext = other.mTransformContext;
       mExpressionContext = other.mExpressionContext;
+      mExpressionContext.setLoadedLayerStore( &tempLayerStore );
       mInvalidGeometryCallback = other.mInvalidGeometryCallback;
       mUseDefaultInvalidGeometryCallback = other.mUseDefaultInvalidGeometryCallback;
       mInvalidGeometryCheck = other.mInvalidGeometryCheck;
@@ -156,7 +157,7 @@ class CORE_EXPORT QgsProcessingContext
     /**
      * Sets the expression \a context.
      */
-    void setExpressionContext( const QgsExpressionContext &context ) { mExpressionContext = context; }
+    void setExpressionContext( const QgsExpressionContext &context );
 
     /**
      * Returns the coordinate transform context.

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -310,6 +310,7 @@ QgsExpressionContext::QgsExpressionContext( const QgsExpressionContext &other ) 
   mHighlightedFunctions = other.mHighlightedFunctions;
   mCachedValues = other.mCachedValues;
   mFeedback = other.mFeedback;
+  mDestinationStore = other.mDestinationStore;
 }
 
 QgsExpressionContext &QgsExpressionContext::operator=( QgsExpressionContext &&other ) noexcept
@@ -325,6 +326,7 @@ QgsExpressionContext &QgsExpressionContext::operator=( QgsExpressionContext &&ot
     mHighlightedFunctions = other.mHighlightedFunctions;
     mCachedValues = other.mCachedValues;
     mFeedback = other.mFeedback;
+    mDestinationStore = other.mDestinationStore;
   }
   return *this;
 }
@@ -344,6 +346,7 @@ QgsExpressionContext &QgsExpressionContext::operator=( const QgsExpressionContex
   mHighlightedFunctions = other.mHighlightedFunctions;
   mCachedValues = other.mCachedValues;
   mFeedback = other.mFeedback;
+  mDestinationStore = other.mDestinationStore;
   return *this;
 }
 
@@ -716,7 +719,20 @@ QList<QgsMapLayerStore *> QgsExpressionContext::layerStores() const
     --it;
     res.append( ( *it )->layerStores() );
   }
+  // ensure that the destination store is also present in the list
+  if ( mDestinationStore && !res.contains( mDestinationStore ) )
+    res.append( mDestinationStore );
   return res;
+}
+
+void QgsExpressionContext::setLoadedLayerStore( QgsMapLayerStore *store )
+{
+  mDestinationStore = store;
+}
+
+QgsMapLayerStore *QgsExpressionContext::loadedLayerStore() const
+{
+  return mDestinationStore;
 }
 
 void QgsExpressionContext::setFeedback( QgsFeedback *feedback )

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -339,6 +339,7 @@ QgsExpressionContext &QgsExpressionContext::operator=( QgsExpressionContext &&ot
   return *this;
 }
 
+// cppcheck-suppress operatorEqVarError
 QgsExpressionContext &QgsExpressionContext::operator=( const QgsExpressionContext &other )
 {
   if ( &other == this )

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -857,6 +857,28 @@ class CORE_EXPORT QgsExpressionContext
     QList< QgsMapLayerStore * > layerStores() const;
 
     /**
+     * Sets the destination layer \a store for any layers loaded during
+     * expression evaluation.
+     *
+     * Ownership of the \a store is not transferred to the context, it is the caller's
+     * responsibility to ensure that the store remains alive for the duration of the
+     * expression context.
+     *
+     * \see loadedLayerStore()
+     * \since QGIS 3.30
+     */
+    void setLoadedLayerStore( QgsMapLayerStore *store );
+
+    /**
+     * Returns the destination layer store for any layers loaded during
+     * expression evaluation.
+     *
+     * \see setLoadedLayerStore()
+     * \since QGIS 3.30
+     */
+    QgsMapLayerStore *loadedLayerStore() const;
+
+    /**
      * Attach a \a feedback object that can be queried regularly by the expression engine to check
      * if expression evaluation should be canceled.
      *
@@ -913,6 +935,8 @@ class CORE_EXPORT QgsExpressionContext
     QStringList mHighlightedFunctions;
 
     QgsFeedback *mFeedback = nullptr;
+
+    QPointer< QgsMapLayerStore > mDestinationStore;
 
     // Cache is mutable because we want to be able to add cached values to const contexts
     mutable QMap< QString, QVariant > mCachedValues;

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -29,6 +29,7 @@
 
 class QgsReadWriteContext;
 class QgsMapLayerStore;
+class LoadLayerFunction;
 
 /**
  * \ingroup core
@@ -481,7 +482,7 @@ class CORE_EXPORT QgsExpressionContext
   public:
 
     //! Constructor for QgsExpressionContext
-    QgsExpressionContext() = default;
+    QgsExpressionContext();
 
     /**
      * Initializes the context with given list of scopes.
@@ -936,6 +937,7 @@ class CORE_EXPORT QgsExpressionContext
 
     QgsFeedback *mFeedback = nullptr;
 
+    std::unique_ptr< LoadLayerFunction > mLoadLayerFunction;
     QPointer< QgsMapLayerStore > mDestinationStore;
 
     // Cache is mutable because we want to be able to add cached values to const contexts

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1228,6 +1228,8 @@ void TestQgsProcessing::context()
   context.setInvalidGeometryCheck( QgsFeatureRequest::GeometrySkipInvalid );
   QCOMPARE( context.invalidGeometryCheck(), QgsFeatureRequest::GeometrySkipInvalid );
 
+  QCOMPARE( context.expressionContext().loadedLayerStore(), context.temporaryLayerStore() );
+
   QgsVectorLayer *vector = new QgsVectorLayer( "Polygon", "vector", "memory" );
   context.temporaryLayerStore()->addMapLayer( vector );
   QCOMPARE( context.temporaryLayerStore()->mapLayer( vector->id() ), vector );
@@ -1241,6 +1243,15 @@ void TestQgsProcessing::context()
   QCOMPARE( static_cast< int >( context2.logLevel() ), static_cast< int >( QgsProcessingContext::Verbose ) );
   // layers from temporaryLayerStore must not be copied by copyThreadSafeSettings
   QVERIFY( context2.temporaryLayerStore()->mapLayers().isEmpty() );
+  QCOMPARE( context2.expressionContext().loadedLayerStore(), context2.temporaryLayerStore() );
+
+  QgsExpressionContext expContext;
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope();
+  scope->setVariable( QStringLiteral( "var" ), 5 );
+  expContext.appendScope( scope );
+  context2.setExpressionContext( expContext );
+  QCOMPARE( context2.expressionContext().variable( QStringLiteral( "var" ) ).toInt(), 5 );
+  QCOMPARE( context2.expressionContext().loadedLayerStore(), context2.temporaryLayerStore() );
 
   // layers to load on completion
   QgsVectorLayer *v1 = new QgsVectorLayer( "Polygon", "V1", "memory" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5658,6 +5658,13 @@ class TestQgsExpression: public QObject
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
       QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Raster" ) );
+
+      // complex expression
+      exp = QgsExpression( QStringLiteral( "with_variable('layer', load_layer('%1', 'gdal'), layer_property(@layer, 'type') || layer_property(@layer, 'type'))" ).arg( rasterFileName ) );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "RasterRaster" ) );
+
     }
 
 };

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5542,6 +5542,30 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp.evaluate( &context ).toInt(), 20 );
     }
 
+    void testNodeSetCachedStaticValue()
+    {
+      QgsFields fields;
+      fields.append( QgsField( QStringLiteral( "first_field" ), QVariant::Int ) );
+      fields.append( QgsField( QStringLiteral( "second_field" ), QVariant::Int ) );
+      fields.append( QgsField( QStringLiteral( "third_field" ), QVariant::Int ) );
+
+      QgsFeature f( fields );
+      f.setAttributes( QgsAttributes() << 11 << 20 << 300 );
+
+      QgsExpressionContext context;
+      context.setFields( fields );
+      context.setFeature( f );
+
+      QgsExpression exp( QStringLiteral( "CASE WHEN \"first_field\" = 5 then \"second_field\" when \"first_field\" = 6 then \"second_field\" * 2 else \"second_field\" * 3 end" ) );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.rootNode()->hasCachedStaticValue() );
+
+      // force set a cached static value
+      exp.rootNode()->setCachedStaticValue( 55 );
+      QVERIFY( exp.rootNode()->hasCachedStaticValue() );
+      QCOMPARE( exp.rootNode()->cachedStaticValue().toInt(), 55 );
+    }
+
     void testExpressionUtilsToLocalizedString()
     {
       const QVariant t_int( 12346 );

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -1016,6 +1016,7 @@ void TestQgsExpressionContext::layerStores()
 
   QgsExpressionContext context;
   QVERIFY( context.layerStores().isEmpty() );
+  QVERIFY( !context.loadedLayerStore() );
 
   QgsExpressionContextScope *scope2 = new QgsExpressionContextScope();
   context.appendScopes( { scope1, scope2, scope3 } );
@@ -1025,6 +1026,20 @@ void TestQgsExpressionContext::layerStores()
 
   store2.reset();
   QCOMPARE( context.layerStores(), QList< QgsMapLayerStore *>( {&store3, &store1 } ) );
+
+  QVERIFY( !context.loadedLayerStore() );
+  QgsMapLayerStore store4;
+  context.setLoadedLayerStore( &store4 );
+  QCOMPARE( context.loadedLayerStore(), &store4 );
+  // store4 must also be present in layerStores()
+  QCOMPARE( context.layerStores(), QList< QgsMapLayerStore *>( {&store3, &store1, &store4 } ) );
+
+  QgsExpressionContext c2( context );
+  QCOMPARE( c2.loadedLayerStore(), &store4 );
+
+  QgsExpressionContext c3;
+  c3 = context;
+  QCOMPARE( c3.loadedLayerStore(), &store4 );
 }
 
 QGSTEST_MAIN( TestQgsExpressionContext )

--- a/tests/src/python/test_qgsprocessexecutable_pt2.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt2.py
@@ -299,6 +299,12 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
         self.assertIn('OUTPUT:	abc:def', output)
         self.assertEqual(rc, 0)
 
+    def testLoadLayer(self):
+        rc, output, err = self.run_process(['run', '--no-python', 'native:raiseexception', '--MESSAGE=CONFIRMED', '--CONDITION=layer_property(load_layer(\'{}\',\'ogr\'),\'feature_count\')>10'.format(TEST_DATA_DIR + '/points.shp')])
+        self.assertIn('CONFIRMED', self._strip_ignorable_errors(err))
+
+        self.assertEqual(rc, 1)
+
 
 if __name__ == '__main__':
     # look for qgis bin path


### PR DESCRIPTION
This function (available only in Processing expressions for now), allows loading a map layer via a source string and provider name.

It is designed to allow use of the expression functions which directly reference map layers (such as the aggregate functions) with a hardcoded layer path, eg. then permitting these functions to be used outside of a project (such as via the qgis_process tool). Ie. if a user wants to take advantage of complex aggregate functions in the refactor fields algorithm via qgis_process, the only way prior to this new function was for the user to create a manual temporary project containing those layers.

Sponsored by the Research Institute for Nature and Forest, Flemish Govt

