### PR TITLE
Avoid redo-ing the legend symbol hit test for legend edits which won't affect the legend symbols visible in a map

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -312,6 +312,9 @@ bool QgsLayoutItemLegend::autoUpdateModel() const
 
 void QgsLayoutItemLegend::setLegendFilterByMapEnabled( bool enabled )
 {
+  if ( mLegendFilterByMap == enabled )
+    return;
+
   mLegendFilterByMap = enabled;
   updateFilterByMap( false );
 }
@@ -569,7 +572,6 @@ void QgsLayoutItemLegend::setRasterStrokeWidth( double width )
   mSettings.setRasterStrokeWidth( width );
 }
 
-
 void QgsLayoutItemLegend::updateLegend()
 {
   adjustBoxSize();
@@ -814,6 +816,9 @@ void QgsLayoutItemLegend::setupMapConnections( QgsLayoutItemMap *map, bool conne
 
 void QgsLayoutItemLegend::setLinkedMap( QgsLayoutItemMap *map )
 {
+  if ( mMap == map )
+    return;
+
   if ( mMap )
   {
     setupMapConnections( mMap, false );

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -807,8 +807,7 @@ void QgsLayoutLegendWidget::mCheckBoxAutoUpdate_stateChanged( int state, bool us
     mLegend->beginCommand( tr( "Change Auto Update" ) );
 
     mLegend->setAutoUpdateModel( state == Qt::Checked );
-
-    mLegend->updateFilterByMap();
+    mLegend->update();
     mLegend->endCommand();
   }
 
@@ -845,7 +844,7 @@ void QgsLayoutLegendWidget::composerMapChanged( QgsLayoutItem *item )
   {
     mLegend->beginCommand( tr( "Change Legend Map" ) );
     mLegend->setLinkedMap( map );
-    mLegend->updateFilterByMap();
+    mLegend->update();
     mLegend->endCommand();
 
     setLegendMapViewData();
@@ -863,7 +862,7 @@ void QgsLayoutLegendWidget::mCheckboxResizeContents_toggled( bool checked )
   mLegend->setResizeToContents( checked );
   if ( checked )
     mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1227,7 +1226,7 @@ void QgsLayoutLegendWidget::updateLegend()
     // this will reset the model completely, losing any changes
     mLegend->setAutoUpdateModel( true );
     mLegend->setAutoUpdateModel( false );
-    mLegend->updateFilterByMap();
+    mLegend->update();
     mLegend->endCommand();
   }
 }
@@ -1372,7 +1371,7 @@ void QgsLayoutLegendWidget::setCurrentNodeStyleFromAction()
     return;
 
   QgsLegendRenderer::setNodeLegendStyle( mItemTreeView->currentNode(), static_cast< QgsLegendStyle::Style >( a->data().toInt() ) );
-  mLegend->updateFilterByMap();
+  mLegend->update();
 }
 
 void QgsLayoutLegendWidget::setLegendMapViewData()
@@ -1692,7 +1691,7 @@ void QgsLayoutLegendNodeWidget::labelChanged()
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1718,7 +1717,7 @@ void QgsLayoutLegendNodeWidget::patchChanged()
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1790,7 +1789,7 @@ void QgsLayoutLegendNodeWidget::sizeChanged( double )
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1834,7 +1833,7 @@ void QgsLayoutLegendNodeWidget::customSymbolChanged()
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1847,7 +1846,7 @@ void QgsLayoutLegendNodeWidget::colorRampLegendChanged()
   mLegend->model()->refreshLayerLegend( mLayer );
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1870,7 +1869,7 @@ void QgsLayoutLegendNodeWidget::columnBreakToggled( bool checked )
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 
@@ -1884,7 +1883,7 @@ void QgsLayoutLegendNodeWidget::columnSplitChanged()
   }
 
   mLegend->adjustBoxSize();
-  mLegend->updateFilterByMap();
+  mLegend->update();
   mLegend->endCommand();
 }
 


### PR DESCRIPTION
Avoids a lot of unnecessary expensive work, which can result in very slow edits to eg legend item text

Refs #51455
Refs #50905
