### PR TITLE
 make "__file__" available to scripts

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -324,8 +324,8 @@ class Editor(QgsCodeEditorPython):
                 filename = self.createTempFile()
                 deleteTempFile = True
 
-            self.pythonconsole.shell.runCommand("exec(Path('{0}').read_text())"
-                                                .format(filename.replace("\\", "/")))
+            self.pythonconsole.shell.runFile(filename)
+
             if deleteTempFile:
                 Path(filename).unlink()
 


### PR DESCRIPTION
Fixes #49191

## Description

Make the __file__ variable available in Python Console scripts.
When the user runs a file:
- append the script folder to `sys.path`
- set `__file__ `to the script filename
- exec the file content
- del `__file__ `
- pop the script folder from sys.path
