### PR TITLE
Improve zoom-extents in 3d

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -125,6 +125,7 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
   // create terrain entity
 
   createTerrainDeferred();
+  connect( &map, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapScene::createTerrain );
   connect( &map, &Qgs3DMapSettings::terrainGeneratorChanged, this, &Qgs3DMapScene::createTerrain );
   connect( &map, &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapScene::createTerrain );
   connect( &map, &Qgs3DMapSettings::mapTileResolutionChanged, this, &Qgs3DMapScene::createTerrain );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -253,9 +253,9 @@ void Qgs3DMapScene::viewZoomFull()
   const QgsDoubleRange yRange = elevationRange();
   const QgsRectangle extent = sceneExtent();
   const double side = std::max( extent.width(), extent.height() );
-  double d = side / 2 / std::tan( qDegreesToRadians( cameraController()->camera()->fieldOfView() / 2 ) );
+  double d = side / 2 / std::tan( cameraController()->camera()->fieldOfView() / 2 * M_PI / 180 );
   d += yRange.upper();
-  mCameraController->resetView( ( float )d );
+  mCameraController->resetView( static_cast< float >( d ) );
   return;
 }
 
@@ -1231,8 +1231,8 @@ QgsDoubleRange Qgs3DMapScene::elevationRange() const
   if ( mMap.terrainRenderingEnabled() && mTerrain )
   {
     const QgsAABB bbox = mTerrain->rootNode()->bbox();
-    yMin = std::min( yMin, ( double )bbox.yMin );
-    yMax = std::max( yMax, ( double )bbox.yMax );
+    yMin = std::min( yMin, static_cast< double >( bbox.yMin ) );
+    yMax = std::max( yMax, static_cast< double >( bbox.yMax ) );
   }
 
   for ( auto it = mLayerEntities.constBegin(); it != mLayerEntities.constEnd(); it++ )

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -58,6 +58,7 @@ class Qgs3DMapExportSettings;
 class QgsShadowRenderingFrameGraph;
 class QgsPostprocessingEntity;
 class QgsChunkNode;
+class QgsDoubleRange;
 
 #define SIP_NO_FILE
 
@@ -142,6 +143,14 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
      * \since QGIS 3.20
      */
     QgsRectangle sceneExtent();
+
+    /**
+     * Returns the scene's elevation range
+     * \note Only terrain and point cloud layers are taken into account
+     *
+     * \since QGIS 3.30
+     */
+    QgsDoubleRange elevationRange() const;
 
     /**
      * Returns the 3D axis object

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -731,7 +731,6 @@ void Qgs3DMapSettings::setTerrainGenerator( QgsTerrainGenerator *gen )
 {
   if ( mTerrainGenerator )
   {
-    disconnect( mTerrainGenerator.get(), &QgsTerrainGenerator::extentChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
     disconnect( mTerrainGenerator.get(), &QgsTerrainGenerator::terrainChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
   }
 
@@ -751,7 +750,6 @@ void Qgs3DMapSettings::setTerrainGenerator( QgsTerrainGenerator *gen )
   }
   gen->setExtent( terrainExtent );
   mTerrainGenerator.reset( gen );
-  connect( mTerrainGenerator.get(), &QgsTerrainGenerator::extentChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
   connect( mTerrainGenerator.get(), &QgsTerrainGenerator::terrainChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
 
   emit terrainGeneratorChanged();

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -20,6 +20,7 @@
 #include "qgsdemterraingenerator.h"
 #include "qgsmeshterraingenerator.h"
 #include "qgsonlineterraingenerator.h"
+#include "qgsprojectviewsettings.h"
 #include "qgsvectorlayer3drenderer.h"
 #include "qgsmeshlayer3drenderer.h"
 #include "qgspointcloudlayer3drenderer.h"
@@ -130,11 +131,18 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
               elemOrigin.attribute( QStringLiteral( "z" ) ).toDouble() );
 
   QDomElement elemExtent = elem.firstChildElement( QStringLiteral( "extent" ) );
-  mExtent = QgsRectangle(
-              elemExtent.attribute( QStringLiteral( "xMin" ) ).toDouble(),
-              elemExtent.attribute( QStringLiteral( "yMin" ) ).toDouble(),
-              elemExtent.attribute( QStringLiteral( "xMax" ) ).toDouble(),
-              elemExtent.attribute( QStringLiteral( "yMax" ) ).toDouble() );
+  if ( !elemExtent.isNull() )
+  {
+    mExtent = QgsRectangle(
+                elemExtent.attribute( QStringLiteral( "xMin" ) ).toDouble(),
+                elemExtent.attribute( QStringLiteral( "yMin" ) ).toDouble(),
+                elemExtent.attribute( QStringLiteral( "xMax" ) ).toDouble(),
+                elemExtent.attribute( QStringLiteral( "yMax" ) ).toDouble() );
+  }
+  else
+  {
+    mExtent = QgsProject::instance()->viewSettings()->fullExtent();
+  }
 
   QDomElement elemCamera = elem.firstChildElement( QStringLiteral( "camera" ) );
   if ( !elemCamera.isNull() )

--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -132,8 +132,6 @@ void QgsDemTerrainGenerator::setExtent( const QgsRectangle &extent )
   // no need to have an mExtent larger than the actual layer's extent
   mExtent = extent.intersect( layerExtent );
   updateGenerator();
-
-  emit extentChanged();
 }
 
 void QgsDemTerrainGenerator::updateGenerator()

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -142,8 +142,6 @@ void QgsFlatTerrainGenerator::setExtent( const QgsRectangle &extent )
 
   mExtent = extent;
   updateTilingScheme();
-
-  emit extentChanged();
 }
 
 void QgsFlatTerrainGenerator::updateTilingScheme()

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -104,8 +104,6 @@ void QgsOnlineTerrainGenerator::setExtent( const QgsRectangle &extent )
 
   mExtent = extent;
   updateGenerator();
-
-  emit extentChanged();
 }
 
 void QgsOnlineTerrainGenerator::updateGenerator()

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -113,9 +113,6 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
 
   signals:
 
-    //! Emitted when the terrain extent has changed
-    void extentChanged();
-
     //! Emitted when the terrain changed (for example, raster DEM or mesh have data changed)
     void terrainChanged();
 

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -163,53 +163,8 @@ QgsCameraController *Qgs3DMapCanvas::cameraController()
   return mScene ? mScene->cameraController() : nullptr;
 }
 
-void Qgs3DMapCanvas::resetView( bool resetExtent )
+void Qgs3DMapCanvas::resetView()
 {
-  if ( resetExtent )
-  {
-    if ( map()->terrainRenderingEnabled()
-         && map()->terrainGenerator()
-         && ( map()->terrainGenerator()->type() == QgsTerrainGenerator::Flat ||
-              map()->terrainGenerator()->type() == QgsTerrainGenerator::Online ) )
-    {
-      const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
-      QgsCoordinateTransform ct( extent.crs(), map()->crs(), QgsProject::instance()->transformContext() );
-      ct.setBallparkTransformsAreAppropriate( true );
-      QgsRectangle rect;
-      try
-      {
-        rect = ct.transformBoundingBox( extent );
-      }
-      catch ( QgsCsException & )
-      {
-        rect = extent;
-      }
-      map()->terrainGenerator()->setExtent( rect );
-
-      const QgsRectangle te = mScene->sceneExtent();
-      const QgsPointXY center = te.center();
-      map()->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
-    }
-    if ( !map()->terrainRenderingEnabled() || !map()->terrainGenerator() )
-    {
-      const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
-      QgsCoordinateTransform ct( extent.crs(), map()->crs(), QgsProject::instance()->transformContext() );
-      ct.setBallparkTransformsAreAppropriate( true );
-      QgsRectangle rect;
-      try
-      {
-        rect = ct.transformBoundingBox( extent );
-      }
-      catch ( QgsCsException & )
-      {
-        rect = extent;
-      }
-
-      const QgsPointXY center = rect.center();
-      map()->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
-    }
-  }
-
   mScene->viewZoomFull();
 }
 

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -63,7 +63,7 @@ class Qgs3DMapCanvas : public QWidget
     QgsCameraController *cameraController();
 
     //! Resets camera position to the default: looking down at the origin of world coordinates
-    void resetView( bool resetExtent = false );
+    void resetView();
 
     //! Sets camera position to look down at the given point (in map coordinates) in given distance from plane with zero elevation
     void setViewFromTop( const QgsPointXY &center, float distance, float rotation = 0 );

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -392,7 +392,7 @@ void Qgs3DMapCanvasWidget::setMainCanvas( QgsMapCanvas *canvas )
 
 void Qgs3DMapCanvasWidget::resetView()
 {
-  mCanvas->resetView( true );
+  mCanvas->resetView();
 }
 
 void Qgs3DMapCanvasWidget::configure()

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -239,7 +239,6 @@
                  <property name="title">
                   <string>Extent</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_8"/>
                 </widget>
                </item>
                <item>

--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -57,7 +57,6 @@ void initCanvas3D( Qgs3DMapCanvas *canvas )
 
   QgsFlatTerrainGenerator *flatTerrain = new QgsFlatTerrainGenerator;
   flatTerrain->setCrs( map->crs() );
-  flatTerrain->setExtent( fullExtent );
   map->setTerrainGenerator( flatTerrain );
 
   QgsPointLightSettings defaultPointLight;


### PR DESCRIPTION
## Description
This PR is a #51304 followup.
It uses the defined scene's extent when _Zoom full_ is pressed.
The terrain's and pointcloud layers' elevation range is also taken into account so that the camera is not positioned below the scene's contents, which was the case when using the terrain's vertical scale setting to exaggerate the elevation differences.

Also includes:
- fixing the default 3d extent for projects saved in previous versions
- removal of QgsTerrainGenerator::extentChanged signal as this logic should be replaced now by Qgs3DMapSettings::extentChanged

Funded by: [Point cloud processing and 3D data enhancements crowdfunding](https://www.lutraconsulting.co.uk/crowdfunding/pointcloud-processing-qgis/)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
