### PR TITLE
Use utf-8 encoding to call gdal's file operation function

### DIFF
--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -162,7 +162,7 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
     throw QgsProcessingException( QObject::tr( "Error creating GDAL driver" ) );
   }
 
-  gdal::dataset_unique_ptr hOutputDataset( GDALCreate( hOutputFileDriver, outputLayerFileName.toLocal8Bit().constData(), width, height, nBands, GDALDataType::GDT_Byte, nullptr ) );
+  gdal::dataset_unique_ptr hOutputDataset( GDALCreate( hOutputFileDriver, outputLayerFileName.toUtf8().constData(), width, height, nBands, GDALDataType::GDT_Byte, nullptr ) );
   if ( !hOutputDataset )
   {
     throw QgsProcessingException( QObject::tr( "Error creating GDAL output layer" ) );

--- a/src/analysis/raster/qgsalignraster.cpp
+++ b/src/analysis/raster/qgsalignraster.cpp
@@ -428,7 +428,7 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
   }
 
   // Open the source file.
-  const gdal::dataset_unique_ptr hSrcDS( GDALOpen( raster.inputFilename.toLocal8Bit().constData(), GA_ReadOnly ) );
+  const gdal::dataset_unique_ptr hSrcDS( GDALOpen( raster.inputFilename.toUtf8().constData(), GA_ReadOnly ) );
   if ( !hSrcDS )
   {
     mErrorMessage = QObject::tr( "Unable to open input file: %1" ).arg( raster.inputFilename );
@@ -441,7 +441,7 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
   const GDALDataType eDT = GDALGetRasterDataType( GDALGetRasterBand( hSrcDS.get(), 1 ) );
 
   // Create the output file.
-  const gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, raster.outputFilename.toLocal8Bit().constData(), mXSize, mYSize,
+  const gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, raster.outputFilename.toUtf8().constData(), mXSize, mYSize,
                                          bandCount, eDT, nullptr ) );
   if ( !hDstDS )
   {
@@ -550,7 +550,7 @@ bool QgsAlignRaster::suggestedWarpOutput( const QgsAlignRaster::RasterInfo &info
 
 QgsAlignRaster::RasterInfo::RasterInfo( const QString &layerpath )
 {
-  mDataset.reset( GDALOpen( layerpath.toLocal8Bit().constData(), GA_ReadOnly ) );
+  mDataset.reset( GDALOpen( layerpath.toUtf8().constData(), GA_ReadOnly ) );
   if ( !mDataset )
     return;
 

--- a/src/core/browser/qgszipitem.cpp
+++ b/src/core/browser/qgszipitem.cpp
@@ -228,7 +228,7 @@ QStringList QgsZipItem::getZipFileList()
 
   // get list of files inside zip file
   QgsDebugMsgLevel( QStringLiteral( "Open file %1 with gdal vsi" ).arg( mVsiPrefix + mFilePath ), 3 );
-  char **papszSiblingFiles = VSIReadDirRecursive( QString( mVsiPrefix + mFilePath ).toLocal8Bit().constData() );
+  char **papszSiblingFiles = VSIReadDirRecursive( QString( mVsiPrefix + mFilePath ).toUtf8().constData() );
   if ( papszSiblingFiles )
   {
     for ( int i = 0; papszSiblingFiles[i]; i++ )

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1632,8 +1632,8 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
 
   // important - we need to manually specify the DPI in advance, as GDAL will otherwise
   // assume a DPI of 150
-  CPLSetConfigOption( "GDAL_PDF_DPI", QString::number( dpi ).toLocal8Bit().constData() );
-  gdal::dataset_unique_ptr outputDS( GDALOpen( file.toLocal8Bit().constData(), GA_Update ) );
+  CPLSetConfigOption( "GDAL_PDF_DPI", QString::number( dpi ).toUtf8().constData() );
+  gdal::dataset_unique_ptr outputDS( GDALOpen( file.toUtf8().constData(), GA_Update ) );
   if ( outputDS )
   {
     if ( t )

--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -323,7 +323,7 @@ bool QgsMapRendererTask::run()
       if ( mSaveWorldFile || mExportMetadata )
       {
         CPLSetThreadLocalConfigOption( "GDAL_PDF_DPI", QString::number( mMapSettings.outputDpi() ).toLocal8Bit().constData() );
-        const gdal::dataset_unique_ptr outputDS( GDALOpen( mFileName.toLocal8Bit().constData(), GA_Update ) );
+        const gdal::dataset_unique_ptr outputDS( GDALOpen( mFileName.toUtf8().constData(), GA_Update ) );
         if ( outputDS )
         {
           if ( mSaveWorldFile )
@@ -406,7 +406,7 @@ bool QgsMapRendererTask::run()
         bool skipWorldFile = false;
         if ( outputSuffix == QLatin1String( "tif" ) || outputSuffix == QLatin1String( "tiff" ) )
         {
-          const gdal::dataset_unique_ptr outputDS( GDALOpen( mFileName.toLocal8Bit().constData(), GA_Update ) );
+          const gdal::dataset_unique_ptr outputDS( GDALOpen( mFileName.toUtf8().constData(), GA_Update ) );
           if ( outputDS )
           {
             skipWorldFile = true;

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4134,7 +4134,7 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
   {
     // get list of files inside archive file
     QgsDebugMsgLevel( QStringLiteral( "Open file %1 with gdal vsi" ).arg( vsiPrefix + uriParts.value( QStringLiteral( "path" ) ).toString() ), 3 );
-    char **papszSiblingFiles = VSIReadDirRecursive( QString( vsiPrefix + uriParts.value( QStringLiteral( "path" ) ).toString() ).toLocal8Bit().constData() );
+    char **papszSiblingFiles = VSIReadDirRecursive( QString( vsiPrefix + uriParts.value( QStringLiteral( "path" ) ).toString() ).toUtf8().constData() );
     if ( papszSiblingFiles )
     {
       QList<QgsProviderSublayerDetails> res;

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -94,7 +94,7 @@ gdal::dataset_unique_ptr QgsGdalUtils::createSingleBandTiffDataset( const QStrin
   }
 
   // Create the output file.
-  gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, filename.toLocal8Bit().constData(), width, height, 1, dataType, nullptr ) );
+  gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, filename.toUtf8().constData(), width, height, 1, dataType, nullptr ) );
   if ( !hDstDS )
   {
     return gdal::dataset_unique_ptr();

--- a/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
@@ -227,8 +227,8 @@ bool QgsBackgroundCachedSharedData::createCache()
     return false;
   }
   const QString vsimemFilename = QStringLiteral( "/vsimem/qgis_cache_template_%1/features.sqlite" ).arg( reinterpret_cast< quintptr >( this ), QT_POINTER_SIZE * 2, 16, QLatin1Char( '0' ) );
-  mCacheTablename = CPLGetBasename( vsimemFilename.toStdString().c_str() );
-  VSIUnlink( vsimemFilename.toStdString().c_str() );
+  mCacheTablename = CPLGetBasename( vsimemFilename.toLocal8Bit().constData() );
+  VSIUnlink( vsimemFilename.toUtf8().constData() );
   const char *apszOptions[] = { "INIT_WITH_EPSG=NO", "SPATIALITE=YES", nullptr };
   GDALDatasetH hDS = GDALCreate( hDrv, vsimemFilename.toUtf8().constData(), 0, 0, 0, GDT_Unknown, const_cast<char **>( apszOptions ) );
   if ( !hDS )
@@ -240,9 +240,9 @@ bool QgsBackgroundCachedSharedData::createCache()
 
   // Copy the temporary database back to disk
   vsi_l_offset nLength = 0;
-  GByte *pabyData = VSIGetMemFileBuffer( vsimemFilename.toStdString().c_str(), &nLength, TRUE );
+  GByte *pabyData = VSIGetMemFileBuffer( vsimemFilename.toUtf8().constData(), &nLength, TRUE );
   Q_ASSERT( !QFile::exists( mCacheDbname ) );
-  VSILFILE *fp = VSIFOpenL( mCacheDbname.toStdString().c_str(), "wb" );
+  VSILFILE *fp = VSIFOpenL( mCacheDbname.toUtf8().constData(), "wb" );
   if ( fp )
   {
     VSIFWriteL( pabyData, 1, nLength, fp );

--- a/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
@@ -227,7 +227,7 @@ bool QgsBackgroundCachedSharedData::createCache()
     return false;
   }
   const QString vsimemFilename = QStringLiteral( "/vsimem/qgis_cache_template_%1/features.sqlite" ).arg( reinterpret_cast< quintptr >( this ), QT_POINTER_SIZE * 2, 16, QLatin1Char( '0' ) );
-  mCacheTablename = CPLGetBasename( vsimemFilename.toLocal8Bit().constData() );
+  mCacheTablename = CPLGetBasename( vsimemFilename.toUtf8().constData() );
   VSIUnlink( vsimemFilename.toUtf8().constData() );
   const char *apszOptions[] = { "INIT_WITH_EPSG=NO", "SPATIALITE=YES", nullptr };
   GDALDatasetH hDS = GDALCreate( hDrv, vsimemFilename.toUtf8().constData(), 0, 0, 0, GDT_Unknown, const_cast<char **>( apszOptions ) );

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -583,7 +583,7 @@ void TestQgsRasterLayer::buildExternalOverviews()
 
   // Check that the overview is Deflate compressed
   const QString ovrFilename( myTempPath + "landsat.tif.ovr" );
-  GDALDatasetH hDS = GDALOpen( ovrFilename.toLocal8Bit().constData(), GA_ReadOnly );
+  GDALDatasetH hDS = GDALOpen( ovrFilename.toUtf8().constData(), GA_ReadOnly );
   QVERIFY( hDS );
   const char *pszCompression = GDALGetMetadataItem( hDS, "COMPRESSION", "IMAGE_STRUCTURE" );
   QVERIFY( pszCompression && EQUAL( pszCompression, "DEFLATE" ) );


### PR DESCRIPTION
When calling GDALOpen,  GDALCreate,  VSI functions, some places still use toLocal8Bit.
 I think it should be unified into toUtf8.