### PR TITLE
Fix generate_console_pap.py script

### DIFF
--- a/python/qsci_apis/generate_console_pap.py
+++ b/python/qsci_apis/generate_console_pap.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     # print api_files.__repr__()
     # print pap_file.__repr__()
 
-    app = QApplication(sys.argv, False)  # just start a non-gui console app
+    app = QApplication(sys.argv)
     api_lexer = QsciLexerPython()
     prepap = PrepareAPIs(api_lexer, api_files, pap_file)
     prepap.prepareAPI()


### PR DESCRIPTION
This script was still using Qt4 QApplication constructor.

I'm not sure how/whether this script is still in use. @jef-n do you have any insights here? How are the api files generated for the release packages now?