### PR TITLE
Support current_value in HTML widget

### DIFF
--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
@@ -17,6 +17,7 @@
 #include "qgshtmlwidgetwrapper.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgswebframe.h"
+#include "qgsvaluerelationfieldformatter.h"
 #include "qgsattributeform.h"
 #include <QScreen>
 
@@ -43,8 +44,13 @@ QWidget *QgsHtmlWidgetWrapper::createWidget( QWidget *parent )
     {
       if ( attributeChanged )
       {
-        mFormFeature.setAttribute( attribute, newValue );
-        setHtmlContext();
+        const QRegularExpression expRe { QStringLiteral( R"re(expression.evaluate\s*\(\s*"(.*)"\))re" ), QRegularExpression::PatternOption::MultilineOption | QRegularExpression::PatternOption::DotMatchesEverythingOption };
+        const QRegularExpressionMatch match { expRe.match( mHtmlCode ) };
+        if ( match.hasMatch() && QgsValueRelationFieldFormatter::expressionRequiresFormScope( match.captured( 1 ) ) )
+        {
+          mFormFeature.setAttribute( attribute, newValue );
+          setHtmlContext();
+        }
       }
     } );
   }

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
@@ -78,6 +78,7 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
     QgsWebView *mWidget = nullptr;
     QgsFeature mFeature;
     bool mNeedsGeometry = false;
+    QgsFeature mFormFeature;
 
     friend class TestQgsHtmlWidgetWrapper;
 };

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1418,6 +1418,7 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
       } );
 
       QgsFieldExpressionWidget *expressionWidget = new QgsFieldExpressionWidget;
+      expressionWidget->registerExpressionContextGenerator( this );
       expressionWidget->setLayer( mLayer );
       QToolButton *addExpressionButton = new QToolButton();
       addExpressionButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
@@ -1464,6 +1465,19 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
     }
     break;
   }
+}
+
+QgsExpressionContext QgsAttributesDnDTree::createExpressionContext() const
+{
+  QgsExpressionContext expContext;
+  expContext << QgsExpressionContextUtils::globalScope()
+             << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+
+  if ( mLayer )
+    expContext << QgsExpressionContextUtils::layerScope( mLayer );
+
+  expContext.appendScope( QgsExpressionContextUtils::formScope( ) );
+  return expContext;
 }
 
 QgsAttributesDnDTree::Type QgsAttributesDnDTree::type() const

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -342,7 +342,7 @@ QDataStream &operator>> ( QDataStream &stream, QgsAttributesFormProperties::DnDT
  *
  * Graphical representation for the attribute editor drag and drop editor
  */
-class GUI_EXPORT QgsAttributesDnDTree : public QTreeWidget
+class GUI_EXPORT QgsAttributesDnDTree : public QTreeWidget, private QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -391,6 +391,10 @@ class GUI_EXPORT QgsAttributesDnDTree : public QTreeWidget
   private:
     QgsVectorLayer *mLayer = nullptr;
     Type mType = QgsAttributesDnDTree::Type::Drag;
+
+    // QgsExpressionContextGenerator interface
+  public:
+    QgsExpressionContext createExpressionContext() const override;
 };
 
 

--- a/tests/src/gui/testqgshtmlwidgetwrapper.cpp
+++ b/tests/src/gui/testqgshtmlwidgetwrapper.cpp
@@ -74,6 +74,7 @@ void TestQgsHtmlWidgetWrapper::testExpressionEvaluate_data()
   QTest::newRow( "with-geometry" ) << "geom_to_wkt($geometry)" << true << "The text is 'Point (0.5 0.5)'";
   QTest::newRow( "without-geometry" ) << "2+pk" << false << "The text is '3'";
   QTest::newRow( "aggregate newline" ) << "concat('a', \n'b')" << false << "The text is 'ab'";
+  QTest::newRow( "form value" ) << "current_value('pk') + 2" << false << "The text is '3'";
 }
 
 void TestQgsHtmlWidgetWrapper::testExpressionEvaluate()


### PR DESCRIPTION
HTML widget supports `current_value(  '<field_name>' )`  , dynamic update when the form field value changes.

![html_get_current_value](https://user-images.githubusercontent.com/142164/209808148-958e3016-448a-4b94-b8f7-f29f6d677068.gif)
