### PR TITLE
Repair files not included in install

### DIFF
--- a/src/3d/processing/qgs3dalgorithms.h
+++ b/src/3d/processing/qgs3dalgorithms.h
@@ -20,7 +20,7 @@
 
 #include "qgis_3d.h"
 #include "qgis.h"
-#include "processing/qgsprocessingprovider.h"
+#include "qgsprocessingprovider.h"
 
 /**
  * \ingroup analysis

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -19,8 +19,8 @@
 
 #include "qgis_analysis.h"
 #include "qgsfeature.h"
-#include "geometry/qgsabstractgeometry.h"
-#include "geometry/qgspoint.h"
+#include "qgsabstractgeometry.h"
+#include "qgspoint.h"
 #include "qgsgeometrycheckcontext.h"
 #include <qmath.h>
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -520,6 +520,7 @@ target_include_directories(qgis_app PUBLIC
 
   ${CMAKE_SOURCE_DIR}/src/app
   ${CMAKE_SOURCE_DIR}/src/app/decorations
+  ${CMAKE_SOURCE_DIR}/src/app/devtools
   ${CMAKE_SOURCE_DIR}/src/app/devtools/networklogger
   ${CMAKE_SOURCE_DIR}/src/app/labeling
   ${CMAKE_SOURCE_DIR}/src/app/layout
@@ -529,6 +530,7 @@ target_include_directories(qgis_app PUBLIC
   ${CMAKE_SOURCE_DIR}/src/app/maptools
   ${CMAKE_SOURCE_DIR}/src/app/mesh
   ${CMAKE_SOURCE_DIR}/src/app/locator
+  ${CMAKE_SOURCE_DIR}/src/app/options
   ${CMAKE_SOURCE_DIR}/src/app/pointcloud
   ${CMAKE_SOURCE_DIR}/src/app/vectortile
   ${CMAKE_SOURCE_DIR}/src/plugins

--- a/src/app/decorations/qgsdecorationscalebar.h
+++ b/src/app/decorations/qgsdecorationscalebar.h
@@ -23,8 +23,8 @@ email                : sbr00pwb@users.sourceforge.net
 
 #include "qgis.h"
 #include "qgsdecorationitem.h"
-#include "scalebar/qgsscalebarsettings.h"
-#include "scalebar/qgsscalebarrenderer.h"
+#include "qgsscalebarsettings.h"
+#include "qgsscalebarrenderer.h"
 
 class QPainter;
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -181,12 +181,12 @@ class QgsAppGpsSettingsMenu;
 #include "qgsattributetablefiltermodel.h"
 #include "qgsmasterlayoutinterface.h"
 #include "qgsmaptoolselect.h"
-#include "ogr/qgsvectorlayersaveasdialog.h"
+#include "qgsvectorlayersaveasdialog.h"
 #include "qgis.h"
 #include "ui_qgisapp.h"
 #include "qgis_app.h"
-#include "devtools/qgsappdevtoolutils.h"
-#include "options/qgsoptionsutils.h"
+#include "qgsappdevtoolutils.h"
+#include "qgsoptionsutils.h"
 
 #include <QGestureEvent>
 #include <QTapAndHoldGesture>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1189,6 +1189,7 @@ set(QGIS_CORE_HDRS
   qgssourcecache.h
   qgsspatialiteutils.h
   qgssqlexpressioncompiler.h
+  qgssqliteexpressioncompiler.h
   qgssqliteutils.h
   qgssqlstatement.h
   qgsstatisticalsummary.h
@@ -1309,6 +1310,8 @@ set(QGIS_CORE_HDRS
   diagram/qgstextdiagram.h
 
   dxf/qgsdxfexport.h
+  dxf/qgsdxfpaintdevice.h
+  dxf/qgsdxfpaintengine.h
 
   editform/qgseditformconfig.h
   editform/qgsattributeeditoraction.h
@@ -1816,6 +1819,7 @@ set(QGIS_CORE_HDRS
   symbology/qgsmapinfosymbolconverter.h
   symbology/qgsmarkersymbol.h
   symbology/qgsmarkersymbollayer.h
+  symbology/qgsmasksymbollayer.h
   symbology/qgsmergedfeaturerenderer.h
   symbology/qgsnullsymbolrenderer.h
   symbology/qgspointclusterrenderer.h

--- a/src/core/externalstorage/qgshttpexternalstorage_p.h
+++ b/src/core/externalstorage/qgshttpexternalstorage_p.h
@@ -20,7 +20,7 @@
 #include "qgis_sip.h"
 #include "qgstaskmanager.h"
 
-#include "externalstorage/qgsexternalstorage.h"
+#include "qgsexternalstorage.h"
 
 #include <QPointer>
 #include <QUrl>

--- a/src/core/externalstorage/qgssimplecopyexternalstorage_p.h
+++ b/src/core/externalstorage/qgssimplecopyexternalstorage_p.h
@@ -16,7 +16,7 @@
 #ifndef QGSSIMPLECOPYEXTERNALSTORAGE_H
 #define QGSSIMPLECOPYEXTERNALSTORAGE_H
 
-#include "externalstorage/qgsexternalstorage.h"
+#include "qgsexternalstorage.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
 

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -19,8 +19,8 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgslayoutitem.h"
-#include "scalebar/qgsscalebarsettings.h"
-#include "scalebar/qgsscalebarrenderer.h"
+#include "qgsscalebarsettings.h"
+#include "qgsscalebarrenderer.h"
 #include <QFont>
 #include <QPen>
 #include <QColor>

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -30,7 +30,7 @@
 #include "qgsproperty.h"
 #include "qgspropertycollection.h"
 
-#include "diagram/qgsdiagram.h"
+#include "qgsdiagram.h"
 #include "qgsreadwritecontext.h"
 #include "qgsmapunitscale.h"
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -701,6 +701,7 @@ set(QGIS_GUI_HDRS
   qgsabstractmaptoolhandler.h
   qgsaddattrdialog.h
   qgsaddtaborgroup.h
+  qgsadvanceddigitizingcanvasitem.h
   qgsadvanceddigitizingdockwidget.h
   qgsadvanceddigitizingfloater.h
   qgsaggregatetoolbutton.h
@@ -786,6 +787,7 @@ set(QGIS_GUI_HDRS
   qgsfilterlineedit.h
   qgsfindfilesbypatternwidget.h
   qgsfloatingwidget.h
+  qgsfocuskeeper.h
   qgsfocuswatcher.h
   qgsfontbutton.h
   qgsformannotation.h
@@ -1068,6 +1070,7 @@ set(QGIS_GUI_HDRS
   editorwidgets/qgsjsoneditwidgetfactory.h
   editorwidgets/qgsjsoneditwrapper.h
   editorwidgets/qgsjsoneditwidget.h
+  editorwidgets/qgslistconfigdlg.h
   editorwidgets/qgslistwidgetfactory.h
   editorwidgets/qgslistwidgetwrapper.h
   editorwidgets/qgsmultiedittoolbutton.h
@@ -1168,6 +1171,7 @@ set(QGIS_GUI_HDRS
   layout/qgslayoutshapewidget.h
   layout/qgslayouttablebackgroundcolorsdialog.h
   layout/qgslayoutunitscombobox.h
+  layout/qgslayoutvaliditychecks.h
   layout/qgslayoutview.h
   layout/qgslayoutviewmouseevent.h
   layout/qgslayoutviewrubberband.h
@@ -1421,8 +1425,21 @@ set_property(GLOBAL PROPERTY QGIS_GUI_HDRS ${QGIS_GUI_HDRS})
 
 
 set(QGIS_GUI_UI_HDRS
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgs25drendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsaddtaborgroupbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsadvanceddigitizingdockwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsadvanceddigitizingfloaterbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsannotationcommonpropertieswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsarrowsymbollayerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributeactiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributeactionpropertiesdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributeformcontaineredit.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributeloadfrommap.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributesforminitcode.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributesformproperties.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributetypeedit.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributewidgeteditgroupbox.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsattributewidgetrelationeditwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthauthoritieseditor.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthcertificateinfo.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthcertificatemanager.h
@@ -1436,6 +1453,7 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthidentitieseditor.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthimportcertdialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthimportidentitydialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthmasterpassresetdialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthmethodplugins.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthserverseditor.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthsslconfigwidget.h
@@ -1443,36 +1461,208 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthsslimportdialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthsslimporterrors.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsauthtrustedcasdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbasicnumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbearingnumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbrowserdirectorypropertiesbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbrowserlayerpropertiesbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbrowserpropertiesdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsbrowserwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscategorizedsymbolrendererwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscharacterselectdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscheckboxconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscodeditorhistorydialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscodedvaluedomainwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscolorbrewercolorrampwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscolordialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscolorramplegendnodewidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscolorrampshaderwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscompoundcolorwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsconfigureshortcutsdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscptcitycolorrampdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscredentialdialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscrsdefinitionwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscurrencynumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdashspacewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdatadefinedsizelegendwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdatasourcemanagerdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdatasourceselectdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdatetimeeditconfig.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdbsourceselectbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdetaileditemwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdiagrampropertiesbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdualviewbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdummyconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgseditconditionalformatrulewidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgseffectpropertieswidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsembeddedsymbolrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgserrordialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionbuilderdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionstoredialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionbuilder.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionselectiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsextentgroupboxwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexternalresourceconfigdlg.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfeaturefilterwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfeatureselectiondlg.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfieldcalculatorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfieldconditionalformatwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfielddomainwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfindfilesbypatternwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsformlabelformatwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfractionnumericformatwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgenericprojectionselectorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgeographiccoordinatenumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgeometrygeneratorwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsglobdomainwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgradientcolorrampdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgraduatedsymbolrendererwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgroupwmsdatadialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsheatmaprendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgshillshaderendererwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgshistogramwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgshttpheaderwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsinstallgridshiftdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsinterpolatedlinesymbollayerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsinvertedpolygonrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsjoindialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsjsoneditconfigdlg.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsjsoneditwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslabelengineconfigdialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslabelingrulepropswidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslabelingwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslabellineanchorwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslabelobstaclesettingswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayermetadatasearchwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutatlaswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutattributeselectiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutattributetablewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayouthtmlwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutlabelwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutlegendlayersdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutlegendnodewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutlegendwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmanualtablewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmapclippingwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmapgridwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmaplabelingwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmapwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutmarkerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutnewitemproperties.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutpicturewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutpolygonwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutpolylinewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutscalebarwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutshapewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayouttablebackgroundstyles.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslegendpatchshapewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslimitedrandomcolorrampwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslistconfigdlg.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsludialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmanageconnectionsdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmapunitscalewidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmaskingwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmasksymbollayerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmergedfeaturerendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmeshrendereractivedatasetwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmeshrendererscalarsettingswidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessagelogviewer.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessageviewer.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmetadatawidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmodeldesignerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmodelinputreorderwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmultibandcolorrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewauxiliaryfielddialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewauxiliarylayerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewdatabasetablenamewidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewgeopackagelayerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewhttpconnectionbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewmemorylayerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewogrconnectionbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewvectorlayerdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewvectortabledialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnumericformatselectorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsorderbydialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsorganizetablecolumnsdialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsowssourceselectbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsowssourcewidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsarcgisservicesourceselectbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspalettedrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspercentagenumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudattributebyramprendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudclassifiedrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudextentrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudlayersaveasdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudrendererpropsdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudrgbrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointclusterrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointdisplacementrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspresetcolorrampwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingaggregatemappingpanelbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingalgorithmdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingalgorithmprogressdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingdestinationwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingdxflayerdetailswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingenummodelerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingfeaturesourceoptionsbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingfieldsmappingpanelbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessinghelpeditorwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingmatrixmodelerwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingmatrixparameterdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingmeshdatasettimewidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingmultipleselectiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprocessingparameterswidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprojectionselectorbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterlayerpropertiesbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspropertyassistantwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspropertycolorassistantwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspropertygenericnumericassistantwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspropertysizeassistantwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsquerybuilderbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspointcloudquerybuilderbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsqueryresultwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrangeconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrangedomainwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterattributetablewidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterattributetabledialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterattributetableaddrowdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscreaterasterattributetabledialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsloadrasterattributetabledialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterattributetableaddcolumndialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrastercontourrendererwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterformatsaveoptionswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterhistogramwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterlayersaveasdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterlayertemporalpropertieswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterminmaxwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrasterpyramidsoptionswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrastertransparencywidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrelationeditorconfigwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrelationreferenceconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrenderermeshpropswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrendererrasterpropswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrendererrulepropsdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrichtexteditorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrulebasedlabelingwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrulebasedrendererwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsscientificnumericformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssinglebandgrayrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssinglebandpseudocolorrendererwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssmartgroupconditionwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssmartgroupeditordialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssourcefieldsproperties.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssqlcomposerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsstyleexportimportdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsstylegroupselectiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsstyleitemslistwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsstylemanagerdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsstylesavedialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssublayersdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssubstitutionlistwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssymbolanimationsettingswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssymbollevelsdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssymbolselectordialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstableeditorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstableeditorformattingwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstablewidgetuibase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrendererpropsdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgseffectstackpropertieswidgetbase.h
@@ -1484,7 +1674,21 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgspdfexportoptions.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayoutwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsrenderercontainerbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstemporalmapsettingswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstexteditconfigdlg.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstextformatwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsuniquevaluesconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsunitselectionwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvaliditycheckresultsbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvaluemapconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvaluerelationconfigdlgbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectorlayerloadstyledialog.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectorlayerpropertiesbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectorlayersaveasdialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectorlayersavestyledialog.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectorlayertemporalpropertieswidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectortilebasiclabelingwidget.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectortilebasicrendererwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsvectortilelayerpropertiesbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgslayertreeembeddedconfigwidgetbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmeshlayerpropertiesbase.h
@@ -1496,6 +1700,42 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsprovidersublayersdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsdatumtransformdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgscoordinateoperationwidgetbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgswmsdimensiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_animatedmarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_ballooncallout.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_blur.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_centroidfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_coloreffects.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_curvedlinecallout.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_drawsource.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_ellipse.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_filledmarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_fontmarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_glow.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_gradientfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_gradientline.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_hashline.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_layerproperties.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_linepatternfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_markerline.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_pointpatternfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_randommarkerfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_rasterfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_rasterline.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_rastermarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_set_dd_value.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_shadoweffect.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_shapeburstfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_simplefill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_simpleline.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_simplelinecallout.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_simplemarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_svgfill.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_svgmarker.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_svgselector.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_symbolslist.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_transform.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_widget_vectorfield.h
 )
 
 if(ENABLE_MODELTEST)

--- a/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
+++ b/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
@@ -16,7 +16,7 @@
 #ifndef QGSSEARCHWIDGETTOOLBUTTON_H
 #define QGSSEARCHWIDGETTOOLBUTTON_H
 
-#include "editorwidgets/core/qgssearchwidgetwrapper.h"
+#include "qgssearchwidgetwrapper.h"
 #include "qgis_sip.h"
 #include <QToolButton>
 #include "qgis_gui.h"

--- a/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.h
+++ b/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.h
@@ -21,7 +21,7 @@
 
 #include <QWidget>
 #include <QDialog>
-#include "processing/models/qgsprocessingmodelgroupbox.h"
+#include "qgsprocessingmodelgroupbox.h"
 #include "qgis_gui.h"
 
 #define SIP_NO_FILE

--- a/src/gui/processing/models/qgsmodelinputreorderwidget.h
+++ b/src/gui/processing/models/qgsmodelinputreorderwidget.h
@@ -21,7 +21,7 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 #include "ui_qgsmodelinputreorderwidgetbase.h"
-#include "processing/models/qgsprocessingmodelparameter.h"
+#include "qgsprocessingmodelparameter.h"
 #include <QDialog>
 
 class QStandardItemModel;

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -20,8 +20,8 @@
 #include "qgis_gui.h"
 #include "ui_qgsprocessingalgorithmdialogbase.h"
 #include "ui_qgsprocessingalgorithmprogressdialogbase.h"
-#include "processing/qgsprocessingcontext.h"
-#include "processing/qgsprocessingfeedback.h"
+#include "qgsprocessingcontext.h"
+#include "qgsprocessingfeedback.h"
 #include "qgsprocessingwidgetwrapper.h"
 
 ///@cond NOT_STABLE

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -24,7 +24,7 @@
 #include "qgis_sip.h"
 #include <QPointer>
 #include "qgsprocessingcontext.h"
-#include "processing/models/qgsprocessingmodelchildparametersource.h"
+#include "qgsprocessingmodelchildparametersource.h"
 
 class QgsProcessingParameterDefinition;
 class QgsAbstractProcessingParameterWidgetWrapper;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -24,7 +24,7 @@
 #include "qgsprocessingparameterdefinitionwidget.h"
 #include "qgsmaptool.h"
 #include "qgsprocessingcontext.h"
-#include "processing/models/qgsprocessingmodelchildparametersource.h"
+#include "qgsprocessingmodelchildparametersource.h"
 
 #include <QAbstractButton>
 

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -427,7 +427,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -629,7 +629,7 @@ enhancement</string>
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
+++ b/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
@@ -456,7 +456,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -236,7 +236,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -693,7 +693,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -494,31 +494,31 @@
   <customwidget>
    <class>QgsMeshRendererScalarSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>mesh/qgsmeshrendererscalarsettingswidget.h</header>
+   <header>qgsmeshrendererscalarsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMeshRendererActiveDatasetWidget</class>
    <extends>QWidget</extends>
-   <header>mesh/qgsmeshrendereractivedatasetwidget.h</header>
+   <header>qgsmeshrendereractivedatasetwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMeshRendererMeshSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>mesh/qgsmeshrenderermeshsettingswidget.h</header>
+   <header>qgsmeshrenderermeshsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMeshRendererVectorSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>mesh/qgsmeshrenderervectorsettingswidget.h</header>
+   <header>qgsmeshrenderervectorsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMeshRenderer3dAveragingWidget</class>
    <extends>QWidget</extends>
-   <header>mesh/qgsmeshrenderer3daveragingwidget.h</header>
+   <header>qgsmeshrenderer3daveragingwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/pointcloud/qgspointcloudattributebyramprendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudattributebyramprendererwidgetbase.ui
@@ -116,7 +116,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/pointcloud/qgspointcloudsourceselectbase.ui
+++ b/src/ui/pointcloud/qgspointcloudsourceselectbase.ui
@@ -241,7 +241,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsarcgisrestsourcewidgetbase.ui
+++ b/src/ui/qgsarcgisrestsourcewidgetbase.ui
@@ -73,7 +73,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsarcgisvectortileconnectiondialog.ui
+++ b/src/ui/qgsarcgisvectortileconnectiondialog.ui
@@ -174,7 +174,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -2278,7 +2278,7 @@
   <customwidget>
    <class>QgsEffectStackCompactWidget</class>
    <extends>QWidget</extends>
-   <header>effects/qgseffectstackpropertieswidget.h</header>
+   <header>qgseffectstackpropertieswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsdualviewbase.ui
+++ b/src/ui/qgsdualviewbase.ui
@@ -399,12 +399,12 @@
   <customwidget>
    <class>QgsAttributeTableView</class>
    <extends>QTableView</extends>
-   <header>attributetable/qgsattributetableview.h</header>
+   <header>qgsattributetableview.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFeatureListView</class>
    <extends>QListView</extends>
-   <header>attributetable/qgsfeaturelistview.h</header>
+   <header>qgsfeaturelistview.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPanelWidgetStack</class>

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -264,7 +264,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgshananewconnectionbase.ui
+++ b/src/ui/qgshananewconnectionbase.ui
@@ -939,7 +939,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsmultibandcolorrendererwidgetbase.ui
+++ b/src/ui/qgsmultibandcolorrendererwidgetbase.ui
@@ -236,7 +236,7 @@ enhancement</string>
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsnewarcgisrestconnectionbase.ui
+++ b/src/ui/qgsnewarcgisrestconnectionbase.ui
@@ -188,7 +188,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -339,7 +339,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsnewogrconnectionbase.ui
+++ b/src/ui/qgsnewogrconnectionbase.ui
@@ -175,7 +175,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -450,7 +450,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -5166,7 +5166,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -300,7 +300,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgspalettedrendererwidgetbase.ui
+++ b/src/ui/qgspalettedrendererwidgetbase.ui
@@ -189,7 +189,7 @@
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -274,7 +274,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsrastercontourrendererwidget.ui
+++ b/src/ui/qgsrastercontourrendererwidget.ui
@@ -163,7 +163,7 @@
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSymbolButton</class>

--- a/src/ui/qgssinglebandgrayrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandgrayrendererwidgetbase.ui
@@ -151,7 +151,7 @@ enhancement</string>
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -84,12 +84,12 @@
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsvectortileconnectiondialog.ui
+++ b/src/ui/qgsvectortileconnectiondialog.ui
@@ -174,7 +174,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsxyzsourcewidgetbase.ui
+++ b/src/ui/qgsxyzsourcewidgetbase.ui
@@ -178,7 +178,7 @@
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
-   <header>auth/qgsauthsettingswidget.h</header>
+   <header>qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/raster/qgshillshaderendererwidget.ui
+++ b/src/ui/raster/qgshillshaderendererwidget.ui
@@ -181,7 +181,7 @@
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/raster/qgsrasterelevationpropertieswidgetbase.ui
+++ b/src/ui/raster/qgsrasterelevationpropertieswidgetbase.ui
@@ -240,7 +240,7 @@
   <customwidget>
    <class>QgsRasterBandComboBox</class>
    <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
+   <header>qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/symbollayer/qgsinterpolatedlinesymbollayerwidgetbase.ui
+++ b/src/ui/symbollayer/qgsinterpolatedlinesymbollayerwidgetbase.ui
@@ -409,7 +409,7 @@
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
-   <header>raster/qgscolorrampshaderwidget.h</header>
+   <header>qgscolorrampshaderwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
When using QGIS for secondary development, it will prompt that some header files are missing.
Missing ui _ ***. h file
Missing *** / ***. h file
Fixes #33810