### PR TITLE
Fix segfault on exit / add test for EWKT input/output

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2785,3 +2785,65 @@ QString QgsPostgresConn::currentDatabase() const
 
   return database;
 }
+
+QgsCoordinateReferenceSystem QgsPostgresConn::sridToCrs( int srid )
+{
+  QgsCoordinateReferenceSystem crs;
+
+  QMutexLocker locker( &mCrsCacheMutex );
+  if ( mCrsCache.contains( srid ) )
+    crs = mCrsCache.value( srid );
+  else
+  {
+    QgsPostgresResult result( LoggedPQexec( QStringLiteral( "QgsPostgresProvider" ), QStringLiteral( "SELECT auth_name, auth_srid, srtext, proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
+    if ( result.PQresultStatus() == PGRES_TUPLES_OK )
+    {
+      if ( result.PQntuples() > 0 )
+      {
+        const QString authName = result.PQgetvalue( 0, 0 );
+        const QString authSRID = result.PQgetvalue( 0, 1 );
+        const QString srText = result.PQgetvalue( 0, 2 );
+        bool ok = false;
+        if ( authName == QLatin1String( "EPSG" ) || authName == QLatin1String( "ESRI" ) )
+        {
+          ok = crs.createFromUserInput( authName + ':' + authSRID );
+        }
+        if ( !ok && !srText.isEmpty() )
+        {
+          ok = crs.createFromUserInput( srText );
+        }
+        if ( !ok )
+          crs = QgsCoordinateReferenceSystem::fromProj( result.PQgetvalue( 0, 3 ) );
+      }
+      mCrsCache.insert( srid, crs );
+    }
+  }
+  return crs;
+}
+
+int QgsPostgresConn::crsToSrid( const QgsCoordinateReferenceSystem &crs )
+{
+  QMutexLocker locker( &mCrsCacheMutex );
+  int srid = mCrsCache.key( crs );
+
+  if ( srid > -1 )
+    return srid;
+  else
+  {
+    QStringList authParts = crs.authid().split( ':' );
+    if ( authParts.size() != 2 )
+      return -1;
+    const QString authName = authParts.first();
+    const QString authId = authParts.last();
+    QgsPostgresResult result( PQexec( QStringLiteral( "SELECT srid FROM spatial_ref_sys WHERE auth_name='%1' AND auth_srid=%2" ).arg( authName, authId ) ) );
+
+    if ( result.PQresultStatus() == PGRES_TUPLES_OK )
+    {
+      int srid = result.PQgetvalue( 0, 0 ).toInt();
+      mCrsCache.insert( srid, crs );
+      return srid;
+    }
+  }
+
+  return -1;
+}

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -456,6 +456,10 @@ class QgsPostgresConn : public QObject
     void lock() { mLock.lock(); }
     void unlock() { mLock.unlock(); }
 
+    QgsCoordinateReferenceSystem sridToCrs( int srsId );
+
+    int crsToSrid( const QgsCoordinateReferenceSystem &crs );
+
   private:
 
     int mRef;
@@ -529,6 +533,12 @@ class QgsPostgresConn : public QObject
     bool mTransaction;
 
     mutable QRecursiveMutex mLock;
+
+    /* Mutex protecting sCrsCache */
+    QMutex mCrsCacheMutex;
+
+    /* Cache of SRID to CRS */
+    mutable QMap<int, QgsCoordinateReferenceSystem> mCrsCache;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -49,6 +49,8 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 {
     Q_OBJECT
 
+    friend class TestQgsPostgresProvider;
+
   public:
 
     static const QString POSTGRES_KEY;

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -38,7 +38,7 @@ add_qgis_test(testqgswmsprovider.cpp MODULE provider LINKEDLIBRARIES provider_wm
 
 if (POSTGRES_FOUND)
   add_qgis_test(testqgspostgresexpressioncompiler.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
-  add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
+  add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
   add_qgis_test(testqgspostgresconn.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
 endif()
 

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgstest.h"
+#include "qgsconfig.h" // for ENABLE_PGTEST
 #include <QObject>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
@@ -21,11 +22,42 @@
 #include <qgspostgresconn.h>
 #include <qgsfields.h>
 
-
 class TestQgsPostgresProvider: public QObject
 {
     Q_OBJECT
+
+  private:
+
+#ifdef ENABLE_PGTEST
+    QgsPostgresConn *_connection;
+
+
+    QgsPostgresConn *getConnection()
+    {
+      if ( ! _connection )
+      {
+        const char *connstring = getenv( "QGIS_PGTEST_DB" );
+        if ( !connstring ) connstring = "service=qgis_test";
+        _connection = QgsPostgresConn::connectDb( connstring, true );
+      }
+      return _connection;
+    }
+#endif
+
   private slots:
+
+    void initTestCase() // will be called before the first testfunction is executed.
+    {
+#ifdef ENABLE_PGTEST
+      this->_connection = 0;
+#endif
+    }
+    void cleanupTestCase() // will be called after the last testfunction was executed.
+    {
+#ifdef ENABLE_PGTEST
+      if ( this->_connection ) this->_connection->unref();
+#endif
+    }
 
     void decodeHstore();
     void decodeHstoreNoQuote();
@@ -41,6 +73,9 @@ class TestQgsPostgresProvider: public QObject
     void testDecodeDateTimes();
     void testQuotedValueBigInt();
     void testWhereClauseFids();
+#ifdef ENABLE_PGTEST
+    void testEwktInOut();
+#endif
 };
 
 
@@ -427,6 +462,24 @@ void TestQgsPostgresProvider::testWhereClauseFids()
                    QStringList() << "\"fld_int\"=42 AND \"fld\"::text='QGIS ''Rocks''!'"
                    << "\"fld_int\"=43 AND \"fld\"::text='PostGIS too!'" );
 }
+
+#ifdef ENABLE_PGTEST
+void TestQgsPostgresProvider::testEwktInOut()
+{
+  QGSTEST_NEED_PGTEST_DB();
+
+  QgsPostgresConn *conn = getConnection();
+  QVERIFY( conn != nullptr );
+  QgsReferencedGeometry g;
+  QString ewkt_obtained;
+
+  g = QgsPostgresProvider::fromEwkt( "SRID=4326;LINESTRING(0 0,-5 2)", conn );
+  QVERIFY( ! g.isNull() );
+  QCOMPARE( g.crs().authid(), "EPSG:4326" );
+  ewkt_obtained = QgsPostgresProvider::toEwkt( g, conn );
+  QCOMPARE( ewkt_obtained, "SRID=4326;LineString (0 0, -5 2)" );
+}
+#endif // ENABLE_PGTEST
 
 QGSTEST_MAIN( TestQgsPostgresProvider )
 #include "testqgspostgresprovider.moc"


### PR DESCRIPTION
As I'm getting a segfault on exit by just calling  QgsPostgresProvider::toEwkt  I thought I'd create a pull request JUST for this new test.

NOTE: the test is testing a *private* method of QgsPostgresProvider