### PR TITLE
Fix crash when loading more than 16 vector layers

### DIFF
--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -158,15 +158,7 @@ void QgsAppLayerHandling::addSortedLayersToLegend( QList<QgsMapLayer *> &layers 
       {
         QgsVectorLayer *av = qobject_cast<QgsVectorLayer *>( a );
         QgsVectorLayer *bv = qobject_cast<QgsVectorLayer *>( b );
-        if ( ( av->geometryType() == QgsWkbTypes::PointGeometry && bv->geometryType() != QgsWkbTypes::PointGeometry ) ||
-             ( av->geometryType() == QgsWkbTypes::LineGeometry && bv->geometryType() == QgsWkbTypes::PolygonGeometry ) )
-        {
-          return false;
-        }
-        else
-        {
-          return true;
-        }
+        return av->geometryType() > bv->geometryType();
       }
 
       return layerTypeOrdering.value( a->type() ) > layerTypeOrdering.value( b->type() );


### PR DESCRIPTION
## Description
This fixes another unreported regression introduced by #50381. QGIS would crash when trying to load more than 16 vector layers at once.

This was caused by an ambiguous sorting rule passed to `std::sort()` for sorting vector layers based on their geometry type, which would cause the sorting algorithm to try to read past the list's last element.
Sorting 16 or less layers would not crash as `std::sort()` uses a different sorting algorithm for small lists.

Also, fixes proper ordering for multipolygons/multisurface/curvepolygons:
Before:
![image](https://user-images.githubusercontent.com/11358178/217796424-e5c22ca6-8841-4cae-9341-7d3c2aa94216.png)

After:
![image](https://user-images.githubusercontent.com/11358178/217796487-21c927f4-73ad-449c-82a2-d1b29d36f3d9.png)

Kudos to @wonder-sk for tracking this down!
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
