### PR TITLE
Allow to skip PostgreSQL backend dependent tests at runtime

### DIFF
--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -104,6 +104,11 @@
     QCOMPARE( result.replace( QStringLiteral("ts=\" \" cs=\",\""), QStringLiteral("cs=\",\" ts=\" \"") ), expected ); \
   }(void)(0)
 
+// Start your PostgreSQL-backend connection requiring test with this macro
+#define QGSTEST_NEED_PGTEST_DB() \
+  if ( getenv( "QGIS_PGTEST_DB_SKIP" ) ) \
+    QSKIP( "Test disabled due to QGIS_PGTEST_DB_SKIP env variable being set" );
+
 /**
  * Base class for tests.
  *

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -69,7 +69,6 @@ class TestQgsPostgresConn: public QObject
         const char *connstring = getenv( "QGIS_PGTEST_DB" );
         if ( !connstring ) connstring = "service=qgis_test";
         _connection = QgsPostgresConn::connectDb( connstring, true );
-        assert( _connection );
       }
       return _connection;
     }
@@ -162,6 +161,8 @@ class TestQgsPostgresConn: public QObject
 #ifdef ENABLE_PGTEST
     void supportedLayers()
     {
+      QGSTEST_NEED_PGTEST_DB();
+
       QgsPostgresConn *conn = getConnection();
       QVERIFY( conn != 0 );
       QVector<QgsPostgresLayerProperty> layers;
@@ -207,6 +208,8 @@ class TestQgsPostgresConn: public QObject
 
     void connectDb()
     {
+      QGSTEST_NEED_PGTEST_DB();
+
       QgsPostgresConn *conn = getConnection();
       QVERIFY( conn != 0 );
 


### PR DESCRIPTION
Allows users to define a `QGIS_PGTEST_DB_SKIP` environment variable to skip tests requiring the test postgresql database to be run.

This is a spin-off from #51891 in response to @nyalldawson request expressed in https://github.com/qgis/QGIS/pull/51891#discussion_r1109132667