### PR TITLE
[afs] Percent encode text values when creating/updating fields on ArcGIS feature services

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1576,6 +1576,9 @@ QVariant QgsArcGisRestUtils::variantToAttributeValue( const QVariant &variant, Q
 
   switch ( expectedType )
   {
+    case QVariant::String:
+      return QString( QUrl::toPercentEncoding( variant.toString() ) );
+
     case QVariant::DateTime:
     case QVariant::Date:
     {

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -306,7 +306,7 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
                                               'a_date_field': 1646352000000,
                                               'a_double_field': 5.5,
                                               'a_int_field': 5,
-                                              'a_string_field': 'my string value',
+                                              'a_string_field': 'my%20string%20value',
                                               'a_null_value': None},
                                'geometry': {'x': 1.0, 'y': 2.0}})
         # without geometry
@@ -316,7 +316,7 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
                                               'a_date_field': 1646352000000,
                                               'a_double_field': 5.5,
                                               'a_int_field': 5,
-                                              'a_string_field': 'my string value',
+                                              'a_string_field': 'my%20string%20value',
                                               'a_null_value': None}})
         # without attributes
         context.setObjectIdFieldName('a_int_field')
@@ -324,6 +324,19 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
         self.assertEqual(res, {'attributes': {
             'a_int_field': 5},
             'geometry': {'x': 1.0, 'y': 2.0}})
+
+        # with special characters
+
+        attributes[0] = 'aaa" , . - ; : ä ö ü è é à ? + &'
+        test_feature.setAttributes(attributes)
+        res = QgsArcGisRestUtils.featureToJson(test_feature, context, flags=QgsArcGisRestUtils.FeatureToJsonFlags(QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes))
+        self.assertEqual(res, {'attributes': {'a_boolean_field': True,
+                                              'a_datetime_field': 1646395994000,
+                                              'a_date_field': 1646352000000,
+                                              'a_double_field': 5.5,
+                                              'a_int_field': 5,
+                                              'a_string_field': 'aaa%22%20%2C%20.%20-%20%3B%20%3A%20%C3%A4%20%C3%B6%20%C3%BC%20%C3%A8%20%C3%A9%20%C3%A0%20%3F%20%2B%20%26',
+                                              'a_null_value': None}})
 
     def test_field_to_json(self):
         field = QgsField('my name', QVariant.LongLong)


### PR DESCRIPTION
Fixes loss of edits when special characters are used

Fixes #51509
