### PR TITLE
[PyQGIS] Add userProfileManager in QgisInterface (iface)

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -842,6 +842,13 @@ This represents the current layer tree group and index where newly added map lay
 .. versionadded:: 3.10
 %End
 
+    virtual QgsUserProfileManager *userProfileManager() = 0;
+%Docstring
+Returns a reference to the user profile manager
+
+.. versionadded:: 3.30
+%End
+
   public slots: // TODO: do these functions really need to be slots?
 
 

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -903,3 +903,8 @@ QList<QgsMapDecoration *> QgisAppInterface::activeDecorations()
   return qgis->activeDecorations();
 }
 
+QgsUserProfileManager *QgisAppInterface::userProfileManager()
+{
+  return qgis->userProfileManager();
+}
+

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -308,6 +308,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() override;
     void setGpsPanelConnection( QgsGpsConnection *connection ) override;
     QList<QgsMapDecoration *> activeDecorations() override;
+    QgsUserProfileManager *userProfileManager() override;
 
   private slots:
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -70,6 +70,7 @@ class QgsDevToolWidgetFactory;
 class QgsGpsConnection;
 class QgsApplicationExitBlockerInterface;
 class QgsAbstractMapToolHandler;
+class QgsUserProfileManager;
 
 /**
  * \ingroup gui
@@ -742,6 +743,12 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.10
      */
     virtual QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() = 0;
+
+    /**
+     * Returns a reference to the user profile manager
+     * \since QGIS 3.30
+    */
+    virtual QgsUserProfileManager *userProfileManager() = 0;
 
   public slots: // TODO: do these functions really need to be slots?
 


### PR DESCRIPTION
Fixes #48337

## Description

It is currently quite cumbersome to get the list of all users (profiles) from PyQGIS. Creating a `QgsUserProfileManager` without argument result in an uninitialized manager, which just points to the current working directory.Thus, calling `QgsUserProfileManager().allProfiles()`  just list the subfolders of the cwd, and `QgsUserProfileManager().userProfile()` returns `None`.

This PR adds a new method `userProfileManager` to the  `QgisInterface` (iface) to get the actual profile manager used by the QgsApp.

**Usage**:

```
>>> iface.userProfileManager().allProfiles()
['default', 'user1']
>>> iface.userProfileManager().userProfile().name()
'default'
```