### PR TITLE
Correctly  expose optional argument in represent_value function

### DIFF
--- a/resources/function_help/json/represent_value
+++ b/resources/function_help/json/represent_value
@@ -8,7 +8,8 @@
     "description": "The value which should be resolved. Most likely a field."
   }, {
     "arg": "fieldName",
-    "description": "The field name for which the widget configuration should be loaded. (Optional)"
+    "description": "The field name for which the widget configuration should be loaded."
+    "optional": true
   }],
   "examples": [{
     "expression": "represent_value(\"field_with_value_map\")",

--- a/resources/function_help/json/represent_value
+++ b/resources/function_help/json/represent_value
@@ -8,7 +8,7 @@
     "description": "The value which should be resolved. Most likely a field."
   }, {
     "arg": "fieldName",
-    "description": "The field name for which the widget configuration should be loaded."
+    "description": "The field name for which the widget configuration should be loaded.",
     "optional": true
   }],
   "examples": [{


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
