### PR TITLE
Remove Vertical spacer from Mesh Layer Source panel

### DIFF
--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -261,7 +261,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>661</width>
-                <height>508</height>
+                <height>506</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -335,7 +335,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -343,7 +343,7 @@
                    <number>6</number>
                   </property>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -400,19 +400,6 @@
                  </layout>
                 </widget>
                </item>
-               <item>
-                <spacer name="verticalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
               </layout>
              </widget>
             </widget>
@@ -447,7 +434,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>661</width>
-                <height>508</height>
+                <height>506</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -494,7 +481,7 @@
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup" stdset="0">
+             <property name="syncGroup">
               <string notr="true">rastergeneral</string>
              </property>
              <layout class="QGridLayout" name="_5">
@@ -514,7 +501,7 @@
                <number>6</number>
               </property>
               <item row="0" column="0" colspan="2">
-               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                 <property name="toolTip">
                  <string/>
                 </property>
@@ -874,11 +861,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -895,15 +877,20 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>


### PR DESCRIPTION
## Description

Working with meshes/netcdf files with A LOT of datasets in it I saw a lot of unused space in the Properties dialog:

![Screenshot from 2023-02-01 19-59-43](https://user-images.githubusercontent.com/731673/216138896-1f2ea948-9e60-413e-ae56-b217e0e0d60a.png)

Looking into the UI file, it appears there is a vertical spacer place there, to push things UP:

![Screenshot from 2023-02-01 20-00-28](https://user-images.githubusercontent.com/731673/216139213-ed9806e1-a863-44a8-9bf6-1aa20ca8725d.png)

Removing it make it easier to see our datasets:

![Screenshot from 2023-02-01 19-58-30](https://user-images.githubusercontent.com/731673/216139293-792c91bf-2c52-4477-adf9-cf8d361bfcd4.png)

And still looks ok with a mesh with just one dataset (in my opinion):

![Screenshot from 2023-02-01 19-57-57](https://user-images.githubusercontent.com/731673/216139392-0eeee688-4b68-48d9-afaf-3cc41edcfb00.png)

I also find it better looking?

Not sure if anybody has an opinion on this? 
