### PR TITLE
Fix split parts tool

### DIFF
--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -570,7 +570,10 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::splitParts( const QgsPoin
 
         ++numberOfSplitParts;
       }
-      else if ( splitFunctionReturn == Qgis::GeometryOperationResult::NothingHappened )
+      // Note: For multilinestring layers, when the split line does not intersect the feature part,
+      // QgsGeometry::splitGeometry returns InvalidBaseGeometry instead of NothingHappened
+      else if ( splitFunctionReturn == Qgis::GeometryOperationResult::NothingHappened ||
+                splitFunctionReturn == Qgis::GeometryOperationResult::InvalidBaseGeometry )
       {
         // Add part as is
         resultCollection.append( part );


### PR DESCRIPTION
## Description

Fixes #51321
Fixes #50348

When splitting a part of a MultiPolygon or MultiLinestring layer, the split part tools randomly drops some parts of the split feature.

This PR also fix a previous bug which prevented split geometries to be further split, since they were considered invalid by GEOS. The split parts tool calls `splitGeometry` individually on each part, which solves the problem. 

![split](https://user-images.githubusercontent.com/9693475/211929231-67c2d0a6-5cb6-461e-994a-32ef0fd2a702.gif)

⚠️ Resulting multi geometries are still considered invalid though, so may not play well with other algorithms/processing tools.