### PR TITLE
[settings] proper fix for value with default override

### DIFF
--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -407,19 +407,13 @@ class QgsSettingsEntryByReference : public QgsSettingsEntryBase
     //! Returns the settings value with a \a defaultValueOverride and with an optional \a dynamicKeyPart
     inline T valueWithDefaultOverride( const T &defaultValueOverride, const QString &dynamicKeyPart = QString() ) const
     {
-      if ( this->exists( dynamicKeyPart ) )
-        return this->value( dynamicKeyPart );
-      else
-        return defaultValueOverride;
+      return this->convertFromVariant( valueAsVariantWithDefaultOverride( convertToVariant( defaultValueOverride ), dynamicKeyPart ) );
     }
 
     //! Returns the settings value with a \a defaultValueOverride for the \a dynamicKeyPartList
     inline T valueWithDefaultOverride( const T &defaultValueOverride, const QStringList &dynamicKeyPartList ) const
     {
-      if ( this->exists( dynamicKeyPartList ) )
-        return this->value( dynamicKeyPartList );
-      else
-        return defaultValueOverride;
+      return this->convertFromVariant( valueAsVariantWithDefaultOverride( convertToVariant( defaultValueOverride ), dynamicKeyPartList ) );
     }
 
     /**
@@ -575,19 +569,13 @@ class QgsSettingsEntryByValue : public QgsSettingsEntryBase
     //! Returns the settings value with a \a defaultValueOverride and with an optional \a dynamicKeyPart
     inline T valueWithDefaultOverride( T defaultValueOverride, const QString &dynamicKeyPart = QString() ) const
     {
-      if ( this->exists( dynamicKeyPart ) )
-        return this->value( dynamicKeyPart );
-      else
-        return defaultValueOverride;
+      return this->convertFromVariant( valueAsVariantWithDefaultOverride( convertToVariant( defaultValueOverride ), dynamicKeyPart ) );
     }
 
     //! Returns the settings value with a \a defaultValueOverride for the \a dynamicKeyPartList
     inline T valueWithDefaultOverride( T defaultValueOverride, const QStringList &dynamicKeyPartList ) const
     {
-      if ( this->exists( dynamicKeyPartList ) )
-        return this->value( dynamicKeyPartList );
-      else
-        return defaultValueOverride;
+      return this->convertFromVariant( valueAsVariantWithDefaultOverride( convertToVariant( defaultValueOverride ), dynamicKeyPartList ) );
     }
 
     /**

--- a/src/core/settings/qgssettingsentryenumflag.h
+++ b/src/core/settings/qgssettingsentryenumflag.h
@@ -74,7 +74,7 @@ class QgsSettingsEntryEnumFlag : public QgsSettingsEntryByValue<T>
     QgsSettingsEntryEnumFlag( const QString &key, const QString &section, T defaultValue, const QString &description = QString(), Qgis::SettingsOptions options = Qgis::SettingsOptions() )
       : QgsSettingsEntryByValue<T>( key,
                                     section,
-                                    QMetaEnum::fromType<T>().isFlag() ? qgsFlagValueToKeys( defaultValue ) : qgsEnumValueToKey( defaultValue ),
+                                    QVariant::fromValue( defaultValue ),
                                     description,
                                     options )
     {
@@ -83,6 +83,15 @@ class QgsSettingsEntryEnumFlag : public QgsSettingsEntryByValue<T>
       if ( !mMetaEnum.isValid() )
         QgsDebugMsg( QStringLiteral( "Invalid metaenum. Enum/Flag probably misses Q_ENUM/Q_FLAG declaration. Settings key: '%1'" ).arg( this->key() ) );
     }
+
+    QVariant convertToVariant( T value ) const override
+    {
+      if ( mMetaEnum.isFlag() )
+        return qgsFlagValueToKeys( value );
+      else
+        return qgsEnumValueToKey( value );
+    }
+
 
     /**
      * Returns settings default value.

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -141,10 +141,16 @@ void TestQgsSettingsEntry::flagValue()
   // Make sure the setting is not existing
   QgsSettings().remove( settingsKey );
 
-  const QgsSettingsEntryEnumFlag settingsEntryFlag( settingsKey, mSettingsSection, pointAndLine, QStringLiteral( "Filters" ) );
+  const QgsSettingsEntryEnumFlag settingsEntryFlag( settingsKey, mSettingsSection, QgsMapLayerProxyModel::Filters(), QStringLiteral( "Filters" ) );
 
   // Check default value
-  QCOMPARE( settingsEntryFlag.defaultValue(), pointAndLine );
+  QCOMPARE( settingsEntryFlag.defaultValue(), QgsMapLayerProxyModel::Filters() );
+
+  // check no value
+  QCOMPARE( settingsEntryFlag.exists(), false );
+  QCOMPARE( settingsEntryFlag.value(), QgsMapLayerProxyModel::Filters() );
+
+  QCOMPARE( settingsEntryFlag.valueWithDefaultOverride( pointAndLine ), pointAndLine );
 
   // Check set value
   {


### PR DESCRIPTION
correctly call convertToVariant
for enum/flag, save default value as enum and not QVariant

This a better fix than https://github.com/qgis/QGIS/pull/51619