### PR TITLE
Make form combo box widgets shrinkable

### DIFF
--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -36,7 +36,10 @@ void QgsClassificationWidgetWrapper::showIndeterminateState()
 
 QWidget *QgsClassificationWidgetWrapper::createWidget( QWidget *parent )
 {
-  return new QComboBox( parent );
+  QComboBox *combo = new QComboBox( parent );
+  combo->setMinimumContentsLength( 1 );
+  combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+  return combo;
 }
 
 void QgsClassificationWidgetWrapper::initWidget( QWidget *editor )

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -45,7 +45,10 @@ void QgsEnumerationWidgetWrapper::showIndeterminateState()
 
 QWidget *QgsEnumerationWidgetWrapper::createWidget( QWidget *parent )
 {
-  return new QComboBox( parent );
+  QComboBox *combo = new QComboBox( parent );
+  combo->setMinimumContentsLength( 1 );
+  combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+  return combo;
 }
 
 void QgsEnumerationWidgetWrapper::initWidget( QWidget *editor )

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -51,7 +51,12 @@ QWidget *QgsUniqueValuesWidgetWrapper::createWidget( QWidget *parent )
   if ( config( QStringLiteral( "Editable" ) ).toBool() )
     return new QgsFilterLineEdit( parent );
   else
-    return new QComboBox( parent );
+  {
+    QComboBox *combo = new QComboBox( parent );
+    combo->setMinimumContentsLength( 1 );
+    combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+    return combo;
+  }
 }
 
 void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -32,7 +32,10 @@ QgsValueMapSearchWidgetWrapper::QgsValueMapSearchWidgetWrapper( QgsVectorLayer *
 
 QWidget *QgsValueMapSearchWidgetWrapper::createWidget( QWidget *parent )
 {
-  return new QComboBox( parent );
+  auto combo = new QComboBox( parent );
+  combo->setMinimumContentsLength( 1 );
+  combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+  return combo;
 }
 
 void QgsValueMapSearchWidgetWrapper::comboBoxIndexChanged( int idx )

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -52,7 +52,10 @@ void QgsValueMapWidgetWrapper::showIndeterminateState()
 
 QWidget *QgsValueMapWidgetWrapper::createWidget( QWidget *parent )
 {
-  return new QComboBox( parent );
+  QComboBox *combo = new QComboBox( parent );
+  combo->setMinimumContentsLength( 1 );
+  combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+  return combo;
 }
 
 void QgsValueMapWidgetWrapper::initWidget( QWidget *editor )

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -23,7 +23,6 @@
 
 SIP_NO_FILE
 
-
 /**
  * \ingroup gui
  * \brief Wraps a value map widget.
@@ -70,5 +69,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
     QComboBox *mComboBox = nullptr;
 
 };
+
+
 
 #endif // QGSVALUEMAPWIDGETWRAPPER_H

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -202,7 +202,10 @@ QWidget *QgsValueRelationSearchWidgetWrapper::createWidget( QWidget *parent )
   }
   else
   {
-    return new QComboBox( parent );
+    QComboBox *combo = new QComboBox( parent );
+    combo->setMinimumContentsLength( 1 );
+    combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+    return combo;
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -291,7 +291,10 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
   }
   else
   {
-    return new QComboBox( parent );
+    QComboBox *combo = new QComboBox( parent );
+    combo->setMinimumContentsLength( 1 );
+    combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
+    return combo;
   }
 }
 

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -29,6 +29,8 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
   , mModel( new QgsFeatureFilterModel( this ) )
   , mCompleter( new QCompleter( mModel ) )
 {
+  setMinimumContentsLength( 1 );
+  setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
   mCompleter->setCaseSensitivity( Qt::CaseInsensitive );
   mCompleter->setFilterMode( Qt::MatchContains );
   setEditable( true );


### PR DESCRIPTION
When a form widget contains long values it takes by default the length of the longest item.

This can result in very wide forms that cannot be shrinked.

With this PR the combo box can be shrinked and the form itself can be also shrinked.

Funded by: Kanton Solothurn
