### PR TITLE
[Oracle] Don't treat curve as line

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -781,6 +781,8 @@ QString QgsOracleConn::databaseTypeFilter( const QString &alias, QString geomCol
     case QgsWkbTypes::LineStringZ:
     case QgsWkbTypes::CircularString:
     case QgsWkbTypes::CircularStringZ:
+    case QgsWkbTypes::CompoundCurve:
+    case QgsWkbTypes::CompoundCurveZ:
     case QgsWkbTypes::MultiLineString:
     case QgsWkbTypes::MultiLineString25D:
     case QgsWkbTypes::MultiLineStringZ:
@@ -827,7 +829,7 @@ QgsWkbTypes::Type QgsOracleConn::wkbTypeFromDatabase( int gtype )
       case 1:
         return QgsWkbTypes::Point;
       case 2:
-        return QgsWkbTypes::LineString;
+        return QgsWkbTypes::CompoundCurve;
       case 3:
         return QgsWkbTypes::Polygon;
       case 4:
@@ -836,7 +838,7 @@ QgsWkbTypes::Type QgsOracleConn::wkbTypeFromDatabase( int gtype )
       case 5:
         return QgsWkbTypes::MultiPoint;
       case 6:
-        return QgsWkbTypes::MultiLineString;
+        return QgsWkbTypes::MultiCurve;
       case 7:
         return QgsWkbTypes::MultiPolygon;
       default:
@@ -851,7 +853,7 @@ QgsWkbTypes::Type QgsOracleConn::wkbTypeFromDatabase( int gtype )
       case 1:
         return QgsWkbTypes::Point25D;
       case 2:
-        return QgsWkbTypes::LineString25D;
+        return QgsWkbTypes::CompoundCurveZ;
       case 3:
         return QgsWkbTypes::Polygon25D;
       case 4:
@@ -860,7 +862,7 @@ QgsWkbTypes::Type QgsOracleConn::wkbTypeFromDatabase( int gtype )
       case 5:
         return QgsWkbTypes::MultiPoint25D;
       case 6:
-        return QgsWkbTypes::MultiLineString25D;
+        return QgsWkbTypes::MultiCurveZ;
       case 7:
         return QgsWkbTypes::MultiPolygon25D;
       default:

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -495,24 +495,15 @@ void QgsOracleOwnerItem::addLayer( const QgsOracleLayerProperty &layerProperty )
   QString tip = tr( "%1 as %2 in %3" ).arg( layerProperty.geometryColName, QgsWkbTypes::translatedDisplayString( wkbType ) ).arg( layerProperty.srids.at( 0 ) );
 
   Qgis::BrowserLayerType layerType;
-  switch ( wkbType )
+  switch ( QgsWkbTypes::geometryType( wkbType ) )
   {
-    case QgsWkbTypes::Point:
-    case QgsWkbTypes::Point25D:
-    case QgsWkbTypes::MultiPoint:
-    case QgsWkbTypes::MultiPoint25D:
+    case QgsWkbTypes::PointGeometry:
       layerType = Qgis::BrowserLayerType::Point;
       break;
-    case QgsWkbTypes::LineString:
-    case QgsWkbTypes::LineString25D:
-    case QgsWkbTypes::MultiLineString:
-    case QgsWkbTypes::MultiLineString25D:
+    case QgsWkbTypes::LineGeometry:
       layerType = Qgis::BrowserLayerType::Line;
       break;
-    case QgsWkbTypes::Polygon:
-    case QgsWkbTypes::Polygon25D:
-    case QgsWkbTypes::MultiPolygon:
-    case QgsWkbTypes::MultiPolygon25D:
+    case QgsWkbTypes::PolygonGeometry:
       layerType = Qgis::BrowserLayerType::Polygon;
       break;
     default:

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -219,7 +219,11 @@ class TestPyQgsProviderConnectionBase():
             self.assertIsNotNone(table_property)
             self.assertEqual(table_property.tableName(), self.myNewTable)
             self.assertEqual(table_property.geometryColumnCount(), 1)
-            self.assertEqual(table_property.geometryColumnTypes()[0].wkbType, QgsWkbTypes.LineString)
+
+            # with oracle line and curve have the same type, so it defaults to curve https://docs.oracle.com/database/121/SPATL/sdo_geometry-object-type.htm#SPATL494
+            line_wkb_type = QgsWkbTypes.LineString if self.providerKey != 'oracle' else QgsWkbTypes.CompoundCurve
+
+            self.assertEqual(table_property.geometryColumnTypes()[0].wkbType, line_wkb_type)
             cols = table_property.geometryColumnTypes()
             self.assertEqual(cols[0].crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
             self.assertEqual(table_property.defaultName(), self.myNewTable)
@@ -391,22 +395,22 @@ class TestPyQgsProviderConnectionBase():
             self.assertEqual(len(table.geometryColumnTypes()), 1)
             ct = table.geometryColumnTypes()[0]
             self.assertEqual(ct.crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
-            self.assertEqual(ct.wkbType, QgsWkbTypes.LineString)
+            self.assertEqual(ct.wkbType, line_wkb_type)
             # Add a new (existing type)
-            table.addGeometryColumnType(QgsWkbTypes.LineString, QgsCoordinateReferenceSystem.fromEpsgId(3857))
+            table.addGeometryColumnType(line_wkb_type, QgsCoordinateReferenceSystem.fromEpsgId(3857))
             self.assertEqual(len(table.geometryColumnTypes()), 1)
             ct = table.geometryColumnTypes()[0]
             self.assertEqual(ct.crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
-            self.assertEqual(ct.wkbType, QgsWkbTypes.LineString)
+            self.assertEqual(ct.wkbType, line_wkb_type)
             # Add a new one
-            table.addGeometryColumnType(QgsWkbTypes.LineString, QgsCoordinateReferenceSystem.fromEpsgId(4326))
+            table.addGeometryColumnType(line_wkb_type, QgsCoordinateReferenceSystem.fromEpsgId(4326))
             self.assertEqual(len(table.geometryColumnTypes()), 2)
             ct = table.geometryColumnTypes()[0]
             self.assertEqual(ct.crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
-            self.assertEqual(ct.wkbType, QgsWkbTypes.LineString)
+            self.assertEqual(ct.wkbType, line_wkb_type)
             ct = table.geometryColumnTypes()[1]
             self.assertEqual(ct.crs, QgsCoordinateReferenceSystem.fromEpsgId(4326))
-            self.assertEqual(ct.wkbType, QgsWkbTypes.LineString)
+            self.assertEqual(ct.wkbType, line_wkb_type)
 
             # Check fields
             fields = conn.fields(schema, self.myNewTable)


### PR DESCRIPTION
Oracle makes no difference between curve and line (same for multi) when defining geometry type (see [doc](https://docs.oracle.com/database/121/SPATL/sdo_geometry-object-type.htm#SPATL494)). For now, QGIS treats them as line, so with recent modification upon [digitizing](https://github.com/qgis/QGIS/blob/master/src/gui/qgsmaptooldigitizefeature.cpp#L88) curve ends up being segmentized. 

This PR proposes to report all linear geometry type as CompoundCurve (or multicurve) to cover both possible types.