### PR TITLE
Fix loading point clouds by drag and drop from browser

### DIFF
--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -419,7 +419,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addOgrVectorLayers( const QStringLis
   return addedLayers;
 }
 
-QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri, const QString &baseName, const QString &provider, bool showWarningOnInvalid, bool addToLegend )
+QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri, const QString &baseName, const QString &provider, bool addToLegend, bool showWarningOnInvalid )
 {
   QgsCanvasRefreshBlocker refreshBlocker;
   QgsSettings settings;
@@ -815,7 +815,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
 
       case QgsMapLayerType::PointCloudLayer:
       {
-        if ( QgsPointCloudLayer *layer = addPointCloudLayer( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), true, addToLegend ) )
+        if ( QgsPointCloudLayer *layer = addPointCloudLayer( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), addToLegend, true ) )
         {
           ok = true;
           openedLayers << layer;

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -111,8 +111,8 @@ class APP_EXPORT QgsAppLayerHandling
     static QgsPointCloudLayer *addPointCloudLayer( const QString &uri,
         const QString &baseName,
         const QString &provider,
-        bool showWarningOnInvalid = true,
-        bool addToLegend = true );
+        bool addToLegend = true,
+        bool showWarningOnInvalid = true );
 
     /**
      * Adds a plugin layer from a given \a uri and \a provider.


### PR DESCRIPTION
Fixes an unreported regression, when drag and dropping a point cloud layer from the browser, the layer was added twice to the layers panel.

Introduced with the changes in #50381, the `bool addToLegend` parameter in `QgsAppLayerHandling::addPointCloudLayer()` is the 5th parameter, after another bool param, while for all other layer types it is the 4th, making it really easy to miss, as was done in https://github.com/qgis/QGIS/blob/b905cacf9e654e668f757a1f9a9551e594e43efb/src/app/qgisapp.cpp#L2366


master only

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
