### PR TITLE
Remove spacers from 2 Mesh layer styling tabs

### DIFF
--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -41,7 +41,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="iconSize">
       <size>

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -41,7 +41,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -129,7 +129,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+           <widget class="QgsOpacityWidget" name="mOpacityWidget">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -137,19 +137,6 @@
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -200,19 +187,6 @@
           </property>
           <item>
            <widget class="QgsMeshRendererScalarSettingsWidget" name="mMeshRendererScalarSettingsWidget" native="true"/>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -481,15 +455,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsOpacityWidget</class>
    <extends>QWidget</extends>
    <header>qgsopacitywidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMeshRendererScalarSettingsWidget</class>


### PR DESCRIPTION
Follow up of https://github.com/qgis/QGIS/pull/51698

Also removed some spacers on the Styling panel:

Was:

![Screenshot from 2023-02-10 10-26-04](https://user-images.githubusercontent.com/731673/218054451-981bfdf0-e5ef-49a5-921a-0e16b91962ec.png)

Is:

![Screenshot from 2023-02-10 10-17-45](https://user-images.githubusercontent.com/731673/218054339-662dfebe-0178-4372-92aa-faf553b5b11f.png)

Same on styling tab:

Was:

![Screenshot from 2023-02-10 10-21-05](https://user-images.githubusercontent.com/731673/218054612-6391ed8d-8222-4a50-a4bb-46627546607b.png)

Is:

![Screenshot from 2023-02-10 10-20-42](https://user-images.githubusercontent.com/731673/218054657-cfbeacdf-dbd7-4877-ae81-572db72f1c04.png)

I did NOT remove spacers from other tabs, did have a look, but because there is no table, this ends up messy, so NOT removed:

![Screenshot from 2023-02-10 10-10-43](https://user-images.githubusercontent.com/731673/218054791-f899cc6a-47bb-4209-80fb-5d29fb5252b8.png)

Only drawback of the PR  is that having a mesh file with just one DatasetGroup in it, you have a rather empty table (see below), but I find it better then having an empty panel... Hope others agree.

![Screenshot from 2023-02-10 10-30-02](https://user-images.githubusercontent.com/731673/218055739-33a7cd2a-2eda-49aa-9f6a-0702d2a4e169.png)



