### PR TITLE
Fix SLD loading when using external graphic raster image fill

### DIFF
--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -943,6 +943,14 @@ Creates a new QgsRasterFillSymbolLayer from a ``properties`` map. The caller tak
 ownership of the returned object.
 %End
 
+    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+%Docstring
+Creates a new QgsRasterFillSymbolLayer from a SLD ``element``. The caller takes
+ownership of the returned object.
+
+.. versionadded:: 3.30
+%End
+
     static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -437,7 +437,21 @@ Creates a symbol layer list from a DOM ``element``.
 %Docstring
 Converts a polygon symbolizer ``element`` to a list of marker symbol layers.
 %End
+
     static bool hasExternalGraphic( QDomElement &element );
+%Docstring
+Checks if ``element`` contains an ExternalGraphic element with format "image/svg+xml"
+@return ``True`` if the ExternalGraphic with format "image/svg+xml" is found .
+%End
+
+    static bool hasExternalGraphicV2( QDomElement &element, const QString format = QString() );
+%Docstring
+Checks if ``element`` contains an ExternalGraphic element with optionally specified ``format``.
+@return ``True`` if the ExternalGraphic format is found with the optionally specified format.
+
+.. versionadded:: 3.30
+%End
+
     static bool hasWellKnownMark( QDomElement &element );
 
     static bool needFontMarker( QDomElement &element );
@@ -447,6 +461,14 @@ Converts a polygon symbolizer ``element`` to a list of marker symbol layers.
     static bool needLinePatternFill( QDomElement &element );
     static bool needPointPatternFill( QDomElement &element );
     static bool needSvgFill( QDomElement &element );
+
+    static bool needRasterImageFill( QDomElement &element );
+%Docstring
+Checks if ``element`` contains a graphic fill with a raster image of type PNG, JPEG or GIF.
+@return ``True`` if element contains a graphic fill with a raster image.
+
+.. versionadded:: 3.30
+%End
 
     static void fillToSld( QDomDocument &doc, QDomElement &element,
                            Qt::BrushStyle brushStyle, const QColor &color = QColor() );

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -446,8 +446,8 @@ Checks if ``element`` contains an ExternalGraphic element with format "image/svg
 
     static bool hasExternalGraphicV2( QDomElement &element, const QString format = QString() );
 %Docstring
-Checks if ``element`` contains an ExternalGraphic element with optionally specified ``format``.
-@return ``True`` if the ExternalGraphic format is found with the optionally specified format.
+Checks if ``element`` contains an ExternalGraphic element, if the optional ``format`` is specified it will also be checked.
+@return ``True`` if the ExternalGraphic element is found and the optionally specified format matches.
 
 .. versionadded:: 3.30
 %End

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -4416,6 +4416,20 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPatternImage() const
   int distanceXPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDistanceX, mDistanceXUnit, {} ) ) };
   int distanceYPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDistanceY, mDistanceYUnit, {} ) ) };
 
+  const int displacementXPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDisplacementX, mDisplacementXUnit, {} ) ) };
+  const int displacementYPx { static_cast<int>( QgsSymbolLayerUtils::rescaleUom( mDisplacementY, mDisplacementYUnit, {} ) ) };
+
+  // Consider displacement, double the distance.
+  if ( displacementXPx != 0 )
+  {
+    distanceXPx *= 2;
+  }
+
+  if ( displacementYPx != 0 )
+  {
+    distanceYPx *= 2;
+  }
+
   const QSize size { QgsSymbolLayerUtils::tileSize( distanceXPx, distanceYPx, angleRads ) };
 
   QPixmap pixmap( size );
@@ -4433,6 +4447,10 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPatternImage() const
   std::unique_ptr< QgsPointPatternFillSymbolLayer > layerClone( clone() );
 
   layerClone->setAngle( qRadiansToDegrees( angleRads ) );
+
+  // No way we can export a random pattern, disable it.
+  layerClone->setMaximumRandomDeviationX( 0 );
+  layerClone->setMaximumRandomDeviationY( 0 );
 
   layerClone->drawPreviewIcon( symbolContext, pixmap.size() );
   painter.end();

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -896,6 +896,13 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
     static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
 
     /**
+     * Creates a new QgsRasterFillSymbolLayer from a SLD \a element. The caller takes
+     * ownership of the returned object.
+     * \since QGIS 3.30
+     */
+    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+
+    /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
      * Used internally when reading/writing symbols.
      * \since QGIS 3.0

--- a/src/core/symbology/qgssymbollayerregistry.cpp
+++ b/src/core/symbology/qgssymbollayerregistry.cpp
@@ -69,7 +69,7 @@ QgsSymbolLayerRegistry::QgsSymbolLayerRegistry()
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "ShapeburstFill" ), QObject::tr( "Shapeburst Fill" ), Qgis::SymbolType::Fill,
                       QgsShapeburstFillSymbolLayer::create ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "RasterFill" ), QObject::tr( "Raster Image Fill" ), Qgis::SymbolType::Fill,
-                      QgsRasterFillSymbolLayer::create, nullptr, QgsRasterFillSymbolLayer::resolvePaths ) );
+                      QgsRasterFillSymbolLayer::create, QgsRasterFillSymbolLayer::createFromSld, QgsRasterFillSymbolLayer::resolvePaths ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "SVGFill" ), QObject::tr( "SVG Fill" ), Qgis::SymbolType::Fill,
                       QgsSVGFillSymbolLayer::create, QgsSVGFillSymbolLayer::createFromSld, QgsSVGFillSymbolLayer::resolvePaths ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "CentroidFill" ), QObject::tr( "Centroid Fill" ), Qgis::SymbolType::Fill,

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -430,8 +430,8 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static bool hasExternalGraphic( QDomElement &element );
 
     /**
-     * Checks if \a element contains an ExternalGraphic element with optionally specified \a format.
-     * @return TRUE if the ExternalGraphic format is found with the optionally specified format.
+     * Checks if \a element contains an ExternalGraphic element, if the optional \a format is specified it will also be checked.
+     * @return TRUE if the ExternalGraphic element is found and the optionally specified format matches.
      * \since QGIS 3.30
      */
     static bool hasExternalGraphicV2( QDomElement &element, const QString format = QString() );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -422,7 +422,20 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * Converts a polygon symbolizer \a element to a list of marker symbol layers.
      */
     static bool convertPolygonSymbolizerToPointMarker( QDomElement &element, QList<QgsSymbolLayer *> &layerList );
+
+    /**
+     * Checks if \a element contains an ExternalGraphic element with format "image/svg+xml"
+     * @return TRUE if the ExternalGraphic with format "image/svg+xml" is found .
+     */
     static bool hasExternalGraphic( QDomElement &element );
+
+    /**
+     * Checks if \a element contains an ExternalGraphic element with optionally specified \a format.
+     * @return TRUE if the ExternalGraphic format is found with the optionally specified format.
+     * \since QGIS 3.30
+     */
+    static bool hasExternalGraphicV2( QDomElement &element, const QString format = QString() );
+
     static bool hasWellKnownMark( QDomElement &element );
 
     static bool needFontMarker( QDomElement &element );
@@ -432,6 +445,13 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static bool needLinePatternFill( QDomElement &element );
     static bool needPointPatternFill( QDomElement &element );
     static bool needSvgFill( QDomElement &element );
+
+    /**
+     * Checks if \a element contains a graphic fill with a raster image of type PNG, JPEG or GIF.
+     * @return TRUE if element contains a graphic fill with a raster image.
+     * \since QGIS 3.30
+     */
+    static bool needRasterImageFill( QDomElement &element );
 
     static void fillToSld( QDomDocument &doc, QDomElement &element,
                            Qt::BrushStyle brushStyle, const QColor &color = QColor() );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1252,7 +1252,7 @@ void QgsMapCanvas::onElevationShadingRendererChanged()
     return;
   bool wasDeactivated = !mSettings.elevationShadingRenderer().isActive();
   mSettings.setElevationShadingRenderer( mProject->elevationShadingRenderer() );
-  if ( wasDeactivated )
+  if ( mCache && wasDeactivated )
     mCache->clear();
   refresh();
 }


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/51467

- Fix size of SVG marker fill when importing from SLD
- Fix PNG external graphic raster fill (only SVG was supported)