### PR TITLE
[expressions] New is_feature_valid()/is_attribute_valid() functions

### DIFF
--- a/resources/function_help/json/is_attribute_valid
+++ b/resources/function_help/json/is_attribute_valid
@@ -1,0 +1,30 @@
+{
+  "name": "is_attribute_valid",
+  "type": "function",
+  "groups": ["Record and Attributes"],
+  "description": "Returns TRUE if a specific feature attribute meets all constraints.",
+  "arguments": [{
+    "arg": "attribute",
+    "description": "an attribute name"
+  },{
+    "arg": "feature",
+    "description": "a feature; if not set, the feature attached to the expression context will be used",
+    "optional": true
+  },{
+    "arg": "layer",
+    "description": "a vector layer; if not set, the layer attached to the expression context will be used",
+    "optional": true
+  },{
+    "arg": "strength",
+    "description": "set to 'hard' or 'soft' to narrow down to a specific constraint type; if not set, the function will return FALSE if either a hard or a soft constraint fails",
+    "optional": true
+  }],
+  "examples": [{
+    "expression": "is_attribute_valid('HECTARES')",
+    "returns": "TRUE"
+  }, {
+    "expression": "is_attribute_valid('HOUSES',get_feature('my_layer','FID',10), 'my_layer')",
+    "returns": "FALSE"
+  }],
+  "tags": ["constraints", "hard", "soft"]
+}

--- a/resources/function_help/json/is_attribute_valid
+++ b/resources/function_help/json/is_attribute_valid
@@ -8,22 +8,22 @@
     "description": "an attribute name"
   },{
     "arg": "feature",
-    "description": "a feature; if not set, the feature attached to the expression context will be used",
+    "description": "A feature. If not set, the feature attached to the expression context will be used.",
     "optional": true
   },{
     "arg": "layer",
-    "description": "a vector layer; if not set, the layer attached to the expression context will be used",
+    "description": "A vector layer. If not set, the layer attached to the expression context will be used.",
     "optional": true
   },{
     "arg": "strength",
-    "description": "set to 'hard' or 'soft' to narrow down to a specific constraint type; if not set, the function will return FALSE if either a hard or a soft constraint fails",
+    "description": "Set to 'hard' or 'soft' to narrow down to a specific constraint type. If not set, the function will return FALSE if either a hard or a soft constraint fails.",
     "optional": true
   }],
   "examples": [{
     "expression": "is_attribute_valid('HECTARES')",
     "returns": "TRUE"
   }, {
-    "expression": "is_attribute_valid('HOUSES',get_feature('my_layer','FID',10), 'my_layer')",
+    "expression": "is_attribute_valid('HOUSES',get_feature('my_layer', 'FID', 10), 'my_layer')",
     "returns": "FALSE"
   }],
   "tags": ["constraints", "hard", "soft"]

--- a/resources/function_help/json/is_feature_valid
+++ b/resources/function_help/json/is_feature_valid
@@ -1,0 +1,27 @@
+{
+  "name": "is_feature_valid",
+  "type": "function",
+  "groups": ["Record and Attributes"],
+  "description": "Returns TRUE if a feature meets all fields constraints.",
+  "arguments": [{
+    "arg": "feature",
+    "description": "a feature; if not set, the feature attached to the expression context will be used",
+    "optional": true
+  },{
+    "arg": "layer",
+    "description": "a vector layer; if not set, the layer attached to the expression context will be used",
+    "optional": true
+  },{
+    "arg": "strength",
+    "description": "set to 'hard' or 'soft' to narrow down to a specific constraint type; if not set, the function will return FALSE if either a hard or a soft constraint fails",
+    "optional": true
+  }],
+  "examples": [{
+    "expression": "is_feature_valid(strength:='hard')",
+    "returns": "TRUE"
+  }, {
+    "expression": "is_feature_valid(get_feature('my_layer','FID',10), 'my_layer')",
+    "returns": "FALSE"
+  }],
+  "tags": ["constraints", "hard", "soft"]
+}

--- a/resources/function_help/json/is_feature_valid
+++ b/resources/function_help/json/is_feature_valid
@@ -2,25 +2,25 @@
   "name": "is_feature_valid",
   "type": "function",
   "groups": ["Record and Attributes"],
-  "description": "Returns TRUE if a feature meets all fields constraints.",
+  "description": "Returns TRUE if a feature meets all field constraints.",
   "arguments": [{
     "arg": "feature",
-    "description": "a feature; if not set, the feature attached to the expression context will be used",
+    "description": "A feature. If not set, the feature attached to the expression context will be used.",
     "optional": true
   },{
     "arg": "layer",
-    "description": "a vector layer; if not set, the layer attached to the expression context will be used",
+    "description": "A vector layer. If not set, the layer attached to the expression context will be used.",
     "optional": true
   },{
     "arg": "strength",
-    "description": "set to 'hard' or 'soft' to narrow down to a specific constraint type; if not set, the function will return FALSE if either a hard or a soft constraint fails",
+    "description": "Set to 'hard' or 'soft' to narrow down to a specific constraint type. If not set, the function will return FALSE if either a hard or a soft constraint fails.",
     "optional": true
   }],
   "examples": [{
     "expression": "is_feature_valid(strength:='hard')",
     "returns": "TRUE"
   }, {
-    "expression": "is_feature_valid(get_feature('my_layer','FID',10), 'my_layer')",
+    "expression": "is_feature_valid(get_feature('my_layer', 'FID', 10), 'my_layer')",
     "returns": "FALSE"
   }],
   "tags": ["constraints", "hard", "soft"]


### PR DESCRIPTION
## Description

This PR implements a new pair of expression functions: `is_feature_valid()` and `is_attribute_valid()`. Both functions validate a feature / attribute based on constraints attached to fields for a given vector layer.

![image](https://user-images.githubusercontent.com/1728657/209663035-3581518a-0c07-43c1-9adf-55c1b3cbe659.png)

By bringing constraints validity into expressions, users can now use the select by expression to locate features that have unmet constraints. In addition, users can now use the rule-based renderer to provide visual feedback through symbology indicating the constraint validity state of rendered features:

![image](https://user-images.githubusercontent.com/1728657/209663356-f66e823e-9ec0-492a-b29c-6b762b009862.png)

