### PR TITLE
Avoid crash when saving edits after adding a geojson column

### DIFF
--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -628,7 +628,7 @@ bool QgsOgrFeatureIterator::readFeature( const gdal::ogr_feature_unique_ptr &fet
   QVariant *attributeData = attributes.data();
   if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )
   {
-    const int requestedAttributeTotal = mRequestAttributes.size();
+    const int requestedAttributeTotal = qMin( mRequestAttributes.size(), fieldCount );
     if ( requestedAttributeTotal > 0 )
     {
       const int *requestAttribute = mRequestAttributes.constData();

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -628,7 +628,13 @@ bool QgsOgrFeatureIterator::readFeature( const gdal::ogr_feature_unique_ptr &fet
   QVariant *attributeData = attributes.data();
   if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )
   {
-    const int requestedAttributeTotal = std::min( mRequestAttributes.size(), fieldCount );
+    int requestedAttributeTotal = std::min( mRequestAttributes.size(), fieldCount );
+    if ( fieldCount < requestedAttributeTotal )
+    {
+      QgsDebugMsg( "Feature iterator of " + mSource->mLayerName + ": trying to read more fields than available" );
+      requestedAttributeTotal = fieldCount;
+    }
+
     if ( requestedAttributeTotal > 0 )
     {
       const int *requestAttribute = mRequestAttributes.constData();

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -628,7 +628,7 @@ bool QgsOgrFeatureIterator::readFeature( const gdal::ogr_feature_unique_ptr &fet
   QVariant *attributeData = attributes.data();
   if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )
   {
-    const int requestedAttributeTotal = qMin( mRequestAttributes.size(), fieldCount );
+    const int requestedAttributeTotal = std::min( mRequestAttributes.size(), fieldCount );
     if ( requestedAttributeTotal > 0 )
     {
       const int *requestAttribute = mRequestAttributes.constData();

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -515,7 +515,7 @@ void QgsAttributeTableModel::loadLayer()
     }
 
     emit finished();
-    connect( mLayerCache, &QgsVectorLayerCache::invalidated, this, &QgsAttributeTableModel::loadLayer, Qt::UniqueConnection );
+    connect( mLayerCache, &QgsVectorLayerCache::invalidated, this, &QgsAttributeTableModel::loadLayer, static_cast<Qt::ConnectionType>( Qt::UniqueConnection | Qt::QueuedConnection ) );
   }
 
   endResetModel();


### PR DESCRIPTION
This only avoids the crash by postponing `QgsAttributeTableModel::loadLayer` to the next event loop execution, when the OgrProvider is in a consistent state again. This fixes #51262, but an underlying issue remain, see also comment https://github.com/qgis/QGIS/issues/51262#issuecomment-1375325399