### PR TITLE
Fix unreported crash when loading processing plugin

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1018,16 +1018,16 @@ int main( int argc, char *argv[] )
   {
     /* Translation file for QGIS.
     */
-    QString myUserTranslation = QgsApplication::settingsLocaleUserLocale->value();
-    QString myGlobalLocale = QgsApplication::settingsLocaleGlobalLocale->value();
+    QString myUserTranslation = QgsApplication::settingsLocaleUserLocale()->value();
+    QString myGlobalLocale = QgsApplication::settingsLocaleGlobalLocale()->value();
     bool myShowGroupSeparatorFlag = false; // Default to false
-    bool myLocaleOverrideFlag = QgsApplication::settingsLocaleOverrideFlag->value();
+    bool myLocaleOverrideFlag = QgsApplication::settingsLocaleOverrideFlag()->value();
 
     // Override Show Group Separator if the global override flag is set
     if ( myLocaleOverrideFlag )
     {
       // Default to false again
-      myShowGroupSeparatorFlag = QgsApplication::settingsLocaleShowGroupSeparator->value();
+      myShowGroupSeparatorFlag = QgsApplication::settingsLocaleShowGroupSeparator()->value();
     }
 
     //
@@ -1041,7 +1041,7 @@ int main( int argc, char *argv[] )
     //
     if ( !translationCode.isNull() && !translationCode.isEmpty() )
     {
-      QgsApplication::settingsLocaleUserLocale->setValue( translationCode );
+      QgsApplication::settingsLocaleUserLocale()->setValue( translationCode );
     }
     else
     {
@@ -1050,7 +1050,7 @@ int main( int argc, char *argv[] )
         translationCode = QLocale().name();
         //setting the locale/userLocale when the --lang= option is not set will allow third party
         //plugins to always use the same locale as the QGIS, otherwise they can be out of sync
-        QgsApplication::settingsLocaleUserLocale->setValue( translationCode );
+        QgsApplication::settingsLocaleUserLocale()->setValue( translationCode );
       }
       else
       {

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -981,9 +981,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   //
   QString currentLocale = QLocale().name();
   lblSystemLocale->setText( tr( "Detected active locale on your system: %1" ).arg( currentLocale ) );
-  QString userLocale = QgsApplication::settingsLocaleUserLocale->value();
-  bool showGroupSeparator = QgsApplication::settingsLocaleShowGroupSeparator->value();
-  QString globalLocale = QgsApplication::settingsLocaleGlobalLocale->value();
+  QString userLocale = QgsApplication::settingsLocaleUserLocale()->value();
+  bool showGroupSeparator = QgsApplication::settingsLocaleShowGroupSeparator()->value();
+  QString globalLocale = QgsApplication::settingsLocaleGlobalLocale()->value();
   const QStringList language18nList( i18nList() );
   for ( const auto &l : language18nList )
   {
@@ -1010,7 +1010,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   cboTranslation->setCurrentIndex( cboTranslation->findData( userLocale ) );
   cboGlobalLocale->setCurrentIndex( cboGlobalLocale->findData( globalLocale ) );
-  grpLocale->setChecked( QgsApplication::settingsLocaleOverrideFlag->value() );
+  grpLocale->setChecked( QgsApplication::settingsLocaleOverrideFlag()->value() );
   cbShowGroupSeparator->setChecked( showGroupSeparator );
 
 
@@ -1790,12 +1790,12 @@ void QgsOptions::saveOptions()
   //
   // Locale settings
   //
-  QgsApplication::settingsLocaleUserLocale->setValue( cboTranslation->currentData().toString() );
-  QgsApplication::settingsLocaleOverrideFlag->setValue( grpLocale->isChecked() );
-  QgsApplication::settingsLocaleGlobalLocale->setValue( cboGlobalLocale->currentData( ).toString() );
+  QgsApplication::settingsLocaleUserLocale()->setValue( cboTranslation->currentData().toString() );
+  QgsApplication::settingsLocaleOverrideFlag()->setValue( grpLocale->isChecked() );
+  QgsApplication::settingsLocaleGlobalLocale()->setValue( cboGlobalLocale->currentData( ).toString() );
 
   // Number settings
-  QgsApplication::settingsLocaleShowGroupSeparator->setValue( cbShowGroupSeparator->isChecked( ) );
+  QgsApplication::settingsLocaleShowGroupSeparator()->setValue( cbShowGroupSeparator->isChecked( ) );
 
   QgsLocalDefaultSettings::setBearingFormat( mBearingFormat.get() );
   QgsLocalDefaultSettings::setGeographicCoordinateFormat( mCoordinateFormat.get() );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1080,7 +1080,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   }
 
   cbtsLocale->addItem( QIcon( QStringLiteral( ":/images/flags/%1.svg" ).arg( QLatin1String( "en_US" ) ) ), QLocale( QStringLiteral( "en_US" ) ).nativeLanguageName(), QStringLiteral( "en_US" ) );
-  cbtsLocale->setCurrentIndex( cbtsLocale->findData( QgsApplication::settingsLocaleUserLocale->value() ) );
+  cbtsLocale->setCurrentIndex( cbtsLocale->findData( QgsApplication::settingsLocaleUserLocale()->value() ) );
 
   connect( generateTsFileButton, &QPushButton::clicked, this, &QgsProjectProperties::onGenerateTsFileButton );
 

--- a/src/core/network/qgsnewsfeedparser.cpp
+++ b/src/core/network/qgsnewsfeedparser.cpp
@@ -63,7 +63,7 @@ QgsNewsFeedParser::QgsNewsFeedParser( const QUrl &feedUrl, const QString &authcf
   QString feedLanguage = settingsFeedLanguage->value( mFeedKey );
   if ( feedLanguage.isEmpty() )
   {
-    feedLanguage = QgsApplication::settingsLocaleUserLocale->valueWithDefaultOverride( QStringLiteral( "en" ) );
+    feedLanguage = QgsApplication::settingsLocaleUserLocale()->valueWithDefaultOverride( QStringLiteral( "en" ) );
   }
   if ( !feedLanguage.isEmpty() && feedLanguage != QLatin1String( "C" ) )
     query.addQueryItem( QStringLiteral( "lang" ), feedLanguage.mid( 0, 2 ) );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1616,7 +1616,7 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
   QgsApplication::profiler()->clear( QStringLiteral( "projectload" ) );
   QgsScopedRuntimeProfile profile( tr( "Setting up translations" ), QStringLiteral( "projectload" ) );
 
-  const QString localeFileName = QStringLiteral( "%1_%2" ).arg( QFileInfo( projectFile.fileName() ).baseName(), QgsApplication::settingsLocaleUserLocale->value() );
+  const QString localeFileName = QStringLiteral( "%1_%2" ).arg( QFileInfo( projectFile.fileName() ).baseName(), QgsApplication::settingsLocaleUserLocale()->value() );
 
   if ( QFile( QStringLiteral( "%1/%2.qm" ).arg( QFileInfo( projectFile.fileName() ).absolutePath(), localeFileName ) ).exists() )
   {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -115,16 +115,6 @@
 #include <QAuthenticator>
 #include <QRecursiveMutex>
 
-const QgsSettingsEntryString *QgsApplication::settingsLocaleUserLocale = new QgsSettingsEntryString( QStringLiteral( "userLocale" ), QgsSettingsTree::sTreeLocale, QString() );
-
-const QgsSettingsEntryBool *QgsApplication::settingsLocaleOverrideFlag = new QgsSettingsEntryBool( QStringLiteral( "overrideFlag" ), QgsSettingsTree::sTreeLocale, false );
-
-const QgsSettingsEntryString *QgsApplication::settingsLocaleGlobalLocale = new QgsSettingsEntryString( QStringLiteral( "globalLocale" ), QgsSettingsTree::sTreeLocale, QString() );
-
-const QgsSettingsEntryBool *QgsApplication::settingsLocaleShowGroupSeparator = new QgsSettingsEntryBool( QStringLiteral( "showGroupSeparator" ), QgsSettingsTree::sTreeLocale, false );
-
-const QgsSettingsEntryStringList *QgsApplication::settingsSearchPathsForSVG = new QgsSettingsEntryStringList( QStringLiteral( "searchPathsForSVG" ), QgsSettingsTree::sTreeSvg, QStringList() );
-
 #ifndef Q_OS_WIN
 #include <netinet/in.h>
 #include <pwd.h>
@@ -1186,7 +1176,7 @@ QString QgsApplication::srsDatabaseFilePath()
 
 void QgsApplication::setSvgPaths( const QStringList &svgPaths )
 {
-  settingsSearchPathsForSVG->setValue( svgPaths );
+  settingsSearchPathsForSVG()->setValue( svgPaths );
   members()->mSvgPathCacheValid = false;
 }
 
@@ -1205,7 +1195,7 @@ QStringList QgsApplication::svgPaths()
     locker.changeMode( QgsReadWriteLocker::Write );
     //local directories to search when looking for an SVG with a given basename
     //defined by user in options dialog
-    const QStringList pathList = settingsSearchPathsForSVG->value();
+    const QStringList pathList = settingsSearchPathsForSVG()->value();
 
     // maintain user set order while stripping duplicates
     QStringList paths;
@@ -1411,9 +1401,9 @@ QString QgsApplication::applicationFullName()
 
 QString QgsApplication::locale()
 {
-  if ( settingsLocaleOverrideFlag->value() )
+  if ( settingsLocaleOverrideFlag()->value() )
   {
-    QString locale = settingsLocaleUserLocale->value();
+    QString locale = settingsLocaleUserLocale()->value();
     // don't differentiate en_US and en_GB
     if ( locale.startsWith( QLatin1String( "en" ), Qt::CaseInsensitive ) )
     {
@@ -2083,6 +2073,36 @@ QString QgsApplication::translation() const
 void QgsApplication::collectTranslatableObjects( QgsTranslationContext *translationContext )
 {
   emit requestForTranslatableObjects( translationContext );
+}
+
+const QgsSettingsEntryString *QgsApplication::settingsLocaleUserLocale()
+{
+  static QgsSettingsEntryString *s { new QgsSettingsEntryString( QStringLiteral( "userLocale" ), QgsSettingsTree::sTreeLocale, QString() ) };
+  return s;
+}
+
+const QgsSettingsEntryBool *QgsApplication::settingsLocaleOverrideFlag()
+{
+  static QgsSettingsEntryBool *s { new QgsSettingsEntryBool( QStringLiteral( "settingsLocaleOverrideFlag" ), QgsSettingsTree::sTreeLocale, false ) };
+  return s;
+}
+
+const QgsSettingsEntryString *QgsApplication::settingsLocaleGlobalLocale()
+{
+  static QgsSettingsEntryString *s { new QgsSettingsEntryString( QStringLiteral( "globalLocale" ), QgsSettingsTree::sTreeLocale, QString() ) };
+  return s;
+}
+
+const QgsSettingsEntryBool *QgsApplication::settingsLocaleShowGroupSeparator()
+{
+  static QgsSettingsEntryBool *s { new QgsSettingsEntryBool( QStringLiteral( "showGroupSeparator" ), QgsSettingsTree::sTreeLocale, false ) };
+  return s;
+}
+
+const QgsSettingsEntryStringList *QgsApplication::settingsSearchPathsForSVG()
+{
+  static QgsSettingsEntryStringList *s { new QgsSettingsEntryStringList( QStringLiteral( "searchPathsForSVG" ), QgsSettingsTree::sTreeSvg, QStringList() ) };
+  return s;
 }
 
 QString QgsApplication::nullRepresentation()

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -1057,15 +1057,15 @@ class CORE_EXPORT QgsApplication : public QApplication
 
 #ifndef SIP_RUN
     //! Settings entry locale user locale
-    static const QgsSettingsEntryString *settingsLocaleUserLocale;
+    static const QgsSettingsEntryString *settingsLocaleUserLocale();
     //! Settings entry locale override flag
-    static const QgsSettingsEntryBool *settingsLocaleOverrideFlag;
+    static const QgsSettingsEntryBool *settingsLocaleOverrideFlag();
     //! Settings entry locale global locale
-    static const QgsSettingsEntryString *settingsLocaleGlobalLocale;
+    static const QgsSettingsEntryString *settingsLocaleGlobalLocale();
     //! Settings entry locale show group separator
-    static const QgsSettingsEntryBool *settingsLocaleShowGroupSeparator;
+    static const QgsSettingsEntryBool *settingsLocaleShowGroupSeparator();
     //! Settings entry search path for SVG
-    static const QgsSettingsEntryStringList *settingsSearchPathsForSVG;
+    static const QgsSettingsEntryStringList *settingsSearchPathsForSVG();
 #endif
 
 #ifdef SIP_RUN

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -159,7 +159,7 @@ void QgsConfigureShortcutsDialog::saveShortcuts( bool saveAll )
   QDomDocument doc( QStringLiteral( "shortcuts" ) );
   QDomElement root = doc.createElement( QStringLiteral( "qgsshortcuts" ) );
   root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
-  root.setAttribute( QStringLiteral( "locale" ), settings.value( QgsApplication::settingsLocaleUserLocale->key(), "en_US" ).toString() );
+  root.setAttribute( QStringLiteral( "locale" ), settings.value( QgsApplication::settingsLocaleUserLocale()->key(), "en_US" ).toString() );
   doc.appendChild( root );
 
   const QList<QObject *> objects = mManager->listAll();
@@ -252,10 +252,10 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
 
   QString currentLocale;
 
-  const bool localeOverrideFlag = QgsApplication::settingsLocaleOverrideFlag->value();
+  const bool localeOverrideFlag = QgsApplication::settingsLocaleOverrideFlag()->value();
   if ( localeOverrideFlag )
   {
-    currentLocale = QgsApplication::settingsLocaleUserLocale->valueWithDefaultOverride( "en_US" );
+    currentLocale = QgsApplication::settingsLocaleUserLocale()->valueWithDefaultOverride( "en_US" );
   }
   else // use QGIS locale
   {

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -196,7 +196,7 @@ void QgsGui::setWindowManager( QgsWindowManagerInterface *manager )
 
 QgsGui::HigFlags QgsGui::higFlags()
 {
-  if ( QgsApplication::settingsLocaleUserLocale->value().startsWith( QLatin1String( "en" ) ) )
+  if ( QgsApplication::settingsLocaleUserLocale()->value().startsWith( QLatin1String( "en" ) ) )
   {
     return HigMenuTextIsTitleCase | HigDialogTitleIsTitleCase;
   }

--- a/tests/src/core/testqgscompositionconverter.cpp
+++ b/tests/src/core/testqgscompositionconverter.cpp
@@ -166,7 +166,7 @@ void TestQgsCompositionConverter::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
-  QgsApplication::settingsSearchPathsForSVG->setValue( QStringList() << QStringLiteral( TEST_DATA_DIR ) );
+  QgsApplication::settingsSearchPathsForSVG()->setValue( QStringList() << QStringLiteral( TEST_DATA_DIR ) );
 }
 
 void TestQgsCompositionConverter::init()

--- a/tests/src/core/testqgstranslateproject.cpp
+++ b/tests/src/core/testqgstranslateproject.cpp
@@ -57,12 +57,12 @@ void TestQgsTranslateProject::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  original_locale = QgsApplication::settingsLocaleUserLocale->value();
+  original_locale = QgsApplication::settingsLocaleUserLocale()->value();
 }
 
 void TestQgsTranslateProject::cleanupTestCase()
 {
-  QgsApplication::settingsLocaleUserLocale->setValue( original_locale );
+  QgsApplication::settingsLocaleUserLocale()->setValue( original_locale );
   QgsApplication::exitQgis();
 
   //delete translated project file
@@ -91,7 +91,7 @@ void TestQgsTranslateProject::cleanup()
 void TestQgsTranslateProject::createTsFile()
 {
   //open project in english
-  QgsApplication::settingsLocaleUserLocale->setValue( "en" );
+  QgsApplication::settingsLocaleUserLocale()->setValue( "en" );
   QString projectFileName( TEST_DATA_DIR );
   projectFileName = projectFileName + "/project_translation/points_translation.qgs";
   QgsProject::instance()->read( projectFileName );
@@ -163,7 +163,7 @@ void TestQgsTranslateProject::createTsFile()
 void TestQgsTranslateProject::translateProject()
 {
   //open project in german
-  QgsApplication::settingsLocaleUserLocale->setValue( "de" );
+  QgsApplication::settingsLocaleUserLocale()->setValue( "de" );
   QString projectFileName( TEST_DATA_DIR );
   projectFileName = projectFileName + "/project_translation/points_translation.qgs";
   QgsProject::instance()->read( projectFileName );


### PR DESCRIPTION
Due to a call to QgsGui::higFlags() which called a static initialized QgsApplication::settingsLocaleUserLocale.

Replacing all those static members with singletons fixes the issue for me.

