### PR TITLE
[python console][feature] smart brackets

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -471,44 +471,12 @@ class Editor(QgsCodeEditorPython):
 
     def keyPressEvent(self, e):
         t = e.text()
-        startLine, _, endLine, endPos = self.getSelection()
         line, pos = self.getCursorPosition()
-        self.autoCloseBracket = self.settings.value("pythonConsole/autoCloseBracket", False, type=bool)
         self.autoImport = self.settings.value("pythonConsole/autoInsertionImport", True, type=bool)
         txt = self.text(line)[:pos]
-        # Close bracket automatically
-        if t in self.opening and self.autoCloseBracket:
-            self.beginUndoAction()
-            i = self.opening.index(t)
-            if self.hasSelectedText():
-                selText = self.selectedText()
-                self.removeSelectedText()
-                if startLine == endLine:
-                    self.insert(self.opening[i] + selText + self.closing[i])
-                    self.setCursorPosition(endLine, endPos + 2)
-                    self.endUndoAction()
-                    return
-                elif startLine < endLine and self.opening[i] in ("'", '"'):
-                    self.insert("'''" + selText + "'''")
-                    self.setCursorPosition(endLine, endPos + 3)
-                    self.endUndoAction()
-                    return
-            elif t == '(' and (re.match(r'^[ \t]*def \w+$', txt) or re.match(r'^[ \t]*class \w+$', txt)):
-                self.insert('):')
-            else:
-                self.insert(self.closing[i])
-            self.endUndoAction()
-        # FIXES #8392 (automatically removes the redundant char
-        # when autoclosing brackets option is enabled)
-        elif t in [')', ']', '}'] and self.autoCloseBracket:
-            txt = self.text(line)
-            try:
-                if txt[pos - 1] in self.opening and t == txt[pos]:
-                    self.setCursorPosition(line, pos + 1)
-                    self.SendScintilla(QsciScintilla.SCI_DELETEBACK)
-            except IndexError:
-                pass
-        elif t == ' ' and self.autoImport:
+
+        # Automatically insert "import" after "from xxx "
+        if t == ' ' and self.autoImport:
             ptrn = r'^[ \t]*from [\w.]+$'
             if re.match(ptrn, txt):
                 self.insert(' import')

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -469,20 +469,6 @@ class Editor(QgsCodeEditorPython):
 
         return True
 
-    def keyPressEvent(self, e):
-        t = e.text()
-        line, pos = self.getCursorPosition()
-        self.autoImport = self.settings.value("pythonConsole/autoInsertionImport", True, type=bool)
-        txt = self.text(line)[:pos]
-
-        # Automatically insert "import" after "from xxx "
-        if t == ' ' and self.autoImport:
-            ptrn = r'^[ \t]*from [\w.]+$'
-            if re.match(ptrn, txt):
-                self.insert(' import')
-                self.setCursorPosition(line, pos + 7)
-        QgsCodeEditorPython.keyPressEvent(self, e)
-
     def focusInEvent(self, e):
         pathfile = self.parent.path
         if pathfile:

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -205,16 +205,6 @@ class ShellScintilla(QgsCodeEditorPython):
             sys.stdout.fire_keyboard_interrupt = True
             return
 
-        autoImport = self.settings.value("pythonConsole/autoInsertionImport", True, type=bool)
-        # Automatically insert "import" after "from xxx "
-        if e.text() == ' ' and autoImport:
-            line, index = self.getCursorPosition()
-            cmd = self.text(line)
-            ptrn = r'^[ \t]*from [\w.]+$'
-            if re.match(ptrn, cmd):
-                self.insert(' import')
-                self.setCursorPosition(line, index + 7)
-
         QgsCodeEditorPython.keyPressEvent(self, e)
         self.updatePrompt()
 

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -202,7 +202,6 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
             settings.setValue("pythonConsole/autoCompleteSource", 'fromDocAPI')
 
         settings.setValue("pythonConsole/enableObjectInsp", self.enableObjectInspector.isChecked())
-        settings.setValue("pythonConsole/autoCloseBracket", self.autoCloseBracket.isChecked())
         settings.setValue("pythonConsole/autoInsertionImport", self.autoInsertionImport.isChecked())
 
     def restoreSettings(self):
@@ -226,7 +225,6 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.groupBoxAutoCompletion.setChecked(settings.value("pythonConsole/autoCompleteEnabled", True, type=bool))
 
         self.enableObjectInspector.setChecked(settings.value("pythonConsole/enableObjectInsp", False, type=bool))
-        self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", False, type=bool))
         self.autoInsertionImport.setChecked(settings.value("pythonConsole/autoInsertionImport", True, type=bool))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -202,7 +202,8 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
             settings.setValue("pythonConsole/autoCompleteSource", 'fromDocAPI')
 
         settings.setValue("pythonConsole/enableObjectInsp", self.enableObjectInspector.isChecked())
-        settings.setValue("pythonConsole/autoInsertionImport", self.autoInsertionImport.isChecked())
+        settings.setValue("pythonConsole/autoCloseBracket", self.autoCloseBracket.isChecked())
+        settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
     def restoreSettings(self):
         settings = QgsSettings()
@@ -225,7 +226,8 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.groupBoxAutoCompletion.setChecked(settings.value("pythonConsole/autoCompleteEnabled", True, type=bool))
 
         self.enableObjectInspector.setChecked(settings.value("pythonConsole/enableObjectInsp", False, type=bool))
-        self.autoInsertionImport.setChecked(settings.value("pythonConsole/autoInsertionImport", True, type=bool))
+        self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", False, type=bool))
+        self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':
             self.autoCompFromDoc.setChecked(True)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -226,7 +226,7 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.groupBoxAutoCompletion.setChecked(settings.value("pythonConsole/autoCompleteEnabled", True, type=bool))
 
         self.enableObjectInspector.setChecked(settings.value("pythonConsole/enableObjectInsp", False, type=bool))
-        self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", False, type=bool))
+        self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", True, type=bool))
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -203,6 +203,7 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
 
         settings.setValue("pythonConsole/enableObjectInsp", self.enableObjectInspector.isChecked())
         settings.setValue("pythonConsole/autoCloseBracket", self.autoCloseBracket.isChecked())
+        settings.setValue("pythonConsole/autoSurround", self.autoSurround.isChecked())
         settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
     def restoreSettings(self):
@@ -227,6 +228,7 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
 
         self.enableObjectInspector.setChecked(settings.value("pythonConsole/enableObjectInsp", False, type=bool))
         self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", True, type=bool))
+        self.autoSurround.setChecked(settings.value("pythonConsole/autoSurround", True, type=bool))
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -83,8 +83,15 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_11">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="autoInsertionImport">
+            <item row="0" column="0">
+           <widget class="QCheckBox" name="autoCloseBracket">
+            <property name="text">
+             <string>Automatic parentheses insertion</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="autoInsertImport">
             <property name="text">
              <string>Automatic insertion of the 'import' string on 'from xxx'</string>
             </property>
@@ -456,7 +463,8 @@
   <tabstop>autoCompFromDoc</tabstop>
   <tabstop>autoCompFromAPI</tabstop>
   <tabstop>autoCompFromDocAPI</tabstop>
-  <tabstop>autoInsertionImport</tabstop>
+  <tabstop>autoCloseBracket</tabstop>
+  <tabstop>autoInsertImport</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>
   <tabstop>preloadAPI</tabstop>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -90,7 +90,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+            <item row="1" column="0">
+           <widget class="QCheckBox" name="autoSurround">
+            <property name="text">
+             <string>Automatically surround selection when typing quotes or brackets</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QCheckBox" name="autoInsertImport">
             <property name="text">
              <string>Automatic insertion of the 'import' string on 'from xxx'</string>
@@ -464,6 +471,7 @@
   <tabstop>autoCompFromAPI</tabstop>
   <tabstop>autoCompFromDocAPI</tabstop>
   <tabstop>autoCloseBracket</tabstop>
+  <tabstop>autoSurround</tabstop>
   <tabstop>autoInsertImport</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -83,17 +83,10 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_11">
-          <item row="1" column="0">
+          <item row="0" column="0">
            <widget class="QCheckBox" name="autoInsertionImport">
             <property name="text">
              <string>Automatic insertion of the 'import' string on 'from xxx'</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="autoCloseBracket">
-            <property name="text">
-             <string>Automatic parentheses insertion</string>
             </property>
            </widget>
           </item>
@@ -463,7 +456,6 @@
   <tabstop>autoCompFromDoc</tabstop>
   <tabstop>autoCompFromAPI</tabstop>
   <tabstop>autoCompFromDocAPI</tabstop>
-  <tabstop>autoCloseBracket</tabstop>
   <tabstop>autoInsertionImport</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -58,17 +58,23 @@ Loads a ``script`` file.
     bool isCursorInsideString() const;
 %Docstring
 Check whether the current cursor position is inside a string or comment
+
+.. versionadded:: 3.30
 %End
 
     QString characterBeforeCursor() const;
 %Docstring
 Returns the character before the cursor, or an empty string if cursor is set at start
+
+.. versionadded:: 3.30
 %End
 
 
     QString characterAfterCursor() const;
 %Docstring
 Returns the character after the cursor, or an empty string if cursor is set at end
+
+.. versionadded:: 3.30
 %End
 
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -57,12 +57,12 @@ Loads a ``script`` file.
 
     bool isCursorInsideStringLiteralOrComment() const;
 %Docstring
-Check whether the current cursor position is inside a string or comment
+Check whether the current cursor position is inside a string literal or a comment
 
 .. versionadded:: 3.30
 %End
 
-    QString characterBeforeCursor( ) const;
+    QString characterBeforeCursor() const;
 %Docstring
 Returns the character before the cursor, or an empty string if cursor is set at start
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -55,6 +55,23 @@ Load APIs from one or more files
 Loads a ``script`` file.
 %End
 
+    bool isCursorInsideString() const;
+%Docstring
+Check whether the current cursor position is inside a string or comment
+%End
+
+    QString characterBeforeCursor() const;
+%Docstring
+Returns the character before the cursor, or an empty string if cursor is set at start
+%End
+
+
+    QString characterAfterCursor() const;
+%Docstring
+Returns the character after the cursor, or an empty string if cursor is set at end
+%End
+
+
   public slots:
 
     void searchSelectedTextInPyQGISDocs();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -55,14 +55,14 @@ Load APIs from one or more files
 Loads a ``script`` file.
 %End
 
-    bool isCursorInsideString() const;
+    bool isCursorInsideStringLiteralOrComment() const;
 %Docstring
 Check whether the current cursor position is inside a string or comment
 
 .. versionadded:: 3.30
 %End
 
-    QString characterBeforeCursor() const;
+    QString characterBeforeCursor( ) const;
 %Docstring
 Returns the character before the cursor, or an empty string if cursor is set at start
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -69,14 +69,12 @@ Returns the character before the cursor, or an empty string if cursor is set at 
 .. versionadded:: 3.30
 %End
 
-
     QString characterAfterCursor() const;
 %Docstring
-Returns the character after the cursor, or an empty string if cursor is set at end
+Returns the character after the cursor, or an empty string if the cursot is set at end
 
 .. versionadded:: 3.30
 %End
-
 
   public slots:
 

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -170,7 +170,7 @@ void QgsCodeEditor::focusOutEvent( QFocusEvent *event )
 // but only is the auto-completion suggestion list isn't displayed
 void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
 {
-  if( isListActive() )
+  if ( isListActive() )
   {
     QsciScintilla::keyPressEvent( event );
     return;
@@ -209,7 +209,7 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
   }
 
   QsciScintilla::keyPressEvent( event );
-  
+
 }
 
 void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -170,7 +170,13 @@ void QgsCodeEditor::focusOutEvent( QFocusEvent *event )
 // but only is the auto-completion suggestion list isn't displayed
 void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
 {
-  if ( event->key() == Qt::Key_Escape && !isListActive() )
+  if( isListActive() )
+  {
+    QsciScintilla::keyPressEvent( event );
+    return;
+  }
+
+  if ( event->key() == Qt::Key_Escape )
   {
     // Shortcut QScintilla and redirect the event to the QWidget handler
     QWidget::keyPressEvent( event ); // clazy:exclude=skipped-base-method
@@ -188,34 +194,22 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
         return;
 
       case Qt::Key_Down:
-
-        if ( !isListActive() )
-        {
-          showPreviousCommand();
-          updatePrompt();
-          return;
-        }
-        break;
+        showPreviousCommand();
+        updatePrompt();
+        return;
 
       case Qt::Key_Up:
-
-        if ( !isListActive() )
-        {
-          showNextCommand();
-          updatePrompt();
-          return;
-        }
-        break;
+        showNextCommand();
+        updatePrompt();
+        return;
 
       default:
         break;
     }
-    QsciScintilla::keyPressEvent( event );
   }
-  else
-  {
-    QsciScintilla::keyPressEvent( event );
-  }
+
+  QsciScintilla::keyPressEvent( event );
+  
 }
 
 void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -231,9 +231,9 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
 
 
   // Handle closing and opening
-  auto prevChar = characterBeforeCursor();
-  auto nextChar = characterAfterCursor();
-  auto eText = event->text();
+  const QString prevChar = characterBeforeCursor();
+  const QString nextChar = characterAfterCursor();
+  const QString eText = event->text();
 
   int line, column;
   getCursorPosition( &line, &column );
@@ -254,7 +254,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
         QgsCodeEditor::keyPressEvent( event );
       }
 
-      // Update calltips (cursor postion has changed)
+      // Update calltips (cursor position has changed)
       callTip();
       return;
     }
@@ -377,8 +377,8 @@ bool QgsCodeEditorPython::isCursorInsideString() const
 {
   int line, index;
   getCursorPosition( &line, &index );
-  auto postion = positionFromLineIndex( line, index );
-  auto style = SendScintilla( QsciScintillaBase::SCI_GETSTYLEAT, postion );
+  int position = positionFromLineIndex( line, index );
+  long style = SendScintilla( QsciScintillaBase::SCI_GETSTYLEAT, position );
   return style == QsciLexerPython::Comment
          || style == QsciLexerPython::DoubleQuotedString
          || style == QsciLexerPython::SingleQuotedString
@@ -396,7 +396,7 @@ QString QgsCodeEditorPython::characterBeforeCursor() const
 {
   int line, index;
   getCursorPosition( &line, &index );
-  auto position = positionFromLineIndex( line, index );
+  int position = positionFromLineIndex( line, index );
   if ( position <= 0 )
   {
     return "";
@@ -408,7 +408,7 @@ QString QgsCodeEditorPython::characterAfterCursor() const
 {
   int line, index;
   getCursorPosition( &line, &index );
-  auto position = positionFromLineIndex( line, index );
+  int position = positionFromLineIndex( line, index );
   if ( position >= length() )
   {
     return "";

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -260,7 +260,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
     }
 
     // When closing character is entered inside an opening/closing pair, shift the cursor
-    else if ( PAIRS.values().contains( eText )  && nextChar == eText )
+    else if ( PAIRS.key( eText ) != ""  && nextChar == eText )
     {
       setCursorPosition( line, column + 1 );
       event->accept();

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -285,9 +285,9 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
     // Automatically insert "import" after "from xxx " if option is enabled
     if ( autoInsertImport && eText == " " )
     {
-      const QString txt = text( line );
-      const QRegularExpression re( QStringLiteral( "^from [\\w.]+$" ) );
-      if ( re.match( txt.trimmed() ).hasMatch() )
+      const QString lineText = text( line );
+      const thread_local QRegularExpression re( QStringLiteral( "^from [\\w.]+$" ) );
+      if ( re.match( lineText.trimmed() ).hasMatch() )
       {
         insert( QStringLiteral( " import" ) );
         setCursorPosition( line, column + 7 );
@@ -443,7 +443,7 @@ QString QgsCodeEditorPython::characterBeforeCursor() const
   int position = positionFromLineIndex( line, index );
   if ( position <= 0 )
   {
-    return "";
+    return QString();
   }
   return text( position - 1, position );
 }
@@ -455,7 +455,7 @@ QString QgsCodeEditorPython::characterAfterCursor() const
   int position = positionFromLineIndex( line, index );
   if ( position >= length() )
   {
-    return "";
+    return QString();
   }
   return text( position, position + 1 );
 }

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -333,7 +333,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
 
       // Else, if not inside a string or comment and an opening character
       // is entered, also insert the closing character
-      else if ( !isCursorInsideString() && PAIRS.contains( eText ) )
+      else if ( !isCursorInsideStringLiteralOrComment() && PAIRS.contains( eText ) )
       {
         // Check if user is not entering triple quotes
         if ( !( ( eText == "\"" || eText == "'" ) && prevChar == eText ) )
@@ -399,7 +399,7 @@ bool QgsCodeEditorPython::loadScript( const QString &script )
   return true;
 }
 
-bool QgsCodeEditorPython::isCursorInsideString() const
+bool QgsCodeEditorPython::isCursorInsideStringLiteralOrComment() const
 {
   int line, index;
   getCursorPosition( &line, &index );

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -221,6 +221,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
   const QgsSettings settings;
 
   bool autoCloseBracket = settings.value( QStringLiteral( "/pythonConsole/autoCloseBracket" ), true ).toBool();
+  bool autoSurround = settings.value( QStringLiteral( "/pythonConsole/autoSurround" ), true ).toBool();
   bool autoInsertImport = settings.value( QStringLiteral( "/pythonConsole/autoInsertImport" ), false ).toBool();
 
   // Update calltips when cursor position changes with left and right keys
@@ -241,7 +242,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
 
   // If some text is selected and user presses an opening character
   // surround the selection with the opening-closing pair
-  if ( hasSelectedText() )
+  if ( hasSelectedText() && autoSurround )
   {
     if ( PAIRS.contains( eText ) )
     {

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -220,7 +220,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
 
   const QgsSettings settings;
 
-  bool autoCloseBracket = settings.value( QStringLiteral( "/pythonConsole/autoCloseBracket" ), false ).toBool();
+  bool autoCloseBracket = settings.value( QStringLiteral( "/pythonConsole/autoCloseBracket" ), true ).toBool();
   bool autoInsertImport = settings.value( QStringLiteral( "/pythonConsole/autoInsertImport" ), false ).toBool();
 
   // Update calltips when cursor position changes with left and right keys

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -213,6 +213,18 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
     return;
   }
 
+  // Update calltips when cursor position changes with left and right keys
+  if ( event->key() == Qt::Key_Left  || 
+    event->key() == Qt::Key_Right || 
+    event->key() == Qt::Key_Up || 
+    event->key() == Qt::Key_Down )
+  {
+    QgsCodeEditor::keyPressEvent(event);
+    callTip();
+    return;
+  }
+
+
   // Handle closing and opening
   auto prevChar = characterBeforeCursor();
   auto nextChar = characterAfterCursor();
@@ -231,16 +243,26 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
         setSelection(line, column-1 , line, column+1);
         removeSelectedText();
         event->accept();
-        return;
       }
+      else
+      {
+        QgsCodeEditor::keyPressEvent(event);
+      }
+
+    // Update calltips (cursor postion has changed)
+    callTip();
+    return;
     }
 
-    // When closing character is entered inside an opening/closing pair, just shift the cursor
+    // When closing character is entered inside an opening/closing pair, shift the cursor
     else if ( PAIRS.values().contains(eText)  && nextChar == eText )
     {
       setCursorPosition(line, column+1);
       event->accept();
-      return;
+
+      // Will hide calltips when a closing parenthesis is entered
+      callTip();
+      return; 
     }
 
     // Else, if not inside a string or comment and an opening character
@@ -250,8 +272,8 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
       // Check if user is not entering triple quotes
       if ( !((eText == "\"" || eText == "'") && prevChar == eText) )
       {
-        insert(eText+PAIRS[eText]);
-        setCursorPosition(line, column+1);
+        QgsCodeEditor::keyPressEvent(event);
+        insert(PAIRS[eText]);
         event->accept();
         return;
       }

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -41,6 +41,9 @@ namespace
     {"'", "'"},
     {"\"", "\""}
   };
+
+  // Only used for selected text
+  const QStringList SINGLE_CHARS = {"`", "*"};
 }
 
 QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> &filenames, Mode mode )
@@ -306,6 +309,17 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
       );
       setSelection( startLine, startPos + 1, endLine, endPos + 1 );
     }
+    event->accept();
+    return;
+  }
+  else if ( SINGLE_CHARS.contains( eText ) )
+  {
+    int startLine, startPos, endLine, endPos;
+    getSelection( &startLine, &startPos, &endLine, &endPos );
+    replaceSelectedText(
+      QString( "%1%2%1" ).arg( eText ).arg( selectedText() )
+    );
+    setSelection( startLine, startPos + 1, endLine, endPos + 1 );
     event->accept();
     return;
   }

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -208,7 +208,6 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
   {
     return QgsCodeEditor::keyPressEvent( event );
   }
-
   const bool ctrlModifier = event->modifiers() & Qt::ControlModifier;
 
   // Toggle comment when user presses  Ctrl+:
@@ -244,7 +243,7 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
     // When backspace is pressed inside an opening/closing pair, remove both characters
     if ( event->key() == Qt::Key_Backspace )
     {
-      if ( PAIRS[prevChar] == nextChar )
+      if ( PAIRS.contains( prevChar ) && PAIRS[prevChar] == nextChar )
       {
         setSelection( line, column - 1, line, column + 1 );
         removeSelectedText();

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -378,18 +378,36 @@ bool QgsCodeEditorPython::isCursorInsideString() const
   int line, index;
   getCursorPosition( &line, &index );
   int position = positionFromLineIndex( line, index );
-  long style = SendScintilla( QsciScintillaBase::SCI_GETSTYLEAT, position );
-  return style == QsciLexerPython::Comment
-         || style == QsciLexerPython::DoubleQuotedString
-         || style == QsciLexerPython::SingleQuotedString
-         || style == QsciLexerPython::TripleSingleQuotedString
-         || style == QsciLexerPython::TripleDoubleQuotedString
-         || style == QsciLexerPython::CommentBlock
-         || style == QsciLexerPython::UnclosedString
-         || style == QsciLexerPython::DoubleQuotedFString
-         || style == QsciLexerPython::SingleQuotedFString
-         || style == QsciLexerPython::TripleSingleQuotedFString
-         || style == QsciLexerPython::TripleDoubleQuotedFString;
+
+  // Special case: cursor at the end of the document. Style will always be Default,
+  // so  we have to  check the style of the previous character.
+  // It it is an unclosed string (triple string, unclosed, or comment),
+  // consider cursor is inside a string.
+  if ( position >= length() && position > 0 )
+  {
+    long style = SendScintilla( QsciScintillaBase::SCI_GETSTYLEAT, position - 1 );
+    return style == QsciLexerPython::Comment
+           || style == QsciLexerPython::TripleSingleQuotedString
+           || style == QsciLexerPython::TripleDoubleQuotedString
+           || style == QsciLexerPython::TripleSingleQuotedFString
+           || style == QsciLexerPython::TripleDoubleQuotedFString
+           || style == QsciLexerPython::UnclosedString;
+  }
+  else
+  {
+    long style = SendScintilla( QsciScintillaBase::SCI_GETSTYLEAT, position );
+    return style == QsciLexerPython::Comment
+           || style == QsciLexerPython::DoubleQuotedString
+           || style == QsciLexerPython::SingleQuotedString
+           || style == QsciLexerPython::TripleSingleQuotedString
+           || style == QsciLexerPython::TripleDoubleQuotedString
+           || style == QsciLexerPython::CommentBlock
+           || style == QsciLexerPython::UnclosedString
+           || style == QsciLexerPython::DoubleQuotedFString
+           || style == QsciLexerPython::SingleQuotedFString
+           || style == QsciLexerPython::TripleSingleQuotedFString
+           || style == QsciLexerPython::TripleDoubleQuotedFString;
+  }
 }
 
 QString QgsCodeEditorPython::characterBeforeCursor() const

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -245,6 +245,49 @@ bool QgsCodeEditorPython::loadScript( const QString &script )
   return true;
 }
 
+bool QgsCodeEditorPython::isCursorInsideString() const
+{
+  int line, index;
+  getCursorPosition(&line, &index);
+  auto postion = positionFromLineIndex(line, index);
+  auto style = SendScintilla(QsciScintillaBase::SCI_GETSTYLEAT, postion);
+  return style == QsciLexerPython::Comment
+        || style == QsciLexerPython::DoubleQuotedString 
+        || style == QsciLexerPython::SingleQuotedString 
+        || style == QsciLexerPython::TripleSingleQuotedString 
+        || style == QsciLexerPython::TripleDoubleQuotedString 
+        || style == QsciLexerPython::CommentBlock
+        || style == QsciLexerPython::UnclosedString 
+        || style == QsciLexerPython::DoubleQuotedFString 
+        || style == QsciLexerPython::SingleQuotedFString 
+        || style == QsciLexerPython::TripleSingleQuotedFString 
+        || style == QsciLexerPython::TripleDoubleQuotedFString;
+}
+
+QString QgsCodeEditorPython::characterBeforeCursor() const
+{
+  int line, index;
+  getCursorPosition(&line, &index);
+  auto position = positionFromLineIndex(line, index);
+  if ( position <= 0 )
+  {
+    return "";
+  } 
+  return text(position - 1, position);
+}
+
+QString QgsCodeEditorPython::characterAfterCursor() const
+{
+  int line, index;
+  getCursorPosition(&line, &index);
+  auto position = positionFromLineIndex(line, index);
+  if ( position >= length() )
+  {
+    return "";
+  }
+  return text(position, position + 1);
+}
+
 void QgsCodeEditorPython::searchSelectedTextInPyQGISDocs()
 {
   if ( !hasSelectedText() )

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -77,21 +77,21 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
 
     /**
      * Check whether the current cursor position is inside a string or comment
-     * 
+     *
      * \since QGIS 3.30
      */
     bool isCursorInsideString() const;
 
     /**
      * Returns the character before the cursor, or an empty string if cursor is set at start
-     * 
+     *
      * \since QGIS 3.30
      */
     QString characterBeforeCursor() const;
 
     /**
      * Returns the character after the cursor, or an empty string if the cursot is set at end
-     * 
+     *
      * \since QGIS 3.30
      */
     QString characterAfterCursor() const;

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      *
      * \since QGIS 3.30
      */
-    bool isCursorInsideString() const;
+    bool isCursorInsideStringLiteralOrComment() const;
 
     /**
      * Returns the character before the cursor, or an empty string if cursor is set at start

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
     bool loadScript( const QString &script );
 
     /**
-     * Check whether the current cursor position is inside a string or comment
+     * Check whether the current cursor position is inside a string literal or a comment
      *
      * \since QGIS 3.30
      */

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -75,6 +75,21 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      */
     bool loadScript( const QString &script );
 
+    /**
+     * Check whether the current cursor position is inside a string or comment
+     */
+    bool isCursorInsideString() const;
+
+    /**
+     * Returns the character before the cursor, or an empty string if cursor is set at start
+     */
+    QString characterBeforeCursor() const;
+
+    /**
+     * Returns the character after the cursor, or an empty string if the cursot is set at end
+     */
+    QString characterAfterCursor() const;
+
   public slots:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -77,16 +77,22 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
 
     /**
      * Check whether the current cursor position is inside a string or comment
+     * 
+     * \since QGIS 3.30
      */
     bool isCursorInsideString() const;
 
     /**
      * Returns the character before the cursor, or an empty string if cursor is set at start
+     * 
+     * \since QGIS 3.30
      */
     QString characterBeforeCursor() const;
 
     /**
      * Returns the character after the cursor, or an empty string if the cursot is set at end
+     * 
+     * \since QGIS 3.30
      */
     QString characterAfterCursor() const;
 


### PR DESCRIPTION
### Motivation

The QGIS Python Console has an `autoCloseBracket` setting, which automatically insert a closing parentheses / brace / bracket when an opening char is entered. 
- This option does not have a consistent behavior if the closing character is entered. 
- If the user enters an opening character, then backspace, the auto-inserted closing character still remains just after the cursor. 
- It is only available in the Python Console Script Editor, and the Python Console prompt
- Finally, this option does not handle single and double quotes, and does not allow to enclose the selected text with parentheses / quotes / braces...

### Proposal

Tweak `autoCloseBracket` behavior to mimic the behavior of modern IDEs
Add an `autoSurround` setting to surround selected text when typing quotes/parentheses/brackets. 
This is implemented in the `QgsCodeEditorPython`, so it also works in Expression Editor, Project Macro Editor, Script Editor, etc.

![console_settings](https://user-images.githubusercontent.com/9693475/211432887-46a40ab0-08d6-4b94-aed4-7ef1ee1a51ed.png)

![Peek 2023-01-07 10-44](https://user-images.githubusercontent.com/9693475/211144528-701caf5d-b069-47ae-8f3c-58d58be1af13.gif)

![project_macro](https://user-images.githubusercontent.com/9693475/211153355-dd510b12-48f6-4c6b-beb2-18adae56d93e.gif)


#### When some text was selected (and `autoSurround` is on)
- When an opening character is entered, the selected text is enclosed in the opening/closing pair. Selection remains the same, so it is possible to quote a selected word and enclose it in parentheses just by typing `"` then `(`
  - Special case for multiline selection with quotes and double quotes: selection is enclosed in triple single/double quotes. 
#### When no text is selected (and `autoCloseBracket` is on)
- When no text is selected, if an opening character is entered, insert the matching closing character just after the cursor. Note that this behavior is disabled if the current cursor is inside a string or comment
- When the backspace key is pressed, if cursor is directly enclosed in an opening/closing pair, remove both characters
- When a closing character is pressed, if cursor is just before the same closing character, just move the cursor and do not insert a duplicated character 

**Pairs of characters:**
- `[` and `]`
- `{` and `}`
- `[` and `]`
- `"` and `"`
- `'` and `'`

Additionaly, for the characters `` ` `` (backtick) and `*`, only the enclose selected text feature is enabled
