### PR TITLE
Fix missing #includes on master

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -22,6 +22,9 @@
 #include "qgsstringutils.h"
 #include "qgsvariantutils.h"
 
+#include <QDate>
+#include <QDateTime>
+#include <QTime>
 #include <QRegularExpression>
 
 const char *QgsExpressionNodeBinaryOperator::BINARY_OPERATOR_TEXT[] =

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -24,6 +24,9 @@
 #include "qgsvariantutils.h"
 #include "qgsfeaturerequest.h"
 
+#include <QDate>
+#include <QDateTime>
+#include <QTime>
 #include <QThread>
 #include <QLocale>
 #include <functional>

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -55,6 +55,7 @@
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovider.h"
 #include "qgswfsprovider.h"
+#include "qgswfsprovidermetadata.h"
 #include "qgsoapifprovider.h"
 #include "qgsvirtuallayerprovider.h"
 #endif


### PR DESCRIPTION
## Description

When recently updating QField's QGIS version to a recent master revision (in preparation to adopting 3.30), I stumbled on a couple of missing include errors when building against vcpkg. This PR fixes those.