### PR TITLE
Python - Use flynt to transform % strings without braces

### DIFF
--- a/tests/src/python/test_authmanager_oauth2_ows.py
+++ b/tests/src/python/test_authmanager_oauth2_ows.py
@@ -234,7 +234,7 @@ class TestAuthManager(unittest.TestCase):
         }
         if authcfg is not None:
             parms.update({'authcfg': authcfg})
-        uri = '&'.join([("{}={}".format(k, v.replace('=', '%3D'))) for k, v in list(parms.items())])
+        uri = '&'.join([f"{k}={v.replace('=', '%3D')}" for k, v in list(parms.items())])
         wms_layer = QgsRasterLayer(uri, layer_name, 'wms')
         return wms_layer
 

--- a/tests/src/python/test_authmanager_ogr_postgres.py
+++ b/tests/src/python/test_authmanager_ogr_postgres.py
@@ -163,7 +163,7 @@ class TestAuthManager(unittest.TestCase):
 
         cls.server = subprocess.Popen([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'postgres'), '-D',
                                        cls.data_path, '-c',
-                                       "config_file=%s" % cls.pg_conf],
+                                       f"config_file={cls.pg_conf}"],
                                       env=env,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)

--- a/tests/src/python/test_authmanager_password_ows.py
+++ b/tests/src/python/test_authmanager_password_ows.py
@@ -162,7 +162,7 @@ class TestAuthManager(unittest.TestCase):
         }
         if authcfg is not None:
             parms.update({'authcfg': authcfg})
-        uri = '&'.join([("{}={}".format(k, v.replace('=', '%3D'))) for k, v in list(parms.items())])
+        uri = '&'.join([f"{k}={v.replace('=', '%3D')}" for k, v in list(parms.items())])
         wms_layer = QgsRasterLayer(uri, layer_name, 'wms')
         return wms_layer
 
@@ -175,7 +175,7 @@ class TestAuthManager(unittest.TestCase):
             layer_name = 'geojson_' + type_name
         uri = f'{cls.protocol}://{cls.hostname}:{cls.port}/?MAP={cls.project_path}&SERVICE=WFS&REQUEST=GetFeature&TYPENAME={urllib.parse.quote(type_name)}&VERSION=2.0.0&OUTPUTFORMAT=geojson'
         if authcfg is not None:
-            uri += " authcfg='%s'" % authcfg
+            uri += f" authcfg='{authcfg}'"
         geojson_layer = QgsVectorLayer(uri, layer_name, 'ogr')
         return geojson_layer
 
@@ -235,7 +235,7 @@ class TestAuthManager(unittest.TestCase):
         loop.exec_()
 
         self.assertTrue(self.error_was_called)
-        self.assertTrue("Download failed: Host requires authentication" in str(self.error_args), "Error args is: %s" % str(self.error_args))
+        self.assertTrue("Download failed: Host requires authentication" in str(self.error_args), f"Error args is: {str(self.error_args)}")
 
     def testValidAuthFileDownload(self):
         """
@@ -272,7 +272,7 @@ class TestAuthManager(unittest.TestCase):
 
         # Check the we've got a likely PNG image
         self.assertTrue(self.completed_was_called)
-        self.assertTrue(os.path.getsize(destination) > 2000, "Image size: %s" % os.path.getsize(destination))  # > 1MB
+        self.assertTrue(os.path.getsize(destination) > 2000, f"Image size: {os.path.getsize(destination)}")  # > 1MB
         with open(destination, 'rb') as f:
             self.assertTrue(b'PNG' in f.read())  # is a PNG
 

--- a/tests/src/python/test_authmanager_pki_ows.py
+++ b/tests/src/python/test_authmanager_pki_ows.py
@@ -185,7 +185,7 @@ class TestAuthManager(unittest.TestCase):
         }
         if authcfg is not None:
             parms.update({'authcfg': authcfg})
-        uri = '&'.join([("{}={}".format(k, v.replace('=', '%3D'))) for k, v in list(parms.items())])
+        uri = '&'.join([f"{k}={v.replace('=', '%3D')}" for k, v in list(parms.items())])
         wms_layer = QgsRasterLayer(uri, layer_name, 'wms')
         return wms_layer
 

--- a/tests/src/python/test_db_manager_postgis.py
+++ b/tests/src/python/test_db_manager_postgis.py
@@ -147,7 +147,7 @@ class TestPyQgsDBManagerPostgis(unittest.TestCase):
 
         cls.server = subprocess.Popen([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'postgres'), '-D',
                                        cls.data_path, '-c',
-                                       "config_file=%s" % cls.pg_conf],
+                                       f"config_file={cls.pg_conf}"],
                                       env=os.environ,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)
@@ -166,7 +166,7 @@ class TestPyQgsDBManagerPostgis(unittest.TestCase):
         test_sql = os.path.join(unitTestDataPath('provider'), 'testdata_pg.sql')
         subprocess.check_call([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'psql'), '-h', 'localhost', '-p', cls.port, '-f', test_sql, cls.dbname])
         # Create a role
-        subprocess.check_call([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'psql'), '-h', 'localhost', '-p', cls.port, '-c', 'CREATE ROLE "%s" WITH SUPERUSER LOGIN' % cls.username, cls.dbname])
+        subprocess.check_call([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'psql'), '-h', 'localhost', '-p', cls.port, '-c', f'CREATE ROLE "{cls.username}" WITH SUPERUSER LOGIN', cls.dbname])
 
     @classmethod
     def setUpProvider(cls, authId):

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -75,11 +75,11 @@ class TestLayerDependencies(unittest.TestCase):
         con.commit()
         con.close()
 
-        self.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % fn, "points", "spatialite")
+        self.pointsLayer = QgsVectorLayer(f"dbname='{fn}' table=\"node\" (geom) sql=", "points", "spatialite")
         assert (self.pointsLayer.isValid())
-        self.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % fn, "lines", "spatialite")
+        self.linesLayer = QgsVectorLayer(f"dbname='{fn}' table=\"section\" (geom) sql=", "lines", "spatialite")
         assert (self.linesLayer.isValid())
-        self.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % fn, "_points2", "spatialite")
+        self.pointsLayer2 = QgsVectorLayer(f"dbname='{fn}' table=\"node2\" (geom) sql=", "_points2", "spatialite")
         assert (self.pointsLayer2.isValid())
         QgsProject.instance().addMapLayers([self.pointsLayer, self.linesLayer, self.pointsLayer2])
 
@@ -281,11 +281,11 @@ class TestLayerDependencies(unittest.TestCase):
         # remove all layers
         QgsProject.instance().removeAllMapLayers()
         # set dependencies and add back layers
-        self.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % self.fn, "points", "spatialite")
+        self.pointsLayer = QgsVectorLayer(f"dbname='{self.fn}' table=\"node\" (geom) sql=", "points", "spatialite")
         assert (self.pointsLayer.isValid())
-        self.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % self.fn, "lines", "spatialite")
+        self.linesLayer = QgsVectorLayer(f"dbname='{self.fn}' table=\"section\" (geom) sql=", "lines", "spatialite")
         assert (self.linesLayer.isValid())
-        self.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % self.fn, "_points2", "spatialite")
+        self.pointsLayer2 = QgsVectorLayer(f"dbname='{self.fn}' table=\"node2\" (geom) sql=", "_points2", "spatialite")
         assert (self.pointsLayer2.isValid())
         self.pointsLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
         self.pointsLayer2.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())])

--- a/tests/src/python/test_offline_editing_wfs.py
+++ b/tests/src/python/test_offline_editing_wfs.py
@@ -95,7 +95,7 @@ class TestWFST(unittest.TestCase, OfflineTestBase):
         self.port = int(re.findall(br':(\d+)', line)[0])
         assert self.port != 0
         # Wait for the server process to start
-        assert waitServer('http://127.0.0.1:%s' % self.port), "Server is not responding!"
+        assert waitServer(f'http://127.0.0.1:{self.port}'), "Server is not responding!"
         self._setUp()
 
     def tearDown(self):

--- a/tests/src/python/test_plugindependencies.py
+++ b/tests/src/python/test_plugindependencies.py
@@ -38,7 +38,7 @@ class PluginDependenciesTest(unittest.TestCase):
 
         QCoreApplication.setOrganizationName("QGIS")
         QCoreApplication.setOrganizationDomain("qgis.org")
-        QCoreApplication.setApplicationName("QGIS-TEST-%s" % uuid.uuid1())
+        QCoreApplication.setApplicationName(f"QGIS-TEST-{uuid.uuid1()}")
         qgis_app = start_app()
 
         # Installed plugins

--- a/tests/src/python/test_processing_importintopostgis.py
+++ b/tests/src/python/test_processing_importintopostgis.py
@@ -86,7 +86,7 @@ class TestExportToPostGis(unittest.TestCase):
         # Check that data have been imported correctly
         exported = QgsVectorLayer(unitTestDataPath() + '/points.shp', 'exported')
         self.assertTrue(exported.isValid())
-        imported = QgsVectorLayer("service='qgis_test' table=\"CamelCaseSchema\".\"%s\" (geom)" % table_name, 'imported', 'postgres')
+        imported = QgsVectorLayer(f"service='qgis_test' table=\"CamelCaseSchema\".\"{table_name}\" (geom)", 'imported', 'postgres')
         self.assertTrue(imported.isValid())
         imported_fields = [f.name() for f in imported.fields()]
         for f in exported.fields():

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -142,7 +142,7 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         testVectors = ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "None"]
         for v in testVectors:
             layer = QgsVectorLayer(v, "test", "memory")
-            assert layer.isValid(), "Failed to create valid %s memory layer" % (v)
+            assert layer.isValid(), f"Failed to create valid {v} memory layer"
 
     def testLayerGeometry(self):
         testVectors = [("Point", QgsWkbTypes.PointGeometry, QgsWkbTypes.Point),
@@ -179,12 +179,10 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         for v in testVectors:
             layer = QgsVectorLayer(v[0], "test", "memory")
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (v[1], layer.geometryType()))
+            myMessage = f'Expected: {v[1]}\nGot: {layer.geometryType()}\n'
             assert layer.geometryType() == v[1], myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (v[2], layer.wkbType()))
+            myMessage = f'Expected: {v[2]}\nGot: {layer.wkbType()}\n'
             assert layer.wkbType() == v[2], myMessage
 
     def testAddFeatures(self):
@@ -196,8 +194,7 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
                                       QgsField("size", QVariant.Double)])
         assert res, "Failed to add attributes"
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (3, len(provider.fields())))
+        myMessage = f'Expected: {3}\nGot: {len(provider.fields())}\n'
 
         assert len(provider.fields()) == 3, myMessage
 
@@ -210,30 +207,25 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
 
         assert res, "Failed to add feature"
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (1, provider.featureCount()))
+        myMessage = f'Expected: {1}\nGot: {provider.featureCount()}\n'
         assert provider.featureCount() == 1, myMessage
 
         for f in provider.getFeatures(QgsFeatureRequest()):
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         ("Johny", f[0]))
+            myMessage = f"Expected: {'Johny'}\nGot: {f[0]}\n"
 
             assert f[0] == "Johny", myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (20, f[1]))
+            myMessage = f'Expected: {20}\nGot: {f[1]}\n'
 
             assert f[1] == 20, myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (0.3, f[2]))
+            myMessage = f'Expected: {0.3}\nGot: {f[2]}\n'
 
             assert (f[2] - 0.3) < 0.0000001, myMessage
 
             geom = f.geometry()
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         ("Point (10 10)", str(geom.asWkt())))
+            myMessage = f"Expected: {'Point (10 10)'}\nGot: {str(geom.asWkt())}\n"
 
             assert compareWkt(str(geom.asWkt()), "Point (10 10)"), myMessage
 

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -430,7 +430,7 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(errmsg)
 
         mFilePath = QDir.toNativeSeparators(
-            '{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "singleSymbol"))
+            f"{unitTestDataPath()}/symbol_layer/singleSymbol.qml")
         status = vl.loadNamedStyle(mFilePath)
         self.assertTrue(status)
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -390,7 +390,7 @@ class PyQgsOGRProvider(unittest.TestCase):
             datasource = os.path.join(self.basetestpath, 'test.csv')
             with open(datasource, 'w') as f:
                 f.write('id,WKT\n')
-                f.write('1,"%s"' % row[0])
+                f.write(f'1,"{row[0]}"')
 
             vl = QgsVectorLayer(datasource, 'test', 'ogr')
             self.assertTrue(vl.isValid())
@@ -2312,7 +2312,7 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(res[0].layerNumber(), 0)
         self.assertEqual(res[0].name(), "ARC")
         self.assertEqual(res[0].description(), "")
-        self.assertEqual(res[0].uri(), '{}|layername=ARC'.format(os.path.join(TEST_DATA_DIR, 'esri_coverage', 'testpolyavc')))
+        self.assertEqual(res[0].uri(), f"{os.path.join(TEST_DATA_DIR, 'esri_coverage', 'testpolyavc')}|layername=ARC")
         self.assertEqual(res[0].providerKey(), "ogr")
         self.assertEqual(res[0].type(), QgsMapLayerType.VectorLayer)
         self.assertFalse(res[0].skippedContainerScan())
@@ -2465,7 +2465,7 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(res[0].layerNumber(), 0)
         self.assertEqual(res[0].name(), "ARC")
         self.assertEqual(res[0].description(), "")
-        self.assertEqual(res[0].uri(), '{}|layername=ARC'.format(os.path.join(TEST_DATA_DIR, 'esri_coverage', 'testpolyavc')))
+        self.assertEqual(res[0].uri(), f"{os.path.join(TEST_DATA_DIR, 'esri_coverage', 'testpolyavc')}|layername=ARC")
         self.assertEqual(res[0].providerKey(), "ogr")
         self.assertEqual(res[0].type(), QgsMapLayerType.VectorLayer)
         self.assertFalse(res[0].skippedContainerScan())

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -1397,7 +1397,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         testPath = tmpfile + '|layername=bug_17795'
         subSetString = '"name" = \'int\''
-        subSet = '|subset=%s' % subSetString
+        subSet = f'|subset={subSetString}'
 
         # unfiltered
         vl = QgsVectorLayer(testPath, 'test', 'ogr')
@@ -2131,7 +2131,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         for tmpfile in (tmpfile1, tmpfile2):
             ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
             for i in range(2):
-                lyr = ds.CreateLayer('test%s' % i, geom_type=ogr.wkbPoint)
+                lyr = ds.CreateLayer(f'test{i}', geom_type=ogr.wkbPoint)
                 lyr.CreateField(ogr.FieldDefn('str_field', ogr.OFTString))
                 f = ogr.Feature(lyr.GetLayerDefn())
                 f.SetGeometry(ogr.CreateGeometryFromWkt('POINT (1 1)'))

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -460,14 +460,14 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 featureids.append(f.id())
             self.assertEqual(len(features), num_features)
 
-        vl = QgsVectorLayer('{} srid=4326 table="qgis_test".{} (geom) sql='.format(self.dbconn, 'someData'), "testgeom",
+        vl = QgsVectorLayer(f"{self.dbconn} srid=4326 table=\"qgis_test\".someData (geom) sql=", "testgeom",
                             "postgres")
         self.assertTrue(vl.isValid())
         # Test someData
         test_unique([f for f in vl.getFeatures()], 5)
 
         # Test base_table_bad: layer is invalid
-        vl = QgsVectorLayer('{} srid=4326 table="qgis_test".{} (geom) sql='.format(self.dbconn, 'base_table_bad'),
+        vl = QgsVectorLayer(f"{self.dbconn} srid=4326 table=\"qgis_test\".base_table_bad (geom) sql=",
                             "testgeom", "postgres")
         self.assertFalse(vl.isValid())
         # Test base_table_bad with use estimated metadata: layer is valid because the unique test is skipped
@@ -478,7 +478,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.isValid())
 
         # Test base_table_good: layer is valid
-        vl = QgsVectorLayer('{} srid=4326 table="qgis_test".{} (geom) sql='.format(self.dbconn, 'base_table_good'),
+        vl = QgsVectorLayer(f"{self.dbconn} srid=4326 table=\"qgis_test\".base_table_good (geom) sql=",
                             "testgeom", "postgres")
         self.assertTrue(vl.isValid())
         test_unique([f for f in vl.getFeatures()], 4)
@@ -559,7 +559,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
              1)
 
     def testPktIntInsert(self):
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" key="pk" sql='.format(self.dbconn, 'bikes_view'), "bikes_view",
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"bikes_view\" key=\"pk\" sql=", "bikes_view",
                             "postgres")
         self.assertTrue(vl.isValid())
         f = QgsFeature(vl.fields())
@@ -585,7 +585,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.execSQLCommand('CREATE TABLE qgis_test.test_gen_col_edit AS SELECT id,name,geom FROM qgis_test.test_gen_col')
 
         # Geometry columns
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (geom) srid=4326 type=POLYGON key=\"id\" sql=", "test_gen_col", "postgres")
         self.assertTrue(vl.isValid())
 
         # writing geometry...
@@ -601,7 +601,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.commitChanges())
 
         # reading back to see if we saved the centroid correctly.
-        vl2 = QgsVectorLayer('{} table="qgis_test"."{}" (cent) srid=4326 type=POINT key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl2 = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (cent) srid=4326 type=POINT key=\"id\" sql=", "test_gen_col", "postgres")
         f2 = next(vl2.getFeatures(QgsFeatureRequest()))
         generated_geometry = f2.geometry().asWkt()
         expected_geometry = 'Point (-68.047619047619051 -0.90476190476190477)'
@@ -619,7 +619,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl2.commitChanges())
 
         # getting a brand new QgsVectorLayer
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (geom) srid=4326 type=POLYGON key=\"id\" sql=", "test_gen_col", "postgres")
         self.assertTrue(vl.isValid())
 
         # checking if the name field was correctly updated
@@ -634,12 +634,12 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.commitChanges())
 
         # reading back
-        vl2 = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl2 = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (geom) srid=4326 type=POLYGON key=\"id\" sql=", "test_gen_col", "postgres")
         f2 = next(vl2.getFeatures(QgsFeatureRequest()))
         self.assertAlmostEqual(f2['poly_area'], expected_area, places=4)
 
         # now, getting a brand new QgsVectorLayer to check if changes (UPDATE) in the geometry are reflected in the generated fields
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" (geom) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (geom) srid=4326 type=POLYGON key=\"id\" sql=", "test_gen_col", "postgres")
         self.assertTrue(vl.isValid())
         f = next(vl.getFeatures(QgsFeatureRequest()))
         vl.startEditing()
@@ -648,7 +648,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         vl.commitChanges()
 
         # reading back...
-        vl2 = QgsVectorLayer('{} table="qgis_test"."{}" (cent) srid=4326 type=POINT key="id" sql='.format(self.dbconn, "test_gen_col"), "test_gen_col", "postgres")
+        vl2 = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_col\" (cent) srid=4326 type=POINT key=\"id\" sql=", "test_gen_col", "postgres")
         f2 = next(vl2.getFeatures(QgsFeatureRequest()))
         generated_geometry = f2.geometry().asWkt()
 
@@ -661,7 +661,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(f2['name'], 'New')
 
         # Geography columns
-        vl3 = QgsVectorLayer('{} table="qgis_test"."{}" (geog) srid=4326 type=POLYGON key="id" sql='.format(self.dbconn, "test_gen_geog_col"), "test_gen_geog_col", "postgres")
+        vl3 = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_geog_col\" (geog) srid=4326 type=POLYGON key=\"id\" sql=", "test_gen_geog_col", "postgres")
         self.assertTrue(vl3.isValid())
 
         # writing geography...
@@ -672,7 +672,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl3.commitChanges())
 
         # reading back geography and checking values
-        vl4 = QgsVectorLayer('{} table="qgis_test"."{}" (cent) srid=4326 type=POINT key="id" sql='.format(self.dbconn, "test_gen_geog_col"), "test_gen_geog_col", "postgres")
+        vl4 = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"test_gen_geog_col\" (cent) srid=4326 type=POINT key=\"id\" sql=", "test_gen_geog_col", "postgres")
         f4 = next(vl4.getFeatures(QgsFeatureRequest()))
         generated_geometry = f4.geometry().asWkt()
         expected_geometry = 'Point (-68.0477406158202 -0.904960604589168)'
@@ -1131,7 +1131,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # TODO: implement NUMERIC primary keys/arbitrary precision arithmethics/fixed point math in QGIS.
 
     def testPktMapInsert(self):
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" key="obj_id" sql='.format(self.dbconn, 'oid_serial_table'),
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"oid_serial_table\" key=\"obj_id\" sql=",
                             "oid_serial", "postgres")
         self.assertTrue(vl.isValid())
         f = QgsFeature(vl.fields())
@@ -1836,7 +1836,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         f['f2'] = 123.456
         f['f3'] = '12345678.90123456789'
         lyr.dataProvider().addFeatures([f])
-        uri = '%s table="qgis_test"."b18155" (g) key=\'f1\'' % (self.dbconn)
+        uri = f'{self.dbconn} table="qgis_test"."b18155" (g) key=\'f1\''
         self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.b18155')
         err = QgsVectorLayerExporter.exportLayer(
             lyr, uri, "postgres", lyr.crs())
@@ -1859,9 +1859,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         def testKey(lyr, key, kfnames):
             self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.import_test')
-            uri = '%s table="qgis_test"."import_test" (g)' % self.dbconn
+            uri = f'{self.dbconn} table="qgis_test"."import_test" (g)'
             if key is not None:
-                uri += ' key=\'%s\'' % key
+                uri += f' key=\'{key}\''
             err = QgsVectorLayerExporter.exportLayer(
                 lyr, uri, "postgres", lyr.crs())
             self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
@@ -1896,21 +1896,20 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
     def testImportWithoutSchema(self):
 
         def _test(table, schema=None):
-            self.execSQLCommand('DROP TABLE IF EXISTS %s CASCADE' % table)
+            self.execSQLCommand(f'DROP TABLE IF EXISTS {table} CASCADE')
             uri = 'point?field=f1:int'
             uri += '&field=F2:double(6,4)'
             uri += '&field=f3:string(20)'
             lyr = QgsVectorLayer(uri, "x", "memory")
             self.assertTrue(lyr.isValid())
 
-            table = ("%s" % table) if schema is None else (
+            table = f"{table}" if schema is None else (
                 f"\"{schema}\".\"{table}\"")
-            dest_uri = "{} sslmode=disable table={}  (geom) sql".format(
-                self.dbconn, table)
+            dest_uri = f"{self.dbconn} sslmode=disable table={table}  (geom) sql"
             QgsVectorLayerExporter.exportLayer(
                 lyr, dest_uri, "postgres", lyr.crs())
             olyr = QgsVectorLayer(dest_uri, "y", "postgres")
-            self.assertTrue(olyr.isValid(), "Failed URI: %s" % dest_uri)
+            self.assertTrue(olyr.isValid(), f"Failed URI: {dest_uri}")
 
         # Test bug 17518
         _test('b17518')
@@ -1958,7 +1957,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(errmsg)
 
         mFilePath = QDir.toNativeSeparators(
-            '{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "singleSymbol"))
+            f"{unitTestDataPath()}/symbol_layer/singleSymbol.qml")
         status = vl.loadNamedStyle(mFilePath)
         self.assertTrue(status)
 
@@ -2122,7 +2121,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.dataProvider().isDeleteStyleFromDatabaseSupported())
 
         mFilePath = QDir.toNativeSeparators(
-            '{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "fontSymbol"))
+            f"{unitTestDataPath()}/symbol_layer/fontSymbol.qml")
         status = vl.loadNamedStyle(mFilePath)
         self.assertTrue(status)
 
@@ -2148,7 +2147,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
     def testHasMetadata(self):
         # views don't have metadata
-        vl = QgsVectorLayer('{} table="qgis_test"."{}" key="pk" sql='.format(self.dbconn, 'bikes_view'), "bikes_view",
+        vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"bikes_view\" key=\"pk\" sql=", "bikes_view",
                             "postgres")
         self.assertTrue(vl.isValid())
         self.assertFalse(vl.dataProvider().hasMetadata())
@@ -2455,7 +2454,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.addFeatures(features))
         self.assertTrue(vl.commitChanges())
         self.assertEqual(vl.featureCount(), 4000)
-        print("--- %s seconds ---" % (time.time() - start_time))
+        print(f"--- {time.time() - start_time} seconds ---")
 
         self.execSQLCommand('TRUNCATE massive_paste')
         start_time = time.time()
@@ -2475,7 +2474,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.addFeatures(features))
         self.assertTrue(vl.commitChanges())
         self.assertEqual(vl.featureCount(), 4000)
-        print("--- %s seconds ---" % (time.time() - start_time))
+        print(f"--- {time.time() - start_time} seconds ---")
 
     def testFilterOnCustomBbox(self):
         extent = QgsRectangle(-68, 70, -67, 80)
@@ -3086,22 +3085,22 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 '{} sslmode=disable key=id srid=3857 type=LINESTRING table="{}"."target_3857" (g) sql='
                 .format(self.dbconn, schema),
                 'target_3857', 'postgres')
-            self.assertTrue(vl_target_3857.isValid(), "Could not create a layer from the '{}.target_3857' table using dbconn '{}'" .format(schema, self.dbconn))
+            self.assertTrue(vl_target_3857.isValid(), f"Could not create a layer from the '{schema}.target_3857' table using dbconn '{self.dbconn}'")
             vl_reference_3857 = QgsVectorLayer(
                 '{} sslmode=disable key=id srid=3857 type=POINT table="{}"."reference_3857" (g) sql='
                 .format(self.dbconn, schema),
                 'reference_3857', 'postgres')
-            self.assertTrue(vl_reference_3857.isValid(), "Could not create a layer from the '{}.reference_3857' table using dbconn '{}'" .format(schema, self.dbconn))
+            self.assertTrue(vl_reference_3857.isValid(), f"Could not create a layer from the '{schema}.reference_3857' table using dbconn '{self.dbconn}'")
             vl_target_4326 = QgsVectorLayer(
                 '{} sslmode=disable key=id srid=4326 type=LINESTRING table="{}"."target_4326" (g) sql='
                 .format(self.dbconn, schema),
                 'target_4326', 'postgres')
-            self.assertTrue(vl_target_4326.isValid(), "Could not create a layer from the '{}.target_4326' table using dbconn '{}'" .format(schema, self.dbconn))
+            self.assertTrue(vl_target_4326.isValid(), f"Could not create a layer from the '{schema}.target_4326' table using dbconn '{self.dbconn}'")
             vl_reference_4326 = QgsVectorLayer(
                 '{} sslmode=disable key=id srid=4326 type=POINT table="{}"."reference_4326" (g) sql='
                 .format(self.dbconn, schema),
                 'reference_4326', 'postgres')
-            self.assertTrue(vl_reference_4326.isValid(), "Could not create a layer from the '{}.reference_4326' table using dbconn '{}'" .format(schema, self.dbconn))
+            self.assertTrue(vl_reference_4326.isValid(), f"Could not create a layer from the '{schema}.reference_4326' table using dbconn '{self.dbconn}'")
 
             # Create the ExtractWithinDistance algorithm
             # TODO: move registry initialization in class initialization ?
@@ -3402,8 +3401,7 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
 
     def testGetFeaturesFidTests(self):
         fids = [f.id() for f in self.source.getFeatures()]
-        assert len(fids) == 5, 'Expected 5 features, got {} instead'.format(
-            len(fids))
+        assert len(fids) == 5, f'Expected 5 features, got {len(fids)} instead'
         for id in fids:
             features = [f for f in self.source.getFeatures(
                 QgsFeatureRequest().setFilterFid(id))]

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -216,16 +216,14 @@ class TestPyQgsPostgresRasterProvider(unittest.TestCase):
 
         def _speed_check(schema, table, width, height):
             print('-' * 80)
-            print("Testing: {schema}.{table}".format(
-                table=table, schema=schema))
+            print(f"Testing: {schema}.{table}")
             print('-' * 80)
 
             # GDAL
             start = time.time()
             rl = QgsRasterLayer(
                 "PG: " + conn +
-                "table={table} mode=2 schema={schema}".format(
-                    table=table, schema=schema), 'gdal_layer',
+                f"table={table} mode=2 schema={schema}", 'gdal_layer',
                 'gdal')
             self.assertTrue(rl.isValid())
             # Make is smaller than full extent
@@ -234,12 +232,10 @@ class TestPyQgsPostgresRasterProvider(unittest.TestCase):
             print(f"Tiled GDAL start time: {checkpoint_1 - start:.6f}")
             rl.dataProvider().block(1, extent, width, height)
             checkpoint_2 = time.time()
-            print("Tiled GDAL first block time: {:.6f}".format(
-                checkpoint_2 - checkpoint_1))
+            print(f"Tiled GDAL first block time: {checkpoint_2 - checkpoint_1:.6f}")
             # rl.dataProvider().block(1, extent, width, height)
             checkpoint_3 = time.time()
-            print("Tiled GDAL second block time: {:.6f}".format(
-                checkpoint_3 - checkpoint_2))
+            print(f"Tiled GDAL second block time: {checkpoint_3 - checkpoint_2:.6f}")
             print(f"Total GDAL time: {checkpoint_3 - start:.6f}")
             print('-' * 80)
 
@@ -253,12 +249,10 @@ class TestPyQgsPostgresRasterProvider(unittest.TestCase):
             print(f"Tiled PG start time: {checkpoint_1 - start:.6f}")
             rl.dataProvider().block(1, extent, width, height)
             checkpoint_2 = time.time()
-            print("Tiled PG first block time: {:.6f}".format(
-                checkpoint_2 - checkpoint_1))
+            print(f"Tiled PG first block time: {checkpoint_2 - checkpoint_1:.6f}")
             rl.dataProvider().block(1, extent, width, height)
             checkpoint_3 = time.time()
-            print("Tiled PG second block time: {:.6f}".format(
-                checkpoint_3 - checkpoint_2))
+            print(f"Tiled PG second block time: {checkpoint_3 - checkpoint_2:.6f}")
             print(f"Total PG time: {checkpoint_3 - start:.6f}")
             print('-' * 80)
 
@@ -269,8 +263,7 @@ class TestPyQgsPostgresRasterProvider(unittest.TestCase):
         See: GH #34823"""
 
         rl = QgsRasterLayer(
-            self.dbconn + " sslmode=disable table={table} schema={schema}".format(
-                table='cosmo_i5_snow', schema='idro'),
+            self.dbconn + " sslmode=disable table=cosmo_i5_snow schema=idro",
             'pg_layer', 'postgresraster')
         self.assertTrue(rl.isValid())
         self.assertTrue(compareWkt(rl.extent().asWktPolygon(),

--- a/tests/src/python/test_provider_python.py
+++ b/tests/src/python/test_provider_python.py
@@ -160,7 +160,7 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
         testVectors = ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "None"]
         for v in testVectors:
             layer = QgsVectorLayer(v, "test", "pythonprovider")
-            assert layer.isValid(), "Failed to create valid %s pythonprovider layer" % (v)
+            assert layer.isValid(), f"Failed to create valid {v} pythonprovider layer"
 
     def testLayerGeometry(self):
         testVectors = [("Point", QgsWkbTypes.PointGeometry, QgsWkbTypes.Point),
@@ -197,12 +197,10 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
         for v in testVectors:
             layer = QgsVectorLayer(v[0], "test", "pythonprovider")
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (v[1], layer.geometryType()))
+            myMessage = f'Expected: {v[1]}\nGot: {layer.geometryType()}\n'
             assert layer.geometryType() == v[1], myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (v[2], layer.wkbType()))
+            myMessage = f'Expected: {v[2]}\nGot: {layer.wkbType()}\n'
             assert layer.wkbType() == v[2], myMessage
 
     def testAddFeatures(self):
@@ -214,8 +212,7 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
                                       QgsField("size", QVariant.Double)])
         assert res, "Failed to add attributes"
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (3, len(provider.fields())))
+        myMessage = f'Expected: {3}\nGot: {len(provider.fields())}\n'
 
         assert len(provider.fields()) == 3, myMessage
 
@@ -228,30 +225,25 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
 
         assert res, "Failed to add feature"
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (1, provider.featureCount()))
+        myMessage = f'Expected: {1}\nGot: {provider.featureCount()}\n'
         assert provider.featureCount() == 1, myMessage
 
         for f in provider.getFeatures(QgsFeatureRequest()):
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         ("Johny", f[0]))
+            myMessage = f"Expected: {'Johny'}\nGot: {f[0]}\n"
 
             assert f[0] == "Johny", myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (20, f[1]))
+            myMessage = f'Expected: {20}\nGot: {f[1]}\n'
 
             assert f[1] == 20, myMessage
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         (0.3, f[2]))
+            myMessage = f'Expected: {0.3}\nGot: {f[2]}\n'
 
             assert (f[2] - 0.3) < 0.0000001, myMessage
 
             geom = f.geometry()
 
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         ("Point (10 10)", str(geom.asWkt())))
+            myMessage = f"Expected: {'Point (10 10)'}\nGot: {str(geom.asWkt())}\n"
 
             assert compareWkt(str(geom.asWkt()), "Point (10 10)"), myMessage
 
@@ -262,8 +254,7 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
         provider.addAttributes([QgsField("name", QVariant.String),
                                 QgsField("age", QVariant.Int),
                                 QgsField("size", QVariant.Double)])
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (3, len(provider.fields())))
+        myMessage = f'Expected: {3}\nGot: {len(provider.fields())}\n'
 
         assert len(provider.fields()) == 3, myMessage
 
@@ -275,8 +266,7 @@ class TestPyQgsPythonProvider(unittest.TestCase, ProviderTestCase):
         provider.addFeatures([ft])
 
         for f in provider.getFeatures(QgsFeatureRequest()):
-            myMessage = ('Expected: %s\nGot: %s\n' %
-                         ("Johny", f['name']))
+            myMessage = f"Expected: {'Johny'}\nGot: {f['name']}\n"
 
             self.assertEqual(f["name"], "Johny", myMessage)
 

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -752,7 +752,7 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
 
         testPath = TEST_DATA_DIR + '/' + 'points.shp'
         subSetString = '"Class" = \'Biplane\''
-        subSet = '|layerid=0|subset=%s' % subSetString
+        subSet = f'|layerid=0|subset={subSetString}'
 
         # unfiltered
         vl = QgsVectorLayer(testPath, 'test', 'ogr')

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -312,8 +312,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         shutil.copy(os.path.join(srcpath, 'spatialite.db'), datasource)
 
         vl = QgsVectorLayer(
-            'dbname=\'{}\' table="somedata" (geom) sql='.format(
-                datasource), 'test',
+            f'dbname=\'{datasource}\' table="somedata" (geom) sql=', 'test',
             'spatialite')
         return vl
 
@@ -460,7 +459,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         Test that constraint detection does not crash
         """
         # should be no crash!
-        QgsVectorLayer("dbname={} table=KNN".format(TEST_DATA_DIR + '/views_test.sqlite'), "KNN",
+        QgsVectorLayer(f"dbname={TEST_DATA_DIR + '/views_test.sqlite'} table=KNN", "KNN",
                        "spatialite")
 
     def test_queries(self):
@@ -468,7 +467,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
         # a query with a geometry, but no unique id
         # the id will be autoincremented
-        l = QgsVectorLayer("dbname=%s table='(select * from test_q)' (geometry)" % self.dbname, "test_pg_query1",
+        l = QgsVectorLayer(f"dbname={self.dbname} table='(select * from test_q)' (geometry)", "test_pg_query1",
                            "spatialite")
         self.assertTrue(l.isValid())
         # the id() is autoincremented
@@ -479,7 +478,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(sum_id2, 32)  # 11 + 21
 
         # and now with an id declared
-        l = QgsVectorLayer("dbname=%s table='(select * from test_q)' (geometry) key='id'" % self.dbname,
+        l = QgsVectorLayer(f"dbname={self.dbname} table='(select * from test_q)' (geometry) key='id'",
                            "test_pg_query1", "spatialite")
         self.assertTrue(l.isValid())
         sum_id1 = sum(f.id() for f in l.getFeatures())
@@ -488,7 +487,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(sum_id2, 32)
 
         # a query, but no geometry
-        l = QgsVectorLayer("dbname=%s table='(select id,name from test_q)' key='id'" % self.dbname, "test_pg_query1",
+        l = QgsVectorLayer(f"dbname={self.dbname} table='(select id,name from test_q)' key='id'", "test_pg_query1",
                            "spatialite")
         self.assertTrue(l.isValid())
         sum_id1 = sum(f.id() for f in l.getFeatures())
@@ -700,10 +699,10 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         read_back = l.getFeature(new_f['id'])
 
     def test_discover_relation(self):
-        artist = QgsVectorLayer("dbname=%s table=test_relation_a (geometry)" % self.dbname, "test_relation_a",
+        artist = QgsVectorLayer(f"dbname={self.dbname} table=test_relation_a (geometry)", "test_relation_a",
                                 "spatialite")
         self.assertTrue(artist.isValid())
-        track = QgsVectorLayer("dbname=%s table=test_relation_b (geometry)" % self.dbname, "test_relation_b",
+        track = QgsVectorLayer(f"dbname={self.dbname} table=test_relation_b (geometry)", "test_relation_b",
                                "spatialite")
         self.assertTrue(track.isValid())
         QgsProject.instance().addMapLayer(artist)
@@ -725,7 +724,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
             QgsProject.instance().removeMapLayer(artist.id())
 
     def testNotNullConstraint(self):
-        vl = QgsVectorLayer("dbname=%s table=test_constraints key='id'" % self.dbname, "test_constraints",
+        vl = QgsVectorLayer(f"dbname={self.dbname} table=test_constraints key='id'", "test_constraints",
                             "spatialite")
         self.assertTrue(vl.isValid())
         self.assertEqual(len(vl.fields()), 5)
@@ -767,7 +766,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
                          QgsFieldConstraints.ConstraintOriginProvider)
 
     def testUniqueConstraint(self):
-        vl = QgsVectorLayer("dbname=%s table=test_constraints key='id'" % self.dbname, "test_constraints",
+        vl = QgsVectorLayer(f"dbname={self.dbname} table=test_constraints key='id'", "test_constraints",
                             "spatialite")
         self.assertTrue(vl.isValid())
         self.assertEqual(len(vl.fields()), 5)
@@ -809,7 +808,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
                          QgsFieldConstraints.ConstraintOriginProvider)
 
     def testSkipConstraintCheck(self):
-        vl = QgsVectorLayer("dbname=%s table=test_autoincrement" % self.dbname, "test_autoincrement",
+        vl = QgsVectorLayer(f"dbname={self.dbname} table=test_autoincrement", "test_autoincrement",
                             "spatialite")
         self.assertTrue(vl.isValid())
 
@@ -912,7 +911,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
     def testSubsetStringRegexp(self):
         """Check that the provider supports the REGEXP syntax"""
 
-        testPath = "dbname=%s table='test_filter' (geometry) key='id'" % self.dbname
+        testPath = f"dbname={self.dbname} table='test_filter' (geometry) key='id'"
         vl = QgsVectorLayer(testPath, 'test', 'spatialite')
         self.assertTrue(vl.isValid())
         vl.setSubsetString('"name" REGEXP \'[txe]{3}\'')
@@ -926,10 +925,10 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         def _lessdigits(s):
             return re.sub(r'(\d+\.\d{3})\d+', r'\1', s)
 
-        testPath = "dbname=%s table='test_filter' (geometry) key='id'" % self.dbname
+        testPath = f"dbname={self.dbname} table='test_filter' (geometry) key='id'"
 
         subSetString = '"name" = \'int\''
-        subSet = ' sql=%s' % subSetString
+        subSet = f' sql={subSetString}'
 
         # unfiltered
         vl = QgsVectorLayer(testPath, 'test', 'spatialite')
@@ -1030,8 +1029,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
             cur.execute("COMMIT")
 
-            testPath = "dbname={} table='{}' (geometry)".format(
-                dbname, table_name)
+            testPath = f"dbname={dbname} table='{table_name}' (geometry)"
             vl = QgsVectorLayer(testPath, 'test', 'spatialite')
             self.assertTrue(vl.isValid())
             self.assertEqual(vl.featureCount(), 1)
@@ -1076,7 +1074,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         cur.execute("COMMIT")
         con.close()
 
-        testPath = "dbname=%s table='test_pg' (geometry) key='id'" % dbname
+        testPath = f"dbname={dbname} table='test_pg' (geometry) key='id'"
         vl = QgsVectorLayer(testPath, 'test', 'spatialite')
         self.assertTrue(vl.isValid())
         self.assertEqual(vl.featureCount(), 1)
@@ -1141,7 +1139,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         cur.execute("COMMIT")
         con.close()
 
-        testPath = "dbname=%s table='test_pg' (geometry) key='id'" % dbname
+        testPath = f"dbname={dbname} table='test_pg' (geometry) key='id'"
         vl = QgsVectorLayer(testPath, 'test', 'spatialite')
         self.assertTrue(vl.isValid())
 
@@ -1304,14 +1302,14 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
         def _make_table(table_name):
             # simple table without primary key
-            sql = "CREATE TABLE \"%s\" (name TEXT NOT NULL)" % table_name
+            sql = f"CREATE TABLE \"{table_name}\" (name TEXT NOT NULL)"
             cur.execute(sql)
 
-            sql = "SELECT AddGeometryColumn('%s', 'geom', 4326, 'POINT', 'XY')" % table_name
+            sql = f"SELECT AddGeometryColumn('{table_name}', 'geom', 4326, 'POINT', 'XY')"
             cur.execute(sql)
 
             for i in range(11, 21):
-                sql = "INSERT INTO \"%s\" (name, geom) " % table_name
+                sql = f"INSERT INTO \"{table_name}\" (name, geom) "
                 sql += "VALUES ('name {id}', GeomFromText('POINT({id} {id})', 4326))".format(id=i)
                 cur.execute(sql)
 
@@ -1338,17 +1336,17 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
                                  'Point ({id} {id})'.format(id=i))
                 i += 1
 
-        vl_pk = QgsVectorLayer('dbname=\'%s\' table="(select * from \\"test pk\\")" (geometry) sql=' % dbname, 'pk',
+        vl_pk = QgsVectorLayer(f'dbname=\'{dbname}\' table="(select * from \\"test pk\\")" (geometry) sql=', 'pk',
                                'spatialite')
         self.assertTrue(vl_pk.isValid())
         _check_features(vl_pk, 0)
 
-        vl_no_pk = QgsVectorLayer('dbname=\'%s\' table="(select * from somedata)" (geom) sql=' % dbname, 'pk',
+        vl_no_pk = QgsVectorLayer(f'dbname=\'{dbname}\' table="(select * from somedata)" (geom) sql=', 'pk',
                                   'spatialite')
         self.assertTrue(vl_no_pk.isValid())
         _check_features(vl_no_pk, 10)
 
-        vl_no_pk = QgsVectorLayer('dbname=\'%s\' table="(select * from \\"some data\\")" (geom) sql=' % dbname, 'pk',
+        vl_no_pk = QgsVectorLayer(f'dbname=\'{dbname}\' table="(select * from \\"some data\\")" (geom) sql=', 'pk',
                                   'spatialite')
         self.assertTrue(vl_no_pk.isValid())
         _check_features(vl_no_pk, 10)
@@ -1412,13 +1410,13 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
                 self.assertTrue(vl.getFeature(f.id()).isValid())
                 self.assertEqual(vl.getFeature(f.id()).id(), f.id())
 
-        testPath = "dbname=%s table='test_pg' (geometry) key='id'" % dbname
+        testPath = f"dbname={dbname} table='test_pg' (geometry) key='id'"
         _test_db(testPath)
-        testPath = "dbname=%s table='test_pg' (geometry)" % dbname
+        testPath = f"dbname={dbname} table='test_pg' (geometry)"
         _test_db(testPath)
-        testPath = "dbname=%s table='test_pg' key='id'" % dbname
+        testPath = f"dbname={dbname} table='test_pg' key='id'"
         _test_db(testPath)
-        testPath = "dbname=%s table='test_pg'" % dbname
+        testPath = f"dbname={dbname} table='test_pg'"
         _test_db(testPath)
 
     def testGeometryTypes(self):
@@ -1499,7 +1497,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
     def testBigint(self):
         """Test unique values bigint, see GH #33585"""
 
-        l = QgsVectorLayer("dbname=%s table='test_bigint' (position) key='id'" % self.dbname, "test_bigint",
+        l = QgsVectorLayer(f"dbname={self.dbname} table='test_bigint' (position) key='id'", "test_bigint",
                            "spatialite")
         self.assertTrue(l.isValid())
         self.assertEqual(l.uniqueValues(1), {1, 2})
@@ -1536,7 +1534,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         cur.execute("COMMIT")
         con.close()
 
-        vl = QgsVectorLayer("dbname='%s' table='test_table_default_values'" % dbname, 'test_table_default_values',
+        vl = QgsVectorLayer(f"dbname='{dbname}' table='test_table_default_values'", 'test_table_default_values',
                             'spatialite')
         self.assertTrue(vl.isValid())
 
@@ -1575,7 +1573,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         del (vl)
 
         # Verify
-        vl2 = QgsVectorLayer("dbname='%s' table='test_table_default_values'" % dbname, 'test_table_default_values',
+        vl2 = QgsVectorLayer(f"dbname='{dbname}' table='test_table_default_values'", 'test_table_default_values',
                              'spatialite')
         self.assertTrue(vl2.isValid())
         feature = next(vl2.getFeatures())
@@ -1610,7 +1608,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         cur.execute("COMMIT")
         con.close()
 
-        vl = QgsVectorLayer("dbname='%s' table='test_aspatial_multiple_edits'" % dbname, 'test_aspatial_multiple_edits',
+        vl = QgsVectorLayer(f"dbname='{dbname}' table='test_aspatial_multiple_edits'", 'test_aspatial_multiple_edits',
                             'spatialite')
         self.assertTrue(vl.isValid())
 
@@ -1649,7 +1647,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
     def testBLOBType(self):
         """Test binary field"""
-        vl = QgsVectorLayer('dbname=%s table="blob_table" sql=' % self.dbname, "testBLOBType", "spatialite")
+        vl = QgsVectorLayer(f'dbname={self.dbname} table="blob_table" sql=', "testBLOBType", "spatialite")
         self.assertTrue(vl.isValid())
 
         fields = vl.dataProvider().fields()

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -111,7 +111,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         # cross join
         query = toPercent("SELECT * FROM france_parts,points")
-        vl = QgsVectorLayer("?query=%s" % query, "tt", "virtual")
+        vl = QgsVectorLayer(f"?query={query}", "tt", "virtual")
 
         self.assertEqual(vl.featureCount(), l0.featureCount() * l1.featureCount())
 
@@ -178,7 +178,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         # the source contains ',' and single quotes
         fn = os.path.join(tempfile.gettempdir(), "test,.db")
         create_test_db(fn)
-        source = "dbname='%s' table=\"test\" (geometry) sql=" % fn
+        source = f"dbname='{fn}' table=\"test\" (geometry) sql="
         d = QgsVirtualLayerDefinition()
         d.addSource("t", source, "spatialite")
         l = QgsVectorLayer(d.toString(), "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
@@ -187,7 +187,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         # the source contains ':' and single quotes
         fn = os.path.join(tempfile.gettempdir(), "test:.db")
         create_test_db(fn)
-        source = "dbname='%s' table=\"test\" (geometry) sql=" % fn
+        source = f"dbname='{fn}' table=\"test\" (geometry) sql="
         d = QgsVirtualLayerDefinition()
         d.addSource("t", source, "spatialite")
         l = QgsVectorLayer(d.toString(), "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
@@ -217,7 +217,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         l2 = QgsVectorLayer("?layer_ref=" + l1.id(), "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l2.isValid(), True)
 
-        l2 = QgsVectorLayer("?layer_ref=%s:nn" % l1.id(), "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l2 = QgsVectorLayer(f"?layer_ref={l1.id()}:nn", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l2.isValid(), True)
 
         QgsProject.instance().removeMapLayer(l1.id())
@@ -363,7 +363,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
                (11, "MULTICURVE", "(COMPOUNDCURVE(CIRCULARSTRING(0 0, 1 0, 1 1)),COMPOUNDCURVE(CIRCULARSTRING(2 2, 3 2, 3 3)))"),
                (12, "MULTISURFACE", "(CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0, 1 0, 1 1))),CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(2 2, 3 2, 3 3))))")]
         for wkb_type, wkt_type, wkt in geo:
-            l = QgsVectorLayer("%s?crs=epsg:4326" % wkt_type, "m1", "memory", QgsVectorLayer.LayerOptions(False))
+            l = QgsVectorLayer(f"{wkt_type}?crs=epsg:4326", "m1", "memory", QgsVectorLayer.LayerOptions(False))
             self.assertEqual(l.isValid(), True)
             QgsProject.instance().addMapLayer(l)
 
@@ -373,7 +373,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
             f1.setGeometry(g)
             l.dataProvider().addFeatures([f1])
 
-            l2 = QgsVectorLayer("?layer_ref=%s" % l.id(), "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+            l2 = QgsVectorLayer(f"?layer_ref={l.id()}", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
             self.assertEqual(l2.isValid(), True)
             self.assertEqual(l2.dataProvider().featureCount(), 1)
             # we ensure the geom type matches the original (segmentized) type
@@ -388,10 +388,10 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
     def test_embeddedLayer(self):
         source = toPercent(os.path.join(self.testDataDir, "france_parts.shp"))
-        l = QgsVectorLayer("?layer=ogr:%s" % source, "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l = QgsVectorLayer(f"?layer=ogr:{source}", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
 
-        l = QgsVectorLayer("?layer=ogr:%s:nn" % source, "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l = QgsVectorLayer(f"?layer=ogr:{source}:nn", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
 
     def test_filter_rect(self):
@@ -407,7 +407,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
     def test_recursiveLayer(self):
         source = toPercent(os.path.join(self.testDataDir, "france_parts.shp"))
-        l = QgsVectorLayer("?layer=ogr:%s" % source, "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l = QgsVectorLayer(f"?layer=ogr:{source}", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
         QgsProject.instance().addMapLayer(l)
 
@@ -548,7 +548,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().addMapLayer(l2)
 
         query = toPercent("SELECT * FROM france_parts")
-        l4 = QgsVectorLayer("?query=%s&uid=ObjectId" % query, "tt", "virtual")
+        l4 = QgsVectorLayer(f"?query={query}&uid=ObjectId", "tt", "virtual")
         self.assertEqual(l4.isValid(), True)
 
         self.assertEqual(l4.dataProvider().wkbType(), 6)
@@ -564,7 +564,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         # use uid
         query = toPercent("SELECT * FROM france_parts")
-        l5 = QgsVectorLayer("?query=%s&geometry=geometry:polygon:4326&uid=ObjectId" % query, "tt", "virtual")
+        l5 = QgsVectorLayer(f"?query={query}&geometry=geometry:polygon:4326&uid=ObjectId", "tt", "virtual")
         self.assertEqual(l5.isValid(), True)
 
         idSum = sum(f.id() for f in l5.getFeatures())
@@ -607,14 +607,14 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         # unnamed column
         query = toPercent("SELECT count(*)")
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().fields().at(0).name(), "count(*)")
         self.assertEqual(l4.dataProvider().fields().at(0).type(), QVariant.LongLong)
 
     def test_sql_field_types(self):
         query = toPercent("SELECT 42 as t, 'ok'||'ok' as t2, GeomFromText('') as t3, 3.14*2 as t4")
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().fields().at(0).name(), "t")
         self.assertEqual(l4.dataProvider().fields().at(0).type(), QVariant.LongLong)
@@ -628,7 +628,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         # with type annotations
         query = toPercent(
             "SELECT '42.0' as t /*:real*/, 3 as t2/*:text  */, GeomFromText('') as t3 /*:multiPoInT:4326 */, 3.14*2 as t4/*:int*/")
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().fields().at(0).name(), "t")
         self.assertEqual(l4.dataProvider().fields().at(0).type(), QVariant.Double)
@@ -646,14 +646,14 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         # with type annotations and url options
         query = toPercent("SELECT 1 as id /*:int*/, geomfromtext('point(0 0)',4326) as geometry/*:point:4326*/")
-        l4 = QgsVectorLayer("?query=%s&geometry=geometry" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}&geometry=geometry", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().wkbType(), 1)  # point
 
         # with type annotations and url options (2)
         query = toPercent(
             "SELECT 1 as id /*:int*/, 3.14 as f, geomfromtext('point(0 0)',4326) as geometry/*:point:4326*/")
-        l4 = QgsVectorLayer("?query=%s&geometry=geometry&field=id:text" % query, "tt", "virtual",
+        l4 = QgsVectorLayer(f"?query={query}&geometry=geometry&field=id:text", "tt", "virtual",
                             QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().fields().at(0).name(), "id")
@@ -664,19 +664,19 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
     def test_sql3b(self):
         query = toPercent("SELECT GeomFromText('POINT(0 0)') as geom")
-        l4 = QgsVectorLayer("?query=%s&geometry=geom" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}&geometry=geom", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().wkbType(), 1)
 
         # forced geometry type
         query = toPercent("SELECT GeomFromText('POINT(0 0)') as geom")
-        l4 = QgsVectorLayer("?query=%s&geometry=geom:point:0" % query, "tt", "virtual",
+        l4 = QgsVectorLayer(f"?query={query}&geometry=geom:point:0", "tt", "virtual",
                             QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().wkbType(), 1)
 
         query = toPercent("SELECT CastToPoint(GeomFromText('POINT(0 0)')) as geom")
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         self.assertEqual(l4.dataProvider().wkbType(), 1)
 
@@ -687,7 +687,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().addMapLayer(l2)
 
         query = toPercent("SELECT OBJECTId from france_parts")
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         s = sum(f.attributes()[0] for f in l4.getFeatures())
         self.assertEqual(s, 10659)
@@ -700,7 +700,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().addMapLayer(l2)
 
         query = toPercent('SELECT OBJECTId from "FranCe parts"')
-        l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", QgsVectorLayer.LayerOptions(False))
+        l4 = QgsVectorLayer(f"?query={query}", "tt", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l4.isValid(), True)
         s = sum(f.attributes()[0] for f in l4.getFeatures())
         self.assertEqual(s, 10659)
@@ -708,14 +708,14 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
     def test_encoding(self):
         # changes encoding on a shapefile (the only provider supporting setEncoding)
         source = toPercent(os.path.join(self.testDataDir, "shp_latin1.dbf"))
-        l = QgsVectorLayer("?layer=ogr:%s:fp:latin1" % source, "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l = QgsVectorLayer(f"?layer=ogr:{source}:fp:latin1", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
 
         for f in l.getFeatures():
             self.assertEqual(f.attributes()[1], "accents éàè")
 
         # use UTF-8 now
-        l = QgsVectorLayer("?layer=ogr:%s:fp:UTF-8" % source, "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
+        l = QgsVectorLayer(f"?layer=ogr:{source}:fp:UTF-8", "vtab", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
         for f in l.getFeatures():
             self.assertEqual(f.attributes()[1], "accents \ufffd\ufffd\ufffd")  # invalid unicode characters
@@ -732,7 +732,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
     def test_geometry_conversion(self):
         query = toPercent("select geomfromtext('multipoint((0 0),(1 1))') as geom")
-        l = QgsVectorLayer("?query=%s&geometry=geom:multipoint:0" % query, "tt", "virtual",
+        l = QgsVectorLayer(f"?query={query}&geometry=geom:multipoint:0", "tt", "virtual",
                            QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
         for f in l.getFeatures():
@@ -741,7 +741,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         query = toPercent(
             "select geomfromtext('multipolygon(((0 0,1 0,1 1,0 1,0 0)),((0 1,1 1,1 2,0 2,0 1)))') as geom")
-        l = QgsVectorLayer("?query=%s&geometry=geom:multipolygon:0" % query, "tt", "virtual",
+        l = QgsVectorLayer(f"?query={query}&geometry=geom:multipolygon:0", "tt", "virtual",
                            QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
         for f in l.getFeatures():
@@ -749,7 +749,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
             self.assertEqual(")),((" in f.geometry().asWkt(), True)  # has two polygons
 
         query = toPercent("select geomfromtext('multilinestring((0 0,1 0,1 1,0 1,0 0),(0 1,1 1,1 2,0 2,0 1))') as geom")
-        l = QgsVectorLayer("?query=%s&geometry=geom:multilinestring:0" % query, "tt", "virtual",
+        l = QgsVectorLayer(f"?query={query}&geometry=geom:multilinestring:0", "tt", "virtual",
                            QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l.isValid(), True)
         for f in l.getFeatures():
@@ -788,7 +788,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().addMapLayer(l1)
 
         query = toPercent("SELECT * FROM france_parts")
-        l2 = QgsVectorLayer("?query=%s" % query, "aa", "virtual", QgsVectorLayer.LayerOptions(False))
+        l2 = QgsVectorLayer(f"?query={query}", "aa", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l2.isValid(), True)
         QgsProject.instance().addMapLayer(l2)
 
@@ -797,7 +797,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(ll0.layerId().startswith('france_parts'), True)
 
         query = toPercent("SELECT t1.objectid, t2.name_0 FROM france_parts as t1, aa as t2")
-        l3 = QgsVectorLayer("?query=%s" % query, "bb", "virtual", QgsVectorLayer.LayerOptions(False))
+        l3 = QgsVectorLayer(f"?query={query}", "bb", "virtual", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l3.isValid(), True)
         QgsProject.instance().addMapLayer(l3)
 
@@ -1160,7 +1160,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().addMapLayer(pl)
 
         query = toPercent("SELECT * FROM points")
-        vl = QgsVectorLayer("?query=%s&uid=OBJECTID" % (query), "vl", "virtual")
+        vl = QgsVectorLayer(f"?query={query}&uid=OBJECTID", "vl", "virtual")
         self.assertEqual(vl.isValid(), True)
         self.assertEqual(vl.dataProvider().featureCount(), 17)
 

--- a/tests/src/python/test_qgsanimatedmarkersymbollayer.py
+++ b/tests/src/python/test_qgsanimatedmarkersymbollayer.py
@@ -70,7 +70,7 @@ class TestQgsAnimatedMarkerSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsAnimatedMarkerSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -55,7 +55,7 @@ class TestQgsAnnotation(unittest.TestCase):
         self.report = "<h1>Python QgsAnnotation Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -62,7 +62,7 @@ class TestQgsAnnotationLayer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsannotationlineitem.py
+++ b/tests/src/python/test_qgsannotationlineitem.py
@@ -58,7 +58,7 @@ class TestQgsAnnotationLineItem(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsannotationmarkeritem.py
+++ b/tests/src/python/test_qgsannotationmarkeritem.py
@@ -56,7 +56,7 @@ class TestQgsAnnotationMarkerItem(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsannotationpointtextitem.py
+++ b/tests/src/python/test_qgsannotationpointtextitem.py
@@ -58,7 +58,7 @@ class TestQgsAnnotationPointTextItem(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsannotationpolygonitem.py
+++ b/tests/src/python/test_qgsannotationpolygonitem.py
@@ -60,7 +60,7 @@ class TestQgsAnnotationPolygonItem(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsapplication.py
+++ b/tests/src/python/test_qgsapplication.py
@@ -23,8 +23,7 @@ class TestPyQgsApplication(unittest.TestCase):
         QGISAPP.setUITheme('fooobar')
         myExpectedResult = 'default'
         myResult = QGISAPP.themeName()
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     (myExpectedResult, myResult))
+        myMessage = f'Expected:\n{myExpectedResult}\nGot:\n{myResult}\n'
         assert myExpectedResult == myResult, myMessage
 
 

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -79,11 +79,11 @@ class TestPyQgsAppStartup(unittest.TestCase):
         while not os.path.exists(myTestFile):
             p.poll()
             if p.returncode is not None:
-                raise Exception('Return code: {}, Call: "{}", Env: {}'.format(p.returncode, ' '.join(call), env))
+                raise Exception(f"Return code: {p.returncode}, Call: \"{' '.join(call)}\", Env: {env}")
             time.sleep(1)
             s += 1
             if s > timeOut:
-                raise Exception('Timed out waiting for application start, Call: "{}", Env: {}'.format(' '.join(call), env))
+                raise Exception(f"Timed out waiting for application start, Call: \"{' '.join(call)}\", Env: {env}")
 
         with open(myTestFile, encoding='utf-8') as res_file:
             lines = res_file.readlines()
@@ -102,8 +102,7 @@ class TestPyQgsAppStartup(unittest.TestCase):
         testfile = 'pyqgis_startup.txt'
         testfilepath = os.path.join(self.TMP_DIR, testfile).replace('\\', '/')
         testcode = [
-            "from qgis.core import QgsApplication\n"
-            "f = open('{}', 'w')\n".format(testfilepath),
+            f"from qgis.core import QgsApplication\nf = open('{testfilepath}', 'w')\n",
             "f.write('Platform: ' + QgsApplication.platform())\n",
             "f.close()\n"
         ]
@@ -123,8 +122,7 @@ class TestPyQgsAppStartup(unittest.TestCase):
         testfile = 'pyqgis_code.txt'
         testfilepath = os.path.join(self.TMP_DIR, testfile).replace('\\', '/')
         testcode = [
-            "import sys\n"
-            "f = open('{}', 'a')\n".format(testfilepath),
+            f"import sys\nf = open('{testfilepath}', 'a')\n",
             "for arg in sys.argv:\n"
             "  f.write(arg)\n",
             "  f.write('\\n')\n",

--- a/tests/src/python/test_qgsarrowsymbollayer.py
+++ b/tests/src/python/test_qgsarrowsymbollayer.py
@@ -78,7 +78,7 @@ class TestQgsArrowSymbolLayer(unittest.TestCase):
 
     def tearDown(self):
         QgsProject.instance().removeAllMapLayers()
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -43,7 +43,7 @@ class TestQgsAttributeForm(unittest.TestCase):
 
     @classmethod
     def createLayerWithOnePoint(cls, field_type):
-        layer = QgsVectorLayer("Point?field=fld:%s" % field_type,
+        layer = QgsVectorLayer(f"Point?field=fld:{field_type}",
                                "vl", "memory")
         pr = layer.dataProvider()
         f = QgsFeature()

--- a/tests/src/python/test_qgsauthsystem.py
+++ b/tests/src/python/test_qgsauthsystem.py
@@ -48,8 +48,7 @@ class TestQgsAuthManager(unittest.TestCase):
 
     def setUp(self):
         testid = self.id().split('.')
-        testheader = '\n#####_____ {0}.{1} _____#####\n'. \
-            format(testid[1], testid[2])
+        testheader = f'\n#####_____ {testid[1]}.{testid[2]} _____#####\n'
         qDebug(testheader)
 
         if (not self.authm.masterPasswordIsSet() or
@@ -385,10 +384,7 @@ class TestQgsAuthManager(unittest.TestCase):
         for _ in range(50):
             # time.sleep(0.01)  # or else the salt is not random enough
             uids.append(self.authm.uniqueConfigId())
-        msg = 'Generated 50 config ids are not unique:\n{}\n{}'.format(
-            uids,
-            list(set(uids))
-        )
+        msg = f'Generated 50 config ids are not unique:\n{uids}\n{list(set(uids))}'
         self.assertEqual(len(uids), len(list(set(uids))), msg)
 
     def config_list(self):

--- a/tests/src/python/test_qgsblockingprocess.py
+++ b/tests/src/python/test_qgsblockingprocess.py
@@ -190,7 +190,7 @@ class TestQgsBlockingProcess(unittest.TestCase):
             f.write('echo $PATH')
 
         prev_path_val = os.getenv('PATH')
-        new_path = "{}{}{}".format('/my_test/folder', os.pathsep, prev_path_val)
+        new_path = f"/my_test/folder{os.pathsep}{prev_path_val}"
         os.environ['PATH'] = new_path
 
         std_out.val = ''

--- a/tests/src/python/test_qgscolorramplegendnode.py
+++ b/tests/src/python/test_qgscolorramplegendnode.py
@@ -57,7 +57,7 @@ class TestQgsColorRampLegendNode(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsdistancearea.py
+++ b/tests/src/python/test_qgsdistancearea.py
@@ -58,8 +58,7 @@ class TestQgsDistanceArea(unittest.TestCase):
         )
         da = QgsDistanceArea()
         length = da.measureLength(linestring)
-        myMessage = ('Expected:\n%f\nGot:\n%f\n' %
-                     (4, length))
+        myMessage = f'Expected:\n{4:f}\nGot:\n{length:f}\n'
         assert length == 4, myMessage
 
     def testBearing(self):
@@ -559,8 +558,7 @@ class TestQgsDistanceArea(unittest.TestCase):
         )
         da = QgsDistanceArea()
         length = da.measureLength(linestring)
-        myMessage = ('Expected:\n%f\nGot:\n%f\n' %
-                     (9, length))
+        myMessage = f'Expected:\n{9:f}\nGot:\n{length:f}\n'
         assert length == 9, myMessage
 
     def testMeasurePolygon(self):

--- a/tests/src/python/test_qgselevationprofilecanvas.py
+++ b/tests/src/python/test_qgselevationprofilecanvas.py
@@ -76,7 +76,7 @@ class TestQgsElevationProfileCanvas(unittest.TestCase):
         self.report = "<h1>Python QgsElevationProfileCanvas Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsembeddedsymbolrenderer.py
+++ b/tests/src/python/test_qgsembeddedsymbolrenderer.py
@@ -52,7 +52,7 @@ class TestQgsEmbeddedSymbolRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -22,7 +22,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     @qgsfunction(1, 'testing', register=False)
     def testfun(values, feature, parent):
         """ Function help """
-        return "Testing_%s" % values[0]
+        return f"Testing_{values[0]}"
 
     @qgsfunction(args="auto", group='testing', register=False)
     def autocount(value1, value2, value3, feature, parent):

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -133,7 +133,7 @@ class TestQgsFeature(unittest.TestCase):
         fit.nextFeature(feat)
         fit.close()
         myValidValue = feat.isValid()
-        myMessage = '\nExpected: {}\nGot: {}'.format("True", myValidValue)
+        myMessage = f"\nExpected: True\nGot: {myValidValue}"
         assert myValidValue, myMessage
 
     def test_Validity(self):
@@ -169,10 +169,7 @@ class TestQgsFeature(unittest.TestCase):
 
         # Only for printing purposes
         myExpectedAttributes = ["Highway", 1]
-        myMessage = '\nExpected: {}\nGot: {}'.format(
-            myExpectedAttributes,
-            myAttributes
-        )
+        myMessage = f'\nExpected: {myExpectedAttributes}\nGot: {myAttributes}'
 
         assert myAttributes == myExpectedAttributes, myMessage
 

--- a/tests/src/python/test_qgsfieldvalidator.py
+++ b/tests/src/python/test_qgsfieldvalidator.py
@@ -114,7 +114,7 @@ class TestQgsFieldValidator(unittest.TestCase):
 
         # Invalid
         _test('12345-1234', QValidator.Invalid)
-        _test('12345%s1234' % DECIMAL_SEPARATOR, QValidator.Invalid)
+        _test(f'12345{DECIMAL_SEPARATOR}1234', QValidator.Invalid)
         _test('onetwothree', QValidator.Invalid)
 
     def test_doubleValidator(self):

--- a/tests/src/python/test_qgsfillsymbollayers.py
+++ b/tests/src/python/test_qgsfillsymbollayers.py
@@ -32,7 +32,7 @@ class TestQgsFillSymbolLayers(unittest.TestCase):
         self.report = "<h1>Python QgsFillSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -849,7 +849,7 @@ class TestQgsGeometry(unittest.TestCase):
                 # test that geometry can be created from WKT
                 geom = QgsGeometry.fromWkt(row['wkt'])
                 if row['valid_wkt']:
-                    assert geom, "WKT conversion {} failed: could not create geom:\n{}\n".format(i + 1, row['wkt'])
+                    assert geom, f"WKT conversion {i + 1} failed: could not create geom:\n{row['wkt']}\n"
                 else:
                     assert not geom, "Corrupt WKT {} was incorrectly converted to geometry:\n{}\n".format(i + 1,
                                                                                                           row['wkt'])
@@ -1018,8 +1018,7 @@ class TestQgsGeometry(unittest.TestCase):
             QgsPointXY(2, 0),
             QgsPointXY(0, 0)]])
         touchesGeom = QgsGeometry.touches(myLine, myPoly)
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     ("True", touchesGeom))
+        myMessage = f"Expected:\n{'True'}\nGot:\n{touchesGeom}\n"
         assert touchesGeom, myMessage
 
     def testOverlaps(self):
@@ -1035,8 +1034,7 @@ class TestQgsGeometry(unittest.TestCase):
             QgsPointXY(0, 2),
             QgsPointXY(0, 0)]])
         overlapsGeom = QgsGeometry.overlaps(myPolyA, myPolyB)
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     ("True", overlapsGeom))
+        myMessage = f"Expected:\n{'True'}\nGot:\n{overlapsGeom}\n"
         assert overlapsGeom, myMessage
 
     def testWithin(self):
@@ -1052,16 +1050,14 @@ class TestQgsGeometry(unittest.TestCase):
             QgsPointXY(0, 2),
             QgsPointXY(0, 0)]])
         withinGeom = QgsGeometry.within(myLine, myPoly)
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     ("True", withinGeom))
+        myMessage = f"Expected:\n{'True'}\nGot:\n{withinGeom}\n"
         assert withinGeom, myMessage
 
     def testEquals(self):
         myPointA = QgsGeometry.fromPointXY(QgsPointXY(1, 1))
         myPointB = QgsGeometry.fromPointXY(QgsPointXY(1, 1))
         equalsGeom = QgsGeometry.equals(myPointA, myPointB)
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     ("True", equalsGeom))
+        myMessage = f"Expected:\n{'True'}\nGot:\n{equalsGeom}\n"
         assert equalsGeom, myMessage
 
     def testCrosses(self):
@@ -1076,8 +1072,7 @@ class TestQgsGeometry(unittest.TestCase):
             QgsPointXY(1, 2),
             QgsPointXY(1, 0)]])
         crossesGeom = QgsGeometry.crosses(myLine, myPoly)
-        myMessage = ('Expected:\n%s\nGot:\n%s\n' %
-                     ("True", crossesGeom))
+        myMessage = f"Expected:\n{'True'}\nGot:\n{crossesGeom}\n"
         assert crossesGeom, myMessage
 
     def testSimplifyIssue4189(self):
@@ -1164,7 +1159,7 @@ class TestQgsGeometry(unittest.TestCase):
             QgsPointXY(30, 20),
             QgsPointXY(20, 20),
         ]])
-        print('Clip: %s' % myClipPolygon.asWkt())
+        print(f'Clip: {myClipPolygon.asWkt()}')
         writeShape(myMemoryLayer, 'clipGeometryBefore.shp')
         fit = myProvider.getFeatures()
         myFeatures = []
@@ -1183,7 +1178,7 @@ class TestQgsGeometry(unittest.TestCase):
                 # print 'Original: %s' % myGeometry.asWkt()
                 # print 'Combined: %s' % myCombinedGeometry.asWkt()
                 # print 'Difference: %s' % myDifferenceGeometry.asWkt()
-                print('Symmetrical: %s' % mySymmetricalGeometry.asWkt())
+                print(f'Symmetrical: {mySymmetricalGeometry.asWkt()}')
 
                 if self.geos39:
                     myExpectedWkt = 'Polygon ((20 30, 30 30, 30 20, 20 20, 20 30))'
@@ -2400,7 +2395,7 @@ class TestQgsGeometry(unittest.TestCase):
         T = 'linestring_add_curve'
         geoms[T] = polyline1_geom()
         parts[T] = curve()
-        expec[T] = 'MultiLineString ({},{})'.format(polyline1_geom().asWkt()[len('LineString '):], curve().curveToLine().asWkt()[len('LineString '):])
+        expec[T] = f"MultiLineString ({polyline1_geom().asWkt()[len('LineString '):]},{curve().curveToLine().asWkt()[len('LineString '):]})"
 
         T = 'polygon_add_ring_1_point'
         geoms[T] = polygon1_geom()
@@ -2480,7 +2475,7 @@ class TestQgsGeometry(unittest.TestCase):
         T = 'multipolygon_add_curvepolygon'
         geoms[T] = multi_polygon1_geom()
         parts[T] = circle_curvepolygon()
-        expec[T] = 'MultiPolygon ({},{})'.format(polygon1_geom().asWkt()[len('Polygon '):], circle_polygon().asWkt()[len('Polygon '):])
+        expec[T] = f"MultiPolygon ({polygon1_geom().asWkt()[len('Polygon '):]},{circle_polygon().asWkt()[len('Polygon '):]})"
 
         T = 'multisurface_add_curvepolygon'
         geoms[T] = multi_surface_geom()
@@ -6949,7 +6944,7 @@ class TestQgsGeometry(unittest.TestCase):
 
         for test in tests:
             geom = QgsGeometry.fromWkt(test['wkt'])
-            self.assertTrue(geom and not geom.isNull(), 'Could not create geometry {}'.format(test['wkt']))
+            self.assertTrue(geom and not geom.isNull(), f"Could not create geometry {test['wkt']}")
             rendered_image = self.renderGeometry(geom, test['use_pen'])
             self.assertTrue(self.imageCheck(test['name'], test['reference_image'], rendered_image), test['name'])
 
@@ -7048,7 +7043,7 @@ class TestQgsGeometry(unittest.TestCase):
             def get_geom():
                 if 'geom' not in test:
                     geom = QgsGeometry.fromWkt(test['wkt'])
-                    assert geom and not geom.isNull(), 'Could not create geometry {}'.format(test['wkt'])
+                    assert geom and not geom.isNull(), f"Could not create geometry {test['wkt']}"
                 else:
                     geom = test['geom']
                 return geom

--- a/tests/src/python/test_qgsgeometrygeneratorsymbollayer.py
+++ b/tests/src/python/test_qgsgeometrygeneratorsymbollayer.py
@@ -95,7 +95,7 @@ class TestQgsGeometryGeneratorSymbolLayerV2(unittest.TestCase):
 
     def tearDown(self):
         QgsProject.instance().removeAllMapLayers()
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsgrouplayer.py
+++ b/tests/src/python/test_qgsgrouplayer.py
@@ -59,7 +59,7 @@ class TestQgsGroupLayer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgshashlinesymbollayer.py
+++ b/tests/src/python/test_qgshashlinesymbollayer.py
@@ -68,7 +68,7 @@ class TestQgsHashedLineSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsHashedLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgshighlight.py
+++ b/tests/src/python/test_qgshighlight.py
@@ -62,7 +62,7 @@ class TestQgsHighlight(unittest.TestCase):
         self.report = "<h1>Python QgsMapCanvas Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsimagecache.py
+++ b/tests/src/python/test_qgsimagecache.py
@@ -56,7 +56,7 @@ class TestQgsImageCache(unittest.TestCase):
         QgsApplication.imageCache().remoteImageFetched.connect(self.imageFetched)
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsinterpolatedlinesymbollayers.py
+++ b/tests/src/python/test_qgsinterpolatedlinesymbollayers.py
@@ -40,7 +40,7 @@ class TestQgsLineSymbolLayers(unittest.TestCase):
         self.report = "<h1>Python QgsInterpolatedLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslayermetadataresultsmodel.py
+++ b/tests/src/python/test_qgslayermetadataresultsmodel.py
@@ -75,7 +75,7 @@ class TestQgsLayerMetadataResultModels(TestCase):
         self.conn.store('test_conn')
 
         for i in range(NUM_LAYERS):
-            lyr = ds.CreateLayer("layer_%s" % i, geom_type=ogr.wkbPoint, options=['SPATIAL_INDEX=NO'])
+            lyr = ds.CreateLayer(f"layer_{i}", geom_type=ogr.wkbPoint, options=['SPATIAL_INDEX=NO'])
             lyr.CreateField(ogr.FieldDefn('text_field', ogr.OFTString))
             f = ogr.Feature(lyr.GetLayerDefn())
             f['text_field'] = 'foo'

--- a/tests/src/python/test_qgslayoutatlas.py
+++ b/tests/src/python/test_qgslayoutatlas.py
@@ -68,7 +68,7 @@ class TestQgsLayoutAtlas(unittest.TestCase):
         self.report = "<h1>Python QgsLayoutAtlas Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslayoutelevationprofile.py
+++ b/tests/src/python/test_qgslayoutelevationprofile.py
@@ -72,7 +72,7 @@ class TestQgsLayoutItemElevationProfile(unittest.TestCase, LayoutItemTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -97,7 +97,7 @@ def pdfToPng(pdf_file_path, rendered_file_path, page, dpi=96):
     else:
         return False, ''
 
-    print("exportToPdf call: {}".format(' '.join(call)))
+    print(f"exportToPdf call: {' '.join(call)}")
     try:
         subprocess.check_call(call)
     except subprocess.CalledProcessError as e:
@@ -140,7 +140,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.report = "<h1>Python QgsLayoutExporter Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -60,7 +60,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgslayoutmap.py
+++ b/tests/src/python/test_qgslayoutmap.py
@@ -66,7 +66,7 @@ class TestQgsLayoutMap(unittest.TestCase, LayoutItemTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgslayoutmapgrid.py
+++ b/tests/src/python/test_qgslayoutmapgrid.py
@@ -39,7 +39,7 @@ class TestQgsLayoutMapGrid(unittest.TestCase):
         self.report = "<h1>Python QgsLayoutItemMap Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslayoutmapoverview.py
+++ b/tests/src/python/test_qgslayoutmapoverview.py
@@ -53,7 +53,7 @@ class TestQgsLayoutMap(unittest.TestCase, LayoutItemTestCase):
         self.report = "<h1>Python QgsLayoutItemMap Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslayoutpicture.py
+++ b/tests/src/python/test_qgslayoutpicture.py
@@ -74,7 +74,7 @@ class TestQgsLayoutPicture(unittest.TestCase, LayoutItemTestCase):
         self.report = "<h1>Python QgsLayoutItemPicture Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslegendpatchshape.py
+++ b/tests/src/python/test_qgslegendpatchshape.py
@@ -50,7 +50,7 @@ class TestQgsLegendPatchShape(unittest.TestCase):
         self.report = "<h1>Python QgsLegendPatchShape Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslineburstsymbollayer.py
+++ b/tests/src/python/test_qgslineburstsymbollayer.py
@@ -49,7 +49,7 @@ class TestQgsLineburstSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsLineburstSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgslinesymbollayers.py
+++ b/tests/src/python/test_qgslinesymbollayers.py
@@ -32,7 +32,7 @@ class TestQgsLineSymbolLayers(unittest.TestCase):
         self.report = "<h1>Python QgsLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -57,7 +57,7 @@ class TestQgsMapCanvas(unittest.TestCase):
         self.report = "<h1>Python QgsMapCanvas Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -152,12 +152,12 @@ class TestQgsMapLayer(unittest.TestCase):
         uri = layer.styleURI()
         self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.qml'))
 
-        layer = QgsVectorLayer("{}|layername=bug_17795".format(os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.gpkg')), "layer", "ogr")
+        layer = QgsVectorLayer(f"{os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.gpkg')}|layername=bug_17795", "layer", "ogr")
         uri = layer.styleURI()
         self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.qml'))
 
         # delimited text
-        uri = 'file://{}?type=csv&detectTypes=yes&geomType=none'.format(os.path.join(TEST_DATA_DIR, 'delimitedtext', 'test.csv'))
+        uri = f"file://{os.path.join(TEST_DATA_DIR, 'delimitedtext', 'test.csv')}?type=csv&detectTypes=yes&geomType=none"
         layer = QgsVectorLayer(uri, "layer", "delimitedtext")
         uri = layer.styleURI()
         self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'delimitedtext', 'test.qml'))

--- a/tests/src/python/test_qgsmaplayerfactory.py
+++ b/tests/src/python/test_qgsmaplayerfactory.py
@@ -110,7 +110,7 @@ class TestQgsMapLayerFactory(unittest.TestCase):
         # vector tile layer
         ds = QgsDataSourceUri()
         ds.setParam("type", "xyz")
-        ds.setParam("url", "file://{}/{{z}}-{{x}}-{{y}}.pbf".format(os.path.join(unitTestDataPath(), 'vector_tile')))
+        ds.setParam("url", f"file://{os.path.join(unitTestDataPath(), 'vector_tile')}/{{z}}-{{x}}-{{y}}.pbf")
         ds.setParam("zmax", "1")
         ml = QgsMapLayerFactory.createLayer(ds.encodedUri().data().decode(), 'vtl', QgsMapLayerType.VectorTileLayer, options)
         self.assertTrue(ml.isValid())

--- a/tests/src/python/test_qgsmaplayerstore.py
+++ b/tests/src/python/test_qgsmaplayerstore.py
@@ -559,7 +559,7 @@ class TestQgsMapLayerStore(unittest.TestCase):
 
         doc = QDomDocument()
         doc.setContent(
-            '<maplayer><provider encoding="UTF-8">ogr</provider><layername>fixed</layername><id>%s</id></maplayer>' % vl2.id())
+            f'<maplayer><provider encoding="UTF-8">ogr</provider><layername>fixed</layername><id>{vl2.id()}</id></maplayer>')
         layer_node = QDomNode(doc.firstChild())
         self.assertTrue(vl2.writeXml(layer_node, doc, QgsReadWriteContext()))
         datasource_node = doc.createElement("datasource")

--- a/tests/src/python/test_qgsmarkerlinesymbollayer.py
+++ b/tests/src/python/test_qgsmarkerlinesymbollayer.py
@@ -68,7 +68,7 @@ class TestQgsMarkerLineSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsMarkerLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsmergedfeaturerenderer.py
+++ b/tests/src/python/test_qgsmergedfeaturerenderer.py
@@ -44,7 +44,7 @@ class TestQgsMergedFeatureRenderer(unittest.TestCase):
         self.report = "<h1>Python QgsMergedFeatureRenderer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsnewvectortabledialog.py
+++ b/tests/src/python/test_qgsnewvectortabledialog.py
@@ -49,8 +49,7 @@ class TestPyQgsNewVectorTableDialog(unittest.TestCase):
             TEST_DATA_DIR)
         cls.gpkg_path = tempfile.mktemp('.gpkg')
         shutil.copy(gpkg_original_path, cls.gpkg_path)
-        vl = QgsVectorLayer('{}|layername=cdb_lines'.format(
-            cls.gpkg_path), 'test', 'ogr')
+        vl = QgsVectorLayer(f'{cls.gpkg_path}|layername=cdb_lines', 'test', 'ogr')
         assert vl.isValid()
         cls.uri = cls.gpkg_path
 

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -230,13 +230,11 @@ class TestQgsPalLabeling(unittest.TestCase):
         testid = self.id().split('.')
         self._TestGroup = testid[1]
         self._TestFunction = testid[2]
-        testheader = '\n#####_____ {0}.{1} _____#####\n'.\
-            format(self._TestGroup, self._TestFunction)
+        testheader = f'\n#####_____ {self._TestGroup}.{self._TestFunction} _____#####\n'
         qDebug(testheader)
 
         # define the shorthand name of the test (to minimize file name length)
-        self._Test = '{}_{}'.format(self._TestGroupAbbr,
-                                    self._TestFunction.replace('test_', ''))
+        self._Test = f"{self._TestGroupAbbr}_{self._TestFunction.replace('test_', '')}"
 
     def defaultLayerSettings(self):
         lyr = QgsPalLayerSettings()
@@ -296,8 +294,7 @@ class TestQgsPalLabeling(unittest.TestCase):
         for f in glob.glob(imgbasepath + '.*'):
             if os.path.exists(f):
                 os.remove(f)
-        qDebug('Control image for {}.{}'.format(self._TestGroup,
-                                                self._TestFunction))
+        qDebug(f'Control image for {self._TestGroup}.{self._TestFunction}')
 
         if not tmpimg:
             # TODO: this can be deprecated, when per-base-test-class rendering

--- a/tests/src/python/test_qgspallabeling_layout.py
+++ b/tests/src/python/test_qgspallabeling_layout.py
@@ -262,7 +262,7 @@ class TestLayoutBase(TestQgsPalLabeling):
         else:
             return False, ''
 
-        qDebug("_get_layout_pdf_image call: {}".format(' '.join(call)))
+        qDebug(f"_get_layout_pdf_image call: {' '.join(call)}")
         res = False
         try:
             subprocess.check_call(call)

--- a/tests/src/python/test_qgsplot.py
+++ b/tests/src/python/test_qgsplot.py
@@ -50,7 +50,7 @@ class TestQgsPlot(unittest.TestCase):
         self.report = "<h1>Python QgsPlot Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgspointcloudattributebyramprenderer.py
+++ b/tests/src/python/test_qgspointcloudattributebyramprenderer.py
@@ -52,7 +52,7 @@ class TestQgsPointCloudAttributeByRampRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgspointcloudclassifiedrenderer.py
+++ b/tests/src/python/test_qgspointcloudclassifiedrenderer.py
@@ -54,7 +54,7 @@ class TestQgsPointCloudClassifiedRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgspointcloudextentrenderer.py
+++ b/tests/src/python/test_qgspointcloudextentrenderer.py
@@ -51,7 +51,7 @@ class TestQgsPointCloudExtentRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgspointcloudlayerprofilegenerator.py
+++ b/tests/src/python/test_qgspointcloudlayerprofilegenerator.py
@@ -56,7 +56,7 @@ class TestQgsPointCloudLayerProfileGenerator(unittest.TestCase):
         self.report = "<h1>Python QgsPointCloudLayerProfileGenerator Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgspointcloudprovider.py
+++ b/tests/src/python/test_qgspointcloudprovider.py
@@ -33,7 +33,7 @@ class TestQgsPointCloudDataProvider(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgspointcloudrgbrenderer.py
+++ b/tests/src/python/test_qgspointcloudrgbrenderer.py
@@ -48,7 +48,7 @@ class TestQgsPointCloudRgbRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -66,7 +66,7 @@ class TestQgsPointDisplacementRenderer(unittest.TestCase):
         self.report = "<h1>Python QgsPointDisplacementRenderer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsprocessexecutable_pt1.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt1.py
@@ -186,7 +186,7 @@ class TestQgsProcessExecutablePt1(unittest.TestCase):
 
     def testAlgorithmRunLegacy(self):
         output_file = self.TMP_DIR + '/polygon_centroid.shp'
-        rc, output, err = self.run_process(['run', '--no-python', 'native:centroids', '--INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), f'--OUTPUT={output_file}'])
+        rc, output, err = self.run_process(['run', '--no-python', 'native:centroids', f"--INPUT={TEST_DATA_DIR + '/polys.shp'}", f'--OUTPUT={output_file}'])
         self.assertFalse(self._strip_ignorable_errors(err))
         self.assertIn('0...10...20...30...40...50...60...70...80...90', output.lower())
         self.assertIn('results', output.lower())
@@ -196,7 +196,7 @@ class TestQgsProcessExecutablePt1(unittest.TestCase):
 
     def testAlgorithmRun(self):
         output_file = self.TMP_DIR + '/polygon_centroid.shp'
-        rc, output, err = self.run_process(['run', '--no-python', 'native:centroids', '--', 'INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), f'OUTPUT={output_file}'])
+        rc, output, err = self.run_process(['run', '--no-python', 'native:centroids', '--', f"INPUT={TEST_DATA_DIR + '/polys.shp'}", f'OUTPUT={output_file}'])
         self.assertFalse(self._strip_ignorable_errors(err))
         self.assertIn('0...10...20...30...40...50...60...70...80...90', output.lower())
         self.assertIn('results', output.lower())

--- a/tests/src/python/test_qgsprocessexecutable_pt2.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt2.py
@@ -100,7 +100,7 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
 
     def testAlgorithmRunJson(self):
         output_file = self.TMP_DIR + '/polygon_centroid2.shp'
-        rc, output, err = self.run_process(['run', '--no-python', '--json', 'native:centroids', '--', 'INPUT={}'.format(TEST_DATA_DIR + '/polys.shp'), f'OUTPUT={output_file}'])
+        rc, output, err = self.run_process(['run', '--no-python', '--json', 'native:centroids', '--', f"INPUT={TEST_DATA_DIR + '/polys.shp'}", f'OUTPUT={output_file}'])
         res = json.loads(output)
 
         self.assertIn('gdal_version', res)
@@ -124,9 +124,9 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
         """
         output_file = self.TMP_DIR + '/package.gpkg'
         rc, output, err = self.run_process(['run', '--no-python', '--json', 'native:package', '--',
-                                            'LAYERS={}'.format(TEST_DATA_DIR + '/polys.shp'),
-                                            'LAYERS={}'.format(TEST_DATA_DIR + '/points.shp'),
-                                            'LAYERS={}'.format(TEST_DATA_DIR + '/lines.shp'),
+                                            f"LAYERS={TEST_DATA_DIR + '/polys.shp'}",
+                                            f"LAYERS={TEST_DATA_DIR + '/points.shp'}",
+                                            f"LAYERS={TEST_DATA_DIR + '/lines.shp'}",
                                             f'OUTPUT={output_file}'])
         res = json.loads(output)
 
@@ -158,7 +158,7 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
 
     def testModelRun(self):
         output_file = self.TMP_DIR + '/model_output.shp'
-        rc, output, err = self.run_process(['run', '--no-python', TEST_DATA_DIR + '/test_model.model3', '--', 'FEATS={}'.format(TEST_DATA_DIR + '/polys.shp'), f'native:centroids_1:CENTROIDS={output_file}'])
+        rc, output, err = self.run_process(['run', '--no-python', TEST_DATA_DIR + '/test_model.model3', '--', f"FEATS={TEST_DATA_DIR + '/polys.shp'}", f'native:centroids_1:CENTROIDS={output_file}'])
         self.assertFalse(self._strip_ignorable_errors(err))
         self.assertEqual(rc, 0)
         self.assertIn('0...10...20...30...40...50...60...70...80...90', output.lower())
@@ -191,7 +191,7 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
 
     def testModelRunJson(self):
         output_file = self.TMP_DIR + '/model_output2.shp'
-        rc, output, err = self.run_process(['run', TEST_DATA_DIR + '/test_model.model3', '--no-python', '--json', '--', 'FEATS={}'.format(TEST_DATA_DIR + '/polys.shp'), f'native:centroids_1:CENTROIDS={output_file}'])
+        rc, output, err = self.run_process(['run', TEST_DATA_DIR + '/test_model.model3', '--no-python', '--json', '--', f"FEATS={TEST_DATA_DIR + '/polys.shp'}", f'native:centroids_1:CENTROIDS={output_file}'])
         self.assertFalse(self._strip_ignorable_errors(err))
         self.assertEqual(rc, 0)
 
@@ -299,7 +299,7 @@ class TestQgsProcessExecutablePt2(unittest.TestCase):
         self.assertEqual(rc, 0)
 
     def testLoadLayer(self):
-        rc, output, err = self.run_process(['run', '--no-python', 'native:raiseexception', '--MESSAGE=CONFIRMED', '--CONDITION=layer_property(load_layer(\'{}\',\'ogr\'),\'feature_count\')>10'.format(TEST_DATA_DIR + '/points.shp')])
+        rc, output, err = self.run_process(['run', '--no-python', 'native:raiseexception', '--MESSAGE=CONFIRMED', f"--CONDITION=layer_property(load_layer('{TEST_DATA_DIR + '/points.shp'}','ogr'),'feature_count')>10"])
         self.assertIn('CONFIRMED', self._strip_ignorable_errors(err))
 
         self.assertEqual(rc, 1)

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -131,7 +131,7 @@ class TestQgsProcessingInPlace(unittest.TestCase):
         wkb_type = getattr(QgsWkbTypes, layer_wkb_name)
         fields.append(QgsField('int_f', QVariant.Int))
         layer = QgsMemoryProviderUtils.createMemoryLayer(
-            '%s_layer' % layer_wkb_name, fields, wkb_type, QgsCoordinateReferenceSystem('EPSG:4326'))
+            f'{layer_wkb_name}_layer', fields, wkb_type, QgsCoordinateReferenceSystem('EPSG:4326'))
         self.assertTrue(layer.isValid())
         self.assertEqual(layer.wkbType(), wkb_type)
         return layer

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -131,13 +131,13 @@ class TestQgsProject(unittest.TestCase):
         for token in validTokens:
             self.messageCaught = False
             prj.readEntry("test", token)
-            myMessage = "valid token '%s' not accepted" % (token)
+            myMessage = f"valid token '{token}' not accepted"
             assert not self.messageCaught, myMessage
 
         for token in invalidTokens:
             self.messageCaught = False
             prj.readEntry("test", token)
-            myMessage = "invalid token '%s' accepted" % (token)
+            myMessage = f"invalid token '{token}' accepted"
             assert self.messageCaught, myMessage
 
         logger.messageReceived.disconnect(self.catchMessage)

--- a/tests/src/python/test_qgsprojectbadlayers.py
+++ b/tests/src/python/test_qgsprojectbadlayers.py
@@ -97,7 +97,7 @@ class TestQgsProjectBadLayers(unittest.TestCase):
         p = QgsProject.instance()
         temp_dir = QTemporaryDir()
         for ext in ('shp', 'dbf', 'shx', 'prj'):
-            copyfile(os.path.join(TEST_DATA_DIR, 'lines.%s' % ext), os.path.join(temp_dir.path(), 'lines.%s' % ext))
+            copyfile(os.path.join(TEST_DATA_DIR, f'lines.{ext}'), os.path.join(temp_dir.path(), f'lines.{ext}'))
         copyfile(os.path.join(TEST_DATA_DIR, 'raster', 'band1_byte_ct_epsg4326.tif'), os.path.join(temp_dir.path(), 'band1_byte_ct_epsg4326.tif'))
         copyfile(os.path.join(TEST_DATA_DIR, 'raster', 'band1_byte_ct_epsg4326.tif'), os.path.join(temp_dir.path(), 'band1_byte_ct_epsg4326_copy.tif'))
         l = QgsVectorLayer(os.path.join(temp_dir.path(), 'lines.shp'), 'lines', 'ogr')
@@ -175,7 +175,7 @@ class TestQgsProjectBadLayers(unittest.TestCase):
         temp_dir = QTemporaryDir()
         p = QgsProject.instance()
         for ext in ('qgs', 'gpkg'):
-            copyfile(os.path.join(TEST_DATA_DIR, 'projects', 'relation_reference_test.%s' % ext), os.path.join(temp_dir.path(), 'relation_reference_test.%s' % ext))
+            copyfile(os.path.join(TEST_DATA_DIR, 'projects', f'relation_reference_test.{ext}'), os.path.join(temp_dir.path(), f'relation_reference_test.{ext}'))
 
         # Load the good project
         project_path = os.path.join(temp_dir.path(), 'relation_reference_test.qgs')

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -248,7 +248,7 @@ class TestPyQgsProviderConnectionBase():
             # Check executeSql
             if capabilities & QgsAbstractDatabaseProviderConnection.ExecuteSql:
                 if schema:
-                    table = "\"%s\".\"myNewAspatialTable\"" % schema
+                    table = f"\"{schema}\".\"myNewAspatialTable\""
                 else:
                     table = 'myNewAspatialTable'
 
@@ -261,7 +261,7 @@ class TestPyQgsProviderConnectionBase():
                 )
                 res = conn.executeSql(sql)
                 self.assertEqual(res, [])
-                sql = "SELECT \"string_t\", \"long_t\", \"double_t\", \"integer_t\", \"date_t\", \"datetime_t\" FROM %s" % table
+                sql = f"SELECT \"string_t\", \"long_t\", \"double_t\", \"integer_t\", \"date_t\", \"datetime_t\" FROM {table}"
                 res = conn.executeSql(sql)
 
                 expected_date = QtCore.QDate(2019, 7, 8)
@@ -311,7 +311,7 @@ class TestPyQgsProviderConnectionBase():
                 self.assertFalse(res.hasNextRow())
 
                 # Test time_t
-                sql = "SELECT \"time_t\" FROM %s" % table
+                sql = f"SELECT \"time_t\" FROM {table}"
                 res = conn.executeSql(sql)
 
                 # This does not work in MSSQL and returns a QByteArray, we have no way to know that it is a time
@@ -323,7 +323,7 @@ class TestPyQgsProviderConnectionBase():
                     table, 'N' if self.providerKey == 'mssql' else '')
                 res = conn.executeSql(sql)
                 self.assertEqual(res, [])
-                sql = "SELECT \"string_t\", \"integer_t\" FROM %s" % table
+                sql = f"SELECT \"string_t\", \"integer_t\" FROM {table}"
                 res = conn.executeSql(sql)
                 self.assertEqual(res, [])
 

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -104,7 +104,7 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         conn.table('', 'osm')
         conn.table('', 'cdb_lines')
 
-        self.assertEqual(conn.tableUri('', 'osm'), "GPKG:%s:osm" % self.uri)
+        self.assertEqual(conn.tableUri('', 'osm'), f"GPKG:{self.uri}:osm")
         rl = QgsRasterLayer(conn.tableUri('', 'osm'), 'r', 'gdal')
         self.assertTrue(rl.isValid())
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -73,7 +73,7 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
 
         # Test raster
         self.assertEqual(conn.tableUri('qgis_test', 'Raster1'),
-                         '%s table="qgis_test"."Raster1"' % self.uri)
+                         f'{self.uri} table="qgis_test"."Raster1"')
 
         rl = QgsRasterLayer(conn.tableUri('qgis_test', 'Raster1'), 'r1', 'postgresraster')
         self.assertTrue(rl.isValid())

--- a/tests/src/python/test_qgsproviderconnection_spatialite.py
+++ b/tests/src/python/test_qgsproviderconnection_spatialite.py
@@ -64,7 +64,7 @@ class TestPyQgsProviderConnectionSpatialite(unittest.TestCase, TestPyQgsProvider
         spatialite_original_path = f'{TEST_DATA_DIR}/qgis_server/test_project_wms_grouped_layers.sqlite'
         cls.spatialite_path = os.path.join(cls.basetestpath, 'test.sqlite')
         shutil.copy(spatialite_original_path, cls.spatialite_path)
-        cls.uri = "dbname=\'%s\'" % cls.spatialite_path
+        cls.uri = f"dbname='{cls.spatialite_path}'"
         vl = QgsVectorLayer(f'{cls.uri} table=\'cdb_lines\'', 'test', 'spatialite')
         assert vl.isValid()
 

--- a/tests/src/python/test_qgsqueryresultmodel.py
+++ b/tests/src/python/test_qgsqueryresultmodel.py
@@ -48,7 +48,7 @@ class TestPyQgsQgsQueryResultModel(unittest.TestCase):
         md = QgsProviderRegistry.instance().providerMetadata('postgres')
         conn = md.createConnection(cls.uri, {})
         conn.executeSql('DROP TABLE IF EXISTS qgis_test.random_big_data CASCADE;')
-        conn.executeSql('SELECT * INTO qgis_test.random_big_data FROM ( SELECT x AS id, md5(random()::text) AS descr FROM generate_series(1,%s) x ) AS foo_row;' % cls.NUM_RECORDS)
+        conn.executeSql(f'SELECT * INTO qgis_test.random_big_data FROM ( SELECT x AS id, md5(random()::text) AS descr FROM generate_series(1,{cls.NUM_RECORDS}) x ) AS foo_row;')
 
     @classmethod
     def tearDownClass(cls):
@@ -140,7 +140,7 @@ class TestPyQgsQgsQueryResultModel(unittest.TestCase):
         v.setModel(model)
 
         def _set_row_count(idx, first, last):
-            lbl.setText('Rows %s fetched' % model.rowCount(model.index(-1, -1)))  # noqa: F821
+            lbl.setText(f'Rows {model.rowCount(model.index(-1, -1))} fetched')  # noqa: F821
 
         model.rowsInserted.connect(_set_row_count)
 

--- a/tests/src/python/test_qgsrandommarkersymbollayer.py
+++ b/tests/src/python/test_qgsrandommarkersymbollayer.py
@@ -63,7 +63,7 @@ class TestQgsRandomMarkerSymbolLayer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -85,14 +85,14 @@ class TestQgsRasterFileWriter(unittest.TestCase):
         return ok
 
     def testWrite(self):
-        for name in glob.glob("%s/raster/*.tif" % self.testDataDir):
+        for name in glob.glob(f"{self.testDataDir}/raster/*.tif"):
             baseName = os.path.basename(name)
             allOk = True
-            ok = self.write("raster/%s" % baseName)
+            ok = self.write(f"raster/{baseName}")
             if not ok:
                 allOk = False
 
-        reportFilePath = "%s/qgistest.html" % QDir.tempPath()
+        reportFilePath = f"{QDir.tempPath()}/qgistest.html"
         reportFile = open(reportFilePath, 'a')
         reportFile.write(self.report)
         reportFile.close()
@@ -169,7 +169,7 @@ class TestQgsRasterFileWriter(unittest.TestCase):
                                         provider.crs()), 0)
 
         # Check that the test geopackage contains the raster layer and compare
-        rlayer = QgsRasterLayer('GPKG:%s:imported_table' % test_gpkg)
+        rlayer = QgsRasterLayer(f'GPKG:{test_gpkg}:imported_table')
         self.assertTrue(rlayer.isValid())
         out_provider = rlayer.dataProvider()
         for i in range(3):

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -87,7 +87,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         myFileInfo = QFileInfo(myPath)
         myBaseName = myFileInfo.baseName()
         myRasterLayer = QgsRasterLayer(myPath, myBaseName)
-        myMessage = 'Raster not loaded: %s' % myPath
+        myMessage = f'Raster not loaded: {myPath}'
         assert myRasterLayer.isValid(), myMessage
         myPoint = QgsPointXY(786690, 3345803)
         # print 'Extents: %s' % myRasterLayer.extent().toString()
@@ -259,7 +259,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         myFileInfo = QFileInfo(myPath)
         myBaseName = myFileInfo.baseName()
         myRasterLayer = QgsRasterLayer(myPath, myBaseName)
-        myMessage = 'Raster not loaded: %s' % myPath
+        myMessage = f'Raster not loaded: {myPath}'
         assert myRasterLayer.isValid(), myMessage
 
         renderer = QgsSingleBandGrayRenderer(myRasterLayer.dataProvider(), 1)
@@ -329,7 +329,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         myFileInfo = QFileInfo(myPath)
         myBaseName = myFileInfo.baseName()
         myRasterLayer = QgsRasterLayer(myPath, myBaseName)
-        myMessage = 'Raster not loaded: %s' % myPath
+        myMessage = f'Raster not loaded: {myPath}'
         assert myRasterLayer.isValid(), myMessage
         # crash on next line
         QgsProject.instance().addMapLayers([myRasterLayer])
@@ -341,7 +341,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         myFileInfo = QFileInfo(myPath)
         myBaseName = myFileInfo.baseName()
         myRasterLayer = QgsRasterLayer(myPath, myBaseName)
-        myMessage = 'Raster not loaded: %s' % myPath
+        myMessage = f'Raster not loaded: {myPath}'
         assert myRasterLayer.isValid(), myMessage
 
         myRasterShader = QgsRasterShader()
@@ -1116,7 +1116,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         myFileInfo = QFileInfo(myPath)
         myBaseName = myFileInfo.baseName()
         myRasterLayer = QgsRasterLayer(myPath, myBaseName)
-        myMessage = 'Raster not loaded: %s' % myPath
+        myMessage = f'Raster not loaded: {myPath}'
         assert myRasterLayer.isValid(), myMessage
 
         # do generic export with default layer values

--- a/tests/src/python/test_qgsrasterlayerrenderer.py
+++ b/tests/src/python/test_qgsrasterlayerrenderer.py
@@ -40,7 +40,7 @@ class TestQgsRasterLayerRenderer(unittest.TestCase):
         self.report = "<h1>Python QgsRasterLayerRenderer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsrasterlinesymbollayer.py
+++ b/tests/src/python/test_qgsrasterlinesymbollayer.py
@@ -69,7 +69,7 @@ class TestQgsRasterLineSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsRasterLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsrasterrerderer_createsld.py
+++ b/tests/src/python/test_qgsrasterrerderer_createsld.py
@@ -549,7 +549,7 @@ class TestQgsRasterRendererCreateSld(unittest.TestCase):
                 self.assertEqual(expectedMax, vendorOption.firstChild().nodeValue())
             else:
                 self.fail(
-                    'Unrecognised vendorOption name {}'.format(vendorOption.attributes().namedItem('name').nodeValue()))
+                    f"Unrecognised vendorOption name {vendorOption.attributes().namedItem('name').nodeValue()}")
 
     def assertChannelBand(self, root, bandTag, expectedValue, index=0):
         channelSelection = root.elementsByTagName('sld:ChannelSelection').item(index)

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -108,8 +108,7 @@ class TestQgsRectangle(unittest.TestCase):
         myExpectedWkt = ('0 0, '
                          '5 5')
         myWkt = rect1.asWktCoordinates()
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (myExpectedWkt, myWkt))
+        myMessage = f'Expected: {myExpectedWkt}\nGot: {myWkt}\n'
         self.assertTrue(compareWkt(myWkt, myExpectedWkt), myMessage)
 
     def testAsWktPolygon(self):
@@ -121,8 +120,7 @@ class TestQgsRectangle(unittest.TestCase):
                          '0 5, '
                          '0 0))')
         myWkt = rect1.asWktPolygon()
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (myExpectedWkt, myWkt))
+        myMessage = f'Expected: {myExpectedWkt}\nGot: {myWkt}\n'
         self.assertTrue(compareWkt(myWkt, myExpectedWkt), myMessage)
 
     def testToString(self):

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -270,7 +270,7 @@ class QgsServerTestBase(unittest.TestCase):
 
         self.assertEqual(
             headers.get("Content-Type"), contentType,
-            "Content type is wrong: {} instead of {}\n{}".format(headers.get("Content-Type"), contentType, response))
+            f"Content type is wrong: {headers.get('Content-Type')} instead of {contentType}\n{response}")
 
         test, report = self._img_diff(response, image, max_diff, max_size_diff, outputFormat)
 
@@ -405,10 +405,10 @@ class TestQgsServer(QgsServerTestBase):
     def test_multiple_servers(self):
         """Segfaults?"""
         for i in range(10):
-            locals()["s%s" % i] = QgsServer()
-            locals()["rq%s" % i] = QgsBufferServerRequest("")
-            locals()["re%s" % i] = QgsBufferServerResponse()
-            locals()["s%s" % i].handleRequest(locals()["rq%s" % i], locals()["re%s" % i])
+            locals()[f"s{i}"] = QgsServer()
+            locals()[f"rq{i}"] = QgsBufferServerRequest("")
+            locals()[f"re{i}"] = QgsBufferServerResponse()
+            locals()[f"s{i}"].handleRequest(locals()[f"rq{i}"], locals()[f"re{i}"])
 
     def test_requestHandler(self):
         """Test request handler"""
@@ -443,7 +443,7 @@ class TestQgsServer(QgsServerTestBase):
 
         # Test response when project is specified but without service
         project = self.testdata_path + "test_project_wfs.qgs"
-        qs = '?MAP=%s' % (urllib.parse.quote(project))
+        qs = f'?MAP={urllib.parse.quote(project)}'
         header, body = self._execute_request(qs)
         response = self.strip_version_xmlns(header + body)
         expected = self.strip_version_xmlns(b'Content-Length: 365\nContent-Type: text/xml; charset=utf-8\n\n<?xml version="1.0" encoding="UTF-8"?>\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
@@ -472,7 +472,7 @@ class TestQgsServer(QgsServerTestBase):
         response = re.sub(RE_STRIP_UNCHECKABLE, b'', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'', expected)
 
-        self.assertXMLEqual(response, expected, msg="request {} failed.\n Query: {}\n Expected:\n{}\n\n Response:\n{}".format(query_string, request, expected.decode('utf-8'), response.decode('utf-8')))
+        self.assertXMLEqual(response, expected, msg=f"request {query_string} failed.\n Query: {request}\n Expected:\n{expected.decode('utf-8')}\n\n Response:\n{response.decode('utf-8')}")
 
     def test_project_wcs(self):
         """Test some WCS request"""

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -273,4 +273,4 @@ class TestQgsServerAccessControl(QgsServerTestBase):
             )
             self.assertTrue(
                 str(response).find(f"<qgs:color>{color}</qgs:color>") != -1,
-                "Wrong color in result\n%s" % response)
+                f"Wrong color in result\n{response}")

--- a/tests/src/python/test_qgsserver_accesscontrol_fix_filters.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_fix_filters.py
@@ -47,7 +47,7 @@ class TestQgsServerAccessControlFixFilters(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(wfs_query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
 
         # Execute a restricted WMS request
         # That will store the filter expression in cache
@@ -62,7 +62,7 @@ class TestQgsServerAccessControlFixFilters(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(wfs_query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_accesscontrol_wcs.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wcs.py
@@ -31,12 +31,12 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<name>dem</name>") != -1,
-            "No dem layer in WCS/GetCapabilities\n%s" % response)
+            f"No dem layer in WCS/GetCapabilities\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<name>dem</name>") != -1,
-            "No dem layer in WCS/GetCapabilities\n%s" % response)
+            f"No dem layer in WCS/GetCapabilities\n{response}")
 
         query_string = "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
@@ -49,7 +49,7 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<name>dem</name>") != -1,
-            "Unexpected dem layer in WCS/GetCapabilities\n%s" % response)
+            f"Unexpected dem layer in WCS/GetCapabilities\n{response}")
 
     def test_wcs_describecoverage(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -63,12 +63,12 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<name>dem</name>") != -1,
-            "No dem layer in DescribeCoverage\n%s" % response)
+            f"No dem layer in DescribeCoverage\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<name>dem</name>") != -1,
-            "No dem layer in DescribeCoverage\n%s" % response)
+            f"No dem layer in DescribeCoverage\n{response}")
 
         query_string = "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
@@ -82,7 +82,7 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<name>dem</name>") != -1,
-            "Unexpected dem layer in DescribeCoverage\n%s" % response)
+            f"Unexpected dem layer in DescribeCoverage\n{response}")
 
     def test_wcs_getcoverage(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -101,7 +101,7 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "image/tiff",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             self._geo_img_diff(response, "WCS_GetCoverage.geotiff") == 0,
             "Image for GetCoverage is wrong")
@@ -109,7 +109,7 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "image/tiff",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             self._geo_img_diff(response, "WCS_GetCoverage.geotiff") == 0,
             "Image for GetCoverage is wrong")
@@ -131,7 +131,7 @@ class TestQgsServerAccessControlWCS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="RequestNotWellFormed">') != -1,
             "The layer for the COVERAGE 'dem' is not found")

--- a/tests/src/python/test_qgsserver_accesscontrol_wfs.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wfs.py
@@ -31,21 +31,21 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<Name>Hello</Name>") != -1,
-            "No Hello layer in WFS/GetCapabilities\n%s" % response)
+            f"No Hello layer in WFS/GetCapabilities\n{response}")
         self.assertTrue(
             str(response).find("<Name>Hello_OnOff</Name>") != -1,
-            "No Hello layer in WFS/GetCapabilities\n%s" % response)
+            f"No Hello layer in WFS/GetCapabilities\n{response}")
         self.assertTrue(
             str(response).find("<Name>Country</Name>") != -1,
-            "No Country layer in WFS/GetCapabilities\n%s" % response)
+            f"No Country layer in WFS/GetCapabilities\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<Name>Hello</Name>") != -1,
-            "No Hello layer in WFS/GetCapabilities\n%s" % response)
+            f"No Hello layer in WFS/GetCapabilities\n{response}")
         self.assertFalse(
             str(response).find("<Name>Country</Name>") != -1,
-            "Unexpected Country layer in WFS/GetCapabilities\n%s" % response)
+            f"Unexpected Country layer in WFS/GetCapabilities\n{response}")
 
     def test_wfs_describefeaturetype_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -59,12 +59,12 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find('name="Hello"') != -1,
-            "No Hello layer in DescribeFeatureType\n%s" % response)
+            f"No Hello layer in DescribeFeatureType\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find('name="Hello"') != -1,
-            "No Hello layer in DescribeFeatureType\n%s" % response)
+            f"No Hello layer in DescribeFeatureType\n{response}")
 
     def test_wfs_describefeaturetype_country(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -78,12 +78,12 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find('name="Country"') != -1,
-            "No Country layer in DescribeFeatureType\n%s" % response)
+            f"No Country layer in DescribeFeatureType\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find('name="Country"') != -1,
-            "Unexpected Country layer in DescribeFeatureType\n%s" % response)
+            f"Unexpected Country layer in DescribeFeatureType\n{response}")
 
     def test_wfs_getfeature_hello(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -97,21 +97,21 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "No color in result of GetFeature\n%s" % response)
+            f"No color in result of GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "Unexpected color in result of GetFeature\n%s" % response)
+            f"Unexpected color in result of GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
-            "Unexpected color NULL in result of GetFeature\n%s" % response)
+            f"Unexpected color NULL in result of GetFeature\n{response}")
 
     def test_wfs_getfeature_hello2(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -125,18 +125,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_filter(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -150,18 +150,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_filter2(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -175,18 +175,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_country(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -200,12 +200,12 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)  # spellok
+            f"Unexpected result in GetFeature\n{response}")  # spellok
 
     # # Subset String # #
 
@@ -221,18 +221,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No good result in GetFeature\n%s" % response)
+            f"No good result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No good result in GetFeature\n%s" % response)
+            f"No good result in GetFeature\n{response}")
 
     def test_wfs_getfeature_subsetstring2(self):
         data = """<?xml version="1.0" encoding="UTF-8"?>
@@ -246,15 +246,15 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No good result in GetFeature\n%s" % response)
+            f"No good result in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_project_subsetstring(self):
         """Tests access control with a subset string already applied to a layer in a project
@@ -273,18 +273,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Feature with pkuid=7 not found in GetFeature\n%s" % response)
+            f"Feature with pkuid=7 not found in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Feature with pkuid=7 not found in GetFeature, has been incorrectly filtered out by access controls\n%s" % response)
+            f"Feature with pkuid=7 not found in GetFeature, has been incorrectly filtered out by access controls\n{response}")
 
     def test_wfs_getfeature_project_subsetstring2(self):
         """Tests access control with a subset string already applied to a layer in a project
@@ -303,15 +303,15 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>8</qgs:pk>") != -1,
-            "Feature with pkuid=8 not found in GetFeature\n%s" % response)
+            f"Feature with pkuid=8 not found in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Feature with pkuid=8 was found in GetFeature, but should have been filtered out by access controls\n%s" % response)
+            f"Feature with pkuid=8 was found in GetFeature, but should have been filtered out by access controls\n{response}")
 
     def test_wfs_getfeature_project_subsetstring3(self):
         """Tests access control with a subset string already applied to a layer in a project
@@ -331,12 +331,12 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertTrue(
             str(response).find("<qgs:pk>") == -1,
-            "Project based layer subsetString not respected in GetFeature\n%s" % response)
+            f"Project based layer subsetString not respected in GetFeature\n{response}")
 
         response, headers = self._post_restricted(data)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Project based layer subsetString not respected in GetFeature with restricted access\n%s" % response)
+            f"Project based layer subsetString not respected in GetFeature with restricted access\n{response}")
 
     def test_wfs_getfeature_exp_filter_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -351,21 +351,21 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "No color in result of GetFeature\n%s" % response)
+            f"No color in result of GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "Unexpected color in result of GetFeature\n%s" % response)
+            f"Unexpected color in result of GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
-            "Unexpected color NULL in result of GetFeature\n%s" % response)
+            f"Unexpected color NULL in result of GetFeature\n{response}")
 
     def test_wfs_getfeature_exp_filter_hello2(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -380,18 +380,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_exp_filter_hello_filter(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -406,18 +406,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_exp_filter_hello_filter2(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -432,18 +432,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_featureid_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -458,21 +458,21 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertTrue(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "No color in result of GetFeature\n%s" % response)
+            f"No color in result of GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "Unexpected color in result of GetFeature\n%s" % response)
+            f"Unexpected color in result of GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
-            "Unexpected color NULL in result of GetFeature\n%s" % response)
+            f"Unexpected color NULL in result of GetFeature\n{response}")
 
     def test_wfs_getfeature_featureid_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -487,18 +487,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_featureid_hello_filter(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -513,18 +513,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
     def test_wfs_getfeature_featureid_hello_filter2(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -539,18 +539,18 @@ class TestQgsServerAccessControlWFS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>6</qgs:pk>") != -1,
-            "No result in GetFeature\n%s" % response)
+            f"No result in GetFeature\n{response}")
         self.assertFalse(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "Unexpected result in GetFeature\n%s" % response)
+            f"Unexpected result in GetFeature\n{response}")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_accesscontrol_wfs_transactional.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wfs_transactional.py
@@ -67,37 +67,37 @@ class TestQgsServerAccessControlWFSTransactional(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data.format(color="red", gid=2))
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Insert is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Insert is wrong: {headers.get('Content-Type')}")
 
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Insert don't succeed\n%s" % response)
+            f"WFS/Transactions Insert don't succeed\n{response}")
         self._test_colors({2: "red"})
 
         response, headers = self._post_restricted(data.format(color="blue", gid=3))
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Insert is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Insert is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") == -1,
-            "WFS/Transactions Insert succeed\n%s" % response)
+            f"WFS/Transactions Insert succeed\n{response}")
 
         response, headers = self._post_restricted(data.format(color="red", gid=4), "LAYER_PERM=no")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Insert is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Insert is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find(
                 '<ServiceException code="Security">No permissions to do WFS changes on layer \\\'db_point\\\'</ServiceException>') != -1,
-            "WFS/Transactions Insert succeed\n%s" % response)
+            f"WFS/Transactions Insert succeed\n{response}")
 
         response, headers = self._post_restricted(data.format(color="yellow", gid=5), "LAYER_PERM=yes")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Insert is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Insert is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Insert don't succeed\n%s" % response)
+            f"WFS/Transactions Insert don't succeed\n{response}")
         self._test_colors({5: "yellow"})
 
     def test_wfstransaction_update(self):
@@ -107,47 +107,47 @@ class TestQgsServerAccessControlWFSTransactional(TestQgsServerAccessControl):
         response, headers = self._post_restricted(data.format(color="yellow"))
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") == -1,
-            "WFS/Transactions Update succeed\n%s" % response)
+            f"WFS/Transactions Update succeed\n{response}")
         self._test_colors({1: "blue"})
 
         response, headers = self._post_fullaccess(data.format(color="red"))
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Update is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Update is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Update don't succeed\n%s" % response)
+            f"WFS/Transactions Update don't succeed\n{response}")
         self._test_colors({1: "red"})
 
         response, headers = self._post_restricted(data.format(color="blue"))
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Update is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Update is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") == -1,
-            "WFS/Transactions Update succeed\n%s" % response)
+            f"WFS/Transactions Update succeed\n{response}")
         self._test_colors({1: "red"})
 
         response, headers = self._post_restricted(data.format(color="yellow"), "LAYER_PERM=no")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Update is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Update is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find(
                 '<ServiceException code="Security">No permissions to do WFS changes on layer \\\'db_point\\\'</ServiceException>') != -1,
-            "WFS/Transactions Update succeed\n%s" % response)
+            f"WFS/Transactions Update succeed\n{response}")
         self._test_colors({1: "red"})
 
         response, headers = self._post_restricted(data.format(color="yellow"), "LAYER_PERM=yes")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for Update is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for Update is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Update don't succeed\n%s" % response)
+            f"WFS/Transactions Update don't succeed\n{response}")
         self._test_colors({1: "yellow"})
 
     def test_wfstransaction_delete_fullaccess(self):
@@ -157,10 +157,10 @@ class TestQgsServerAccessControlWFSTransactional(TestQgsServerAccessControl):
         response, headers = self._post_fullaccess(data)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Delete didn't succeed\n%s" % response)
+            f"WFS/Transactions Delete didn't succeed\n{response}")
 
     def test_wfstransaction_delete_restricted(self):
         data = WFS_TRANSACTION_DELETE.format(id="0", xml_ns=XML_NS)
@@ -169,10 +169,10 @@ class TestQgsServerAccessControlWFSTransactional(TestQgsServerAccessControl):
         response, headers = self._post_restricted(data)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") == -1,
-            "WFS/Transactions Delete succeed\n%s" % response)
+            f"WFS/Transactions Delete succeed\n{response}")
 
         data_update = WFS_TRANSACTION_UPDATE.format(id="0", color="red", xml_ns=XML_NS)
         response, headers = self._post_fullaccess(data_update)
@@ -181,19 +181,19 @@ class TestQgsServerAccessControlWFSTransactional(TestQgsServerAccessControl):
         response, headers = self._post_restricted(data, "LAYER_PERM=no")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find(
                 '<ServiceException code="Security">No permissions to do WFS changes on layer \\\'db_point\\\'</ServiceException>') != -1,
-            "WFS/Transactions Delete succeed\n%s" % response)
+            f"WFS/Transactions Delete succeed\n{response}")
 
         response, headers = self._post_restricted(data, "LAYER_PERM=yes")
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find("<SUCCESS/>") != -1,
-            "WFS/Transactions Delete don't succeed\n%s" % response)
+            f"WFS/Transactions Delete don't succeed\n{response}")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_accesscontrol_wms.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms.py
@@ -43,18 +43,18 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<Name>Hello</Name>") != -1,
-            "No Hello layer in GetCapabilities\n%s" % response)
+            f"No Hello layer in GetCapabilities\n{response}")
         self.assertTrue(
             str(response).find("<Name>Country</Name>") != -1,
-            "No Country layer in GetCapabilities\n%s" % response)
+            f"No Country layer in GetCapabilities\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<Name>Hello</Name>") != -1,
-            "No Hello layer in GetCapabilities\n%s" % response)
+            f"No Hello layer in GetCapabilities\n{response}")
         self.assertFalse(
             str(response).find("<Name>Country</Name>") != -1,
-            "Unexpected Country layer in GetCapabilities\n%s" % response)
+            f"Unexpected Country layer in GetCapabilities\n{response}")
 
     def test_wms_getprojectsettings(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -67,32 +67,32 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<TreeName>Hello</TreeName>") != -1,
-            "No Hello layer in GetProjectSettings\n%s" % response)
+            f"No Hello layer in GetProjectSettings\n{response}")
         self.assertTrue(
             str(response).find("<TreeName>Country</TreeName>") != -1,
-            "No Country layer in GetProjectSettings\n%s" % response)
+            f"No Country layer in GetProjectSettings\n{response}")
         self.assertTrue(
             str(response).find("<TreeName>Country_grp</TreeName>") != -1,
-            "No Country_grp layer in GetProjectSettings\n%s" % response)
+            f"No Country_grp layer in GetProjectSettings\n{response}")
         self.assertTrue(
             str(response).find(
                 "<LayerDrawingOrder>Country_Diagrams,Country_Labels,Country,dem,Hello_Filter_SubsetString,Hello_Project_SubsetString,Hello_SubsetString,Hello,db_point</LayerDrawingOrder>") != -1,
-            "LayerDrawingOrder in GetProjectSettings\n%s" % response)
+            f"LayerDrawingOrder in GetProjectSettings\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<TreeName>Hello</TreeName>") != -1,
-            "No Hello layer in GetProjectSettings\n%s" % response)
+            f"No Hello layer in GetProjectSettings\n{response}")
         self.assertFalse(
             str(response).find("<TreeName>Country</TreeName>") != -1,
-            "Unexpected Country layer in GetProjectSettings\n%s" % response)
+            f"Unexpected Country layer in GetProjectSettings\n{response}")
         self.assertFalse(
             str(response).find("<TreeName>Country_grp</TreeName>") != -1,
-            "Unexpected Country_grp layer in GetProjectSettings\n%s" % response)
+            f"Unexpected Country_grp layer in GetProjectSettings\n{response}")
         self.assertTrue(
             str(response).find(
                 "<LayerDrawingOrder>Country_Diagrams,Country_Labels,dem,Hello_Filter_SubsetString,Hello_Project_SubsetString,Hello_SubsetString,Hello,db_point</LayerDrawingOrder>") != -1,
-            "Wrong LayerDrawingOrder in GetProjectSettings\n%s" % response)
+            f"Wrong LayerDrawingOrder in GetProjectSettings\n{response}")
 
     def test_wms_getprojectsettings(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -105,22 +105,22 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("name=\"Hello\"") != -1,
-            "No Hello layer in GetContext\n%s" % response)
+            f"No Hello layer in GetContext\n{response}")
         self.assertTrue(
             str(response).find("name=\"Country\"") != -1,
-            "No Country layer in GetProjectSettings\n%s" % response)
+            f"No Country layer in GetProjectSettings\n{response}")
         self.assertTrue(
             str(response).find("name=\"Country\"")
             < str(response).find("name=\"Hello\""),
-            "Hello layer not after Country layer\n%s" % response)
+            f"Hello layer not after Country layer\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("name=\"Hello\"") != -1,
-            "No Hello layer in GetContext\n%s" % response)
+            f"No Hello layer in GetContext\n{response}")
         self.assertFalse(
             str(response).find("name=\"Country\"") != -1,
-            "Unexpected Country layer in GetProjectSettings\n%s" % response)
+            f"Unexpected Country layer in GetProjectSettings\n{response}")
 
     def test_wms_describelayer_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -135,12 +135,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<se:FeatureTypeName>Hello</se:FeatureTypeName>") != -1,
-            "No Hello layer in DescribeLayer\n%s" % response)
+            f"No Hello layer in DescribeLayer\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<se:FeatureTypeName>Hello</se:FeatureTypeName>") != -1,
-            "No Hello layer in DescribeLayer\n%s" % response)
+            f"No Hello layer in DescribeLayer\n{response}")
 
     def test_wms_describelayer_country(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -155,12 +155,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<se:FeatureTypeName>Country</se:FeatureTypeName>") != -1,
-            "No Country layer in DescribeLayer\n%s" % response)
+            f"No Country layer in DescribeLayer\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<se:FeatureTypeName>Country</se:FeatureTypeName>") != -1,
-            "Unexpected Country layer in DescribeLayer\n%s" % response)
+            f"Unexpected Country layer in DescribeLayer\n{response}")
 
     def test_wms_getmap(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -212,7 +212,7 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed do a GetMap on Country"
@@ -268,7 +268,7 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed do a GetMap on Country_grp"
@@ -297,15 +297,15 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeatureInfo\n%s" % response)
+            f"No result in GetFeatureInfo\n{response}")
         self.assertTrue(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "No color in result of GetFeatureInfo\n%s" % response)
+            f"No color in result of GetFeatureInfo\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetFeatureInfo is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetFeatureInfo is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed do a GetFeatureInfo on Country"
@@ -332,13 +332,13 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeatureInfo\n%s" % response)
+            f"No result in GetFeatureInfo\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>red</qgs:color>") != -1,  # spellok
-            "Unexpected color in result of GetFeatureInfo\n%s" % response)
+            f"Unexpected color in result of GetFeatureInfo\n{response}")
         self.assertFalse(
             str(response).find("<qgs:color>NULL</qgs:color>") != -1,  # spellok
-            "Unexpected color NULL in result of GetFeatureInfo\n%s" % response)
+            f"Unexpected color NULL in result of GetFeatureInfo\n{response}")
 
     def test_wms_getfeatureinfo_hello_grp(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -363,12 +363,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertFalse(
             str(response).find("Layer \'Hello_grp\' is not queryable") != -1,
-            "The WMS layer group are queryable GetFeatureInfo\n%s" % response)
+            f"The WMS layer group are queryable GetFeatureInfo\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("Layer \'Hello_grp\' is not queryable") != -1,
-            "The WMS layer group are queryable GetFeatureInfo\n%s" % response)
+            f"The WMS layer group are queryable GetFeatureInfo\n{response}")
 
     def test_wms_getfeatureinfo_hello2(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -393,12 +393,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No result in GetFeatureInfo\n%s" % response)
+            f"No result in GetFeatureInfo\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "Unexpected result in GetFeatureInfo\n%s" % response)
+            f"Unexpected result in GetFeatureInfo\n{response}")
 
     def test_wms_getfeatureinfo_country(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -423,12 +423,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeatureInfo\n%s" % response)
+            f"No result in GetFeatureInfo\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeatureInfo\n%s" % response)
+            f"Unexpected result in GetFeatureInfo\n{response}")
 
     def test_wms_getfeatureinfo_country_grp(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -453,12 +453,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No result in GetFeatureInfo\n%s" % response)
+            f"No result in GetFeatureInfo\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "Unexpected result in GetFeatureInfo\n%s" % response)
+            f"Unexpected result in GetFeatureInfo\n{response}")
 
     # # Subset String # #
 
@@ -618,15 +618,15 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeatureInfo Hello/1\n%s" % response)
+            f"No result in GetFeatureInfo Hello/1\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No good result in GetFeatureInfo Hello/1\n%s" % response)
+            f"No good result in GetFeatureInfo Hello/1\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetFeatureInfo is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetFeatureInfo is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed do a GetFeatureInfo on Country"
@@ -653,10 +653,10 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result in GetFeatureInfo Hello/1\n%s" % response)
+            f"No result in GetFeatureInfo Hello/1\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
-            "No good result in GetFeatureInfo Hello/1\n%s" % response)
+            f"No good result in GetFeatureInfo Hello/1\n{response}")
 
     def test_wms_getfeatureinfo_subsetstring2(self):
         query_string = "&".join(["%s=%s" % i for i in list({
@@ -681,15 +681,15 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>2</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Unexpected result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"Unexpected result result in GetFeatureInfo Hello/2\n{response}")
 
     def test_wms_getfeatureinfo_projectsubsetstring(self):
         """test that layer subsetStrings set in projects are honored. This test checks for a feature which should be filtered
@@ -717,12 +717,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Project set layer subsetString not honored in WMS GetFeatureInfo/1\n%s" % response)
+            f"Project set layer subsetString not honored in WMS GetFeatureInfo/1\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Project set layer subsetString not honored in WMS GetFeatureInfo when access control applied/1\n%s" % response)
+            f"Project set layer subsetString not honored in WMS GetFeatureInfo when access control applied/1\n{response}")
 
     def test_wms_getfeatureinfo_projectsubsetstring5(self):
         """test that layer subsetStrings set in projects are honored. This test checks for a feature which should pass
@@ -750,18 +750,18 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
     def test_wms_getfeatureinfo_projectsubsetstring3(self):
         """test that layer subsetStrings set in projects are honored. This test checks for a feature which should pass
@@ -789,15 +789,15 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>8</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Unexpected result from GetFeatureInfo Hello/2\n%s" % response)
+            f"Unexpected result from GetFeatureInfo Hello/2\n{response}")
 
     def test_wms_getfeatureinfo_subsetstring_with_filter(self):
         """test that request filters are honored. This test checks for a feature which should be filtered
@@ -826,12 +826,12 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Request filter not honored in WMS GetFeatureInfo/1\n%s" % response)
+            f"Request filter not honored in WMS GetFeatureInfo/1\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Request filter not honored in WMS GetFeatureInfo when access control applied/1\n%s" % response)
+            f"Request filter not honored in WMS GetFeatureInfo when access control applied/1\n{response}")
 
     def test_wms_getfeatureinfo_projectsubsetstring4(self):
         """test that request filters are honored. This test checks for a feature which should pass
@@ -860,18 +860,18 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>7</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
     def test_wms_getfeatureinfo_projectsubsetstring2(self):
         """test that request filters are honored. This test checks for a feature which should pass
@@ -900,15 +900,15 @@ class TestQgsServerAccessControlWMS(TestQgsServerAccessControl):
         response, headers = self._get_fullaccess(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,
-            "No result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No result result in GetFeatureInfo Hello/2\n{response}")
         self.assertTrue(
             str(response).find("<qgs:pk>8</qgs:pk>") != -1,
-            "No good result result in GetFeatureInfo Hello/2\n%s" % response)
+            f"No good result result in GetFeatureInfo Hello/2\n{response}")
 
         response, headers = self._get_restricted(query_string)
         self.assertFalse(
             str(response).find("<qgs:pk>") != -1,
-            "Unexpected result from GetFeatureInfo Hello/2\n%s" % response)
+            f"Unexpected result from GetFeatureInfo Hello/2\n{response}")
 
     def test_security_issue_gh32475(self):
         """Test access control security issue GH 32475"""

--- a/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
@@ -68,7 +68,7 @@ class TestQgsServerAccessControlWMSGetlegendgraphic(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed GetLegendGraphic"
@@ -96,7 +96,7 @@ class TestQgsServerAccessControlWMSGetlegendgraphic(TestQgsServerAccessControl):
         response, headers = self._get_restricted(query_string)
         self.assertEqual(
             headers.get("Content-Type"), "text/xml; charset=utf-8",
-            "Content type for GetMap is wrong: %s" % headers.get("Content-Type"))
+            f"Content type for GetMap is wrong: {headers.get('Content-Type')}")
         self.assertTrue(
             str(response).find('<ServiceException code="Security">') != -1,
             "Not allowed GetLegendGraphic"

--- a/tests/src/python/test_qgsserver_accesscontrol_wms_getprint_postgres.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms_getprint_postgres.py
@@ -131,7 +131,7 @@ class TestQgsServerAccessControlWMSGetPrintPG(QgsServerTestBase):
 
         project = open(project_path).read()
         with open(cls.temp_project_path, 'w+') as f:
-            f.write(re.sub(r'<datasource>.*</datasource>', '<datasource>%s</datasource>' % cls.layer_uri, project))
+            f.write(re.sub(r'<datasource>.*</datasource>', f'<datasource>{cls.layer_uri}</datasource>', project))
 
         cls.test_project = QgsProject()
         cls.test_project.read(cls.temp_project_path)

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -275,7 +275,7 @@ class QgsServerAPITestBase(QgsServerTestBase):
             f = open(path.encode('utf8'), 'w+', encoding='utf8')
             f.write(result)
             f.close()
-            print("Reference file %s regenerated!" % path.encode('utf8'))
+            print(f"Reference file {path.encode('utf8')} regenerated!")
 
         with open(path.encode('utf8'), encoding='utf8') as f:
             if reference_file.endswith('json'):
@@ -713,7 +713,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
         # Invalid request
         data = b'not json!'
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items' % insert_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{insert_layer}/items',
                                          QgsBufferServerRequest.PostMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -745,7 +745,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         },
         "type": "Feature"
         }"""
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items' % insert_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{insert_layer}/items',
                                          QgsBufferServerRequest.PostMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -792,7 +792,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
         # Invalid request
         data = b'not json!'
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -826,7 +826,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         }"""
 
         # Unauthorized layer
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % insert_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{insert_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -836,7 +836,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         self.assertEqual(response.statusCode(), 403)
 
         # Authorized layer
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -881,7 +881,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         },
         "type": "Feature"
         }"""
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -923,7 +923,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         },
         "type": "Feature"
         }"""
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % hidden_text_2_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{hidden_text_2_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/geo+json'},
                                          data
@@ -953,7 +953,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
         # Valid request on unauthorized layer
         data = b''
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.DeleteMethod)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response, project)
@@ -961,7 +961,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
         # Valid request on authorized layer
         data = b''
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % delete_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{delete_layer}/items/1',
                                          QgsBufferServerRequest.DeleteMethod)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response, project)
@@ -993,7 +993,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
         # Invalid request
         data = b'not json!'
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PutMethod,
                                          {'Content-Type': 'application/json'},
                                          data
@@ -1015,7 +1015,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
             }
         }
         """
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PatchMethod,
                                          {'Content-Type': 'application/json'},
                                          data
@@ -1035,7 +1035,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         }"""
 
         # Unauthorized layer
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % insert_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{insert_layer}/items/1',
                                          QgsBufferServerRequest.PatchMethod,
                                          {'Content-Type': 'application/json'},
                                          data
@@ -1045,7 +1045,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         self.assertEqual(response.statusCode(), 403)
 
         # Authorized layer
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % update_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{update_layer}/items/1',
                                          QgsBufferServerRequest.PatchMethod,
                                          {'Content-Type': 'application/json'},
                                          data
@@ -1074,7 +1074,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
             r'\.\d+', '', feature.geometry().asWkt().upper()), 'MULTIPOINT ((804542 5593348))')
 
         # Try to update a forbidden (unpublished) field
-        request = QgsBufferServerRequest('http://server.qgis.org/wfs3/collections/%s/items/1' % hidden_text_2_layer,
+        request = QgsBufferServerRequest(f'http://server.qgis.org/wfs3/collections/{hidden_text_2_layer}/items/1',
                                          QgsBufferServerRequest.PatchMethod,
                                          {'Content-Type': 'application/json'},
                                          data
@@ -1389,7 +1389,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
         def _date_tester(project_path, datetime, expected, unexpected):
             # Test "created" date field exact
             request = QgsBufferServerRequest(
-                'http://server.qgis.org/wfs3/collections/points/items?datetime=%s' % datetime)
+                f'http://server.qgis.org/wfs3/collections/points/items?datetime={datetime}')
             response = QgsBufferServerResponse()
             project.read(project_path)
             self.server.handleRequest(request, response, project)

--- a/tests/src/python/test_qgsserver_cachemanager.py
+++ b/tests/src/python/test_qgsserver_cachemanager.py
@@ -196,7 +196,7 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         assert os.path.exists(project), "Project file not found: " + project
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WMS&VERSION=1.3.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
         header, body = self._execute_request(query_string)
         doc = QDomDocument("wms_getcapabilities_130.xml")
         doc.setContent(body)
@@ -204,25 +204,25 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         header, body = self._execute_request(query_string)
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WMS&VERSION=1.1.1&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities"
         header, body = self._execute_request(query_string)
         # with cache
         header, body = self._execute_request(query_string)
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WFS&VERSION=1.1.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities"
         header, body = self._execute_request(query_string)
         # with cache
         header, body = self._execute_request(query_string)
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WFS&VERSION=1.0.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities"
         header, body = self._execute_request(query_string)
         # with cache
         header, body = self._execute_request(query_string)
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WCS&VERSION=1.0.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities"
         header, body = self._execute_request(query_string)
         # with cache
         header, body = self._execute_request(query_string)
@@ -247,7 +247,7 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         prj = QgsProject()
         prj.read(project)
 
-        query_string = '?MAP={}&SERVICE=WMS&VERSION=1.3.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetCapabilities')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
         request = QgsBufferServerRequest(query_string, QgsServerRequest.GetMethod, {}, None)
 
         accessControls = self._server_iface.accessControls()
@@ -269,7 +269,7 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         assert os.path.exists(project), "Project file not found: " + project
 
         # without cache
-        query_string = '?MAP={}&SERVICE=WMS&VERSION=1.3.0&REQUEST={}'.format(urllib.parse.quote(project), 'GetContext')
+        query_string = f"?MAP={urllib.parse.quote(project)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetContext"
         header, body = self._execute_request(query_string)
         # with cache
         header, body = self._execute_request(query_string)
@@ -332,13 +332,13 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMS_GetLegendGraphic_Basic", max_size_diff=QSize(1, 1))
         # with cache
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMS_GetLegendGraphic_Basic", max_size_diff=QSize(1, 1))
 
         filelist = [f for f in os.listdir(self._servercache._tile_cache_dir) if f.endswith(".png")]
@@ -373,12 +373,12 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         # with cache
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(project),
@@ -398,12 +398,12 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         # with cache
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(project),
@@ -423,13 +423,13 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMTS_GetTile_Project_3857_0", 20000)
         # with cache
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMTS_GetTile_Project_3857_0", 20000)
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({
@@ -450,13 +450,13 @@ class TestQgsServerCacheManager(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMTS_GetTile_Project_4326_0", 20000)
         # with cache
         r, h = self._result(self._execute_request(qs))
         self.assertEqual(
             h.get("Content-Type"), "image/png",
-            "Content type is wrong: {}\n{}".format(h.get("Content-Type"), r))
+            f"Content type is wrong: {h.get('Content-Type')}\n{r}")
         self._img_diff_error(r, h, "WMTS_GetTile_Project_4326_0", 20000)
 
         filelist = [f for f in os.listdir(self._servercache._tile_cache_dir) if f.endswith(".png")]

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -130,7 +130,7 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
             f = open(expected_path.encode('utf8'), 'w+', encoding='utf8')
             f.write(actual)
             f.close()
-            print("Reference file %s regenerated!" % expected_path.encode('utf8'))
+            print(f"Reference file {expected_path.encode('utf8')} regenerated!")
 
         for title in expected_projects.keys():
             self.assertLinesEqual(json.dumps(actual_projects[title], indent=4), json.dumps(expected_projects[title], indent=4), expected_path.encode('utf8'))
@@ -170,7 +170,7 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
                 'http://server.qgis.org/map/' + identifier)
             request.setHeader('Accept', 'application/json')
             self.compareApi(
-                request, None, 'test_project_{}.json'.format(name.replace('.', '_')), subdir='landingpage')
+                request, None, f"test_project_{name.replace('.', '_')}.json", subdir='landingpage')
 
     def test_landing_page_json_empty(self):
         """Test landing page in JSON format with no projects"""

--- a/tests/src/python/test_qgsserver_plugins.py
+++ b/tests/src/python/test_qgsserver_plugins.py
@@ -205,7 +205,7 @@ class TestQgsServerPlugins(QgsServerTestBase):
         serverIface.registerFilter(Filter0(serverIface), 100)
 
         # Test using MAP
-        self._execute_request('?service=simple&MAP=%s' % self.projectPath)
+        self._execute_request(f'?service=simple&MAP={self.projectPath}')
 
         # Check config file path
         self.assertEqual(configFilePath2, self.projectPath)
@@ -359,13 +359,13 @@ class TestQgsServerPlugins(QgsServerTestBase):
 
         # Test no propagation
         filter1.propagate = False
-        _, body = self._execute_request_project('?service=%s' % service0.name(), project=project)
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
         self.assertFalse(filter2.request_ready)
         self.assertEqual(body, b'ABC')
 
         # Test with propagation
         filter1.propagate = True
-        _, body = self._execute_request_project('?service=%s' % service0.name(), project=project)
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
         self.assertTrue(filter2.request_ready)
         self.assertEqual(body, b'ABDCE')
 

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -68,10 +68,10 @@ class TestQgsServerWFS(QgsServerTestBase):
         query_string = '?MAP={}&SERVICE=WFS&REQUEST={}'.format(
             urllib.parse.quote(project), request)
         if version:
-            query_string += '&VERSION=%s' % version
+            query_string += f'&VERSION={version}'
 
         if extra_query_string:
-            query_string += '&%s' % extra_query_string
+            query_string += f'&{extra_query_string}'
 
         header, body = self._execute_request(
             query_string, requestMethod=requestMethod, data=data)
@@ -104,7 +104,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         return header, body
 
     def test_operation_not_supported(self):
-        qs = '?MAP=%s&SERVICE=WFS&VERSION=1.1.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        qs = f'?MAP={urllib.parse.quote(self.projectPath)}&SERVICE=WFS&VERSION=1.1.0&REQUEST=NotAValidRequest'
         self._assert_status_code(501, qs)
 
     def test_project_wfs(self):
@@ -129,10 +129,7 @@ class TestQgsServerWFS(QgsServerTestBase):
 
         self.result_compare(
             'wfs_getfeature_' + requestid + '.txt',
-            "request {} failed.\n Query: {}".format(
-                query_string,
-                request,
-            ),
+            f"request {query_string} failed.\n Query: {request}",
             header, body
         )
 
@@ -249,8 +246,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         f.close()
         response = re.sub(RE_STRIP_UNCHECKABLE, b'', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'', expected)
-        self.assertXMLEqual(response, expected, msg="%s\n" %
-                            (error_msg_header))
+        self.assertXMLEqual(response, expected, msg=f"{error_msg_header}\n")
 
     def wfs_getfeature_post_compare(self, requestid, request):
 
@@ -677,7 +673,7 @@ class TestQgsServerWFS(QgsServerTestBase):
                 self.testdata_path + 'test_project_wms_grouped_layers.qgs'))
             if value is not None:
                 xml_value = '<qgs:{0}>{1}</qgs:{0}>'.format(field, value).encode('utf8')
-                self.assertTrue(xml_value in body, "%s not found in body" % xml_value)
+                self.assertTrue(xml_value in body, f"{xml_value} not found in body")
             else:
                 xml_value = f'<qgs:{field}>'.encode()
                 self.assertFalse(xml_value in body)
@@ -724,7 +720,7 @@ class TestQgsServerWFS(QgsServerTestBase):
             self.wfs_request_compare(
                 "GetFeature",
                 '1.0.0',
-                ("OUTPUTFORMAT=%s" % ct)
+                f"OUTPUTFORMAT={ct}"
                 + "&SRSNAME=EPSG:4326&TYPENAME=testlayer&FEATUREID=testlayer.0",
                 'wfs_getFeature_1_0_0_featureid_0_json')
 
@@ -848,8 +844,7 @@ class TestQgsServerWFS(QgsServerTestBase):
             "test_project_wms_grouped_layers.qgs"
         assert os.path.exists(project), "Project file not found: " + project
 
-        query_string = '?SERVICE=WFS&MAP={}'.format(
-            urllib.parse.quote(project))
+        query_string = f'?SERVICE=WFS&MAP={urllib.parse.quote(project)}'
         request = post_data.format(
             name='4326-test1',
             version='1.1.0',
@@ -896,7 +891,7 @@ class TestQgsServerWFS(QgsServerTestBase):
 
         def _test(version, srsName, lat_lon=False):
             self.i += 1
-            name = '4326-test_%s' % self.i
+            name = f'4326-test_{self.i}'
             request = post_data.format(
                 name=name,
                 version=version,
@@ -905,7 +900,7 @@ class TestQgsServerWFS(QgsServerTestBase):
             )
             header, body = self._execute_request(
                 query_string, requestMethod=QgsServerRequest.PostMethod, data=request.encode('utf-8'))
-            feature = next(vl.getFeatures(QgsFeatureRequest(QgsExpression('"name" = \'%s\'' % name))))
+            feature = next(vl.getFeatures(QgsFeatureRequest(QgsExpression(f'"name" = \'{name}\''))))
             geom = feature.geometry()
             self.assertEqual(geom.asWkt(0), geom_4326.asWkt(0), f"Transaction Failed: {version} , {srsName}, lat_lon={lat_lon}")
 

--- a/tests/src/python/test_qgsserver_wfst.py
+++ b/tests/src/python/test_qgsserver_wfst.py
@@ -94,8 +94,7 @@ class TestWFST(unittest.TestCase):
         cls.port = int(re.findall(br':(\d+)', line)[0])
         assert cls.port != 0
         # Wait for the server process to start
-        assert waitServer('http://127.0.0.1:%s' %
-                          cls.port), "Server is not responding!"
+        assert waitServer(f'http://127.0.0.1:{cls.port}'), "Server is not responding!"
 
     @classmethod
     def tearDownClass(cls):
@@ -153,8 +152,7 @@ class TestWFST(unittest.TestCase):
         parms = {
             'srsname': 'EPSG:4326',
             'typename': type_name,
-            'url': 'http://127.0.0.1:{}/?map={}'.format(cls.port,
-                                                        cls.project_path),
+            'url': f'http://127.0.0.1:{cls.port}/?map={cls.project_path}',
             'version': cls.VERSION,
             'table': '',
             # 'sql': '',
@@ -170,13 +168,11 @@ class TestWFST(unittest.TestCase):
         Find the feature and return it, raise exception if not found
         """
 
-        request = QgsFeatureRequest(QgsExpression("{}={}".format(attr_name,
-                                                                 attr_value)))
+        request = QgsFeatureRequest(QgsExpression(f"{attr_name}={attr_value}"))
         try:
             return next(layer.dataProvider().getFeatures(request))
         except StopIteration:
-            raise Exception("Wrong attributes in WFS layer %s" %
-                            layer.name())
+            raise Exception(f"Wrong attributes in WFS layer {layer.name()}")
 
     def _checkAddFeatures(self, wfs_layer, layer, features):
         """
@@ -195,7 +191,7 @@ class TestWFST(unittest.TestCase):
         # Verify features from the layers
         for f in ogr_features:
             geom = next(wfs_layer.dataProvider().getFeatures(QgsFeatureRequest(
-                QgsExpression('"id" = %s' % f.attribute('id'))))).geometry()
+                QgsExpression(f"\"id\" = {f.attribute('id')}")))).geometry()
             self.assertEqual(geom.boundingBox(), f.geometry().boundingBox())
 
     def _checkUpdateFeatures(self, wfs_layer, old_features, new_features):

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -94,7 +94,7 @@ class TestQgsServerWMSTestBase(QgsServerTestBase):
                 response = re.sub(RE_STRIP_EXTENTS, b'*****', response)
                 expected = re.sub(RE_STRIP_EXTENTS, b'*****', expected)
 
-            msg = "request {} failed.\nQuery: {}\nExpected file: {}\nResponse:\n{}".format(query_string, request, reference_path, response.decode('utf-8'))
+            msg = f"request {query_string} failed.\nQuery: {request}\nExpected file: {reference_path}\nResponse:\n{response.decode('utf-8')}"
 
             try:
                 self.assertXMLEqual(response, expected, msg=msg, raw=raw)
@@ -148,7 +148,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         self.wms_request_compare('GetContext')
 
     def test_operation_not_supported(self):
-        qs = '?MAP=%s&SERVICE=WMS&VERSION=1.3.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        qs = f'?MAP={urllib.parse.quote(self.projectPath)}&SERVICE=WMS&VERSION=1.3.0&REQUEST=NotAValidRequest'
         self._assert_status_code(501, qs)
 
     def test_describelayer(self):
@@ -185,8 +185,8 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
             "LAYERS": "db_point"
         }.items())])
         r, h = self._result(self._execute_request(qs))
-        assert "StyledLayerDescriptor" in str(r), "StyledLayerDescriptor not in %s" % r
-        assert "__sld_style" not in str(r), "__sld_style in %s" % r
+        assert "StyledLayerDescriptor" in str(r), f"StyledLayerDescriptor not in {r}"
+        assert "__sld_style" not in str(r), f"__sld_style in {r}"
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
@@ -212,8 +212,8 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
             "LAYERS": "db_point"
         }.items())])
         r, h = self._result(self._execute_request(qs))
-        assert "StyledLayerDescriptor" in str(r), "StyledLayerDescriptor not in %s" % r
-        assert "__sld_style" not in str(r), "__sld_style in %s" % r
+        assert "StyledLayerDescriptor" in str(r), f"StyledLayerDescriptor not in {r}"
+        assert "__sld_style" not in str(r), f"__sld_style in {r}"
 
     def test_wms_getschemaextension(self):
         self.wms_request_compare('GetSchemaExtension',
@@ -227,7 +227,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         project = QgsProject()
         project.read(projectPath)
 
-        query_string = 'https://www.qgis.org/?SERVICE=WMS&VERSION=1.3.0&REQUEST=%s' % (request)
+        query_string = f'https://www.qgis.org/?SERVICE=WMS&VERSION=1.3.0&REQUEST={request}'
         if extra is not None:
             query_string += extra
         header, body = self._execute_request_project(query_string, project)
@@ -240,7 +240,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         response = re.sub(RE_STRIP_UNCHECKABLE, b'*****', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'*****', expected)
 
-        self.assertXMLEqual(response, expected, msg="request {} failed.\nQuery: {}\nExpected file: {}\nResponse:\n{}".format(query_string, request, reference_path, response.decode('utf-8')))
+        self.assertXMLEqual(response, expected, msg=f"request {query_string} failed.\nQuery: {request}\nExpected file: {reference_path}\nResponse:\n{response.decode('utf-8')}")
 
     def test_wms_getcapabilities_project(self):
         """WMS GetCapabilities without map parameter"""
@@ -266,7 +266,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         f.close()
         response = re.sub(RE_STRIP_UNCHECKABLE, b'', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'', expected)
-        self.assertXMLEqual(response, expected, msg="request {} failed.\nQuery: {}\nExpected file: {}\nResponse:\n{}".format(query_string, request, reference_path, response.decode('utf-8')))
+        self.assertXMLEqual(response, expected, msg=f"request {query_string} failed.\nQuery: {request}\nExpected file: {reference_path}\nResponse:\n{response.decode('utf-8')}")
 
     def test_project_wms_inspire(self):
         """Test some WMS request"""

--- a/tests/src/python/test_qgsserver_wms_getprint_outputs.py
+++ b/tests/src/python/test_qgsserver_wms_getprint_outputs.py
@@ -77,7 +77,7 @@ class PyQgsServerWMSGetPrintOutputs(QgsServerTestBase):
         else:
             return False, ''
 
-        print("exportToPdf call: {}".format(' '.join(call)))
+        print(f"exportToPdf call: {' '.join(call)}")
         try:
             subprocess.check_call(call)
         except subprocess.CalledProcessError as e:
@@ -88,12 +88,12 @@ class PyQgsServerWMSGetPrintOutputs(QgsServerTestBase):
 
     def _pdf_diff(self, pdf, control_image, max_diff, max_size_diff=QSize(), dpi=96):
 
-        temp_pdf = os.path.join(tempfile.gettempdir(), "%s_result.pdf" % control_image)
+        temp_pdf = os.path.join(tempfile.gettempdir(), f"{control_image}_result.pdf")
 
         with open(temp_pdf, "wb") as f:
             f.write(pdf)
 
-        temp_image = os.path.join(tempfile.gettempdir(), "%s_result.png" % control_image)
+        temp_image = os.path.join(tempfile.gettempdir(), f"{control_image}_result.png")
         self._pdf_to_png(temp_pdf, temp_image, dpi=dpi, page=1)
 
         control = QgsMultiRenderChecker()
@@ -112,13 +112,13 @@ class PyQgsServerWMSGetPrintOutputs(QgsServerTestBase):
 
         self.assertEqual(
             headers.get("Content-Type"), 'application/pdf',
-            "Content type is wrong: {} instead of {}\n{}".format(headers.get("Content-Type"), 'application/pdf', response))
+            f"Content type is wrong: {headers.get('Content-Type')} instead of application/pdf\n{response}")
 
         test, report = self._pdf_diff(response, image, max_diff, max_size_diff, dpi)
 
         with open(os.path.join(tempfile.gettempdir(), image + "_result.pdf"), "rb") as rendered_file:
             if not os.environ.get('ENCODED_OUTPUT'):
-                message = "PDF is wrong: rendered file {}/{}_result.{}".format(tempfile.gettempdir(), image, 'pdf')
+                message = f"PDF is wrong: rendered file {tempfile.gettempdir()}/{image}_result.pdf"
             else:
                 encoded_rendered_file = base64.b64encode(rendered_file.read())
                 message = "PDF is wrong\n{}File:\necho '{}' | base64 -d >{}/{}_result.{}".format(
@@ -127,7 +127,7 @@ class PyQgsServerWMSGetPrintOutputs(QgsServerTestBase):
 
         with open(os.path.join(tempfile.gettempdir(), image + "_result.png"), "rb") as rendered_file:
             if not os.environ.get('ENCODED_OUTPUT'):
-                message = "Image is wrong: rendered file {}/{}_result.{}".format(tempfile.gettempdir(), image, 'png')
+                message = f"Image is wrong: rendered file {tempfile.gettempdir()}/{image}_result.png"
             else:
                 encoded_rendered_file = base64.b64encode(rendered_file.read())
                 message = "Image is wrong\n{}\nImage:\necho '{}' | base64 -d >{}/{}_result.{}".format(
@@ -138,7 +138,7 @@ class PyQgsServerWMSGetPrintOutputs(QgsServerTestBase):
         if os.path.exists(os.path.join(tempfile.gettempdir(), image + "_result_diff.png")):
             with open(os.path.join(tempfile.gettempdir(), image + "_result_diff.png"), "rb") as diff_file:
                 if not os.environ.get('ENCODED_OUTPUT'):
-                    message = "Image is wrong: diff file {}/{}_result_diff.{}".format(tempfile.gettempdir(), image, 'png')
+                    message = f"Image is wrong: diff file {tempfile.gettempdir()}/{image}_result_diff.png"
                 else:
                     encoded_diff_file = base64.b64encode(diff_file.read())
                     message += "\nDiff:\necho '{}' | base64 -d > {}/{}_result_diff.{}".format(

--- a/tests/src/python/test_qgsserver_wmts.py
+++ b/tests/src/python/test_qgsserver_wmts.py
@@ -52,10 +52,10 @@ class TestQgsServerWMTS(QgsServerTestBase):
 
         query_string = f'?MAP={urllib.parse.quote(project)}&SERVICE=WMTS&REQUEST={request}'
         if version:
-            query_string += '&VERSION=%s' % version
+            query_string += f'&VERSION={version}'
 
         if extra_query_string:
-            query_string += '&%s' % extra_query_string
+            query_string += f'&{extra_query_string}'
 
         header, body = self._execute_request(query_string)
         self.assert_headers(header, body)
@@ -80,12 +80,12 @@ class TestQgsServerWMTS(QgsServerTestBase):
 
     def wmts_request_compare_project(self, project, request, version='', extra_query_string='',
                                      reference_base_name=None):
-        query_string = 'https://www.qgis.org/?SERVICE=WMTS&REQUEST=%s' % (request)
+        query_string = f'https://www.qgis.org/?SERVICE=WMTS&REQUEST={request}'
         if version:
-            query_string += '&VERSION=%s' % version
+            query_string += f'&VERSION={version}'
 
         if extra_query_string:
-            query_string += '&%s' % extra_query_string
+            query_string += f'&{extra_query_string}'
 
         header, body = self._execute_request_project(query_string, project)
         self.assert_headers(header, body)
@@ -109,7 +109,7 @@ class TestQgsServerWMTS(QgsServerTestBase):
         self.assertXMLEqual(response, expected, msg=f"request {query_string} failed.\n Query: {request}")
 
     def test_operation_not_supported(self):
-        qs = '?MAP=%s&SERVICE=WFS&VERSION=1.0.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        qs = f'?MAP={urllib.parse.quote(self.projectPath)}&SERVICE=WFS&VERSION=1.0.0&REQUEST=NotAValidRequest'
         self._assert_status_code(501, qs)
 
     def test_project_wmts(self):

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -33,7 +33,7 @@ class TestQgsSettings(unittest.TestCase):
         h, path = tempfile.mkstemp('.ini')
         Path(path).touch()
         assert QgsSettings.setGlobalSettingsPath(path)
-        self.settings = QgsSettings('testqgissettings', 'testqgissettings%s' % self.cnt)
+        self.settings = QgsSettings('testqgissettings', f'testqgissettings{self.cnt}')
         self.globalsettings = QSettings(self.settings.globalSettingsPath(), QSettings.IniFormat)
         self.globalsettings.sync()
         assert os.path.exists(self.globalsettings.fileName())

--- a/tests/src/python/test_qgssimplefillsymbollayer.py
+++ b/tests/src/python/test_qgssimplefillsymbollayer.py
@@ -57,7 +57,7 @@ class TestQgsSimpleFillSymbolLayer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgssimplelinesymbollayer.py
+++ b/tests/src/python/test_qgssimplelinesymbollayer.py
@@ -63,7 +63,7 @@ class TestQgsSimpleLineSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsSimpleLineSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsspatialindex.py
+++ b/tests/src/python/test_qgsspatialindex.py
@@ -43,8 +43,7 @@ class TestQgsSpatialIndex(unittest.TestCase):
         myMessage = f'Expected: {myExpectedValue} Got: {myValue}'
         self.assertEqual(myValue, myExpectedValue, myMessage)
         fids.sort()
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     ([1, 2, 5, 6], fids))
+        myMessage = f'Expected: {[1, 2, 5, 6]}\nGot: {fids}\n'
         assert fids == [1, 2, 5, 6], myMessage
 
         # nearest neighbor test
@@ -54,8 +53,7 @@ class TestQgsSpatialIndex(unittest.TestCase):
         myMessage = f'Expected: {myExpectedValue} Got: {myValue}'
 
         fids.sort()
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     ([0, 1, 5], fids))
+        myMessage = f'Expected: {[0, 1, 5]}\nGot: {fids}\n'
         assert fids == [0, 1, 5], myMessage
 
     def testGetGeometry(self):

--- a/tests/src/python/test_qgssvgcache.py
+++ b/tests/src/python/test_qgssvgcache.py
@@ -56,7 +56,7 @@ class TestQgsSvgCache(unittest.TestCase):
         QgsApplication.svgCache().remoteSvgFetched.connect(self.svgFetched)
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -78,7 +78,7 @@ class TestQgsSymbol(unittest.TestCase):
         self.report = "<h1>Python QgsSymbol Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 
@@ -288,7 +288,7 @@ class TestQgsSymbol(unittest.TestCase):
             def get_geom():
                 if 'geom' not in test:
                     geom = QgsGeometry.fromWkt(test['wkt'])
-                    assert geom and not geom.isNull(), 'Could not create geometry {}'.format(test['wkt'])
+                    assert geom and not geom.isNull(), f"Could not create geometry {test['wkt']}"
                 else:
                     geom = test['geom']
                 return geom
@@ -875,7 +875,7 @@ class TestQgsMarkerSymbol(unittest.TestCase):
         self.report = "<h1>Python QgsMarkerSymbol Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 
@@ -1155,7 +1155,7 @@ class TestQgsLineSymbol(unittest.TestCase):
         self.report = "<h1>Python QgsLineSymbol Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 
@@ -1220,7 +1220,7 @@ class TestQgsFillSymbol(unittest.TestCase):
         self.report = "<h1>Python QgsFillSymbol Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgssymbollayer.py
+++ b/tests/src/python/test_qgssymbollayer.py
@@ -107,7 +107,7 @@ class TestQgsSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgssymbollayer_createsld.py
+++ b/tests/src/python/test_qgssymbollayer_createsld.py
@@ -385,7 +385,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
 
     def testSingleSymbolNoScaleDependencies(self):
         layer = QgsVectorLayer("Point", "addfeat", "memory")
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "singleSymbol"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/singleSymbol.qml")
         layer.loadNamedStyle(mFilePath)
 
         dom, root = self.layerToSld(layer)
@@ -395,7 +395,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
 
     def testSingleSymbolScaleDependencies(self):
         layer = QgsVectorLayer("Point", "addfeat", "memory")
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "singleSymbol"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/singleSymbol.qml")
         layer.loadNamedStyle(mFilePath)
         layer.setMaximumScale(1000)
         layer.setMinimumScale(500000)
@@ -408,7 +408,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
 
     def testCategorizedNoScaleDependencies(self):
         layer = QgsVectorLayer("Polygon", "addfeat", "memory")
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "categorized"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/categorized.qml")
         layer.loadNamedStyle(mFilePath)
 
         dom, root = self.layerToSld(layer)
@@ -420,7 +420,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
 
     def testCategorizedWithScaleDependencies(self):
         layer = QgsVectorLayer("Polygon", "addfeat", "memory")
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "categorized"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/categorized.qml")
         layer.loadNamedStyle(mFilePath)
         layer.setMaximumScale(1000)
         layer.setMinimumScale(500000)
@@ -436,7 +436,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
     def testGraduatedNoScaleDependencies(self):
         layer = QgsVectorLayer("Polygon", "addfeat", "memory")
 
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "graduated"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/graduated.qml")
         status = layer.loadNamedStyle(mFilePath)  # NOQA
 
         dom, root = self.layerToSld(layer)
@@ -462,7 +462,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
     def testRuleBasedNoRootScaleDependencies(self):
         layer = QgsVectorLayer("Polygon", "addfeat", "memory")
 
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "ruleBased"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/ruleBased.qml")
         status = layer.loadNamedStyle(mFilePath)  # NOQA
         layer.setMaximumScale(5000)
         layer.setMinimumScale(50000000)
@@ -479,7 +479,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
         layer = QgsVectorLayer("Point", "addfeat", "memory")
 
         mFilePath = QDir.toNativeSeparators(
-            '{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "categorizedFunctionConflict"))
+            f"{unitTestDataPath()}/symbol_layer/categorizedFunctionConflict.qml")
         status = layer.loadNamedStyle(mFilePath)  # NOQA
 
         dom, root = self.layerToSld(layer)
@@ -1213,7 +1213,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
     def testRuleBaseEmptyFilter(self):
         layer = QgsVectorLayer("Point", "addfeat", "memory")
 
-        mFilePath = QDir.toNativeSeparators('{}/symbol_layer/{}.qml'.format(unitTestDataPath(), "categorizedEmptyValue"))
+        mFilePath = QDir.toNativeSeparators(f"{unitTestDataPath()}/symbol_layer/categorizedEmptyValue.qml")
         status = layer.loadNamedStyle(mFilePath)  # NOQA
 
         dom, root = self.layerToSld(layer)

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -57,7 +57,7 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -65,7 +65,7 @@ class PyQgsTextRenderer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(cls.report)
 

--- a/tests/src/python/test_qgsvectorfieldmarkersymbollayer.py
+++ b/tests/src/python/test_qgsvectorfieldmarkersymbollayer.py
@@ -52,7 +52,7 @@ class TestQgsVectorFieldMarkerSymbolLayer(unittest.TestCase):
         self.report = "<h1>Python QgsVectorFieldMarkerSymbolLayer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -938,7 +938,7 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertEqual(write_result, QgsVectorFileWriter.NoError, error_message)
 
         # Real test
-        vl = QgsVectorLayer("%s|layername=test" % filename, 'src_test', 'ogr')
+        vl = QgsVectorLayer(f"{filename}|layername=test", 'src_test', 'ogr')
         self.assertTrue(vl.isValid())
         self.assertEqual(vl.featureCount(), 1)
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -189,7 +189,7 @@ def dumpFeature(f):
         print("geometry wkb: %d" % geom.wkbType())
     else:
         print("no geometry")
-    print("attrs: %s" % str(f.attributes()))
+    print(f"attrs: {str(f.attributes())}")
 
 
 def formatAttributes(attrs):

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -57,7 +57,7 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         self.report = "<h1>Python QgsVectorLayerProfileGenerator Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsvectorlayerrenderer.py
+++ b/tests/src/python/test_qgsvectorlayerrenderer.py
@@ -47,7 +47,7 @@ class TestQgsVectorLayerRenderer(unittest.TestCase):
         self.report = "<h1>Python QgsVectorLayerRenderer Tests</h1>\n"
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -725,7 +725,7 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         context = vl.createExpressionContext()
         for i in range(2):
             features_data.append(
-                QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 44)'), {0: 'test_%s' % i, 1: 123}))
+                QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 44)'), {0: f'test_{i}', 1: 123}))
         features = QgsVectorLayerUtils.createFeatures(vl, features_data, context)
 
         self.assertEqual(features[0].attributes()[1], 124)

--- a/tests/src/python/test_qgsvectortile.py
+++ b/tests/src/python/test_qgsvectortile.py
@@ -134,7 +134,7 @@ class TestVectorTile(unittest.TestCase):
         self.assertEqual(vl.sourceMaxZoom(), 19)
 
     def testSelection(self):
-        layer = QgsVectorTileLayer('type=vtpk&url={}'.format(unitTestDataPath() + '/testvtpk.vtpk'), 'tiles')
+        layer = QgsVectorTileLayer(f"type=vtpk&url={unitTestDataPath() + '/testvtpk.vtpk'}", 'tiles')
         self.assertTrue(layer.isValid())
 
         self.assertFalse(layer.selectedFeatures())

--- a/tests/src/python/test_qgsvtpk.py
+++ b/tests/src/python/test_qgsvtpk.py
@@ -131,7 +131,7 @@ class TestQgsVtpk(unittest.TestCase):
         self.assertEqual(layer_metadata.extent().spatialExtents()[0].extentCrs.authid(), 'EPSG:4326')
 
     def testVectorTileLayer(self):
-        layer = QgsVectorTileLayer('type=vtpk&url={}'.format(unitTestDataPath() + '/testvtpk.vtpk'), 'tiles')
+        layer = QgsVectorTileLayer(f"type=vtpk&url={unitTestDataPath() + '/testvtpk.vtpk'}", 'tiles')
         self.assertTrue(layer.isValid())
         self.assertEqual(layer.sourceType(), 'vtpk')
         self.assertEqual(layer.sourcePath(), unitTestDataPath() + '/testvtpk.vtpk')

--- a/tests/src/python/test_selective_masking.py
+++ b/tests/src/python/test_selective_masking.py
@@ -154,7 +154,7 @@ class TestSelectiveMasking(unittest.TestCase):
         self.map_settings.setLayers([self.points_layer, self.lines_layer, self.polys_layer])
 
     def tearDown(self):
-        report_file_path = "%s/qgistest.html" % QDir.tempPath()
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 

--- a/tests/src/python/test_stylestorage_spatialite.py
+++ b/tests/src/python/test_stylestorage_spatialite.py
@@ -37,7 +37,7 @@ class StyleStorageTest(StyleStorageTestCaseBase, StyleStorageTestBase):
         self.temp_path = self.temp_dir.path()
         md = QgsProviderRegistry.instance().providerMetadata(self.providerKey)
         shutil.copy(os.path.join(TEST_DATA_DIR, 'provider', 'spatialite.db'), os.path.join(self.temp_path, 'spatialite.db'))
-        self.test_uri = "dbname='{}'".format(os.path.join(self.temp_path, 'spatialite.db'))
+        self.test_uri = f"dbname='{os.path.join(self.temp_path, 'spatialite.db')}'"
         self.uri = self.test_uri
 
     def layerUri(self, conn, schema_name, table_name):


### PR DESCRIPTION
Pyupgrade doesn't transform strings like 

```python
"config_file=%s" % pg_conf
```
because it can't guess if `pg_conf` is tuple or not.

I found another tool, flynt, which does this transformation but warn about possible mistakes about this situation

https://github.com/ikamensh/flynt#dangers-of-conversion

> It is not guaranteed that formatted strings will be exactly the same as before conversion.

```
➜ flynt test_*.py
Running flynt v.0.77

Flynt run has finished. Stats:

Execution time:                            8.736s
Files checked:                             528
Files modified:                            131
Character count reduction:                 3727 (0.04%)

Per expression type:
Old style (`%`) expressions attempted:     512/917 (55.8%)
`.format(...)` calls attempted:            341/365 (93.4%)
No concatenations attempted.
No static string joins attempted.
F-string expressions created:              558
Out of all attempted transforms, 431 resulted in errors.
```

So let's check about the CI...