### PR TITLE
Revert "remove transfer annotations"

### DIFF
--- a/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -33,7 +33,7 @@ typedef QgsSettingsEntryByReference<QVariant> QgsSettingsEntryByReferenceQVarian
                              QgsSettingsTreeNode *parent,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryVariant.
 
@@ -51,7 +51,7 @@ Constructor for QgsSettingsEntryVariant.
                              const QString &section,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryVariant.
 
@@ -69,7 +69,7 @@ Constructor for QgsSettingsEntryVariant.
                              const QString &pluginName,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryVariant.
 This constructor is intended to be used from plugins.
@@ -136,7 +136,7 @@ typedef QgsSettingsEntryByReference<QString> QgsSettingsEntryByReferenceQStringB
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) throw( QgsSettingsException );
+                            int maxLength = -1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryString.
 
@@ -156,7 +156,7 @@ Constructor for QgsSettingsEntryString.
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) throw( QgsSettingsException );
+                            int maxLength = -1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryString.
 
@@ -176,7 +176,7 @@ Constructor for QgsSettingsEntryString.
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) throw( QgsSettingsException );
+                            int maxLength = -1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryString.
 This constructor is intended to be used from plugins.
@@ -234,7 +234,7 @@ typedef QgsSettingsEntryByReference<QStringList> QgsSettingsEntryByReferenceQStr
                                 QgsSettingsTreeNode *parent,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryStringList.
 
@@ -250,7 +250,7 @@ Constructor for QgsSettingsEntryStringList.
                                 const QString &section,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryStringList.
 
@@ -267,7 +267,7 @@ Constructor for QgsSettingsEntryStringList.
                                 const QString &pluginName,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryStringList.
 This constructor is intended to be used from plugins.
@@ -313,7 +313,7 @@ typedef QgsSettingsEntryByValue<bool> QgsSettingsEntryByValueboolBase;
                           QgsSettingsTreeNode *parent,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryBool.
 
@@ -329,7 +329,7 @@ Constructor for QgsSettingsEntryBool.
                           const QString &section,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryBool.
 
@@ -345,7 +345,7 @@ Constructor for QgsSettingsEntryBool.
                           const QString &pluginName,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryBool.
 This constructor is intended to be used from plugins.
@@ -394,7 +394,7 @@ typedef QgsSettingsEntryByValue<int> QgsSettingsEntryByValueintBase;
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = INT_MIN,
-                             int maxValue = INT_MAX ) throw( QgsSettingsException );
+                             int maxValue = INT_MAX ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryInteger.
 
@@ -414,7 +414,7 @@ Constructor for QgsSettingsEntryInteger.
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = INT_MIN,
-                             int maxValue = INT_MAX ) throw( QgsSettingsException );
+                             int maxValue = INT_MAX ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryInteger.
 
@@ -434,7 +434,7 @@ Constructor for QgsSettingsEntryInteger.
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = INT_MIN,
-                             int maxValue = INT_MAX ) throw( QgsSettingsException );
+                             int maxValue = INT_MAX ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryInteger.
 This constructor is intended to be used from plugins.
@@ -497,7 +497,7 @@ typedef QgsSettingsEntryByValue<double> QgsSettingsEntryByValuedoubleBase;
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = -DBL_MAX,
                             double maxValue = DBL_MAX,
-                            int displayDecimals = 1 ) throw( QgsSettingsException );
+                            int displayDecimals = 1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryDouble.
 
@@ -520,7 +520,7 @@ Constructor for QgsSettingsEntryDouble.
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = -DBL_MAX,
                             double maxValue = DBL_MAX,
-                            int displayDecimals = 1 ) throw( QgsSettingsException );
+                            int displayDecimals = 1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryDouble.
 
@@ -543,7 +543,7 @@ Constructor for QgsSettingsEntryDouble.
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = -DBL_MAX,
                             double maxValue = DBL_MAX,
-                            int displayDecimals = 1 ) throw( QgsSettingsException );
+                            int displayDecimals = 1 ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryDouble.
 This constructor is intended to be used from plugins.
@@ -619,7 +619,7 @@ typedef QgsSettingsEntryByReference<QColor> QgsSettingsEntryByReferenceQColorBas
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) throw( QgsSettingsException );
+                           bool allowAlpha = true ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryColor.
 
@@ -637,7 +637,7 @@ Constructor for QgsSettingsEntryColor.
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) throw( QgsSettingsException );
+                           bool allowAlpha = true ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryColor.
 
@@ -655,7 +655,7 @@ Constructor for QgsSettingsEntryColor.
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) throw( QgsSettingsException );
+                           bool allowAlpha = true ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryColor.
 This constructor is intended to be used from plugins.
@@ -713,7 +713,7 @@ typedef QgsSettingsEntryByReference<QVariantMap> QgsSettingsEntryByReferenceQVar
                                 QgsSettingsTreeNode *parent,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryVariantMap.
 
@@ -729,7 +729,7 @@ Constructor for QgsSettingsEntryVariantMap.
                                 const QString &section,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for QgsSettingsEntryVariantMap.
 
@@ -745,7 +745,7 @@ Constructor for QgsSettingsEntryVariantMap.
                                 const QString &pluginName,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
 Constructor for :py:class:`QgsSettingsEntryStringMap`.
 This constructor is intended to be used from plugins.

--- a/src/core/settings/qgssettingsentryimpl.h
+++ b/src/core/settings/qgssettingsentryimpl.h
@@ -45,8 +45,8 @@ class CORE_EXPORT QgsSettingsEntryVariant : public QgsSettingsEntryByReference<Q
                              QgsSettingsTreeNode *parent,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
     {}
 
     /**
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsSettingsEntryVariant : public QgsSettingsEntryByReference<Q
                              const QString &section,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByReference( key, section, defaultValue, description, options )
     {}
 
@@ -83,7 +83,7 @@ class CORE_EXPORT QgsSettingsEntryVariant : public QgsSettingsEntryByReference<Q
                              const QString &pluginName,
                              const QVariant &defaultValue = QVariant(),
                              const QString &description = QString(),
-                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException );
+                             Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryVariant( QgsSettingsEntryVariant( *a0, QgsSettings::createPluginTreeElement( *a1 ), *a2, *a3, *a4 ) );
     % End
@@ -146,10 +146,10 @@ class CORE_EXPORT QgsSettingsEntryString : public QgsSettingsEntryByReference<QS
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByReference<QString>( key, parent, defaultValue, description, options )
-      , mMinLength( minLength )
-      , mMaxLength( maxLength )
+                            int maxLength = -1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByReference<QString>( key, parent, defaultValue, description, options )
+    , mMinLength( minLength )
+    , mMaxLength( maxLength )
     {}
 
     /**
@@ -169,7 +169,7 @@ class CORE_EXPORT QgsSettingsEntryString : public QgsSettingsEntryByReference<QS
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                            int maxLength = -1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByReference<QString>( key, section, defaultValue, description, options )
     , mMinLength( minLength )
     , mMaxLength( maxLength )
@@ -193,7 +193,7 @@ class CORE_EXPORT QgsSettingsEntryString : public QgsSettingsEntryByReference<QS
                             const QString &description = QString(),
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             int minLength = 0,
-                            int maxLength = -1 ) SIP_THROW( QgsSettingsException );
+                            int maxLength = -1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryString( QgsSettingsEntryString( *a0, QgsSettings::createPluginTreeElement( *a1 ), *a2, *a3, *a4 ) );
     % End
@@ -245,8 +245,8 @@ class CORE_EXPORT QgsSettingsEntryStringList : public QgsSettingsEntryByReferenc
                                 QgsSettingsTreeNode *parent,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
     {}
 
     /**
@@ -262,7 +262,7 @@ class CORE_EXPORT QgsSettingsEntryStringList : public QgsSettingsEntryByReferenc
                                 const QString &section,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByReference( key, section, defaultValue, description, options )
     {}
 
@@ -283,7 +283,7 @@ class CORE_EXPORT QgsSettingsEntryStringList : public QgsSettingsEntryByReferenc
                                 const QString &pluginName,
                                 const QStringList &defaultValue = QStringList(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryStringList( QgsSettingsEntryStringList( *a0, QgsSettings::createPluginTreeElement( *a1 ), *a2, *a3, *a4 ) );
     % End
@@ -321,8 +321,8 @@ class CORE_EXPORT QgsSettingsEntryBool : public QgsSettingsEntryByValue<bool>
                           QgsSettingsTreeNode *parent,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
     {}
 
     /**
@@ -338,7 +338,7 @@ class CORE_EXPORT QgsSettingsEntryBool : public QgsSettingsEntryByValue<bool>
                           const QString &section,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByValue( key, section, defaultValue, description, options )
     {}
 
@@ -358,7 +358,7 @@ class CORE_EXPORT QgsSettingsEntryBool : public QgsSettingsEntryByValue<bool>
                           const QString &pluginName,
                           bool defaultValue = false,
                           const QString &description = QString(),
-                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException );
+                          Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryBool( QgsSettingsEntryBool( *a0, QgsSettings::createPluginTreeElement( *a1 ), a2, *a3, *a4 ) );
     % End
@@ -400,10 +400,10 @@ class CORE_EXPORT QgsSettingsEntryInteger : public QgsSettingsEntryByValue<int>
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = std::numeric_limits<int>::min(),
-                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
-      , mMinValue( minValue )
-      , mMaxValue( maxValue )
+                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
+    , mMinValue( minValue )
+    , mMaxValue( maxValue )
     { }
 
     /**
@@ -423,7 +423,7 @@ class CORE_EXPORT QgsSettingsEntryInteger : public QgsSettingsEntryByValue<int>
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = std::numeric_limits<int>::min(),
-                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByValue( key, section, defaultValue, description, options )
     , mMinValue( minValue )
     , mMaxValue( maxValue )
@@ -449,7 +449,7 @@ class CORE_EXPORT QgsSettingsEntryInteger : public QgsSettingsEntryByValue<int>
                              const QString &description = QString(),
                              Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                              int minValue = std::numeric_limits<int>::min(),
-                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException );
+                             int maxValue = std::numeric_limits<int>::max() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryInteger( QgsSettingsEntryInteger( *a0, QgsSettings::createPluginTreeElement( *a1 ), a2, *a3, *a4, a5, a6 ) );
     % End
@@ -585,11 +585,11 @@ class CORE_EXPORT QgsSettingsEntryDouble : public QgsSettingsEntryByValue<double
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = std::numeric_limits<double>::lowest(),
                             double maxValue = std::numeric_limits<double>::max(),
-                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
-      , mMinValue( minValue )
-      , mMaxValue( maxValue )
-      , mDisplayHintDecimals( displayDecimals )
+                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByValue( key, parent, defaultValue, description, options )
+    , mMinValue( minValue )
+    , mMaxValue( maxValue )
+    , mDisplayHintDecimals( displayDecimals )
     {}
 
     /**
@@ -612,7 +612,7 @@ class CORE_EXPORT QgsSettingsEntryDouble : public QgsSettingsEntryByValue<double
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = std::numeric_limits<double>::lowest(),
                             double maxValue = std::numeric_limits<double>::max(),
-                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByValue( key, section, defaultValue, description, options )
     , mMinValue( minValue )
     , mMaxValue( maxValue )
@@ -641,7 +641,7 @@ class CORE_EXPORT QgsSettingsEntryDouble : public QgsSettingsEntryByValue<double
                             Qgis::SettingsOptions options = Qgis::SettingsOptions(),
                             double minValue = std::numeric_limits<double>::lowest(),
                             double maxValue = std::numeric_limits<double>::max(),
-                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException );
+                            int displayDecimals = 1 ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryDouble( QgsSettingsEntryDouble( *a0, QgsSettings::createPluginTreeElement( *a1 ), a2, *a3, *a4, a5, a6, a7 ) );
     % End
@@ -710,9 +710,9 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryByReference<QCo
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
-      , mAllowAlpha( allowAlpha )
+                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
+    , mAllowAlpha( allowAlpha )
     {}
 
     /**
@@ -730,7 +730,7 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryByReference<QCo
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByReference( key, section, defaultValue, description, options )
     , mAllowAlpha( allowAlpha )
     {}
@@ -752,7 +752,7 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryByReference<QCo
                            const QColor &defaultValue = QColor(),
                            const QString &description = QString(),
                            Qgis::SettingsOptions options = Qgis::SettingsOptions(),
-                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException );
+                           bool allowAlpha = true ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryColor( QgsSettingsEntryColor( *a0, QgsSettings::createPluginTreeElement( *a1 ), *a2, *a3, *a4, a5 ) );
     % End
@@ -811,8 +811,8 @@ class CORE_EXPORT QgsSettingsEntryVariantMap : public QgsSettingsEntryByReferenc
                                 QgsSettingsTreeNode *parent,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException )
-      : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER
+  : QgsSettingsEntryByReference( key, parent, defaultValue, description, options )
     {
     }
 
@@ -829,7 +829,7 @@ class CORE_EXPORT QgsSettingsEntryVariantMap : public QgsSettingsEntryByReferenc
                                 const QString &section,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_MAKE_PRIVATE
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER SIP_MAKE_PRIVATE
   : QgsSettingsEntryByReference( key, section, defaultValue, description, options )
     {
     }
@@ -850,7 +850,7 @@ class CORE_EXPORT QgsSettingsEntryVariantMap : public QgsSettingsEntryByReferenc
                                 const QString &pluginName,
                                 const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
-                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException );
+                                Qgis::SettingsOptions options = Qgis::SettingsOptions() ) SIP_THROW( QgsSettingsException ) SIP_TRANSFER;
     % MethodCode
     sipCpp = new sipQgsSettingsEntryVariantMap( QgsSettingsEntryVariantMap( *a0, QgsSettings::createPluginTreeElement( *a1 ), *a2, *a3, *a4 ) );
     % End


### PR DESCRIPTION
This might be the cause of the random crashes in the settings tree test.

https://www.riverbankcomputing.com/static/Docs/sip/annotations.html#function-annotation-Transfer