### PR TITLE
[Feature] Add shortcuts manager to print layouts

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -73,6 +73,8 @@
 #include "qgslayoutlabelwidget.h"
 #include "qgslabelingresults.h"
 #include "qgsscreenhelper.h"
+#include "qgsshortcutsmanager.h"
+#include "qgsconfigureshortcutsdialog.h"
 #include "ui_defaults.h"
 
 #include <QShortcut>
@@ -993,6 +995,12 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   std::sort( actions.begin(), actions.end(), cmpByText_ );
   mToolbarMenu->insertActions( nullptr, actions );
 
+  // Create the shortcuts manager
+  mShortcutsManager = new QgsShortcutsManager( this, "LayoutDesigner/shortcuts/" );
+  mShortcutsManager->registerAllChildren( this );
+  mShortcutsDialog = new QgsConfigureShortcutsDialog( this, mShortcutsManager ) ;
+  connect( mActionKeyboardShortcuts, &QAction::triggered, mShortcutsDialog, &QDialog::show );
+
   restoreWindowState();
 
   //listen out to status bar updates from the view
@@ -1124,6 +1132,13 @@ std::unique_ptr<QgsLayoutDesignerInterface::ExportResults> QgsLayoutDesignerDial
 {
   return mLastExportResults ? std::make_unique< QgsLayoutDesignerInterface::ExportResults>( *mLastExportResults ) : nullptr;
 }
+
+
+QgsShortcutsManager *QgsLayoutDesignerDialog::shortcutsManager()
+{
+  return mShortcutsManager;
+}
+
 
 QgsLayout *QgsLayoutDesignerDialog::currentLayout()
 {

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -50,6 +50,7 @@ class QgsMasterLayoutInterface;
 class QgsLayoutGuideWidget;
 class QgsScreenHelper;
 class QgsConfigureShortcutsDialog;
+class QgsShortcutsManager;
 
 class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
 {

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -49,6 +49,7 @@ class QgsFeature;
 class QgsMasterLayoutInterface;
 class QgsLayoutGuideWidget;
 class QgsScreenHelper;
+class QgsConfigureShortcutsDialog;
 
 class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
 {
@@ -208,6 +209,12 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
      * May be NULLPTR if no export has been performed in the designer.
      */
     std::unique_ptr< QgsLayoutDesignerInterface::ExportResults > lastExportResults() const;
+
+    /**
+     * Returns the keyboard shortcuts manager
+     *
+     */
+    QgsShortcutsManager *shortcutsManager();
 
   public slots:
 
@@ -516,6 +523,10 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     void storeExportResults( QgsLayoutExporter::ExportResult result, QgsLayoutExporter *exporter = nullptr );
     std::unique_ptr< QgsLayoutDesignerInterface::ExportResults> mLastExportResults;
     QMap< QString, QgsLabelingResults *> mLastExportLabelingResults;
+
+    //! Shortcuts manager and dialog
+    QgsShortcutsManager *mShortcutsManager = nullptr;
+    QgsConfigureShortcutsDialog *mShortcutsDialog = nullptr;
 
     //! Save window state
     void saveWindowState();

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -182,7 +182,7 @@
      <x>0</x>
      <y>0</y>
      <width>2180</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="mLayoutMenu">
@@ -387,6 +387,7 @@
      <string>Settings</string>
     </property>
     <addaction name="mActionOptions"/>
+    <addaction name="mActionKeyboardShortcuts"/>
    </widget>
    <addaction name="mLayoutMenu"/>
    <addaction name="menuEdit"/>
@@ -1573,6 +1574,15 @@
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
+   </property>
+  </action>
+  <action name="mActionKeyboardShortcuts">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionKeyboardShortcuts.svg</normaloff>:/images/themes/default/mActionKeyboardShortcuts.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Keyboard Shortcuts...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Fixes #41610
- Fixes #25011

## Description

QGIS main window has a shortcut manager, accessible from the settings menu, that allow to configure and override existing keyboard shortcuts (`QShortcut` and `QAction`).

This PR adds a similar keyboard manager ([`QgsShortcutsManager`](https://api.qgis.org/api/classQgsShortcutsManager.html)) and its configuration dialog ([`QgsConfigureShortcutsDialog`](https://api.qgis.org/api/classQgsConfigureShortcutsDialog.html)) to the Print Layout interface.

![shortcuts_layout](https://user-images.githubusercontent.com/9693475/212564207-1b2538cf-a4eb-48fb-b0be-aa04cb67ea35.gif)



