### PR TITLE
HANA: Don't limit FilterRect to SRS bounds

### DIFF
--- a/src/providers/hana/qgshanafeatureiterator.cpp
+++ b/src/providers/hana/qgshanafeatureiterator.cpp
@@ -309,8 +309,6 @@ QString QgsHanaFeatureIterator::buildSqlQuery( const QgsFeatureRequest &request 
   bool limitAtProvider = ( request.limit() >= 0 ) && mRequest.spatialFilterType() != Qgis::SpatialFilterType::DistanceWithin;
 
   QgsRectangle filterRect = mFilterRect;
-  if ( !mSource->mSrsExtent.isEmpty() )
-    filterRect = mSource->mSrsExtent.intersect( filterRect );
 
   if ( !filterRect.isFinite() )
     QgsMessageLog::logMessage( QObject::tr( "Infinite filter rectangle specified" ), QObject::tr( "SAP HANA" ) );
@@ -511,7 +509,6 @@ QgsHanaFeatureSource::QgsHanaFeatureSource( const QgsHanaProvider *p )
   , mGeometryColumn( p->mGeometryColumn )
   , mGeometryType( p->wkbType() )
   , mSrid( p->mSrid )
-  , mSrsExtent( p->mSrsExtent )
   , mCrs( p->crs() )
 {
   if ( p->mHasSrsPlanarEquivalent && p->mDatabaseVersion.majorVersion() <= 1 )

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -1473,21 +1473,13 @@ void QgsHanaProvider::readSrsInformation( QgsHanaConnection &conn )
       return;
   }
 
-  QgsRectangle ext;
   bool isRoundEarth = false;
-  QString sql = QStringLiteral( "SELECT MIN_X, MIN_Y, MAX_X, MAX_Y, ROUND_EARTH FROM SYS.ST_SPATIAL_REFERENCE_SYSTEMS "
+  QString sql = QStringLiteral( "SELECT ROUND_EARTH FROM SYS.ST_SPATIAL_REFERENCE_SYSTEMS "
                                 "WHERE SRS_ID = ?" );
   QgsHanaResultSetRef rs = conn.executeQuery( sql, { mSrid } );
   if ( rs->next() )
-  {
-    ext.setXMinimum( rs->getDouble( 1 ) );
-    ext.setYMinimum( rs->getDouble( 2 ) );
-    ext.setXMaximum( rs->getDouble( 3 ) );
-    ext.setYMaximum( rs->getDouble( 4 ) );
-    isRoundEarth = ( rs->getString( 5 ) == QLatin1String( "TRUE" ) );
-  }
+    isRoundEarth = ( rs->getString( 1 ) == QLatin1String( "TRUE" ) );
   rs->close();
-  mSrsExtent = ext;
 
   if ( isRoundEarth )
   {

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -128,8 +128,6 @@ class QgsHanaProvider final : public QgsVectorDataProvider
     QgsDataSourceUri mUri;
     // Srid of the geometry column
     int mSrid = -1;
-    // Srs extent
-    QgsRectangle mSrsExtent;
     // Flag that shows the presence of a planar equivalent in a database
     bool mHasSrsPlanarEquivalent = false;
     // Name of the table with no schema


### PR DESCRIPTION
This PR fixes the following issue in HANA provider.
Geometries lying outside the bounds of an SRS specified in HANA may disappear from a map when the viewport coordinates don't intersect the bounds of the layer's SRS.