### PR TITLE
GPS - onTimeOut - disconnectGps -error - Update qgsappgpsconnection.cpp

### DIFF
--- a/src/app/gps/qgsappgpsconnection.cpp
+++ b/src/app/gps/qgsappgpsconnection.cpp
@@ -178,11 +178,18 @@ void QgsAppGpsConnection::disconnectGps()
 
 void QgsAppGpsConnection::onTimeOut()
 {
-  disconnectGps();
+  std::unique_ptr< QgsGpsConnection > oldConnection( mConnection );  emit disconnected();
+  mConnection = nullptr;
+
+  emit disconnected();
+  emit statusChanged( Qgis::GpsConnectionStatus::Disconnected );
+  emit fixStatusChanged( Qgis::GpsFixStatus::NoData );
   emit connectionTimedOut();
 
   QgisApp::instance()->statusBarIface()->clearMessage();
   showGpsConnectFailureWarning( tr( "TIMEOUT - Failed to connect to GPS device." ) );
+
+  QgsApplication::gpsConnectionRegistry()->unregisterConnection( oldConnection.get() );
 }
 
 void QgsAppGpsConnection::onConnected( QgsGpsConnection *conn )


### PR DESCRIPTION
If GNSS receiver connected to COM port (Bluetooth) is turned off and the connection is made, the procedure QgsAppGpsConnection::onTimeOut does not execute QgsAppGpsConnection::disconnectGps.
Qgis remains blocked.