### PR TITLE
Add feature_id(some feature) function

### DIFF
--- a/resources/function_help/json/feature_id
+++ b/resources/function_help/json/feature_id
@@ -1,0 +1,15 @@
+{
+  "name": "feature_id",
+  "type": "function",
+  "groups": ["Record and Attributes"],
+  "description": "Returns a feature's unique ID.",
+  "arguments": [{
+    "arg": "feature",
+    "description": "a feature object"
+  }],
+  "examples": [{
+    "expression": "feature_id( @feature )",
+    "returns": "the ID of the current feature"
+  }],
+  "tags": []
+}

--- a/resources/function_help/json/feature_id
+++ b/resources/function_help/json/feature_id
@@ -2,7 +2,7 @@
   "name": "feature_id",
   "type": "function",
   "groups": ["Record and Attributes"],
-  "description": "Returns a feature's unique ID.",
+  "description": "Returns a feature's unique ID, or NULL if the feature is not valid.",
   "arguments": [{
     "arg": "feature",
     "description": "a feature object"

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6058,6 +6058,14 @@ static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionC
   return QVariant();
 }
 
+static QVariant fcnGetFeatureId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QgsFeature feat = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
+  if ( !feat.isValid() )
+    return QVariant();
+  return feat.id();
+}
+
 static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
@@ -8730,6 +8738,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     functions << uuidFunc;
 
     functions
+        << new QgsStaticExpressionFunction( QStringLiteral( "feature_id" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "feature" ) ), fcnGetFeatureId, QStringLiteral( "Record and Attributes" ), QString(), true )
         << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "attribute" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "value" ), true ),

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2342,6 +2342,7 @@ class TestQgsExpression: public QObject
     void eval_feature_id()
     {
       QgsFeature f( 100 );
+      f.setValid( true );
       // older form
       QgsExpression exp( QStringLiteral( "$id * 2" ) );
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
@@ -2352,11 +2353,16 @@ class TestQgsExpression: public QObject
       QgsExpression exp2( QStringLiteral( "@id * 2" ) );
       v = exp.evaluate( &context );
       QCOMPARE( v.toInt(), 200 );
+
+      QgsExpression exp3( QStringLiteral( "feature_id(@feature)" ) );
+      v = exp3.evaluate( &context );
+      QCOMPARE( v.toInt(), 100 );
     }
 
     void eval_current_feature()
     {
       QgsFeature f( 100 );
+      f.setValid( true );
       // older form
       QgsExpression exp( QStringLiteral( "$currentfeature" ) );
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
@@ -2364,11 +2370,19 @@ class TestQgsExpression: public QObject
       QgsFeature evalFeature = v.value<QgsFeature>();
       QCOMPARE( evalFeature.id(), f.id() );
 
+      QgsExpression expId( QStringLiteral( "feature_id($currentfeature)" ) );
+      v = expId.evaluate( &context );
+      QCOMPARE( v.toInt(), f.id() );
+
       // newer form
       QgsExpression exp2( QStringLiteral( "@feature" ) );
       v = exp2.evaluate( &context );
       evalFeature = v.value<QgsFeature>();
       QCOMPARE( evalFeature.id(), f.id() );
+
+      QgsExpression exp2Id( QStringLiteral( "feature_id(@feature)" ) );
+      v = exp2Id.evaluate( &context );
+      QCOMPARE( v.toInt(), f.id() );
     }
 
     void eval_current_geometry()
@@ -2521,6 +2535,10 @@ class TestQgsExpression: public QObject
       {
         QgsFeature feat = res.value<QgsFeature>();
         QCOMPARE( feat.id(), static_cast<QgsFeatureId>( featureId ) );
+
+        QgsExpression featureIdExp( QStringLiteral( "feature_id(%1)" ).arg( string ) );
+        const QVariant idRes = featureIdExp.evaluate();
+        QCOMPARE( idRes.toInt(), featureId );
       }
     }
 


### PR DESCRIPTION
Allows for retrieving the feature ID of a feature object. Accepts one argument which must be a feature object. Accordingly this function can be used with the results of any other function which returns feature objects, such as "get_feature", "overlay_*", etc.

Fixes #51116
