### PR TITLE
Fix: #49145 (Distance to nearest hub - No destination hubs)

### DIFF
--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -27,6 +27,7 @@ from qgis.core import (QgsField,
                        QgsDistanceArea,
                        QgsFeature,
                        QgsFeatureSink,
+                       QgsFeatureSource,
                        QgsFeatureRequest,
                        QgsWkbTypes,
                        QgsUnitTypes,
@@ -103,7 +104,7 @@ class HubDistanceLines(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
-        if hub_source.featureCount() <= 0:
+        if hub_source.hasFeatures() == QgsFeatureSource.FeatureAvailability.NoFeaturesAvailable:
             raise QgsProcessingException(
                 self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
             )

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -103,6 +103,10 @@ class HubDistanceLines(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
+        if hub_source.featureCount() <= 0:
+            raise QgsProcessingException(
+                self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
+            )
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -27,7 +27,6 @@ from qgis.core import (QgsField,
                        QgsDistanceArea,
                        QgsFeature,
                        QgsFeatureSink,
-                       QgsFeatureSource,
                        QgsFeatureRequest,
                        QgsWkbTypes,
                        QgsUnitTypes,
@@ -104,10 +103,6 @@ class HubDistanceLines(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
-        if hub_source.hasFeatures() == QgsFeatureSource.FeatureAvailability.NoFeaturesAvailable:
-            raise QgsProcessingException(
-                self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
-            )
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 
@@ -141,6 +136,9 @@ class HubDistanceLines(QgisAlgorithm):
             src = f.geometry().boundingBox().center()
 
             neighbors = index.nearestNeighbor(src, 1)
+            if len(neighbors) == 0:
+                continue
+
             ft = next(hub_source.getFeatures(QgsFeatureRequest().setFilterFid(neighbors[0]).setSubsetOfAttributes([fieldName], hub_source.fields()).setDestinationCrs(point_source.sourceCrs(), context.transformContext())))
             closest = ft.geometry().boundingBox().center()
             hubDist = distance.measureLine(src, closest)

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -100,6 +100,10 @@ class HubDistancePoints(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
+        if hub_source.featureCount() <= 0:
+            raise QgsProcessingException(
+                self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
+            )
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -28,6 +28,7 @@ from qgis.core import (QgsField,
                        QgsDistanceArea,
                        QgsFeature,
                        QgsFeatureRequest,
+                       QgsFeatureSource,
                        QgsSpatialIndex,
                        QgsWkbTypes,
                        QgsUnitTypes,
@@ -100,7 +101,7 @@ class HubDistancePoints(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
-        if hub_source.featureCount() <= 0:
+        if hub_source.hasFeatures() == QgsFeatureSource.FeatureAvailability.NoFeaturesAvailable:
             raise QgsProcessingException(
                 self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
             )

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -28,7 +28,6 @@ from qgis.core import (QgsField,
                        QgsDistanceArea,
                        QgsFeature,
                        QgsFeatureRequest,
-                       QgsFeatureSource,
                        QgsSpatialIndex,
                        QgsWkbTypes,
                        QgsUnitTypes,
@@ -101,10 +100,6 @@ class HubDistancePoints(QgisAlgorithm):
         hub_source = self.parameterAsSource(parameters, self.HUBS, context)
         if hub_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.HUBS))
-        if hub_source.hasFeatures() == QgsFeatureSource.FeatureAvailability.NoFeaturesAvailable:
-            raise QgsProcessingException(
-                self.tr('Input "destination hubs layer" has no features, at least 1 feature is required')
-            )
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 
@@ -139,6 +134,9 @@ class HubDistancePoints(QgisAlgorithm):
             src = f.geometry().boundingBox().center()
 
             neighbors = index.nearestNeighbor(src, 1)
+            if len(neighbors) == 0:
+                continue
+
             ft = next(hub_source.getFeatures(QgsFeatureRequest().setFilterFid(neighbors[0]).setSubsetOfAttributes([fieldName], hub_source.fields()).setDestinationCrs(point_source.sourceCrs(), context.transformContext())))
             closest = ft.geometry().boundingBox().center()
             hubDist = distance.measureLine(src, closest)


### PR DESCRIPTION
## Description

When running the algorithms `Distance to nearest hub (points)` or `Distance to nearest hub (line to hub)` with the parameter `Destination hubs layer` being an layer without any features the algorithm crashes with the following message
```
Traceback (most recent call last):
File "my/path/QGIS32~1.2/apps/qgis/./python/plugins\processing\algs\qgis\HubDistanceLines.py", line 139, in processAlgorithm
ft = next(hub_source.getFeatures(QgsFeatureRequest().setFilterFid(neighbors[0]).setSubsetOfAttributes([fieldName], hub_source.fields()).setDestinationCrs(point_source.sourceCrs(), context.transformContext())))
IndexError: list index out of range
```

This PR fixes this by raising an exception with an informative error message instead.

Fixes #49145