### PR TITLE
Fix logic for triggering a full model reset in attribute table after changing attributes

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -862,12 +862,32 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
   mBulkEditCommandRunning = false;
   // Full model update if the changed rows are more than half the total rows
   // or if their count is > layer cache size
-  const int changeCount( std::max( mAttributeValueChanges.count(), mInsertedRowsChanges.count() ) );
-  const bool fullModelUpdate = changeCount > mLayerCache->cacheSize() ||
-                               changeCount > rowCount() * 0.5;
 
-  QgsDebugMsgLevel( QStringLiteral( "Bulk edit command ended with %1 modified rows over (%4), cache size is %2, starting %3 update." )
-                    .arg( changeCount )
+  const long long fullModelUpdateThreshold = std::min<long long >( mLayerCache->cacheSize(), std::ceil( rowCount() * 0.5 ) );
+  bool fullModelUpdate = false;
+
+  // try the cheaper check first
+  if ( mInsertedRowsChanges.size() > fullModelUpdateThreshold )
+  {
+    fullModelUpdate = true;
+  }
+  else
+  {
+    QSet< QgsFeatureId > changedRows;
+    changedRows.reserve( mAttributeValueChanges.size() );
+    // we need to count changed features, not the total of changed attributes (which may all apply to one feature)
+    for ( auto it = mAttributeValueChanges.constBegin(); it != mAttributeValueChanges.constEnd(); ++it )
+    {
+      changedRows.insert( it.key().first );
+      if ( changedRows.size() > fullModelUpdateThreshold )
+      {
+        fullModelUpdate = true;
+        break;
+      }
+    }
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "Bulk edit command ended modified rows over (%3), cache size is %1, starting %2 update." )
                     .arg( mLayerCache->cacheSize() )
                     .arg( fullModelUpdate ? QStringLiteral( "full" ) :  QStringLiteral( "incremental" ) )
                     .arg( rowCount() ),


### PR DESCRIPTION
The old logic was incorrectly equating the total number of changed attributes with the number of changed rows, and accordingly changing a few fields in a single feature for a small table could trigger the "changes > more than half the total number of rows" threshold and force a full model reset even though only one feature had changed.

In reality the full model reset condition should only ever be triggered when a bulk operation is occurring, such as using the field calculator, NOT when edits are made to a single feature.

The consequence of this was that the attribute table was being reset when changing values in a small table, ie resorting the features and changing the current feature back to the first feature.
