### PR TITLE
Split features tool, don't beginEditCommand without a split line/point

### DIFF
--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -64,7 +64,6 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
   bool split = false;
 
-
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -68,17 +68,21 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
+    int error = 0;
     //If we snap the first point on a vertex of a line layer, we directly split the feature at this point
     if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry && pointsZM().isEmpty() )
     {
       const QgsPointLocator::Match m = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(), QgsPointLocator::Vertex );
       if ( m.isValid() )
       {
+        error = addVertex( e->mapPoint(), m );
         split = true;
       }
     }
 
-    const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
+    if ( !split )
+      error = addVertex( e->mapPoint(), e->mapPointMatch() );
+
     if ( error == 2 )
     {
       //problem with coordinate transformation
@@ -93,6 +97,12 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
+    if ( !split && size() < 2 )
+    {
+      stopCapturing();
+      return;
+    }
+
     split = true;
   }
 

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -39,8 +39,6 @@ bool QgsMapToolSplitParts::supportsTechnique( Qgis::CaptureTechnique technique )
       return true;
 
     case Qgis::CaptureTechnique::CircularString:
-      return false;
-
     case Qgis::CaptureTechnique::Shape:
       return false;
   }
@@ -69,17 +67,21 @@ void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
+    int error = 0;
     //If we snap the first point on a vertex of a line layer, we directly split the feature at this point
     if ( vlayer->geometryType() == QgsWkbTypes::LineGeometry && pointsZM().isEmpty() )
     {
       const QgsPointLocator::Match m = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(), QgsPointLocator::Vertex );
       if ( m.isValid() )
       {
+        error = addVertex( e->mapPoint(), m );
         split = true;
       }
     }
 
-    const int error = addVertex( e->mapPoint() );
+    if ( !split )
+      error = addVertex( e->mapPoint(), e->mapPointMatch() );
+
     if ( error == 2 )
     {
       //problem with coordinate transformation
@@ -94,6 +96,12 @@ void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
+    if ( !split && size() < 2 )
+    {
+      stopCapturing();
+      return;
+    }
+
     split = true;
   }
   if ( split )


### PR DESCRIPTION
## Description
Fixes unreported bug, the split features map tool (and split parts map tool) would run the splitting logic on every mouse right click, regardless of the number of digitized points in the split line.
With this PR it exits early when less than two points are collected, while still allowing to split with a single click on a vertex.
see https://github.com/qgis/QGIS/issues/51815#issuecomment-1427486758
Closes #51815
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
