### PR TITLE
Don't enable link in QgsFileWidget if NULL

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -445,7 +445,7 @@ QSize QgsFileWidget::minimumSizeHint() const
 QString QgsFileWidget::toUrl( const QString &path ) const
 {
   QString rep;
-  if ( path.isEmpty() )
+  if ( path.isEmpty() || path == QgsApplication::nullRepresentation() )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/tests/src/gui/testqgsfilewidget.cpp
+++ b/tests/src/gui/testqgsfilewidget.cpp
@@ -85,6 +85,9 @@ void TestQgsFileWidget::toUrl()
   w->setFullUrl( false );
   QCOMPARE( w->toUrl( "/home/test2/file5.ext" ), QString( "<a href=\"file:///home/test2/file5.ext\">file5.ext</a>" ) );
   QCOMPARE( w->toUrl( "../test2/file6.ext" ), QString( "<a href=\"file:///home/test2/file6.ext\">file6.ext</a>" ) );
+
+  QCOMPARE( w->toUrl( QString() ), QgsApplication::nullRepresentation() );
+  QCOMPARE( w->toUrl( QgsApplication::nullRepresentation() ), QgsApplication::nullRepresentation() );
 }
 
 void TestQgsFileWidget::testDroppedFiles()


### PR DESCRIPTION
Fixes #50892

Contrary of what was proposed in the issue, I chose to display NULL without href link instead of an empty string in order to be consistent with all others widget behavior.