### PR TITLE
[API] Defined QgsApplication::applicationFullName() and use it in Postgres and Server

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -445,6 +445,21 @@ Returns the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "ex
 .. versionadded:: 2.14
 %End
 
+
+    static QString applicationFullName();
+%Docstring
+Returns the QGIS application full name.
+
+It can be defined by the environment variable QGIS_APPLICATION_FULL_NAME or the /qgis/application_full_name
+in the QGIS config file.
+
+By default it is equal to :py:func:`~QgsApplication.applicationName`+' '+:py:func:`~QgsApplication.platform`
+
+.. seealso:: :py:func:`platform`
+
+.. versionadded:: 3.30
+%End
+
     static QString locale();
 %Docstring
 Returns the QGIS locale.

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -63,6 +63,7 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_PROJECT_CACHE_CHECK_INTERVAL,
       QGIS_SERVER_PROJECT_CACHE_STRATEGY,
       QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS,
+      QGIS_SERVER_APPLICATION_NAME,
     };
 };
 
@@ -339,6 +340,16 @@ The default value is an empty string, the value can be changed by setting the en
 variable QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS.
 
 .. versionadded:: 3.28
+%End
+
+    QString applicationName() const;
+%Docstring
+Returns the QGIS Server application name.
+The default value is the concatenation of :py:func:`QgsApplication.applicationName()`
+and :py:func:`QgsApplication.platform()` separated by a space, the value can be changed
+by setting the environment variable QGIS_SERVER_APPLICATION_NAME.
+
+.. versionadded:: 3.30
 %End
 
     static QString name( QgsServerSettingsEnv::EnvVar env );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -181,6 +181,7 @@ Q_GLOBAL_STATIC( QString, sAuthDbDirPath )
 Q_GLOBAL_STATIC( QString, sUserName )
 Q_GLOBAL_STATIC( QString, sUserFullName )
 Q_GLOBAL_STATIC_WITH_ARGS( QString, sPlatformName, ( "external" ) )
+Q_GLOBAL_STATIC( QString, sApplicationFullName )
 Q_GLOBAL_STATIC( QString, sTranslation )
 
 Q_GLOBAL_STATIC( QTemporaryDir, sIconCacheDir )
@@ -1373,6 +1374,25 @@ int QgsApplication::systemMemorySizeMb()
 QString QgsApplication::platform()
 {
   return *sPlatformName();
+}
+
+QString QgsApplication::applicationFullName()
+{
+  if ( !sApplicationFullName()->isEmpty() )
+    return *sApplicationFullName();
+
+  //use environment variables
+  *sApplicationFullName() = qgetenv( "QGIS_APPLICATION_FULL_NAME" );
+  if ( !sApplicationFullName()->isEmpty() )
+    return *sApplicationFullName();
+
+  //last resort
+  QgsSettings settings;
+  *sApplicationFullName() = settings.value(
+                              QStringLiteral( "/qgis/application_full_name" ),
+                              QStringLiteral( "%1 %2" ).arg( applicationName(), platform() )
+                            ).toString();
+  return *sApplicationFullName();
 }
 
 QString QgsApplication::locale()

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -474,6 +474,20 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     static QString platform();
 
+
+    /**
+     * Returns the QGIS application full name.
+     *
+     * It can be defined by the environment variable QGIS_APPLICATION_FULL_NAME or the /qgis/application_full_name
+     * in the QGIS config file.
+     *
+     * By default it is equal to applicationName()+' '+platform()
+     *
+     * \see platform()
+     * \since QGIS 3.30
+     */
+    static QString applicationFullName();
+
     /**
      * Returns the QGIS locale.
      * \since QGIS 3.0

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -32,6 +32,7 @@
 #include "qgspostgresconnpool.h"
 #include "qgsvariantutils.h"
 #include "qgsdbquerylog.h"
+#include "qgsapplication.h"
 
 #include <QApplication>
 #include <QStringList>
@@ -449,8 +450,11 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
 
   if ( mPostgresqlVersion >= 90000 )
   {
-    LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "SET application_name='QGIS'" ) );
-    LoggedPQexecNR( "QgsPostgresConn", QStringLiteral( "SET extra_float_digits=3" ) );
+    // Quoting floating point values and application name for PostgreSQL connection in 1 request
+    LoggedPQexecNR(
+      "QgsPostgresConn",
+      QStringLiteral( "SET extra_float_digits=3; SET application_name=%1" ).arg( quotedValue( QgsApplication::applicationFullName() ) )
+    );
   }
 
   PQsetNoticeProcessor( mConn, noticeProcessor, nullptr );

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -379,6 +379,16 @@ void QgsServerSettings::initSettings()
                                          };
   mSettings[ sAllowedExtraSqlTokens.envVar ] = sAllowedExtraSqlTokens;
 
+  const Setting sApplicationName = { QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME,
+                                     QgsServerSettingsEnv::DEFAULT_VALUE,
+                                     QStringLiteral( "The QGIS Server application name" ),
+                                     QStringLiteral( "/qgis/application_full_name" ),
+                                     QVariant::String,
+                                     QVariant( QgsApplication::applicationFullName() ),
+                                     QVariant()
+                                   };
+  mSettings[ sApplicationName.envVar ] = sApplicationName;
+
 }
 
 void QgsServerSettings::load()
@@ -693,4 +703,9 @@ QStringList QgsServerSettings::allowedExtraSqlTokens() const
     return QStringList();
   }
   return strVal.split( ',' );
+}
+
+QString QgsServerSettings::applicationName() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME ).toString().trimmed();
 }

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -81,6 +81,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_PROJECT_CACHE_CHECK_INTERVAL, //! Set the interval for cache invalidation strategy 'interval', default to 0 which select the legacy File system watcher  (since QGIS 3.26).
       QGIS_SERVER_PROJECT_CACHE_STRATEGY, //! Set the project cache strategy. Possible values are 'filesystem', 'periodic' or 'off' (since QGIS 3.26).
       QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS, //! Adds these tokens to the list of allowed tokens that the services accept when filtering features (since QGIS 3.28).
+      QGIS_SERVER_APPLICATION_NAME, //! Define the QGIS Server application name (since QGIS 3.30).
     };
     Q_ENUM( EnvVar )
 };
@@ -338,6 +339,16 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.28
      */
     QStringList allowedExtraSqlTokens() const;
+
+    /**
+     * Returns the QGIS Server application name.
+     * The default value is the concatenation of QgsApplication::applicationName()
+     * and QgsApplication::platform() separated by a space, the value can be changed
+     * by setting the environment variable QGIS_SERVER_APPLICATION_NAME.
+     *
+     * \since QGIS 3.30
+     */
+    QString applicationName() const;
 
     /**
      * Returns the string representation of a setting.

--- a/tests/src/core/testqgsapplication.cpp
+++ b/tests/src/core/testqgsapplication.cpp
@@ -39,6 +39,7 @@ class TestQgsApplication: public QgsTest
     void accountName();
     void osName();
     void platformName();
+    void applicationFullName();
     void themeIcon();
 
   private:
@@ -50,9 +51,14 @@ class TestQgsApplication: public QgsTest
 
 void TestQgsApplication::initTestCase()
 {
-  //
   // Runs once before any tests are run
-  //
+
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
   // init QGIS's paths - true means that all path will be inited from prefix
   QgsApplication::init();
   QgsApplication::initQgis();
@@ -90,6 +96,12 @@ void TestQgsApplication::platformName()
 {
   // test will always be run under external platform
   QCOMPARE( QgsApplication::platform(), QString( "external" ) );
+}
+
+void TestQgsApplication::applicationFullName()
+{
+  // test will always be run under external platform
+  QCOMPARE( QgsApplication::applicationFullName(), QString( "QGIS-TEST external" ) );
 }
 
 void TestQgsApplication::themeIcon()


### PR DESCRIPTION
the QgsApplication::applicationFullName() static method returns the QGIS application full name.

It can be defined by the environment variable QGIS_APPLICATION_FULL_NAME or the /qgis/application_full_name
in the QGIS config file.

By default it is equal to `QgsApplication::applicationName()+' '+QgsApplication::platform()`

Using QgsApplication::applicationFullName for PostgreSQL application_name.

For QGIS Server defining QGIS_SERVER_APPLICATION_NAME variable. The QGIS_SERVER_APPLICATION_NAME variable can be used instead of QGIS_APPLICATION_FULL_NAME.

For QGIS Server Logger using QGIS Server application name by default log tag.

Funded by 3liz https://3liz.com