### PR TITLE
migrate arcgis settings

### DIFF
--- a/python/core/auto_generated/qgsowsconnection.sip.in
+++ b/python/core/auto_generated/qgsowsconnection.sip.in
@@ -12,6 +12,10 @@
 
 
 
+
+
+
+
 class QgsOwsConnection : QObject
 {
 %Docstring(signature="appended")

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -44,6 +44,15 @@ const QgsSettingsEntryString *QgsXyzConnectionSettings::settingsPassword = new Q
 const QgsSettingsEntryString *QgsXyzConnectionSettings::settingsAuthcfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeXyzConnections ) ;
 
 
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsUrl = new QgsSettingsEntryString( QStringLiteral( "url" ), sTreeConnectionArcgis );
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsAuthcfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeConnectionArcgis );
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsUsername = new QgsSettingsEntryString( QStringLiteral( "username" ), sTreeConnectionArcgis );
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsPassword = new QgsSettingsEntryString( QStringLiteral( "password" ), sTreeConnectionArcgis );
+const QgsSettingsEntryVariantMap *QgsArcGisConnectionSettings::settingsHeaders = new QgsSettingsEntryVariantMap( QStringLiteral( "http-header" ), sTreeConnectionArcgis );
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsContentEndpoint = new QgsSettingsEntryString( QStringLiteral( "content-endpoint" ), sTreeConnectionArcgis );
+const QgsSettingsEntryString *QgsArcGisConnectionSettings::settingsCommunityEndpoint = new QgsSettingsEntryString( QStringLiteral( "community-endpoint" ), sTreeConnectionArcgis );
+
+
 const QgsSettingsEntryString *QgsOwsConnection::settingsUrl = new QgsSettingsEntryString( QStringLiteral( "url" ), sTreeOwsConnections, QString() ) ;
 const QgsSettingsEntryVariantMap *QgsOwsConnection::settingsHeaders = new QgsSettingsEntryVariantMap( QStringLiteral( "http-header" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsVersion = new QgsSettingsEntryString( QStringLiteral( "version" ), sTreeOwsConnections, QString() ) ;

--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -30,6 +30,8 @@
 #include <QStringList>
 #include <QPushButton>
 
+
+
 /**
  * \ingroup core
  * \brief Connections settingss for XYZ
@@ -51,6 +53,26 @@ class CORE_EXPORT QgsXyzConnectionSettings SIP_SKIP
     static const QgsSettingsEntryString *settingsUsername;
     static const QgsSettingsEntryString *settingsPassword;
     static const QgsSettingsEntryString *settingsAuthcfg;
+};
+
+
+/**
+ * \ingroup core
+ * \brief Connections settingss for Arcgis
+ * \since QGIS 3.30
+ */
+class CORE_EXPORT QgsArcGisConnectionSettings SIP_SKIP
+{
+  public:
+    static inline QgsSettingsTreeNamedListNode *sTreeConnectionArcgis = QgsSettings::sTreeConnections->createNamedListElement( QStringLiteral( "arcgisfeatureserver" ), QgsSettingsTreeNamedListNode::Option::NamedListSelectedItemSetting );
+
+    static const QgsSettingsEntryString *settingsUrl;
+    static const QgsSettingsEntryString *settingsAuthcfg;
+    static const QgsSettingsEntryString *settingsUsername;
+    static const QgsSettingsEntryString *settingsPassword;
+    static const QgsSettingsEntryVariantMap *settingsHeaders;
+    static const QgsSettingsEntryString *settingsContentEndpoint;
+    static const QgsSettingsEntryString *settingsCommunityEndpoint;
 };
 
 

--- a/src/gui/qgsmanageconnectionsdialog.h
+++ b/src/gui/qgsmanageconnectionsdialog.h
@@ -50,7 +50,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
       HANA,
       GeoNode,
       XyzTiles,
-      ArcgisMapServer,
+      ArcgisMapServer, // TODO QGIS 4: remove
       ArcgisFeatureServer,
       VectorTile
     };
@@ -77,7 +77,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     QDomDocument saveHanaConnections( const QStringList &connections );
     QDomDocument saveGeonodeConnections( const QStringList &connections );
     QDomDocument saveXyzTilesConnections( const QStringList &connections );
-    QDomDocument saveArcgisConnections( const QStringList &connections, const QString &service );
+    QDomDocument saveArcgisConnections( const QStringList &connections );
     QDomDocument saveVectorTileConnections( const QStringList &connections );
 
     void loadOWSConnections( const QDomDocument &doc, const QStringList &items, const QString &service );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -29,9 +29,6 @@
 #include "qgsreadwritelocker.h"
 #include "qgsvariantutils.h"
 
-const QString QgsAfsProvider::AFS_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
-const QString QgsAfsProvider::AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Service data provider" );
-
 
 QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &options, QgsDataProvider::ReadFlags flags )
   : QgsVectorDataProvider( uri, options, flags )

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -20,12 +20,13 @@
 
 #include <memory>
 #include "qgsvectordataprovider.h"
-#include "qgsdatasourceuri.h"
 #include "qgsafsshareddata.h"
 #include "qgscoordinatereferencesystem.h"
 #include "geometry/qgswkbtypes.h"
 #include "qgsfields.h"
 #include "qgslayermetadata.h"
+#include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 
 #include "qgsprovidermetadata.h"
 #include "qgshttpheaders.h"
@@ -39,8 +40,8 @@ class QgsAfsProvider : public QgsVectorDataProvider
 
   public:
 
-    static const QString AFS_PROVIDER_KEY;
-    static const QString AFS_PROVIDER_DESCRIPTION;
+    static const inline QString AFS_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
+    static const inline QString AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Service data provider" );
 
     QgsAfsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -139,7 +139,7 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
 
 void QgsArcGisRestDataItemGuiProvider::newConnection( QgsDataItem *item )
 {
-  QgsNewArcGisRestConnectionDialog nc( nullptr, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), QString() );
+  QgsNewArcGisRestConnectionDialog nc( nullptr, QString() );
   nc.setWindowTitle( tr( "Create a New ArcGIS REST Server Connection" ) );
 
   if ( nc.exec() )
@@ -150,7 +150,7 @@ void QgsArcGisRestDataItemGuiProvider::newConnection( QgsDataItem *item )
 
 void QgsArcGisRestDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
-  QgsNewArcGisRestConnectionDialog nc( nullptr, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), item->name() );
+  QgsNewArcGisRestConnectionDialog nc( nullptr, item->name() );
   nc.setWindowTitle( tr( "Modify ArcGIS REST Server Connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -222,7 +222,7 @@ void QgsArcGisRestSourceSelect::refresh()
 
 void QgsArcGisRestSourceSelect::addEntryToServerList()
 {
-  QgsNewArcGisRestConnectionDialog nc( nullptr, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), QString() );
+  QgsNewArcGisRestConnectionDialog nc( nullptr, QString() );
   nc.setWindowTitle( tr( "Create a New ArcGIS REST Server Connection" ) );
 
   if ( nc.exec() )
@@ -234,7 +234,7 @@ void QgsArcGisRestSourceSelect::addEntryToServerList()
 
 void QgsArcGisRestSourceSelect::modifyEntryOfServerList()
 {
-  QgsNewArcGisRestConnectionDialog nc( nullptr, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), cmbConnections->currentText() );
+  QgsNewArcGisRestConnectionDialog nc( nullptr, cmbConnections->currentText() );
   nc.setWindowTitle( tr( "Modify ArcGIS REST Server Connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsarcgisrestsourceselect.h"
 #include "qgsowsconnection.h"
-#include "qgsprojectionselectiondialog.h"
 #include "qgsexpressionbuilderdialog.h"
 #include "qgsproject.h"
 #include "qgscoordinatereferencesystem.h"
@@ -25,7 +24,6 @@
 #include "qgslogger.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgsexception.h"
-#include "qgssettings.h"
 #include "qgsmapcanvas.h"
 #include "qgshelp.h"
 #include "qgsgui.h"
@@ -195,7 +193,7 @@ void QgsArcGisRestSourceSelect::showEvent( QShowEvent * )
 
 void QgsArcGisRestSourceSelect::populateConnectionList()
 {
-  const QStringList conns = QgsOwsConnection::connectionList( QStringLiteral( "ARCGISFEATURESERVER" ) );
+  const QStringList conns = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
   cmbConnections->clear();
   for ( const QString &item : conns )
   {
@@ -207,7 +205,7 @@ void QgsArcGisRestSourceSelect::populateConnectionList()
   btnSave->setEnabled( connectionsAvailable );
 
   //set last used connection
-  const QString selectedConnection = QgsOwsConnection::selectedConnection( QStringLiteral( "ARCGISFEATURESERVER" ) );
+  const QString selectedConnection = QgsArcGisConnectionSettings::sTreeConnectionArcgis->selectedItem();
   const int index = cmbConnections->findText( selectedConnection );
   if ( index != -1 )
   {
@@ -252,7 +250,7 @@ void QgsArcGisRestSourceSelect::deleteEntryOfServerList()
   const QMessageBox::StandardButton result = QMessageBox::question( this, tr( "Confirm Delete" ), msg, QMessageBox::Yes | QMessageBox::No );
   if ( result == QMessageBox::Yes )
   {
-    QgsOwsConnection::deleteConnection( QStringLiteral( "ARCGISFEATURESERVER" ), selectedConnection );
+    QgsArcGisConnectionSettings::sTreeConnectionArcgis->deleteItem( selectedConnection );
     cmbConnections->removeItem( cmbConnections->currentIndex() );
     emit connectionsChanged();
     const bool connectionsAvailable = cmbConnections->count() > 0;
@@ -271,7 +269,6 @@ void QgsArcGisRestSourceSelect::connectToServer()
   btnConnect->setEnabled( false );
 
   mConnectedService = cmbConnections->currentText();
-  const QgsOwsConnection connection( QStringLiteral( "ARCGISFEATURESERVER" ), mConnectedService );
 
   // find index of corresponding node
   if ( mBrowserModel && mProxyModel )
@@ -300,8 +297,6 @@ void QgsArcGisRestSourceSelect::addButtonClicked()
   {
     return;
   }
-
-  const QgsOwsConnection connection( QStringLiteral( "ARCGISFEATURESERVER" ), cmbConnections->currentText() );
 
   const QgsCoordinateReferenceSystem pCrs( labelCoordRefSys->text() );
   // prepare canvas extent info for layers with "cache features" option not set
@@ -410,7 +405,7 @@ void QgsArcGisRestSourceSelect::updateImageEncodings()
 void QgsArcGisRestSourceSelect::cmbConnections_activated( int index )
 {
   Q_UNUSED( index )
-  QgsOwsConnection::setSelectedConnection( QStringLiteral( "ARCGISFEATURESERVER" ), cmbConnections->currentText() );
+  QgsArcGisConnectionSettings::sTreeConnectionArcgis->setSelectedItem( cmbConnections->currentText() );
 }
 
 void QgsArcGisRestSourceSelect::treeWidgetCurrentRowChanged( const QModelIndex &current, const QModelIndex &previous )

--- a/src/providers/arcgisrest/qgsnewarcgisrestconnection.cpp
+++ b/src/providers/arcgisrest/qgsnewarcgisrestconnection.cpp
@@ -16,10 +16,9 @@
  ***************************************************************************/
 #include "qgsnewarcgisrestconnection.h"
 #include "qgsauthsettingswidget.h"
-#include "qgshttpheaderwidget.h"
-#include "qgssettings.h"
 #include "qgshelp.h"
 #include "qgsgui.h"
+#include "qgsowsconnection.h"
 #include "fromencodedcomponenthelper.h"
 
 #include <QMessageBox>
@@ -29,9 +28,8 @@
 #include <QRegularExpressionValidator>
 #include <QUrlQuery>
 
-QgsNewArcGisRestConnectionDialog::QgsNewArcGisRestConnectionDialog( QWidget *parent, const QString &baseKey, const QString &connectionName, Qt::WindowFlags fl )
+QgsNewArcGisRestConnectionDialog::QgsNewArcGisRestConnectionDialog( QWidget *parent, const QString &connectionName, Qt::WindowFlags fl )
   : QDialog( parent, fl )
-  , mBaseKey( baseKey )
   , mOriginalConnName( connectionName )
 {
   setupUi( this );
@@ -40,15 +38,7 @@ QgsNewArcGisRestConnectionDialog::QgsNewArcGisRestConnectionDialog( QWidget *par
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsNewArcGisRestConnectionDialog::showHelp );
 
-  const QRegularExpression rx( QStringLiteral( "/connections-([^/]+)/" ) );
-  const QRegularExpressionMatch match = rx.match( baseKey );
-  if ( match.hasMatch() )
-  {
-    const QString connectionType( match.captured( 1 ).toUpper() );
-    setWindowTitle( tr( "Create a New %1 Connection" ).arg( connectionType ) );
-  }
-
-  mCredentialsBaseKey = mBaseKey.split( '-' ).last().toUpper();
+  setWindowTitle( tr( "Create a New arcgisfeatureserver Connection" ) );
 
   txtName->setValidator( new QRegularExpressionValidator( QRegularExpression( QStringLiteral( "[^\\/]+" ) ), txtName ) );
 
@@ -57,24 +47,19 @@ QgsNewArcGisRestConnectionDialog::QgsNewArcGisRestConnectionDialog( QWidget *par
     // populate the dialog with the information stored for the connection
     // populate the fields with the stored setting parameters
 
-    const QgsSettings settings;
-
-    const QString key = mBaseKey + connectionName;
-    const QString credentialsKey = "qgis/" + mCredentialsBaseKey + '/' + connectionName;
     txtName->setText( connectionName );
-    txtUrl->setText( settings.value( key + "/url" ).toString() );
-    Q_NOWARN_DEPRECATED_PUSH
-    mHttpHeaders->setFromSettings( settings, key );
-    Q_NOWARN_DEPRECATED_POP
+    txtUrl->setText( QgsArcGisConnectionSettings::settingsUrl->value( connectionName ) );
+    mHttpHeaders->setHeaders( QgsHttpHeaders( QgsArcGisConnectionSettings::settingsHeaders->value( connectionName ) ) );
+
 
     // portal
-    mContentEndPointLineEdit->setText( settings.value( key + "/content_endpoint" ).toString() );
-    mCommunityEndPointLineEdit->setText( settings.value( key + "/community_endpoint" ).toString() );
+    mContentEndPointLineEdit->setText( QgsArcGisConnectionSettings::settingsContentEndpoint->value( connectionName ) );
+    mCommunityEndPointLineEdit->setText( QgsArcGisConnectionSettings::settingsCommunityEndpoint->value( connectionName ) );
 
     // Authentication
-    mAuthSettings->setUsername( settings.value( credentialsKey + "/username" ).toString() );
-    mAuthSettings->setPassword( settings.value( credentialsKey + "/password" ).toString() );
-    mAuthSettings->setConfigId( settings.value( credentialsKey + "/authcfg" ).toString() );
+    mAuthSettings->setUsername( QgsArcGisConnectionSettings::settingsUsername->value( connectionName ) );
+    mAuthSettings->setPassword( QgsArcGisConnectionSettings::settingsPassword->value( connectionName ) );
+    mAuthSettings->setConfigId( QgsArcGisConnectionSettings::settingsAuthcfg->value( connectionName ) );
   }
 
   // Adjust height
@@ -122,15 +107,15 @@ void QgsNewArcGisRestConnectionDialog::updateOkButtonState()
 
 bool QgsNewArcGisRestConnectionDialog::validate()
 {
-  const QgsSettings settings;
-  const QString key = mBaseKey + txtName->text();
+  const QString newName = txtName->text();
+  bool newNameAlreadyExists = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items().contains( newName );
 
   // warn if entry was renamed to an existing connection
-  if ( ( mOriginalConnName.isNull() || mOriginalConnName.compare( txtName->text(), Qt::CaseInsensitive ) != 0 ) &&
-       settings.contains( key + "/url" ) &&
+  if ( ( mOriginalConnName.isNull() || mOriginalConnName.compare( newName, Qt::CaseInsensitive ) != 0 ) &&
+       newNameAlreadyExists &&
        QMessageBox::question( this,
                               tr( "Save Connection" ),
-                              tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
+                              tr( "Should the existing connection '%1' be overwritten?" ).arg( newName ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return false;
@@ -170,37 +155,31 @@ QUrl QgsNewArcGisRestConnectionDialog::urlTrimmed() const
 
 void QgsNewArcGisRestConnectionDialog::accept()
 {
-  QgsSettings settings;
-  const QString key = mBaseKey + txtName->text();
-  const QString credentialsKey = "qgis/" + mCredentialsBaseKey + '/' + txtName->text();
+  const QString newName = txtName->text();
 
   if ( !validate() )
     return;
 
   // on rename delete original entry first
-  if ( !mOriginalConnName.isNull() && mOriginalConnName != key )
+  if ( !mOriginalConnName.isNull() && mOriginalConnName != newName )
   {
-    settings.remove( mBaseKey + mOriginalConnName );
-    settings.remove( "qgis/" + mCredentialsBaseKey + '/' + mOriginalConnName );
-    settings.sync();
+    QgsArcGisConnectionSettings::sTreeConnectionArcgis->deleteItem( mOriginalConnName );
   }
 
   const QUrl url( urlTrimmed() );
-  settings.setValue( key + "/url", url.toString() );
+  QgsArcGisConnectionSettings::settingsUrl->setValue( url.toString(), newName );
 
-  settings.setValue( credentialsKey + "/username", mAuthSettings->username() );
-  settings.setValue( credentialsKey + "/password", mAuthSettings->password() );
+  QgsArcGisConnectionSettings::settingsUsername->setValue( mAuthSettings->username(), newName );
+  QgsArcGisConnectionSettings::settingsPassword->setValue( mAuthSettings->password(), newName );
 
-  settings.setValue( key + "/content_endpoint", mContentEndPointLineEdit->text() );
-  settings.setValue( key + "/community_endpoint", mCommunityEndPointLineEdit->text() );
+  QgsArcGisConnectionSettings::settingsContentEndpoint->setValue( mContentEndPointLineEdit->text(), newName );
+  QgsArcGisConnectionSettings::settingsCommunityEndpoint->setValue( mCommunityEndPointLineEdit->text(), newName );
 
-  settings.setValue( credentialsKey + "/authcfg", mAuthSettings->configId() );
+  QgsArcGisConnectionSettings::settingsAuthcfg->setValue( mAuthSettings->configId(), newName );
 
-  Q_NOWARN_DEPRECATED_PUSH
-  mHttpHeaders->updateSettings( settings, key );
-  Q_NOWARN_DEPRECATED_POP
+  QgsArcGisConnectionSettings::settingsHeaders->setValue( mHttpHeaders->httpHeaders().headers(), newName );
 
-  settings.setValue( mBaseKey + "/selected", txtName->text() );
+  QgsArcGisConnectionSettings::sTreeConnectionArcgis->setSelectedItem( newName );
 
   QDialog::accept();
 }

--- a/src/providers/arcgisrest/qgsnewarcgisrestconnection.h
+++ b/src/providers/arcgisrest/qgsnewarcgisrestconnection.h
@@ -39,7 +39,6 @@ class QgsNewArcGisRestConnectionDialog : public QDialog, private Ui::QgsNewArcGi
      * Constructor for QgsNewArcGisRestConnectionDialog.
      */
     QgsNewArcGisRestConnectionDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr,
-                                      const QString &baseKey = "qgis/connections-wms/",
                                       const QString &connectionName = QString(),
                                       Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
@@ -77,9 +76,6 @@ class QgsNewArcGisRestConnectionDialog : public QDialog, private Ui::QgsNewArcGi
     QUrl urlTrimmed() const SIP_SKIP;
 
   private:
-
-    QString mBaseKey;
-    QString mCredentialsBaseKey;
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();
 


### PR DESCRIPTION
migrate settings for Arcgis connections to new structure

if I understood well the current code, all settings were moved from using  both `arcgismapserver` and `arcgisfeatureserver` keys to only `arcgisfeatureserver`.

