### PR TITLE
In data source manager, allow users to directly add an XYZ   tile layer without having to create a connection first

### DIFF
--- a/python/gui/auto_generated/qgsprovidersourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsprovidersourcewidget.sip.in
@@ -65,6 +65,13 @@ If ``isValid`` is ``False`` then the widget is not valid, and any dialog using t
 being accepted.
 %End
 
+    void changed();
+%Docstring
+Emitted whenever the configuration of the widget changes.
+
+.. versionadded:: 3.30
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/gui/qgsprovidersourcewidget.h
+++ b/src/gui/qgsprovidersourcewidget.h
@@ -78,6 +78,13 @@ class GUI_EXPORT QgsProviderSourceWidget : public QWidget
      */
     void validChanged( bool isValid );
 
+    /**
+     * Emitted whenever the configuration of the widget changes.
+     *
+     * \since QGIS 3.30
+     */
+    void changed();
+
   private:
     QgsMapCanvas *mMapCanvas = nullptr;
 

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -36,6 +36,8 @@ QgsVectorTileSourceSelect::QgsVectorTileSourceSelect( QWidget *parent, Qt::Windo
 {
   setupUi( this );
 
+  mConnectionDetailsGroupBox->hide();
+
   setWindowTitle( tr( "Add Vector Tile Layer" ) );
   mConnectionsGroupBox->setTitle( tr( "Vector Tile Connections" ) );
 

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -35,6 +35,8 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     QgsXyzConnection connection() const;
 
+    QgsXyzSourceWidget *sourceWidget() { return mSourceWidget; }
+
     void accept() override;
 
   private slots:

--- a/src/providers/wms/qgsxyzsourceselect.cpp
+++ b/src/providers/wms/qgsxyzsourceselect.cpp
@@ -22,6 +22,7 @@
 #include "qgsxyzconnection.h"
 #include "qgsxyzconnectiondialog.h"
 #include "qgsowsconnection.h"
+#include "qgsxyzsourcewidget.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -34,6 +35,23 @@ QgsXyzSourceSelect::QgsXyzSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   setWindowTitle( tr( "Add XYZ Layer" ) );
   mConnectionsGroupBox->setTitle( tr( "XYZ Connections" ) );
+
+  mSourceWidget = new QgsXyzSourceWidget();
+  QHBoxLayout *hlayout = new QHBoxLayout();
+  hlayout->setContentsMargins( 0, 0, 0, 0 );
+  hlayout->addWidget( mSourceWidget );
+  mSourceContainerWidget->setLayout( hlayout );
+
+  connect( mSourceWidget, &QgsProviderSourceWidget::validChanged, this, &QgsXyzSourceSelect::enableButtons );
+  connect( mSourceWidget, &QgsProviderSourceWidget::changed, this, [this]
+  {
+    if ( mBlockChanges )
+      return;
+
+    mBlockChanges++;
+    cmbConnections->setCurrentIndex( cmbConnections->findData( QStringLiteral( "~~custom~~" ) ) );
+    mBlockChanges--;
+  } );
 
   QgsGui::enableAutoGeometryRestore( this );
 
@@ -50,10 +68,19 @@ QgsXyzSourceSelect::QgsXyzSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
 void QgsXyzSourceSelect::btnNew_clicked()
 {
+  const bool isCustom = cmbConnections->currentData().toString() == QLatin1String( "~~custom~~" );
+
   QgsXyzConnectionDialog nc( this );
+  if ( isCustom )
+  {
+    // when creating a new connection, default to the current connection parameters
+    nc.sourceWidget()->setSourceUri( mSourceWidget->sourceUri() );
+  }
   if ( nc.exec() )
   {
     QgsXyzConnectionUtils::addConnection( nc.connection() );
+
+    QgsXyzConnectionSettings::sTreeXyzConnections->setSelectedItem( nc.connection().name );
     populateConnectionList();
     emit connectionsChanged();
   }
@@ -106,20 +133,19 @@ void QgsXyzSourceSelect::btnLoad_clicked()
 
 void QgsXyzSourceSelect::addButtonClicked()
 {
-  emit addRasterLayer( QgsXyzConnectionUtils::connection( cmbConnections->currentText() ).encodedUri(), cmbConnections->currentText(), QStringLiteral( "wms" ) );
+  const bool isCustom = cmbConnections->currentData().toString() == QLatin1String( "~~custom~~" );
+  emit addRasterLayer( mSourceWidget->sourceUri(), isCustom ? tr( "XYZ Layer" ) : cmbConnections->currentText(), QStringLiteral( "wms" ) );
 }
 
 void QgsXyzSourceSelect::populateConnectionList()
 {
   cmbConnections->blockSignals( true );
   cmbConnections->clear();
+  cmbConnections->addItem( tr( "Custom" ), QStringLiteral( "~~custom~~" ) );
   cmbConnections->addItems( QgsXyzConnectionUtils::connectionList() );
   cmbConnections->blockSignals( false );
 
-  btnEdit->setDisabled( cmbConnections->count() == 0 );
-  btnDelete->setDisabled( cmbConnections->count() == 0 );
-  btnSave->setDisabled( cmbConnections->count() == 0 );
-  cmbConnections->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 1 );
 
   setConnectionListPosition();
 }
@@ -138,13 +164,32 @@ void QgsXyzSourceSelect::setConnectionListPosition()
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
   }
 
-  emit enableButtons( !cmbConnections->currentText().isEmpty() );
+  const bool isCustom = cmbConnections->currentData().toString() == QLatin1String( "~~custom~~" );
+  btnEdit->setDisabled( isCustom );
+  btnDelete->setDisabled( isCustom );
 }
 
 void QgsXyzSourceSelect::cmbConnections_currentTextChanged( const QString &text )
 {
   QgsXyzConnectionSettings::sTreeXyzConnections->setSelectedItem( text );
-  emit enableButtons( !text.isEmpty() );
+
+  const bool isCustom = cmbConnections->currentData().toString() == QLatin1String( "~~custom~~" );
+  btnEdit->setDisabled( isCustom );
+  btnDelete->setDisabled( isCustom );
+
+  if ( !mBlockChanges )
+  {
+    mBlockChanges++;
+    if ( isCustom )
+    {
+      mSourceWidget->setSourceUri( QString() );
+    }
+    else
+    {
+      mSourceWidget->setSourceUri( QgsXyzConnectionUtils::connection( cmbConnections->currentText() ).encodedUri() );
+    }
+    mBlockChanges--;
+  }
 }
 
 void QgsXyzSourceSelect::showHelp()

--- a/src/providers/wms/qgsxyzsourceselect.h
+++ b/src/providers/wms/qgsxyzsourceselect.h
@@ -21,6 +21,8 @@
 #include "qgsabstractdatasourcewidget.h"
 #include "ui_qgstilesourceselectbase.h"
 
+class QgsXyzSourceWidget;
+
 /*!
  * \brief   Dialog to create connections to XYZ servers.
  *
@@ -60,6 +62,9 @@ class QgsXyzSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsTi
     void populateConnectionList();
     void setConnectionListPosition();
     void showHelp();
+
+    QgsXyzSourceWidget *mSourceWidget = nullptr;
+    int mBlockChanges = 0;
 };
 
 #endif // QGSXYZSOURCESELECT_H

--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -32,8 +32,22 @@ QgsXyzSourceWidget::QgsXyzSourceWidget( QWidget *parent )
   mSpinZMax->setClearValue( 18 );
 
   connect( mEditUrl, &QLineEdit::textChanged, this, &QgsXyzSourceWidget::validate );
+  connect( mEditUrl, &QLineEdit::textChanged, this, &QgsProviderSourceWidget::changed );
+
+  connect( mCheckBoxZMin, &QCheckBox::toggled, this, &QgsProviderSourceWidget::changed );
+  connect( mSpinZMin, qOverload< int >( &QSpinBox::valueChanged ), this, &QgsProviderSourceWidget::changed );
+  connect( mCheckBoxZMax, &QCheckBox::toggled, this, &QgsProviderSourceWidget::changed );
+  connect( mSpinZMax, qOverload< int >( &QSpinBox::valueChanged ), this, &QgsProviderSourceWidget::changed );
+  connect( mAuthSettings, &QgsAuthSettingsWidget::configIdChanged, this, &QgsProviderSourceWidget::changed );
+  connect( mAuthSettings, &QgsAuthSettingsWidget::usernameChanged, this, &QgsProviderSourceWidget::changed );
+  connect( mAuthSettings, &QgsAuthSettingsWidget::passwordChanged, this, &QgsProviderSourceWidget::changed );
+  connect( mEditReferer, &QLineEdit::textChanged, this, &QgsProviderSourceWidget::changed );
+  connect( mComboTileResolution, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsProviderSourceWidget::changed );
+
   mInterpretationCombo = new QgsWmsInterpretationComboBox( this );
   mInterpretationLayout->addWidget( mInterpretationCombo );
+
+  connect( mInterpretationCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsProviderSourceWidget::changed );
 }
 
 void QgsXyzSourceWidget::setSourceUri( const QString &uri )

--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -19,8 +19,6 @@
 #include "qgswmssourceselect.h"
 #include "qgsproviderregistry.h"
 
-#include "qgswmsprovider.h"
-
 QgsXyzSourceWidget::QgsXyzSourceWidget( QWidget *parent )
   : QgsProviderSourceWidget( parent )
 {

--- a/src/ui/qgstilesourceselectbase.ui
+++ b/src/ui/qgstilesourceselectbase.ui
@@ -7,10 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>558</width>
-    <height>166</height>
+    <height>259</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="mConnectionsGroupBox">
      <property name="title">
@@ -95,14 +105,16 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Connection Details</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QWidget" name="mSourceContainerWidget" native="true"/>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="2" column="0">

--- a/src/ui/qgstilesourceselectbase.ui
+++ b/src/ui/qgstilesourceselectbase.ui
@@ -106,7 +106,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="mConnectionDetailsGroupBox">
      <property name="title">
       <string>Connection Details</string>
      </property>


### PR DESCRIPTION
This permits users to easily add ad-hoc XYZ layers to their map without polluting their lists of saved connections with entries for these.

(Selecting from a saved connection fills the XYZ options with their saved values from the connection)


https://user-images.githubusercontent.com/1829991/214993441-70d5f210-b481-4d8e-8921-c1439d016f7e.mp4

