### PR TITLE
ArcGIS WMS GetFeatureInfo fixes

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -526,7 +526,7 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
       format = Qgis::RasterIdentifyFormat::Text;
     else if ( f == QLatin1String( "text/html" ) )
       format = Qgis::RasterIdentifyFormat::Html;
-    else if ( f.startsWith( QLatin1String( "GML." ) ) || f == QLatin1String( "application/vnd.ogc.gml" ) || f == QLatin1String( "application/json" ) || f == QLatin1String( "application/geojson" ) || f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) || f == QLatin1String( "text/xml" ) )
+    else if ( f.startsWith( QLatin1String( "GML." ) ) || f == QLatin1String( "application/vnd.ogc.gml" ) || f == QLatin1String( "application/json" ) || f == QLatin1String( "application/geojson" ) || f == QLatin1String( "application/geo+json" ) || f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) || f == QLatin1String( "text/xml" ) )
       format = Qgis::RasterIdentifyFormat::Feature;
 
     mIdentifyFormats.insert( format, f );
@@ -1992,7 +1992,8 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
                 || ( format == QLatin1String( "application/vnd.ogc.gml" ) )
                 || ( format.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) )
                 || ( format == QLatin1String( "application/json" ) )
-                || ( format == QLatin1String( "application/geojson" ) ) )
+                || ( format == QLatin1String( "application/geojson" ) )
+                || ( format == QLatin1String( "application/geo+json" ) ) )
         fmt = Qgis::RasterIdentifyFormat::Feature;
       else
       {
@@ -2240,7 +2241,8 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
                   || ( format == QLatin1String( "application/vnd.ogc.gml" ) )
                   || ( format.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) )
                   || ( format == QLatin1String( "application/json" ) )
-                  || ( format == QLatin1String( "application/geojson" ) ) )
+                  || ( format == QLatin1String( "application/geojson" ) )
+                  || ( format == QLatin1String( "application/geo+json" ) ) )
           fmt = Qgis::RasterIdentifyFormat::Feature;
         else
         {

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -526,7 +526,7 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
       format = Qgis::RasterIdentifyFormat::Text;
     else if ( f == QLatin1String( "text/html" ) )
       format = Qgis::RasterIdentifyFormat::Html;
-    else if ( f.startsWith( QLatin1String( "GML." ) ) || f == QLatin1String( "application/vnd.ogc.gml" ) || f == QLatin1String( "application/json" ) || f == QLatin1String( "application/geojson" ) || f == QLatin1String( "application/geo+json" ) || f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) || f == QLatin1String( "text/xml" ) )
+    else if ( f.startsWith( QLatin1String( "GML." ) ) || f == QLatin1String( "application/vnd.ogc.gml" ) || f == QLatin1String( "application/json" ) || f == QLatin1String( "application/geojson" ) || f == QLatin1String( "application/geo+json" ) || f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) || ( f == QLatin1String( "text/xml" ) && !mBaseUrl.contains( "MapServer" ) ) )
       format = Qgis::RasterIdentifyFormat::Feature;
 
     mIdentifyFormats.insert( format, f );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -614,11 +614,12 @@ bool QgsWmsProvider::setImageCrs( QString const &crs )
 
 void QgsWmsProvider::setQueryItem( QUrlQuery &url, const QString &item, const QString &value )
 {
-  url.removeQueryItem( item );
+  QString key = QUrl::toPercentEncoding( item );
+  url.removeQueryItem( key );
   if ( value.isNull() )
-    url.addQueryItem( item, "" );
+    url.addQueryItem( key, "" );
   else
-    url.addQueryItem( item, value );
+    url.addQueryItem( key, QUrl::toPercentEncoding( value ) );
 }
 
 void QgsWmsProvider::setFormatQueryItem( QUrlQuery &url )
@@ -1238,8 +1239,8 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
   {
     if ( mActiveSubLayerVisibility.constFind( *it ).value() )
     {
-      visibleLayers += QUrl::toPercentEncoding( *it );
-      visibleStyles += QUrl::toPercentEncoding( *it2 );
+      visibleLayers += *it;
+      visibleStyles += *it2;
     }
 
     ++it2;

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -460,6 +460,7 @@ class TestQgsWmsCapabilities: public QObject
       QTest::newRow( "text/html" ) << QByteArray( "text/html" ) << static_cast<int>( QgsRasterInterface::IdentifyHtml );
       QTest::newRow( "application/json" ) << QByteArray( "application/json" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
       QTest::newRow( "application/geojson" ) << QByteArray( "application/geojson" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
+      QTest::newRow( "application/geo+json" ) << QByteArray( "application/geo+json" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
       QTest::newRow( "application/vnd.ogc.gml" ) << QByteArray( "application/vnd.ogc.gml" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
       QTest::newRow( "application/vnd.esri.wms_featureinfo_xml" ) << QByteArray( "application/vnd.esri.wms_featureinfo_xml" ) << static_cast<int>( QgsRasterInterface::NoCapabilities );
     }

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -100,7 +100,7 @@ class TestQgsWmsProvider: public QgsTest
       QgsWmsProvider provider( failingAddress, QgsDataProvider::ProviderOptions(), mCapabilities );
       QUrl url( provider.createRequestUrlWMS( QgsRectangle( 0, 0, 90, 90 ), 100, 100 ) );
       QCOMPARE( url.toString(), QString( "http://localhost:8380/mapserv?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap"
-                                         "&BBOX=0,0,90,90&CRS=CRS:84&WIDTH=100&HEIGHT=100&LAYERS=&"
+                                         "&BBOX=0%2C0%2C90%2C90&CRS=CRS%3A84&WIDTH=100&HEIGHT=100&LAYERS=&"
                                          "STYLES=&FORMAT=&TRANSPARENT=TRUE" ) );
     }
 
@@ -116,8 +116,8 @@ class TestQgsWmsProvider: public QgsTest
       QVERIFY( cap.parseResponse( content, config ) );
       QgsWmsProvider provider( failingAddress, QgsDataProvider::ProviderOptions(), &cap );
       QUrl url( provider.createRequestUrlWMS( QgsRectangle( 0, 0, 90, 90 ), 100, 100 ) );
-      QCOMPARE( url.toString(), QString( "http://localhost:8380/mapserv?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=0,0,90,90&"
-                                         "CRS=EPSG:2056&WIDTH=100&HEIGHT=100&"
+      QCOMPARE( url.toString(), QString( "http://localhost:8380/mapserv?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=0%2C0%2C90%2C90&"
+                                         "CRS=EPSG%3A2056&WIDTH=100&HEIGHT=100&"
                                          "LAYERS=plus%2Bsign&STYLES=&FORMAT=&TRANSPARENT=TRUE" ) );
     }
 


### PR DESCRIPTION
ArcGIS 10.9.1 advertizes `application/geo+json` rather than `application/geojson` as supported identify format. This PR adds that format to the recognized formats, and ensures the query items are properly percent encoded as QUrlQuery expects (this is particularly relevant for `application/geo+json` where the `+` would be interpreted as a space.

Also, ignore `text/xml` as supported format for MapServer WMS layers. The returned XML document has a different structure than QGIS expects for its own `text/xml` format.