### PR TITLE
Support data defined parameter values when using qgis_process tool

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -498,6 +498,15 @@ appropriate string values where possible.
 .. versionadded:: 3.26
 %End
 
+    static QVariantMap preprocessQgisProcessParameters( const QVariantMap &parameters, bool &ok, QString &error );
+%Docstring
+Pre-processes a set of ``parameter`` values for the qgis_process command.
+
+In particular, this function upgrades encoded data defined values to :py:class:`QgsProperty` objects.
+
+.. versionadded:: 3.30
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2692,12 +2692,10 @@ QString QgsProcessingParameterDefinition::valueAsStringPrivate( const QVariant &
         return QString();
       case QgsProperty::StaticProperty:
         return valueAsString( prop.staticValue(), context, ok );
-
-      // these are not supported for serialization
       case QgsProperty::FieldBasedProperty:
+        return QStringLiteral( "field:%1" ).arg( prop.field() );
       case QgsProperty::ExpressionBasedProperty:
-        QgsDebugMsg( QStringLiteral( "could not convert expression/field based property to string" ) );
-        return QString();
+        return QStringLiteral( "expression:%1" ).arg( prop.expressionString() );
     }
   }
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2499,7 +2499,6 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
         break;
     }
 
-
     if ( value.userType() == QMetaType::type( "QgsProperty" ) )
     {
       const QgsProperty prop = value.value< QgsProperty >();
@@ -2509,12 +2508,10 @@ QVariant QgsProcessingParameterDefinition::valueAsJsonObjectPrivate( const QVari
           return QVariant();
         case QgsProperty::StaticProperty:
           return valueAsJsonObject( prop.staticValue(), context );
-
-        // these are not supported for serialization
         case QgsProperty::FieldBasedProperty:
+          return QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "field" ), prop.field() }} );
         case QgsProperty::ExpressionBasedProperty:
-          QgsDebugMsg( QStringLiteral( "could not convert expression/field based property to JSON object" ) );
-          return QVariant();
+          return QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "expression" ), prop.expressionString() }} );
       }
     }
 

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -292,7 +292,9 @@ class CORE_EXPORT QgsProcessingParameterTypeBoolean : public QgsProcessingParame
     QStringList acceptedStringValues() const override
     {
       return QStringList() << QObject::tr( "1 for true/yes" )
-             << QObject::tr( "0 for false/no" );
+             << QObject::tr( "0 for false/no" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1124,7 +1126,9 @@ class CORE_EXPORT QgsProcessingParameterTypeString : public QgsProcessingParamet
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "String value" );
+      return QStringList() << QObject::tr( "String value" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1330,7 +1334,9 @@ class CORE_EXPORT QgsProcessingParameterTypeNumber : public QgsProcessingParamet
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "A numeric value" );
+      return QStringList() << QObject::tr( "A numeric value" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1382,7 +1388,9 @@ class CORE_EXPORT QgsProcessingParameterTypeDistance : public QgsProcessingParam
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "A numeric value" );
+      return QStringList() << QObject::tr( "A numeric value" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1434,7 +1442,9 @@ class CORE_EXPORT QgsProcessingParameterTypeDuration : public QgsProcessingParam
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "A numeric value (unit type set by algorithms)" );
+      return QStringList() << QObject::tr( "A numeric value (unit type set by algorithms)" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1753,7 +1763,9 @@ class CORE_EXPORT QgsProcessingParameterTypeColor : public QgsProcessingParamete
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "String representation of color, e.g #ff0000 or rgba(200,100,50,0.8)" );
+      return QStringList() << QObject::tr( "String representation of color, e.g #ff0000 or rgba(200,100,50,0.8)" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 
@@ -1908,7 +1920,9 @@ class CORE_EXPORT QgsProcessingParameterTypeDateTime : public QgsProcessingParam
 
     QStringList acceptedStringValues() const override
     {
-      return QStringList() << QObject::tr( "A datetime value in ISO format" );
+      return QStringList() << QObject::tr( "A datetime value in ISO format" )
+             << QObject::tr( "field:FIELD_NAME to use a data defined value taken from the FIELD_NAME field" )
+             << QObject::tr( "expression:SOME EXPRESSION to use a data defined value calculated using a custom QGIS expression" );
     }
 };
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1411,6 +1411,23 @@ QVariantMap QgsProcessingUtils::preprocessQgisProcessParameters( const QVariantM
         output.insert( it.key(), it.value() );
       }
     }
+    else if ( it.value().type() == QVariant::String )
+    {
+      const QString stringValue = it.value().toString();
+
+      if ( stringValue.startsWith( QLatin1String( "field:" ) ) )
+      {
+        output.insert( it.key(), QgsProperty::fromField( stringValue.mid( 6 ) ) );
+      }
+      else if ( stringValue.startsWith( QLatin1String( "expression:" ) ) )
+      {
+        output.insert( it.key(), QgsProperty::fromExpression( stringValue.mid( 11 ) ) );
+      }
+      else
+      {
+        output.insert( it.key(), it.value() );
+      }
+    }
     else
     {
       output.insert( it.key(), it.value() );

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -502,6 +502,15 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QVariantMap removePointerValuesFromMap( const QVariantMap &map );
 
+    /**
+     * Pre-processes a set of \a parameter values for the qgis_process command.
+     *
+     * In particular, this function upgrades encoded data defined values to QgsProperty objects.
+     *
+     * \since QGIS 3.30
+     */
+    static QVariantMap preprocessQgisProcessParameters( const QVariantMap &parameters, bool &ok, QString &error );
+
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -234,7 +234,11 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
         if ( parameterValues.isEmpty() )
           return;
 
-        setParameters( parameterValues );
+        bool ok = false;
+        QString error;
+        const QVariantMap preparedValues = QgsProcessingUtils::preprocessQgisProcessParameters( parameterValues, ok, error );
+
+        setParameters( preparedValues );
       } );
 
       mButtonBox->addButton( mAdvancedButton, QDialogButtonBox::ResetRole );

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -1114,7 +1114,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
     std::cout << "----------------\n\n";
   }
   QVariantMap inputsJson;
-  for ( auto it = params.constBegin(); it != params.constEnd(); ++it )
+  for ( auto it = inputs.constBegin(); it != inputs.constEnd(); ++it )
   {
     if ( !useJson )
       std::cout << it.key().toLocal8Bit().constData() << ":\t" << it.value().toString().toLocal8Bit().constData() << '\n';

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -998,12 +998,21 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
   return 0;
 }
 
-int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &params, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit, QgsProcessingContext::LogLevel logLevel, bool useJson, const QString &projectPath )
+int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &inputs, const QString &ellipsoid, QgsUnitTypes::DistanceUnit distanceUnit, QgsUnitTypes::AreaUnit areaUnit, QgsProcessingContext::LogLevel logLevel, bool useJson, const QString &projectPath )
 {
   QVariantMap json;
   if ( useJson )
   {
     addVersionInformation( json );
+  }
+
+  bool ok = false;
+  QString error;
+  const QVariantMap params = QgsProcessingUtils::preprocessQgisProcessParameters( inputs, ok, error );
+  if ( !ok )
+  {
+    std::cerr << error.toLocal8Bit().constData();
+    return 1;
   }
 
   QString id = inputId;
@@ -1200,7 +1209,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &param
   } );
 #endif
 
-  bool ok = false;
+  ok = false;
   if ( !useJson )
     std::cout << "\n";
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -396,6 +396,14 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       params.insert( "p2", QStringLiteral( "thisisa'test" ) );
       QCOMPARE( asQgisProcessCommand( params, context, ok ), QStringLiteral( "qgis_process run test --distance_units=meters --p1=a --p2='thisisa'\\''test'" ) );
       QVERIFY( ok );
+
+      addParameter( new QgsProcessingParameterString( "dd_field", QString(), true ) );
+      addParameter( new QgsProcessingParameterString( "dd_expression", QString(), true ) );
+
+      params.insert( "dd_field", QgsProperty::fromField( QStringLiteral( "my field" ) ) );
+      params.insert( "dd_expression", QgsProperty::fromExpression( QStringLiteral( "\"some field\" * 200" ) ) );
+      QCOMPARE( asQgisProcessCommand( params, context, ok ), QStringLiteral( "qgis_process run test --distance_units=meters --p1=a --p2='thisisa'\\''test' --dd_field='field:my field' --dd_expression='expression:\"some field\" * 200'" ) );
+      QVERIFY( ok );
     }
 
     void runAsAsJsonMapChecks()
@@ -11679,6 +11687,8 @@ void TestQgsProcessing::preprocessParameters()
   inputs.insert( QStringLiteral( "string" ), QStringLiteral( "a string" ) );
   inputs.insert( QStringLiteral( "data defined field" ), QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "field" ), QStringLiteral( "DEPTH_FIELD" ) }} ) );
   inputs.insert( QStringLiteral( "data defined expression" ), QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "expression" ), QStringLiteral( "A_FIELD * 200" ) }} ) );
+  inputs.insert( QStringLiteral( "data defined field using string" ), QStringLiteral( "field:MY FIELD" ) );
+  inputs.insert( QStringLiteral( "data defined expression using string" ), QStringLiteral( "expression:SOME_FIELD * 2" ) );
   inputs.insert( QStringLiteral( "invalid" ), QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}} ) );
 
   bool ok = false;
@@ -11697,8 +11707,12 @@ void TestQgsProcessing::preprocessParameters()
   QCOMPARE( outputs.value( QStringLiteral( "string" ) ).toString(), QStringLiteral( "a string" ) );
   QCOMPARE( outputs.value( QStringLiteral( "data defined field" ) ).value< QgsProperty >().propertyType(), QgsProperty::FieldBasedProperty );
   QCOMPARE( outputs.value( QStringLiteral( "data defined field" ) ).value< QgsProperty >().field(), QStringLiteral( "DEPTH_FIELD" ) );
+  QCOMPARE( outputs.value( QStringLiteral( "data defined field using string" ) ).value< QgsProperty >().propertyType(), QgsProperty::FieldBasedProperty );
+  QCOMPARE( outputs.value( QStringLiteral( "data defined field using string" ) ).value< QgsProperty >().field(), QStringLiteral( "MY FIELD" ) );
   QCOMPARE( outputs.value( QStringLiteral( "data defined expression" ) ).value< QgsProperty >().propertyType(), QgsProperty::ExpressionBasedProperty );
   QCOMPARE( outputs.value( QStringLiteral( "data defined expression" ) ).value< QgsProperty >().expressionString(), QStringLiteral( "A_FIELD * 200" ) );
+  QCOMPARE( outputs.value( QStringLiteral( "data defined expression using string" ) ).value< QgsProperty >().propertyType(), QgsProperty::ExpressionBasedProperty );
+  QCOMPARE( outputs.value( QStringLiteral( "data defined expression using string" ) ).value< QgsProperty >().expressionString(), QStringLiteral( "SOME_FIELD * 2" ) );
 
   // test round trip of data defined parameters
   const QgsProcessingAlgorithm *bufferAlg = QgsApplication::processingRegistry()->algorithmById( "native:buffer" );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6099,6 +6099,10 @@ void TestQgsProcessing::parameterString()
   QCOMPARE( def->valueAsJsonObject( "uri='complex' username=\"complex\"", context ), QVariant( QStringLiteral( "uri='complex' username=\"complex\"" ) ) );
   QCOMPARE( def->valueAsJsonObject( QStringLiteral( "c:\\test\\new data\\test.dat" ), context ), QVariant( QStringLiteral( "c:\\test\\new data\\test.dat" ) ) );
 
+  QCOMPARE( def->valueAsJsonObject( QVariant::fromValue( QgsProperty::fromValue( QStringLiteral( "test" ) ) ), context ), QVariant( QStringLiteral( "test" ) ) );
+  QCOMPARE( def->valueAsJsonObject( QVariant::fromValue( QgsProperty::fromField( QStringLiteral( "a field" ) ) ), context ), QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "field" ), QStringLiteral( "a field" ) }} ) );
+  QCOMPARE( def->valueAsJsonObject( QVariant::fromValue( QgsProperty::fromExpression( QStringLiteral( "\"a field\" * 2" ) ) ), context ), QVariantMap( {{QStringLiteral( "type" ), QStringLiteral( "data_defined" )}, {QStringLiteral( "expression" ),  QStringLiteral( "\"a field\" * 2" ) }} ) );
+
   bool ok = false;
   QCOMPARE( def->valueAsString( QVariant(), context, ok ), QString() );
   QVERIFY( ok );
@@ -11695,6 +11699,32 @@ void TestQgsProcessing::preprocessParameters()
   QCOMPARE( outputs.value( QStringLiteral( "data defined field" ) ).value< QgsProperty >().field(), QStringLiteral( "DEPTH_FIELD" ) );
   QCOMPARE( outputs.value( QStringLiteral( "data defined expression" ) ).value< QgsProperty >().propertyType(), QgsProperty::ExpressionBasedProperty );
   QCOMPARE( outputs.value( QStringLiteral( "data defined expression" ) ).value< QgsProperty >().expressionString(), QStringLiteral( "A_FIELD * 200" ) );
+
+  // test round trip of data defined parameters
+  const QgsProcessingAlgorithm *bufferAlg = QgsApplication::processingRegistry()->algorithmById( "native:buffer" );
+  QVERIFY( bufferAlg );
+
+  inputs.clear();
+  inputs.insert( QStringLiteral( "DISTANCE" ), QgsProperty::fromField( QStringLiteral( "DEPTH_FIELD" ) ) );
+
+  QgsProcessingContext context;
+  QVariantMap exportedParams = bufferAlg->asMap( inputs, context );
+  outputs = QgsProcessingUtils::preprocessQgisProcessParameters( inputs, ok, error );
+  QVERIFY( ok );
+  QVERIFY( error.isEmpty() );
+
+  QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().propertyType(), QgsProperty::FieldBasedProperty );
+  QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().field(), QStringLiteral( "DEPTH_FIELD" ) );
+
+  inputs.insert( QStringLiteral( "DISTANCE" ), QgsProperty::fromExpression( QStringLiteral( "A_FIELD * 200" ) ) );
+
+  exportedParams = bufferAlg->asMap( inputs, context );
+  outputs = QgsProcessingUtils::preprocessQgisProcessParameters( inputs, ok, error );
+  QVERIFY( ok );
+  QVERIFY( error.isEmpty() );
+
+  QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().propertyType(), QgsProperty::ExpressionBasedProperty );
+  QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().expressionString(), QStringLiteral( "A_FIELD * 200" ) );
 }
 
 QGSTEST_MAIN( TestQgsProcessing )

--- a/tests/src/python/test_qgsprocessexecutable_pt2.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt2.py
@@ -305,6 +305,28 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
 
         self.assertEqual(rc, 1)
 
+    def testDynamicParameters(self):
+        output_file = self.TMP_DIR + '/dynamic_out.shp'
+
+        params = {
+            'inputs':
+                {
+                    'INPUT': TEST_DATA_DIR + '/points.shp',
+                    'DISTANCE': {'type': 'data_defined', 'field': 'fid'},
+                    'OUTPUT': output_file
+                }
+        }
+
+        rc, output, err = self.run_process_stdin(
+            ['run', 'native:buffer', '-'], json.dumps(params))
+        self.assertFalse(self._strip_ignorable_errors(err))
+
+        self.assertEqual(rc, 0)
+
+        res = json.loads(output)
+        self.assertEqual(res['algorithm_details']['id'], 'native:buffer')
+        self.assertEqual(res['inputs']['DISTANCE'], {'field': 'fid', 'type': 'data_defined'})
+
 
 if __name__ == '__main__':
     # look for qgis bin path

--- a/tests/src/python/test_qgsprocessexecutable_pt2.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt2.py
@@ -306,6 +306,19 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
         self.assertEqual(rc, 1)
 
     def testDynamicParameters(self):
+        output_file = self.TMP_DIR + '/dynamic_out2.shp'
+
+        rc, output, err = self.run_process(
+            ['run', 'native:buffer', '--INPUT=' + TEST_DATA_DIR + '/points.shp', '--OUTPUT=' + output_file, '--DISTANCE=field:fid', '--json'])
+        self.assertFalse(self._strip_ignorable_errors(err))
+
+        self.assertEqual(rc, 0)
+
+        res = json.loads(output)
+        self.assertEqual(res['algorithm_details']['id'], 'native:buffer')
+        self.assertEqual(res['inputs']['DISTANCE'], 'field:fid')
+
+    def testDynamicParametersJson(self):
         output_file = self.TMP_DIR + '/dynamic_out.shp'
 
         params = {


### PR DESCRIPTION
While many processing algorithms support data defined parameter values, these were not possible to specify when using the qgis_process tool (or when representing algorithm settings as JSON or qgis_process commands)

This PR adds new syntax to allow specifying data defined parameter values when running qgis_process, and ensures that all the helper functions for copying settings as JSON/qgis_process commands correctly handle data defined values.

Fixes https://github.com/qgis/QGIS/issues/50482

Sponsored by the Research Institute for Nature and Forest, Flemish Govt