### PR TITLE
[GDAL provider] Minimal support for GDT_Int8 of GDAL 3.7.0

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -1429,6 +1429,16 @@ double QgsGdalProvider::sample( const QgsPointXY &point, int band, bool *ok, con
   const GDALDataType dataType {GDALGetRasterDataType( hBand )};
   switch ( dataType )
   {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+    case GDT_Int8:
+    {
+      int8_t tempVal{0};
+      err = GDALRasterIO( hBand, GF_Read, col, row, 1, 1,
+                          &tempVal, 1, 1, dataType, 0, 0 );
+      value = static_cast<double>( tempVal );
+      break;
+    }
+#endif
     case GDT_Byte:
     {
       unsigned char tempVal{0};
@@ -3567,6 +3577,9 @@ void QgsGdalProvider::initBaseDataset()
         case GDT_Unknown:
         case GDT_TypeCount:
           break;
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+        case GDT_Int8:
+#endif
         case GDT_Byte:
         case GDT_UInt16:
         case GDT_Int16:
@@ -3590,6 +3603,12 @@ void QgsGdalProvider::initBaseDataset()
       }
     }
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+    if ( myGdalDataType == GDT_Int8 )
+    {
+      myGdalDataType = GDT_Int16;
+    }
+#endif
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
     if ( myGdalDataType == GDT_Int64 || myGdalDataType == GDT_UInt64 )
     {
@@ -3665,6 +3684,10 @@ bool QgsGdalProvider::write( void *data, int band, int width, int height, int xO
     return false;
   }
   GDALDataType gdalDataType = GDALGetRasterDataType( rasterBand );
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+  if ( gdalDataType == GDT_Int8 )
+    gdalDataType = GDT_Int16;
+#endif
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
   if ( gdalDataType == GDT_Int64 || gdalDataType == GDT_UInt64 )
     gdalDataType = GDT_Float64;

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -152,6 +152,11 @@ Qgis::DataType QgsGdalProviderBase::dataTypeFromGdal( const GDALDataType gdalDat
 {
   switch ( gdalDataType )
   {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+    case GDT_Int8:
+      // Promote to Int16 due to lack of native Qgis data type for Int8
+      return Qgis::DataType::Int16;
+#endif
     case GDT_Byte:
       return Qgis::DataType::Byte;
     case GDT_UInt16:


### PR DESCRIPTION
Fixes #50907

GDAL 3.7.0 brings GDT_Int8, which triggers compiler warnings in QGIS due to those new enumeration values not being handled.

We do a minimal handling of them, by exposing them as QGIS Int16 rasters

A more ambitious fix would be to add proper Int8 support to QGIS.
