### PR TITLE
Allow layout elevation profile items to use the atlas feature as the source of the profile curve

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemelevationprofile.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemelevationprofile.sip.in
@@ -139,6 +139,8 @@ Returns whether the profile curve is set to follow the current atlas feature.
 %Docstring
 Sets whether the profile curve will follow the current atlas feature.
 
+This requires an active layout atlas or report, using a line geometry type coverage layer.
+
 .. seealso:: :py:func:`atlasDriven`
 %End
 

--- a/python/core/auto_generated/layout/qgslayoutitemelevationprofile.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemelevationprofile.sip.in
@@ -128,6 +128,20 @@ ignore this tolerance if it is not appropriate for the particular source.
 .. seealso:: :py:func:`setTolerance`
 %End
 
+    bool atlasDriven() const;
+%Docstring
+Returns whether the profile curve is set to follow the current atlas feature.
+
+.. seealso:: :py:func:`setAtlasDriven`
+%End
+
+    void setAtlasDriven( bool enabled );
+%Docstring
+Sets whether the profile curve will follow the current atlas feature.
+
+.. seealso:: :py:func:`atlasDriven`
+%End
+
     QgsProfileRequest profileRequest() const;
 %Docstring
 Returns the profile request used to generate the elevation profile.

--- a/src/core/layout/qgslayoutitemelevationprofile.h
+++ b/src/core/layout/qgslayoutitemelevationprofile.h
@@ -154,6 +154,8 @@ class CORE_EXPORT QgsLayoutItemElevationProfile: public QgsLayoutItem
     /**
      * Sets whether the profile curve will follow the current atlas feature.
      *
+     * This requires an active layout atlas or report, using a line geometry type coverage layer.
+     *
      * \see atlasDriven()
      */
     void setAtlasDriven( bool enabled );

--- a/src/core/layout/qgslayoutitemelevationprofile.h
+++ b/src/core/layout/qgslayoutitemelevationprofile.h
@@ -145,6 +145,20 @@ class CORE_EXPORT QgsLayoutItemElevationProfile: public QgsLayoutItem
     double tolerance() const;
 
     /**
+     * Returns whether the profile curve is set to follow the current atlas feature.
+
+     * \see setAtlasDriven()
+     */
+    bool atlasDriven() const { return mAtlasDriven; }
+
+    /**
+     * Sets whether the profile curve will follow the current atlas feature.
+     *
+     * \see atlasDriven()
+     */
+    void setAtlasDriven( bool enabled );
+
+    /**
      * Returns the profile request used to generate the elevation profile.
      */
     QgsProfileRequest profileRequest() const;
@@ -173,6 +187,7 @@ class CORE_EXPORT QgsLayoutItemElevationProfile: public QgsLayoutItem
 
     QgsCoordinateReferenceSystem mCrs;
     std::unique_ptr< QgsCurve> mCurve;
+    bool mAtlasDriven = false;
 
     double mTolerance = 0;
 
@@ -190,6 +205,7 @@ class CORE_EXPORT QgsLayoutItemElevationProfile: public QgsLayoutItem
     std::unique_ptr< QPainter > mPainter;
     std::unique_ptr< QgsProfilePlotRenderer > mRenderJob;
     bool mPainterCancelWait = false;
+
 
 };
 

--- a/src/gui/layout/qgslayoutelevationprofilewidget.h
+++ b/src/gui/layout/qgslayoutelevationprofilewidget.h
@@ -48,6 +48,7 @@ class GUI_EXPORT QgsLayoutElevationProfileWidget: public QgsLayoutItemBaseWidget
     void setMasterLayout( QgsMasterLayoutInterface *masterLayout ) override;
     QgsExpressionContext createExpressionContext() const override;
     void setDesignerInterface( QgsLayoutDesignerInterface *iface ) override;
+    void setReportTypeString( const QString &string ) override;
 
     /**
      * Copies selected settings from a elevation profile \a canvas.
@@ -64,6 +65,8 @@ class GUI_EXPORT QgsLayoutElevationProfileWidget: public QgsLayoutItemBaseWidget
 
     void setGuiElementValues();
     void updateItemLayers();
+    void layoutAtlasToggled( bool atlasEnabled );
+    void atlasLayerChanged( QgsVectorLayer *layer );
 
   private:
 

--- a/src/ui/layout/qgslayoutelevationprofilewidgetbase.ui
+++ b/src/ui/layout/qgslayoutelevationprofilewidgetbase.ui
@@ -79,7 +79,7 @@
         <x>0</x>
         <y>0</y>
         <width>548</width>
-        <height>1345</height>
+        <height>1375</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -111,10 +111,10 @@
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="groupChartRanges_2">
          <property name="title">
-          <string>Profile Settings</string>
+          <string>Profile Curve</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,2,0">
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QgsDoubleSpinBox" name="mSpinTolerance">
             <property name="decimals">
              <number>6</number>
@@ -124,17 +124,24 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_27">
+            <property name="text">
+             <string>Tolerance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
            <widget class="QgsPropertyOverrideButton" name="mDDBtnTolerance">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_27">
+          <item row="0" column="0" colspan="3">
+           <widget class="QCheckBox" name="mCheckControlledByAtlas">
             <property name="text">
-             <string>Tolerance</string>
+             <string>Controlled by atlas</string>
             </property>
            </widget>
           </item>
@@ -746,15 +753,21 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -767,12 +780,6 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
@@ -782,6 +789,7 @@
   <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Requires a line geometry type for the atlas layer

Temporarily includes https://github.com/qgis/QGIS/pull/51577

Now you can make beautiful atlas' including elevation profiles!

![image](https://user-images.githubusercontent.com/1829991/215012048-b71453e4-8f8e-4e99-bf3f-308280ad4376.png)


