### PR TITLE
[Feature] Data defined form widget editable state.

### DIFF
--- a/python/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -75,6 +75,7 @@ Constructor for TabData
       NoProperty,
       AllProperties,
       Alias,
+      Editable,
     };
 
     QgsEditFormConfig( const QgsEditFormConfig &o );

--- a/src/core/editform/qgseditformconfig.h
+++ b/src/core/editform/qgseditformconfig.h
@@ -113,6 +113,7 @@ class CORE_EXPORT QgsEditFormConfig
       NoProperty = 0, //!< No property
       AllProperties = 1, //!< All properties for item
       Alias = 2, //!< Alias
+      Editable = 3, //!< Editable state \since QGIS 3.30
     };
 
     /**

--- a/src/core/editform/qgseditformconfig_p.h
+++ b/src/core/editform/qgseditformconfig_p.h
@@ -64,6 +64,12 @@ class QgsEditFormConfigPrivate : public QSharedData
                                  QObject::tr( "Alias" ),
                                  QgsPropertyDefinition::String )
         },
+        {
+          QgsEditFormConfig::DataDefinedProperty::Editable,
+          QgsPropertyDefinition( "dataDefinedEditable",
+                                 QObject::tr( "Editable" ),
+                                 QgsPropertyDefinition::Boolean )
+        },
       };
       return sPropertyDefinitions;
     };

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -75,6 +75,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   mExpressionWidget->setLayer( mLayer );
 
   mEditableExpressionButton->registerExpressionContextGenerator( this );
+  mEditableExpressionButton->init( QgsEditFormConfig::DataDefinedProperty::Editable, mDataDefinedProperties.property( QgsEditFormConfig::DataDefinedProperty::Editable ), vl->editFormConfig().propertyDefinitions(), vl );
   mEditableExpressionButton->registerLinkedWidget( isFieldEditableCheckBox );
   connect( mEditableExpressionButton, &QgsPropertyOverrideButton::changed, this, [ = ]
   {
@@ -82,6 +83,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   } );
 
   mAliasExpressionButton->registerExpressionContextGenerator( this );
+  mAliasExpressionButton->init( QgsEditFormConfig::DataDefinedProperty::Alias, mDataDefinedProperties.property( QgsEditFormConfig::DataDefinedProperty::Alias ), vl->editFormConfig().propertyDefinitions(), vl );
   connect( mAliasExpressionButton, &QgsPropertyOverrideButton::changed, this, [ = ]
   {
     mDataDefinedProperties.setProperty( QgsEditFormConfig::DataDefinedProperty::Alias, mAliasExpressionButton->toProperty() );

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -74,6 +74,13 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   mExpressionWidget->registerExpressionContextGenerator( this );
   mExpressionWidget->setLayer( mLayer );
 
+  mEditableExpressionButton->registerExpressionContextGenerator( this );
+  mEditableExpressionButton->registerLinkedWidget( isFieldEditableCheckBox );
+  connect( mEditableExpressionButton, &QgsPropertyOverrideButton::changed, this, [ = ]
+  {
+    mDataDefinedProperties.setProperty( QgsEditFormConfig::DataDefinedProperty::Editable, mEditableExpressionButton->toProperty() );
+  } );
+
   mAliasExpressionButton->registerExpressionContextGenerator( this );
   connect( mAliasExpressionButton, &QgsPropertyOverrideButton::changed, this, [ = ]
   {
@@ -321,6 +328,7 @@ QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
       << QgsExpressionContextUtils::globalScope()
       << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
       << QgsExpressionContextUtils::layerScope( mLayer )
+      << QgsExpressionContextUtils::formScope( )
       << QgsExpressionContextUtils::mapToolCaptureScope( QList<QgsPointLocator::Match>() );
 
   return context;
@@ -371,6 +379,10 @@ void QgsAttributeTypeDialog::setDataDefinedProperties( const QgsPropertyCollecti
   if ( properties.hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
   {
     mAliasExpressionButton->setToProperty( properties.property( QgsEditFormConfig::DataDefinedProperty::Alias ) );
+  }
+  if ( properties.hasProperty( QgsEditFormConfig::DataDefinedProperty::Editable ) )
+  {
+    mEditableExpressionButton->setToProperty( properties.property( QgsEditFormConfig::DataDefinedProperty::Editable ) );
   }
 }
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1809,7 +1809,7 @@ void QgsAttributeForm::init()
             if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
             {
               const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-              if ( property.isActive() && ! property.expressionString().isEmpty() )
+              if ( property.isActive() )
               {
                 mLabelDataDefinedProperties[ label ] = property;
               }
@@ -1817,7 +1817,7 @@ void QgsAttributeForm::init()
             if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Editable ) )
             {
               const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Editable ) };
-              if ( property.isActive() && ! property.expressionString().isEmpty() )
+              if ( property.isActive() )
               {
                 mEditableDataDefinedProperties[ widgetInfo.widget ] = property;
               }
@@ -1900,7 +1900,7 @@ void QgsAttributeForm::init()
       if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
       {
         const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-        if ( property.isActive() && ! property.expressionString().isEmpty() )
+        if ( property.isActive() )
         {
           mLabelDataDefinedProperties[ label ] = property;
         }
@@ -1922,7 +1922,7 @@ void QgsAttributeForm::init()
         if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Editable ) )
         {
           const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Editable ) };
-          if ( property.isActive() && ! property.expressionString().isEmpty() )
+          if ( property.isActive() )
           {
             mEditableDataDefinedProperties[ formWidget ] = property;
           }
@@ -2439,7 +2439,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
               if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
               {
                 const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-                if ( property.isActive() && ! property.expressionString().isEmpty() )
+                if ( property.isActive() )
                 {
                   mLabelDataDefinedProperties[ mypLabel ] = property;
                 }
@@ -2447,7 +2447,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
               if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Editable ) )
               {
                 const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Editable ) };
-                if ( property.isActive() && ! property.expressionString().isEmpty() )
+                if ( property.isActive() )
                 {
                   mEditableDataDefinedProperties[ widgetInfo.widget ] = property;
                 }

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -448,6 +448,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateContainersVisibility();
     void updateConstraint( const QgsFeature &ft, QgsEditorWidgetWrapper *eww );
     void updateLabels();
+    void updateEditableState();
     bool currentFormValuesFeature( QgsFeature &feature );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
     bool currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
@@ -473,6 +474,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList< QgsAttributeFormWidget *> mFormWidgets;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
     QMap<QLabel *, QgsProperty> mLabelDataDefinedProperties;
+    QMap<QWidget *, QgsProperty> mEditableDataDefinedProperties;
     bool mValuesInitialized = false;
     bool mDirty = false;
     bool mIsSettingFeature = false;

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>752</width>
-    <height>620</height>
+    <width>1033</width>
+    <height>880</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,14 +19,11 @@
      <property name="title">
       <string>General</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0" columnstretch="0,0,1,0,0">
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="reuseLastValuesCheckBox">
-        <property name="toolTip">
-         <string>If checked, then the most recent value entered for this field will be remembered and reused when creating a new feature.</string>
-        </property>
+     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0" columnstretch="0,0,1,0,0,0">
+      <item row="2" column="3">
+       <widget class="QCheckBox" name="labelOnTopCheckBox">
         <property name="text">
-         <string>Reuse last entered value</string>
+         <string>Label on top</string>
         </property>
         <property name="checked">
          <bool>false</bool>
@@ -40,13 +37,13 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
-       <widget class="QCheckBox" name="labelOnTopCheckBox">
+      <item row="1" column="2" colspan="3">
+       <widget class="QLabel" name="laComment">
         <property name="text">
-         <string>Label on top</string>
+         <string/>
         </property>
-        <property name="checked">
-         <bool>false</bool>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -60,6 +57,26 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="5">
+       <widget class="QgsPropertyOverrideButton" name="mAliasExpressionButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="reuseLastValuesCheckBox">
+        <property name="toolTip">
+         <string>If checked, then the most recent value entered for this field will be remembered and reused when creating a new feature.</string>
+        </property>
+        <property name="text">
+         <string>Reuse last entered value</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
@@ -67,23 +84,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="4">
-       <widget class="QgsPropertyOverrideButton" name="mAliasExpressionButton">
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
+      <item row="0" column="2" colspan="3">
        <widget class="QLineEdit" name="mAlias"/>
       </item>
-      <item row="1" column="1" colspan="3">
-       <widget class="QLabel" name="laComment">
+      <item row="2" column="1">
+       <widget class="QgsPropertyOverrideButton" name="mEditableExpressionButton">
         <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+         <string>...</string>
         </property>
        </widget>
       </item>
@@ -329,6 +336,7 @@
   <tabstop>mApplyDefaultValueOnUpdateCheckBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
## Data-defined expression for widget editable status

The "Editable" checkbox status can now be controlled through an expression, the expression supports the "form" context, meaning that it can use `current_value( '<field_name>' )` to dynamically change the editable status according to changes to other fields in the form.

![editable-data-defined](https://user-images.githubusercontent.com/142164/213728077-b2302f1a-e71f-483c-beaa-d3d256caaeec.gif)


Funded by: Kanton Solothurn