### PR TITLE
Expose list of projects in cache to Python API

### DIFF
--- a/python/server/auto_generated/qgsconfigcache.sip.in
+++ b/python/server/auto_generated/qgsconfigcache.sip.in
@@ -68,6 +68,13 @@ Returns the name of the current strategy
 .. versionadded:: 3.26
 %End
 
+    QMap<QString, QDateTime> projects() const;
+%Docstring
+Returns projects currently in cache.
+
+.. versionadded:: 3.30
+%End
+
   public:
     QgsConfigCache( QgsServerSettings *settings );
 %Docstring

--- a/python/server/auto_generated/qgsconfigcache.sip.in
+++ b/python/server/auto_generated/qgsconfigcache.sip.in
@@ -68,7 +68,7 @@ Returns the name of the current strategy
 .. versionadded:: 3.26
 %End
 
-    QMap<QString, QDateTime> projects() const;
+    QList<QgsProject *> projects() const;
 %Docstring
 Returns projects currently in cache.
 

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -182,14 +182,14 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
   return entry ? entry->second.get() : nullptr;
 }
 
-QMap<QString, QDateTime> QgsConfigCache::projects() const
+QList<QgsProject *> QgsConfigCache::projects() const
 {
-  QMap<QString, QDateTime> projects;
+  QList<QgsProject *> projects;
 
   const auto constKeys {  mProjectCache.keys() };
   for ( const auto &path : std::as_const( constKeys ) )
   {
-    projects[path] = mProjectCache[path]->first;
+    projects << mProjectCache[path]->second.get();
   }
 
   return projects;

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -182,6 +182,19 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
   return entry ? entry->second.get() : nullptr;
 }
 
+QMap<QString, QDateTime> QgsConfigCache::projects() const
+{
+  QMap<QString, QDateTime> projects;
+
+  const auto constKeys {  mProjectCache.keys() };
+  for ( const auto &path : std::as_const( constKeys ) )
+  {
+    projects[path] = mProjectCache[path]->first;
+  }
+
+  return projects;
+}
+
 QDomDocument *QgsConfigCache::xmlDocument( const QString &filePath )
 {
   //first open file

--- a/src/server/qgsconfigcache.h
+++ b/src/server/qgsconfigcache.h
@@ -121,7 +121,7 @@ class SERVER_EXPORT QgsConfigCache : public QObject
      * Returns projects currently in cache.
      * \since QGIS 3.30
      */
-    QMap<QString, QDateTime> projects() const;
+    QList<QgsProject *> projects() const;
 
   public:
     //! Initialize from settings

--- a/src/server/qgsconfigcache.h
+++ b/src/server/qgsconfigcache.h
@@ -117,6 +117,12 @@ class SERVER_EXPORT QgsConfigCache : public QObject
      */
     QString strategyName() const { return mStrategy->name(); }
 
+    /**
+     * Returns projects currently in cache.
+     * \since QGIS 3.30
+     */
+    QMap<QString, QDateTime> projects() const;
+
   public:
     //! Initialize from settings
     QgsConfigCache( QgsServerSettings *settings );

--- a/tests/src/python/test_qgsserver_configcache.py
+++ b/tests/src/python/test_qgsserver_configcache.py
@@ -199,6 +199,18 @@ class TestQgsServerConfigCache(unittest.TestCase):
 
         self.assertEqual(QgsConfigCache.instance().strategyName(), 'off')
 
+    def test_list_projects(self):
+        settings = QgsServerSettings()
+        settings.load()
+        cache = QgsConfigCache(settings)
+
+        path = Path(unitTestDataPath('qgis_server_project')) / 'project.qgs'
+        prj1 = cache.project(str(path))
+
+        projects = cache.projects()
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].fileName(), path.as_posix())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

``` python
$ print(QgsConfigCache.instance().projects())
[<QgsProject: 'QGIS-Training-Data/exercise_data/qgis-server-tutorial-data/world.qgs'>, <QgsProject: 'postgresql:?service=myservice&schema=public&project=myproject'>]
```