### PR TITLE
Topology checker rules enabling/disabling and filtering

### DIFF
--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -400,7 +400,7 @@ void checkDock::runTests( ValidateType type )
     mErrorList << errors;
   }
 
-  for ( TopolError *error : mErrorList )
+  for ( TopolError *error : std::as_const( mErrorList ) )
   {
     if ( !mErrorNames.contains( error->name() ) )
     {

--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -333,6 +333,9 @@ void checkDock::runTests( ValidateType type )
     if ( mTest->testCanceled() )
       break;
 
+    if ( mTestTable->item( i, 0 )->checkState() != Qt::Checked )
+      continue;
+
     const QString testName = mTestTable->item( i, 0 )->text();
     const QString layer1Str = mTestTable->item( i, 3 )->text();
     const QString layer2Str = mTestTable->item( i, 4 )->text();

--- a/src/plugins/topology/checkDock.h
+++ b/src/plugins/topology/checkDock.h
@@ -106,6 +106,16 @@ class checkDock : public QgsDockWidget, private Ui::checkDock
      */
     void updateRubberBands( bool visible );
 
+    /**
+     * Update the filter combo box to reflect
+     * current error names
+     */
+    void updateFilterComboBox();
+
+    /**
+     * Filter errors using the current filter combo box's value
+     */
+    void filterErrors();
 
   private:
     rulesDialog *mConfigureDialog = nullptr;
@@ -119,8 +129,9 @@ class checkDock : public QgsDockWidget, private Ui::checkDock
     QgsVertexMarker *mVMFeature2 = nullptr;
     QList<QgsRubberBand *> mRbErrorMarkers;
 
+    QStringList mErrorNames;
     ErrorList mErrorList;
-    DockModel *mErrorListModel = nullptr;
+    DockFilterModel *mErrorListModel = nullptr;
 
     QgisInterface *qgsInterface = nullptr;
 

--- a/src/plugins/topology/checkDock.ui
+++ b/src/plugins/topology/checkDock.ui
@@ -14,11 +14,11 @@
    <string>Topology Checker Panel</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QGridLayout" name="gridLayout_2">
+   <layout class="QVBoxLayout" name="mainVerticalLayout">
     <property name="margin">
      <number>0</number>
     </property>
-    <item row="0" column="0">
+    <item>
      <widget class="QToolBar" name="mTopologyToolbar">
       <property name="iconSize">
        <size>
@@ -34,7 +34,34 @@
       <addaction name="actionConfigure"/>
      </widget>
     </item>
-    <item row="1" column="0">
+    <item>
+     <layout class="QHBoxLayout" name="filterLayout">
+      <item>
+       <widget class="QLabel" name="filterLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Show:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="mFilterComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>       
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
        <widget class="QTableView" name="mErrorTableView">
@@ -45,7 +72,7 @@
       </item>
      </layout>
     </item>
-    <item row="2" column="0">
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <item>
        <widget class="QCheckBox" name="mToggleRubberband">
@@ -53,7 +80,7 @@
          <string>Show topology errors</string>
         </property>
         <property name="text">
-         <string>Show errors</string>
+         <string>Show errors on the canvas</string>
         </property>
         <property name="checked">
          <bool>false</bool>
@@ -69,7 +96,7 @@
       </item>
      </layout>
     </item>
-    <item row="3" column="0">
+    <item>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="QComboBox" name="mFixBox">

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -135,15 +135,11 @@ void DockModel::reload( const QModelIndex &index1, const QModelIndex &index2 )
 }
 
 DockFilterModel::DockFilterModel( ErrorList &errorList, QObject *parent = nullptr )
-  : mDockModel( new DockModel( errorList, parent ) )
+  : QSortFilterProxyModel( parent )
+  , mDockModel( new DockModel( errorList, parent ) )
 {
   setSourceModel( mDockModel );
   setFilterKeyColumn( 0 );
-}
-
-DockFilterModel::~DockFilterModel()
-{
-  mDockModel->deleteLater();
 }
 
 void DockFilterModel::reload( const QModelIndex &index1, const QModelIndex &index2 )

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -20,7 +20,8 @@
 #include "qgsvectorlayer.h"
 #include <qlogging.h>
 
-DockModel::DockModel( ErrorList &errorList, QObject *parent = nullptr ) : mErrorlist( errorList )
+DockModel::DockModel( ErrorList &errorList, QObject *parent = nullptr )
+  : mErrorlist( errorList )
 {
   Q_UNUSED( parent )
   mHeader << QObject::tr( "Error" ) << QObject::tr( "Layer" ) << QObject::tr( "Feature ID" );
@@ -131,4 +132,26 @@ void DockModel::reload( const QModelIndex &index1, const QModelIndex &index2 )
 
 {
   emit dataChanged( index1, index2 );
+}
+
+DockFilterModel::DockFilterModel( ErrorList &errorList, QObject *parent = nullptr )
+  : mDockModel( new DockModel( errorList, parent ) )
+{
+  setSourceModel( mDockModel );
+  setFilterKeyColumn( 0 );
+}
+
+DockFilterModel::~DockFilterModel()
+{
+  mDockModel->deleteLater();
+}
+
+void DockFilterModel::reload( const QModelIndex &index1, const QModelIndex &index2 )
+{
+  mDockModel->reload( index1, index2 );
+}
+
+void DockFilterModel::resetModel()
+{
+  mDockModel->resetModel();
 }

--- a/src/plugins/topology/dockModel.h
+++ b/src/plugins/topology/dockModel.h
@@ -109,7 +109,7 @@ class DockFilterModel : public QSortFilterProxyModel
      */
     DockFilterModel( ErrorList &errorList, QObject *parent );
 
-    ~DockFilterModel();
+    ~DockFilterModel() = default;
 
     /**
      * Reloads the model data between indices

--- a/src/plugins/topology/dockModel.h
+++ b/src/plugins/topology/dockModel.h
@@ -19,12 +19,13 @@
 #define DOCKMODEL_H
 
 #include <QAbstractTableModel>
+#include <QSortFilterProxyModel>
 #include <QModelIndex>
 #include <QObject>
 
 #include "topolError.h"
 
-class DockModel: public QAbstractTableModel
+class DockModel : public QAbstractTableModel
 {
     Q_OBJECT
 
@@ -93,6 +94,39 @@ class DockModel: public QAbstractTableModel
   private:
     ErrorList &mErrorlist;
     QList<QString> mHeader;
+};
+
+class DockFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor
+     * \param errorList reference to the ErrorList where errors will be stored
+     * \param parent parent object
+     */
+    DockFilterModel( ErrorList &errorList, QObject *parent );
+
+    ~DockFilterModel();
+
+    /**
+     * Reloads the model data between indices
+     * \param index1 start index
+     * \param index2 end index
+     */
+    void reload( const QModelIndex &index1, const QModelIndex &index2 );
+
+    /**
+     * Resets the model
+     */
+    void resetModel();
+
+  private:
+
+    DockModel *mDockModel = nullptr;
+
 };
 
 #endif

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -75,14 +75,11 @@ void rulesDialog::setHorizontalHeaderItems()
 
 void rulesDialog::readTest( int index, QgsProject *project )
 {
-  QString testName;
-  QString layer1Id;
-  QString layer2Id;
   const QString postfix = QString::number( index );
-
-  testName = project->readEntry( QStringLiteral( "Topol" ), "/testname_" + postfix, QString() );
-  layer1Id = project->readEntry( QStringLiteral( "Topol" ), "/layer1_" + postfix, QString() );
-  layer2Id = project->readEntry( QStringLiteral( "Topol" ), "/layer2_" + postfix, QString() );
+  const bool testEnabled = project->readBoolEntry( QStringLiteral( "Topol" ), "/testenabled_" + postfix, true );
+  const QString testName = project->readEntry( QStringLiteral( "Topol" ), "/testname_" + postfix, QString() );
+  const QString layer1Id = project->readEntry( QStringLiteral( "Topol" ), "/layer1_" + postfix, QString() );
+  const QString layer2Id = project->readEntry( QStringLiteral( "Topol" ), "/layer2_" + postfix, QString() );
 
   QgsVectorLayer *l1 = nullptr;
   if ( !( QgsVectorLayer * )project->mapLayers().contains( layer1Id ) )
@@ -115,6 +112,7 @@ void rulesDialog::readTest( int index, QgsProject *project )
   QTableWidgetItem *newItem = nullptr;
   newItem = new QTableWidgetItem( testName );
   newItem->setFlags( newItem->flags() & ~Qt::ItemIsEditable );
+  newItem->setCheckState( testEnabled ? Qt::Checked : Qt::Unchecked );
   mRulesTable->setItem( row, 0, newItem );
 
   newItem = new QTableWidgetItem( layer1Name );
@@ -216,15 +214,14 @@ void rulesDialog::addRule()
 
   QTableWidgetItem *newItem = nullptr;
   newItem = new QTableWidgetItem( test );
+  newItem->setFlags( newItem->flags() & ~Qt::ItemIsEditable );
+  newItem->setCheckState( Qt::Checked );
   mRulesTable->setItem( row, 0, newItem );
   newItem = new QTableWidgetItem( layer1 );
+  newItem->setFlags( newItem->flags() & ~Qt::ItemIsEditable );
   mRulesTable->setItem( row, 1, newItem );
-
-  if ( mTestConfMap[test].useSecondLayer )
-    newItem = new QTableWidgetItem( layer2 );
-  else
-    newItem = new QTableWidgetItem( tr( "No layer" ) );
-
+  newItem = new QTableWidgetItem( mTestConfMap[test].useSecondLayer ? layer2 : tr( "No layer" ) );
+  newItem->setFlags( newItem->flags() & ~Qt::ItemIsEditable );
   mRulesTable->setItem( row, 2, newItem );
 
   QString layer1ID, layer2ID;
@@ -248,6 +245,7 @@ void rulesDialog::addRule()
   QgsProject *project = QgsProject::instance();
 
   project->writeEntry( QStringLiteral( "Topol" ), QStringLiteral( "/testCount" ), row + 1 );
+  project->writeEntry( QStringLiteral( "Topol" ), "/testenabled_" + postfix, true );
   project->writeEntry( QStringLiteral( "Topol" ), "/testname_" + postfix, test );
   project->writeEntry( QStringLiteral( "Topol" ), "/layer1_" + postfix, layer1ID );
   project->writeEntry( QStringLiteral( "Topol" ), "/layer2_" + postfix, layer2ID );

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -267,8 +267,8 @@ void rulesDialog::addRule()
 void rulesDialog::deleteTest()
 {
   std::set<int, std::greater<int>> selectedRows;
-  QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
-  for ( QModelIndex index : selectedIndexes )
+  const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
+  for ( const QModelIndex index : selectedIndexes )
   {
     selectedRows.insert( index.row() );
   }

--- a/src/plugins/topology/rulesDialog.ui
+++ b/src/plugins/topology/rulesDialog.ui
@@ -127,8 +127,8 @@
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QPushButton" name="mDeleteTestButton">
-       <property name="text">
-        <string>Delete Selected Rule</string>
+       <property name="toolTip">
+        <string>Delete selected rules</string>
        </property>
       </widget>
      </item>

--- a/src/plugins/topology/rulesDialog.ui
+++ b/src/plugins/topology/rulesDialog.ui
@@ -13,18 +13,24 @@
   <property name="windowTitle">
    <string>Topology Rule Settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Current Rules</string>
+      <string>New Rule</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QComboBox" name="mLayer1Box">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToContents</enum>
        </property>
@@ -37,6 +43,12 @@
      </item>
      <item>
       <widget class="QComboBox" name="mRuleBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToContents</enum>
        </property>
@@ -44,6 +56,12 @@
      </item>
      <item>
       <widget class="QComboBox" name="mLayer2Box">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToContents</enum>
        </property>
@@ -54,40 +72,29 @@
        </item>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item>
       <widget class="QPushButton" name="mAddTestButton">
-       <property name="text">
-        <string>Add Rule</string>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mDeleteTestButton">
        <property name="text">
-        <string>Delete Rule</string>
+        <string></string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Current Rules</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableWidget" name="mRulesTable">
      <column>
       <property name="text">
@@ -116,7 +123,31 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QPushButton" name="mDeleteTestButton">
+       <property name="text">
+        <string>Delete Selected Rule</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
## Description

This PR adds functionalities to better manage topology checker rules as well as filtering large number of errors. While visiting this plugin, I've applied a few UI/UX improvements to better align it to the rest of QGIS

First, the topology checker rules dialog now feature check boxes attached to individual rules to allow for enabling/disabling rules when running validity _without having to delete them_. This avoids scenarios when users don't want to lose rules but are only interested in validating a subset.

![image](https://user-images.githubusercontent.com/1728657/214211945-2e05aa50-b5a8-4a70-8db3-0d540f9105bf.png)
_You'll notice the slightly improved UI here with the relocation of the delete and add buttons; the delete button now only activates when rows are selected and allow for multiple rules to be deleted at once_

Second, the topology checker panel has a a new combo box below its toolbar to allow for quick filtering of errors to focus on on specific error type. By default, it is set to show all error types.

![image](https://user-images.githubusercontent.com/1728657/214212136-6b04f286-3fe1-4627-9fe4-21b4e3f2b55d.png)

