### PR TITLE
Avoid crash when using geometry generators and point displacement renderer

### DIFF
--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -97,12 +97,16 @@ void QgsPointDisplacementRenderer::drawGroup( QPointF centerPoint, QgsRenderCont
   //only draw circle/grid if there's a pen present - otherwise skip drawing transparent grids
   if ( mCircleColor.isValid() && mCircleColor.alpha() > 0 )
   {
-    //draw circle
-    if ( circleRadius > 0 )
-      drawCircle( circleRadius, symbolContext, centerPoint, group.size() );
-    //draw grid
-    else
-      drawGrid( gridSize, symbolContext, symbolPositions, group.size() );
+    switch ( mPlacement )
+    {
+      case Ring:
+      case ConcentricRings:
+        drawCircle( circleRadius, symbolContext, centerPoint, group.size() );
+        break;
+      case Grid:
+        drawGrid( gridSize, symbolContext, symbolPositions, group.size() );
+        break;
+    }
   }
 
   if ( group.size() > 1 )


### PR DESCRIPTION
Fixes #51070

There is no point in using geometry generators and point displacement renderer, because the last relies on symbol size to lay out the point on a grid or radius, which is unknown for geometry generator.

symbol size being 0, computed circle radius was -1 and so we switch to grid rendering and crash before the PR.