### PR TITLE
get map shading on Everest

### DIFF
--- a/python/core/auto_generated/qgselevationmap.sip.in
+++ b/python/core/auto_generated/qgselevationmap.sip.in
@@ -20,7 +20,7 @@ be used for post-processing effects of the rendered color map image.
 Elevations are encoded as colors in QImage, thanks to this it is not
 only possible to set elevation for each pixel, but also to use QPainter
 for more complex updates of elevations. We encode elevations to 24 bits
-in range of [-8000, 8777] with precision of three decimal digits, which
+in range of [-7900, 8877] with precision of three decimal digits, which
 should give millimiter precision and enough range for elevation values
 in meters.
 

--- a/src/core/qgselevationmap.cpp
+++ b/src/core/qgselevationmap.cpp
@@ -22,7 +22,7 @@
 #include <cmath>
 
 
-static const int ELEVATION_OFFSET = 8000;
+static const int ELEVATION_OFFSET = 7900;
 static const int ELEVATION_SCALE = 1000;
 
 

--- a/src/core/qgselevationmap.h
+++ b/src/core/qgselevationmap.h
@@ -33,7 +33,7 @@ class QgsRasterBlock;
  * Elevations are encoded as colors in QImage, thanks to this it is not
  * only possible to set elevation for each pixel, but also to use QPainter
  * for more complex updates of elevations. We encode elevations to 24 bits
- * in range of [-8000, 8777] with precision of three decimal digits, which
+ * in range of [-7900, 8877] with precision of three decimal digits, which
  * should give millimiter precision and enough range for elevation values
  * in meters.
  *


### PR DESCRIPTION
Before this PR, encoding of elevation for the global map shading allow elevation between -8000 and 8777 m. Mount Everest was not included in the range.
This PR allows shading on the mount Everest by changing the range to -7900 / 8877 m.