### PR TITLE
Fix trust parameter not saved and not read

### DIFF
--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -687,6 +687,8 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * \since QGIS 3.12
     */
     virtual void reloadProviderData() {}
+
+    friend class TestQgsProject;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDataProvider::ReadFlags )


### PR DESCRIPTION
When taking a look at #51110 , I met these issues when dealing with flags :

- when enabling/disabling trust or evaluate default parameter, the project doesn't appeared as modified
- trust parameter is not considered in provider (because we need to read flags before loading layer)

