### PR TITLE
Fix #51543 and make big forms more fluid by reducing calls to updateFieldDependencies

### DIFF
--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -982,9 +982,9 @@ void TestQgsAttributeForm::testDefaultValueUpdate()
   //col3 - "col2"
 
   // set constraints for each field
-  layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "\"col0\"+1" ) ) );
-  layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col0\"+\"col1\"" ) ) );
-  layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"" ) ) );
+  layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "\"col0\"+1" ), true ) );
+  layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col0\"+\"col1\"" ), true ) );
+  layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"" ), true ) );
 
   layer->startEditing();
 
@@ -1044,10 +1044,10 @@ void TestQgsAttributeForm::testDefaultValueUpdateRecursion()
   //col3 - COALESCE( 0, "col2"+1)
 
   // set constraints for each field
-  layer->setDefaultValueDefinition( 0, QgsDefaultValue( QStringLiteral( "\"col3\"+1" ) ) );
-  layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "\"col0\"+1" ) ) );
-  layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col1\"+1" ) ) );
-  layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"+1" ) ) );
+  layer->setDefaultValueDefinition( 0, QgsDefaultValue( QStringLiteral( "\"col3\"+1" ), true ) );
+  layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "\"col0\"+1" ), true ) );
+  layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col1\"+1" ), true ) );
+  layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"+1" ), true ) );
 
   layer->startEditing();
 

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -178,7 +178,7 @@ class TestQgsAttributeForm(unittest.TestCase):
         form.changeAttribute('age', 7)
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 7])
 
-    def test_default_value_alway_updated(self):
+    def test_default_value_always_updated(self):
         """Test that default values are not updated on every edit operation
         when containing an 'attribute' expression"""
 


### PR DESCRIPTION
As of the current implementation when creating a new feature the attribute form behaves as "Always apply default values" checkbox was activated for all default values. After this pr the checkbox will be respected even when creating new features. 

1. Update default values only during setting the feature (or always if "Always apply default values" checkbox is checked)

2. updateFieldDependencies only when resetting the form. This should make working with big forms more fluid as it spares a lot of loops trough all fields. Small downside for an edge case: if the dependencies are changed (for example default value expression on children layer) when a form is open, that form will not reflect the changes until reopened.