### PR TITLE
Remember the collapsed state of the vector layer renderer group box

### DIFF
--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -522,7 +522,6 @@ void QgsCollapsibleGroupBox::setSettings( QgsSettings *settings )
   mDelSettings = false; // don't delete outside obj
 }
 
-
 void QgsCollapsibleGroupBox::init()
 {
   // use pointer to app qsettings if no custom qsettings specified
@@ -540,6 +539,10 @@ void QgsCollapsibleGroupBox::init()
   mSaveCheckedState = false;
 
   connect( this, &QObject::objectNameChanged, this, &QgsCollapsibleGroupBox::loadState );
+
+  // save state immediately when collapsed state changes, so that other widgets created
+  // before this one is destroyed will correctly restore the new collapsed state
+  connect( this, &QgsCollapsibleGroupBoxBasic::collapsedStateChanged, this, &QgsCollapsibleGroupBox::saveState );
 }
 
 void QgsCollapsibleGroupBox::showEvent( QShowEvent *event )

--- a/src/ui/qgsrendererpropsdialogbase.ui
+++ b/src/ui/qgsrendererpropsdialogbase.ui
@@ -105,7 +105,7 @@
             <bool>true</bool>
            </property>
            <property name="saveCollapsedState" stdset="0">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout">
             <property name="leftMargin">


### PR DESCRIPTION
so that this doesn't have to be expanded every time the layer is changed
