### PR TITLE
correctly migrate global settings

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -250,6 +250,8 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
   *sProfilePath() = profileFolder;
 
   connect( instance(), &QgsApplication::localeChanged, &QgsDateTimeFieldFormatter::applyLocaleChange );
+
+  mApplicationMembers->mSettingsRegistryCore->migrateOldSettings();
 }
 
 void QgsApplication::init( QString profileFolder )
@@ -485,6 +487,8 @@ void QgsApplication::init( QString profileFolder )
 
 QgsApplication::~QgsApplication()
 {
+  mApplicationMembers->mSettingsRegistryCore->backwardCompatibility();
+
   delete mDataItemProviderRegistry;
   delete mApplicationMembers;
   delete mQgisTranslator;

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -25,7 +25,6 @@
 #include "qgslayout.h"
 #include "qgslocator.h"
 #include "qgsnetworkaccessmanager.h"
-#include "qgslayoututils.h"
 #include "qgsowsconnection.h"
 #include "qgsprocessing.h"
 #include "qgsvectortileconnection.h"
@@ -114,12 +113,10 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsMapScales = n
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {
-  migrateOldSettings();
 }
 
 QgsSettingsRegistryCore::~QgsSettingsRegistryCore()
 {
-  backwardCompatibility();
 }
 
 void QgsSettingsRegistryCore::migrateOldSettings()

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -167,6 +167,8 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     static const QgsSettingsEntryStringList *settingsMapScales;
 
   private:
+    friend class QgsApplication;
+
     void migrateOldSettings();
     void backwardCompatibility();
 


### PR DESCRIPTION
We need to wait for the global settings ini path to be set before migrating the settings.

This the correct fix for the issue mentioned in #51689

