### PR TITLE
Multilayer selection drop support

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -207,8 +207,8 @@ Constructor for QgsProcessingMultipleInputPanelWidget.
 Sets the project associated with the widget.
 %End
 
-
   protected:
+
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -103,6 +103,8 @@ Adds a new option to the widget.
 Returns pointer to the list view
 %End
 
+
+
 };
 
 
@@ -205,6 +207,8 @@ Constructor for QgsProcessingMultipleInputPanelWidget.
 Sets the project associated with the widget.
 %End
 
+
+  protected: 
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -208,7 +208,7 @@ Sets the project associated with the widget.
 %End
 
 
-  protected: 
+  protected:
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -103,13 +103,13 @@ Adds a new option to the widget.
 Returns pointer to the list view
 %End
 
+
     virtual void dragEnterEvent( QDragEnterEvent *event );
 
 %Docstring
 Value formatter
 %End
     virtual void dropEvent( QDropEvent *event );
-
 
 
 };

--- a/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmultipleselectiondialog.sip.in
@@ -103,6 +103,13 @@ Adds a new option to the widget.
 Returns pointer to the list view
 %End
 
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+%Docstring
+Value formatter
+%End
+    virtual void dropEvent( QDropEvent *event );
+
 
 
 };
@@ -208,6 +215,10 @@ Sets the project associated with the widget.
 %End
 
   protected:
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+    virtual void dropEvent( QDropEvent *event );
+
 
 };
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -232,18 +232,6 @@ void QgsProcessingMultipleSelectionPanelWidget::dragEnterEvent( QDragEnterEvent 
     // dragged an acceptable layer, phew
     event->setDropAction( Qt::CopyAction );
     event->accept();
-    mDragActive = true;
-    update();
-  }
-}
-
-void QgsProcessingMultipleSelectionPanelWidget::dragLeaveEvent( QDragLeaveEvent *event )
-{
-  QWidget::dragLeaveEvent( event );
-  if ( mDragActive )
-  {
-    event->accept();
-    mDragActive = false;
     update();
   }
 }
@@ -267,7 +255,6 @@ void QgsProcessingMultipleSelectionPanelWidget::dropEvent( QDropEvent *event )
     }
     emit selectionChanged();
   }
-  mDragActive = false;
   update();
 }
 
@@ -449,18 +436,6 @@ void QgsProcessingMultipleInputPanelWidget::dragEnterEvent( QDragEnterEvent *eve
     // dragged an acceptable layer, phew
     event->setDropAction( Qt::CopyAction );
     event->accept();
-    mDragActive = true;
-    update();
-  }
-}
-
-void QgsProcessingMultipleInputPanelWidget::dragLeaveEvent( QDragLeaveEvent *event )
-{
-  // QWidget::dragLeaveEvent( event ); // might not be needed
-  if ( mDragActive )
-  {
-    event->accept();
-    mDragActive = false;
     update();
   }
 }
@@ -484,7 +459,6 @@ void QgsProcessingMultipleInputPanelWidget::dropEvent( QDropEvent *event )
     }
     emit selectionChanged();
   }
-  mDragActive = false;
   update();
 }
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -212,11 +212,11 @@ QList< int> QgsProcessingMultipleSelectionPanelWidget::existingMapLayerFromMimeD
         // try to match project layers to current layers
         if ( mModel->item( i )->data( Qt::UserRole ) == layer->id() )
         {
-          indexes.append(i);
+          indexes.append( i );
         }
         else if ( mModel->item( i )->data( Qt::UserRole ) == layer->source() )
         {
-          indexes.append(i);
+          indexes.append( i );
         }
       }
     }
@@ -343,7 +343,7 @@ QgsProcessingMultipleInputPanelWidget::QgsProcessingMultipleInputPanelWidget( co
   QPushButton *addFileButton = new QPushButton( tr( "Add File(s)…" ) );
   connect( addFileButton, &QPushButton::clicked, this, &QgsProcessingMultipleInputPanelWidget::addFiles );
   buttonBox()->addButton( addFileButton, QDialogButtonBox::ActionRole );
-  
+
   QPushButton *addDirButton = new QPushButton( tr( "Add Directory…" ) );
   connect( addDirButton, &QPushButton::clicked, this, &QgsProcessingMultipleInputPanelWidget::addDirectory );
   buttonBox()->addButton( addDirButton, QDialogButtonBox::ActionRole );
@@ -432,11 +432,11 @@ QList< int> QgsProcessingMultipleInputPanelWidget::existingMapLayerFromMimeData(
         // try to match project layers to current layers
         if ( mModel->item( i )->data( Qt::UserRole ) == layer->id() )
         {
-          indexes.append(i);
+          indexes.append( i );
         }
         else if ( mModel->item( i )->data( Qt::UserRole ) == layer->source() )
         {
-          indexes.append(i);
+          indexes.append( i );
         }
       }
     }

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -456,7 +456,7 @@ void QgsProcessingMultipleInputPanelWidget::dragEnterEvent( QDragEnterEvent *eve
 
 void QgsProcessingMultipleInputPanelWidget::dragLeaveEvent( QDragLeaveEvent *event )
 {
-  QWidget::dragLeaveEvent( event );
+  // QWidget::dragLeaveEvent( event ); // might not be needed
   if ( mDragActive )
   {
     event->accept();

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -210,11 +210,8 @@ QList< int> QgsProcessingMultipleSelectionPanelWidget::existingMapLayerFromMimeD
       for ( int i = 0; i < mModel->rowCount(); ++i )
       {
         // try to match project layers to current layers
-        if ( mModel->item( i )->data( Qt::UserRole ) == layer->id() )
-        {
-          indexes.append( i );
-        }
-        else if ( mModel->item( i )->data( Qt::UserRole ) == layer->source() )
+        QString userRole = mModel->item( i )->data( Qt::UserRole ).toString();
+        if ( userRole == layer->id() || userRole == layer->source() )
         {
           indexes.append( i );
         }
@@ -430,11 +427,8 @@ QList< int> QgsProcessingMultipleInputPanelWidget::existingMapLayerFromMimeData(
       for ( int i = 0; i < mModel->rowCount(); ++i )
       {
         // try to match project layers to current layers
-        if ( mModel->item( i )->data( Qt::UserRole ) == layer->id() )
-        {
-          indexes.append( i );
-        }
-        else if ( mModel->item( i )->data( Qt::UserRole ) == layer->source() )
+        QString userRole = mModel->item( i )->data( Qt::UserRole ).toString();
+        if ( userRole == layer->id() || userRole == layer->source() )
         {
           indexes.append( i );
         }

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -226,7 +226,7 @@ void QgsProcessingMultipleSelectionPanelWidget::dragEnterEvent( QDragEnterEvent 
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes = existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dragged an acceptable layer, phew
@@ -240,7 +240,7 @@ void QgsProcessingMultipleSelectionPanelWidget::dropEvent( QDropEvent *event )
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  const QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes = existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dropped an acceptable layer, phew
@@ -412,7 +412,7 @@ QList< int> QgsProcessingMultipleInputPanelWidget::existingMapLayerFromMimeData(
       for ( int i = 0; i < mModel->rowCount(); ++i )
       {
         // try to match project layers to current layers
-        QString userRole = mModel->item( i )->data( Qt::UserRole ).toString();
+        const QString userRole = mModel->item( i )->data( Qt::UserRole ).toString();
         if ( userRole == layer->id() || userRole == layer->source() )
         {
           indexes.append( i );
@@ -428,7 +428,7 @@ void QgsProcessingMultipleInputPanelWidget::dragEnterEvent( QDragEnterEvent *eve
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes = existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dragged an acceptable layer, phew
@@ -442,7 +442,7 @@ void QgsProcessingMultipleInputPanelWidget::dropEvent( QDropEvent *event )
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  const QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes = existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dropped an acceptable layer, phew

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -232,7 +232,6 @@ void QgsProcessingMultipleSelectionPanelWidget::dragEnterEvent( QDragEnterEvent 
     // dragged an acceptable layer, phew
     event->setDropAction( Qt::CopyAction );
     event->accept();
-    update();
   }
 }
 
@@ -241,7 +240,7 @@ void QgsProcessingMultipleSelectionPanelWidget::dropEvent( QDropEvent *event )
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dropped an acceptable layer, phew
@@ -255,7 +254,6 @@ void QgsProcessingMultipleSelectionPanelWidget::dropEvent( QDropEvent *event )
     }
     emit selectionChanged();
   }
-  update();
 }
 
 void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value, const QString &title, bool selected, bool updateExistingTitle )
@@ -436,7 +434,6 @@ void QgsProcessingMultipleInputPanelWidget::dragEnterEvent( QDragEnterEvent *eve
     // dragged an acceptable layer, phew
     event->setDropAction( Qt::CopyAction );
     event->accept();
-    update();
   }
 }
 
@@ -445,7 +442,7 @@ void QgsProcessingMultipleInputPanelWidget::dropEvent( QDropEvent *event )
   if ( !( event->possibleActions() & Qt::CopyAction ) )
     return;
 
-  QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
+  const QList< int> indexes =  existingMapLayerFromMimeData( event->mimeData() );
   if ( !indexes.isEmpty() )
   {
     // dropped an acceptable layer, phew
@@ -459,7 +456,6 @@ void QgsProcessingMultipleInputPanelWidget::dropEvent( QDropEvent *event )
     }
     emit selectionChanged();
   }
-  update();
 }
 
 void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *project )

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -125,10 +125,10 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     //! Value formatter
     std::function< QString( const QVariant & )> mValueFormatter;
 
-    void dragEnterEvent( QDragEnterEvent *event ) override;
-    void dragLeaveEvent( QDragLeaveEvent *event ) override;
-    void dropEvent( QDropEvent *event ) override;
-    //void paintEvent( QPaintEvent *e ) override;
+    void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override SIP_SKIP;
+    void dropEvent( QDropEvent *event ) override SIP_SKIP;
+
   private slots:
 
     void selectAll( bool checked );
@@ -257,10 +257,10 @@ class GUI_EXPORT QgsProcessingMultipleInputPanelWidget : public QgsProcessingMul
     void addFiles();
     void addDirectory();
 
-    protected:
-    void dragEnterEvent( QDragEnterEvent *event ) override;
-    void dragLeaveEvent( QDragLeaveEvent *event ) override;
-    void dropEvent( QDropEvent *event ) override;
+  protected:
+    void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override SIP_SKIP;
+    void dropEvent( QDropEvent *event ) override SIP_SKIP;
 
   private:
     bool mDragActive = false;

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -128,7 +128,7 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     void dragEnterEvent( QDragEnterEvent *event ) override;
     void dragLeaveEvent( QDragLeaveEvent *event ) override;
     void dropEvent( QDropEvent *event ) override;
-    void paintEvent( QPaintEvent *e ) override;
+    //void paintEvent( QPaintEvent *e ) override;
   private slots:
 
     void selectAll( bool checked );
@@ -257,8 +257,19 @@ class GUI_EXPORT QgsProcessingMultipleInputPanelWidget : public QgsProcessingMul
     void addFiles();
     void addDirectory();
 
-  private:
+    protected:
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
 
+  private:
+    bool mDragActive = false;
+
+    /**
+     * Returns a map layer, compatible with the filters set for the combo box, from
+     * the specified mime \a data (if possible!).
+     */
+    QList<int> existingMapLayerFromMimeData( const QMimeData *data ) const;
     void populateFromProject( QgsProject *project );
 
     const QgsProcessingParameterMultipleLayers *mParameter = nullptr;

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -126,7 +126,6 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     std::function< QString( const QVariant & )> mValueFormatter;
 
     void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
-    void dragLeaveEvent( QDragLeaveEvent *event ) override SIP_SKIP;
     void dropEvent( QDropEvent *event ) override SIP_SKIP;
 
   private slots:
@@ -145,7 +144,6 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     void populateList( const QVariantList &availableOptions, const QVariantList &selectedOptions );
 
     friend class TestProcessingGui;
-    bool mDragActive = false;
 
     /**
      * Returns a map layer, compatible with the filters set for the combo box, from
@@ -259,7 +257,6 @@ class GUI_EXPORT QgsProcessingMultipleInputPanelWidget : public QgsProcessingMul
 
   protected:
     void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
-    void dragLeaveEvent( QDragLeaveEvent *event ) override SIP_SKIP;
     void dropEvent( QDropEvent *event ) override SIP_SKIP;
 
   private:

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -124,6 +124,11 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     QStandardItemModel *mModel = nullptr;
     //! Value formatter
     std::function< QString( const QVariant & )> mValueFormatter;
+
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
+    void paintEvent( QPaintEvent *e ) override;
   private slots:
 
     void selectAll( bool checked );
@@ -137,10 +142,16 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
 
     QList< QStandardItem * > currentItems();
 
-
     void populateList( const QVariantList &availableOptions, const QVariantList &selectedOptions );
 
     friend class TestProcessingGui;
+    bool mDragActive = false;
+
+    /**
+     * Returns a map layer, compatible with the filters set for the combo box, from
+     * the specified mime \a data (if possible!).
+     */
+    QList<int> existingMapLayerFromMimeData( const QMimeData *data ) const;
 };
 
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.h
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.h
@@ -125,8 +125,8 @@ class GUI_EXPORT QgsProcessingMultipleSelectionPanelWidget : public QgsPanelWidg
     //! Value formatter
     std::function< QString( const QVariant & )> mValueFormatter;
 
-    void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
-    void dropEvent( QDropEvent *event ) override SIP_SKIP;
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
 
   private slots:
 
@@ -256,11 +256,10 @@ class GUI_EXPORT QgsProcessingMultipleInputPanelWidget : public QgsProcessingMul
     void addDirectory();
 
   protected:
-    void dragEnterEvent( QDragEnterEvent *event ) override SIP_SKIP;
-    void dropEvent( QDropEvent *event ) override SIP_SKIP;
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
 
   private:
-    bool mDragActive = false;
 
     /**
      * Returns a map layer, compatible with the filters set for the combo box, from


### PR DESCRIPTION
## Description

This is a small improvement I had laying around, feel free to close it if I already have too many PR pending review.

This simply add drop support for layer in the layer selection widget to more efficiently select the desired elements. Especially useful in big project of with duplicated layer names.
![drag drop_multi](https://user-images.githubusercontent.com/12854129/210833487-04bb83cd-8713-401d-8846-8071d3f0c6a1.gif)
