### PR TITLE
Don't allow status bar coordinate widget to change sizes so regularly

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -26,9 +26,11 @@ class QValidator;
 
 class QgsMapCanvas;
 
-#include <QWidget>
 #include "qgis_app.h"
 #include "qgspointxy.h"
+
+#include <QWidget>
+#include <QElapsedTimer>
 
 class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
 {
@@ -86,6 +88,9 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     unsigned int mMousePrecisionDecimalPlaces;
 
     QgsPointXY mLastCoordinate;
+
+    bool mIsFirstSizeChange = true;
+    QElapsedTimer mLastSizeChangeTimer;
 
 };
 


### PR DESCRIPTION
Now, the widget will always immediately grow to fit the coordinates, but won't immediately reshrink until a short timeout has occurred. This avoids yuck UI movement which occurs when the mouse is moved over a map and the coordinate widget size jumps all around the place.
