### PR TITLE
fix  update temporal for 3D scene

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -750,9 +750,9 @@ void Qgs3DMapScene::onLayersChanged()
 
 void Qgs3DMapScene::updateTemporal()
 {
-  for ( auto it = mLayerEntities.keyBegin(); it != mLayerEntities.keyEnd(); it++ )
+  const QList<QgsMapLayer * > layers = mLayerEntities.keys();
+  for ( QgsMapLayer *layer : layers )
   {
-    QgsMapLayer *layer = *it;
     if ( layer->temporalProperties()->isActive() )
     {
       removeLayerEntity( layer );


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/50529 , the 3D scene crashes when the time range is changed.
This is due to the loop made directly on the  `QMap<QgsMapLayer *, Qt3DCore::QEntity *>` whereas the container is changed inside the loop. Before the #50529 changes, the loop was on members of the container **before** the loop start.
This PR fixes the crash.