### PR TITLE
SLD: export options png

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -182,7 +182,8 @@ Qgis.SettingsType.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.SldExportOption.NoOptions.__doc__ = "Default SLD export"
 Qgis.SldExportOption.Svg.__doc__ = "Export complex styles to separate SVG files for better compatibility with OGC servers"
-Qgis.SldExportOption.__doc__ = 'SLD export options\n\n.. versionadded:: 3.30\n\n' + '* ``NoOptions``: ' + Qgis.SldExportOption.NoOptions.__doc__ + '\n' + '* ``Svg``: ' + Qgis.SldExportOption.Svg.__doc__
+Qgis.SldExportOption.Png.__doc__ = "Export complex styles to separate PNG files for better compatibility with OGC servers"
+Qgis.SldExportOption.__doc__ = 'SLD export options\n\n.. versionadded:: 3.30\n\n' + '* ``NoOptions``: ' + Qgis.SldExportOption.NoOptions.__doc__ + '\n' + '* ``Svg``: ' + Qgis.SldExportOption.Svg.__doc__ + '\n' + '* ``Png``: ' + Qgis.SldExportOption.Png.__doc__
 # --
 Qgis.SldExportOption.baseClass = Qgis
 Qgis.SldExportOptions.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -165,6 +165,7 @@ The development version
     {
       NoOptions,
       Svg,
+      Png,
     };
     typedef QFlags<Qgis::SldExportOption> SldExportOptions;
 

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -198,7 +198,7 @@ E.g. if ``path`` is "/home/user/Pictures/test.png", the returned list will conta
 %Docstring
 Creates a unique file path name from a desired path by appending "_<n>" (where "<n>" is an integer number) before the file suffix.
 
-E.g. if "/path/my_image.png" already exists "/path/my_image_1.png" (and "_2", "_3" etc.) will be checked until a file path that does not already exist is found.
+E.g. if "/path/my_image.png" already exists "/path/my_image_2.png" (and "_3", "_4" etc.) will be checked until a file path that does not already exist is found.
 
 :param path: the desired path.
 

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -193,6 +193,24 @@ E.g. if ``path`` is "/home/user/Pictures/test.png", the returned list will conta
 
 .. versionadded:: 3.28
 %End
+
+    static QString uniquePath( const QString &path );
+%Docstring
+Creates a unique file path name from a desired path by appending "_<n>" (where "<n>" is an integer number) before the file suffix.
+
+E.g. if "/path/my_image.png" already exists "/path/my_image_1.png" (and "_2", "_3" etc.) will be checked until a file path that does not already exist is found.
+
+:param path: the desired path.
+
+:return: the unmodified path if path is already unique or the new path with "_<n>" (where "<n>" is an integer number) appended to the file name before the suffix.
+
+.. note::
+
+   This function does not make any check on path validity and write permissions.
+
+.. versionadded:: 3.30
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1065,15 +1065,14 @@ Saves the properties of this layer to an SLD format file.
 .. seealso:: :py:func:`saveSldStyleV2`
 %End
 
-    virtual QString saveSldStyleV2( bool &resultFlag, const QgsSldExportContext &exportContext ) const;
+    virtual QString saveSldStyleV2( bool &resultFlag /Out/, const QgsSldExportContext &exportContext ) const;
 %Docstring
 Saves the properties of this layer to an SLD format file.
 
-:param resultFlag: a reference to a flag that will be set to ``False`` if
-                   the SLD file could not be generated
 :param exportContext: SLD export context
 
-:return: a string with any status or error messages
+:return: - a string with any status or error messages
+         - resultFlag: a reference to a flag that will be set to ``False`` if the SLD file could not be generated
 
 .. seealso:: :py:func:`loadSldStyle`
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -982,6 +982,8 @@ Export the properties of this layer as SLD style in a QDomDocument
 :param doc: the target QDomDocument
 :param errorMsg: this QString will be initialized on error
                  during the execution of writeSymbology
+
+.. seealso:: :py:func:`exportSldStyleV2`
 %End
 
     virtual void exportSldStyleV2( QDomDocument &doc, QString &errorMsg, const QgsSldExportContext &exportContext ) const;
@@ -1063,11 +1065,10 @@ Saves the properties of this layer to an SLD format file.
 .. seealso:: :py:func:`saveSldStyleV2`
 %End
 
-    virtual QString saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const;
+    virtual QString saveSldStyleV2( bool &resultFlag, const QgsSldExportContext &exportContext ) const;
 %Docstring
 Saves the properties of this layer to an SLD format file.
 
-:param uri: uri of destination for exported SLD file.
 :param resultFlag: a reference to a flag that will be set to ``False`` if
                    the SLD file could not be generated
 :param exportContext: SLD export context

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -186,6 +186,8 @@ Returns the map unit scale for the fill's offset.
 
     virtual Qt::BrushStyle dxfBrushStyle() const;
 
+    virtual QImage toTiledPattern( ) const;
+
 
   protected:
 
@@ -1547,6 +1549,8 @@ ownership of the returned object.
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
+    virtual QImage toTiledPattern( ) const;
+
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
 
 
@@ -1841,6 +1845,8 @@ Caller takes ownership of the returned symbol layer.
     virtual QgsPointPatternFillSymbolLayer *clone() const /Factory/;
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
+
+    virtual QImage toTiledPattern( ) const;
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
 

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -186,7 +186,7 @@ Returns the map unit scale for the fill's offset.
 
     virtual Qt::BrushStyle dxfBrushStyle() const;
 
-    virtual QImage toTiledPattern( ) const;
+    virtual QImage toTiledPatternImage( ) const;
 
 
   protected:
@@ -1549,7 +1549,7 @@ ownership of the returned object.
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
-    virtual QImage toTiledPattern( ) const;
+    virtual QImage toTiledPatternImage( ) const;
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
 
@@ -1846,7 +1846,7 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
-    virtual QImage toTiledPattern( ) const;
+    virtual QImage toTiledPatternImage( ) const;
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
 

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -1315,7 +1315,7 @@ The ``rings`` argument optionally specifies a list of polygon rings to render as
 
     virtual QImage toTiledPatternImage( ) const;
 %Docstring
-Renders the symbol layer to an image that can be used as a seamless pattern fill
+Renders the symbol layer as an image that can be used as a seamless pattern fill
 for polygons, this method is used by SLD export to generate image tiles for
 ExternalGraphic polygon fills.
 

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -1313,6 +1313,16 @@ The ``rings`` argument optionally specifies a list of polygon rings to render as
     void setAngle( double angle );
     double angle() const;
 
+    virtual QImage toTiledPattern( ) const;
+%Docstring
+Renders the symbol layer to an image that can be used as a seamless pattern fill.
+The default implementation returns a null image.
+
+:return: the tile image (not necessarily a square) or a null image if not implemented.
+
+.. versionadded:: 3.30
+%End
+
   protected:
     QgsFillSymbolLayer( bool locked = false );
     void _renderPolygon( QPainter *p, const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -1313,9 +1313,12 @@ The ``rings`` argument optionally specifies a list of polygon rings to render as
     void setAngle( double angle );
     double angle() const;
 
-    virtual QImage toTiledPattern( ) const;
+    virtual QImage toTiledPatternImage( ) const;
 %Docstring
-Renders the symbol layer to an image that can be used as a seamless pattern fill.
+Renders the symbol layer to an image that can be used as a seamless pattern fill
+for polygons, this method is used by SLD export to generate image tiles for
+ExternalGraphic polygon fills.
+
 The default implementation returns a null image.
 
 :return: the tile image (not necessarily a square) or a null image if not implemented.

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -1002,6 +1002,10 @@ Evaluates a map of properties using the given ``context`` and returns a variant 
 Calculate the minimum size in pixels of a symbol tile given the symbol ``width`` and ``height`` and the grid rotation ``angle`` in radians.
 The method makes approximations and can modify ``angle`` in order to generate the smallest possible tile.
 
+.. note::
+
+   Angle must be >= 0 and < 2 * PI
+
 .. versionadded:: 3.30
 %End
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -997,10 +997,10 @@ Evaluates a map of properties using the given ``context`` and returns a variant 
 .. versionadded:: 3.18
 %End
 
-    static QSize tileSize( int width, int height, double &angleRad /In,Out/, const QSize maxSize = QSize() );
+    static QSize tileSize( int width, int height, double &angleRad /In,Out/ );
 %Docstring
 Calculate the minimum size in pixels of a symbol tile given the symbol ``width`` and ``height`` and the grid rotation ``angle`` in radians.
-The method makes approximations in order to generate the smallest possible tile.
+The method makes approximations and can modify ``angle`` in order to generate the smallest possible tile.
 
 .. versionadded:: 3.30
 %End

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -997,6 +997,14 @@ Evaluates a map of properties using the given ``context`` and returns a variant 
 .. versionadded:: 3.18
 %End
 
+    static QSize tileSize( int width, int height, double &angleRad /In,Out/, const QSize maxSize = QSize() );
+%Docstring
+Calculate the minimum size in pixels of a symbol tile given the symbol ``width`` and ``height`` and the grid rotation ``angle`` in radians.
+The method makes approximations in order to generate the smallest possible tile.
+
+.. versionadded:: 3.30
+%End
+
 
 };
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -999,12 +999,14 @@ Evaluates a map of properties using the given ``context`` and returns a variant 
 
     static QSize tileSize( int width, int height, double &angleRad /In,Out/ );
 %Docstring
-Calculate the minimum size in pixels of a symbol tile given the symbol ``width`` and ``height`` and the grid rotation ``angle`` in radians.
+Calculate the minimum size in pixels of a symbol tile given the symbol ``width`` and ``height`` and the symbol layer rotation ``angleRad`` in radians (counter clockwise).
 The method makes approximations and can modify ``angle`` in order to generate the smallest possible tile.
 
-.. note::
+:param width: marker width, including margins
+:param height: marker height, including margins
+:param angleRad: symbol layer rotation angle in radians (counter clockwise), it may be approximated by the method to minimize the tile size.
 
-   Angle must be >= 0 and < 2 * PI
+:return: the size of the tile
 
 .. versionadded:: 3.30
 %End

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -250,6 +250,7 @@ class CORE_EXPORT Qgis
     {
       NoOptions = 0,                      //!< Default SLD export
       Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
+      Png = 1 << 1,                       //!< Export complex styles to separate PNG files for better compatibility with OGC servers
     };
     Q_ENUM( SldExportOption )
     Q_DECLARE_FLAGS( SldExportOptions, SldExportOption )

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -539,7 +539,7 @@ QString QgsFileUtils::uniquePath( const QString &path )
 
   QFileInfo info { path };
   const QString suffix { info.completeSuffix() };
-  const QString pathPattern { QString( suffix.length() > 0 ? path.chopped( suffix.length() + 1 ) : path ).append( QStringLiteral( "_%1." ) ).append( suffix ) };
+  const QString pathPattern { QString( suffix.isEmpty() ? path : path.chopped( suffix.length() + 1 ) ).append( suffix.isEmpty() ? QStringLiteral( "_%1" ) : QStringLiteral( "_%1." ) ).append( suffix ) };
   int i { 2 };
   QString uniquePath { pathPattern.arg( i ) };
   while ( QFileInfo::exists( uniquePath ) )

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -540,7 +540,7 @@ QString QgsFileUtils::uniquePath( const QString &path )
   QFileInfo info { path };
   const QString suffix { info.completeSuffix() };
   const QString pathPattern { QString( suffix.length() > 0 ? path.chopped( suffix.length() + 1 ) : path ).append( QStringLiteral( "_%1." ) ).append( suffix ) };
-  int i { 1 };
+  int i { 2 };
   QString uniquePath { pathPattern.arg( i ) };
   while ( QFileInfo::exists( uniquePath ) )
   {

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -529,3 +529,23 @@ QStringList QgsFileUtils::splitPathToComponents( const QString &input )
   std::reverse( result.begin(), result.end() );
   return result;
 }
+
+QString QgsFileUtils::uniquePath( const QString &path )
+{
+  if ( ! QFileInfo::exists( path ) )
+  {
+    return path;
+  }
+
+  QFileInfo info { path };
+  const QString suffix { info.completeSuffix() };
+  const QString pathPattern { QString( suffix.length() > 0 ? path.chopped( suffix.length() + 1 ) : path ).append( QStringLiteral( "_%1." ) ).append( suffix ) };
+  int i { 1 };
+  QString uniquePath { pathPattern.arg( i ) };
+  while ( QFileInfo::exists( uniquePath ) )
+  {
+    ++i;
+    uniquePath = pathPattern.arg( i );
+  }
+  return uniquePath;
+}

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -224,6 +224,19 @@ class CORE_EXPORT QgsFileUtils
      * \since QGIS 3.28
      */
     static QStringList splitPathToComponents( const QString &path );
+
+    /**
+     * Creates a unique file path name from a desired path by appending "_<n>" (where "<n>" is an integer number) before the file suffix.
+     *
+     * E.g. if "/path/my_image.png" already exists "/path/my_image_1.png" (and "_2", "_3" etc.) will be checked until a file path that does not already exist is found.
+     *
+     * \param path the desired path.
+     * \return the unmodified path if path is already unique or the new path with "_<n>" (where "<n>" is an integer number) appended to the file name before the suffix.
+     * \note This function does not make any check on path validity and write permissions.
+     * \since QGIS 3.30
+     */
+    static QString uniquePath( const QString &path );
+
 };
 
 #endif // QGSFILEUTILS_H

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -228,7 +228,7 @@ class CORE_EXPORT QgsFileUtils
     /**
      * Creates a unique file path name from a desired path by appending "_<n>" (where "<n>" is an integer number) before the file suffix.
      *
-     * E.g. if "/path/my_image.png" already exists "/path/my_image_1.png" (and "_2", "_3" etc.) will be checked until a file path that does not already exist is found.
+     * E.g. if "/path/my_image.png" already exists "/path/my_image_2.png" (and "_3", "_4" etc.) will be checked until a file path that does not already exist is found.
      *
      * \param path the desired path.
      * \return the unmodified path if path is already unique or the new path with "_<n>" (where "<n>" is an integer number) appended to the file name before the suffix.

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1758,6 +1758,7 @@ QString QgsMapLayer::saveNamedStyle( const QString &uri, bool &resultFlag, Style
 
 void QgsMapLayer::exportSldStyle( QDomDocument &doc, QString &errorMsg ) const
 {
+
   return exportSldStyleV2( doc, errorMsg, QgsSldExportContext() );
 }
 
@@ -1848,15 +1849,18 @@ void QgsMapLayer::exportSldStyleV2( QDomDocument &doc, QString &errorMsg, const 
 
 QString QgsMapLayer::saveSldStyle( const QString &uri, bool &resultFlag ) const
 {
-  return saveSldStyleV2( uri, resultFlag, QgsSldExportContext() );
+  QgsSldExportContext context;
+  context.setExportFilePath( uri );
+  return saveSldStyleV2( resultFlag, context );
 }
 
-QString QgsMapLayer::saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const
+QString QgsMapLayer::saveSldStyleV2( bool &resultFlag, const QgsSldExportContext &exportContext ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   const QgsMapLayer *mlayer = qobject_cast<const QgsMapLayer *>( this );
 
+  const QString uri { exportContext.exportFilePath() };
 
   // check if the uri is a file or ends with .sld,
   // which indicates that it should become one

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1174,7 +1174,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see loadSldStyle()
      * \since QGIS 3.30
      */
-    virtual QString saveSldStyleV2( bool &resultFlag, const QgsSldExportContext &exportContext ) const;
+    virtual QString saveSldStyleV2( bool &resultFlag SIP_OUT, const QgsSldExportContext &exportContext ) const;
 
     /**
      * Attempts to style the layer using the formatting from an SLD type file.

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1096,6 +1096,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \param doc the target QDomDocument
      * \param errorMsg this QString will be initialized on error
      * during the execution of writeSymbology
+     * \see exportSldStyleV2()
      */
     virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg ) const;
 
@@ -1165,7 +1166,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Saves the properties of this layer to an SLD format file.
-     * \param uri uri of destination for exported SLD file.
      * \param resultFlag a reference to a flag that will be set to FALSE if
      *        the SLD file could not be generated
      * \param exportContext SLD export context
@@ -1174,7 +1174,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see loadSldStyle()
      * \since QGIS 3.30
      */
-    virtual QString saveSldStyleV2( const QString &uri, bool &resultFlag, const QgsSldExportContext &exportContext ) const;
+    virtual QString saveSldStyleV2( bool &resultFlag, const QgsSldExportContext &exportContext ) const;
 
     /**
      * Attempts to style the layer using the formatting from an SLD type file.

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -409,7 +409,7 @@ void QgsSimpleFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
   const QgsSldExportContext context { props.value( QStringLiteral( "SldExportContext" ), QVariant::fromValue( QgsSldExportContext() ) ).value< QgsSldExportContext >() };
 
 
-  // Export to PNG (TODO: SVG)
+  // Export to PNG
   bool exportOk { false };
   if ( ! context.exportFilePath().isEmpty() && context.exportOptions().testFlag( Qgis::SldExportOption::Png ) && mBrush.style() != Qt::NoBrush )
   {
@@ -2648,7 +2648,7 @@ QImage QgsLinePatternFillSymbolLayer::toTiledPattern() const
 
   QSize size { static_cast<int>( distancePx ), static_cast<int>( distancePx ) };
 
-  if ( ! qgsDoubleNear( lineAngleRads,  0 ) )
+  if ( static_cast<int>( mLineAngle ) % 90 != 0 )
   {
     size = QSize( static_cast<int>( distancePx / std::sin( lineAngleRads ) ), static_cast<int>( distancePx / std::cos( lineAngleRads ) ) );
   }
@@ -4416,12 +4416,7 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPattern() const
   int distanceXPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDistanceX, mDistanceXUnit, {} ) ) };
   int distanceYPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDistanceY, mDistanceYUnit, {} ) ) };
 
-  QSize size { static_cast<int>( distanceXPx ), static_cast<int>( distanceYPx ) };
-
-  if ( ! qgsDoubleNear( angleRads,  0 ) )
-  {
-    size = QgsSymbolLayerUtils::tileSize( distanceXPx, distanceYPx, angleRads );
-  }
+  const QSize size { QgsSymbolLayerUtils::tileSize( distanceXPx, distanceYPx, angleRads ) };
 
   QPixmap pixmap( size );
   pixmap.fill( Qt::transparent );

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -2642,14 +2642,15 @@ void QgsLinePatternFillSymbolLayer::stopFeatureRender( const QgsFeature &, QgsRe
 
 QImage QgsLinePatternFillSymbolLayer::toTiledPattern() const
 {
-  const double lineAngleRads { qDegreesToRadians( mLineAngle ) };
-  double distancePx = QgsSymbolLayerUtils::rescaleUom( mDistance, mDistanceUnit, {} );
-  // adjust tile size to generate a tile with seamless edges
-  const QSize size { static_cast<int>( distancePx / std::cos( lineAngleRads ) ), static_cast<int>( distancePx / std::sin( lineAngleRads ) ) };
 
-  if ( size.isEmpty() || size.width() > 512 || size.height() > 512 )
+  double lineAngleRads { qDegreesToRadians( mLineAngle ) };
+  double distancePx { QgsSymbolLayerUtils::rescaleUom( mDistance, mDistanceUnit, {} ) };
+
+  QSize size { static_cast<int>( distancePx ), static_cast<int>( distancePx ) };
+
+  if ( ! qgsDoubleNear( lineAngleRads,  0 ) )
   {
-    return QImage( );
+    size = QSize( static_cast<int>( distancePx / std::sin( lineAngleRads ) ), static_cast<int>( distancePx / std::cos( lineAngleRads ) ) );
   }
 
   QPixmap pixmap( size );
@@ -4417,18 +4418,10 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPattern() const
 
   QSize size { static_cast<int>( distanceXPx ), static_cast<int>( distanceYPx ) };
 
-
-  if ( mAngle != 0 )
+  if ( ! qgsDoubleNear( angleRads,  0 ) )
   {
     size = QgsSymbolLayerUtils::tileSize( distanceXPx, distanceYPx, angleRads );
   }
-
-  /*
-  if ( size.isEmpty() || size.width() > 512 || size.height() > 512 )
-  {
-    return QImage( );
-  }
-  */
 
   QPixmap pixmap( size );
   pixmap.fill( Qt::transparent );
@@ -4444,7 +4437,6 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPattern() const
 
   std::unique_ptr< QgsPointPatternFillSymbolLayer > layerClone( clone() );
 
-  // !!!!!!!
   layerClone->setAngle( qRadiansToDegrees( angleRads ) );
 
   layerClone->drawPreviewIcon( symbolContext, pixmap.size() );

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -2569,7 +2569,7 @@ void QgsSVGFillSymbolLayer::setParameters( const QMap<QString, QgsProperty> &par
 QgsLinePatternFillSymbolLayer::QgsLinePatternFillSymbolLayer()
   : QgsImageFillSymbolLayer()
 {
-  setSubSymbol( new QgsLineSymbol() );
+  mFillLineSymbol = std::make_unique<QgsLineSymbol>( );
   QgsImageFillSymbolLayer::setSubSymbol( nullptr ); //no stroke
 }
 
@@ -3571,7 +3571,7 @@ QgsSymbolLayer *QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &eleme
 QgsPointPatternFillSymbolLayer::QgsPointPatternFillSymbolLayer()
   : QgsImageFillSymbolLayer()
 {
-  setSubSymbol( new QgsMarkerSymbol() );
+  mMarkerSymbol = std::make_unique<QgsMarkerSymbol>();
   QgsImageFillSymbolLayer::setSubSymbol( nullptr ); //no stroke
 }
 

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -399,10 +399,6 @@ void QgsSimpleFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
     symbolizerElem.setAttribute( QStringLiteral( "uom" ), props.value( QStringLiteral( "uom" ), QString() ).toString() );
   element.appendChild( symbolizerElem );
 
-  // <Fill>
-  QDomElement fillElem = doc.createElement( QStringLiteral( "se:Fill" ) );
-  symbolizerElem.appendChild( fillElem );
-
   // <Geometry>
   QgsSymbolLayerUtils::createGeometryElement( doc, symbolizerElem, props.value( QStringLiteral( "geom" ), QString() ).toString() );
 
@@ -416,6 +412,9 @@ void QgsSimpleFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
     const QImage image { toTiledPatternImage( ) };
     if ( ! image.isNull() )
     {
+      // <Fill>
+      QDomElement fillElem = doc.createElement( QStringLiteral( "se:Fill" ) );
+      symbolizerElem.appendChild( fillElem );
       QDomElement graphicFillElem = doc.createElement( QStringLiteral( "se:GraphicFill" ) );
       fillElem.appendChild( graphicFillElem );
       QDomElement graphicElem = doc.createElement( QStringLiteral( "se:Graphic" ) );
@@ -444,6 +443,9 @@ void QgsSimpleFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
       {
         color.setAlphaF( color.alphaF() * alpha );
       }
+      // <Fill>
+      QDomElement fillElem = doc.createElement( QStringLiteral( "se:Fill" ) );
+      symbolizerElem.appendChild( fillElem );
       QgsSymbolLayerUtils::fillToSld( doc, fillElem, mBrushStyle, color );
     }
 

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -179,6 +179,7 @@ class CORE_EXPORT QgsSimpleFillSymbolLayer : public QgsFillSymbolLayer
     Qt::PenStyle dxfPenStyle() const override;
     QColor dxfBrushColor( QgsSymbolRenderContext &context ) const override;
     Qt::BrushStyle dxfBrushStyle() const override;
+    QImage toTiledPattern( ) const override;
 
   protected:
     QBrush mBrush;
@@ -200,6 +201,7 @@ class CORE_EXPORT QgsSimpleFillSymbolLayer : public QgsFillSymbolLayer
   private:
     //helper functions for data defined symbology
     void applyDataDefinedSymbology( QgsSymbolRenderContext &context, QBrush &brush, QPen &pen, QPen &selPen );
+
 };
 
 class QgsColorRamp;
@@ -1417,6 +1419,7 @@ class CORE_EXPORT QgsLinePatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QVariantMap properties() const override;
     QgsLinePatternFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const override;
+    QImage toTiledPattern( ) const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
 
     QString ogrFeatureStyleWidth( double widthScaleFactor ) const;
@@ -1688,6 +1691,7 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QVariantMap properties() const override;
     QgsPointPatternFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const override;
+    QImage toTiledPattern( ) const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
     bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
     QgsSymbol *subSymbol() override;

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -179,7 +179,7 @@ class CORE_EXPORT QgsSimpleFillSymbolLayer : public QgsFillSymbolLayer
     Qt::PenStyle dxfPenStyle() const override;
     QColor dxfBrushColor( QgsSymbolRenderContext &context ) const override;
     Qt::BrushStyle dxfBrushStyle() const override;
-    QImage toTiledPattern( ) const override;
+    QImage toTiledPatternImage( ) const override;
 
   protected:
     QBrush mBrush;
@@ -1419,7 +1419,7 @@ class CORE_EXPORT QgsLinePatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QVariantMap properties() const override;
     QgsLinePatternFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const override;
-    QImage toTiledPattern( ) const override;
+    QImage toTiledPatternImage( ) const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
 
     QString ogrFeatureStyleWidth( double widthScaleFactor ) const;
@@ -1691,7 +1691,7 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QVariantMap properties() const override;
     QgsPointPatternFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const override;
-    QImage toTiledPattern( ) const override;
+    QImage toTiledPatternImage( ) const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
     bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
     QgsSymbol *subSymbol() override;

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -844,7 +844,7 @@ void QgsFillSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext &context, QSize
   stopRender( context );
 }
 
-QImage QgsFillSymbolLayer::toTiledPattern() const
+QImage QgsFillSymbolLayer::toTiledPatternImage() const
 {
   return QImage();
 }

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -844,6 +844,11 @@ void QgsFillSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext &context, QSize
   stopRender( context );
 }
 
+QImage QgsFillSymbolLayer::toTiledPattern() const
+{
+  return QImage();
+}
+
 void QgsFillSymbolLayer::_renderPolygon( QPainter *p, const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context )
 {
   if ( !p )

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -1242,7 +1242,7 @@ class CORE_EXPORT QgsFillSymbolLayer : public QgsSymbolLayer
     double angle() const { return mAngle; }
 
     /**
-     * Renders the symbol layer to an image that can be used as a seamless pattern fill
+     * Renders the symbol layer as an image that can be used as a seamless pattern fill
      * for polygons, this method is used by SLD export to generate image tiles for
      * ExternalGraphic polygon fills.
      *

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -1242,13 +1242,16 @@ class CORE_EXPORT QgsFillSymbolLayer : public QgsSymbolLayer
     double angle() const { return mAngle; }
 
     /**
-     * Renders the symbol layer to an image that can be used as a seamless pattern fill.
+     * Renders the symbol layer to an image that can be used as a seamless pattern fill
+     * for polygons, this method is used by SLD export to generate image tiles for
+     * ExternalGraphic polygon fills.
+     *
      * The default implementation returns a null image.
      *
      * \return the tile image (not necessarily a square) or a null image if not implemented.
      * \since QGIS 3.30
      */
-    virtual QImage toTiledPattern( ) const;
+    virtual QImage toTiledPatternImage( ) const;
 
   protected:
     QgsFillSymbolLayer( bool locked = false );

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -1241,6 +1241,15 @@ class CORE_EXPORT QgsFillSymbolLayer : public QgsSymbolLayer
     void setAngle( double angle ) { mAngle = angle; }
     double angle() const { return mAngle; }
 
+    /**
+     * Renders the symbol layer to an image that can be used as a seamless pattern fill.
+     * The default implementation returns a null image.
+     *
+     * \return the tile image (not necessarily a square) or a null image if not implemented.
+     * \since QGIS 3.30
+     */
+    virtual QImage toTiledPattern( ) const;
+
   protected:
     QgsFillSymbolLayer( bool locked = false );
     //! Default method to render polygon

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -5101,8 +5101,12 @@ QgsStringMap QgsSymbolLayerUtils::evaluatePropertiesMap( const QMap<QString, Qgs
 QSize QgsSymbolLayerUtils::tileSize( int width, int height, double &angleRad )
 {
 
-  // Precondition
-  Q_ASSERT( angleRad >= 0 && angleRad < M_PI * 2 );
+  angleRad = std::fmod( angleRad, M_PI * 2 );
+
+  if ( angleRad < 0 )
+  {
+    angleRad += M_PI * 2;
+  }
 
   // tan with rational sin/cos
   struct rationalTangent
@@ -5257,13 +5261,13 @@ QSize QgsSymbolLayerUtils::tileSize( int width, int height, double &angleRad )
     }
   }
 
-  if ( qgsDoubleNear( angleRad, 0 ) )
+  if ( qgsDoubleNear( angleRad, 0, 10E-3 ) )
   {
     angleRad = 0;
     tileSize.setWidth( width );
     tileSize.setHeight( height );
   }
-  else if ( qgsDoubleNear( angleRad, M_PI_2 ) )
+  else if ( qgsDoubleNear( angleRad, M_PI_2, 10E-3 ) )
   {
     angleRad = M_PI_2;
     tileSize.setWidth( height );
@@ -5277,9 +5281,8 @@ QSize QgsSymbolLayerUtils::tileSize( int width, int height, double &angleRad )
     for ( int idx = 0; idx < rationalTangents.count(); ++idx )
     {
       const auto item = rationalTangents.at( idx );
-      if ( qgsDoubleNear( item.angle, angleRad ) || item.angle > angleRad )
+      if ( qgsDoubleNear( item.angle, angleRad, 10E-3 ) || item.angle > angleRad )
       {
-        angleRad = item.angle;
         rTanIdx = idx;
         break;
       }

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -5101,13 +5101,118 @@ QgsStringMap QgsSymbolLayerUtils::evaluatePropertiesMap( const QMap<QString, Qgs
 QSize QgsSymbolLayerUtils::tileSize( int width, int height, double &angleRad )
 {
 
+  // Precondition
+  Q_ASSERT( angleRad >= 0 && angleRad < M_PI * 2 );
+
+  // tan with rational sin/cos
   struct rationalTangent
   {
-    int a;
-    int b;
-    double angle;
+    int p; // numerator
+    int q; // denominator
+    double angle; // "good" angle
   };
 
+#if 0
+
+  // This list is more granular (approx 1 degree steps) but some
+  // values can lead to huge tiles
+  // List of "good" angles from 0 to PI/2
+  static const QList<rationalTangent> __rationalTangents
+  {
+    { 1, 57, 0.01754206006 },
+    { 3, 86, 0.03486958155 },
+    { 1, 19, 0.05258306161 },
+    { 3, 43, 0.06965457373 },
+    { 7, 80, 0.08727771295 },
+    { 2, 19, 0.1048769387 },
+    { 7, 57, 0.1221951707 },
+    { 9, 64, 0.1397088743 },
+    { 13, 82, 0.157228051 },
+    { 3, 17, 0.174672199 },
+    { 7, 36, 0.1920480172 },
+    { 17, 80, 0.209385393 },
+    { 3, 13, 0.2267988481 },
+    { 1, 4, 0.2449786631 },
+    { 26, 97, 0.2618852647 },
+    { 27, 94, 0.2797041525 },
+    { 26, 85, 0.2968446734 },
+    { 13, 40, 0.3142318991 },
+    { 21, 61, 0.3315541619 },
+    { 4, 11, 0.3487710036 },
+    { 38, 99, 0.3664967859 },
+    { 40, 99, 0.383984624 },
+    { 31, 73, 0.4015805401 },
+    { 41, 92, 0.4192323938 },
+    { 7, 15, 0.4366271598 },
+    { 20, 41, 0.4538440015 },
+    { 27, 53, 0.4711662643 },
+    { 42, 79, 0.4886424026 },
+    { 51, 92, 0.5061751436 },
+    { 56, 97, 0.5235757641 },
+    { 3, 5, 0.5404195003 },
+    { 5, 8, 0.5585993153 },
+    { 50, 77, 0.5759185996 },
+    { 29, 43, 0.5933501462 },
+    { 7, 10, 0.6107259644 },
+    { 69, 95, 0.6281701124 },
+    { 52, 69, 0.6458159195 },
+    { 25, 32, 0.6632029927 },
+    { 17, 21, 0.6805212247 },
+    { 73, 87, 0.6981204504 },
+    { 73, 84, 0.7154487784 },
+    { 9, 10, 0.7328151018 },
+    { 83, 89, 0.7505285818 },
+    { 28, 29, 0.7678561033 },
+    { 1, 1, 0.7853981634 },
+    { 29, 28, 0.8029402235 },
+    { 89, 83, 0.820267745 },
+    { 10, 9, 0.837981225 },
+    { 107, 93, 0.855284165 },
+    { 87, 73, 0.8726758763 },
+    { 121, 98, 0.8900374031 },
+    { 32, 25, 0.9075933341 },
+    { 69, 52, 0.9249804073 },
+    { 128, 93, 0.9424647244 },
+    { 10, 7, 0.9600703624 },
+    { 43, 29, 0.9774461806 },
+    { 77, 50, 0.9948777272 },
+    { 8, 5, 1.012197011 },
+    { 163, 98, 1.029475114 },
+    { 168, 97, 1.047174539 },
+    { 175, 97, 1.064668696 },
+    { 126, 67, 1.082075603 },
+    { 157, 80, 1.099534652 },
+    { 203, 99, 1.117049384 },
+    { 193, 90, 1.134452855 },
+    { 146, 65, 1.151936673 },
+    { 139, 59, 1.169382787 },
+    { 99, 40, 1.186811703 },
+    { 211, 81, 1.204257817 },
+    { 272, 99, 1.221730164 },
+    { 273, 94, 1.239188479 },
+    { 277, 90, 1.25664606 },
+    { 157, 48, 1.274088705 },
+    { 279, 80, 1.291550147 },
+    { 362, 97, 1.308990773 },
+    { 373, 93, 1.326448578 },
+    { 420, 97, 1.343823596 },
+    { 207, 44, 1.361353157 },
+    { 427, 83, 1.378810994 },
+    { 414, 73, 1.396261926 },
+    { 322, 51, 1.413716057 },
+    { 185, 26, 1.431170275 },
+    { 790, 97, 1.448623034 },
+    { 333, 35, 1.466075711 },
+    { 1063, 93, 1.483530284 },
+    { 1330, 93, 1.500985147 },
+    { 706, 37, 1.518436297 },
+    { 315, 11, 1.535889876 },
+    { 3953, 69, 1.553343002 },
+  };
+#endif
+
+  // Optimized "good" angles list, it produces small tiles but
+  // it has approximately 10 degrees steps
   static const QList<rationalTangent> rationalTangents
   {
     { 1, 10, qDegreesToRadians( 5.71059 ) },
@@ -5124,42 +5229,102 @@ QSize QgsSymbolLayerUtils::tileSize( int width, int height, double &angleRad )
     { 10, 1, qDegreesToRadians( 84.2894 ) },
   };
 
-  // TODO: clean angleRad
+  const int quadrant { static_cast<int>( angleRad / M_PI_2 ) };
+  Q_ASSERT( quadrant >= 0 && quadrant <= 3 );
 
+  QSize tileSize;
 
-  if ( qgsDoubleNear( angleRad, 0 ) )
+  switch ( quadrant )
   {
-    angleRad = 0;
-    return QSize( width, height );
-  }
-
-  if ( qgsDoubleNear( angleRad, M_PI_2 ) )
-  {
-    angleRad = M_PI_2;
-    return QSize( height, width );
-  }
-
-  int rTanIdx = 0;
-
-  for ( int idx = 0; idx < rationalTangents.count(); ++idx )
-  {
-    const auto item = rationalTangents.at( idx );
-    if ( qgsDoubleNear( item.angle, angleRad ) || item.angle > angleRad )
+    case 0:
     {
-      angleRad = item.angle;
-      rTanIdx = idx;
+      break;
+    }
+    case 1:
+    {
+      angleRad -= M_PI / 2;
+      break;
+    }
+    case 2:
+    {
+      angleRad -= M_PI;
+      break;
+    }
+    case 3:
+    {
+      angleRad -= M_PI + M_PI_2;
       break;
     }
   }
 
-  const rationalTangent bTan { rationalTangents.at( rTanIdx ) };
-  angleRad = bTan.angle;
-  const double k { bTan.b *height *width / std::cos( angleRad ) };
-  const int hcfH { std::gcd( bTan.a * height, bTan.b * width ) };
-  const int hcfW { std::gcd( bTan.b * height, bTan.a * width ) };
-  const int W1 { static_cast<int>( std::round( k / hcfW ) ) };
-  const int H1 { static_cast<int>( std::round( k / hcfH ) ) };
+  if ( qgsDoubleNear( angleRad, 0 ) )
+  {
+    angleRad = 0;
+    tileSize.setWidth( width );
+    tileSize.setHeight( height );
+  }
+  else if ( qgsDoubleNear( angleRad, M_PI_2 ) )
+  {
+    angleRad = M_PI_2;
+    tileSize.setWidth( height );
+    tileSize.setHeight( width );
+  }
+  else
+  {
 
-  return QSize( W1, H1 );
+    int rTanIdx = 0;
+
+    for ( int idx = 0; idx < rationalTangents.count(); ++idx )
+    {
+      const auto item = rationalTangents.at( idx );
+      if ( qgsDoubleNear( item.angle, angleRad ) || item.angle > angleRad )
+      {
+        angleRad = item.angle;
+        rTanIdx = idx;
+        break;
+      }
+    }
+
+    const rationalTangent bTan { rationalTangents.at( rTanIdx ) };
+    angleRad = bTan.angle;
+    const double k { bTan.q *height *width / std::cos( angleRad ) };
+    const int hcfH { std::gcd( bTan.p * height, bTan.q * width ) };
+    const int hcfW { std::gcd( bTan.q * height, bTan.p * width ) };
+    const int W1 { static_cast<int>( std::round( k / hcfW ) ) };
+    const int H1 { static_cast<int>( std::round( k / hcfH ) ) };
+    tileSize.setWidth( W1 );
+    tileSize.setHeight( H1 );
+  }
+
+  switch ( quadrant )
+  {
+    case 0:
+    {
+      break;
+    }
+    case 1:
+    {
+      angleRad += M_PI / 2;
+      const int h { tileSize.height() };
+      tileSize.setHeight( tileSize.width() );
+      tileSize.setWidth( h );
+      break;
+    }
+    case 2:
+    {
+      angleRad += M_PI;
+      break;
+    }
+    case 3:
+    {
+      angleRad += M_PI + M_PI_2;
+      const int h { tileSize.height() };
+      tileSize.setHeight( tileSize.width() );
+      tileSize.setWidth( h );
+      break;
+    }
+  }
+
+  return tileSize;
 
 }

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -900,6 +900,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
     /**
      * Calculate the minimum size in pixels of a symbol tile given the symbol \a width and \a height and the grid rotation \a angle in radians.
      * The method makes approximations and can modify \a angle in order to generate the smallest possible tile.
+     * \note Angle must be >= 0 and < 2 * PI
      * \since QGIS 3.30
      */
     static QSize tileSize( int width, int height, double &angleRad SIP_INOUT );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -898,9 +898,12 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static QgsStringMap evaluatePropertiesMap( const QMap<QString, QgsProperty> &propertiesMap, const QgsExpressionContext &context );
 
     /**
-     * Calculate the minimum size in pixels of a symbol tile given the symbol \a width and \a height and the grid rotation \a angle in radians.
+     * Calculate the minimum size in pixels of a symbol tile given the symbol \a width and \a height and the symbol layer rotation \a angleRad in radians (counter clockwise).
      * The method makes approximations and can modify \a angle in order to generate the smallest possible tile.
-     * \note Angle must be >= 0 and < 2 * PI
+     * \param width marker width, including margins
+     * \param height marker height, including margins
+     * \param angleRad symbol layer rotation angle in radians (counter clockwise), it may be approximated by the method to minimize the tile size.
+     * \return the size of the tile
      * \since QGIS 3.30
      */
     static QSize tileSize( int width, int height, double &angleRad SIP_INOUT );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -899,10 +899,10 @@ class CORE_EXPORT QgsSymbolLayerUtils
 
     /**
      * Calculate the minimum size in pixels of a symbol tile given the symbol \a width and \a height and the grid rotation \a angle in radians.
-     * The method makes approximations in order to generate the smallest possible tile.
+     * The method makes approximations and can modify \a angle in order to generate the smallest possible tile.
      * \since QGIS 3.30
      */
-    static QSize tileSize( int width, int height, double &angleRad SIP_INOUT, const QSize maxSize = QSize() );
+    static QSize tileSize( int width, int height, double &angleRad SIP_INOUT );
 
     ///@cond PRIVATE
 #ifndef SIP_RUN

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -897,6 +897,13 @@ class CORE_EXPORT QgsSymbolLayerUtils
      */
     static QgsStringMap evaluatePropertiesMap( const QMap<QString, QgsProperty> &propertiesMap, const QgsExpressionContext &context );
 
+    /**
+     * Calculate the minimum size in pixels of a symbol tile given the symbol \a width and \a height and the grid rotation \a angle in radians.
+     * The method makes approximations in order to generate the smallest possible tile.
+     * \since QGIS 3.30
+     */
+    static QSize tileSize( int width, int height, double &angleRad SIP_INOUT, const QSize maxSize = QSize() );
+
     ///@cond PRIVATE
 #ifndef SIP_RUN
     static QgsProperty rotateWholeSymbol( double additionalRotation, const QgsProperty &property )

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -21,6 +21,7 @@
 
 #include "qgsactionmanager.h"
 #include "qgsjoindialog.h"
+#include "qgssldexportcontext.h"
 #include "qgswmsdimensiondialog.h"
 #include "qgsapplication.h"
 #include "qgsattributeactiondialog.h"
@@ -1230,7 +1231,10 @@ void QgsVectorLayerProperties::saveStyleAs()
         if ( type == QML )
           errorMessage = mLayer->saveNamedStyle( filePath, defaultLoadedFlag, dlg.styleCategories() );
         else
-          errorMessage = mLayer->saveSldStyle( filePath, defaultLoadedFlag );
+        {
+          const QgsSldExportContext sldContext { dlg.sldExportOptions(), Qgis::SldExportVendorExtension::NoVendorExtension, filePath };
+          errorMessage = mLayer->saveSldStyleV2( defaultLoadedFlag, sldContext );
+        }
 
         //reset if the default style was loaded OK only
         if ( defaultLoadedFlag )

--- a/src/gui/vector/qgsvectorlayersavestyledialog.cpp
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.cpp
@@ -41,6 +41,7 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
     mFileLabel->setVisible( type != QgsVectorLayerProperties::DB && type != QgsVectorLayerProperties::Local );
     mFileWidget->setVisible( type != QgsVectorLayerProperties::DB && type != QgsVectorLayerProperties::Local );
     mSaveToDbWidget->setVisible( type == QgsVectorLayerProperties::DB );
+    mSaveToSldWidget->setVisible( type == QgsVectorLayerProperties::SLD && layer->geometryType() == QgsWkbTypes::GeometryType::PolygonGeometry );
     mStyleCategoriesListView->setEnabled( type != QgsVectorLayerProperties::SLD );
     mFileWidget->setFilter( type == QgsVectorLayerProperties::QML ? tr( "QGIS Layer Style File (*.qml)" ) : tr( "SLD File (*.sld)" ) );
     updateSaveButtonState();
@@ -246,6 +247,16 @@ const QListWidget *QgsVectorLayerSaveStyleDialog::stylesWidget()
   return mStylesWidget;
 }
 
+Qgis::SldExportOptions QgsVectorLayerSaveStyleDialog::sldExportOptions() const
+{
+  Qgis::SldExportOptions options;
+
+  if ( mStyleTypeComboBox->currentData( ) == QgsVectorLayerProperties::SLD )
+  {
+    options.setFlag( Qgis::SldExportOption::Png );
+  }
+  return options;
+}
 
 void QgsVectorLayerSaveStyleDialog::showHelp()
 {

--- a/src/gui/vector/qgsvectorlayersavestyledialog.h
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.h
@@ -63,6 +63,12 @@ class GUI_EXPORT QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::Qgs
 
     const QListWidget *stylesWidget( );
 
+    /**
+     * Returns the SLD export options.
+     * \since QGIS 3.30
+     */
+    Qgis::SldExportOptions sldExportOptions( ) const;
+
   public slots:
     void accept() override;
 

--- a/src/ui/qgsvectorlayersavestyledialog.ui
+++ b/src/ui/qgsvectorlayersavestyledialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>491</width>
+    <width>492</width>
     <height>728</height>
    </rect>
   </property>
@@ -43,7 +43,26 @@
    </item>
    <item row="2" column="0" colspan="2">
     <widget class="QWidget" name="mSaveToSldWidget" native="true">
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QFormLayout" name="formLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>SLD Options</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QCheckBox" name="mSldExportPng">
         <property name="toolTip">
@@ -53,19 +72,6 @@
          <string>Export polygon fills as PNG tiles</string>
         </property>
        </widget>
-      </item>
-      <item row="0" column="0">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsvectorlayersavestyledialog.ui
+++ b/src/ui/qgsvectorlayersavestyledialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>491</width>
-    <height>614</height>
+    <height>728</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,17 +41,46 @@
    <item row="1" column="1">
     <widget class="QListWidget" name="mStylesWidget"/>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="0" colspan="2">
+    <widget class="QWidget" name="mSaveToSldWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="mSldExportPng">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Complex and rotated polygon fills are generally not supported by SLD. &lt;/p&gt;&lt;p&gt;By checking this option supported symbols will be exported as PNG tiles in the same directory of the SLD document and the SLD document will refer to the PNG images as external graphic symbols.&lt;/p&gt;&lt;p&gt;Note that not all symbols can be exported to PNG, if the symbol cannot be exported the default SLD export implementation will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Export polygon fills as PNG tiles</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QLabel" name="mFileLabel">
      <property name="text">
       <string>File</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QgsFileWidget" name="mFileWidget"/>
+   <item row="3" column="1">
+    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="leftMargin">
@@ -67,7 +96,7 @@
        <number>0</number>
       </property>
       <item row="2" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
         <property name="toolTip">
          <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
         </property>
@@ -116,14 +145,14 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Categories</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QListView" name="mStyleCategoriesListView">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -133,7 +162,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -20,6 +20,7 @@ from qgis.core import (
     Qgis,
     QgsFileUtils
 )
+from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.testing import unittest
 from utilities import unitTestDataPath
 
@@ -310,6 +311,24 @@ class TestQgsFileUtils(unittest.TestCase):
         self.assertEqual(QgsFileUtils.splitPathToComponents('/'), ["/"])
         self.assertEqual(QgsFileUtils.splitPathToComponents(''), [])
         self.assertEqual(QgsFileUtils.splitPathToComponents('c:/home/user'), ["c:", "home", "user"])
+
+    def testUniquePath(self):
+        temp_dir = QTemporaryDir()
+        temp_path = temp_dir.path()
+
+        with open(os.path.join(temp_path, 'test.txt'), 'w+') as f:
+            f.close()
+
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'my_test.txt')), os.path.join(temp_path, 'my_test.txt'))
+
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test.txt')), os.path.join(temp_path, 'test_2.txt'))
+
+        with open(os.path.join(temp_path, 'test_2.txt'), 'w+') as f:
+            f.close()
+
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test_2.txt')), os.path.join(temp_path, 'test_2_2.txt'))
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test.txt')), os.path.join(temp_path, 'test_3.txt'))
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test_1.txt')), os.path.join(temp_path, 'test_1.txt'))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -330,6 +330,11 @@ class TestQgsFileUtils(unittest.TestCase):
         self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test.txt')), os.path.join(temp_path, 'test_3.txt'))
         self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test_1.txt')), os.path.join(temp_path, 'test_1.txt'))
 
+        with open(os.path.join(temp_path, 'test'), 'w+') as f:
+            f.close()
+
+        self.assertEqual(QgsFileUtils.uniquePath(os.path.join(temp_path, 'test')), os.path.join(temp_path, 'test_2'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgssymbollayer_createsld.py
+++ b/tests/src/python/test_qgssymbollayer_createsld.py
@@ -20,10 +20,10 @@ __date__ = 'July 2016'
 __copyright__ = '(C) 2012, Andrea Aime'
 
 import qgis  # NOQA
-
-from qgis.PyQt.QtCore import Qt, QDir, QFile, QIODevice, QPointF, QSizeF
+import os
+from qgis.PyQt.QtCore import Qt, QDir, QFile, QIODevice, QPointF, QSizeF, QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
-from qgis.PyQt.QtGui import QColor, QFont
+from qgis.PyQt.QtGui import QColor, QFont, QImage
 
 from qgis.core import (
     Qgis,
@@ -32,7 +32,7 @@ from qgis.core import (
     QgsMarkerLineSymbolLayer, QgsMarkerSymbol, QgsSimpleFillSymbolLayer, QgsSVGFillSymbolLayer,
     QgsLinePatternFillSymbolLayer, QgsPointPatternFillSymbolLayer, QgsVectorLayer, QgsVectorLayerSimpleLabeling,
     QgsTextBufferSettings, QgsPalLayerSettings, QgsTextBackgroundSettings, QgsRuleBasedLabeling,
-    QgsLineSymbol, QgsSymbolLayer, QgsSimpleMarkerSymbolLayer, QgsProperty)
+    QgsLineSymbol, QgsSymbolLayer, QgsSimpleMarkerSymbolLayer, QgsProperty, QgsSldExportContext)
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
 
@@ -1236,6 +1236,64 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
         rot = dom.elementsByTagName('se:Rotation').at(0).firstChild().toElement()
         self.assertEqual(rot.tagName(), 'ogc:PropertyName')
         self.assertEqual(rot.text(), 'field_a')
+
+    def testSaveSldStyleV2Png(self):
+        """Test SLD export for polygons with PNG tiles"""
+
+        # Point pattern
+        layer = QgsVectorLayer("Polygon", "addfeat", "memory")
+        error, ok = layer.loadSldStyle(os.path.join(unitTestDataPath('symbol_layer'), 'QgsPointPatternFillSymbolLayer.sld'))
+        self.assertTrue(ok)
+        temp_dir = QTemporaryDir()
+        temp_path = temp_dir.path()
+        sld_path = os.path.join(temp_path, 'export.sld')
+        context = QgsSldExportContext(Qgis.SldExportOption.Png, Qgis.SldExportVendorExtension.NoVendorExtension, sld_path)
+        message, ok = layer.saveSldStyleV2(context)
+        self.assertTrue(ok)
+        self.assertTrue(os.path.exists(os.path.join(temp_path, 'export.png')))
+
+        with open(sld_path, 'r') as f:
+            self.assertIn('export.png', f.read())
+
+        image = QImage(os.path.join(temp_path, 'export.png'))
+        self.assertTrue(image.hasAlphaChannel())
+        self.assertEqual(image.height(), 33)
+        self.assertEqual(image.width(), 33)
+
+        for x, y in ((16, 0), (0, 16), (16, 16), (32, 16), (16, 32)):
+            self.assertEqual(image.pixelColor(x, y).name(), '#000000')
+            self.assertEqual(image.pixelColor(x, y).alpha(), 0)
+
+        for x, y in ((0, 0), (0, 32), (32, 0), (32, 32)):
+            self.assertNotEqual(image.pixelColor(x, y).name(), '#000000')
+            self.assertGreater(image.pixelColor(x, y).alpha(), 0)
+
+        # Line pattern
+        error, ok = layer.loadSldStyle(os.path.join(unitTestDataPath('symbol_layer'), 'QgsLinePatternFillSymbolLayer.sld'))
+        self.assertTrue(ok)
+        temp_dir = QTemporaryDir()
+        temp_path = temp_dir.path()
+        sld_path = os.path.join(temp_path, 'export.sld')
+        context = QgsSldExportContext(Qgis.SldExportOption.Png, Qgis.SldExportVendorExtension.NoVendorExtension, sld_path)
+        message, ok = layer.saveSldStyleV2(context)
+        self.assertTrue(ok)
+        self.assertTrue(os.path.exists(os.path.join(temp_path, 'export.png')))
+
+        with open(sld_path, 'r') as f:
+            self.assertIn('export.png', f.read())
+
+        image = QImage(os.path.join(temp_path, 'export.png'))
+        self.assertTrue(image.hasAlphaChannel())
+        self.assertEqual(image.height(), 7)
+        self.assertEqual(image.width(), 4)
+
+        for x, y in ((0, 0), (3, 3), (3, 3), (0, 6)):
+            self.assertEqual(image.pixelColor(x, y).name(), '#000000')
+            self.assertEqual(image.pixelColor(x, y).alpha(), 0)
+
+        for x, y in ((2, 0), (0, 3), (3, 6)):
+            self.assertNotEqual(image.pixelColor(x, y).name(), '#000000')
+            self.assertGreater(image.pixelColor(x, y).alpha(), 0)
 
     def assertScaleDenominator(self, root, expectedMinScale, expectedMaxScale, index=0):
         rule = root.elementsByTagName('se:Rule').item(index).toElement()

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -672,22 +672,22 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
             [10, 10, math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 4],
             [10, 20, math.pi / 2, 20, 10, math.pi / 2],
             [10, 20, math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 4],
-            [10, 20, math.pi / 6, 36, 72, 0.5880031703261417], # Angle approx
+            [10, 20, math.pi / 6, 36, 72, 0.5880031703261417],  # Angle approx
 
             # Second quadrant
-            [10, 20, math.pi / 2 + math.pi / 6, 72, 36, math.pi / 2 + 0.5880031703261417], # Angle approx
+            [10, 20, math.pi / 2 + math.pi / 6, 72, 36, math.pi / 2 + 0.5880031703261417],  # Angle approx
             [10, 10, math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 2 + math.pi / 4],
             [10, 20, math.pi / 2 + math.pi / 2, 10, 20, math.pi / 2 + math.pi / 2],
             [10, 20, math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 2 + math.pi / 4],
 
             # Third quadrant
-            [10, 20, math.pi + math.pi / 6, 36, 72, math.pi + 0.5880031703261417], # Angle approx
+            [10, 20, math.pi + math.pi / 6, 36, 72, math.pi + 0.5880031703261417],  # Angle approx
             [10, 10, math.pi + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 4],
             [10, 20, math.pi + math.pi / 2, 20, 10, math.pi + math.pi / 2],
             [10, 20, math.pi + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 4],
 
             # Fourth quadrant
-            [10, 20, math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417], # Angle approx
+            [10, 20, math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417],  # Angle approx
             [10, 10, math.pi + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
             [10, 20, math.pi + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
         ]

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -11,6 +11,7 @@ __date__ = '2016-09'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
 import qgis  # NOQA
+import math
 from qgis.PyQt.QtCore import (
     QSizeF,
     QPointF,
@@ -661,6 +662,41 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
         result = checker.compareImages(name, 20)
         PyQgsSymbolLayerUtils.report += checker.report()
         return result
+
+    def testTileSize(self):
+
+        test_data = [
+            # First quadrant
+            [10, 20, 0, 10, 20, 0],
+            [10, 20, math.pi, 10, 20, math.pi],
+            [10, 10, math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 4],
+            [10, 20, math.pi / 2, 20, 10, math.pi / 2],
+            [10, 20, math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 4],
+            [10, 20, math.pi / 6, 36, 72, 0.5880031703261417], # Angle approx
+
+            # Second quadrant
+            [10, 20, math.pi / 2 + math.pi / 6, 72, 36, math.pi / 2 + 0.5880031703261417], # Angle approx
+            [10, 10, math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+            [10, 20, math.pi / 2 + math.pi / 2, 10, 20, math.pi / 2 + math.pi / 2],
+            [10, 20, math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+
+            # Third quadrant
+            [10, 20, math.pi + math.pi / 6, 36, 72, math.pi + 0.5880031703261417], # Angle approx
+            [10, 10, math.pi + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 4],
+            [10, 20, math.pi + math.pi / 2, 20, 10, math.pi + math.pi / 2],
+            [10, 20, math.pi + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 4],
+
+            # Fourth quadrant
+            [10, 20, math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417], # Angle approx
+            [10, 10, math.pi + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+            [10, 20, math.pi + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+        ]
+
+        for width, height, angle, exp_width, exp_height, exp_angle in test_data:
+            (res_size, res_angle) = QgsSymbolLayerUtils.tileSize(width, height, angle)
+            self.assertEqual(res_size.height(), int(exp_height))
+            self.assertEqual(res_size.width(), int(exp_width))
+            self.assertAlmostEqual(res_angle, exp_angle)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -690,11 +690,62 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
             [10, 20, math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417],  # Angle approx
             [10, 10, math.pi + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
             [10, 20, math.pi + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+
+            # Test out of range angles > 2 PI
+
+            # First quadrant
+            [10, 10, math.pi * 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 4],
+            [10, 20, math.pi * 2 + math.pi / 2, 20, 10, math.pi / 2],
+            [10, 20, math.pi * 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 4],
+            [10, 20, math.pi * 2 + math.pi / 6, 36, 72, 0.5880031703261417],  # Angle approx
+
+            # Second quadrant
+            [10, 20, math.pi * 2 + math.pi / 2 + math.pi / 6, 72, 36, math.pi / 2 + 0.5880031703261417],  # Angle approx
+            [10, 10, math.pi * 2 + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+            [10, 20, math.pi * 2 + math.pi / 2 + math.pi / 2, 10, 20, math.pi / 2 + math.pi / 2],
+            [10, 20, math.pi * 2 + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+
+            # Third quadrant
+            [10, 20, math.pi * 2 + math.pi + math.pi / 6, 36, 72, math.pi + 0.5880031703261417],  # Angle approx
+            [10, 10, math.pi * 2 + math.pi + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 4],
+            [10, 20, math.pi * 2 + math.pi + math.pi / 2, 20, 10, math.pi + math.pi / 2],
+            [10, 20, math.pi * 2 + math.pi + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 4],
+
+            # Fourth quadrant
+            [10, 20, math.pi * 2 + math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417],  # Angle approx
+            [10, 10, math.pi * 2 + math.pi + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+            [10, 20, math.pi * 2 + math.pi + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+
+            # Test out of range angles < 0
+
+            # First quadrant
+            [10, 10, - math.pi * 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 4],
+            [10, 20, - math.pi * 2 + math.pi / 2, 20, 10, math.pi / 2],
+            [10, 20, - math.pi * 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 4],
+            [10, 20, - math.pi * 2 + math.pi / 6, 36, 72, 0.5880031703261417],  # Angle approx
+
+            # Second quadrant
+            [10, 20, - math.pi * 2 + math.pi / 2 + math.pi / 6, 72, 36, math.pi / 2 + 0.5880031703261417],  # Angle approx
+            [10, 10, - math.pi * 2 + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+            [10, 20, - math.pi * 2 + math.pi / 2 + math.pi / 2, 10, 20, math.pi / 2 + math.pi / 2],
+            [10, 20, - math.pi * 2 + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi / 2 + math.pi / 4],
+
+            # Third quadrant
+            [10, 20, - math.pi * 2 + math.pi + math.pi / 6, 36, 72, math.pi + 0.5880031703261417],  # Angle approx
+            [10, 10, - math.pi * 2 + math.pi + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 4],
+            [10, 20, - math.pi * 2 + math.pi + math.pi / 2, 20, 10, math.pi + math.pi / 2],
+            [10, 20, - math.pi * 2 + math.pi + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 4],
+
+            # Fourth quadrant
+            [10, 20, - math.pi * 2 + math.pi + math.pi / 2 + math.pi / 6, 72, 36, math.pi + math.pi / 2 + 0.5880031703261417],  # Angle approx
+            [10, 10, - math.pi * 2 + math.pi + math.pi / 2 + math.pi / 4, 10 * math.sqrt(2), 10 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+            [10, 20, - math.pi * 2 + math.pi + math.pi / 2 + math.pi / 4, 20 * math.sqrt(2), 20 * math.sqrt(2), math.pi + math.pi / 2 + math.pi / 4],
+
         ]
 
         for width, height, angle, exp_width, exp_height, exp_angle in test_data:
             (res_size, res_angle) = QgsSymbolLayerUtils.tileSize(width, height, angle)
-            self.assertEqual(res_size.height(), int(exp_height))
+            self.assertEqual(res_size.height(), int(exp_height), angle)
             self.assertEqual(res_size.width(), int(exp_width))
             self.assertAlmostEqual(res_angle, exp_angle)
 


### PR DESCRIPTION
Followup recent SLD improvements https://github.com/qgis/QGIS/pull/51277 this PR adds a few small fixes and the new option to export polygon point pattern and line pattern fills as PNG ExternalGraphic images in the SLD.

By choosing the new SLD export option (only available for polygon layers), the symbol layer export implementation will try to convert the symbol to a PNG tile that can be used as an external graphic symbol by the SLD polygon fill symbolizer.

The PNG image tiles are saved in the same directory of the exported SLD.

![sld_png_export](https://user-images.githubusercontent.com/142164/212315549-4b4970af-3cb2-42de-a896-1961f1a37982.png)

## Examples

Generated tile and rendering on Deegree

![SLD_Single_Polygon_hatches](https://user-images.githubusercontent.com/142164/212630205-f2c523cc-9c70-4127-8330-296505f2dbc4.png)


![immagine](https://user-images.githubusercontent.com/142164/212630093-67ddb608-2cc8-4f54-b8ca-b073d89b9ba8.png)

![SLD_Single_Polygon_point_pattern_315](https://user-images.githubusercontent.com/142164/212630513-26640456-182b-4cfd-b55c-9e27aa3d99c9.png)


![immagine](https://user-images.githubusercontent.com/142164/212630447-2beb0729-b9ca-46c9-85e9-c7d0bfcd6126.png)
