### PR TITLE
[Feature][Python Console] Add Reformat code action

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -165,6 +165,7 @@
         <file>themes/default/console/iconNewTabEditorConsole.svg</file>
         <file>themes/default/console/iconRestoreTabsConsole.svg</file>
         <file>themes/default/console/iconFileTabsMenuConsole.svg</file>
+        <file>themes/default/console/iconFormatCode.svg</file>
         <file>themes/default/console/iconShowEditorConsole.svg</file>
         <file>themes/default/console/iconCommentEditorConsole.svg</file>
         <file>themes/default/console/iconUncommentEditorConsole.svg</file>

--- a/images/themes/default/console/iconFormatCode.svg
+++ b/images/themes/default/console/iconFormatCode.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.1" id="Capa_1" x="0px" y="0px" viewBox="0 0 353.176 353.176" style="enable-background:new 0 0 353.176 353.176;" xml:space="preserve" sodipodi:docname="wizard.svg" inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata id="metadata57"><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/></cc:Work></rdf:RDF></metadata><defs id="defs55"/><sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="1017" id="namedview53" showgrid="false" inkscape:zoom="0.94500874" inkscape:cx="2.7621272" inkscape:cy="243.91811" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="g16"/>
+<g id="g20">
+	<g id="g18">
+		<g id="g16">
+			
+			
+			<path d="m 281.90157,77.256044 c 2.12,0.11 4.193,-0.644 5.747,-2.09 l 37.094,-37.094 c 2.597,-3.462 1.895,-8.375 -1.567,-10.971 -2.786,-2.09 -6.618,-2.09 -9.404,0 l -37.094,37.094 c -2.987,3.047 -2.987,7.924 0,10.971 1.392,1.366 3.273,2.118 5.224,2.09 z" id="path6" inkscape:connector-curvature="0"/>
+			<path d="m 346.42112,112.327 h -43.29114 c -3.58626,0 -6.49388,3.509 -6.49388,7.837 0,4.328 2.90762,7.837 6.49388,7.837 h 43.29114 c 3.58626,0 6.49388,-3.509 6.49388,-7.837 -8.3e-4,-4.329 -2.90762,-7.837 -6.49388,-7.837 z" id="path8" inkscape:connector-curvature="0" style="stroke-width:0.91028452"/>
+			<path d="m 330.03253,197.08272 -37.094,-37.094 c -3.22,-2.529 -7.751,-2.529 -10.971,0 -3.052,3.224 -3.052,8.27 0,11.494 l 37.094,36.571 c 1.303,1.559 3.196,2.505 5.224,2.612 2.183,-0.086 4.246,-1.024 5.747,-2.612 3.03,-2.672 3.32,-7.294 0.648,-10.324 -0.202,-0.228 -0.418,-0.445 -0.648,-0.647 z" id="path10" inkscape:connector-curvature="0"/>
+			<path d="m 181.41809,73.049661 c 3.315,2.813 8.179,2.813 11.494,0 2.529,-3.22 2.529,-7.751 0,-10.971 l -37.094,-37.094 c -3.463,-2.597 -8.375,-1.895 -10.971,1.567 -2.09,2.786 -2.09,6.618 0,9.404 z" id="path12" inkscape:connector-curvature="0"/>
+			<path d="m 232.751,63.685235 c 4.328,0 7.837,-3.290313 7.837,-7.348585 V 7.3485849 C 240.588,3.2903132 237.079,0 232.751,0 c -4.328,0 -7.837,3.2903132 -7.837,7.3485849 V 56.337588 c 0,4.058271 3.509,7.347647 7.837,7.347647 z" id="path14" inkscape:connector-curvature="0" style="stroke-width:0.96833789"/>
+		<g id="g4588"><g id="g4597" transform="rotate(42.726697,172.50888,321.10701)" inkscape:transform-center-x="64.888571" inkscape:transform-center-y="38.220033"><g id="g4592" transform="translate(-1.1928715,11.1853)"><rect y="91.802742" x="52.909565" height="71.957001" width="57.14233" id="rect4567" style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:9.60000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" ry="1.0581913"/><rect ry="0" y="182.88254" x="62.070442" height="227.99924" width="36.957619" id="rect4567-9" style="opacity:1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:9.60000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"/></g></g></g></g>
+	</g>
+</g>
+<g id="g22">
+</g>
+<g id="g24">
+</g>
+<g id="g26">
+</g>
+<g id="g28">
+</g>
+<g id="g30">
+</g>
+<g id="g32">
+</g>
+<g id="g34">
+</g>
+<g id="g36">
+</g>
+<g id="g38">
+</g>
+<g id="g40">
+</g>
+<g id="g42">
+</g>
+<g id="g44">
+</g>
+<g id="g46">
+</g>
+<g id="g48">
+</g>
+<g id="g50">
+</g>
+</svg>

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -290,16 +290,16 @@ class PythonConsoleWidget(QWidget):
         self.toggleCommentEditorButton.setText(toggleText)
 
         # Action Format code
-        formatCodeText = QCoreApplication.translate("PythonConsole", "Format Code")
-        self.formatCodeEditorButton = QAction(self)
-        self.formatCodeEditorButton.setCheckable(False)
-        self.formatCodeEditorButton.setEnabled(True)
-        self.formatCodeEditorButton.setIcon(QgsApplication.getThemeIcon("console/iconFormatCode.svg"))
-        self.formatCodeEditorButton.setMenuRole(QAction.PreferencesRole)
-        self.formatCodeEditorButton.setIconVisibleInMenu(True)
-        self.formatCodeEditorButton.setToolTip(formatCodeText + " <b>Ctrl+Alt+F</b>")
-        self.formatCodeEditorButton.setShortcut("Ctrl+Alt+F")
-        self.formatCodeEditorButton.setText(formatCodeText)
+        reformatCodeText = QCoreApplication.translate("PythonConsole", "Reformat Code")
+        self.reformatCodeEditorButton = QAction(self)
+        self.reformatCodeEditorButton.setCheckable(False)
+        self.reformatCodeEditorButton.setEnabled(True)
+        self.reformatCodeEditorButton.setIcon(QgsApplication.getThemeIcon("console/iconFormatCode.svg"))
+        self.reformatCodeEditorButton.setMenuRole(QAction.PreferencesRole)
+        self.reformatCodeEditorButton.setIconVisibleInMenu(True)
+        self.reformatCodeEditorButton.setToolTip(reformatCodeText + " <b>Ctrl+Alt+F</b>")
+        self.reformatCodeEditorButton.setShortcut("Ctrl+Alt+F")
+        self.reformatCodeEditorButton.setText(reformatCodeText)
 
         # Action for Object browser
         objList = QCoreApplication.translate("PythonConsole", "Object Inspector…")
@@ -429,7 +429,7 @@ class PythonConsoleWidget(QWidget):
         self.toolBarEditor.addAction(self.findTextButton)
         self.toolBarEditor.addSeparator()
         self.toolBarEditor.addAction(self.toggleCommentEditorButton)
-        self.toolBarEditor.addAction(self.formatCodeEditorButton)
+        self.toolBarEditor.addAction(self.reformatCodeEditorButton)
         self.toolBarEditor.addSeparator()
         self.toolBarEditor.addAction(self.objectListButton)
 
@@ -523,7 +523,7 @@ class PythonConsoleWidget(QWidget):
         self.findTextButton.triggered.connect(self._toggleFind)
         self.objectListButton.toggled.connect(self.toggleObjectListWidget)
         self.toggleCommentEditorButton.triggered.connect(self.toggleComment)
-        self.formatCodeEditorButton.triggered.connect(self.formatCode)
+        self.reformatCodeEditorButton.triggered.connect(self.reformatCode)
         self.runScriptEditorButton.triggered.connect(self.runScriptEditor)
         self.cutEditorButton.triggered.connect(self.cutEditor)
         self.copyEditorButton.triggered.connect(self.copyEditor)
@@ -655,8 +655,8 @@ class PythonConsoleWidget(QWidget):
     def toggleComment(self):
         self.tabEditorWidget.currentWidget().toggleComment()
 
-    def formatCode(self):
-        self.tabEditorWidget.currentWidget().newEditor.formatCode()
+    def reformatCode(self):
+        self.tabEditorWidget.currentWidget().newEditor.reformatCode()
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -289,6 +289,18 @@ class PythonConsoleWidget(QWidget):
         self.toggleCommentEditorButton.setToolTip(toggleText + " <b>Ctrl+:</b>")
         self.toggleCommentEditorButton.setText(toggleText)
 
+        # Action Format code
+        formatCodeText = QCoreApplication.translate("PythonConsole", "Format Code")
+        self.formatCodeEditorButton = QAction(self)
+        self.formatCodeEditorButton.setCheckable(False)
+        self.formatCodeEditorButton.setEnabled(True)
+        self.formatCodeEditorButton.setIcon(QgsApplication.getThemeIcon("console/iconFormatCode.svg"))
+        self.formatCodeEditorButton.setMenuRole(QAction.PreferencesRole)
+        self.formatCodeEditorButton.setIconVisibleInMenu(True)
+        self.formatCodeEditorButton.setToolTip(formatCodeText + " <b>Ctrl+Alt+F</b>")
+        self.formatCodeEditorButton.setShortcut("Ctrl+Alt+F")
+        self.formatCodeEditorButton.setText(formatCodeText)
+
         # Action for Object browser
         objList = QCoreApplication.translate("PythonConsole", "Object Inspector…")
         self.objectListButton = QAction(self)
@@ -417,6 +429,7 @@ class PythonConsoleWidget(QWidget):
         self.toolBarEditor.addAction(self.findTextButton)
         self.toolBarEditor.addSeparator()
         self.toolBarEditor.addAction(self.toggleCommentEditorButton)
+        self.toolBarEditor.addAction(self.formatCodeEditorButton)
         self.toolBarEditor.addSeparator()
         self.toolBarEditor.addAction(self.objectListButton)
 
@@ -510,6 +523,7 @@ class PythonConsoleWidget(QWidget):
         self.findTextButton.triggered.connect(self._toggleFind)
         self.objectListButton.toggled.connect(self.toggleObjectListWidget)
         self.toggleCommentEditorButton.triggered.connect(self.toggleComment)
+        self.formatCodeEditorButton.triggered.connect(self.formatCode)
         self.runScriptEditorButton.triggered.connect(self.runScriptEditor)
         self.cutEditorButton.triggered.connect(self.cutEditor)
         self.copyEditorButton.triggered.connect(self.copyEditor)
@@ -640,6 +654,9 @@ class PythonConsoleWidget(QWidget):
 
     def toggleComment(self):
         self.tabEditorWidget.currentWidget().toggleComment()
+
+    def formatCode(self):
+        self.tabEditorWidget.currentWidget().newEditor.formatCode()
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -656,7 +656,7 @@ class PythonConsoleWidget(QWidget):
         self.tabEditorWidget.currentWidget().toggleComment()
 
     def reformatCode(self):
-        self.tabEditorWidget.currentWidget().newEditor.reformatCode()
+        self.tabEditorWidget.currentWidget().reformatCode()
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -69,27 +69,29 @@ def findMinimalDistanceIndex(source, target):
 
     ref_dist_more = d0
     ref_index_more = index
-    while True:
-        new_dist = lev(source[:ref_index_more + 1], target)
-        if new_dist <= ref_dist_more:
-            ref_dist_more = new_dist
-            ref_index_more = ref_index_more + 1
-            if ref_index_more == len(source) - 1:
+    if index < len(source) - 1:
+        while True:
+            new_dist = lev(source[:ref_index_more + 1], target)
+            if new_dist <= ref_dist_more:
+                ref_dist_more = new_dist
+                ref_index_more = ref_index_more + 1
+                if ref_index_more == len(source) - 1:
+                    break
+            else:
                 break
-        else:
-            break
 
     ref_dist_less = d0
     ref_index_less = index
-    while True:
-        new_dist = lev(source[:ref_index_less - 1], target)
-        if new_dist <= ref_dist_less:
-            ref_dist_less = new_dist
-            ref_index_less = ref_index_less - 1
-            if ref_index_less == 0:
+    if index > 0:
+        while True:
+            new_dist = lev(source[:ref_index_less - 1], target)
+            if new_dist <= ref_dist_less:
+                ref_dist_less = new_dist
+                ref_index_less = ref_index_less - 1
+                if ref_index_less == 0:
+                    break
+            else:
                 break
-        else:
-            break
 
     if ref_dist_more < ref_dist_less:
         return ref_index_more
@@ -110,11 +112,11 @@ class Editor(QgsCodeEditorPython):
         self.setMinimumHeight(120)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
-        # Disable command key
+        # Disable default scintilla shortcuts
         ctrl, shift = self.SCMOD_CTRL << 16, self.SCMOD_SHIFT << 16
-        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('L') + ctrl)
-        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('T') + ctrl)
-        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('D') + ctrl)
+        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('T') + ctrl) # Switch current line with the next one
+        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('D') + ctrl) # Duplicate current line / selection
+        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('L') + ctrl) # Delete current line
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord('L') + ctrl + shift)
 
         # New QShortcut = ctrl+space/ctrl+alt+space for Autocomplete

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -30,7 +30,7 @@ from functools import partial
 from operator import itemgetter
 from pathlib import Path
 
-from qgis.core import Qgis, QgsApplication, QgsBlockingNetworkRequest, QgsFileUtils, QgsSettings
+from qgis.core import Qgis, QgsApplication, QgsBlockingNetworkRequest, QgsStringUtils, QgsSettings
 from qgis.gui import QgsCodeEditorPython, QgsMessageBar
 from qgis.PyQt.Qsci import QsciScintilla
 from qgis.PyQt.QtCore import QByteArray, QCoreApplication, QDir, QEvent, QFileInfo, QJsonDocument, QSize, Qt, QUrl
@@ -59,15 +59,7 @@ def findMinimalDistanceIndex(source, target):
     """ Find the source substring index that most closely matches the target string"""
     index = min(len(source), len(target))
 
-    # Fallback to difflib if Levenshtein is not available
-    # Levenshtein is faster than difflib
-    try:
-        from Levenshtein import distance
-    except ImportError:
-        from difflib import SequenceMatcher
-
-        def distance(s, t):
-            return 1 - SequenceMatcher(None, s, t).ratio()
+    distance = QgsStringUtils.levenshteinDistance
 
     d0 = distance(source[:index], target)
     if d0 == 0:

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -65,7 +65,9 @@ def findMinimalDistanceIndex(source, target):
         from Levenshtein import distance
     except ImportError:
         from difflib import SequenceMatcher
-        def distance(s, t): return 1 - SequenceMatcher(None, s, t).ratio()
+
+        def distance(s, t):
+            return 1 - SequenceMatcher(None, s, t).ratio()
 
     d0 = distance(source[:index], target)
     if d0 == 0:

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -58,11 +58,16 @@ from qgis.utils import OverrideCursor
 def findMinimalDistanceIndex(source, target):
     """ Find the source substring index that most closely matches the target string"""
     index = min(len(source), len(target))
+
+    # Fallback to difflib if Levenshtein is not available
+    # Levenshtein is faster than difflib
     try:
-        from Levenshtein import distance as lev
+        from Levenshtein import distance
     except ImportError:
-        return index
-    d0 = lev(source[:index], target)
+        from difflib import SequenceMatcher
+        def distance(s, t): return 1 - SequenceMatcher(None, s, t).ratio()
+
+    d0 = distance(source[:index], target)
     if d0 == 0:
         return index
 
@@ -70,7 +75,7 @@ def findMinimalDistanceIndex(source, target):
     ref_index_more = index
     if index < len(source) - 1:
         while True:
-            new_dist = lev(source[:ref_index_more + 1], target)
+            new_dist = distance(source[:ref_index_more + 1], target)
             if new_dist <= ref_dist_more:
                 ref_dist_more = new_dist
                 ref_index_more = ref_index_more + 1
@@ -83,7 +88,7 @@ def findMinimalDistanceIndex(source, target):
     ref_index_less = index
     if index > 0:
         while True:
-            new_dist = lev(source[:ref_index_less - 1], target)
+            new_dist = distance(source[:ref_index_less - 1], target)
             if new_dist <= ref_dist_less:
                 ref_dist_less = new_dist
                 ref_index_less = ref_index_less - 1

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -30,6 +30,8 @@ from functools import partial
 from operator import itemgetter
 from pathlib import Path
 
+import autopep8
+
 from qgis.core import Qgis, QgsApplication, QgsBlockingNetworkRequest, QgsFileUtils, QgsSettings
 from qgis.gui import QgsCodeEditorPython, QgsMessageBar
 from qgis.PyQt.Qsci import QsciScintilla
@@ -228,6 +230,23 @@ class Editor(QgsCodeEditorPython):
 
     def findPrevious(self):
         self.findText(False)
+
+    def formatCode(self):
+
+        new_text = autopep8.fix_code(self.text())
+        if new_text == self.text():
+            return
+
+        # Try to preserve the cursor position and scroll position
+        old_pos = self.getCursorPosition()
+        old_scroll_value = self.verticalScrollBar().value()
+        self.beginUndoAction()
+        self.selectAll()
+        self.removeSelectedText()
+        self.insert(new_text)
+        self.setCursorPosition(*old_pos)
+        self.verticalScrollBar().setValue(old_scroll_value)
+        self.endUndoAction()
 
     def objectListEditor(self):
         listObj = self.pythonconsole.listClassMethod

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -274,8 +274,8 @@ class Editor(QgsCodeEditorPython):
     def textBeforeCursor(self):
         return self.text(0, self.positionFromLineIndex(*self.getCursorPosition()))
 
-    def formatCode(self):
-        """ Format the code using the selected formatter """
+    def reformatCode(self):
+        """ Reformat the code using the selected formatter """
 
         formatter = self.settings.value("pythonConsole/formatter", "autopep8", type=str)
         max_line_length = self.settings.value("pythonConsole/maxLineLength", 80, type=int)
@@ -507,7 +507,7 @@ class Editor(QgsCodeEditorPython):
             return
 
         if self.pythonconsole.settings.value("pythonConsole/formatOnSave", False, type=bool):
-            self.formatCode()
+            self.reformatCode()
 
         tabwidget = self.tabwidget
         index = tabwidget.indexOf(self.parent)

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -302,10 +302,9 @@ class Editor(QgsCodeEditorPython):
                 new_text = isort.code(new_text, **options)
 
             except ImportError:
-                self.parent.infoBar.pushMessage(
+                self.parent.infoBar.pushWarning(
                     QCoreApplication.translate("PythonConsole", "Python Console"),
                     QCoreApplication.translate("PythonConsole", "Module {0} is missing").format("isort"),
-                    duration=2,
                 )
 
         # autopep8
@@ -313,11 +312,9 @@ class Editor(QgsCodeEditorPython):
             try:
                 import autopep8
             except ImportError:
-                self.parent.infoBar.pushMessage(
+                self.parent.infoBar.pushWarning(
                     QCoreApplication.translate("PythonConsole", "Python Console"),
                     QCoreApplication.translate("PythonConsole", "Module {0} is missing").format("autopep8"),
-                    duration=2,
-                    level=Qgis.Warning,
                 )
                 return
             level = self.settings.value("pythonConsole/autopep8Level", 1, type=int)
@@ -329,19 +326,15 @@ class Editor(QgsCodeEditorPython):
             try:
                 import black
             except ImportError:
-                self.parent.infoBar.pushMessage(
+                self.parent.infoBar.pushWarning(
                     QCoreApplication.translate("PythonConsole", "Python Console"),
                     QCoreApplication.translate("PythonConsole", "Module {0} is missing").format("black"),
-                    duration=2,
-                    level=Qgis.Warning,
                 )
                 return
             if not self.syntaxCheck():
-                self.parent.infoBar.pushMessage(
+                self.parent.infoBar.pushWarning(
                     QCoreApplication.translate("PythonConsole", "Code formatting failed"),
                     QCoreApplication.translate("PythonConsole", "The code contains syntax errors"),
-                    level=Qgis.Warning,
-                    duration=2,
                 )
                 return
 

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -232,8 +232,12 @@ class Editor(QgsCodeEditorPython):
         self.findText(False)
 
     def formatCode(self):
-
-        new_text = autopep8.fix_code(self.text())
+        """ Format the code using autopep8 """
+        options = {
+            "aggressive": self.settings.value("pythonConsole/autopep8Aggressiveness", 1, type=int),
+            "max_line_length": self.settings.value("pythonConsole/maxLineLength", 80, type=int),
+        }
+        new_text = autopep8.fix_code(self.text(), options=options)
         if new_text == self.text():
             return
 
@@ -424,6 +428,10 @@ class Editor(QgsCodeEditorPython):
     def save(self, filename=None):
         if self.isReadOnly():
             return
+
+        if self.pythonconsole.settings.value("pythonConsole/formatOnSave", False, type=bool):
+            self.formatCode()
+
         tabwidget = self.tabwidget
         index = tabwidget.indexOf(self.parent)
         if filename:

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -73,6 +73,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.parent = parent
         self.setupUi(self)
 
+        # Set up the formatter combo box
+        self.formatter.addItems(["autopep8", "black"])
+
         self.listPath = []
         self.lineEdit.setReadOnly(True)
 

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -90,6 +90,8 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.compileAPIs.clicked.connect(self._prepareAPI)
 
         self.generateToken.clicked.connect(self.generateGHToken)
+        self.formatter.currentTextChanged.connect(self.onFormatterChanged)
+        self.onFormatterChanged()
 
     def generateGHToken(self):
         description = self.tr("PyQGIS Console")
@@ -207,7 +209,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
         settings.setValue("pythonConsole/formatOnSave", self.formatOnSave.isChecked())
+        settings.setValue("pythonConsole/formatter", self.formatter.currentText())
         settings.setValue("pythonConsole/autopep8Aggressiveness", self.autopep8Aggressiveness.value())
+        settings.setValue("pythonConsole/blackNormalizeQuotes", self.blackNormalizeQuotes.isChecked())
         settings.setValue("pythonConsole/maxLineLength", self.maxLineLength.value())
 
     def restoreSettings(self):
@@ -236,7 +240,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         self.formatOnSave.setChecked(settings.value("pythonConsole/formatOnSave", False, type=bool))
+        self.formatter.setCurrentText(settings.value("pythonConsole/formatter", "autopep8", type=str))
         self.autopep8Aggressiveness.setValue(settings.value("pythonConsole/autopep8Aggressiveness", 1, type=int))
+        self.blackNormalizeQuotes.setChecked(settings.value("pythonConsole/blackNormalizeQuotes", True, type=bool))
         self.maxLineLength.setValue(settings.value("pythonConsole/maxLineLength", 80, type=int))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':
@@ -245,3 +251,14 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
             self.autoCompFromAPI.setChecked(True)
         elif settings.value("pythonConsole/autoCompleteSource") == 'fromDocAPI':
             self.autoCompFromDocAPI.setChecked(True)
+
+    def onFormatterChanged(self):
+        """ Toggle formatter-specific options visibility when the formatter is changed """
+        if self.formatter.currentText() == 'autopep8':
+            self.autopep8Aggressiveness.setVisible(True)
+            self.autopep8AggressivenessLabel.setVisible(True)
+            self.blackNormalizeQuotes.setVisible(False)
+        else:  # black
+            self.autopep8Aggressiveness.setVisible(False)
+            self.autopep8AggressivenessLabel.setVisible(False)
+            self.blackNormalizeQuotes.setVisible(True)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -206,6 +206,10 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/autoSurround", self.autoSurround.isChecked())
         settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
+        settings.setValue("pythonConsole/formatOnSave", self.formatOnSave.isChecked())
+        settings.setValue("pythonConsole/autopep8Aggressiveness", self.autopep8Aggressiveness.value())
+        settings.setValue("pythonConsole/maxLineLength", self.maxLineLength.value())
+
     def restoreSettings(self):
         settings = QgsSettings()
         self.preloadAPI.setChecked(settings.value("pythonConsole/preloadAPI", True, type=bool))
@@ -230,6 +234,10 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", True, type=bool))
         self.autoSurround.setChecked(settings.value("pythonConsole/autoSurround", True, type=bool))
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
+
+        self.formatOnSave.setChecked(settings.value("pythonConsole/formatOnSave", False, type=bool))
+        self.autopep8Aggressiveness.setValue(settings.value("pythonConsole/autopep8Aggressiveness", 1, type=int))
+        self.maxLineLength.setValue(settings.value("pythonConsole/maxLineLength", 80, type=int))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':
             self.autoCompFromDoc.setChecked(True)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -209,8 +209,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
         settings.setValue("pythonConsole/formatOnSave", self.formatOnSave.isChecked())
+        settings.setValue("pythonConsole/sortImports", self.sortImports.isChecked())
         settings.setValue("pythonConsole/formatter", self.formatter.currentText())
-        settings.setValue("pythonConsole/autopep8Aggressiveness", self.autopep8Aggressiveness.value())
+        settings.setValue("pythonConsole/autopep8Level", self.autopep8Level.value())
         settings.setValue("pythonConsole/blackNormalizeQuotes", self.blackNormalizeQuotes.isChecked())
         settings.setValue("pythonConsole/maxLineLength", self.maxLineLength.value())
 
@@ -240,8 +241,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         self.formatOnSave.setChecked(settings.value("pythonConsole/formatOnSave", False, type=bool))
+        self.sortImports.setChecked(settings.value("pythonConsole/sortImports", True, type=bool))
         self.formatter.setCurrentText(settings.value("pythonConsole/formatter", "autopep8", type=str))
-        self.autopep8Aggressiveness.setValue(settings.value("pythonConsole/autopep8Aggressiveness", 1, type=int))
+        self.autopep8Level.setValue(settings.value("pythonConsole/autopep8Level", 1, type=int))
         self.blackNormalizeQuotes.setChecked(settings.value("pythonConsole/blackNormalizeQuotes", True, type=bool))
         self.maxLineLength.setValue(settings.value("pythonConsole/maxLineLength", 80, type=int))
 
@@ -255,10 +257,10 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
     def onFormatterChanged(self):
         """ Toggle formatter-specific options visibility when the formatter is changed """
         if self.formatter.currentText() == 'autopep8':
-            self.autopep8Aggressiveness.setVisible(True)
-            self.autopep8AggressivenessLabel.setVisible(True)
+            self.autopep8Level.setVisible(True)
+            self.autopep8LevelLabel.setVisible(True)
             self.blackNormalizeQuotes.setVisible(False)
         else:  # black
-            self.autopep8Aggressiveness.setVisible(False)
-            self.autopep8AggressivenessLabel.setVisible(False)
+            self.autopep8Level.setVisible(False)
+            self.autopep8LevelLabel.setVisible(False)
             self.blackNormalizeQuotes.setVisible(True)

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -508,16 +508,6 @@
               <height>0</height>
              </size>
             </property>
-            <item>
-             <property name="text">
-              <string>autopep8</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>black</string>
-             </property>
-            </item>
            </widget>
           </item>
           <item row="1" column="0" colspan="2">

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1055</width>
+    <width>888</width>
     <height>731</height>
    </rect>
   </property>
@@ -54,8 +54,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1041</width>
-        <height>854</height>
+        <width>874</width>
+        <height>914</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -456,26 +456,16 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Maximum line length</string>
+             <string>Formatter</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_7">
+          <item row="4" column="0" colspan="2">
+           <widget class="QCheckBox" name="blackNormalizeQuotes">
             <property name="text">
-             <string>Autopep8 agressiveness</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="autopep8Aggressiveness">
-            <property name="maximum">
-             <number>3</number>
-            </property>
-            <property name="value">
-             <number>1</number>
+             <string>Normalize quotes</string>
             </property>
            </widget>
           </item>
@@ -486,7 +476,51 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="autopep8AggressivenessLabel">
+            <property name="text">
+             <string>Autopep8 agressiveness</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="autopep8Aggressiveness">
+            <property name="maximum">
+             <number>3</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
+           <widget class="QComboBox" name="formatter">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <item>
+             <property name="text">
+              <string>autopep8</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>black</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Maximum line length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
            <widget class="QSpinBox" name="maxLineLength">
             <property name="minimum">
              <number>60</number>
@@ -499,7 +533,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="0" column="2">
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -540,8 +574,9 @@
   <tabstop>autoSurround</tabstop>
   <tabstop>autoInsertImport</tabstop>
   <tabstop>formatOnSave</tabstop>
+  <tabstop>formatter</tabstop>
   <tabstop>autopep8Aggressiveness</tabstop>
-  <tabstop>maxLineLength</tabstop>
+  <tabstop>blackNormalizeQuotes</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>
   <tabstop>preloadAPI</tabstop>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>888</width>
-    <height>731</height>
+    <width>809</width>
+    <height>860</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_16">
    <property name="leftMargin">
-    <number>0</number>
+    <number>20</number>
    </property>
    <property name="topMargin">
     <number>0</number>
@@ -54,8 +54,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>874</width>
-        <height>914</height>
+        <width>789</width>
+        <height>860</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -95,9 +95,15 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxApi">
          <property name="title">
           <string>APIs</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
           <item row="0" column="0">
@@ -178,7 +184,7 @@
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>150</height>
+                <height>100</height>
                </size>
               </property>
               <property name="editTriggers">
@@ -291,17 +297,20 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxTyping">
          <property name="title">
           <string>Typing</string>
          </property>
          <property name="collapsed" stdset="0">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="saveCollapsedState" stdset="0">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_11">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
           <item row="0" column="0">
            <widget class="QCheckBox" name="autoCloseBracket">
             <property name="text">
@@ -332,12 +341,15 @@
           <string>Run and Debug</string>
          </property>
          <property name="collapsed" stdset="0">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="saveCollapsedState" stdset="0">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_21">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
           <item row="1" column="0">
            <widget class="QCheckBox" name="autoSaveScript">
             <property name="text">
@@ -379,6 +391,9 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
           <item row="0" column="2">
            <widget class="QLabel" name="label_36">
             <property name="text">
@@ -444,56 +459,48 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="formattingGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxFromatting">
          <property name="title">
           <string>Formatting</string>
          </property>
          <property name="collapsed" stdset="0">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="saveCollapsedState" stdset="0">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Formatter</string>
+          <property name="verticalSpacing">
+           <number>2</number>
+          </property>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="maxLineLength">
+            <property name="minimum">
+             <number>60</number>
+            </property>
+            <property name="maximum">
+             <number>200</number>
+            </property>
+            <property name="value">
+             <number>80</number>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QCheckBox" name="blackNormalizeQuotes">
-            <property name="text">
-             <string>Normalize quotes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
+          <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="formatOnSave">
             <property name="text">
              <string>Format on save</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="autopep8AggressivenessLabel">
+          <item row="5" column="0" colspan="2">
+           <widget class="QCheckBox" name="blackNormalizeQuotes">
             <property name="text">
-             <string>Autopep8 agressiveness</string>
+             <string>Normalize quotes</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QSpinBox" name="autopep8Aggressiveness">
-            <property name="maximum">
-             <number>3</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
            <widget class="QComboBox" name="formatter">
             <property name="minimumSize">
              <size>
@@ -513,28 +520,46 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="sortImports">
+            <property name="text">
+             <string>Sort imports</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="autopep8LevelLabel">
+            <property name="text">
+             <string>Autopep8 level</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Maximum line length</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="maxLineLength">
-            <property name="minimum">
-             <number>60</number>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Formatter</string>
             </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QSpinBox" name="autopep8Level">
             <property name="maximum">
-             <number>200</number>
+             <number>3</number>
             </property>
             <property name="value">
-             <number>80</number>
+             <number>1</number>
             </property>
            </widget>
           </item>
           <item row="0" column="2">
-           <spacer name="horizontalSpacer">
+           <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -564,8 +589,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea</tabstop>
   <tabstop>groupBoxAutoCompletion</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>autoCompThreshold</tabstop>
   <tabstop>autoCompFromDoc</tabstop>
   <tabstop>autoCompFromAPI</tabstop>
@@ -574,8 +599,10 @@
   <tabstop>autoSurround</tabstop>
   <tabstop>autoInsertImport</tabstop>
   <tabstop>formatOnSave</tabstop>
+  <tabstop>sortImports</tabstop>
+  <tabstop>maxLineLength</tabstop>
   <tabstop>formatter</tabstop>
-  <tabstop>autopep8Aggressiveness</tabstop>
+  <tabstop>autopep8Level</tabstop>
   <tabstop>blackNormalizeQuotes</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -54,8 +54,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1055</width>
-        <height>731</height>
+        <width>1041</width>
+        <height>854</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -71,43 +71,7 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="1" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Typing</string>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_11">
-            <item row="0" column="0">
-           <widget class="QCheckBox" name="autoCloseBracket">
-            <property name="text">
-             <string>Automatic parentheses insertion</string>
-            </property>
-           </widget>
-          </item>
-            <item row="1" column="0">
-           <widget class="QCheckBox" name="autoSurround">
-            <property name="text">
-             <string>Automatically surround selection when typing quotes or brackets</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="autoInsertImport">
-            <property name="text">
-             <string>Automatic insertion of the 'import' string on 'from xxx'</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>GitHub Access Token</string>
@@ -130,92 +94,7 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
-         <property name="title">
-          <string>Autocompletion</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="saveCheckedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="saveCollapsedState" stdset="0">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_36">
-            <property name="text">
-             <string>characters</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="autoCompThreshold">
-            <property name="maximum">
-             <number>10</number>
-            </property>
-            <property name="value">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Autocompletion threshold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <layout class="QGridLayout" name="layoutRadioButton">
-            <item row="0" column="2">
-             <widget class="QRadioButton" name="autoCompFromDocAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from current document and installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From doc and APIs</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="autoCompFromAPI">
-              <property name="toolTip">
-               <string>Get autocompletion from installed APIs</string>
-              </property>
-              <property name="text">
-               <string>From API files</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="autoCompFromDoc">
-              <property name="toolTip">
-               <string>Get autocompletion from current document</string>
-              </property>
-              <property name="text">
-               <string>From document</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
          <property name="title">
           <string>APIs</string>
@@ -411,7 +290,43 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Typing</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_11">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="autoCloseBracket">
+            <property name="text">
+             <string>Automatic parentheses insertion</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="autoSurround">
+            <property name="text">
+             <string>Automatically surround selection when typing quotes or brackets</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="autoInsertImport">
+            <property name="text">
+             <string>Automatic insertion of the 'import' string on 'from xxx'</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBoxRunDebugEditor">
          <property name="title">
           <string>Run and Debug</string>
@@ -423,6 +338,13 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_21">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="autoSaveScript">
+            <property name="text">
+             <string>Auto-save script before running</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="enableObjectInspector">
             <property name="text">
@@ -433,12 +355,162 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="autoSaveScript">
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
+         <property name="title">
+          <string>Autocompletion</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="saveCheckedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_36">
             <property name="text">
-             <string>Auto-save script before running</string>
+             <string>characters</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="autoCompThreshold">
+            <property name="maximum">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Autocompletion threshold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <layout class="QGridLayout" name="layoutRadioButton">
+            <item row="0" column="2">
+             <widget class="QRadioButton" name="autoCompFromDocAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from current document and installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From doc and APIs</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="autoCompFromAPI">
+              <property name="toolTip">
+               <string>Get autocompletion from installed APIs</string>
+              </property>
+              <property name="text">
+               <string>From API files</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="autoCompFromDoc">
+              <property name="toolTip">
+               <string>Get autocompletion from current document</string>
+              </property>
+              <property name="text">
+               <string>From document</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QgsCollapsibleGroupBox" name="formattingGroupBox">
+         <property name="title">
+          <string>Formatting</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Maximum line length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Autopep8 agressiveness</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="autopep8Aggressiveness">
+            <property name="maximum">
+             <number>3</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="formatOnSave">
+            <property name="text">
+             <string>Format on save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="maxLineLength">
+            <property name="minimum">
+             <number>60</number>
+            </property>
+            <property name="maximum">
+             <number>200</number>
+            </property>
+            <property name="value">
+             <number>80</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -456,12 +528,6 @@
    <header>qgis.gui</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QPushButton</extends>
-   <header location="global">qgis.gui</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
@@ -473,6 +539,9 @@
   <tabstop>autoCloseBracket</tabstop>
   <tabstop>autoSurround</tabstop>
   <tabstop>autoInsertImport</tabstop>
+  <tabstop>formatOnSave</tabstop>
+  <tabstop>autopep8Aggressiveness</tabstop>
+  <tabstop>maxLineLength</tabstop>
   <tabstop>enableObjectInspector</tabstop>
   <tabstop>autoSaveScript</tabstop>
   <tabstop>preloadAPI</tabstop>

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -489,7 +489,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="formatOnSave">
             <property name="text">
-             <string>Format on save</string>
+             <string>Reformat on save</string>
             </property>
            </widget>
           </item>

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -66,9 +66,11 @@ Qgis::ScriptLanguage QgsCodeEditorPython::language() const
 
 void QgsCodeEditorPython::initializeLexer()
 {
+  const QgsSettings settings;
+
   // current line
   setEdgeMode( QsciScintilla::EdgeLine );
-  setEdgeColumn( 80 );
+  setEdgeColumn( settings.value( QStringLiteral( "pythonConsole/maxLineLength" ), 80 ).toInt() );
   setEdgeColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::Edge ) );
 
   setWhitespaceVisibility( QsciScintilla::WsVisibleAfterIndent );
@@ -112,8 +114,6 @@ void QgsCodeEditorPython::initializeLexer()
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::TripleDoubleQuote ), QsciLexerPython::TripleDoubleQuotedString );
 
   std::unique_ptr< QsciAPIs > apis = std::make_unique< QsciAPIs >( pyLexer );
-
-  const QgsSettings settings;
 
   if ( mAPISFilesList.isEmpty() )
   {


### PR DESCRIPTION
## Description

Add a format code action in the Python Console Editor:

![format](https://user-images.githubusercontent.com/9693475/216796333-fac0f655-7f09-4c9e-9378-18bef2378458.gif)

### Settings

- Format on save: if enabled, formatting is applied just before saving the script
- Sort imports: Sort import statements using isort
- Max line length: Control how the formatter will wrap the lines, and controls the editor ruler
- Formatter: autopep8 or black
    - Level (autopep8 only) See [Autopep8 aggressiveness level](https://pypi.org/project/autopep8/#more-advanced-usage)
    - Normalize quotes (black only): Replace all single quotes with double quotes if possible
    

black                      | autopep8
:-------------------------:|:----------------------:
![black](https://user-images.githubusercontent.com/9693475/217098981-264a98ce-e9c9-4a2a-ba62-90ae72461691.png) | ![autopep8](https://user-images.githubusercontent.com/9693475/217103178-a75eaf2c-9996-44d6-98ac-12ec1ba32dfe.png)


### Sorting example

isort will sort import statement in three different groups: 
- standard library imports (re, os, sys, json, ...)
- third-party modules (PyQt5, pandas, dateutil, ...)
- first-party modules (qgis, processing, ...)

![sort_imports](https://user-images.githubusercontent.com/9693475/217099006-261a49bb-132f-4855-87a1-533ee9c27ba8.gif)



