### PR TITLE
External storage: status is now private with a setter

### DIFF
--- a/python/core/auto_generated/externalstorage/qgsexternalstorage.sip.in
+++ b/python/core/auto_generated/externalstorage/qgsexternalstorage.sip.in
@@ -145,7 +145,7 @@ Inherited classes should call this method whenever they meet an error.
 
     void setStatus( Qgis::ContentStatus status );
 %Docstring
-Sets the external storage status
+Sets the external storage ``status``
 %End
 
 

--- a/python/core/auto_generated/externalstorage/qgsexternalstorage.sip.in
+++ b/python/core/auto_generated/externalstorage/qgsexternalstorage.sip.in
@@ -143,6 +143,13 @@ Update content according to given ``errorMsg`` error message
 Inherited classes should call this method whenever they meet an error.
 %End
 
+    void setStatus( Qgis::ContentStatus status );
+%Docstring
+Sets the external storage status
+%End
+
+
+
 };
 
 class QgsExternalStorageFetchedContent : QgsExternalStorageContent

--- a/src/core/externalstorage/qgsexternalstorage.cpp
+++ b/src/core/externalstorage/qgsexternalstorage.cpp
@@ -17,9 +17,14 @@
 
 void QgsExternalStorageContent::reportError( const QString &errorMsg )
 {
-  mStatus = Qgis::ContentStatus::Failed;
+  setStatus( Qgis::ContentStatus::Failed );
   mErrorString = errorMsg;
   emit errorOccurred( mErrorString );
+}
+
+void QgsExternalStorageContent::setStatus( Qgis::ContentStatus status )
+{
+  mStatus = status;
 }
 
 Qgis::ContentStatus QgsExternalStorageContent::status() const

--- a/src/core/externalstorage/qgsexternalstorage.h
+++ b/src/core/externalstorage/qgsexternalstorage.h
@@ -157,8 +157,17 @@ class CORE_EXPORT QgsExternalStorageContent : public QObject
      */
     void reportError( const QString &errorMsg );
 
-    Qgis::ContentStatus mStatus = Qgis::ContentStatus::NotStarted;
+    /**
+     * Sets the external storage status
+     */
+    void setStatus( Qgis::ContentStatus status );
+
     QString mErrorString;
+
+
+  private:
+
+    Qgis::ContentStatus mStatus = Qgis::ContentStatus::NotStarted;
 };
 
 /**

--- a/src/core/externalstorage/qgsexternalstorage.h
+++ b/src/core/externalstorage/qgsexternalstorage.h
@@ -158,7 +158,7 @@ class CORE_EXPORT QgsExternalStorageContent : public QObject
     void reportError( const QString &errorMsg );
 
     /**
-     * Sets the external storage status
+     * Sets the external storage \a status
      */
     void setStatus( Qgis::ContentStatus status );
 

--- a/src/core/externalstorage/qgshttpexternalstorage.cpp
+++ b/src/core/externalstorage/qgshttpexternalstorage.cpp
@@ -97,7 +97,7 @@ QgsHttpExternalStorageStoredContent::QgsHttpExternalStorageStoredContent( const 
   connect( mUploadTask, &QgsTask::taskCompleted, this, [ = ]
   {
     mUrl = storageUrl;
-    mStatus = Qgis::ContentStatus::Finished;
+    setStatus( Qgis::ContentStatus::Finished );
     emit stored();
   } );
 
@@ -114,7 +114,7 @@ QgsHttpExternalStorageStoredContent::QgsHttpExternalStorageStoredContent( const 
 
 void QgsHttpExternalStorageStoredContent::store()
 {
-  mStatus = Qgis::ContentStatus::Running;
+  setStatus( Qgis::ContentStatus::Running );
   QgsApplication::taskManager()->addTask( mUploadTask );
 }
 
@@ -127,7 +127,7 @@ void QgsHttpExternalStorageStoredContent::cancel()
   disconnect( mUploadTask, &QgsTask::taskTerminated, this, nullptr );
   connect( mUploadTask, &QgsTask::taskTerminated, this, [ = ]
   {
-    mStatus = Qgis::ContentStatus::Canceled;
+    setStatus( Qgis::ContentStatus::Canceled );
     emit canceled();
   } );
 
@@ -161,13 +161,13 @@ void QgsHttpExternalStorageFetchedContent::fetch()
   if ( !mFetchedContent )
     return;
 
-  mStatus = Qgis::ContentStatus::Running;
+  setStatus( Qgis::ContentStatus::Running );
   mFetchedContent->download();
 
   // could be already fetched/cached
   if ( mFetchedContent->status() == QgsFetchedContent::Finished )
   {
-    mStatus = Qgis::ContentStatus::Finished;
+    setStatus( Qgis::ContentStatus::Finished );
     emit fetched();
   }
 }
@@ -184,7 +184,7 @@ void QgsHttpExternalStorageFetchedContent::onFetched()
 
   if ( mFetchedContent->status() == QgsFetchedContent::Finished )
   {
-    mStatus = Qgis::ContentStatus::Finished;
+    setStatus( Qgis::ContentStatus::Finished );
     emit fetched();
   }
 }

--- a/src/core/externalstorage/qgssimplecopyexternalstorage.cpp
+++ b/src/core/externalstorage/qgssimplecopyexternalstorage.cpp
@@ -31,7 +31,7 @@ QgsSimpleCopyExternalStorageStoredContent::QgsSimpleCopyExternalStorageStoredCon
   connect( mCopyTask, &QgsTask::taskCompleted, this, [ = ]
   {
     mUrl = mCopyTask->destination();
-    mStatus = Qgis::ContentStatus::Finished;
+    setStatus( Qgis::ContentStatus::Finished );
     emit stored();
   } );
 
@@ -48,7 +48,7 @@ QgsSimpleCopyExternalStorageStoredContent::QgsSimpleCopyExternalStorageStoredCon
 
 void QgsSimpleCopyExternalStorageStoredContent::store()
 {
-  mStatus = Qgis::ContentStatus::Running;
+  setStatus( Qgis::ContentStatus::Running );
   QgsApplication::taskManager()->addTask( mCopyTask );
 }
 
@@ -60,7 +60,7 @@ void QgsSimpleCopyExternalStorageStoredContent::cancel()
   disconnect( mCopyTask, &QgsTask::taskTerminated, this, nullptr );
   connect( mCopyTask, &QgsTask::taskTerminated, this, [ = ]
   {
-    mStatus = Qgis::ContentStatus::Canceled;
+    setStatus( Qgis::ContentStatus::Canceled );
     emit canceled();
   } );
 
@@ -86,7 +86,7 @@ void QgsSimpleCopyExternalStorageFetchedContent::fetch()
   }
   else
   {
-    mStatus = Qgis::ContentStatus::Finished;
+    setStatus( Qgis::ContentStatus::Finished );
     mResultFilePath = mFilePath;
     emit fetched();
   }

--- a/tests/src/gui/testqgsexternalresourcewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsexternalresourcewidgetwrapper.cpp
@@ -94,11 +94,11 @@ class QgsTestExternalStorageFetchedContent
     {
       if ( mCached )
       {
-        mStatus = Qgis::ContentStatus::Finished;
+        setStatus( Qgis::ContentStatus::Finished );
         emit fetched();
       }
       else
-        mStatus = Qgis::ContentStatus::Running;
+        setStatus( Qgis::ContentStatus::Running );
     }
 
 
@@ -109,20 +109,20 @@ class QgsTestExternalStorageFetchedContent
 
     void emitFetched()
     {
-      mStatus = Qgis::ContentStatus::Finished;
+      setStatus( Qgis::ContentStatus::Finished );
       emit fetched();
     }
 
     void emitErrorOccurred()
     {
-      mStatus = Qgis::ContentStatus::Failed;
+      setStatus( Qgis::ContentStatus::Failed );
       mErrorString = QStringLiteral( "an error" );
       emit errorOccurred( mErrorString );
     }
 
     void cancel() override
     {
-      mStatus = Qgis::ContentStatus::Canceled;
+      setStatus( Qgis::ContentStatus::Canceled );
       emit canceled();
     }
 
@@ -147,25 +147,25 @@ class QgsTestExternalStorageStoredContent
 
     void store() override
     {
-      mStatus = Qgis::ContentStatus::Running;
+      setStatus( Qgis::ContentStatus::Running );
     }
 
     void emitStored()
     {
-      mStatus = Qgis::ContentStatus::Finished;
+      setStatus( Qgis::ContentStatus::Finished );
       emit stored();
     }
 
     void emitErrorOccurred()
     {
-      mStatus = Qgis::ContentStatus::Failed;
+      setStatus( Qgis::ContentStatus::Failed );
       mErrorString = "an error";
       emit errorOccurred( mErrorString );
     }
 
     void cancel() override
     {
-      mStatus = Qgis::ContentStatus::Canceled;
+      setStatus( Qgis::ContentStatus::Canceled );
       emit canceled();
     };
 

--- a/tests/src/gui/testqgsexternalstoragefilewidget.cpp
+++ b/tests/src/gui/testqgsexternalstoragefilewidget.cpp
@@ -71,18 +71,18 @@ class QgsTestExternalStorageStoredContent : public QgsExternalStorageStoredConte
 
     void store() override
     {
-      mStatus = Qgis::ContentStatus::Running;
+      setStatus( Qgis::ContentStatus::Running );
     }
 
     void cancel() override
     {
-      mStatus = Qgis::ContentStatus::Canceled;
+      setStatus( Qgis::ContentStatus::Canceled );
       emit canceled();
     };
 
     void error()
     {
-      mStatus = Qgis::ContentStatus::Failed;
+      setStatus( Qgis::ContentStatus::Failed );
       mErrorString = QStringLiteral( "error" );
       emit errorOccurred( mErrorString );
     }
@@ -94,7 +94,7 @@ class QgsTestExternalStorageStoredContent : public QgsExternalStorageStoredConte
 
     void finish()
     {
-      mStatus = Qgis::ContentStatus::Finished;
+      setStatus( Qgis::ContentStatus::Finished );
       emit stored();
     }
 


### PR DESCRIPTION
## Description

It is impossible to use python to inherit `QgsExternalStorageContent` and have a proper class, because `mStatus` being protected, it's not present in python bindings.

So we need a setter (protected) for `mStatus` to change its value in inherited python classes.

Therefore, I chose to put `mStatus` as private, to be sure that the setter will be used every time it's needed.

--- 
PS: I don't have the rights to add the backport label, if someone please can add it.

Thanks

---

Funded by Kristianstads kommun