### PR TITLE
Add support for geometry fields to memory provider

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -119,6 +119,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
 
                   // complex types
                   << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Map ), QStringLiteral( "map" ), QVariant::Map, -1, -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Geometry" ), QStringLiteral( "geometry" ), QVariant::UserType )
                 );
 
   if ( query.hasQueryItem( QStringLiteral( "field" ) ) )

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -20,7 +20,7 @@
 #include "qgsvectorlayer.h"
 #include <QUrl>
 
-QString memoryLayerFieldType( QVariant::Type type )
+QString memoryLayerFieldType( QVariant::Type type, const QString &typeString )
 {
   switch ( type )
   {
@@ -54,6 +54,13 @@ QString memoryLayerFieldType( QVariant::Type type )
     case QVariant::Map:
       return QStringLiteral( "map" );
 
+    case QVariant::UserType:
+      if ( typeString.compare( QLatin1String( "geometry" ), Qt::CaseInsensitive ) == 0 )
+      {
+        return QStringLiteral( "geometry" );
+      }
+      break;
+
     default:
       break;
   }
@@ -74,11 +81,11 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
     else
       parts << QStringLiteral( "crs=wkt:%1" ).arg( crs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) );
   }
-  for ( const auto &field : fields )
+  for ( const QgsField &field : fields )
   {
     const QString lengthPrecision = QStringLiteral( "(%1,%2)" ).arg( field.length() ).arg( field.precision() );
     parts << QStringLiteral( "field=%1:%2%3%4" ).arg( QString( QUrl::toPercentEncoding( field.name() ) ),
-          memoryLayerFieldType( field.type() == QVariant::List || field.type() == QVariant::StringList ? field.subType() : field.type() ),
+          memoryLayerFieldType( field.type() == QVariant::List || field.type() == QVariant::StringList ? field.subType() : field.type(), field.typeName() ),
           lengthPrecision,
           field.type() == QVariant::List || field.type() == QVariant::StringList ? QStringLiteral( "[]" ) : QString() );
   }

--- a/src/gui/qgsfieldvalidator.cpp
+++ b/src/gui/qgsfieldvalidator.cpp
@@ -159,6 +159,10 @@ QValidator::State QgsFieldValidator::validate( QString &s, int &i ) const
   {
     return Acceptable;
   }
+  else if ( mField.type() == QVariant::UserType && mField.typeName().compare( QLatin1String( "geometry" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return Acceptable;
+  }
   else
   {
     QgsDebugMsg(

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -97,6 +97,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ), "doublelist" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), "integer64list" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Map ), QgsVariantUtils::typeToDisplayString( QVariant::Map ), "map" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::UserType, QVariant::Invalid, QStringLiteral( "geometry" ) ), tr( "Geometry" ), "geometry" );
   mTypeBox_currentIndexChanged( 1 );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
@@ -154,71 +155,78 @@ void QgsNewMemoryLayerDialog::geometryTypeChanged( int )
   mOkButton->setEnabled( ok );
 }
 
-void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int index )
+void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int )
 {
-  switch ( index )
+  const QString fieldType = mTypeBox->currentData().toString();
+  if ( fieldType == QStringLiteral( "string" ) )
   {
-    case 0: // Text data
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 255 )
-        mWidth->setText( QStringLiteral( "255" ) );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      mWidth->setValidator( new QIntValidator( 1, 255, this ) );
-      break;
-    case 1: // Whole number
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 10 )
-        mWidth->setText( QStringLiteral( "10" ) );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      mWidth->setValidator( new QIntValidator( 1, 10, this ) );
-      break;
-    case 2: // Decimal number
-      if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 30 )
-        mWidth->setText( QStringLiteral( "30" ) );
-      if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 30 )
-        mPrecision->setText( QStringLiteral( "6" ) );
-      mPrecision->setEnabled( true );
-      mWidth->setValidator( new QIntValidator( 1, 20, this ) );
-      break;
-    case 3: // Boolean
-      mWidth->clear();
-      mWidth->setEnabled( false );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      break;
-    case 4: // Date
-      mWidth->clear();
-      mWidth->setEnabled( false );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      break;
-    case 5: // Time
-      mWidth->clear();
-      mWidth->setEnabled( false );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      break;
-    case 6: // Datetime
-      mWidth->clear();
-      mWidth->setEnabled( false );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      break;
-    case 7: // Binary
-    case 8: // Stringlist
-    case 9: // Integerlist
-    case 10: // Doublelist
-    case 11: // Integer64list
-    case 12: // Map
-      mWidth->clear();
-      mWidth->setEnabled( false );
-      mPrecision->clear();
-      mPrecision->setEnabled( false );
-      break;
-
-    default:
-      QgsDebugMsg( QStringLiteral( "unexpected index" ) );
-      break;
+    if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 255 )
+      mWidth->setText( QStringLiteral( "255" ) );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+    mWidth->setValidator( new QIntValidator( 1, 255, this ) );
+  }
+  else if ( fieldType == QStringLiteral( "integer" ) )
+  {
+    if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 10 )
+      mWidth->setText( QStringLiteral( "10" ) );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+    mWidth->setValidator( new QIntValidator( 1, 10, this ) );
+  }
+  else if ( fieldType == QStringLiteral( "double" ) )
+  {
+    if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 30 )
+      mWidth->setText( QStringLiteral( "30" ) );
+    if ( mPrecision->text().toInt() < 1 || mPrecision->text().toInt() > 30 )
+      mPrecision->setText( QStringLiteral( "6" ) );
+    mPrecision->setEnabled( true );
+    mWidth->setValidator( new QIntValidator( 1, 20, this ) );
+  }
+  else if ( fieldType == QStringLiteral( "bool" ) )
+  {
+    mWidth->clear();
+    mWidth->setEnabled( false );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+  }
+  else if ( fieldType == QStringLiteral( "date" ) )
+  {
+    mWidth->clear();
+    mWidth->setEnabled( false );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+  }
+  else if ( fieldType == QStringLiteral( "time" ) )
+  {
+    mWidth->clear();
+    mWidth->setEnabled( false );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+  }
+  else if ( fieldType == QStringLiteral( "datetime" ) )
+  {
+    mWidth->clear();
+    mWidth->setEnabled( false );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+  }
+  else if ( fieldType == QStringLiteral( "binary" )
+            || fieldType == QStringLiteral( "stringlist" )
+            || fieldType == QStringLiteral( "integerlist" )
+            || fieldType == QStringLiteral( "doublelist" )
+            || fieldType == QStringLiteral( "integer64list" )
+            || fieldType == QStringLiteral( "map" )
+            || fieldType == QStringLiteral( "geometry" ) )
+  {
+    mWidth->clear();
+    mWidth->setEnabled( false );
+    mPrecision->clear();
+    mPrecision->setEnabled( false );
+  }
+  else
+  {
+    QgsDebugMsg( QStringLiteral( "unexpected index" ) );
   }
 }
 
@@ -298,6 +306,8 @@ QgsFields QgsNewMemoryLayerDialog::fields() const
     }
     else if ( typeName == QLatin1String( "map" ) )
       fieldType = QVariant::Map;
+    else if ( typeName == QLatin1String( "geometry" ) )
+      fieldType = QVariant::UserType;
 
     const QgsField field = QgsField( name, fieldType, typeName, width, precision, QString(), fieldSubType );
     fields.append( field );


### PR DESCRIPTION
Since the postgres provider supports these, the memory provider MUST also support them or we risk data loss

Temporarily includes https://github.com/qgis/QGIS/pull/51842, https://github.com/qgis/QGIS/pull/51844, https://github.com/qgis/QGIS/pull/51845