### PR TITLE
Atlas map geometry override

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -927,6 +927,13 @@ Returns the map's item based clip path settings.
 .. versionadded:: 3.16
 %End
 
+    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
+%Docstring
+Returns the current geometry ( from the source layer or data-defined ) in the provided crs.
+
+.. versionadded:: 3.32
+%End
+
   protected:
 
     virtual void draw( QgsLayoutItemRenderContext &context );

--- a/python/core/auto_generated/layout/qgslayoutobject.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutobject.sip.in
@@ -207,6 +207,7 @@ A base class for objects which belong to a layout.
       ElevationProfileMaximumDistance,
       ElevationProfileMinimumElevation,
       ElevationProfileMaximumElevation,
+      AtlasGeometryOverride,
     };
 
     enum PropertyValueType

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -458,7 +458,10 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
   std::unique_ptr< QgsGeometryEngine > atlasGeometryEngine;
   if ( mFilterToAtlasIntersection )
   {
-    atlasGeometry = mLayout->reportContext().currentGeometry( layer->crs() );
+    if ( mMap )
+      atlasGeomtry = mMap->atlasGeometry( layer->crs() );
+    else
+      atlasGeometry = mLayout->reportContext().currentGeometry( layer->crs() );
     if ( !atlasGeometry.isNull() )
     {
       if ( selectionRect.isNull() )

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -459,7 +459,7 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
   if ( mFilterToAtlasIntersection )
   {
     if ( mMap )
-      atlasGeomtry = mMap->atlasGeometry( layer->crs() );
+      atlasGeometry = mMap->atlasGeometry( layer->crs() );
     else
       atlasGeometry = mLayout->reportContext().currentGeometry( layer->crs() );
     if ( !atlasGeometry.isNull() )

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -2655,7 +2655,7 @@ void QgsLayoutItemMap::updateAtlasFeature()
   QgsRectangle originalExtent = mExtent;
 
   //sanity check - only allow fixed scale mode for point layers
-  bool isPointLayer = bounds.area() == 0.0
+  bool isPointLayer = bounds.area() == 0.0;
 
   if ( mAtlasScalingMode == Fixed || mAtlasScalingMode == Predefined || isPointLayer )
   {

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -2655,7 +2655,7 @@ void QgsLayoutItemMap::updateAtlasFeature()
   QgsRectangle originalExtent = mExtent;
 
   //sanity check - only allow fixed scale mode for point layers
-  bool isPointLayer = QgsWkbTypes::geometryType( mLayout->reportContext().layer()->wkbType() ) == Qgis::GeometryType::Point;
+  bool isPointLayer = bounds.area() == 0.0
 
   if ( mAtlasScalingMode == Fixed || mAtlasScalingMode == Predefined || isPointLayer )
   {

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1596,7 +1596,7 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   if ( mAtlasClippingSettings->enabled() && mLayout->reportContext().feature().isValid() )
   {
     QgsGeometry clipGeom( atlasGeometry( jobMapSettings.destinationCrs() ) );
-    if ( clipGeom.type() != QgsWkbTypes::PolygonGeometry )
+    if ( QgsWkbTypes::geometryType( clipGeom.wkbType() ) != Qgis::GeometryType::Polygon )
       return jobMapSettings;
     QgsMapClippingRegion region( clipGeom );
     region.setFeatureClip( mAtlasClippingSettings->featureClippingType() );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -2804,8 +2804,7 @@ QgsGeometry QgsLayoutItemMap::atlasGeometry( const QgsCoordinateReferenceSystem 
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::AtlasGeometryOverride ) )
   {
     QgsExpressionContext context = createExpressionContext();
-    //mDataDefinedProperties.prepare( context );
-    //expression QgsExpression( mDataDefinedProperties.value( QgsLayoutObject::AtlasGeometryOverride, context ).expressionString() )expression.evaluate( &context) )
+    //mDataDefinedProperties.prepare( context ); // needed?
     QgsGeometry geometry = mDataDefinedProperties.value( QgsLayoutObject::AtlasGeometryOverride, context ).value<QgsGeometry>();
     QgsCoordinateReferenceSystem layerCrs = mLayout->reportContext().layer()->crs();
     if ( crs.isValid() && crs != layerCrs )
@@ -2814,7 +2813,7 @@ QgsGeometry QgsLayoutItemMap::atlasGeometry( const QgsCoordinateReferenceSystem 
       return ( geometry );
   }
 
-  return( mLayout->reportContext().currentGeometry( crs ) );
+  return ( mLayout->reportContext().currentGeometry( crs ) );
 }
 
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -1185,6 +1185,8 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
 
     QPolygonF calculateVisibleExtentPolygon( bool includeClipping ) const;
 
+    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
+
     friend class QgsLayoutItemMapGrid;
     friend class QgsLayoutItemMapOverview;
     friend class QgsLayoutItemLegend;

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -862,12 +862,12 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      * \since QGIS 3.16
      */
     QgsLayoutItemMapItemClipPathSettings *itemClippingSettings() { return mItemClippingSettings; }
-    
+
     /**
-     * Returns the current geometry ( from the source layer or overriden ) in the provided crs.
+     * Returns the current geometry ( from the source layer or data-defined ) in the provided crs.
      *
-     * \since QGIS 3.30
-     */ 
+     * \since QGIS 3.32
+     */
     QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
 
   protected:

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -935,6 +935,13 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      * \since QGIS 3.20
      */
     void previewRefreshed();
+    
+    /**
+     * Returns the current geometry in the provided crs.
+     *
+     * \since QGIS 3.30
+     */ 
+    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
 
   public slots:
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -862,6 +862,13 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      * \since QGIS 3.16
      */
     QgsLayoutItemMapItemClipPathSettings *itemClippingSettings() { return mItemClippingSettings; }
+    
+    /**
+     * Returns the current geometry ( from the source layer or overriden ) in the provided crs.
+     *
+     * \since QGIS 3.30
+     */ 
+    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
 
   protected:
 
@@ -935,13 +942,6 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      * \since QGIS 3.20
      */
     void previewRefreshed();
-    
-    /**
-     * Returns the current geometry ( from the source layer or overriden ) in the provided crs.
-     *
-     * \since QGIS 3.30
-     */ 
-    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
 
   public slots:
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -937,7 +937,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
     void previewRefreshed();
     
     /**
-     * Returns the current geometry in the provided crs.
+     * Returns the current geometry ( from the source layer or overriden ) in the provided crs.
      *
      * \since QGIS 3.30
      */ 
@@ -1191,8 +1191,6 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
     void createStagedRenderJob( const QgsRectangle &extent, const QSizeF size, double dpi );
 
     QPolygonF calculateVisibleExtentPolygon( bool includeClipping ) const;
-
-    QgsGeometry atlasGeometry( const QgsCoordinateReferenceSystem crs ) const;
 
     friend class QgsLayoutItemMapGrid;
     friend class QgsLayoutItemMapOverview;

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -59,6 +59,7 @@ void QgsLayoutObject::initPropertyDefinitions()
     { QgsLayoutObject::MarginTop, QgsPropertyDefinition( "dataDefinedMarginTop", QObject::tr( "Top margin" ), QgsPropertyDefinition::DoublePositive ) },
     { QgsLayoutObject::MarginRight, QgsPropertyDefinition( "dataDefinedMarginRight", QObject::tr( "Right margin" ), QgsPropertyDefinition::DoublePositive ) },
     { QgsLayoutObject::MarginBottom, QgsPropertyDefinition( "dataDefinedMarginBottom", QObject::tr( "Bottom margin" ), QgsPropertyDefinition::DoublePositive ) },
+    { QgsLayoutObject::AtlasGeometryOverride, QgsPropertyDefinition( "dataDefinedAtlasGeometryOverride", QgsPropertyDefinition::DataTypeString, QObject::tr( "Atlas Geometry" ), tr( "geometry to use as the map extent" ) ) },
     { QgsLayoutObject::MapRotation, QgsPropertyDefinition( "dataDefinedMapRotation", QObject::tr( "Map rotation" ), QgsPropertyDefinition::Rotation ) },
     { QgsLayoutObject::MapScale, QgsPropertyDefinition( "dataDefinedMapScale", QObject::tr( "Map scale" ), QgsPropertyDefinition::DoublePositive ) },
     { QgsLayoutObject::MapXMin, QgsPropertyDefinition( "dataDefinedMapXMin", QObject::tr( "Extent minimum X" ), QgsPropertyDefinition::Double ) },
@@ -158,6 +159,7 @@ bool QgsLayoutObject::propertyAssociatesWithParentMultiframe( QgsLayoutObject::D
     case QgsLayoutObject::ExcludeFromExports:
     case QgsLayoutObject::FrameColor:
     case QgsLayoutObject::BackgroundColor:
+    case QgsLayoutObject::AtlasGeometryOverride:
     case QgsLayoutObject::MapRotation:
     case QgsLayoutObject::MapScale:
     case QgsLayoutObject::MapXMin:

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -235,6 +235,7 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
       ElevationProfileMaximumDistance, //!< Maximum distance value for elevation profile (since QGIS 3.30)
       ElevationProfileMinimumElevation, //!< Minimum elevation value for elevation profile (since QGIS 3.30)
       ElevationProfileMaximumElevation, //!< Maximum elevation value for elevation profile (since QGIS 3.30)
+      AtlasGeometryOverride,
     };
 
     /**

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -2160,7 +2160,7 @@ void QgsLayoutMapClippingWidget::updateGuiElements()
 
 void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 {
-  if ( !layer )
+  if ( !layer || QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point )
   {
     //non-polygon layer, disable atlas control
     mClipToAtlasCheckBox->setChecked( false );
@@ -2176,7 +2176,8 @@ void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 void QgsLayoutMapClippingWidget::atlasToggled( bool atlasEnabled )
 {
   if ( atlasEnabled &&
-       mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer() )
+       mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer() &&
+       QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) != Qgis::GeometryType::Point )
   {
     mClipToAtlasCheckBox->setEnabled( true );
   }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -191,6 +191,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   registerDataDefinedButton( mCRSDDBtn, QgsLayoutObject::MapCrs );
   registerDataDefinedButton( mStartDateTimeDDBtn, QgsLayoutObject::StartDateTime );
   registerDataDefinedButton( mEndDateTimeDDBtn, QgsLayoutObject::EndDateTime );
+  registerDataDefinedButton( mGeometryOverrideDDBtn, QgsLayoutObject::AtlasGeometryOverride );
 
   updateGuiElements();
   loadGridEntries();
@@ -273,6 +274,7 @@ void QgsLayoutMapWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mCRSDDBtn );
   updateDataDefinedButton( mStartDateTimeDDBtn );
   updateDataDefinedButton( mEndDateTimeDDBtn );
+  updateDataDefinedButton( mGeometryOverrideDDBtn );
 }
 
 void QgsLayoutMapWidget::compositionAtlasToggled( bool atlasEnabled )
@@ -946,7 +948,7 @@ void QgsLayoutMapWidget::toggleAtlasScalingOptionsByLayerType()
     return;
   }
 
-  if ( QgsWkbTypes::geometryType( layer->wkbType() ) == Qgis::GeometryType::Point )
+  if ( QgsWkbTypes::geometryType( layer->wkbType() ) == Qgis::GeometryType::Point && !mDataDefinedProperties.isActive( QgsLayoutObject::AtlasGeometryOverride ) )
   {
     //For point layers buffer setting makes no sense, so set "fixed scale" on and disable margin control
     if ( mMapItem->atlasScalingMode() == QgsLayoutItemMap::Auto )
@@ -2156,7 +2158,7 @@ void QgsLayoutMapClippingWidget::updateGuiElements()
 
 void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 {
-  if ( !layer || layer->geometryType() != Qgis::GeometryType::Polygon )
+  if ( !layer )
   {
     //non-polygon layer, disable atlas control
     mClipToAtlasCheckBox->setChecked( false );
@@ -2172,8 +2174,7 @@ void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 void QgsLayoutMapClippingWidget::atlasToggled( bool atlasEnabled )
 {
   if ( atlasEnabled &&
-       mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer()
-       && mMapItem->layout()->reportContext().layer()->geometryType() == Qgis::GeometryType::Polygon )
+       mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer() )
   {
     mClipToAtlasCheckBox->setEnabled( true );
   }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -950,7 +950,7 @@ void QgsLayoutMapWidget::toggleAtlasScalingOptionsByLayerType()
     return;
   }
 
-  if ( QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point && !mDataDefinedProperties.isActive( QgsLayoutObject::AtlasGeometryOverride ) )
+  if ( QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point )
   {
     //For point layers buffer setting makes no sense, so set "fixed scale" on and disable margin control
     if ( mMapItem->atlasScalingMode() == QgsLayoutItemMap::Auto )
@@ -2160,7 +2160,7 @@ void QgsLayoutMapClippingWidget::updateGuiElements()
 
 void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 {
-  if ( !layer || QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point )
+  if ( !layer || QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) != Qgis::GeometryType::Polygon )
   {
     //non-polygon layer, disable atlas control
     mClipToAtlasCheckBox->setChecked( false );
@@ -2177,7 +2177,7 @@ void QgsLayoutMapClippingWidget::atlasToggled( bool atlasEnabled )
 {
   if ( atlasEnabled &&
        mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer() &&
-       QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) != Qgis::GeometryType::Point )
+       QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Polygon )
   {
     mClipToAtlasCheckBox->setEnabled( true );
   }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -950,7 +950,7 @@ void QgsLayoutMapWidget::toggleAtlasScalingOptionsByLayerType()
     return;
   }
 
-  if ( QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point )
+  if ( QgsWkbTypes::geometryType( mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point )
   {
     //For point layers buffer setting makes no sense, so set "fixed scale" on and disable margin control
     if ( mMapItem->atlasScalingMode() == QgsLayoutItemMap::Auto )
@@ -2160,7 +2160,7 @@ void QgsLayoutMapClippingWidget::updateGuiElements()
 
 void QgsLayoutMapClippingWidget::atlasLayerChanged( QgsVectorLayer *layer )
 {
-  if ( !layer || QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) != Qgis::GeometryType::Polygon )
+  if ( !layer || QgsWkbTypes::geometryType( mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) != Qgis::GeometryType::Polygon )
   {
     //non-polygon layer, disable atlas control
     mClipToAtlasCheckBox->setChecked( false );
@@ -2177,7 +2177,7 @@ void QgsLayoutMapClippingWidget::atlasToggled( bool atlasEnabled )
 {
   if ( atlasEnabled &&
        mMapItem && mMapItem->layout() && mMapItem->layout()->reportContext().layer() &&
-       QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Polygon )
+       QgsWkbTypes::geometryType( mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Polygon )
   {
     mClipToAtlasCheckBox->setEnabled( true );
   }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -201,7 +201,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   connect( mMapItem, &QgsLayoutItemMap::extentChanged, mItemPropertiesWidget, &QgsLayoutItemPropertiesWidget::updateVariables );
   connect( mMapItem, &QgsLayoutItemMap::mapRotationChanged, mItemPropertiesWidget, &QgsLayoutItemPropertiesWidget::updateVariables );
 
-  connect( mGeometryOverrideDDBtn, &QgsPropertyOverrideButton::changed ,mMapItem, &QgsLayoutItemMap::refresh );
+  connect( mGeometryOverrideDDBtn, &QgsPropertyOverrideButton::changed, mMapItem, &QgsLayoutItemMap::refresh );
 
   blockAllSignals( false );
 }

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -201,6 +201,8 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item, QgsMapCanvas *ma
   connect( mMapItem, &QgsLayoutItemMap::extentChanged, mItemPropertiesWidget, &QgsLayoutItemPropertiesWidget::updateVariables );
   connect( mMapItem, &QgsLayoutItemMap::mapRotationChanged, mItemPropertiesWidget, &QgsLayoutItemPropertiesWidget::updateVariables );
 
+  connect( mGeometryOverrideDDBtn, &QgsPropertyOverrideButton::changed ,mMapItem, &QgsLayoutItemMap::refresh );
+
   blockAllSignals( false );
 }
 
@@ -948,7 +950,7 @@ void QgsLayoutMapWidget::toggleAtlasScalingOptionsByLayerType()
     return;
   }
 
-  if ( QgsWkbTypes::geometryType( layer->wkbType() ) == Qgis::GeometryType::Point && !mDataDefinedProperties.isActive( QgsLayoutObject::AtlasGeometryOverride ) )
+  if ( QgsWkbTypes::geometryType( layer->mMapItem->atlasGeometry( mMapItem->crs() ).wkbType() ) == Qgis::GeometryType::Point && !mDataDefinedProperties.isActive( QgsLayoutObject::AtlasGeometryOverride ) )
   {
     //For point layers buffer setting makes no sense, so set "fixed scale" on and disable margin control
     if ( mMapItem->atlasScalingMode() == QgsLayoutItemMap::Auto )

--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -88,9 +88,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>548</width>
-        <height>1336</height>
+        <y>-155</y>
+        <width>545</width>
+        <height>1244</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -175,7 +175,7 @@
             <item row="2" column="0">
              <layout class="QHBoxLayout" name="horizontalLayout_2">
               <item>
-               <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+               <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                 <property name="focusPolicy">
                  <enum>Qt::StrongFocus</enum>
                 </property>
@@ -542,7 +542,17 @@
           <string notr="true">composeritem</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="mAtlasPredefinedScaleRadio">
+            <property name="toolTip">
+             <string>Use one of the predefined scales of the project where the atlas feature best fits.</string>
+            </property>
+            <property name="text">
+             <string>Predefined scale (best fit)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QRadioButton" name="mAtlasMarginRadio">
             <property name="enabled">
              <bool>false</bool>
@@ -552,7 +562,40 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="0">
+           <widget class="QLabel" name="mGeometryOverrideLabel">
+            <property name="text">
+             <string>Atlas Geometry override</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QRadioButton" name="mAtlasFixedScaleRadio">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Fixed scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mGeometryOverrideDDBtn"/>
+          </item>
+          <item row="2" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_11">
             <item>
              <widget class="QgsSpinBox" name="mAtlasMarginSpinBox">
@@ -584,26 +627,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="mAtlasPredefinedScaleRadio">
-            <property name="toolTip">
-             <string>Use one of the predefined scales of the project where the atlas feature best fits.</string>
-            </property>
-            <property name="text">
-             <string>Predefined scale (best fit)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QRadioButton" name="mAtlasFixedScaleRadio">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Fixed scale</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -1016,10 +1039,9 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -1028,14 +1050,14 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSymbolButton</class>
@@ -1043,14 +1065,15 @@
    <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>


### PR DESCRIPTION
## Description

The goal of this PR is to provied a way to override the atlas geometry with an expression. This should add some more control over atlas rendering and creation. 

It simply add an intermediate functions when fecting the atlas geometry to either get the current feature geometry or evaluate the expression with the proper expression context.

![208318474-29abee65-96b6-4f77-9dbb-6736197ad1b5](https://user-images.githubusercontent.com/12854129/218564020-0f79b01e-4b8c-4086-8c35-25cb6370400d.gif)

Fixes #51141 