### PR TITLE
Keep ZM coordinates when simplifying geometry

### DIFF
--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -200,6 +200,10 @@ Appends the contents of another circular ``string`` to the end of this circular 
 
     virtual double yAt( int index ) const /HoldGIL/;
 
+    virtual double zAt( int index ) const /HoldGIL/;
+
+    virtual double mAt( int index ) const /HoldGIL/;
+
 
     virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -197,6 +197,10 @@ Appends first point if not already closed.
 
     virtual double yAt( int index ) const /HoldGIL/;
 
+    virtual double zAt( int index ) const /HoldGIL/;
+
+    virtual double mAt( int index ) const /HoldGIL/;
+
 
     virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
 

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -229,6 +229,28 @@ Returns the y-coordinate of the specified node in the line string.
 :return: y-coordinate of node, or 0.0 if index is out of bounds
 %End
 
+    virtual double zAt( int index ) const = 0;
+%Docstring
+Returns the z-coordinate of the specified node in the line string.
+
+:param index: index of node, where the first node in the line is 0
+
+:return: z-coordinate of node, or 0.0 if index is out of bounds
+
+.. versionadded:: 3.28
+%End
+
+    virtual double mAt( int index ) const = 0;
+%Docstring
+Returns the m-coordinate of the specified node in the line string.
+
+:param index: index of node, where the first node in the line is 0
+
+:return: m-coordinate of node, or 0.0 if index is out of bounds
+
+.. versionadded:: 3.28
+%End
+
     virtual QPolygonF asQPolygonF() const;
 %Docstring
 Returns a QPolygonF representing the points.

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -363,7 +363,8 @@ corresponds to the last point in the line.
 
 
 
-    double zAt( int index ) const;
+    virtual double zAt( int index ) const;
+
 %Docstring
 Returns the z-coordinate of the specified node in the line string.
 
@@ -391,7 +392,8 @@ corresponds to the last point in the line.
 %End
 
 
-    double mAt( int index ) const;
+    virtual double mAt( int index ) const;
+
 %Docstring
 Returns the m-coordinate of the specified node in the line string.
 

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -792,6 +792,22 @@ double QgsCircularString::yAt( int index ) const
     return 0.0;
 }
 
+double QgsCircularString::zAt( int index ) const
+{
+  if ( index >= 0 && index < mZ.size() )
+    return mZ.at( index );
+  else
+    return 0.0;
+}
+
+double QgsCircularString::mAt( int index ) const
+{
+  if ( index >= 0 && index < mM.size() )
+    return mM.at( index );
+  else
+    return 0.0;
+}
+
 bool QgsCircularString::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback )
 {
   if ( !transformer )

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -161,6 +161,8 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     void swapXy() override;
     double xAt( int index ) const override SIP_HOLDGIL;
     double yAt( int index ) const override SIP_HOLDGIL;
+    double zAt( int index ) const override SIP_HOLDGIL;
+    double mAt( int index ) const override SIP_HOLDGIL;
 
     bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
     void scroll( int firstVertexIndex ) final;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -1067,6 +1067,36 @@ double QgsCompoundCurve::yAt( int index ) const
   return 0.0;
 }
 
+double QgsCompoundCurve::zAt( int index ) const
+{
+  int currentVertexId = 0;
+  for ( int j = 0; j < mCurves.size(); ++j )
+  {
+    int nCurvePoints = mCurves.at( j )->numPoints();
+    if ( ( index - currentVertexId ) < nCurvePoints )
+    {
+      return mCurves.at( j )->zAt( index - currentVertexId );
+    }
+    currentVertexId += ( nCurvePoints - 1 );
+  }
+  return 0.0;
+}
+
+double QgsCompoundCurve::mAt( int index ) const
+{
+  int currentVertexId = 0;
+  for ( int j = 0; j < mCurves.size(); ++j )
+  {
+    int nCurvePoints = mCurves.at( j )->numPoints();
+    if ( ( index - currentVertexId ) < nCurvePoints )
+    {
+      return mCurves.at( j )->mAt( index - currentVertexId );
+    }
+    currentVertexId += ( nCurvePoints - 1 );
+  }
+  return 0.0;
+}
+
 bool QgsCompoundCurve::transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback )
 {
   bool res = true;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -157,6 +157,8 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
     double xAt( int index ) const override SIP_HOLDGIL;
     double yAt( int index ) const override SIP_HOLDGIL;
+    double zAt( int index ) const override SIP_HOLDGIL;
+    double mAt( int index ) const override SIP_HOLDGIL;
 
     bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
     void scroll( int firstVertexIndex ) final;

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -209,6 +209,22 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     virtual double yAt( int index ) const = 0;
 
     /**
+     * Returns the z-coordinate of the specified node in the line string.
+    * \param index index of node, where the first node in the line is 0
+    * \returns z-coordinate of node, or 0.0 if index is out of bounds
+    * \since QGIS 3.28
+    */
+    virtual double zAt( int index ) const = 0;
+
+    /**
+     * Returns the m-coordinate of the specified node in the line string.
+     * \param index index of node, where the first node in the line is 0
+     * \returns m-coordinate of node, or 0.0 if index is out of bounds
+     * \since QGIS 3.28
+     */
+    virtual double mAt( int index ) const = 0;
+
+    /**
      * Returns a QPolygonF representing the points.
      */
     virtual QPolygonF asQPolygonF() const;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * does not have a z dimension
      * \see setZAt()
      */
-    double zAt( int index ) const
+    double zAt( int index ) const override
     {
       if ( index >= 0 && index < mZ.size() )
         return mZ.at( index );
@@ -527,7 +527,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      *
      * \throws IndexError if no point with the specified index exists.
     */
-    double zAt( int index ) const;
+    double zAt( int index ) const override;
     % MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 < -count || a0 >= count )
@@ -554,7 +554,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * does not have m values
      * \see setMAt()
      */
-    double mAt( int index ) const
+    double mAt( int index ) const override
     {
       if ( index >= 0 && index < mM.size() )
         return mM.at( index );
@@ -573,7 +573,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      *
      * \throws IndexError if no point with the specified index exists.
     */
-    double mAt( int index ) const;
+    double mAt( int index ) const override;
     % MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 < -count || a0 >= count )

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -177,6 +177,8 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
 
     bool isLongSegment;
     bool hasLongSegments = false; //-> To avoid replace the simplified geometry by its BBOX when there are 'long' segments.
+    const bool is3D = geometry.is3D();
+    const bool isMeasure = geometry.isMeasure();
 
     // Check whether the LinearRing is really closed.
     if ( isaLinearRing )
@@ -205,10 +207,10 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
           xData = qgsgeometry_cast< const QgsLineString * >( &srcCurve )->xData();
           yData = qgsgeometry_cast< const QgsLineString * >( &srcCurve )->yData();
 
-          if ( geometry.is3D() )
+          if ( is3D )
             zData = qgsgeometry_cast< const QgsLineString * >( &srcCurve )->zData();
 
-          if ( geometry.isMeasure() )
+          if ( isMeasure )
             mData = qgsgeometry_cast< const QgsLineString * >( &srcCurve )->mData();
         }
 
@@ -218,24 +220,18 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
           {
             x = *xData++;
             y = *yData++;
-
-            if ( geometry.is3D() )
-              z = *zData++;
-
-            if ( geometry.isMeasure() )
-              m = *mData++;
           }
           else
           {
             x = srcCurve.xAt( i );
             y = srcCurve.yAt( i );
-
-            if ( geometry.is3D() )
-              z = srcCurve.zAt( i );
-
-            if ( geometry.isMeasure() )
-              m = srcCurve.mAt( i );
           }
+
+          if ( is3D )
+            z = zData ? *zData++ : srcCurve.zAt( i );
+
+          if ( isMeasure )
+            m = mData ? *mData++ : srcCurve.mAt( i );
 
           if ( i == 0 ||
                !isGeneralizable ||
@@ -249,10 +245,10 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
               lineStringX.append( x );
               lineStringY.append( y );
 
-              if ( geometry.is3D() )
+              if ( is3D )
                 lineStringZ.append( z );
 
-              if ( geometry.isMeasure() )
+              if ( isMeasure )
                 lineStringM.append( m );
             }
             lastX = x;
@@ -288,10 +284,10 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
               lineStringX.append( ea.inpts.at( i ).x() );
               lineStringY.append( ea.inpts.at( i ).y() );
 
-              if ( geometry.is3D() )
+              if ( is3D )
                 lineStringZ.append( ea.inpts.at( i ).z() );
 
-              if ( geometry.isMeasure() )
+              if ( isMeasure )
                 lineStringM.append( ea.inpts.at( i ).m() );
             }
           }

--- a/tests/src/core/geometry/testqgscompoundcurve.cpp
+++ b/tests/src/core/geometry/testqgscompoundcurve.cpp
@@ -672,6 +672,10 @@ void TestQgsCompoundCurve::gettersSetters()
   ( void )cc.xAt( 1 );
   ( void )cc.yAt( -1 );
   ( void )cc.yAt( 1 );
+  ( void )cc.zAt( -1 );
+  ( void )cc.zAt( 1 );
+  ( void )cc.mAt( -1 );
+  ( void )cc.mAt( 1 );
 
   QgsCircularString cs;
   cs.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 )
@@ -689,6 +693,16 @@ void TestQgsCompoundCurve::gettersSetters()
   QCOMPARE( cc.yAt( 2 ), 22.0 );
   ( void ) cc.yAt( -1 ); //out of range
   ( void ) cc.yAt( 11 ); //out of range
+  QCOMPARE( cc.zAt( 0 ), 3.0 );
+  QCOMPARE( cc.zAt( 1 ), 13.0 );
+  QCOMPARE( cc.zAt( 2 ), 23.0 );
+  ( void ) cc.zAt( -1 ); //out of range
+  ( void ) cc.zAt( 11 ); //out of range
+  QCOMPARE( cc.mAt( 0 ), 4.0 );
+  QCOMPARE( cc.mAt( 1 ), 14.0 );
+  QCOMPARE( cc.mAt( 2 ), 24.0 );
+  ( void ) cc.mAt( -1 ); //out of range
+  ( void ) cc.mAt( 11 ); //out of range
 
   cs.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 21, 22, 23, 24 )
                 << QgsPoint( QgsWkbTypes::PointZM, 31, 22, 13, 14 ) );
@@ -708,14 +722,32 @@ void TestQgsCompoundCurve::gettersSetters()
   QCOMPARE( cc.yAt( 4 ), 0.0 );
   ( void ) cc.yAt( -1 ); //out of range
   ( void ) cc.yAt( 11 ); //out of range
+  QCOMPARE( cc.zAt( 0 ), 3.0 );
+  QCOMPARE( cc.zAt( 1 ), 13.0 );
+  QCOMPARE( cc.zAt( 2 ), 23.0 );
+  QCOMPARE( cc.zAt( 3 ), 13.0 );
+  QCOMPARE( cc.zAt( 4 ), 0.0 );
+  ( void ) cc.zAt( -1 ); //out of range
+  ( void ) cc.zAt( 11 ); //out of range
+  QCOMPARE( cc.mAt( 0 ), 4.0 );
+  QCOMPARE( cc.mAt( 1 ), 14.0 );
+  QCOMPARE( cc.mAt( 2 ), 24.0 );
+  QCOMPARE( cc.mAt( 3 ), 14.0 );
+  QCOMPARE( cc.mAt( 4 ), 0.0 );
+  ( void ) cc.mAt( -1 ); //out of range
+  ( void ) cc.mAt( 11 ); //out of range
 
   cc.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 51.0, 52.0 ) );
   QCOMPARE( cc.xAt( 0 ), 51.0 );
   QCOMPARE( cc.yAt( 0 ), 52.0 );
+  QCOMPARE( cc.zAt( 0 ), 3.0 );
+  QCOMPARE( cc.mAt( 0 ), 4.0 );
 
   cc.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 61.0, 62 ) );
   QCOMPARE( cc.xAt( 1 ), 61.0 );
   QCOMPARE( cc.yAt( 1 ), 62.0 );
+  QCOMPARE( cc.zAt( 1 ), 13.0 );
+  QCOMPARE( cc.mAt( 1 ), 14.0 );
 
   cc.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 71.0, 2 ) ); //out of range
   cc.moveVertex( QgsVertexId( 0, 0, 11 ), QgsPoint( 71.0, 2 ) ); //out of range

--- a/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
+++ b/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
@@ -75,7 +75,10 @@ class TestQgsMapToPixelGeometrySimplifier : public QObject
     void testIsGeneralizableByMapBoundingBox();
     void testWkbDimensionMismatch();
     void testCircularString();
+    void testSnapToGrid();
+    void testSnapToGridZM();
     void testVisvalingam();
+    void testVisvalingamZM();
     void testRingValidity();
     void testAbstractGeometrySimplify();
 
@@ -196,6 +199,28 @@ void TestQgsMapToPixelGeometrySimplifier::testCircularString()
   QCOMPARE( simplifier.simplify( g ).asWkt(), WKT );
 }
 
+void TestQgsMapToPixelGeometrySimplifier::testSnapToGrid()
+{
+  const QString wkt( QStringLiteral( "LineString (0 0, 30 0, 31 30, 32 0, 40 0, 41 100, 42 0, 50 0)" ) );
+  const QgsGeometry g = QgsGeometry::fromWkt( wkt );
+
+  const QgsMapToPixelSimplifier simplifier( QgsMapToPixelSimplifier::SimplifyGeometry, 80, QgsMapToPixelSimplifier::SnapToGrid );
+  const QString expectedWkt( QStringLiteral( "LineString (0 0, 30 0, 32 0, 41 100, 42 0, 50 0)" ) );
+
+  QCOMPARE( simplifier.simplify( g ).asWkt(), expectedWkt );
+}
+
+void TestQgsMapToPixelGeometrySimplifier::testSnapToGridZM()
+{
+  const QString wkt( QStringLiteral( "LineString (0 0 101 1, 30 0 102 2, 31 30 103 3, 32 0 104 4, 40 0 105 5, 41 100 106 6, 42 0 107 7, 50 0 108 8)" ) );
+  const QgsGeometry g = QgsGeometry::fromWkt( wkt );
+
+  const QgsMapToPixelSimplifier simplifier( QgsMapToPixelSimplifier::SimplifyGeometry, 80, QgsMapToPixelSimplifier::SnapToGrid );
+  const QString expectedWkt( QStringLiteral( "LineStringZM (0 0 101 1, 30 0 102 2, 32 0 104 4, 41 100 106 6, 42 0 107 7, 50 0 108 8)" ) );
+
+  QCOMPARE( simplifier.simplify( g ).asWkt(), expectedWkt );
+}
+
 void TestQgsMapToPixelGeometrySimplifier::testVisvalingam()
 {
   const QString wkt( QStringLiteral( "LineString (0 0, 30 0, 31 30, 32 0, 40 0, 41 100, 42 0, 50 0)" ) );
@@ -203,6 +228,17 @@ void TestQgsMapToPixelGeometrySimplifier::testVisvalingam()
 
   const QgsMapToPixelSimplifier simplifier( QgsMapToPixelSimplifier::SimplifyGeometry, 7, QgsMapToPixelSimplifier::Visvalingam );
   const QString expectedWkt( QStringLiteral( "LineString (0 0, 40 0, 41 100, 42 0, 50 0)" ) );
+
+  QCOMPARE( simplifier.simplify( g ).asWkt(), expectedWkt );
+}
+
+void TestQgsMapToPixelGeometrySimplifier::testVisvalingamZM()
+{
+  const QString wkt( QStringLiteral( "LineStringZM (0 0 100 1, 30 0 100 1, 31 30 100 1, 32 0 100 1, 40 0 100 1, 41 100 100 1, 42 0 100 1, 50 0 100 1)" ) );
+  const QgsGeometry g = QgsGeometry::fromWkt( wkt );
+
+  const QgsMapToPixelSimplifier simplifier( QgsMapToPixelSimplifier::SimplifyGeometry, 7, QgsMapToPixelSimplifier::Visvalingam );
+  const QString expectedWkt( QStringLiteral( "LineStringZM (0 0 100 1, 40 0 100 1, 41 100 100 1, 42 0 100 1, 50 0 100 1)" ) );
 
   QCOMPARE( simplifier.simplify( g ).asWkt(), expectedWkt );
 }


### PR DESCRIPTION
Fixes #50742

Fix Visvalingam and snaptogrid, not Douglas-Peucker distance method which remove M but not Z and rely on Geos.

