### PR TITLE
Add dataset relationship editing and creation capabilities in browser

### DIFF
--- a/python/gui/auto_generated/qgsdbrelationshipwidget.sip.in
+++ b/python/gui/auto_generated/qgsdbrelationshipwidget.sip.in
@@ -1,0 +1,112 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdbrelationshipwidget.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsDbRelationWidget : QWidget
+{
+%Docstring(signature="appended")
+A widget for configuration of the properties of a relationship in a database.
+
+.. versionadded:: 3.30
+%End
+
+%TypeHeaderCode
+#include "qgsdbrelationshipwidget.h"
+%End
+  public:
+
+    QgsDbRelationWidget( QgsAbstractDatabaseProviderConnection *connection /Transfer/, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsDbRelationWidget with the specified ``parent`` widget, for the specified ``connection``.
+
+Ownership of ``connection`` is transferred to the widget.
+%End
+
+    void setRelationship( const QgsWeakRelation &relationship );
+%Docstring
+Sets the current ``relationship`` to show properties for in the widget.
+
+.. seealso:: :py:func:`relationship`
+%End
+
+    QgsWeakRelation relationship() const;
+%Docstring
+Returns the relationship as defined in the widget.
+
+.. seealso:: :py:func:`setRelationship`
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the widget currently represents a valid relationship configuration.
+
+.. seealso:: :py:func:`validityChanged`
+%End
+
+  signals:
+
+    void validityChanged( bool isValid );
+%Docstring
+Emitted whenever the validity of the relationship configuration in the widget changes.
+
+.. seealso:: :py:func:`isValid`
+%End
+
+};
+
+
+
+class QgsDbRelationDialog: QDialog
+{
+%Docstring(signature="appended")
+A dialog for configuration of the properties of a relationship in a database.
+
+.. versionadded:: 3.30
+%End
+
+%TypeHeaderCode
+#include "qgsdbrelationshipwidget.h"
+%End
+  public:
+
+    explicit QgsDbRelationDialog( QgsAbstractDatabaseProviderConnection *connection /Transfer/, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::WindowFlags() );
+%Docstring
+Constructor for QgsDbRelationDialog, with the specified ``parent`` widget and window ``flags``, for the specified ``connection``.
+
+Ownership of ``connection`` is transferred to the widget.
+%End
+
+    void setRelationship( const QgsWeakRelation &relationship );
+%Docstring
+Sets the current ``relationship`` to show properties for in the dialog.
+
+.. seealso:: :py:func:`relationship`
+%End
+
+    QgsWeakRelation relationship() const;
+%Docstring
+Returns the relationship as defined in the dialog.
+
+.. seealso:: :py:func:`setRelationship`
+%End
+
+  public slots:
+
+    virtual void accept();
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdbrelationshipwidget.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -47,6 +47,7 @@
 %Include auto_generated/qgsdataitemguiprovider.sip
 %Include auto_generated/qgsdataitemguiproviderregistry.sip
 %Include auto_generated/qgsdatasourceselectdialog.sip
+%Include auto_generated/qgsdbrelationshipwidget.sip
 %Include auto_generated/qgsnewdatabasetablenamewidget.sip
 %Include auto_generated/qgsdetaileditemdata.sip
 %Include auto_generated/qgsdetaileditemdelegate.sip

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2000,6 +2000,13 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
         connect( createRelationshipAction, &QAction::triggered, this, [ = ]
         {
           std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn { static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, {} ) ) };
+
+          if ( conn->tables().isEmpty() )
+          {
+            notify( QString(), QObject::tr( "Relationships cannot be created in an empty database" ), context, Qgis::MessageLevel::Warning );
+            return;
+          }
+
           QgsDbRelationDialog dialog( conn.release(), QgisApp::instance() );
           dialog.setWindowTitle( tr( "New Relationship" ) );
           if ( dialog.exec() )

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -269,6 +269,8 @@ class QgsRelationshipItemGuiProvider : public QObject, public QgsDataItemGuiProv
     QgsRelationshipItemGuiProvider() = default;
 
     QString name() override;
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
     QWidget *createParamWidget( QgsDataItem *item, QgsDataItemGuiContext context ) override;
 };
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -17,17 +17,11 @@
 #include <sqlite3.h>
 
 #include "qgsgeopackageproviderconnection.h"
-#include "qgsogrdbconnection.h"
 #include "qgssettings.h"
-#include "qgsogrprovider.h"
 #include "qgsmessagelog.h"
-#include "qgsproviderregistry.h"
-#include "qgsprovidermetadata.h"
 #include "qgsapplication.h"
 #include "qgsvectorlayer.h"
 #include "qgsfeedback.h"
-#include "qgsogrutils.h"
-#include "qgsfielddomain.h"
 #include "qgscoordinatetransform.h"
 
 #include <QTextCodec>
@@ -354,6 +348,12 @@ void QgsGeoPackageProviderConnection::setDefaultCapabilities()
   {
     Qgis::SqlLayerDefinitionCapability::SubsetStringFilter,
   };
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+  mCapabilities |= Capability::AddRelationship;
+  mCapabilities |= Capability::UpdateRelationship;
+  mCapabilities |= Capability::DeleteRelationship;
+#endif
 }
 
 QString QgsGeoPackageProviderConnection::primaryKeyColumnName( const QString &table ) const

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -19,7 +19,6 @@
 
 #include "qgsabstractdatabaseproviderconnection.h"
 #include "qgsogrproviderconnection.h"
-#include "qgsogrutils.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE

--- a/src/core/providers/qgsabstractproviderconnection.h
+++ b/src/core/providers/qgsabstractproviderconnection.h
@@ -21,8 +21,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgsdatasourceuri.h"
-#include "qgsexception.h"
 
 /**
  * \brief The QgsAbstractProviderConnection provides an interface for data provider connections.

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -24,6 +24,7 @@
 #include <QStringList>
 
 #include "qgsabstractproviderconnection.h"
+#include "qgshttpheaders.h"
 
 class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderConnection
 {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -485,6 +485,7 @@ set(QGIS_GUI_SRCS
   qgsdataitemguiproviderregistry.cpp
   qgsdatumtransformdialog.cpp
   qgsdatasourceselectdialog.cpp
+  qgsdbrelationshipwidget.cpp
   qgsdetaileditemdata.cpp
   qgsdetaileditemdelegate.cpp
   qgsdetaileditemwidget.cpp
@@ -747,6 +748,7 @@ set(QGIS_GUI_HDRS
   qgsdataitemguiproviderregistry.h
   qgsdatasourcemanagerdialog.h
   qgsdatasourceselectdialog.h
+  qgsdbrelationshipwidget.h
   qgsnewdatabasetablenamewidget.h
   qgsdatumtransformdialog.h
   qgsdetaileditemdata.h

--- a/src/gui/qgsdbrelationshipwidget.cpp
+++ b/src/gui/qgsdbrelationshipwidget.cpp
@@ -58,6 +58,19 @@ QgsDbRelationWidget::QgsDbRelationWidget( QgsAbstractDatabaseProviderConnection 
       mStrengthCombo->addItem( QgsRelation::strengthToDisplayString( strength ), QVariant::fromValue( strength ) );
   }
 
+  const Qgis::RelationshipCapabilities capabilities = mConnection->supportedRelationshipCapabilities();
+  if ( !( capabilities & Qgis::RelationshipCapability::ForwardPathLabel ) )
+  {
+    mForwardLabelLineEdit->hide();
+    mForwardLabel->hide();
+  }
+
+  if ( !( capabilities & Qgis::RelationshipCapability::BackwardPathLabel ) )
+  {
+    mBackwardLabelLineEdit->hide();
+    mReverseLabel->hide();
+  }
+
   const QStringList relatedTableTypes = mConnection->relatedTableTypes();
   mRelatedTableTypeCombo->addItems( relatedTableTypes );
 

--- a/src/gui/qgsdbrelationshipwidget.cpp
+++ b/src/gui/qgsdbrelationshipwidget.cpp
@@ -98,26 +98,21 @@ QgsDbRelationWidget::QgsDbRelationWidget( QgsAbstractDatabaseProviderConnection 
     mRightFieldsCombo->setFields( mConnection->fields( QString(), mRightTableCombo->currentText() ) );
     emit validityChanged( isValid() );
   } );
-  connect( mCardinalityCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+
+  for ( QComboBox *combo :
+        {
+          mCardinalityCombo,
+          qobject_cast< QComboBox *>( mLeftFieldsCombo ),
+          qobject_cast< QComboBox *>( mRightFieldsCombo ),
+          mStrengthCombo,
+          mRelatedTableTypeCombo
+        } )
   {
-    emit validityChanged( isValid() );
-  } );
-  connect( mLeftFieldsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
-  {
-    emit validityChanged( isValid() );
-  } );
-  connect( mRightFieldsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
-  {
-    emit validityChanged( isValid() );
-  } );
-  connect( mStrengthCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
-  {
-    emit validityChanged( isValid() );
-  } );
-  connect( mRelatedTableTypeCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
-  {
-    emit validityChanged( isValid() );
-  } );
+    connect( combo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+    {
+      emit validityChanged( isValid() );
+    } );
+  }
 
   mLeftFieldsCombo->setFields( mConnection->fields( QString(), mLeftTableCombo->currentText() ) );
   mRightFieldsCombo->setFields( mConnection->fields( QString(), mRightTableCombo->currentText() ) );

--- a/src/gui/qgsdbrelationshipwidget.cpp
+++ b/src/gui/qgsdbrelationshipwidget.cpp
@@ -1,0 +1,212 @@
+/***************************************************************************
+    qgsdbrelationshipwidget.cpp
+    ------------------
+    Date                 : November 2022
+    Copyright            : (C) 2022 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdbrelationshipwidget.h"
+#include "qgsgui.h"
+#include "qgsdatabasetablemodel.h"
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QSortFilterProxyModel>
+
+//
+// QgsDbRelationWidget
+//
+
+QgsDbRelationWidget::QgsDbRelationWidget( QgsAbstractDatabaseProviderConnection *connection, QWidget *parent )
+  : QWidget( parent )
+  , mConnection( connection )
+{
+  setupUi( this );
+
+  // takes ownership of connection
+  mTableModel = new QgsDatabaseTableModel( connection, QString(), this );
+
+  const QList<Qgis::RelationshipCardinality> cardinalities = mConnection->supportedRelationshipCardinalities();
+  for ( Qgis::RelationshipCardinality cardinality :
+        {
+          Qgis::RelationshipCardinality::OneToMany,
+          Qgis::RelationshipCardinality::ManyToOne,
+          Qgis::RelationshipCardinality::OneToOne,
+          Qgis::RelationshipCardinality::ManyToMany
+        } )
+  {
+    if ( cardinalities.contains( cardinality ) )
+      mCardinalityCombo->addItem( QgsRelation::cardinalityToDisplayString( cardinality ), QVariant::fromValue( cardinality ) );
+  }
+
+  const QList<Qgis::RelationshipStrength> strengths = mConnection->supportedRelationshipStrengths();
+  for ( Qgis::RelationshipStrength strength :
+        {
+          Qgis::RelationshipStrength::Association,
+          Qgis::RelationshipStrength::Composition
+        } )
+  {
+    if ( strengths.contains( strength ) )
+      mStrengthCombo->addItem( QgsRelation::strengthToDisplayString( strength ), QVariant::fromValue( strength ) );
+  }
+
+  const QStringList relatedTableTypes = mConnection->relatedTableTypes();
+  mRelatedTableTypeCombo->addItems( relatedTableTypes );
+
+  mProxyModel = new QSortFilterProxyModel( mTableModel );
+  mProxyModel->setSourceModel( mTableModel );
+  mProxyModel->setDynamicSortFilter( true );
+  mProxyModel->setSortCaseSensitivity( Qt::CaseInsensitive );
+  mProxyModel->setSortRole( Qt::DisplayRole );
+  mProxyModel->sort( 0 );
+
+  mLeftTableCombo->setModel( mProxyModel );
+  mRightTableCombo->setModel( mProxyModel );
+
+  connect( mNameEdit, &QLineEdit::textChanged, this, [ = ]
+  {
+    emit validityChanged( isValid() );
+  } );
+  connect( mLeftTableCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    mLeftFieldsCombo->setFields( mConnection->fields( QString(), mLeftTableCombo->currentText() ) );
+    emit validityChanged( isValid() );
+  } );
+  connect( mRightTableCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    mRightFieldsCombo->setFields( mConnection->fields( QString(), mRightTableCombo->currentText() ) );
+    emit validityChanged( isValid() );
+  } );
+  connect( mCardinalityCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    emit validityChanged( isValid() );
+  } );
+  connect( mLeftFieldsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    emit validityChanged( isValid() );
+  } );
+  connect( mRightFieldsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    emit validityChanged( isValid() );
+  } );
+  connect( mStrengthCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    emit validityChanged( isValid() );
+  } );
+  connect( mRelatedTableTypeCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    emit validityChanged( isValid() );
+  } );
+
+  mLeftFieldsCombo->setFields( mConnection->fields( QString(), mLeftTableCombo->currentText() ) );
+  mRightFieldsCombo->setFields( mConnection->fields( QString(), mRightTableCombo->currentText() ) );
+}
+
+void QgsDbRelationWidget::setRelationship( const QgsWeakRelation &relationship )
+{
+  mNameEdit->setText( relationship.name() );
+}
+
+QgsWeakRelation QgsDbRelationWidget::relationship() const
+{
+  QgsWeakRelation result( mNameEdit->text(),
+                          mNameEdit->text(),
+                          mStrengthCombo->currentData().value< Qgis::RelationshipStrength >(),
+                          QString(),
+                          QString(),
+                          mConnection->tableUri( QString(), mRightTableCombo->currentText() ),
+                          mConnection->providerKey(),
+                          QString(),
+                          QString(),
+                          mConnection->tableUri( QString(), mLeftTableCombo->currentText() ),
+                          mConnection->providerKey()
+                        );
+  result.setCardinality( mCardinalityCombo->currentData().value< Qgis::RelationshipCardinality >() );
+  result.setReferencedLayerFields( { mLeftFieldsCombo->currentText() } );
+  result.setReferencingLayerFields( { mRightFieldsCombo->currentText() } );
+  result.setForwardPathLabel( mForwardLabelLineEdit->text() );
+  result.setBackwardPathLabel( mBackwardLabelLineEdit->text() );
+
+  if ( mRelatedTableTypeCombo->currentIndex() >= 0 )
+    result.setRelatedTableType( mRelatedTableTypeCombo->currentText() );
+  return result;
+}
+
+bool QgsDbRelationWidget::isValid() const
+{
+  if ( mNameEdit->text().trimmed().isEmpty() )
+    return false;
+
+  if ( mLeftTableCombo->currentText().isEmpty() )
+    return false;
+
+  if ( mRightTableCombo->currentText().isEmpty() )
+    return false;
+
+  if ( mLeftTableCombo->currentText() == mRightTableCombo->currentText() )
+    return false;
+
+  if ( mLeftFieldsCombo->currentText().isEmpty() )
+    return false;
+
+  if ( mRightFieldsCombo->currentText().isEmpty() )
+    return false;
+
+
+  return true;
+}
+
+//
+// QgsDbRelationDialog
+//
+
+QgsDbRelationDialog::QgsDbRelationDialog( QgsAbstractDatabaseProviderConnection *connection, QWidget *parent, Qt::WindowFlags flags )
+  : QDialog( parent, flags )
+{
+  setObjectName( QStringLiteral( "QgsDbRelationDialog" ) );
+
+  QVBoxLayout *vLayout = new QVBoxLayout();
+  mWidget = new QgsDbRelationWidget( connection );
+  vLayout->addWidget( mWidget, 1 );
+
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vLayout->addWidget( mButtonBox );
+
+  setLayout( vLayout );
+  connect( mWidget, &QgsDbRelationWidget::validityChanged, this, &QgsDbRelationDialog::validityChanged );
+  validityChanged( mWidget->isValid() );
+
+  QgsGui::enableAutoGeometryRestore( this );
+}
+
+void QgsDbRelationDialog::setRelationship( const QgsWeakRelation &relationship )
+{
+  mWidget->setRelationship( relationship );
+}
+
+QgsWeakRelation QgsDbRelationDialog::relationship() const
+{
+  return mWidget->relationship();
+}
+
+void QgsDbRelationDialog::accept()
+{
+  if ( !mWidget->isValid() )
+    return;
+
+  QDialog::accept();
+}
+
+void QgsDbRelationDialog::validityChanged( bool isValid )
+{
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( isValid );
+}

--- a/src/gui/qgsdbrelationshipwidget.cpp
+++ b/src/gui/qgsdbrelationshipwidget.cpp
@@ -127,6 +127,7 @@ void QgsDbRelationWidget::setRelationship( const QgsWeakRelation &relationship )
 {
   mRelation = relationship;
   mNameEdit->setText( mRelation.name() );
+  mNameEdit->setEnabled( false );
   mStrengthCombo->setCurrentIndex( mStrengthCombo->findData( QVariant::fromValue( mRelation.strength() ) ) );
 
   QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( mConnection->providerKey(), mRelation.referencedLayerSource() );
@@ -145,7 +146,7 @@ void QgsDbRelationWidget::setRelationship( const QgsWeakRelation &relationship )
 QgsWeakRelation QgsDbRelationWidget::relationship() const
 {
   QgsWeakRelation result( mRelation.id().isEmpty() ? mNameEdit->text() : mRelation.id(),
-                          mNameEdit->text(),
+                          mRelation.name().isEmpty() ? mNameEdit->text() : mRelation.name(),
                           mStrengthCombo->currentData().value< Qgis::RelationshipStrength >(),
                           QString(),
                           QString(),

--- a/src/gui/qgsdbrelationshipwidget.h
+++ b/src/gui/qgsdbrelationshipwidget.h
@@ -1,0 +1,136 @@
+/***************************************************************************
+    qgsdbrelationshipwidget.h
+    ------------------
+    Date                 : November 2022
+    Copyright            : (C) 2022 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDBRELATIONSHIPWIDGET_H
+#define QGSDBRELATIONSHIPWIDGET_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "ui_qgsdbrelationshipwidgetbase.h"
+#include "qgis.h"
+#include "qgsweakrelation.h"
+#include <QAbstractTableModel>
+#include <QDialog>
+
+class QDialogButtonBox;
+class QgsAbstractDatabaseProviderConnection;
+class QgsDatabaseTableModel;
+class QSortFilterProxyModel;
+
+/**
+ * \ingroup gui
+ * \brief A widget for configuration of the properties of a relationship in a database.
+ *
+ * \since QGIS 3.30
+ */
+class GUI_EXPORT QgsDbRelationWidget : public QWidget, private Ui_QgsDbRelationshipWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsDbRelationWidget with the specified \a parent widget, for the specified \a connection.
+     *
+     * Ownership of \a connection is transferred to the widget.
+     */
+    QgsDbRelationWidget( QgsAbstractDatabaseProviderConnection *connection SIP_TRANSFER, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Sets the current \a relationship to show properties for in the widget.
+     *
+     * \see relationship()
+     */
+    void setRelationship( const QgsWeakRelation &relationship );
+
+    /**
+     * Returns the relationship as defined in the widget.
+     *
+     * \see setRelationship()
+     */
+    QgsWeakRelation relationship() const;
+
+    /**
+     * Returns TRUE if the widget currently represents a valid relationship configuration.
+     *
+     * \see validityChanged()
+     */
+    bool isValid() const;
+
+  signals:
+
+    /**
+     * Emitted whenever the validity of the relationship configuration in the widget changes.
+     *
+     * \see isValid()
+     */
+    void validityChanged( bool isValid );
+
+  private:
+
+    QgsAbstractDatabaseProviderConnection *mConnection = nullptr;
+    QgsDatabaseTableModel *mTableModel = nullptr;
+    QSortFilterProxyModel *mProxyModel = nullptr;
+
+};
+
+
+
+/**
+ * \ingroup gui
+ * \brief A dialog for configuration of the properties of a relationship in a database.
+ *
+ * \since QGIS 3.30
+ */
+class GUI_EXPORT QgsDbRelationDialog: public QDialog
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsDbRelationDialog, with the specified \a parent widget and window \a flags, for the specified \a connection.
+     *
+     * Ownership of \a connection is transferred to the widget.
+     */
+    explicit QgsDbRelationDialog( QgsAbstractDatabaseProviderConnection *connection SIP_TRANSFER, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
+
+    /**
+     * Sets the current \a relationship to show properties for in the dialog.
+     *
+     * \see relationship()
+     */
+    void setRelationship( const QgsWeakRelation &relationship );
+
+    /**
+     * Returns the relationship as defined in the dialog.
+     *
+     * \see setRelationship()
+     */
+    QgsWeakRelation relationship() const;
+
+  public slots:
+
+    void accept() override;
+
+  private slots:
+
+    void validityChanged( bool isValid );
+
+  private:
+    QgsDbRelationWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
+};
+
+#endif // QGSDBRELATIONSHIPWIDGET_H

--- a/src/gui/qgsdbrelationshipwidget.h
+++ b/src/gui/qgsdbrelationshipwidget.h
@@ -82,6 +82,7 @@ class GUI_EXPORT QgsDbRelationWidget : public QWidget, private Ui_QgsDbRelations
     QgsAbstractDatabaseProviderConnection *mConnection = nullptr;
     QgsDatabaseTableModel *mTableModel = nullptr;
     QSortFilterProxyModel *mProxyModel = nullptr;
+    QgsWeakRelation mRelation;
 
 };
 

--- a/src/ui/qgsdbrelationshipwidgetbase.ui
+++ b/src/ui/qgsdbrelationshipwidgetbase.ui
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDbRelationshipWidgetBase</class>
+ <widget class="QWidget" name="QgsDbRelationshipWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>712</width>
+    <height>670</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Field Domain</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Cardinality</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mCardinalityCombo"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="mStrengthCombo"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Strength</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Advanced</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Related table type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mForwardLabelLineEdit"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Forward label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="mRelatedTableTypeCombo"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Reverse label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="mBackwardLabelLineEdit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mNameEdit"/>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Tables</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Parent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="mLeftTableCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Child</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="mRightTableCombo"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Fields</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Parent field</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsFieldComboBox" name="mLeftFieldsCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Child field</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsFieldComboBox" name="mRightFieldsCombo"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsdbrelationshipwidgetbase.ui
+++ b/src/ui/qgsdbrelationshipwidgetbase.ui
@@ -70,7 +70,7 @@
        <widget class="QLineEdit" name="mForwardLabelLineEdit"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="mForwardLabel">
         <property name="text">
          <string>Forward label</string>
         </property>
@@ -80,7 +80,7 @@
        <widget class="QComboBox" name="mRelatedTableTypeCombo"/>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_13">
+       <widget class="QLabel" name="mReverseLabel">
         <property name="text">
          <string>Reverse label</string>
         </property>


### PR DESCRIPTION
Currently supported for GDAL supported database files, ie:

- ESRI FileGeodatabases on GDAL 3.6+
- GeoPackage and sqlite databases on GDAL 3.7+

This allows for creation of new embedded relationship definition in these database files, and for deleting and modification of existing relationships (depending on the constraints of the actual database format!)

Sponsored by Provincie Zuid-Holland

https://user-images.githubusercontent.com/1829991/211723673-b81524df-330a-4116-9499-91e86e050419.mp4

