### PR TITLE
Fix layout item position calculation with DD Expression

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -668,6 +668,15 @@ Returns the page the item is currently on, with the first page returning 0.
 .. seealso:: :py:func:`pagePos`
 %End
 
+    int anchorPage() const;
+%Docstring
+Returns the reference page of the item, should be different than :py:func:`page` when using expression to move the object.
+
+.. seealso:: :py:func:`page`
+
+.. versionadded:: 3.30
+%End
+
     QPointF pagePos() const;
 %Docstring
 Returns the item's position (in layout units) relative to the top left corner of its current page.

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -670,11 +670,11 @@ Returns the page the item is currently on, with the first page returning 0.
 
     int anchorPage() const;
 %Docstring
-Returns the reference page of the item, should be different than :py:func:`page` when using expression to move the object.
+Returns the reference page of the item, should be different than :py:func:`~QgsLayoutItem.page` when using expression to move the object. 
 
 .. seealso:: :py:func:`page`
 
-.. versionadded:: 3.30
+.. versionadded:: 3.32
 %End
 
     QPointF pagePos() const;

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -670,7 +670,7 @@ Returns the page the item is currently on, with the first page returning 0.
 
     int anchorPage() const;
 %Docstring
-Returns the reference page of the item, should be different than :py:func:`~QgsLayoutItem.page` when using expression to move the object. 
+Returns the reference page of the item, should be different than :py:func:`~QgsLayoutItem.page` when using expression to move the object.
 
 .. seealso:: :py:func:`page`
 

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -479,7 +479,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
     return;
   }
 
-  if ( page != mAnchorPage )
+  if ( page != mAnchorPage && page >= 0 )
   {
     mAnchorPage = page;
   }
@@ -501,12 +501,11 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
   }
 
   evaluatedPoint = applyDataDefinedPosition( evaluatedPoint );
-  if ( page >= 0 )
-  {
-    evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
-  }
-  else if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
+
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
     evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
+  else
+    evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -479,7 +479,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
     return;
   }
 
-  if ( page != mAnchorPage && page >= 0 )
+  if ( page > -1 )
   {
     mAnchorPage = page;
   }
@@ -505,7 +505,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
     evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
   else
-    evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
+    evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( mAnchorPage, evaluatedPoint );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -504,7 +504,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
 
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
     evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
-  else
+  else if ( mAnchorPage > 0 )
     evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( mAnchorPage, evaluatedPoint );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -480,10 +480,6 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
   }
 
   QgsLayoutPoint point = p;
-  if ( page >= 0 )
-  {
-    point = mLayout->pageCollection()->pagePositionToAbsolute( page, p );
-  }
 
   if ( includesFrame )
   {
@@ -500,6 +496,10 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
   }
 
   evaluatedPoint = applyDataDefinedPosition( evaluatedPoint );
+  if ( page >= 0 )
+  {
+    evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
+  }
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -481,7 +481,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
 
   if ( page != mAnchorPage )
   {
-    mAnchroPage = page;
+    mAnchorPage = page;
   }
 
   QgsLayoutPoint point = p;
@@ -506,7 +506,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
     evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
   }
   else if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
-      evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
+    evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -500,6 +500,8 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
   {
     evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
   }
+  else if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
+      evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( this->page() )->pos().y(), evaluatedPoint.units() ).length() );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -479,6 +479,11 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
     return;
   }
 
+  if ( page != mAnchorPage )
+  {
+    mAnchroPage = page;
+  }
+
   QgsLayoutPoint point = p;
 
   if ( includesFrame )
@@ -501,7 +506,7 @@ void QgsLayoutItem::attemptMove( const QgsLayoutPoint &p, bool useReferencePoint
     evaluatedPoint = mLayout->pageCollection()->pagePositionToAbsolute( page, evaluatedPoint );
   }
   else if ( mDataDefinedProperties.isActive( QgsLayoutObject::PositionY ) )
-      evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( this->page() )->pos().y(), evaluatedPoint.units() ).length() );
+      evaluatedPoint.setY( evaluatedPoint.y() + mLayout->convertFromLayoutUnits( mLayout->pageCollection()->page( mAnchorPage )->pos().y(), evaluatedPoint.units() ).length() );
   const QPointF evaluatedPointLayoutUnits = mLayout->convertToLayoutUnits( evaluatedPoint );
   const QPointF topLeftPointLayoutUnits = adjustPointForReferencePosition( evaluatedPointLayoutUnits, rect().size(), mReferencePoint );
   if ( topLeftPointLayoutUnits == scenePos() && point.units() == mItemPosition.units() )

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -682,6 +682,14 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     int page() const;
 
     /**
+     * Returns the reference page of the item, should be different than page() when using expression to move the object.
+     * \see page()
+     * 
+     * \since QGIS 3.30
+     */
+    int anchorPage() const{return mAnchorPage; }
+
+    /**
      * Returns the item's position (in layout units) relative to the top left corner of its current page.
      * \see page()
      * \see pagePositionWithUnits()
@@ -1351,6 +1359,8 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     friend class QgsLayout;
     friend class QgsLayoutItemGroup;
     friend class QgsCompositionConverter;
+
+    int mAnchorPage =0;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLayoutItem::Flags )

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -684,10 +684,10 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     /**
      * Returns the reference page of the item, should be different than page() when using expression to move the object.
      * \see page()
-     * 
-     * \since QGIS 3.30
+     *
+     * \since QGIS 3.32
      */
-    int anchorPage() const{return mAnchorPage; }
+    int anchorPage() const {return mAnchorPage; }
 
     /**
      * Returns the item's position (in layout units) relative to the top left corner of its current page.
@@ -1360,7 +1360,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     friend class QgsLayoutItemGroup;
     friend class QgsCompositionConverter;
 
-    int mAnchorPage =0;
+    int mAnchorPage = 0;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLayoutItem::Flags )

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -716,7 +716,7 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiPositionElements()
   mPosLockAspectRatio->resetRatio();
 
   if ( !mFreezePageSpin )
-    mPageSpinBox->setValue( mItem->page() + 1 );
+    mPageSpinBox->setValue( mItem->anchorPage() + 1 );
 
   block( false );
 }

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -507,10 +507,10 @@ void TestQgsLayoutItem::dataDefinedPosition()
   //validate that the page is accounted for even with DD variable during movement
   item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionX, QgsProperty() );
   item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionY, QgsProperty::fromExpression( QStringLiteral( "2+11" ) ) );
-  item->attemptMove( QgsLayoutPoint( 8.0, 5.90, QgsUnitTypes::LayoutCentimeters ), true, false, 2 );
+  item->attemptMove( QgsLayoutPoint( 8.0, 5.90, Qgis::LayoutUnit::Centimeters ), true, false, 2 );
   QCOMPARE( item->positionWithUnits().x(), 8.0 );
   QCOMPARE( item->positionWithUnits().y(), 13.0 );
-  QCOMPARE( item->positionWithUnits().units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( item->positionWithUnits().units(), Qgis::LayoutUnit::Centimeters );
 
   QList<QgsLayoutItem *> items = l.pageCollection()->itemsOnPage( 2 );
   QCOMPARE( items.length(), 2 );

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -496,7 +496,6 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->scenePos().x(), 140.0 ); //mm
   QCOMPARE( item->scenePos().y(), 40.0 ); //mm
 
-  QgsLayout l( &proj );
   QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
   page1->setPageSize( "A4" );
   l.pageCollection()->addPage( page1 );
@@ -512,9 +511,9 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->positionWithUnits().y(), 13.0 );
   QCOMPARE( item->positionWithUnits().units(), QgsUnitTypes::LayoutCentimeters );
 
-  items = l.pageCollection()->itemsOnPage( 2 );
+  QList<QgsLayoutItem *> items = l.pageCollection()->itemsOnPage( 2 );
   QCOMPARE( items.length(), 2 );
-  QCOMPARE( item.page(), 2 );
+  QCOMPARE( item->page(), 2 );
 
   l.pageCollection()->deletePage( 2 );
   l.pageCollection()->deletePage( 1 );

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -496,6 +496,29 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->scenePos().x(), 140.0 ); //mm
   QCOMPARE( item->scenePos().y(), 40.0 ); //mm
 
+  QgsLayout l( &proj );
+  QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
+  page1->setPageSize( "A4" );
+  l.pageCollection()->addPage( page1 );
+  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
+  page2->setPageSize( "A4" );
+  l.pageCollection()->addPage( page2 );
+
+  //validate that the page is accounted for even with DD variable during movement
+  item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionX, QgsProperty() );
+  item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionY, QgsProperty::fromExpression( QStringLiteral( "2+11" ) ) );
+  item->attemptMove( QgsLayoutPoint( 8.0, 5.90, QgsUnitTypes::LayoutCentimeters ), true, false, 2 );
+  QCOMPARE( item->positionWithUnits().x(), 8.0 );
+  QCOMPARE( item->positionWithUnits().y(), 13.0 );
+  QCOMPARE( item->positionWithUnits().units(), QgsUnitTypes::LayoutCentimeters );
+
+  items = l.pageCollection()->itemsOnPage( 2 );
+  QCOMPARE( items.length(), 2 );
+  QCOMPARE( item.page(), 2 );
+
+  l.pageCollection()->deletePage( 2 );
+  l.pageCollection()->deletePage( 1 );
+
   delete item;
 }
 

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -496,12 +496,14 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->scenePos().x(), 140.0 ); //mm
   QCOMPARE( item->scenePos().y(), 40.0 ); //mm
 
-
+  QgsLayoutItemPage *page0 = new QgsLayoutItemPage( &l );
+  page0->setPageSize( "A4" );
+  l.pageCollection()->addPage( page0 );
   std::unique_ptr< QgsLayoutItemPage > page1( new QgsLayoutItemPage( &l ) );
-  page1->setPageSize( "A4" );
+  page1->setPageSize( "A2", QgsLayoutItemPage::Landscape );
   l.pageCollection()->addPage( page1.release() );
   std::unique_ptr< QgsLayoutItemPage > page2( new QgsLayoutItemPage( &l ) );
-  page2->setPageSize( "A4" );
+  page2->setPageSize( "A3", QgsLayoutItemPage::Landscape );
   l.pageCollection()->addPage( page2.release() );
 
   //validate that the page is accounted for even with DD variable during movement
@@ -515,9 +517,6 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QList<QgsLayoutItem *> items = l.pageCollection()->itemsOnPage( 2 );
   QCOMPARE( items.length(), 2 );
   QCOMPARE( item->page(), 2 );
-
-  l.pageCollection()->deletePage( 2 );
-  l.pageCollection()->deletePage( 1 );
 
   delete item;
 }

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -496,12 +496,13 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->scenePos().x(), 140.0 ); //mm
   QCOMPARE( item->scenePos().y(), 40.0 ); //mm
 
-  QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
+
+  std::unique_ptr< QgsLayoutItemPage > page1( new QgsLayoutItemPage( &l ) );
   page1->setPageSize( "A4" );
-  l.pageCollection()->addPage( page1 );
-  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
+  l.pageCollection()->addPage( page1.release() );
+  std::unique_ptr< QgsLayoutItemPage > page2( new QgsLayoutItemPage( &l ) );
   page2->setPageSize( "A4" );
-  l.pageCollection()->addPage( page2 );
+  l.pageCollection()->addPage( page2.release() );
 
   //validate that the page is accounted for even with DD variable during movement
   item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionX, QgsProperty() );

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -514,7 +514,7 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->positionWithUnits().y(), 13.0 );
   QCOMPARE( item->positionWithUnits().units(), Qgis::LayoutUnit::Centimeters );
 
-  QList<QgsLayoutItem *> pgaeItems = l.pageCollection()->itemsOnPage( 2 );
+  QList<QgsLayoutItem *> pageItems = l.pageCollection()->itemsOnPage( 2 );
   QCOMPARE( pageItems.length(), 2 );
 
   delete item;

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -406,10 +406,10 @@ void TestQgsLayoutItem::dataDefinedPosition()
 {
   QgsProject p;
   QgsLayout l( &p );
+  l.setUnits( Qgis::LayoutUnit::Millimeters );
 
   //test setting data defined position
   TestItem *item = new TestItem( &l );
-  l.setUnits( Qgis::LayoutUnit::Millimeters );
   item->attemptMove( QgsLayoutPoint( 6.0, 1.50, Qgis::LayoutUnit::Centimeters ) );
   item->attemptResize( QgsLayoutSize( 2.0, 4.0, Qgis::LayoutUnit::Centimeters ) );
 
@@ -514,9 +514,8 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QCOMPARE( item->positionWithUnits().y(), 13.0 );
   QCOMPARE( item->positionWithUnits().units(), Qgis::LayoutUnit::Centimeters );
 
-  QList<QgsLayoutItem *> items = l.pageCollection()->itemsOnPage( 2 );
-  QCOMPARE( items.length(), 2 );
-  QCOMPARE( item->page(), 2 );
+  QList<QgsLayoutItem *> pgaeItems = l.pageCollection()->itemsOnPage( 2 );
+  QCOMPARE( pageItems.length(), 2 );
 
   delete item;
 }

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -499,12 +499,12 @@ void TestQgsLayoutItem::dataDefinedPosition()
   QgsLayoutItemPage *page0 = new QgsLayoutItemPage( &l );
   page0->setPageSize( "A4" );
   l.pageCollection()->addPage( page0 );
-  std::unique_ptr< QgsLayoutItemPage > page1( new QgsLayoutItemPage( &l ) );
+  QgsLayoutItemPage *page1 = new QgsLayoutItemPage( &l );
   page1->setPageSize( "A2", QgsLayoutItemPage::Landscape );
-  l.pageCollection()->addPage( page1.release() );
-  std::unique_ptr< QgsLayoutItemPage > page2( new QgsLayoutItemPage( &l ) );
+  l.pageCollection()->addPage( page1 );
+  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
   page2->setPageSize( "A3", QgsLayoutItemPage::Landscape );
-  l.pageCollection()->addPage( page2.release() );
+  l.pageCollection()->addPage( page2 );
 
   //validate that the page is accounted for even with DD variable during movement
   item->dataDefinedProperties().setProperty( QgsLayoutObject::PositionX, QgsProperty() );


### PR DESCRIPTION
## Description

Fixes #50396

This simply moves the page offset lower in the code to prevent it being overwritten by Data-Defined values, and instead perform the calculation after the evaluation.

Credits go to @agiudiceandrea 