### PR TITLE
[bug] Do not silently load existing profile - Fixes #51505

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -15664,12 +15664,29 @@ void QgisApp::keyPressEvent( QKeyEvent *e )
 
 void QgisApp::newProfile()
 {
-  QString text = QInputDialog::getText( this, tr( "New profile name" ), tr( "New profile name" ) );
-  if ( text.isEmpty() )
+  QgsNewNameDialog dlg( QString(), QString(), QStringList(), userProfileManager()->allProfiles(), Qt::CaseInsensitive, this );
+  dlg.setConflictingNameWarning( tr( "A profile with this name already exists" ) );
+  dlg.setOverwriteEnabled( false );
+  dlg.setHintString( tr( "New profile name" ) );
+  dlg.setWindowTitle( tr( "New profile name" ) );
+
+  // Prevent from entering slashes and backslashes
+  dlg.setRegularExpression( "[^/\\\\]+" );
+
+  if ( dlg.exec() != QDialog::Accepted )
     return;
 
-  userProfileManager()->createUserProfile( text );
-  userProfileManager()->loadUserProfile( text );
+  QString profileName = dlg.name();
+  QgsError error = userProfileManager()->createUserProfile( profileName );
+  if ( error.isEmpty() )
+  {
+    userProfileManager()->loadUserProfile( profileName );
+  }
+  else
+  {
+    QMessageBox::warning( this, tr( "New Profile" ), tr( "Cannot create folder '%1'" ).arg( profileName ) );
+    return;
+  }
 }
 
 void QgisApp::onTaskCompleteShowNotify( long taskId, int status )

--- a/src/core/qgsuserprofilemanager.cpp
+++ b/src/core/qgsuserprofilemanager.cpp
@@ -142,7 +142,11 @@ QgsError QgsUserProfileManager::createUserProfile( const QString &name )
   const QDir folder( mRootProfilePath + QDir::separator() + name );
   if ( !folder.exists() )
   {
-    QDir().mkpath( folder.absolutePath() );
+    if ( !QDir().mkpath( folder.absolutePath() ) )
+    {
+      error.append( tr( "Cannot write '%1'" ).arg( folder.absolutePath() ) );
+      return error;
+    }
   }
 
   QFile qgisPrivateDbFile( folder.absolutePath() + QDir::separator() + "qgis.db" );


### PR DESCRIPTION
Fixes #51505

## Description

When user wants to create an new user profile, QGIS does not check whether the profile already exists or not.
If it does, it is silently loaded, which can cause the user to mistakenly believe he is using a clean new QGIS profile.

This PR use the [`QgsNewNameDialog`](https://api.qgis.org/api/classQgsNewNameDialog.html) instead of the standard `QInputDialog `to ensure the new profile name does not aleady exists.
Besides, it forbid the use of slashes and backslashes in the name, and warn the user if the profile was not created (eg, a name that contains `<>?` on Windows)