### PR TITLE
extract httpheaders when creating QgsDataSourceUri from string

### DIFF
--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -149,6 +149,14 @@ Returns a cleansed ``key``
     QVariant &operator[]( const QString &key );
 
 
+    void insert( const QString &key, const QVariant &value );
+%Docstring
+insert a ``key`` with the specific ``value``
+
+:param key: a key to add
+:param value: a value to add for the key
+%End
+
     QList<QString> keys() const;
 %Docstring
 

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -272,3 +272,15 @@ QList<QString> QgsHttpHeaders::keys() const
 {
   return mHeaders.keys();
 }
+
+
+void QgsHttpHeaders::insert( const QString &key, const QVariant &val )
+{
+  QString k2 = key;
+
+  if ( k2.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+  {
+    k2 = k2.right( k2.length() - QgsHttpHeaders::PARAM_PREFIX.length() );
+  }
+  mHeaders.insert( k2, val );
+}

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -175,6 +175,13 @@ class CORE_EXPORT QgsHttpHeaders
     QgsHttpHeaders &operator = ( const QMap<QString, QVariant> &headers ) SIP_SKIP;
 
     /**
+     * \brief insert a \a key with the specific \a value
+     * \param key a key to add
+     * \param value a value to add for the key
+     */
+    void insert( const QString &key, const QVariant &value );
+
+    /**
      * \return the list of all http header keys
      */
     QList<QString> keys() const;

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -209,6 +209,10 @@ QgsDataSourceUri::QgsDataSourceUri( const QString &u )
       {
         QgsDebugMsg( QStringLiteral( "gsslib ignored" ) );
       }
+      else if ( pname.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+      {
+        mHttpHeaders.insert( pname, pval );
+      }
       else
       {
         QgsDebugMsgLevel( "parameter \"" + pname + "\":\"" + pval + "\" added", 4 );

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -148,6 +148,14 @@ void TestQgsHttpheaders::createQgsOwsConnection()
   QgsDataSourceUri uri( QString( "https://www.ogc.org/?p1=v1" ) );
   QgsDataSourceUri uri2 = ows.addWmsWcsConnectionSettings( uri, "service", "name" );
   QCOMPARE( uri2.encodedUri(), "https://www.ogc.org/?p1=v1&http-header:other_http_header=value&http-header:referer=http://test.com" );
+
+  // check space separated string
+  QCOMPARE( uri2.uri(), " https://www.ogc.org/?p1='v1' http-header:other_http_header='value' http-header:referer='http://test.com' referer='http://test.com'" );
+  // build new QgsDataSourceUri according to space separated string
+  QgsDataSourceUri uri3( uri2.uri() );
+  QCOMPARE( uri3.httpHeader( QgsHttpHeaders::KEY_REFERER ), "http://test.com" );
+  QCOMPARE( uri3.httpHeader( "other_http_header" ), "value" );
+  QCOMPARE( uri3.encodedUri(), "https://www.ogc.org/?p1=v1&referer=http://test.com&http-header:other_http_header=value&http-header:referer=http://test.com" );
 }
 
 


### PR DESCRIPTION
When QgsDataSourceUri was built from uri (like previously serialized to space delimiter form), httpHeaders were not extracted. This induced partial uri and therefore invalid network requests.

PR needs to be backported

fix #51409 