### PR TITLE
[server landingpage] Remove WMS overlay when switching back to ServerCatalog

### DIFF
--- a/resources/server/src/landingpage/src/js/WmsSource.js
+++ b/resources/server/src/landingpage/src/js/WmsSource.js
@@ -101,6 +101,11 @@ var WmsSource = WMS.Source.extend({
     }
     return result
   },
+  onRemove: function () {
+    if (this._overlay) {
+      delete this._overlay;
+    }
+  }
 })
 
 export default {


### PR DESCRIPTION
Fixes the following error (WMS overlay is the single/combined WMS layer):

<img src="https://user-images.githubusercontent.com/20856381/211318470-28e587c1-f64e-4e11-9b12-534df11e8a93.png" width="600">

![image](https://user-images.githubusercontent.com/20856381/211319701-cb0f4b9a-281f-4937-911c-4d8e3258dbd2.png)

