### PR TITLE
Follow up 7e2e622 : improve functions help

### DIFF
--- a/resources/function_help/json/is_attribute_valid
+++ b/resources/function_help/json/is_attribute_valid
@@ -8,11 +8,11 @@
     "description": "an attribute name"
   },{
     "arg": "feature",
-    "description": "A feature. If not set, the feature attached to the expression context will be used.",
+    "description": "A feature. If not set, the current feature will be used.",
     "optional": true
   },{
     "arg": "layer",
-    "description": "A vector layer. If not set, the layer attached to the expression context will be used.",
+    "description": "A vector layer. If not set, the current layer will be used.",
     "optional": true
   },{
     "arg": "strength",
@@ -21,10 +21,10 @@
   }],
   "examples": [{
     "expression": "is_attribute_valid('HECTARES')",
-    "returns": "TRUE"
+    "returns": "TRUE if the current feature's value in the \"HECTARES\" field meets all constraints."
   }, {
     "expression": "is_attribute_valid('HOUSES',get_feature('my_layer', 'FID', 10), 'my_layer')",
-    "returns": "FALSE"
+    "returns": "FALSE if the value in the \"HOUSES\" field from the feature with \"FID\"=10 in 'my_layer' fails to meet all constraints."
   }],
   "tags": ["constraints", "hard", "soft"]
 }

--- a/resources/function_help/json/is_feature_valid
+++ b/resources/function_help/json/is_feature_valid
@@ -5,11 +5,11 @@
   "description": "Returns TRUE if a feature meets all field constraints.",
   "arguments": [{
     "arg": "feature",
-    "description": "A feature. If not set, the feature attached to the expression context will be used.",
+    "description": "A feature. If not set, the current feature will be used.",
     "optional": true
   },{
     "arg": "layer",
-    "description": "A vector layer. If not set, the layer attached to the expression context will be used.",
+    "description": "A vector layer. If not set, the current layer will be used.",
     "optional": true
   },{
     "arg": "strength",
@@ -18,10 +18,10 @@
   }],
   "examples": [{
     "expression": "is_feature_valid(strength:='hard')",
-    "returns": "TRUE"
+    "returns": "TRUE if all fields from the current feature meet their hard constraints."
   }, {
     "expression": "is_feature_valid(get_feature('my_layer', 'FID', 10), 'my_layer')",
-    "returns": "FALSE"
+    "returns": "FALSE if all fields from feature with \"FID\"=10 in 'my_layer' fails to meet all constraints."
   }],
   "tags": ["constraints", "hard", "soft"]
 }


### PR DESCRIPTION
## Description

@DelazJ , thanks for the function help suggestions, this takes care of the points you raised.

As for the parameter ordering, the parameters come with the logic of scoping out of the current context one step at a time:
- is_feature_valid() -> current feature used against current layer
- is_feature_valid(@other_feature) -> @other_feature used against current layer
- is_feature_valid(@other_feature, @other_layer) -> @other_feature used against @other_layer

As for display_expression et cie, they are using parameter count to define order, which comes at the cost of _not_ supporting named parameters:
![image](https://user-images.githubusercontent.com/1728657/210292268-d6a7b674-12ae-4487-93c3-d2bdc11778d9.png)

I'd rather not do that. If you ask me, we should consider updating those expression to rely on named parameters, and therefore switch the ordering. If people feel like stating the layer first, they could use display_expression(layer:='my_layer',feature:=@my_feature). 

TODO 4.0.