### PR TITLE
Actually applyColorRamp when 'live update' enabled

### DIFF
--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -208,7 +208,7 @@ void QgsColorRampShaderWidget::autoLabel()
       currentItem->setForeground( LabelColumn, QBrush( QColor( Qt::gray ) ) );
     }
   }
-
+  applyColorRamp();
 }
 
 void QgsColorRampShaderWidget::setUnitFromLabels()


### PR DESCRIPTION
side note 1: I really do not know if this interferes with things, or there was a special reason to NOT add this line..

side note 2: the reason I came here was actually because I want the Min and Max reflect the 'label precision'
(https://github.com/qgis/QGIS/issues/50950) but I do not think I can fix that easily?

THIS PR is about:

When styling Mesh layers, you can change the label precision and unit suffix of the labels.
But when you have 'Live Update' enabled, it is NOT shown in the layer manager/legend.

This one liner calls applyColorRamp() on changes in label precision or unit suffix.
It also does NOT apply the colorRamp in the legend when the checkbox 'Live Update' is disabled.

In the screencast below you can see this:

left is the old behaviour: changes are only shown in layer panel

right is the new behaviour: changes are reflected both in layer panel AND in the legend
BUT only if 'Live Update' is checked. The last part I unchecked to Live Update checkbox

[leftOldRightNew.webm](https://user-images.githubusercontent.com/731673/219607639-53a20f35-d42c-4592-a7af-94e55877b66b.webm)
