### PR TITLE
Update INSTALL.md: remove deprecated git:// URL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -235,7 +235,7 @@ changes.
 
 ```bash
 cd ${HOME}/dev/cpp
-git clone git://github.com/qgis/QGIS.git
+git clone https://github.com/qgis/QGIS.git
 ```
 
 2. Developer Checkout


### PR DESCRIPTION
## Description
The git protocol stopped working almost a year ago and anonymous cloning should now happen using https. 
https://github.blog/2021-09-01-improving-git-protocol-security-github/
