### PR TITLE
Ensure correct crs is available for QgsMapCanvas for slots connected to extentsChanged when canvas CRS is changed

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -1347,6 +1347,13 @@ called when panning is in action, reset indicates end of panning
     virtual void showEvent( QShowEvent *event );
 
 
+    void emitExtentsChanged();
+%Docstring
+Emits the extentsChanged signal when appropriate.
+
+.. versionadded:: 3.30
+%End
+
 
 
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -513,6 +513,12 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
     }
   }
 
+  // defer extent and scale changed signals until we've correctly
+  // set the destination crs, otherwise slots which connect to these signals
+  // may retrieve an outdated CRS for the map canvas
+  mBlockExtentChangedSignal++;
+  mBlockScaleChangedSignal++;
+
   if ( !rect.isEmpty() )
   {
     // we will be manually calling updateCanvasItemPositions() later, AFTER setting the updating the mSettings destination CRS, and we don't
@@ -522,8 +528,13 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
     mBlockItemPositionUpdates--;
   }
 
+  mBlockExtentChangedSignal--;
+  mBlockScaleChangedSignal--;
+
   mSettings.setDestinationCrs( crs );
   updateScale();
+  emitExtentsChanged();
+
   updateCanvasItemPositions();
 
   QgsDebugMsgLevel( QStringLiteral( "refreshing after destination CRS changed" ), 2 );
@@ -1437,6 +1448,7 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
 
     // ### QGIS 3: do not allow empty extent - require users to call setCenter() explicitly
     QgsDebugMsgLevel( QStringLiteral( "Empty extent - keeping old scale with new center!" ), 2 );
+
     setCenter( r.center() );
   }
   else
@@ -1459,7 +1471,7 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
       mSettings.setExtent( r, magnified );
     }
   }
-  emit extentsChanged();
+  emitExtentsChanged();
   updateScale();
 
   //clear all extent items after current index
@@ -1535,7 +1547,7 @@ QgsPointXY QgsMapCanvas::cursorPoint() const
 double QgsMapCanvas::rotation() const
 {
   return mapSettings().rotation();
-} // rotation
+}
 
 void QgsMapCanvas::setRotation( double degrees )
 {
@@ -1546,13 +1558,13 @@ void QgsMapCanvas::setRotation( double degrees )
 
   mSettings.setRotation( degrees );
   emit rotationChanged( degrees );
-  emit extentsChanged(); // visible extent changes with rotation
-} // setRotation
-
+  emitExtentsChanged(); // visible extent changes with rotation
+}
 
 void QgsMapCanvas::updateScale()
 {
-  emit scaleChanged( mapSettings().scale() );
+  if ( !mBlockScaleChangedSignal )
+    emit scaleChanged( mapSettings().scale() );
 }
 
 void QgsMapCanvas::zoomToFullExtent()
@@ -1588,7 +1600,7 @@ void QgsMapCanvas::zoomToPreviousExtent()
   {
     mLastExtentIndex--;
     mSettings.setExtent( mLastExtent[mLastExtentIndex] );
-    emit extentsChanged();
+    emitExtentsChanged();
     updateScale();
     refresh();
     // update controls' enabled state
@@ -1604,7 +1616,7 @@ void QgsMapCanvas::zoomToNextExtent()
   {
     mLastExtentIndex++;
     mSettings.setExtent( mLastExtent[mLastExtentIndex] );
-    emit extentsChanged();
+    emitExtentsChanged();
     updateScale();
     refresh();
     // update controls' enabled state
@@ -2535,7 +2547,7 @@ void QgsMapCanvas::resizeEvent( QResizeEvent *e )
     updateScale();
   }
 
-  emit extentsChanged();
+  emitExtentsChanged();
 }
 
 void QgsMapCanvas::paintEvent( QPaintEvent *e )
@@ -3092,6 +3104,12 @@ void QgsMapCanvas::showEvent( QShowEvent *event )
 {
   Q_UNUSED( event )
   updateDevicePixelFromScreen();
+}
+
+void QgsMapCanvas::emitExtentsChanged()
+{
+  if ( !mBlockExtentChangedSignal )
+    emit extentsChanged();
 }
 
 QPoint QgsMapCanvas::mouseLastXY()

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1229,6 +1229,13 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
     void showEvent( QShowEvent *event ) override;
 
+    /**
+     * Emits the extentsChanged signal when appropriate.
+     *
+     * \since QGIS 3.30
+     */
+    void emitExtentsChanged();
+
     /// implementation struct
     class CanvasProperties;
 
@@ -1427,6 +1434,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     QList< QgsMapCanvasInteractionBlocker * > mInteractionBlockers;
 
     int mBlockItemPositionUpdates = 0;
+    int mBlockExtentChangedSignal = 0;
+    int mBlockScaleChangedSignal = 0;
 
     std::unique_ptr< QgsTemporaryCursorOverride > mTemporaryCursorOverride;
 

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -767,6 +767,33 @@ class TestQgsMapCanvas(unittest.TestCase):
         self.assertEqual(canvas.mapSettings().frameRate(), -1)
         self.assertEqual(canvas.mapSettings().currentFrame(), -1)
 
+    def test_crs_change_signals(self):
+        """
+        Test behavior of signals when crs is changed
+        """
+        canvas = QgsMapCanvas()
+        canvas.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        canvas.setFrameStyle(0)
+        canvas.resize(600, 400)
+        self.assertEqual(canvas.width(), 600)
+        self.assertEqual(canvas.height(), 400)
+        canvas.setExtent(QgsRectangle(10, 30, 20, 35))
+
+        def on_extent_changed():
+            TestQgsMapCanvas.new_extent = canvas.extent()
+            TestQgsMapCanvas.new_crs = canvas.mapSettings().destinationCrs()
+
+        canvas.extentsChanged.connect(on_extent_changed)
+
+        TestQgsMapCanvas.new_extent = None
+        TestQgsMapCanvas.new_crs = None
+
+        canvas.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+
+        self.assertAlmostEqual(TestQgsMapCanvas.new_extent.xMinimum(), 1008988, places=-3)
+
+        self.assertEqual(TestQgsMapCanvas.new_crs, QgsCoordinateReferenceSystem('EPSG:3857'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #51833

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
