### PR TITLE
Fix creation of GeoPDF with exported themes containing slashes

### DIFF
--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -123,7 +123,10 @@ bool QgsAbstractGeoPdfExporter::finalize( const QList<ComponentLayerDetail> &com
 
 QString QgsAbstractGeoPdfExporter::generateTemporaryFilepath( const QString &filename ) const
 {
-  return mTemporaryDir.filePath( filename );
+  QString cleanedFileName = filename;
+  cleanedFileName.replace( '\\', '_' );
+  cleanedFileName.replace( '/', '_' );
+  return mTemporaryDir.filePath( cleanedFileName );
 }
 
 bool QgsAbstractGeoPdfExporter::compositionModeSupported( QPainter::CompositionMode mode )

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -37,6 +37,7 @@ class TestQgsLayoutGeoPdfExport : public QgsTest
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
     void cleanupTestCase();// will be called after the last testfunction was executed.
+    void testTempFilenames();
     void testCollectingFeatures();
     void skipLayers();
     void layerOrder();
@@ -51,6 +52,23 @@ void TestQgsLayoutGeoPdfExport::initTestCase()
 void TestQgsLayoutGeoPdfExport::cleanupTestCase()
 {
   QgsApplication::exitQgis();
+}
+
+void TestQgsLayoutGeoPdfExport::testTempFilenames()
+{
+  QgsProject p;
+  QgsLayout l( &p );
+  QgsLayoutGeoPdfExporter geoPdfExporter( &l );
+
+  QString outputFile = geoPdfExporter.generateTemporaryFilepath( QStringLiteral( "test_src.pdf" ) );
+  QVERIFY( outputFile.endsWith( QStringLiteral( "test_src.pdf" ) ) );
+
+  // test generating temporary file path with slash characters (https://github.com/qgis/QGIS/issues/51480)
+  outputFile = geoPdfExporter.generateTemporaryFilepath( QStringLiteral( "test/ src.pdf" ) );
+  QVERIFY( outputFile.endsWith( QStringLiteral( "test_ src.pdf" ) ) );
+
+  outputFile = geoPdfExporter.generateTemporaryFilepath( QStringLiteral( "test\\ src.pdf" ) );
+  QVERIFY( outputFile.endsWith( QStringLiteral( "test_ src.pdf" ) ) );
 }
 
 void TestQgsLayoutGeoPdfExport::testCollectingFeatures()


### PR DESCRIPTION
Fixes #51480
