### PR TITLE
Feature request 50829 move layer tree nodes up down

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4835,6 +4835,18 @@ void QgisApp::initLayerTreeView()
   actionCollapseAll->setToolTip( tr( "Collapse All" ) );
   connect( actionCollapseAll, &QAction::triggered, mLayerTreeView, &QgsLayerTreeView::collapseAllNodes );
 
+  // move up / move down tool buttons
+  mActionMoveUp = new QAction( tr( "Move Up" ), this );
+  mActionMoveUp->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionArrowUp.svg" ) ) );
+  mActionMoveUp->setToolTip( tr( "Move Up" ) );
+  mActionMoveUp->setShortcut( QStringLiteral( "Alt+Up" ) );
+  connect( mActionMoveUp, &QAction::triggered, this, [this](){ mLayerTreeView->defaultActions()->moveUp( true ); } );
+  mActionMoveDown = new QAction( tr( "Move Down" ), this );
+  mActionMoveDown->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionArrowDown.svg" ) ) );
+  mActionMoveDown->setToolTip( tr( "Move Down" ) );
+  mActionMoveDown->setShortcut( QStringLiteral( "Alt+Down" ) );
+  connect( mActionMoveDown, &QAction::triggered, this, [this](){ mLayerTreeView->defaultActions()->moveDown( true ); } );
+
   QToolBar *toolbar = new QToolBar();
   toolbar->setIconSize( iconSize( true ) );
   toolbar->addAction( mActionStyleDock );
@@ -4844,6 +4856,8 @@ void QgisApp::initLayerTreeView()
   toolbar->addWidget( mLegendExpressionFilterButton );
   toolbar->addAction( actionExpandAll );
   toolbar->addAction( actionCollapseAll );
+  toolbar->addAction( mActionMoveUp );
+  toolbar->addAction( mActionMoveDown );
   toolbar->addAction( mActionRemoveLayer );
 
   QVBoxLayout *vboxLayout = new QVBoxLayout;
@@ -14593,7 +14607,6 @@ void QgisApp::legendLayerSelectionChanged()
       mLegendExpressionFilterButton->setChecked( exprEnabled );
     }
   }
-
   // remove action - check for required layers
   bool removeEnabled = true;
   for ( QgsLayerTreeLayer *nodeLayer : selectedLayers )
@@ -14605,6 +14618,11 @@ void QgisApp::legendLayerSelectionChanged()
     }
   }
   mActionRemoveLayer->setEnabled( removeEnabled );
+
+  // disable move up action if multiple nodes selected or selected node is top item of layer tree
+  mActionMoveUp->setEnabled( mLayerTreeView && mLayerTreeView->selectedNodes().count() == 1 && ( mLayerTreeView->selectedNodes()[0]->parent()->parent() || mLayerTreeView->node2index( mLayerTreeView->selectedNodes()[0] ).row() > 0 ) );
+  // disable move down action if multiple nodes selected or selected node is bottom item of layer tree
+  mActionMoveDown->setEnabled( mLayerTreeView && mLayerTreeView->selectedNodes().count() == 1 && ( mLayerTreeView->selectedNodes()[0]->parent()->parent() || mLayerTreeView->node2index( mLayerTreeView->selectedNodes()[0] ).row() < mLayerTreeView->currentNode()->parent()->children().count()-1 ) );
 }
 
 void QgisApp::layerEditStateChanged()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2645,6 +2645,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *mFilterLegendByMapContentAction = nullptr;
     QAction *mFilterLegendToggleShowPrivateLayersAction = nullptr;
     QAction *mActionStyleDock = nullptr;
+    QAction *mActionMoveUp = nullptr;
+    QAction *mActionMoveDown = nullptr;
 
     QgsLegendFilterButton *mLegendExpressionFilterButton = nullptr;
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -131,6 +131,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( actions->actionMoveToBottom( menu ) );
       }
 
+      if ( mView->selectedNodes().count() == 1 && ( mView->currentNode()->parent()->parent() || idx.row() > 0 ) )
+      {
+        menu->addAction( actions->actionMoveUp( menu ) );
+      }
+
+      if ( mView->selectedNodes().count() == 1 && ( mView->currentNode()->parent()->parent() || idx.row() < mView->currentNode()->parent()->children().count()-1 ) )
+      {
+        menu->addAction( actions->actionMoveDown( menu ) );
+      }
+
       menu->addSeparator();
 
       if ( !mView->selectedNodes( true ).empty() )
@@ -322,6 +332,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == idx.model()->rowCount() - 1 ) )
       {
         menu->addAction( actions->actionMoveToBottom( menu ) );
+      }
+
+      if ( mView->selectedNodes().count() == 1 && ( mView->currentNode()->parent()->parent() || idx.row() > 0 ) )
+      {
+        menu->addAction( actions->actionMoveUp( menu ) );
+      }
+
+      if ( mView->selectedNodes().count() == 1 && ( mView->currentNode()->parent()->parent() || mView->node2index( mView->currentNode() ).row() < mView->currentNode()->parent()->children().count()-1 ) )
+      {
+        menu->addAction( actions->actionMoveDown( menu ) );
       }
 
       QAction *checkAll = actions->actionCheckAndAllParents( menu );

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -98,6 +98,8 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      * \since QGIS 3.14
      */
     QAction *actionMoveToBottom( QObject *parent = nullptr ) SIP_FACTORY;
+    QAction *actionMoveUp( QObject *parent = nullptr ) SIP_FACTORY;
+    QAction *actionMoveDown( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionGroupSelected( QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
@@ -129,6 +131,18 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
   public slots:
     void showInOverview();
     void addGroup();
+
+    /**
+     * Moves selected layer / group node up one position the layer panel
+     * or, if the node above is a group or sub-group, to the bottom of that group.
+     */
+    bool moveUp( bool updateSelection );
+
+    /**
+     * Moves selected layer / group node down one position the layer panel
+     * or, if the node below is a group or sub-group, to the top of that group.
+     */
+    bool moveDown( bool updateSelection );
 
   protected slots:
     void removeGroupOrLayer();
@@ -178,6 +192,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      * \since QGIS 3.14
      */
     void moveToBottom();
+
     void groupSelected();
 
     /**

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -411,7 +411,6 @@ class TestQgsLayerTreeView(unittest.TestCase):
             groupname + '-' + self.layer5.name(),
             groupname + '-' + self.layer4.name(),
         ])
-#*****************************************************************************#
 
     def testMoveNodeUp(self):
         """Move bottom node up 1 position, without updating selection index"""
@@ -485,8 +484,6 @@ class TestQgsLayerTreeView(unittest.TestCase):
         self.assertEqual(result, False)
         self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
         
-
-#*****************************************************************************#
     def testAddGroupActionLayer(self):
         """Test add group action on single layer"""
 

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -483,7 +483,119 @@ class TestQgsLayerTreeView(unittest.TestCase):
         result = actions.moveDown(True)
         self.assertEqual(result, False)
         self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+  
+    def testMultipleNodesSelected(self):
+        """Attempt move with multiple nodes selected, should return False and
+        layer order should remain unchanged"""
         
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        root = self.project.layerTreeRoot()
+        print(root.layerOrder() == [self.layer, self.layer2, self.layer3])
+        nodeIndex1 = view.node2index(root.children()[0])
+        view.selectionModel().setCurrentIndex(nodeIndex1, QItemSelectionModel.Select)
+        nodeIndex2 = view.node2index(root.children()[1])
+        view.selectionModel().setCurrentIndex(nodeIndex2, QItemSelectionModel.Select)
+        print(view.selectionModel().selectedIndexes() == [nodeIndex1, nodeIndex2])
+        result = actions.moveDown(True)
+        print(result == False)
+        print(root.layerOrder() == [self.layer, self.layer2, self.layer3])
+    
+    def testMoveNodeUpThroughGroup(self):
+        """Move a layer node from last position in the layer tree,
+        through a group, to first position in the layer tree, updating the
+        selection index each time"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        group = rootGroup.addGroup(self.groupname)
+        group.addLayer(self.layer3)
+        group.addLayer(self.layer4)
+        rootGroup.removeChildNode(rootGroup.children()[2])
+        rootGroup.addLayer(self.layer5)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'group', 'group-layer3', 'group-layer4', 'layer5'])
+        nodeIndex = view.node2index(rootGroup.children()[3])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 3)
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'group', 'group-layer3', 'group-layer4', 'group-layer5'])
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'group', 'group-layer3', 'group-layer5', 'group-layer4'])
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'group', 'group-layer5', 'group-layer3', 'group-layer4'])
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'layer5', 'group', 'group-layer3', 'group-layer4'])
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer5', 'layer2', 'group', 'group-layer3', 'group-layer4'])
+        result = actions.moveUp(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer5',
+                'layer1', 'layer2', 'group', 'group-layer3', 'group-layer4'])
+                                
+    def testMoveNodeDownThroughGroup(self):
+        """Move a layer node from first position in the layer tree,
+        through a group, to last position in the layer tree, updating the
+        selection index each time"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        group = rootGroup.addGroup(self.groupname)
+        group.addLayer(self.layer3)
+        group.addLayer(self.layer4)
+        rootGroup.removeChildNode(rootGroup.children()[2])
+        rootGroup.addLayer(self.layer5)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
+                'layer2', 'group', 'group-layer3', 'group-layer4', 'layer5'])
+        nodeIndex = view.node2index(root.children()[0])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 0)
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'layer1', 'group', 'group-layer3', 'group-layer4', 'layer5'])
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'group', 'group-layer1', 'group-layer3', 'group-layer4', 'layer5'])
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'group', 'group-layer3', 'group-layer1', 'group-layer4', 'layer5'])
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'group', 'group-layer3', 'group-layer4', 'group-layer1', 'layer5'])
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'group', 'group-layer3', 'group-layer4', 'layer1', 'layer5'])
+        result = actions.moveDown(True)
+        self.assertEqual(result, True)
+        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
+                'group', 'group-layer3', 'group-layer4', 'layer5', 'layer1'])
+
     def testAddGroupActionLayer(self):
         """Test add group action on single layer"""
 
@@ -766,6 +878,6 @@ class TestQgsLayerTreeView(unittest.TestCase):
         tree_layer2_index = view.node2sourceIndex(node2)
         self.assertEqual(tree_layer2_index, view.node2sourceIndex(node2))
 
-'''
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayerTreeView.
-
 .. note:: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
@@ -412,7 +411,82 @@ class TestQgsLayerTreeView(unittest.TestCase):
             groupname + '-' + self.layer5.name(),
             groupname + '-' + self.layer4.name(),
         ])
+#*****************************************************************************#
 
+    def testMoveNodeUp(self):
+        """Move bottom node up 1 position, without updating selection index"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        nodeIndex = view.node2index(rootGroup.children()[2])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 2)
+        result = actions.moveUp(False)
+        self.assertEqual(result, True)
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer3, self.layer2])
+        self.assertEqual(view.selectionModel().currentIndex().row(), 2)
+        
+    def testMoveNodeDown(self):
+        """Move top node down 1 position, without updating selection index"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        nodeIndex = view.node2index(rootGroup.children()[0])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 0)
+        result = actions.moveDown(False)
+        self.assertEqual(result, True)
+        self.assertEqual(rootGroup.layerOrder(), [self.layer2, self.layer, self.layer3])
+        self.assertEqual(view.selectionModel().currentIndex().row(), 0)
+
+    def testAttemptMoveTopItemUp(self):
+        """Attempt to move the top node up, should return False and
+        layer order should remain unchanged"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        nodeIndex = view.node2index(rootGroup.children()[0])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 0)
+        result = actions.moveUp(True)
+        self.assertEqual(result, False)
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        
+    def testAttemptMoveBottomItemDown(self):
+        """Attempt to move the bottom node down, should return False and
+        layer order should remain unchanged"""
+        
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        if USE_MODEL_TESTER:
+            proxy_tester = QAbstractItemModelTester(view.model())
+        actions = QgsLayerTreeViewDefaultActions(view)
+        rootGroup = self.project.layerTreeRoot()
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        nodeIndex = view.node2index(rootGroup.children()[2])
+        view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
+        self.assertEqual(view.selectionModel().currentIndex().row(), 2)
+        result = actions.moveDown(True)
+        self.assertEqual(result, False)
+        self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
+        
+
+#*****************************************************************************#
     def testAddGroupActionLayer(self):
         """Test add group action on single layer"""
 
@@ -695,6 +769,6 @@ class TestQgsLayerTreeView(unittest.TestCase):
         tree_layer2_index = view.node2sourceIndex(node2)
         self.assertEqual(tree_layer2_index, view.node2sourceIndex(node2))
 
-
+'''
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -484,7 +484,7 @@ class TestQgsLayerTreeView(unittest.TestCase):
         result = actions.moveDown(True)
         self.assertEqual(result, False)
         self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
-  
+
     def testMultipleNodesSelected(self):
         """Attempt move with multiple nodes selected, should return False and
         layer order should remain unchanged"""
@@ -495,15 +495,15 @@ class TestQgsLayerTreeView(unittest.TestCase):
             proxy_tester = QAbstractItemModelTester(view.model())
         actions = QgsLayerTreeViewDefaultActions(view)
         root = self.project.layerTreeRoot()
-        print(root.layerOrder() == [self.layer, self.layer2, self.layer3])
+        self.assertEqual(root.layerOrder(), [self.layer, self.layer2, self.layer3])
         nodeIndex1 = view.node2index(root.children()[0])
         view.selectionModel().setCurrentIndex(nodeIndex1, QItemSelectionModel.Select)
         nodeIndex2 = view.node2index(root.children()[1])
         view.selectionModel().setCurrentIndex(nodeIndex2, QItemSelectionModel.Select)
-        print(view.selectionModel().selectedIndexes() == [nodeIndex1, nodeIndex2])
+        self.assertEqual(view.selectionModel().selectedIndexes(), [nodeIndex1, nodeIndex2])
         result = actions.moveDown(True)
-        print(result == False)
-        print(root.layerOrder() == [self.layer, self.layer2, self.layer3])
+        self.assertEqual(result, False)
+        self.assertEqual(root.layerOrder(), [self.layer, self.layer2, self.layer3])
 
     def testMoveNodeUpThroughGroup(self):
         """Move a layer node from last position in the layer tree,
@@ -521,35 +521,77 @@ class TestQgsLayerTreeView(unittest.TestCase):
         group.addLayer(self.layer4)
         rootGroup.removeChildNode(rootGroup.children()[2])
         rootGroup.addLayer(self.layer5)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'group', 'group-layer3', 'group-layer4', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'layer5'
+        ])
         nodeIndex = view.node2index(rootGroup.children()[3])
         view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
         self.assertEqual(view.selectionModel().currentIndex().row(), 3)
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'group', 'group-layer3', 'group-layer4', 'group-layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'group-layer5'
+        ])
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'group', 'group-layer3', 'group-layer5', 'group-layer4'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer5',
+            'group-layer4'
+        ])
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'group', 'group-layer5', 'group-layer3', 'group-layer4'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer5',
+            'group-layer3',
+            'group-layer4'
+        ])
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'layer5', 'group', 'group-layer3', 'group-layer4'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'layer5',
+            'group',
+            'group-layer3',
+            'group-layer4'
+        ])
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer5', 'layer2', 'group', 'group-layer3', 'group-layer4'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer5',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4'
+        ])
         result = actions.moveUp(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer5',
-                'layer1', 'layer2', 'group', 'group-layer3', 'group-layer4'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer5',
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4'
+        ])
 
     def testMoveNodeDownThroughGroup(self):
         """Move a layer node from first position in the layer tree,
@@ -567,35 +609,77 @@ class TestQgsLayerTreeView(unittest.TestCase):
         group.addLayer(self.layer4)
         rootGroup.removeChildNode(rootGroup.children()[2])
         rootGroup.addLayer(self.layer5)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer1',
-                'layer2', 'group', 'group-layer3', 'group-layer4', 'layer5'])
-        nodeIndex = view.node2index(root.children()[0])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer1',
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'layer5'
+        ])
+        nodeIndex = view.node2index(rootGroup.children()[0])
         view.selectionModel().setCurrentIndex(nodeIndex, QItemSelectionModel.Select)
         self.assertEqual(view.selectionModel().currentIndex().row(), 0)
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'layer1', 'group', 'group-layer3', 'group-layer4', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'layer1',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'layer5'
+        ])
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'group', 'group-layer1', 'group-layer3', 'group-layer4', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'group',
+            'group-layer1',
+            'group-layer3',
+            'group-layer4',
+            'layer5'
+        ])
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'group', 'group-layer3', 'group-layer1', 'group-layer4', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer1',
+            'group-layer4',
+            'layer5'
+        ])
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'group', 'group-layer3', 'group-layer4', 'group-layer1', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'group-layer1',
+            'layer5'
+        ])
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'group', 'group-layer3', 'group-layer4', 'layer1', 'layer5'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'layer1',
+            'layer5'
+        ])
         result = actions.moveDown(True)
         self.assertEqual(result, True)
-        self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer2',
-                'group', 'group-layer3', 'group-layer4', 'layer5', 'layer1'])
+        self.assertEqual(self.nodeOrder(rootGroup.children()), [
+            'layer2',
+            'group',
+            'group-layer3',
+            'group-layer4',
+            'layer5',
+            'layer1'
+        ])
 
     def testAddGroupActionLayer(self):
         """Test add group action on single layer"""

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -29,6 +29,7 @@ from qgis.gui import (
 from qgis.testing import start_app, unittest
 from utilities import (unitTestDataPath)
 from qgis.PyQt.QtCore import QStringListModel
+from qgis.PyQt.QtCore import QItemSelectionModel
 from qgis.PyQt.QtTest import QSignalSpy
 
 from qgis.PyQt.Qt import PYQT_VERSION_STR
@@ -414,7 +415,7 @@ class TestQgsLayerTreeView(unittest.TestCase):
 
     def testMoveNodeUp(self):
         """Move bottom node up 1 position, without updating selection index"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -429,10 +430,10 @@ class TestQgsLayerTreeView(unittest.TestCase):
         self.assertEqual(result, True)
         self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer3, self.layer2])
         self.assertEqual(view.selectionModel().currentIndex().row(), 2)
-        
+
     def testMoveNodeDown(self):
         """Move top node down 1 position, without updating selection index"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -451,7 +452,7 @@ class TestQgsLayerTreeView(unittest.TestCase):
     def testAttemptMoveTopItemUp(self):
         """Attempt to move the top node up, should return False and
         layer order should remain unchanged"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -465,11 +466,11 @@ class TestQgsLayerTreeView(unittest.TestCase):
         result = actions.moveUp(True)
         self.assertEqual(result, False)
         self.assertEqual(rootGroup.layerOrder(), [self.layer, self.layer2, self.layer3])
-        
+
     def testAttemptMoveBottomItemDown(self):
         """Attempt to move the bottom node down, should return False and
         layer order should remain unchanged"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -487,7 +488,7 @@ class TestQgsLayerTreeView(unittest.TestCase):
     def testMultipleNodesSelected(self):
         """Attempt move with multiple nodes selected, should return False and
         layer order should remain unchanged"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -503,12 +504,12 @@ class TestQgsLayerTreeView(unittest.TestCase):
         result = actions.moveDown(True)
         print(result == False)
         print(root.layerOrder() == [self.layer, self.layer2, self.layer3])
-    
+
     def testMoveNodeUpThroughGroup(self):
         """Move a layer node from last position in the layer tree,
         through a group, to first position in the layer tree, updating the
         selection index each time"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:
@@ -549,12 +550,12 @@ class TestQgsLayerTreeView(unittest.TestCase):
         self.assertEqual(result, True)
         self.assertEqual(self.nodeOrder(rootGroup.children()), ['layer5',
                 'layer1', 'layer2', 'group', 'group-layer3', 'group-layer4'])
-                                
+
     def testMoveNodeDownThroughGroup(self):
         """Move a layer node from first position in the layer tree,
         through a group, to last position in the layer tree, updating the
         selection index each time"""
-        
+
         view = QgsLayerTreeView()
         view.setModel(self.model)
         if USE_MODEL_TESTER:


### PR DESCRIPTION
## Description

This PR addresses [feature request 50829](https://github.com/qgis/QGIS/issues/50829), adding two default actions
to the layer tree view menu provider and two action buttons with keyboard shortcuts to the layer tree view toolbar to
move a single selected layer tree node up or down.
When moving a node up, if the sibling node above is a group, the node is placed at the bottom of that group,
otherwise, the node is moved up one position within it's parent.
When moving a node down, if the sibling node below is a group, the node is placed at the top of that group,
otherwise, the node is moved down one position within it's parent.
Both actions are disabled if multiple nodes are selected;
The move up action is disabled if the selected node is the top item in the layer tree
and the move down action is disabled if the selected node is the bottom item in the layer tree.
When using the buttons or keyboard shortcuts, the selection index is updated to the new node     
position.

See the short screencast 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->

https://user-images.githubusercontent.com/47767794/213913241-746b7393-e5d6-4527-bbbb-6699159398c0.mp4

