### PR TITLE
Synchronization stateChanged GNSS information in GxRMC/GxGGA NMEA messages.

### DIFF
--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -170,7 +170,7 @@ void QgsAppGpsConnection::disconnectGps()
     emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
 
     QgisApp::instance()->statusBarIface()->clearMessage();
-    showStatusBarMessage( tr( "Disconnected from GPS device." ) );
+    showMessage( Qgis::MessageLevel::Success, tr( "Disconnected from GPS device." ) );
 
     QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
   }
@@ -178,11 +178,18 @@ void QgsAppGpsConnection::disconnectGps()
 
 void QgsAppGpsConnection::onTimeOut()
 {
-  disconnectGps();
+  std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );  emit disconnected();
+  mConnection = nullptr;
+
+  emit disconnected();
+  emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
+  emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
   emit connectionTimedOut();
 
   QgisApp::instance()->statusBarIface()->clearMessage();
   showGpsConnectFailureWarning( tr( "TIMEOUT - Failed to connect to GPS device." ) );
+
+  QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
 }
 
 void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -18,7 +18,6 @@
 #include "qgsgpsconnection.h"
 #include <QIODevice>
 
-
 QgsGpsConnection::QgsGpsConnection( QIODevice *dev )
   : QObject( nullptr )
   , mSource( dev )
@@ -96,8 +95,11 @@ void QgsGpsConnection::onStateChanged( const QgsGpsInformation &info )
   if ( info.isValid() )
   {
     const QgsPoint oldPosition = mLastLocation;
+    const QDateTime oldDateTime = mLastDateTime;
+    mLastDateTime = info.utcDateTime;
     mLastLocation = QgsPoint( info.longitude, info.latitude, info.elevation );
-    if ( mLastLocation != oldPosition )
+    // if ( mLastLocation != oldPosition )
+    if ( mLastDateTime != oldDateTime )
     {
       emit positionChanged( mLastLocation );
     }

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -195,6 +195,9 @@ class CORE_EXPORT QgsGpsConnection : public QObject
 
     //! Last recorded valid location
     QgsPoint mLastLocation;
+
+   //! Last recorded valid utcDateTime
+    QDateTime mLastDateTime;
 };
 
 #endif // QGSGPSCONNECTION_H

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -196,7 +196,7 @@ class CORE_EXPORT QgsGpsConnection : public QObject
     //! Last recorded valid location
     QgsPoint mLastLocation;
 
-   //! Last recorded valid utcDateTime
+    //! Last recorded valid utcDateTime
     QDateTime mLastDateTime;
 };
 

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -196,7 +196,7 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
     // Check if already processed by RMC
     if ( mLastGPSInformation.longitude != nmea_ndeg2degree( longitude ) || mLastGPSInformation.latitude != nmea_ndeg2degree( latitude ) )
     {
-      if ( mLastGPSInformation.status == 'A' || mLastGPSInformation.status == 'V'  )
+      if ( mLastGPSInformation.status == 'A' || mLastGPSInformation.status == 'V' )
       {
         emit stateChanged( mLastGPSInformation );
       }
@@ -288,7 +288,7 @@ void QgsNmeaConnection::processRmcSentence( const char *data, int len )
     //  Check if already processed by GGA
     if ( mLastGPSInformation.longitude != nmea_ndeg2degree( longitude ) || mLastGPSInformation.latitude != nmea_ndeg2degree( latitude ) )
     {
-      if ( mLastGPSInformation.status == 'A' || mLastGPSInformation.status == 'V'  )
+      if ( mLastGPSInformation.status == 'A' || mLastGPSInformation.status == 'V' )
       {
         emit stateChanged( mLastGPSInformation );
       }

--- a/tests/src/python/test_qgsgpslogger.py
+++ b/tests/src/python/test_qgsgpslogger.py
@@ -117,6 +117,7 @@ class TestQgsGpsLogger(unittest.TestCase):
         spy = QSignalSpy(logger.stateChanged)
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
         self.assertEqual(len(spy), 1)
 
         # not enough vertices for these types yet:
@@ -138,7 +139,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         self.assertEqual(res.asWkt(4), 'PointZ (18.9475 69.6442 0)')
 
         # make elevation available
-        gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
+        # gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01856.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
+        gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01866.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
         res, err = logger.currentGeometry(QgsWkbTypes.PointZ)
         self.assertFalse(err)
         self.assertEqual(res.asWkt(4), 'PointZ (18.9475 69.6609 35)')
@@ -162,7 +164,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         res, err = logger.currentGeometry(QgsWkbTypes.PolygonZ)
         self.assertTrue(err)
 
-        gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01866.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
+        # gps_connection.send_message("$GPGGA,084112.185,6939.6532,N,01866.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
+        gps_connection.send_message("$GPGGA,084113.185,6940.6532,N,01866.8526,E,1,04,1.4,35.0,M,29.4,M,,0000*63")
 
         res, err = logger.currentGeometry(QgsWkbTypes.PointZ)
         self.assertFalse(err)
@@ -211,6 +214,7 @@ class TestQgsGpsLogger(unittest.TestCase):
         points_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 1)
 
         self.assertEqual(points_layer.featureCount(), 1)
@@ -220,8 +224,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         self.assertEqual(f.attributes(), [exp, None, None])
         self.assertEqual(f.geometry().asWkt(-3), 'PointZ (-1297000 21436000 0)')
 
-        gps_connection.send_message(
-            '$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 2)
 
         self.assertEqual(points_layer.featureCount(), 2)
@@ -236,8 +240,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         self.assertEqual(f.attributes(), [exp, 0.004368333651276768, 2.0])
         self.assertEqual(f.geometry().asWkt(-3), 'PointZ (-1297000 21435000 0)')
 
-        gps_connection.send_message(
-            '$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084118.185,A,6939.1152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 3)
 
         self.assertEqual(points_layer.featureCount(), 3)
@@ -259,8 +263,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         # stop recording distance
         logger.setDestinationField(Qgis.GpsInformationComponent.TrackDistanceSinceLastPoint, None)
 
-        gps_connection.send_message(
-            '$GPRMC,084118.185,A,6939.1152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084118.185,A,6939.1152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084119.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 4)
 
         self.assertEqual(points_layer.featureCount(), 4)
@@ -286,8 +290,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         # stop recording time since previous
         logger.setDestinationField(Qgis.GpsInformationComponent.TrackTimeSinceLastPoint, None)
 
-        gps_connection.send_message(
-            '$GPRMC,084119.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084119.185,A,6939.3152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084120.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 5)
 
         self.assertEqual(points_layer.featureCount(), 5)
@@ -317,8 +321,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         # stop recording timestamp
         logger.setDestinationField(Qgis.GpsInformationComponent.Timestamp, None)
 
-        gps_connection.send_message(
-            '$GPRMC,084120.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084120.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084129.185,A,6940.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 6)
 
         self.assertEqual(points_layer.featureCount(), 6)
@@ -355,8 +359,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         logger.setWriteToEditBuffer(False)
         self.assertFalse(logger.writeToEditBuffer())
 
-        gps_connection.send_message(
-            '$GPRMC,084129.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084129.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084130.185,A,6941.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(points_layer.dataProvider().featureCount(), 1)
 
     def test_point_recording_no_z(self):
@@ -379,6 +383,7 @@ class TestQgsGpsLogger(unittest.TestCase):
         points_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084112.185,A,6939.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
         self.assertEqual(len(spy), 1)
 
         self.assertEqual(points_layer.featureCount(), 1)
@@ -407,6 +412,7 @@ class TestQgsGpsLogger(unittest.TestCase):
         points_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 1)
 
         self.assertEqual(logger.lastMValue(), 1579682471185.0)
@@ -417,8 +423,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         exp.setOffsetFromUtc(3000)
         self.assertEqual(f.geometry().asWkt(-3), 'PointM (-1297000 21436000 1579682471000)')
 
-        gps_connection.send_message(
-            '$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,Z2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 2)
         self.assertEqual(logger.lastMValue(), 1579682473185.)
 
@@ -428,8 +434,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         f = next(features)
         self.assertEqual(f.geometry().asWkt(-3), 'PointM (-1297000 21435000 1579682473000)')
 
-        gps_connection.send_message(
-            '$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,Z2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084117.185,A,6939.3152,N,01856.8526,E,0.05,Z2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084118.185,A,6940.3152,N,01856.8526,E,0.05,Z2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 3)
         self.assertEqual(logger.lastMValue(), 1579682477185.0)
 
@@ -461,6 +467,7 @@ class TestQgsGpsLogger(unittest.TestCase):
         points_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message("$GPGGA,084112.185,6938.9152,N,01856.8526,E,1,04,1.4,3335.0,M,29.4,M,,0000*63")
         self.assertEqual(len(spy), 1)
         self.assertEqual(logger.lastMValue(), 0)
 
@@ -470,7 +477,8 @@ class TestQgsGpsLogger(unittest.TestCase):
         exp.setOffsetFromUtc(3000)
         self.assertEqual(f.geometry().asWkt(-3), 'PointZM (-1297000 21436000 0 0)')
 
-        gps_connection.send_message("$GPGGA,084112.185,6938.9152,N,01856.8526,E,1,04,1.4,3335.0,M,29.4,M,,0000*63")
+        # gps_connection.send_message("$GPGGA,084112.185,6938.9152,N,01856.8526,E,1,04,1.4,3335.0,M,29.4,M,,0000*63")
+        gps_connection.send_message("$GPGGA,084113.185,6939.9152,N,01856.8526,E,1,04,1.4,3335.0,M,29.4,M,,0000*63")
         self.assertEqual(len(spy), 2)
         self.assertEqual(logger.lastMValue(), 3335.0)
 
@@ -501,17 +509,18 @@ class TestQgsGpsLogger(unittest.TestCase):
         line_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 1)
 
         # should be no features until track is ended
         self.assertEqual(line_layer.featureCount(), 0)
 
-        gps_connection.send_message(
-            '$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 2)
 
-        gps_connection.send_message(
-            '$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084129.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 3)
 
         self.assertEqual(line_layer.featureCount(), 0)
@@ -537,10 +546,10 @@ class TestQgsGpsLogger(unittest.TestCase):
         logger.setWriteToEditBuffer(False)
         self.assertFalse(logger.writeToEditBuffer())
 
-        gps_connection.send_message(
-            '$GPRMC,084129.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
-        gps_connection.send_message(
-            '$GPRMC,084129.185,A,6939.4152,N,01956.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084129.185,A,6939.4152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084129.185,A,6939.4152,N,01956.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084129.185,A,6939.4152,N,01956.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084130.185,A,6940.4152,N,01956.8526,E,0.05,2.00,220120,,,A*6C')
         logger.endCurrentTrack()
         self.assertEqual(line_layer.dataProvider().featureCount(), 1)
 
@@ -563,17 +572,18 @@ class TestQgsGpsLogger(unittest.TestCase):
         line_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 1)
 
         # should be no features until track is ended
         self.assertEqual(line_layer.featureCount(), 0)
 
-        gps_connection.send_message(
-            '$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 2)
 
-        gps_connection.send_message(
-            '$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084119.185,A,6939.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 3)
 
         self.assertEqual(line_layer.featureCount(), 0)
@@ -612,17 +622,18 @@ class TestQgsGpsLogger(unittest.TestCase):
         line_layer.startEditing()
 
         gps_connection.send_message('$GPRMC,084111.185,A,6938.6531,N,01856.8527,E,0.16,2.00,220120,,,A*6E')
+        gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 1)
 
         # should be no features until track is ended
         self.assertEqual(line_layer.featureCount(), 0)
 
-        gps_connection.send_message(
-            '$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084113.185,A,6938.9152,N,01856.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 2)
 
-        gps_connection.send_message(
-            '$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        # gps_connection.send_message('$GPRMC,084118.185,A,6938.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
+        gps_connection.send_message('$GPRMC,084119.185,A,6939.9152,N,01857.8526,E,0.05,2.00,220120,,,A*6C')
         self.assertEqual(len(spy), 3)
 
         self.assertEqual(line_layer.featureCount(), 0)


### PR DESCRIPTION
Synchronization stateChanged GNSS information in GxRMC/GxGGA NMEA messages.

The number of "emit stateChanged" is decreased.
With this PR the GNSS tracking calculation processes and GNSS information are synchronized on UTCDATETIME obtained from the NMEA RMC message.
The various manufacturers of GNSS receivers build the NMEA sequence differently: specifically, the GxRMC message can be before or after the related GxGGA message.
"emit stateChanged" will be triggered:
- from `processRmcSentence` if GxRMC is before GxGGA;
- or by `processGgaSentence` if GxGGA is before GxRMC;
in the NMEA sequence that has just been completely processed.

Test with GNSS receiver set at 1Hz - 2Hz - 5Hz:
- connection to the device fast, no problem;
- logout OK;
- I no longer had the TIMEOUT problem when connecting my GNSS receiver (u-blox ZED-F9P - ardusimpleRTK2BLite);
- bearing calculation OK;
- track line OK;
- screen refresh OK.

With LOG GeoPackage GNSS receiver at 1Hz - 2Hz:
- in the LOG file I no longer found the presence of double / triple points for the same GNSS position. At 2Hz data recording is not smooth and continuous, there are pauses in screen refresh (cache, memory access, disk writing, ???) .

With LOG GeoPackage with 5Hz GNSS receiver:
- the system seems frozen, no screen refresh at GNSS positions (memory access, disk write, ???);
- some screen refreshes (very delayed);
- the disconnection from the receiver occurs after a long time (30sec to more than 1min);
- in the LOG I should find 5 recordings per second, but in some cases I find 4, there are jumps in the recording. There is no data when the GNSS receiver disconnected.

You will need to investigate the process of writing the GeoPackage LOG file!

The "Automatically Add Track Vertex" function needs to be improved:
- when using "Create Feature fron Track" there will be a hole in the next track for the time the editing fields form is active.
Thank you