### PR TITLE
Pyamids save as options

### DIFF
--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -43,7 +43,9 @@ QgsRasterFormatSaveOptionsWidget::QgsRasterFormatSaveOptionsWidget( QWidget *par
   , mProvider( provider )
 {
   setupUi( this );
-  setMinimumSize( this->fontMetrics().height() * 5, 240 );
+
+  // Set the table minimum size to fit at least 4 rows
+  mOptionsTable->setMinimumSize(200, mOptionsTable->verticalHeader()->defaultSectionSize() * 4 + mOptionsTable->horizontalHeader()->height() + 2 );
 
   connect( mProfileNewButton, &QPushButton::clicked, this, &QgsRasterFormatSaveOptionsWidget::mProfileNewButton_clicked );
   connect( mProfileDeleteButton, &QPushButton::clicked, this, &QgsRasterFormatSaveOptionsWidget::mProfileDeleteButton_clicked );

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -26,7 +26,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QTextEdit>
-#include <QMouseEvent>
+#include <QContextMenuEvent>
 #include <QMenu>
 #include <QFileInfo>
 
@@ -45,7 +45,7 @@ QgsRasterFormatSaveOptionsWidget::QgsRasterFormatSaveOptionsWidget( QWidget *par
   setupUi( this );
 
   // Set the table minimum size to fit at least 4 rows
-  mOptionsTable->setMinimumSize(200, mOptionsTable->verticalHeader()->defaultSectionSize() * 4 + mOptionsTable->horizontalHeader()->height() + 2 );
+  mOptionsTable->setMinimumSize( 200, mOptionsTable->verticalHeader()->defaultSectionSize() * 4 + mOptionsTable->horizontalHeader()->height() + 2 );
 
   connect( mProfileNewButton, &QPushButton::clicked, this, &QgsRasterFormatSaveOptionsWidget::mProfileNewButton_clicked );
   connect( mProfileDeleteButton, &QPushButton::clicked, this, &QgsRasterFormatSaveOptionsWidget::mProfileDeleteButton_clicked );
@@ -100,10 +100,24 @@ QgsRasterFormatSaveOptionsWidget::QgsRasterFormatSaveOptionsWidget( QWidget *par
   connect( mOptionsHelpButton, &QAbstractButton::clicked, this, &QgsRasterFormatSaveOptionsWidget::helpOptions );
   connect( mOptionsValidateButton, &QAbstractButton::clicked, this, [ = ] { validateOptions(); } );
 
-  // create eventFilter to map right click to swapOptionsUI()
-  // mOptionsLabel->installEventFilter( this );
+  // Install an eventFilter to customize the default QLineEdit contextMenu with an added swapOptionsUI action
   mOptionsLineEdit->installEventFilter( this );
-  mOptionsStackedWidget->installEventFilter( this );
+
+  // Use a Custom Context menu for the widget to swap between modes (table / lineedit)
+  setContextMenuPolicy( Qt::CustomContextMenu );
+  connect( this, &QWidget::customContextMenuRequested, this, [this]( QPoint pos )
+  {
+    QMenu menu( this );
+    QString text;
+    if ( mTableWidget->isVisible() )
+      text = tr( "Use Simple Interface" );
+    else
+      text = tr( "Use Table Interface" );
+    QAction *swapAction = menu.addAction( text );
+    connect( swapAction, &QAction::triggered, this, [this]() {swapOptionsUI( -1 ); } );
+    menu.exec( this->mapToGlobal( pos ) );
+  } );
+
 
   updateControls();
   updateProfiles();
@@ -134,15 +148,12 @@ void QgsRasterFormatSaveOptionsWidget::setType( QgsRasterFormatSaveOptionsWidget
     const auto constWidgets = widgets;
     for ( QWidget *widget : constWidgets )
       widget->setVisible( false );
-    mOptionsStackedWidget->setVisible( true );
-    const auto children { mOptionsStackedWidget->findChildren<QWidget *>() };
-    for ( QWidget *widget : children )
-      widget->setVisible( true );
+    mOptionsWidget->setVisible( true );
 
     // show relevant page
     if ( type == Table )
       swapOptionsUI( 0 );
-    else if ( type == LineEdit )
+    else
       swapOptionsUI( 1 );
   }
   else
@@ -157,6 +168,8 @@ void QgsRasterFormatSaveOptionsWidget::setType( QgsRasterFormatSaveOptionsWidget
     // show elevant page
     if ( type == ProfileLineEdit )
       swapOptionsUI( 1 );
+    else
+      swapOptionsUI( 0 );
   }
 }
 
@@ -237,7 +250,7 @@ void QgsRasterFormatSaveOptionsWidget::updateOptions()
     myOptions = PYRAMID_JPEG_COMPRESSION;
   }
 
-  if ( mOptionsStackedWidget->currentIndex() == 0 )
+  if ( mTableWidget->isVisible() )
   {
     mOptionsTable->setRowCount( 0 );
     for ( int i = 0; i < myOptionsList.count(); i++ )
@@ -536,26 +549,12 @@ QStringList QgsRasterFormatSaveOptionsWidget::profiles() const
 
 void QgsRasterFormatSaveOptionsWidget::swapOptionsUI( int newIndex )
 {
-  // set new page
-  int oldIndex;
-  if ( newIndex == -1 )
-  {
-    oldIndex = mOptionsStackedWidget->currentIndex();
-    newIndex = ( oldIndex + 1 ) % 2;
-  }
-  else
-  {
-    oldIndex = ( newIndex + 1 ) % 2;
-  }
-
-  // resize pages to minimum - this works well with gdaltools merge ui, but not raster save as...
-  mOptionsStackedWidget->setCurrentIndex( newIndex );
-  mOptionsStackedWidget->widget( newIndex )->setSizePolicy(
-    QSizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred ) );
-  mOptionsStackedWidget->widget( oldIndex )->setSizePolicy(
-    QSizePolicy( QSizePolicy::Ignored, QSizePolicy::Ignored ) );
-  layout()->activate();
-
+  // If newIndex == -1, toggle option mode
+  // If newIndex == 0, set option mode to Table
+  // If newIndex == 1, set option to lineEdit
+  bool lineEditMode = mOptionsLineEdit->isVisible();
+  mOptionsLineEdit->setVisible( ( newIndex == -1 && !lineEditMode ) || newIndex == 1 );
+  mTableWidget->setVisible( ( newIndex == -1 && lineEditMode ) || newIndex == 0 );
   updateOptions();
 }
 
@@ -569,31 +568,19 @@ void QgsRasterFormatSaveOptionsWidget::updateControls()
 // map options label left mouse click to optionsToggle()
 bool QgsRasterFormatSaveOptionsWidget::eventFilter( QObject *obj, QEvent *event )
 {
-  if ( event->type() == QEvent::MouseButtonPress )
+  if ( event->type() == QEvent::ContextMenu )
   {
-    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>( event );
-    if ( mouseEvent && ( mouseEvent->button() == Qt::RightButton ) )
-    {
-      QMenu *menu = nullptr;
-      QString text;
-      if ( mOptionsStackedWidget->currentIndex() == 0 )
-        text = tr( "Use simple interface" );
-      else
-        text = tr( "Use table interface" );
-      if ( obj->objectName() == QLatin1String( "mOptionsLineEdit" ) )
-      {
-        menu = mOptionsLineEdit->createStandardContextMenu();
-        menu->addSeparator();
-      }
-      else
-        menu = new QMenu( this );
-      QAction *action = new QAction( text, menu );
-      menu->addAction( action );
-      connect( action, &QAction::triggered, this, &QgsRasterFormatSaveOptionsWidget::swapOptionsUI );
-      menu->exec( mouseEvent->globalPos() );
-      delete menu;
-      return true;
-    }
+    QContextMenuEvent *contextEvent = static_cast<QContextMenuEvent *>( event );
+    QMenu *menu = nullptr;
+    menu = mOptionsLineEdit->createStandardContextMenu();
+    menu->addSeparator();
+    QAction *action = new QAction( tr( "Use Table Interface" ), menu );
+    menu->addAction( action );
+    connect( action, &QAction::triggered, this, [this] { swapOptionsUI( 0 ); } );
+    menu->exec( contextEvent->globalPos() );
+    delete menu;
+    return true;
+
   }
   // standard event processing
   return QObject::eventFilter( obj, event );

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -129,6 +129,7 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
   else
   {
     mPyramidsGroupBox->setEnabled( false );
+    mPyramidsGroupBox->setCollapsed( true );
   }
 
   // restore checked state for most groupboxes (default is to restore collapsed state)
@@ -661,6 +662,7 @@ QgsRasterLayerSaveAsDialog::Mode QgsRasterLayerSaveAsDialog::mode() const
 void QgsRasterLayerSaveAsDialog::mRawModeRadioButton_toggled( bool checked )
 {
   mNoDataGroupBox->setEnabled( checked && mDataProvider->bandCount() == 1 );
+  mNoDataGroupBox->setCollapsed( !mNoDataGroupBox->isEnabled() );
 }
 
 void QgsRasterLayerSaveAsDialog::mAddNoDataManuallyToolButton_clicked()

--- a/src/gui/qgsrasterpyramidsoptionswidget.cpp
+++ b/src/gui/qgsrasterpyramidsoptionswidget.cpp
@@ -44,7 +44,6 @@ QgsRasterPyramidsOptionsWidget::QgsRasterPyramidsOptionsWidget( QWidget *parent,
 
   mSaveOptionsWidget->setProvider( provider );
   mSaveOptionsWidget->setPyramidsFormat( Qgis::RasterPyramidFormat::GeoTiff );
-  mSaveOptionsWidget->setType( QgsRasterFormatSaveOptionsWidget::ProfileLineEdit );
 
   updateUi();
 }

--- a/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
+++ b/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
@@ -6,23 +6,41 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>341</width>
-    <height>203</height>
+    <width>354</width>
+    <height>331</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
     <number>1</number>
    </property>
-   <item row="0" column="1">
+   <property name="topMargin">
+    <number>1</number>
+   </property>
+   <property name="rightMargin">
+    <number>1</number>
+   </property>
+   <property name="bottomMargin">
+    <number>1</number>
+   </property>
+   <item>
     <layout class="QGridLayout" name="gridLayout_3">
      <item row="1" column="1">
       <widget class="QWidget" name="mProfileButtons" native="true">
        <layout class="QHBoxLayout" name="mProfileButtonsLayout">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -99,139 +117,148 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="1">
-    <widget class="QStackedWidget" name="mOptionsStackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <layout class="QGridLayout" name="gridLayout_2">
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QTableWidget" name="mOptionsTable">
-         <property name="minimumSize">
-          <size>
-           <width>204</width>
-           <height>0</height>
-          </size>
-         </property>
-         <attribute name="horizontalHeaderMinimumSectionSize">
-          <number>30</number>
-         </attribute>
-         <attribute name="horizontalHeaderStretchLastSection">
-          <bool>true</bool>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>Name</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Value</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0">
-          <widget class="QPushButton" name="mOptionsAddButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QPushButton" name="mOptionsDeleteButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QPushButton" name="mOptionsValidateButton">
-           <property name="text">
-            <string>Validate</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QPushButton" name="mOptionsHelpButton">
-           <property name="text">
-            <string>Help</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page_2">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLineEdit" name="mOptionsLineEdit">
-         <property name="toolTip">
-          <string>Insert KEY=VALUE pairs separated by spaces</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="1" column="1">
+   <item>
     <widget class="Line" name="mSeparator">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="mOptionsWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="mTableWidget" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QTableWidget" name="mOptionsTable">
+           <attribute name="horizontalHeaderMinimumSectionSize">
+            <number>30</number>
+           </attribute>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QPushButton" name="mOptionsAddButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mOptionsDeleteButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mOptionsValidateButton">
+             <property name="text">
+              <string>Validate</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mOptionsHelpButton">
+             <property name="text">
+              <string>Help</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="mOptionsLineEdit">
+        <property name="toolTip">
+         <string>Insert KEY=VALUE pairs separated by spaces</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
- Fixes #49563
- Fixes #49562
- Fixes #47434

## Description

Fixes several bugs:
- Disabled groupboxes in the _save as..._ raster dialog (`QgsRasterLayerSaveAsDialog`) are expanded, and uncollapsible since they're disabled. Auto collapse them
- Buggy right click menu on the `QgsRasterFormatSaveOptionsWidget`, to switch between Tabke and LineEdit mode. Fix it.
- QgsRasterFormatSaveOptionsWidget takes as much space in LineEdit mode as in Table mode. Fix it.

![47434](https://user-images.githubusercontent.com/39594821/154659972-ad002a44-80c8-4508-8850-0eb1f50028f4.png)
