### PR TITLE
DateTime Field edit config : not mixing display format and field format

### DIFF
--- a/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -22,11 +22,13 @@ the field configuration.
 #include "qgsdatetimefieldformatter.h"
 %End
   public:
-    static QString DATE_FORMAT;
+    static const QString DATE_FORMAT;
     static const QString TIME_FORMAT;
-    static QString DATETIME_FORMAT;
+    static const QString DATETIME_FORMAT;
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
+    static QString DATE_DISPLAY_FORMAT; //! Date display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
+    static QString DATETIME_DISPLAY_FORMAT; //! Date time display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
 
     QgsDateTimeFieldFormatter();
 %Docstring
@@ -47,6 +49,18 @@ The type is expected to be one of
 - QVariant.DateTime
 - QVariant.Date
 - QVariant.Time
+%End
+
+    static QString defaultDisplayFormat( QVariant::Type type );
+%Docstring
+Gets the default display format in function of the type.
+The type is expected to be one of
+
+- QVariant.DateTime
+- QVariant.Date
+- QVariant.Time
+
+.. versionadded:: 3.30
 %End
 
 };

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.h
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.h
@@ -31,11 +31,13 @@
 class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
 {
   public:
-    static QString DATE_FORMAT;
+    static const QString DATE_FORMAT; //! Date format was localized by applyLocaleChange before QGIS 3.30
     static const QString TIME_FORMAT;
-    static QString DATETIME_FORMAT;
+    static const QString DATETIME_FORMAT; //! Date time format was localized by applyLocaleChange before QGIS 3.30
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
+    static QString DATE_DISPLAY_FORMAT; //! Date display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
+    static QString DATETIME_DISPLAY_FORMAT; //! Date time display format is localized by applyLocaleChange \see applyLocaleChange \since QGIS 3.30
 
     /**
       * Default constructor of field formatter for a date time field.
@@ -57,7 +59,20 @@ class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
     static QString defaultFormat( QVariant::Type type );
 
     /**
-     * Adjusts the date time formats according to locale.
+     * Gets the default display format in function of the type.
+     * The type is expected to be one of
+     *
+     * - QVariant::DateTime
+     * - QVariant::Date
+     * - QVariant::Time
+     *
+     * \since QGIS 3.30
+     */
+    static QString defaultDisplayFormat( QVariant::Type type );
+
+    /**
+     * Adjusts the date time display formats according to locale.
+     * Before QGIS 3.30, the date time formats was adjusted.
      *
      * \since QGIS 3.22.2
      */

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -438,6 +438,14 @@ void QgsDateTimeEditConfig::updateDisplayFormat( const QString &fieldFormat )
     {
       mDisplayFormatEdit->setText( QgsDateTimeFieldFormatter::DISPLAY_FOR_ISO_FORMAT );
     }
+    else if ( fieldFormat == QgsDateTimeFieldFormatter::DATE_FORMAT )
+    {
+      mDisplayFormatEdit->setText( QgsDateTimeFieldFormatter::DATE_DISPLAY_FORMAT );
+    }
+    else if ( fieldFormat == QgsDateTimeFieldFormatter::DATETIME_FORMAT )
+    {
+      mDisplayFormatEdit->setText( QgsDateTimeFieldFormatter::DATETIME_DISPLAY_FORMAT );
+    }
     else
     {
       mDisplayFormatEdit->setText( fieldFormat );
@@ -505,7 +513,7 @@ void QgsDateTimeEditConfig::setConfig( const QVariantMap &config )
     mFieldFormatComboBox->setCurrentIndex( 4 );
   }
 
-  const QString displayFormat = config.value( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::defaultFormat( fieldDef.type() ) ).toString();
+  const QString displayFormat = config.value( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::defaultDisplayFormat( fieldDef.type() ) ).toString();
   mDisplayFormatEdit->setText( displayFormat );
   if ( displayFormat == mFieldFormatEdit->text() )
   {

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -164,11 +164,13 @@ namespace QgsWfs
                                     QgsDateTimeFieldFormatter::defaultFormat( field.type() )
                                   ).toString();
       // Define type from field format
-      if ( fieldFormat == QgsDateTimeFieldFormatter::TIME_FORMAT ) // const TIME_FORMAT
+      if ( fieldFormat == QgsDateTimeFieldFormatter::TIME_FORMAT ) // const QgsDateTimeFieldFormatter::TIME_FORMAT
         fieldType = QStringLiteral( "time" );
-      else if ( fieldFormat == QLatin1String( "yyyy-MM-dd" ) ) // QgsDateTimeFieldFormatter provide a local date format
+      else if ( fieldFormat == QgsDateTimeFieldFormatter::DATE_FORMAT ) // const QgsDateTimeFieldFormatter::DATE_FORMAT since QGIS 3.30
         fieldType = QStringLiteral( "date" );
-      else
+      else if ( fieldFormat == QgsDateTimeFieldFormatter::DATETIME_FORMAT ) // const QgsDateTimeFieldFormatter::DATETIME_FORMAT since QGIS 3.30
+        fieldType = QStringLiteral( "dateTime" );
+      else if ( fieldFormat == QgsDateTimeFieldFormatter::QT_ISO_FORMAT )
         fieldType = QStringLiteral( "dateTime" );
     }
     else if ( setup.type() ==  QStringLiteral( "Range" ) )

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -720,9 +720,9 @@ class TestQgsDateTimeFieldFormatter(unittest.TestCase):
             QgsApplication.setLocale(locale)
             field_formatter = QgsDateTimeFieldFormatter()
 
-            self.assertEqual(field_formatter.defaultFormat(QVariant.Date), assertions["date_format"], locale.name())
-            self.assertEqual(field_formatter.defaultFormat(QVariant.Time), assertions["time_format"], locale.name())
-            self.assertEqual(field_formatter.defaultFormat(QVariant.DateTime), assertions["datetime_format"], locale.name())
+            self.assertEqual(field_formatter.defaultDisplayFormat(QVariant.Date), assertions["date_format"], locale.name())
+            self.assertEqual(field_formatter.defaultDisplayFormat(QVariant.Time), assertions["time_format"], locale.name())
+            self.assertEqual(field_formatter.defaultDisplayFormat(QVariant.DateTime), assertions["datetime_format"], locale.name())
 
             # default configuration should show timezone information
             config = {}


### PR DESCRIPTION
The default field datetime formats has to be const and equal to the international format. The default display datetime formats has to be localized.

Funded by 3liz https://3liz.com