### PR TITLE
Fix move and rotation map tools preview when layer crs != canvas crs

### DIFF
--- a/src/app/qgsmaptoolmovefeature.h
+++ b/src/app/qgsmaptoolmovefeature.h
@@ -48,6 +48,9 @@ class APP_EXPORT QgsMapToolMoveFeature: public QgsMapToolAdvancedDigitizing
     void keyReleaseEvent( QKeyEvent *e ) override;
 
   private:
+
+    void deleteRubberband();
+
     //! Start point of the move in map coordinates
     QgsPointXY mStartPointMapCoords;
 
@@ -57,12 +60,15 @@ class APP_EXPORT QgsMapToolMoveFeature: public QgsMapToolAdvancedDigitizing
     //! Snapping indicators
     std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
-    //! Id of moved feature
+    //! Id of moved features
     QgsFeatureIds mMovedFeatures;
 
     QPoint mPressPos;
 
     MoveMode mMode;
+
+    // MultiGeometry of the moved features
+    QgsGeometry mGeom;
 
 };
 

--- a/src/app/qgsmaptoolrotatefeature.h
+++ b/src/app/qgsmaptoolrotatefeature.h
@@ -122,6 +122,9 @@ class APP_EXPORT QgsMapToolRotateFeature: public QgsMapToolAdvancedDigitizing
 
     //! Shows current angle value and allows numerical editing
     QgsAngleMagnetWidget *mRotationWidget = nullptr;
+
+    // MultiGeometry of the features being rotated
+    QgsGeometry mGeom;
 };
 
 #endif


### PR DESCRIPTION
## Description

Fixes the Rotate Feature and Move Feature maptools previews, when the layer crs is not the same as the map canvas destination crs.

### Current behavior
![broken_rubber](https://user-images.githubusercontent.com/9693475/212031250-5dba4e1f-174d-4f47-ad0e-16df652e0bea.gif)

### Fixed behavior
![fix_rubber](https://user-images.githubusercontent.com/9693475/212031411-7f0e0295-6426-445e-960f-949303321631.gif)

