### PR TITLE
Fix missing maximize button for attribute  form dialog on Windows

### DIFF
--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -68,7 +68,11 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
   context.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
+
+  //* Skip this code on windows, because the Qt::Tool flag prevents the maximize button to be shown
+#ifndef Q_OS_WIN
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
+#endif
 
   dialog->setObjectName( QStringLiteral( "featureactiondlg:%1:%2" ).arg( mLayer->id() ).arg( f->id() ) );
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -69,9 +69,13 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
 
-  //* Skip this code on windows, because the Qt::Tool flag prevents the maximize button to be shown
+  // Skip this code on windows, because the Qt::Tool flag prevents the maximize button to be shown
 #ifndef Q_OS_WIN
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
+#else
+  dialog->setWindowFlags( dialog->windowFlags() | Qt::CustomizeWindowHint | Qt::WindowMaximizeButtonHint );
+  if ( ! dialog->parent() )
+    dialog->setWindowFlag( Qt::WindowStaysOnTopHint );
 #endif
 
   dialog->setObjectName( QStringLiteral( "featureactiondlg:%1:%2" ).arg( mLayer->id() ).arg( f->id() ) );


### PR DESCRIPTION
On  windows, the attribute form dialog misses the maximize button which can be very useful with large custom forms.

I've tried all possible combination of flags and even a custom windows API event manager but I couldn't make  the maximize button appear when the Qt::Tool flag is set.

