### PR TITLE
[postgres] Do not discard geometry attributes having no SRID

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -417,7 +417,11 @@ QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPos
 
   QRegularExpressionMatch regularExpressionMatch = regularExpressionSRID.match( ewkt );
   if ( !regularExpressionMatch.hasMatch() )
-    return QgsReferencedGeometry();
+  {
+    QgsGeometry geom = QgsGeometry::fromWkt( ewkt );
+    QgsCoordinateReferenceSystem crs; // TODO: use projects' crs ?
+    return QgsReferencedGeometry( geom, crs );
+  }
 
   QString wkt = ewkt.mid( regularExpressionMatch.captured( 0 ).size() );
   int srid = regularExpressionMatch.captured( 1 ).toInt();

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -478,6 +478,15 @@ void TestQgsPostgresProvider::testEwktInOut()
   QCOMPARE( g.crs().authid(), "EPSG:4326" );
   ewkt_obtained = QgsPostgresProvider::toEwkt( g, conn );
   QCOMPARE( ewkt_obtained, "SRID=4326;LineString (0 0, -5 2)" );
+
+  // Test for srid-less geometry
+  // See https://github.com/qgis/QGIS/issues/49380#issuecomment-1282913470
+  g = QgsPostgresProvider::fromEwkt( "POINT(0 0)", conn );
+  QVERIFY( ! g.isNull() );
+  ewkt_obtained = QgsPostgresProvider::toEwkt( g, conn );
+  QVERIFY( ! g.crs().isValid() ); // is unknown
+  QCOMPARE( ewkt_obtained, QString( "SRID=0;Point (0 0)" ) );
+
 }
 #endif // ENABLE_PGTEST
 


### PR DESCRIPTION
See https://github.com/qgis/QGIS/issues/49380#issuecomment-1282913470

This is a spinoff of #50592