### PR TITLE
Fixes Shortcuts prevent inputs with AltGr  #29021

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -891,6 +891,16 @@ int main( int argc, char *argv[] )
   // Initialize the application and the translation stuff
   /////////////////////////////////////////////////////////////////////
 
+
+#if defined(Q_OS_WIN)
+  // FIXES #29021
+  // Prevent Qt from treating the AltGr key as  Ctrl+Alt on Windows,
+  // which causes shortcuts to be fired instead of entering some characters (eg "}", "|")
+  // on some keyboard layouts
+  qputenv( "QT_QPA_PLATFORM", "windows:altgr" );
+#endif
+
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(ANDROID)
   bool myUseGuiFlag = nullptr != getenv( "DISPLAY" );
 #else

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -894,9 +894,9 @@ int main( int argc, char *argv[] )
 
 #if defined(Q_OS_WIN)
   // FIXES #29021
-  // Prevent Qt from treating the AltGr key as  Ctrl+Alt on Windows,
-  // which causes shortcuts to be fired instead of entering some characters (eg "}", "|")
-  // on some keyboard layouts
+  // Prevent Qt from treating the AltGr key as  Ctrl+Alt on Windows, which causes shortcuts to be fired
+  // instead of entering some characters (eg "}", "|") on some keyboard layouts
+  // See https://doc.qt.io/qt-6/qguiapplication.html#platform-specific-arguments
   qputenv( "QT_QPA_PLATFORM", "windows:altgr" );
 #endif
 


### PR DESCRIPTION
Fixes #29021

## Description 
A long standing bug in QGIS is the inability to enter some characters (`}`, `|`, ...) on windows, with keyboard layouts that use the AltGr key (Spanish, French...). This is particularly annoying within the python console.

The reason is that Qt considers by default the AltGr key to be a shortcut for Ctrl+Alt, which causes some QGIS global shortcuts to be fired instead of entering the character.

There has been some discussion about this on PR #38608.
This is not specific to QGIS, as it happens in other Qt applications (see https://bugreports.qt.io/browse/QTBUG-73247)

Setting the environment variable `QT_QPA_PLATFORM=windows:altgr` before creating the QgsApplication on windows builds could neatly solve the issue. (cf. https://doc.qt.io/qt-6/qguiapplication.html#platform-specific-arguments)
