### PR TITLE
Fix map tips do not show for vector layers where the HTML map tip option isn't used

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1528,6 +1528,15 @@ Set placeholder image for legend. If the string is empty, a generated legend wil
 .. versionadded:: 3.22
 %End
 
+    virtual bool hasMapTips() const;
+%Docstring
+Returns ``True`` if the layer contains map tips.
+
+.. seealso:: :py:func:`mapTipTemplate`
+
+.. seealso:: :py:func:`setMapTipTemplate`
+%End
+
     QString mapTipTemplate() const;
 %Docstring
 The mapTip is a pretty, html representation for feature information.
@@ -1553,7 +1562,6 @@ It may also contain embedded expressions.
 
 .. versionadded:: 3.30
 %End
-
 
   public slots:
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -511,6 +511,9 @@ Uses :py:class:`QgsExpression`
 :return: The expression which will be used to preview features for this layer
 %End
 
+    virtual bool hasMapTips() const ${SIP_FINAL};
+
+
     virtual QgsVectorDataProvider *dataProvider() ${SIP_FINAL};
 
     virtual QgsMapLayerTemporalProperties *temporalProperties();

--- a/python/gui/auto_generated/qgsmaptip.sip.in
+++ b/python/gui/auto_generated/qgsmaptip.sip.in
@@ -42,7 +42,7 @@ Default constructor
 
     void showMapTip( QgsMapLayer *thepLayer,
                      QgsPointXY &mapPosition,
-                     QPoint &pixelPosition,
+                     const QPoint &pixelPosition,
                      QgsMapCanvas *mpMapCanvas );
 %Docstring
 Show a maptip at a given point on the map canvas

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14439,13 +14439,13 @@ void QgisApp::showMapTip()
   // Only show maptips if the mouse is still over the map canvas when timer is triggered
   if ( mMapTipsVisible && mMapCanvas->underMouse() )
   {
-    QPoint myPointerPos = mMapCanvas->mouseLastXY();
+    const QPoint pointerPos = mMapCanvas->mouseLastXY();
 
     //  Make sure there is an active layer before proceeding
-    QgsMapLayer *mypLayer = mMapCanvas->currentLayer();
-    if ( mypLayer && !mypLayer->mapTipTemplate().isEmpty() )
+    QgsMapLayer *layer = mMapCanvas->currentLayer();
+    if ( layer && layer->hasMapTips() )
     {
-      mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
+      mpMaptip->showMapTip( layer, mLastMapPosition, pointerPos, mMapCanvas );
     }
   }
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2474,6 +2474,13 @@ bool QgsMapLayer::accept( QgsStyleEntityVisitorInterface * ) const
   return true;
 }
 
+bool QgsMapLayer::hasMapTips() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return !mMapTipTemplate.isEmpty();
+}
+
 void QgsMapLayer::setProviderType( const QString &providerType )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1544,6 +1544,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setLegendPlaceholderImage( const QString &imgPath ) { mLegendPlaceholderImage = imgPath; }
 
     /**
+     * Returns TRUE if the layer contains map tips.
+     *
+     * \see mapTipTemplate()
+     * \see setMapTipTemplate()
+     */
+    virtual bool hasMapTips() const;
+
+    /**
      * The mapTip is a pretty, html representation for feature information.
      *
      * It may also contain embedded expressions.
@@ -1562,7 +1570,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.30
      */
     void setMapTipTemplate( const QString &mapTipTemplate );
-
 
   public slots:
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -4063,6 +4063,14 @@ QString QgsVectorLayer::displayExpression() const
   }
 }
 
+bool QgsVectorLayer::hasMapTips() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  // display expressions are used as a fallback when no explicit map tip template is set
+  return !mapTipTemplate().isEmpty() || !displayExpression().isEmpty();
+}
+
 bool QgsVectorLayer::isEditable() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -661,6 +661,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     QString displayExpression() const;
 
+    bool hasMapTips() const FINAL;
+
     QgsVectorDataProvider *dataProvider() FINAL;
     const QgsVectorDataProvider *dataProvider() const FINAL SIP_SKIP;
     QgsMapLayerTemporalProperties *temporalProperties() override;

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -27,7 +27,6 @@
 #include "qgsrenderer.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsmaplayertemporalproperties.h"
-#include "qgsvectorlayertemporalproperties.h"
 #include "qgsrendercontext.h"
 #include "qgsmapcanvasutils.h"
 
@@ -59,7 +58,7 @@ QgsMapTip::QgsMapTip()
 
 void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
                             QgsPointXY &mapPosition,
-                            QPoint &pixelPosition,
+                            const QPoint &pixelPosition,
                             QgsMapCanvas *pMapCanvas )
 {
   // Do the search using the active layer and the preferred label field for the

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -71,7 +71,7 @@ class GUI_EXPORT QgsMapTip : public QWidget
      */
     void showMapTip( QgsMapLayer *thepLayer,
                      QgsPointXY &mapPosition,
-                     QPoint &pixelPosition,
+                     const QPoint &pixelPosition,
                      QgsMapCanvas *mpMapCanvas );
 
     /**

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -253,6 +253,18 @@ class TestQgsMapLayer(unittest.TestCase):
         self.assertIn('original abstract', vl.metadata().abstract())
         self.assertEqual(vl.metadata().rights(), ['original right 1', 'original right 2'])
 
+    def testMapTips(self):
+        rl = QgsRasterLayer(os.path.join(TEST_DATA_DIR, 'float1-16.tif'), 'test')
+        self.assertFalse(rl.hasMapTips())
+
+        rl.setMapTipTemplate('some template')
+        self.assertEqual(rl.mapTipTemplate(), 'some template')
+        self.assertTrue(rl.hasMapTips())
+
+        rl.setMapTipTemplate(None)
+        self.assertFalse(rl.mapTipTemplate())
+        self.assertFalse(rl.hasMapTips())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -4415,6 +4415,34 @@ class TestQgsVectorLayerTransformContext(unittest.TestCase):
         layer.hasSpatialIndex()
         # layer.accept(QgsStyleEntityVisitorInterface())
 
+    def testMapTips(self):
+        vl = QgsVectorLayer('Point?crs=epsg:3111&field=pk:integer', 'test', 'memory')
+        self.assertEqual(vl.displayExpression(), '"pk"')
+        # layer has map tips because display expression will be used
+        self.assertTrue(vl.hasMapTips())
+
+        vl.setMapTipTemplate('some template')
+        self.assertEqual(vl.mapTipTemplate(), 'some template')
+        self.assertTrue(vl.hasMapTips())
+
+        vl.setMapTipTemplate(None)
+        self.assertFalse(vl.mapTipTemplate())
+        self.assertTrue(vl.hasMapTips())
+
+        # layer with no fields
+        vl = QgsVectorLayer('Point?crs=epsg:3111', 'test', 'memory')
+        self.assertFalse(vl.displayExpression())
+        self.assertFalse(vl.hasMapTips())
+
+        vl.setMapTipTemplate('some template')
+        self.assertEqual(vl.mapTipTemplate(), 'some template')
+        self.assertTrue(vl.hasMapTips())
+
+        vl.setMapTipTemplate(None)
+        self.assertFalse(vl.mapTipTemplate())
+        self.assertFalse(vl.hasMapTips())
+
+
 # TODO:
 # - fetch rect: feat with changed geometry: 1. in rect, 2. out of rect
 # - more join tests


### PR DESCRIPTION
In this case the layer's display expression should be used for the map tip content

Followup https://github.com/qgis/QGIS/pull/50854
