### PR TITLE
Remove template in qgstopologicalmesh.h

### DIFF
--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -20,12 +20,6 @@
 
 #include "qgsmeshdataprovider.h"
 
-#if defined(_MSC_VER)
-template CORE_EXPORT QVector<int> SIP_SKIP;
-template CORE_EXPORT QList<int> SIP_SKIP;
-template CORE_EXPORT QVector<QVector<int>> SIP_SKIP;
-#endif
-
 SIP_NO_FILE
 
 class QgsMeshEditingError;


### PR DESCRIPTION
## Description

@vcloarec , I've meant to open this PR a while back, then life happened and I forgot :) There are three template declarations in qgstopologicalmesh.h that when present leads to fatal compilation error (using vcpkg).

Are these necessary or can we remove them? they feel wrong to me, but I could well miss the point of their existence. 