### PR TITLE
Allow column resizing in the "User fonts" table

### DIFF
--- a/src/app/options/qgsfontoptions.cpp
+++ b/src/app/options/qgsfontoptions.cpp
@@ -34,7 +34,7 @@ QgsFontOptionsWidget::QgsFontOptionsWidget( QWidget *parent )
   mTableReplacements->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
 
   mTableUserFonts->setHorizontalHeaderLabels( {tr( "File" ), tr( "Font Families" ) } );
-  mTableUserFonts->horizontalHeader()->setSectionResizeMode( QHeaderView::Stretch );
+  mTableUserFonts->horizontalHeader()->setSectionResizeMode( QHeaderView::Interactive );
 
   const QMap< QString, QString > replacements = QgsApplication::fontManager()->fontFamilyReplacements();
   mTableReplacements->setRowCount( replacements.size() );


### PR DESCRIPTION
in order to read full path of the fonts file (often longer than the font family name)
We could also consider displaying tooltip but couldn't find how-to.

In the current state, you can't enlarge the column and see the right font you'd like to delete:
![image](https://user-images.githubusercontent.com/7983394/212852826-bf432d1c-8ae8-4d03-b424-4d8ca365a199.png)
