### PR TITLE
Tests - Run pyupgrade on some Python tests files, with 3.7 minimum

### DIFF
--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for annotations.
 
 From build dir, run: ctest -R PyQgsAnnotation -V
@@ -288,7 +287,7 @@ class TestQgsAnnotation(unittest.TestCase):
         return result
 
     def imageCheck(self, name, reference_image, image):
-        self.report += "<h2>Render {}</h2>\n".format(name)
+        self.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'annotation_' + name + ".png"
         image.save(file_name, "PNG")
@@ -299,7 +298,7 @@ class TestQgsAnnotation(unittest.TestCase):
         checker.setColorTolerance(2)
         result = checker.runTest(name, 20)
         self.report += checker.report()
-        print((self.report))
+        print(self.report)
         return result
 
 

--- a/tests/src/python/test_qgsannotationitemeditoperation.py
+++ b/tests/src/python/test_qgsannotationitemeditoperation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationItemEditOperation
 
 From build dir, run: ctest -R QgsAnnotationItemEditOperation -V

--- a/tests/src/python/test_qgsannotationitemnode.py
+++ b/tests/src/python/test_qgsannotationitemnode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationItemNode
 
 From build dir, run: ctest -R PyQgsAnnotationLayer -V

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationLayer.
 
 From build dir, run: ctest -R PyQgsAnnotationLayer -V
@@ -255,7 +254,7 @@ class TestQgsAnnotationLayer(unittest.TestCase):
 
         # save project to xml
         tmpDir = QTemporaryDir()
-        tmpFile = "{}/project.qgs".format(tmpDir.path())
+        tmpFile = f"{tmpDir.path()}/project.qgs"
         self.assertTrue(p.write(tmpFile))
 
         # test that annotation layer is cleared with project
@@ -610,7 +609,7 @@ class TestQgsAnnotationLayer(unittest.TestCase):
                                                                                                             result))
 
     def imageCheck(self, name, reference_image, image):
-        TestQgsAnnotationLayer.report += "<h2>Render {}</h2>\n".format(name)
+        TestQgsAnnotationLayer.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'patch_' + name + ".png"
         image.save(file_name, "PNG")

--- a/tests/src/python/test_qgsannotationlineitem.py
+++ b/tests/src/python/test_qgsannotationlineitem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationLineItem.
 
 From build dir, run: ctest -R PyQgsAnnotationLineItem -V
@@ -252,7 +251,7 @@ class TestQgsAnnotationLineItem(unittest.TestCase):
         self.assertTrue(self.imageCheck('linestring_item_transform', 'linestring_item_transform', image))
 
     def imageCheck(self, name, reference_image, image):
-        TestQgsAnnotationLineItem.report += "<h2>Render {}</h2>\n".format(name)
+        TestQgsAnnotationLineItem.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'patch_' + name + ".png"
         image.save(file_name, "PNG")

--- a/tests/src/python/test_qgsannotationmarkeritem.py
+++ b/tests/src/python/test_qgsannotationmarkeritem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationMarkerItem.
 
 From build dir, run: ctest -R PyQgsAnnotationMarkerItem -V
@@ -212,7 +211,7 @@ class TestQgsAnnotationMarkerItem(unittest.TestCase):
         self.assertTrue(self.imageCheck('marker_item_transform', 'marker_item_transform', image))
 
     def imageCheck(self, name, reference_image, image):
-        TestQgsAnnotationMarkerItem.report += "<h2>Render {}</h2>\n".format(name)
+        TestQgsAnnotationMarkerItem.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'patch_' + name + ".png"
         image.save(file_name, "PNG")

--- a/tests/src/python/test_qgsannotationpointtextitem.py
+++ b/tests/src/python/test_qgsannotationpointtextitem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationPointTextItem.
 
 From build dir, run: ctest -R PyQgsAnnotationPointTextItem -V
@@ -287,7 +286,7 @@ class TestQgsAnnotationPointTextItem(unittest.TestCase):
         self.assertTrue(self.imageCheck('pointtext_item_transform', 'pointtext_item_transform', image))
 
     def imageCheck(self, name, reference_image, image):
-        TestQgsAnnotationPointTextItem.report += "<h2>Render {}</h2>\n".format(name)
+        TestQgsAnnotationPointTextItem.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'patch_' + name + ".png"
         image.save(file_name, "PNG")

--- a/tests/src/python/test_qgsannotationpolygonitem.py
+++ b/tests/src/python/test_qgsannotationpolygonitem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsAnnotationPolygonItem.
 
 From build dir, run: ctest -R PyQgsAnnotationPolygonItem -V
@@ -265,7 +264,7 @@ class TestQgsAnnotationPolygonItem(unittest.TestCase):
         self.assertTrue(self.imageCheck('polygon_item_transform', 'polygon_item_transform', image))
 
     def imageCheck(self, name, reference_image, image):
-        TestQgsAnnotationPolygonItem.report += "<h2>Render {}</h2>\n".format(name)
+        TestQgsAnnotationPolygonItem.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'patch_' + name + ".png"
         image.save(file_name, "PNG")

--- a/tests/src/python/test_qgsconditionalformatwidgets.py
+++ b/tests/src/python/test_qgsconditionalformatwidgets.py
@@ -1,5 +1,3 @@
-
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for the conditional format widgets.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsconditionalstyle.py
+++ b/tests/src/python/test_qgsconditionalstyle.py
@@ -1,5 +1,3 @@
-
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for the memory layer provider.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsconnectionregistry.py
+++ b/tests/src/python/test_qgsconnectionregistry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsConnectionRegistry.
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -43,11 +42,11 @@ class TestQgsConnectionRegistry(unittest.TestCase):
         start_app()
         QgsSettings().clear()
 
-        gpkg_original_path = '{}/qgis_server/test_project_wms_grouped_layers.gpkg'.format(TEST_DATA_DIR)
+        gpkg_original_path = f'{TEST_DATA_DIR}/qgis_server/test_project_wms_grouped_layers.gpkg'
         cls.basetestpath = tempfile.mkdtemp()
-        cls.gpkg_path = '{}/test_gpkg.gpkg'.format(cls.basetestpath)
+        cls.gpkg_path = f'{cls.basetestpath}/test_gpkg.gpkg'
         shutil.copy(gpkg_original_path, cls.gpkg_path)
-        vl = QgsVectorLayer('{}|layername=cdb_lines'.format(cls.gpkg_path), 'test', 'ogr')
+        vl = QgsVectorLayer(f'{cls.gpkg_path}|layername=cdb_lines', 'test', 'ogr')
         assert vl.isValid()
 
     @classmethod

--- a/tests/src/python/test_qgslayout.py
+++ b/tests/src/python/test_qgslayout.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayout
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -403,14 +402,14 @@ class TestQgsLayout(unittest.TestCase):
 
         self.assertFalse(l.selectedLayoutItems())
         item1.setSelected(True)
-        self.assertEqual(set(l.selectedLayoutItems()), set([item1]))
+        self.assertEqual(set(l.selectedLayoutItems()), {item1})
         item2.setSelected(True)
-        self.assertEqual(set(l.selectedLayoutItems()), set([item1, item2]))
+        self.assertEqual(set(l.selectedLayoutItems()), {item1, item2})
         item3.setSelected(True)
-        self.assertEqual(set(l.selectedLayoutItems()), set([item1, item2, item3]))
+        self.assertEqual(set(l.selectedLayoutItems()), {item1, item2, item3})
         item3.setLocked(True)
-        self.assertEqual(set(l.selectedLayoutItems(False)), set([item1, item2]))
-        self.assertEqual(set(l.selectedLayoutItems(True)), set([item1, item2, item3]))
+        self.assertEqual(set(l.selectedLayoutItems(False)), {item1, item2})
+        self.assertEqual(set(l.selectedLayoutItems(True)), {item1, item2, item3})
 
     def testSelections(self):
         p = QgsProject()

--- a/tests/src/python/test_qgslayoutaligner.py
+++ b/tests/src/python/test_qgslayoutaligner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutAligner
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutatlas.py
+++ b/tests/src/python/test_qgslayoutatlas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutAtlas
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutatlasclippingsettings.py
+++ b/tests/src/python/test_qgslayoutatlasclippingsettings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMapAtlasClippingSettings.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutcombobox.py
+++ b/tests/src/python/test_qgslayoutcombobox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutComboBox
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutelevationprofile.py
+++ b/tests/src/python/test_qgslayoutelevationprofile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemElevationProfile.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutExporter
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -98,14 +97,14 @@ def pdfToPng(pdf_file_path, rendered_file_path, page, dpi=96):
     else:
         return False, ''
 
-    print("exportToPdf call: {0}".format(' '.join(call)))
+    print("exportToPdf call: {}".format(' '.join(call)))
     try:
         subprocess.check_call(call)
     except subprocess.CalledProcessError as e:
         assert False, ("exportToPdf failed!\n"
-                       "cmd: {0}\n"
-                       "returncode: {1}\n"
-                       "message: {2}".format(e.cmd, e.returncode, e.message))
+                       "cmd: {}\n"
+                       "returncode: {}\n"
+                       "message: {}".format(e.cmd, e.returncode, e.message))
 
 
 def svgToPng(svg_file_path, rendered_file_path, width):
@@ -154,7 +153,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
         checker.setSizeTolerance(size_tolerance, size_tolerance)
         result = checker.runTest(name, 20)
         self.report += checker.report()
-        print((self.report))
+        print(self.report)
         return result
 
     def testRenderPage(self):
@@ -398,7 +397,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
 
         page2_path = os.path.join(self.basetestpath, 'test_exporttoimagesizebadaspect_2.png')
         im = QImage(page2_path)
-        self.assertTrue(self.checkImage('exporttoimagesize_badaspect', 'exporttoimagedpi_page2', page2_path), '{}x{}'.format(im.width(), im.height()))
+        self.assertTrue(self.checkImage('exporttoimagesize_badaspect', 'exporttoimagedpi_page2', page2_path), f'{im.width()}x{im.height()}')
 
     def testExportToPdf(self):
         md = QgsProject.instance().metadata()
@@ -718,7 +717,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.assertTrue(os.path.exists(svg_file_path))
 
         # expect svg to contain a text object with the scale
-        with open(svg_file_path, 'r') as f:
+        with open(svg_file_path) as f:
             lines = ''.join(f.readlines())
         self.assertIn('<text', lines)
         self.assertIn('>1:666<', lines)
@@ -730,7 +729,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.assertTrue(os.path.exists(svg_file_path))
 
         # expect svg NOT to contain a text object with the scale
-        with open(svg_file_path, 'r') as f:
+        with open(svg_file_path) as f:
             lines = ''.join(f.readlines())
         self.assertNotIn('<text', lines)
         self.assertNotIn('>1:666<', lines)
@@ -820,7 +819,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.assertTrue(os.path.exists(rendered_file_path))
         self.assertTrue(os.path.exists(world_file_path))
 
-        lines = tuple(open(world_file_path, 'r'))
+        lines = tuple(open(world_file_path))
         values = [float(f) for f in lines]
         self.assertAlmostEqual(values[0], 0.794117647059, 2)
         self.assertAlmostEqual(values[1], 0.0, 2)

--- a/tests/src/python/test_qgslayoutframe.py
+++ b/tests/src/python/test_qgslayoutframe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutFrame.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutgridsettings.py
+++ b/tests/src/python/test_qgslayoutgridsettings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutGridSettings.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutguides.py
+++ b/tests/src/python/test_qgslayoutguides.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutGuide/QgsLayoutGuideCollection.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayouthtml.py
+++ b/tests/src/python/test_qgslayouthtml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemHtml.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutitem.py
+++ b/tests/src/python/test_qgslayoutitem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItem.
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -37,7 +36,7 @@ TEST_DATA_DIR = unitTestDataPath()
 start_app()
 
 
-class LayoutItemTestCase(object):
+class LayoutItemTestCase:
     '''
         This is a collection of generic tests for QgsLayoutItem subclasses.
         To make use of it, subclass it and set self.item_class to a QgsLayoutItem subclass you want to test.

--- a/tests/src/python/test_qgslayoutitemcombobox.py
+++ b/tests/src/python/test_qgslayoutitemcombobox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemComboBox
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutitempropertiesdialog.py
+++ b/tests/src/python/test_qgslayoutitempropertiesdialog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemPropertiesDialog
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutlabel.py
+++ b/tests/src/python/test_qgslayoutlabel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemLabel.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemLegend.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmanager.py
+++ b/tests/src/python/test_qgslayoutmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutManager.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmanagermodel.py
+++ b/tests/src/python/test_qgslayoutmanagermodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutManagerModel.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmap.py
+++ b/tests/src/python/test_qgslayoutmap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMap.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmapgrid.py
+++ b/tests/src/python/test_qgslayoutmapgrid.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMapGrid.
 
 .. note. This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmapitemclippingsettings.py
+++ b/tests/src/python/test_qgslayoutmapitemclippingsettings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMapItemClipPathSettings.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmapoverview.py
+++ b/tests/src/python/test_qgslayoutmapoverview.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMap.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutmarker.py
+++ b/tests/src/python/test_qgslayoutmarker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemMarker.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutnortharrowhandler.py
+++ b/tests/src/python/test_qgslayoutnortharrowhandler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutNorthArrowHandler.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutpage.py
+++ b/tests/src/python/test_qgslayoutpage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemPage.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutpagecollection.py
+++ b/tests/src/python/test_qgslayoutpagecollection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutPageCollection
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutpicture.py
+++ b/tests/src/python/test_qgslayoutpicture.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutPicture.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutpolygon.py
+++ b/tests/src/python/test_qgslayoutpolygon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemPolygon.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutpolyline.py
+++ b/tests/src/python/test_qgslayoutpolyline.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemPolyline.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutscalebar.py
+++ b/tests/src/python/test_qgslayoutscalebar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemScaleBar.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutshape.py
+++ b/tests/src/python/test_qgslayoutshape.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutItemShape.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutsnapper.py
+++ b/tests/src/python/test_qgslayoutsnapper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutSnapper.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayouttable.py
+++ b/tests/src/python/test_qgslayouttable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutTable.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutunitscombobox.py
+++ b/tests/src/python/test_qgslayoutunitscombobox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutUnitsComboBox
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgslayoutview.py
+++ b/tests/src/python/test_qgslayoutview.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsLayoutView.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapBoxGlStyleConverter.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapCanvas
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -418,7 +417,7 @@ class TestQgsMapCanvas(unittest.TestCase):
         annotation_layer.clear()
 
     def canvasImageCheck(self, name, reference_image, canvas, expect_fail=False):
-        self.report += "<h2>Render {}</h2>\n".format(name)
+        self.report += f"<h2>Render {name}</h2>\n"
         temp_dir = QDir.tempPath() + '/'
         file_name = temp_dir + 'mapcanvas_' + name + ".png"
         print(file_name)
@@ -431,7 +430,7 @@ class TestQgsMapCanvas(unittest.TestCase):
         checker.setExpectFail(expect_fail)
         result = checker.runTest(name, 20)
         self.report += checker.report()
-        print((self.report))
+        print(self.report)
         return result
 
     def testSaveCanvasVariablesToProject(self):

--- a/tests/src/python/test_qgsmapcanvasannotationitem.py
+++ b/tests/src/python/test_qgsmapcanvasannotationitem.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapCanvasAnnotationItem.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmapclippingregion.py
+++ b/tests/src/python/test_qgsmapclippingregion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapClippingRegion.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmapclippingutils.py
+++ b/tests/src/python/test_qgsmapclippingutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapClippingUtils.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayer
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayeraction.py
+++ b/tests/src/python/test_qgsmaplayeraction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerAction.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerComboBox
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayerfactory.py
+++ b/tests/src/python/test_qgsmaplayerfactory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerFactory.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayermodel.py
+++ b/tests/src/python/test_qgsmaplayermodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerModel
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -94,15 +93,15 @@ class TestQgsMapLayerModel(unittest.TestCase):
         m = QgsMapLayerModel()
         m.setItemsCheckable(True)
         self.assertFalse(m.layersChecked())
-        self.assertEqual(set(m.layersChecked(Qt.Unchecked)), set([l1, l2]))
+        self.assertEqual(set(m.layersChecked(Qt.Unchecked)), {l1, l2})
 
         m.checkAll(Qt.Checked)
-        self.assertEqual(set(m.layersChecked()), set([l1, l2]))
+        self.assertEqual(set(m.layersChecked()), {l1, l2})
         self.assertFalse(set(m.layersChecked(Qt.Unchecked)))
 
         m.checkAll(Qt.Unchecked)
         self.assertFalse(m.layersChecked())
-        self.assertEqual(set(m.layersChecked(Qt.Unchecked)), set([l1, l2]))
+        self.assertEqual(set(m.layersChecked(Qt.Unchecked)), {l1, l2})
 
         QgsProject.instance().removeMapLayers([l1.id(), l2.id()])
 

--- a/tests/src/python/test_qgsmaplayerproxymodel.py
+++ b/tests/src/python/test_qgsmaplayerproxymodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerProxyModel
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayerstore.py
+++ b/tests/src/python/test_qgsmaplayerstore.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerStore.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaplayerutils.py
+++ b/tests/src/python/test_qgsmaplayerutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapLayerUtils.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaprenderer.py
+++ b/tests/src/python/test_qgsmaprenderer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapRenderer.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmaprenderercache.py
+++ b/tests/src/python/test_qgsmaprenderercache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapRendererCache.
 
 .. note:: This program is free software; you can redistribute it and/or modify
@@ -235,7 +234,7 @@ class TestQgsMapRendererCache(unittest.TestCase):
         cache.setCacheImage('no depends', im, [])
         self.assertEqual(cache.dependentLayers('no depends'), [])
         cache.setCacheImage('depends', im, [layer1, layer2])
-        self.assertEqual(set(cache.dependentLayers('depends')), set([layer1, layer2]))
+        self.assertEqual(set(cache.dependentLayers('depends')), {layer1, layer2})
 
     def testLayerRemoval(self):
         """test that cached image is cleared when a dependent layer is removed"""

--- a/tests/src/python/test_qgsmapthemecollection.py
+++ b/tests/src/python/test_qgsmapthemecollection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapThemeCollection.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/tests/src/python/test_qgsmapunitscale.py
+++ b/tests/src/python/test_qgsmapunitscale.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsMapUnitScale.
 
 .. note:: This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
I run the tool https://github.com/asottile/pyupgrade with the 3.7 minimum Python version (so it switch to Python fstrings as well).

Is-there any rule from the [README.md](https://github.com/asottile/pyupgrade/blob/main/README.md) that we don't want to switch to ?
