### PR TITLE
[gps] Catch NMEA UTC times for date-less streams

### DIFF
--- a/python/core/auto_generated/gps/qgsgpsinformation.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsinformation.sip.in
@@ -50,6 +50,8 @@ Encapsulates information relating to a GPS position fix.
 
     double hvacc;
 
+    QTime utcTime;
+
     QDateTime utcDateTime;
 
     QChar fixMode;

--- a/src/core/gps/qgsgpsinformation.h
+++ b/src/core/gps/qgsgpsinformation.h
@@ -130,6 +130,12 @@ class CORE_EXPORT QgsGpsInformation
 #endif
 
     /**
+     * The time at hich this position was reported, in UTC time.
+     * \since QGIS 3.30
+     */
+    QTime utcTime;
+
+    /**
      * The date and time at which this position was reported, in UTC time.
      */
     QDateTime utcDateTime;

--- a/src/core/gps/qgsgpsinformation.h
+++ b/src/core/gps/qgsgpsinformation.h
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsGpsInformation
 #endif
 
     /**
-     * The time at hich this position was reported, in UTC time.
+     * The time at which this position was reported, in UTC time.
      * \since QGIS 3.30
      */
     QTime utcTime;

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -199,6 +199,19 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
     mLastGPSInformation.elevation = result.elv;
     mLastGPSInformation.elevation_diff = result.diff;
 
+    const QTime time( result.utc.hour, result.utc.min, result.utc.sec, result.utc.msec );
+    if ( time.isValid() )
+    {
+      mLastGPSInformation.utcTime = time;
+      if ( mLastGPSInformation.utcDateTime.isValid() )
+      {
+        mLastGPSInformation.utcDateTime.setTimeSpec( Qt::UTC );
+        mLastGPSInformation.utcDateTime.setTime( time );
+      }
+      QgsDebugMsgLevel( QStringLiteral( "utc time:" ), 2 );
+      QgsDebugMsgLevel( mLastGPSInformation.utcTime.toString(), 2 );
+    }
+
     mLastGPSInformation.quality = result.sig;
     if ( result.sig >= 0 && result.sig <= 8 )
     {
@@ -285,17 +298,17 @@ void QgsNmeaConnection::processRmcSentence( const char *data, int len )
       mLastGPSInformation.direction = result.direction;
     mLastGPSInformation.status = result.status;  // A,V
 
-    //date and time
     const QDate date( result.utc.year + 1900, result.utc.mon + 1, result.utc.day );
-    const QTime time( result.utc.hour, result.utc.min, result.utc.sec, result.utc.msec ); // added msec part
+    const QTime time( result.utc.hour, result.utc.min, result.utc.sec, result.utc.msec );
     if ( date.isValid() && time.isValid() )
     {
+      mLastGPSInformation.utcTime = time;
       mLastGPSInformation.utcDateTime.setTimeSpec( Qt::UTC );
       mLastGPSInformation.utcDateTime.setDate( date );
       mLastGPSInformation.utcDateTime.setTime( time );
-      QgsDebugMsgLevel( QStringLiteral( "utc time:" ), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "utc date/time:" ), 2 );
       QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toString(), 2 );
-      QgsDebugMsgLevel( QStringLiteral( "local time:" ), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "local date/time:" ), 2 );
       QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toLocalTime().toString(), 2 );
     }
 

--- a/src/core/gps/qgsqtlocationconnection.cpp
+++ b/src/core/gps/qgsqtlocationconnection.cpp
@@ -69,6 +69,7 @@ void QgsQtLocationConnection::parseData()
       mLastGPSInformation.speed = mInfo.attribute( QGeoPositionInfo::GroundSpeed ) * 3.6; // m/s to km/h
       mLastGPSInformation.direction = mInfo.attribute( QGeoPositionInfo::Direction );
       mLastGPSInformation.utcDateTime = mInfo.timestamp();
+      mLastGPSInformation.utcTime = mInfo.timestamp().time();
       mLastGPSInformation.fixType = mInfo.coordinate().type() + 1;
       switch ( mInfo.coordinate().type() )
       {


### PR DESCRIPTION
## Description

Problem: if a consumer of QgsNmeaConnection wants to regroup state changes by timestamp for NMEA streams that exclude the optional GPRMC sentence, the resulting QgsGpsInformation stays in a perpetual state of utcDateTime invalidity. It comes from the fact that the GPGGA sentence only provides a time as timestamp (which in turn is the ID that binds all NMEA sentences into "one" reading).

Also, while a GPGGA sentence can be served every 1sec, the GPRMC isn't guaranteed to come alongside GPGGA all the time (e.g., it could be served once every 10sec).

This PR adds a utcTime property to QgsGspInformation to keep track of NMEA readings without GPRMC sentences, and also covers scenarios where a GPRMC sentence is served once every few readings by updating the utcDateTime time component using the time value from GPGGA.