### PR TITLE
Fix name and widgets order of Group Properties in Layer styling panel

### DIFF
--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -131,7 +131,7 @@ QgsLayerTreeGroupPropertiesWidgetFactory::QgsLayerTreeGroupPropertiesWidgetFacto
   : QObject( parent )
 {
   setIcon( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ) );
-  setTitle( tr( "Group" ) );
+  setTitle( tr( "Symbology" ) );
 }
 
 QgsMapLayerConfigWidget *QgsLayerTreeGroupPropertiesWidgetFactory::createWidget( QgsMapLayer *, QgsMapCanvas *canvas, bool, QWidget *parent ) const

--- a/src/ui/qgslayertreegrouppropertieswidgetbase.ui
+++ b/src/ui/qgslayertreegrouppropertieswidgetbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Annotation Item Properties</string>
+   <string>Group Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
@@ -116,6 +116,12 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+  <tabstops>
+  <tabstop>mRenderAsGroupCheckBox</tabstop>
+  <tabstop>mOpacityWidget</tabstop>
+  <tabstop>mBlendModeComboBox</tabstop>
+  <tabstop>mEffectWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
And rename group symbology tab