### PR TITLE
Infer file extension from content-type header

### DIFF
--- a/src/core/network/qgsnetworkcontentfetcherregistry.cpp
+++ b/src/core/network/qgsnetworkcontentfetcherregistry.cpp
@@ -180,12 +180,12 @@ void QgsFetchedContent::taskCompleted()
       const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
       if ( extension.isEmpty() && !contentType.isEmpty() )
       {
-        QList<QMimeType> mimeTypes = QMimeDatabase().allMimeTypes();
+        const QList<QMimeType> mimeTypes = QMimeDatabase().allMimeTypes();
         auto it = std::find_if( mimeTypes.constBegin(), mimeTypes.constEnd(), [ = ]( QMimeType mimeType )
         {
           return mimeType.name() == contentType;
         } );
-        if ( it != mimeTypes.end() )
+        if ( it != mimeTypes.constEnd() )
         {
           extension = ( *it ).preferredSuffix();
         }

--- a/src/core/network/qgsnetworkcontentfetcherregistry.cpp
+++ b/src/core/network/qgsnetworkcontentfetcherregistry.cpp
@@ -22,6 +22,8 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QDir>
+#include <QMimeType>
+#include <QMimeDatabase>
 
 QgsNetworkContentFetcherRegistry::~QgsNetworkContentFetcherRegistry()
 {
@@ -167,9 +169,27 @@ void QgsFetchedContent::taskCompleted()
     QNetworkReply *reply = mFetchingTask->reply();
     if ( reply->error() == QNetworkReply::NoError )
     {
-      // keep extension, it can be useful when guessing file content
+
+      // keep or guess extension, it can be useful when guessing file content
       // (when loading this file in a Qt WebView for instance)
-      const QString extension = QFileInfo( reply->request().url().fileName() ).completeSuffix();
+
+      // extension from file name
+      QString extension = QFileInfo( reply->request().url().fileName() ).completeSuffix();
+
+      // extension from contentType header if not found from file name
+      const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+      if ( extension.isEmpty() && !contentType.isEmpty() )
+      {
+        QList<QMimeType> mimeTypes = QMimeDatabase().allMimeTypes();
+        auto it = std::find_if( mimeTypes.constBegin(), mimeTypes.constEnd(), [ = ]( QMimeType mimeType )
+        {
+          return mimeType.name() == contentType;
+        } );
+        if ( it != mimeTypes.end() )
+        {
+          extension = ( *it ).preferredSuffix();
+        }
+      }
 
       QTemporaryFile *tf = new QTemporaryFile( extension.isEmpty() ? QString( "XXXXXX" ) :
           QString( "%1/XXXXXX.%2" ).arg( QDir::tempPath(), extension ) );


### PR DESCRIPTION
## Description of the problem

When downloading a file with `QgsNetworkContentFetcherRegistry`, it can happen that the file has no extension (like when the URL does not contain the file name).

There is a need to have the file extension as often as possible because when using QWebKit to preview a file, it needs the extension, otherwise there is a 102 error "Frame load interrupted".

![image](https://user-images.githubusercontent.com/34267385/214122143-de7feafa-67d5-4a4a-b103-dd78b01daf5d.png)

## Proposed resolution

This PR adds another mean to get the file extension, so we have it more often: by reading the `Content-Type` header from the network reply which, if used, is supposed to have the mime type of the data.

---

Funded by Kristianstads kommun