### PR TITLE
[Backport 3.28] Use macOS label instead of Mac for vector layer actions

### DIFF
--- a/src/core/qgsaction.cpp
+++ b/src/core/qgsaction.cpp
@@ -390,7 +390,7 @@ QString QgsAction::html() const
     }
     case Mac:
     {
-      typeText = QObject::tr( "Mac" );
+      typeText = QObject::tr( "macOS" );
       break;
     }
     case Windows:

--- a/src/gui/vector/qgsattributeactiondialog.cpp
+++ b/src/gui/vector/qgsattributeactiondialog.cpp
@@ -249,7 +249,7 @@ QString QgsAttributeActionDialog::textForType( QgsAction::ActionType type )
     case QgsAction::GenericPython:
       return tr( "Python" );
     case QgsAction::Mac:
-      return tr( "Mac" );
+      return tr( "macOS" );
     case QgsAction::Windows:
       return tr( "Windows" );
     case QgsAction::Unix:


### PR DESCRIPTION
Backports #51484
These are the only occurrences I could find...