### PR TITLE
Audio/video support for the attribute form's attachments editor widget

### DIFF
--- a/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
@@ -42,7 +42,9 @@ It can also be used to display a picture or a web page.
     {
       NoContent,
       Image,
-      Web
+      Web,
+      Audio,
+      Video,
     };
 
     explicit QgsExternalResourceWidget( QWidget *parent /TransferThis/ = 0 );

--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1027,6 +1027,10 @@ QSlider::handle:horizontal:focus, QSlider::handle:vertical:focus {
     border: 1px solid @focus;
 }
 
+QVideoWidget QWidget {
+    background-color: #000000 !important;
+}
+
 /* ==================================================================================== */
 /* QGIS-SPECIFIC TWEAKS                                                                 */
 /* ==================================================================================== */

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1053,6 +1053,10 @@ QSlider::handle:horizontal:focus, QSlider::handle:vertical:focus {
     border: 1px solid @focus;
 }
 
+QVideoWidget QWidget {
+    background-color: #000000 !important;
+}
+
 /* ==================================================================================== */
 /* QGIS-SPECIFIC TWEAKS                                                                 */
 /* ==================================================================================== */

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
@@ -28,7 +28,7 @@ const QgsPropertiesDefinition &QgsWidgetWrapper::propertyDefinitions()
     properties =
     {
       { RootPath, QgsPropertyDefinition( "propertyRootPath", QgsPropertyDefinition::DataTypeString, QObject::tr( "Root path" ), QObject::tr( "string of variable length representing root path to attachment" ) ) },
-      { DocumentViewerContent, QgsPropertyDefinition( "documentViewerContent", QgsPropertyDefinition::DataTypeString, QObject::tr( "Document viewer content" ), QObject::tr( "string" ) + "<b>NoContent</b>|<b>Image</b>|<b>Web</b>" ) },
+      { DocumentViewerContent, QgsPropertyDefinition( "documentViewerContent", QgsPropertyDefinition::DataTypeString, QObject::tr( "Document viewer content" ), QObject::tr( "string" ) + "<b>NoContent</b>|<b>Image</b>|<b>Audio</b>|<b>Video</b>|<b>Web</b>" ) },
       { StorageUrl, QgsPropertyDefinition( "storageUrl", QgsPropertyDefinition::DataTypeString, QObject::tr( "Storage Url" ), QObject::tr( "String of variable length representing the URL used to store document with an external storage" ) ) }
     };
   }

--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -96,14 +96,20 @@ QgsExternalResourceConfigDlg::QgsExternalResourceConfigDlg( QgsVectorLayer *vl, 
   connect( mStorageModeCbx, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mStoragePathCbx, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mDocumentViewerGroupBox, &QGroupBox::toggled, this, &QgsEditorConfigWidget::changed );
-  connect( mDocumentViewerContentComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),  this, [ = ]( int idx )
-  { mDocumentViewerContentSettingsWidget->setEnabled( ( QgsExternalResourceWidget::DocumentViewerContent )idx != QgsExternalResourceWidget::NoContent ); } );
+  connect( mDocumentViewerContentComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),  this, [ = ]( int )
+  {
+    const QgsExternalResourceWidget::DocumentViewerContent content = static_cast<QgsExternalResourceWidget::DocumentViewerContent>( mDocumentViewerContentComboBox->currentData().toInt() );
+    const bool hasSizeSettings = ( content != QgsExternalResourceWidget::NoContent && content != QgsExternalResourceWidget::Audio );
+    mDocumentViewerContentSettingsWidget->setEnabled( hasSizeSettings );
+  } );
   connect( mDocumentViewerHeight, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mDocumentViewerWidth, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mStorageUrlExpression, &QLineEdit::textChanged, this, &QgsEditorConfigWidget::changed );
 
   mDocumentViewerContentComboBox->addItem( tr( "No Content" ), QgsExternalResourceWidget::NoContent );
   mDocumentViewerContentComboBox->addItem( tr( "Image" ), QgsExternalResourceWidget::Image );
+  mDocumentViewerContentComboBox->addItem( tr( "Audio" ), QgsExternalResourceWidget::Audio );
+  mDocumentViewerContentComboBox->addItem( tr( "Video" ), QgsExternalResourceWidget::Video );
   mDocumentViewerContentComboBox->addItem( tr( "Web View" ), QgsExternalResourceWidget::Web );
 }
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -104,6 +104,14 @@ void QgsExternalResourceWidgetWrapper::updateProperties( const QgsFeature &featu
         {
           dvc = QgsExternalResourceWidget::Image;
         }
+        else if ( dvcString.compare( QLatin1String( "audio" ), Qt::CaseInsensitive ) == 0 )
+        {
+          dvc = QgsExternalResourceWidget::Audio;
+        }
+        else if ( dvcString.compare( QLatin1String( "video" ), Qt::CaseInsensitive ) == 0 )
+        {
+          dvc = QgsExternalResourceWidget::Video;
+        }
         else if ( dvcString.compare( QLatin1String( "web" ), Qt::CaseInsensitive ) == 0 )
         {
           dvc = QgsExternalResourceWidget::Web;

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -19,6 +19,7 @@
 
 class QWebView;
 class QgsPixmapLabel;
+class QgsMediaWidget;
 class QgsMessageBar;
 class QgsExternalStorageFileWidget;
 class QgsExternalStorageFetchedContent;
@@ -74,7 +75,9 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
     {
       NoContent,
       Image,
-      Web
+      Web,
+      Audio, // since QGIS 3.30
+      Video, // since QGIS 3.30
     };
 
     /**
@@ -217,9 +220,11 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
 
     //! properties
     bool mFileWidgetVisible = true;
+
     DocumentViewerContent mDocumentViewerContent = NoContent;
     int mDocumentViewerHeight = 0;
     int mDocumentViewerWidth = 0;
+
     QgsFileWidget::RelativeStorage mRelativeStorage = QgsFileWidget::Absolute;
     QString mDefaultRoot; // configured default root path for QgsFileWidget::RelativeStorage::RelativeDefaultPath
 
@@ -230,6 +235,8 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
     //! This webview is used as a container to display the picture
     QWebView *mWebView = nullptr;
 #endif
+    QgsMediaWidget *mMediaWidget = nullptr;
+
     QLabel *mLoadingLabel = nullptr;
     QLabel *mErrorLabel = nullptr;
     QMovie *mLoadingMovie = nullptr;

--- a/tests/src/gui/testqgsexternalresourcewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsexternalresourcewidgetwrapper.cpp
@@ -22,6 +22,7 @@
 #include "qgsexternalstorage.h"
 #include "qgsexternalstorageregistry.h"
 #include "qgspixmaplabel.h"
+#include "qgsmediawidget.h"
 #include "qgsmessagebar.h"
 #include "qgsexternalstoragefilewidget.h"
 
@@ -336,6 +337,8 @@ void TestQgsExternalResourceWidgetWrapper::testLoadExternalDocument_data()
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -377,6 +380,14 @@ void TestQgsExternalResourceWidgetWrapper::testLoadExternalDocument()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
@@ -524,6 +535,8 @@ void TestQgsExternalResourceWidgetWrapper::testLoadNullExternalDocument_data()
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -563,6 +576,14 @@ void TestQgsExternalResourceWidgetWrapper::testLoadNullExternalDocument()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
@@ -613,6 +634,8 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocument_data()
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -663,6 +686,14 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocument()
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
   }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
   {
@@ -707,6 +738,8 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentError_data()
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -755,6 +788,14 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentError()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
@@ -818,6 +859,8 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentCancel_data(
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -866,6 +909,14 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentCancel()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
@@ -931,6 +982,8 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentNoExpression
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -978,6 +1031,14 @@ void TestQgsExternalResourceWidgetWrapper::testStoreExternalDocumentNoExpression
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
   }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
   {
@@ -1020,6 +1081,8 @@ void TestQgsExternalResourceWidgetWrapper::testChangeValueBeforeLoaded_data()
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -1062,6 +1125,14 @@ void TestQgsExternalResourceWidgetWrapper::testChangeValueBeforeLoaded()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )
@@ -1197,6 +1268,8 @@ void TestQgsExternalResourceWidgetWrapper::testChangeValueToNullBeforeLoaded_dat
   QTest::addColumn<int>( "documentType" );
 
   QTest::newRow( "image" ) << static_cast<int>( QgsExternalResourceWidget::Image );
+  QTest::newRow( "audio" ) << static_cast<int>( QgsExternalResourceWidget::Audio );
+  QTest::newRow( "video" ) << static_cast<int>( QgsExternalResourceWidget::Video );
 #ifdef WITH_QTWEBKIT
   QTest::newRow( "webview" ) << static_cast<int>( QgsExternalResourceWidget::Web );
 #endif
@@ -1239,6 +1312,14 @@ void TestQgsExternalResourceWidgetWrapper::testChangeValueToNullBeforeLoaded()
 #else
     QVERIFY( ww.mQgsWidget->mPixmapLabel->pixmap( Qt::ReturnByValue ).isNull() );
 #endif
+  }
+  else if ( documentType == QgsExternalResourceWidget::Audio )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
+  }
+  else if ( documentType == QgsExternalResourceWidget::Video )
+  {
+    QVERIFY( ww.mQgsWidget->mMediaWidget->isVisible() );
   }
 #ifdef WITH_QTWEBKIT
   else if ( documentType == QgsExternalResourceWidget::Web )


### PR DESCRIPTION
## Description

This PR implements an audio and video viewer to the external resources widget (aka attributes form' Attachments widget):

![image](https://user-images.githubusercontent.com/1728657/214749668-3f6d2a0e-1c78-4998-9fbd-5efbe8168d6e.png)

Configuration-wise, two new items in the integrated viewer type combo box are now available:

![image](https://user-images.githubusercontent.com/1728657/214749811-83008d99-52e2-4343-8bf3-1432aad6da6e.png)

The video type will take into consideration the height set by the user. If it's left to auto, the video widget will grow to fill available space.

_(The PR temporarily includes https://github.com/qgis/QGIS/pull/51579 , I will rebase when that is merged)_