### PR TITLE
Fixes QgsMeasureTool create invalid point when measurement is resumed

### DIFF
--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -102,6 +102,17 @@ void QgsMeasureTool::deactivate()
   mDialog->hide();
   mRubberBand->hide();
   mRubberBandPoints->hide();
+
+  // Deactivating the tool does not reset the measure.
+  // Remove the last temporary point as to not duplicate it when
+  // the tool is re activated
+  int nbTempVertices = mRubberBand->numberOfVertices();
+  int nbVertices = mRubberBandPoints->numberOfVertices();
+  if ( nbTempVertices > nbVertices )
+  {
+    mRubberBand->removeLastPoint();
+  }
+
   QgsMapTool::deactivate();
 }
 

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -294,6 +294,7 @@ void QgsMeasureTool::addPoint( const QgsPointXY &point )
   // Append point that we will be moving.
   mPoints.append( pnt );
 
+  mRubberBand->movePoint( point );
   mRubberBand->addPoint( point );
   mRubberBandPoints->addPoint( point );
   if ( ! mDone )    // Prevent the insertion of a new item in segments measure table

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -99,6 +99,8 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
 
     //! Removes the last vertex from mRubberBand
     void undo();
+
+    friend class TestQgsMeasureTool;
 };
 
 #endif

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsunittypes.h"
+#include "qgsrubberband.h"
 
 /**
  * \ingroup UnitTests
@@ -46,6 +47,7 @@ class TestQgsMeasureTool : public QObject
     void testAreaCalculationCartesian();
     void testAreaCalculationProjected();
     void degreeDecimalPlaces();
+    void testToolDesactivationNoExtraPoint();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -372,6 +374,65 @@ void TestQgsMeasureTool::degreeDecimalPlaces()
   QCOMPARE( dlg->formatDistance( 0.00001, false ), QString( "0.000010 deg" ) );
 
 }
+
+void TestQgsMeasureTool::testToolDesactivationNoExtraPoint()
+{
+
+  // set project CRS and ellipsoid
+  const QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:3111" ) );
+  mCanvas->setDestinationCrs( srs );
+  QgsProject::instance()->setCrs( srs );
+  QgsProject::instance()->setEllipsoid( QStringLiteral( "WGS84" ) );
+  QgsProject::instance()->setAreaUnits( QgsUnitTypes::AreaSquareMeters );
+
+  // run length calculation
+  std::unique_ptr< QgsMeasureTool > tool( new QgsMeasureTool( mCanvas, true ) );
+  std::unique_ptr< QgsMeasureDialog > dlg( new QgsMeasureDialog( tool.get() ) );
+
+  dlg->mEllipsoidal->setChecked( true );
+
+  auto moveCanvas = [this]( int x, int y, int delay = 0 )
+  {
+    auto widget = mCanvas->viewport();
+    QTest::mouseMove( widget, QPoint( x, y ), delay );
+  };
+
+  auto clickCanvas = [this]( int x, int y )
+  {
+    auto widget = mCanvas->viewport();
+    QTest::mouseMove( widget, QPoint( x, y ) );
+    QTest::mouseClick( mCanvas->viewport(), Qt::LeftButton, Qt::NoModifier, QPoint( x, y ), 50 );
+  };
+
+  mCanvas->setMapTool( tool.get() );
+
+
+  // Click on two points, then move the cursor
+  clickCanvas( 50, 50 );
+  clickCanvas( 50, 100 );
+  moveCanvas( 150, 150, 50 );
+
+  // Check number of vertices in the rubberbands
+  // The points Rubberband should have one vertice per click
+  QCOMPARE( tool->mRubberBandPoints->numberOfVertices(), 2 );
+  // The temp rubberband should have one more
+  QCOMPARE( tool->mRubberBand->numberOfVertices(), tool->mRubberBandPoints->numberOfVertices() + 1 );
+
+  // Deactivate & reactivate the tool, then move mouse cursor
+  mCanvas->unsetMapTool( tool.get() );
+  mCanvas->setMapTool( tool.get() );
+  moveCanvas( 100, 100, 50 );
+
+  // Check if both rubberbands still have the right number of vertices
+  QCOMPARE( tool->mRubberBandPoints->numberOfVertices(), 2 );
+  QCOMPARE( tool->mRubberBand->numberOfVertices(), tool->mRubberBandPoints->numberOfVertices() + 1 );
+
+
+
+}
+
+
+
 
 QGSTEST_MAIN( TestQgsMeasureTool )
 #include "testqgsmeasuretool.moc"

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -377,7 +377,6 @@ void TestQgsMeasureTool::degreeDecimalPlaces()
 
 void TestQgsMeasureTool::testToolDesactivationNoExtraPoint()
 {
-
   // set project CRS and ellipsoid
   const QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:3111" ) );
   mCanvas->setDestinationCrs( srs );
@@ -406,7 +405,6 @@ void TestQgsMeasureTool::testToolDesactivationNoExtraPoint()
 
   mCanvas->setMapTool( tool.get() );
 
-
   // Click on two points, then move the cursor
   clickCanvas( 50, 50 );
   clickCanvas( 50, 100 );
@@ -426,13 +424,7 @@ void TestQgsMeasureTool::testToolDesactivationNoExtraPoint()
   // Check if both rubberbands still have the right number of vertices
   QCOMPARE( tool->mRubberBandPoints->numberOfVertices(), 2 );
   QCOMPARE( tool->mRubberBand->numberOfVertices(), tool->mRubberBandPoints->numberOfVertices() + 1 );
-
-
-
 }
-
-
-
 
 QGSTEST_MAIN( TestQgsMeasureTool )
 #include "testqgsmeasuretool.moc"


### PR DESCRIPTION
Fixes #46204
Fixes #29345

## Description

When a measurement is ongoing with QgsMeasureTool, and it is deactivated (i.e. by selecting another map tool), QgsMeasureTool keeps the last temporary point in the rubberband. When the measure tool is reactivated, this extra point is displayed in the Line and Polygon rubber bands. (c.f. linked issue). This PR solve the issue by discarding the last temporary point when the tool is deactivated.

### Previous behavior
https://user-images.githubusercontent.com/425243/143387635-8be65152-1e75-4b5e-816a-34c4531d6a61.mp4

### New behavior
![fix_measure_tool](https://user-images.githubusercontent.com/9693475/212768635-977bee4b-f476-4cd3-af99-0491efb95c0e.gif)
