### PR TITLE
[3D] Fix Y-Z inversion in point3dsymbolwidget

### DIFF
--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -327,6 +327,9 @@
        <property name="maximum">
         <double>99999.000000000000000</double>
        </property>
+       <property name="minimum">
+        <double>-99999.000000000000000</double>
+       </property>
       </widget>
      </item>
      <item row="4" column="0">


### PR DESCRIPTION
A point on the 2D plane (x', y') is transformed to (x, -z) in the 3D world. It looks like `point3dsymbolwidget` does not handle this change. This MR fixes it.

### current behavior

![points-avant](https://user-images.githubusercontent.com/497207/218760599-c4f51b0a-1f4b-444a-80cb-f2fc42547fac.gif)

### new behavior

![points-apres](https://user-images.githubusercontent.com/497207/218760642-7c66dba9-42dd-4a19-b090-4ca0dbae1810.gif)

cc @benoitdm-oslandia @wonder-sk 