### PR TITLE
Attribute form D&D: fix editable state restore

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1214,7 +1214,15 @@ void QgsAttributeForm::updateEditableState()
         const bool isEditable { it->valueAsBool( context, true, &ok ) };
         if ( ok )
         {
-          w->setEnabled( isEditable );
+          QgsAttributeFormEditorWidget *editorWidget { qobject_cast<QgsAttributeFormEditorWidget *>( w ) };
+          if ( editorWidget )
+          {
+            editorWidget->editorWidget()->setEnabled( isEditable );
+          }
+          else
+          {
+            w->setEnabled( isEditable );
+          }
         }
       }
     }


### PR DESCRIPTION
When a widget started as not editable is was not possible to restore the editable state from a data-defined expression.

Followup #51525
