### PR TITLE
Python console shortcuts

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -558,13 +558,13 @@ class PythonConsoleWidget(QWidget):
             # iterate backwards through tabs, as we may be closing some as we go
             tab_index = tab_count - i - 1
             tab_widget = self.tabEditorWidget.widget(tab_index)
-            if tab_widget.newEditor.isModified():
+            if tab_widget.editor.isModified():
                 ret = QMessageBox.question(self, self.tr("Save {}").format(self.tabEditorWidget.tabText(tab_index)),
                                            self.tr("There are unsaved changes in this script. Do you want to keep those?"),
                                            QMessageBox.Save | QMessageBox.Cancel | QMessageBox.Discard, QMessageBox.Cancel)
                 if ret == QMessageBox.Save:
-                    tab_widget.save()
-                    if tab_widget.newEditor.isModified():
+                    tab_widget.edisave()
+                    if tab_widget.editor.isModified():
                         # save failed, treat as cancel
                         return False
                 elif ret == QMessageBox.Discard:
@@ -577,36 +577,36 @@ class PythonConsoleWidget(QWidget):
         return True
 
     def _toggleFind(self):
-        self.tabEditorWidget.currentWidget().newEditor.toggleFindWidget()
+        self.tabEditorWidget.currentWidget().editor.toggleFindWidget()
 
     def _openFind(self):
-        self.tabEditorWidget.currentWidget().newEditor.openFindWidget()
+        self.tabEditorWidget.currentWidget().editor.openFindWidget()
 
     def _closeFind(self):
-        self.tabEditorWidget.currentWidget().newEditor.closeFindWidget()
+        self.tabEditorWidget.currentWidget().editor.closeFindWidget()
 
     def _findNext(self):
-        self.tabEditorWidget.currentWidget().newEditor.findText(True)
+        self.tabEditorWidget.currentWidget().editor.findText(True)
 
     def _findPrev(self):
-        self.tabEditorWidget.currentWidget().newEditor.findText(False)
+        self.tabEditorWidget.currentWidget().editor.findText(False)
 
     def _textFindChanged(self):
         if self.lineEditFind.text():
             self.findNextButton.setEnabled(True)
             self.findPrevButton.setEnabled(True)
-            self.tabEditorWidget.currentWidget().newEditor.findText(True, showMessage=False, findFirst=True)
+            self.tabEditorWidget.currentWidget().editor.findText(True, showMessage=False, findFirst=True)
         else:
             self.lineEditFind.setStyleSheet('')
             self.findNextButton.setEnabled(False)
             self.findPrevButton.setEnabled(False)
 
     def onClickGoToLine(self, item, column):
-        tabEditor = self.tabEditorWidget.currentWidget().newEditor
+        tabEditor = self.tabEditorWidget.currentWidget().editor
         if item.text(1) == 'syntaxError':
             check = tabEditor.syntaxCheck()
             if check and not tabEditor.isReadOnly():
-                self.tabEditorWidget.currentWidget().save()
+                self.tabEditorWidget.currentWidget().edisave()
             return
         linenr = int(item.text(1))
         itemName = str(item.text(0))
@@ -627,19 +627,19 @@ class PythonConsoleWidget(QWidget):
         self.listClassMethod.show() if checked else self.listClassMethod.hide()
 
     def pasteEditor(self):
-        self.tabEditorWidget.currentWidget().newEditor.paste()
+        self.tabEditorWidget.currentWidget().editor.paste()
 
     def cutEditor(self):
-        self.tabEditorWidget.currentWidget().newEditor.cut()
+        self.tabEditorWidget.currentWidget().editor.cut()
 
     def copyEditor(self):
-        self.tabEditorWidget.currentWidget().newEditor.copy()
+        self.tabEditorWidget.currentWidget().editor.copy()
 
     def runScriptEditor(self):
-        self.tabEditorWidget.currentWidget().newEditor.runScriptCode()
+        self.tabEditorWidget.currentWidget().editor.runScriptCode()
 
     def toggleComment(self):
-        self.tabEditorWidget.currentWidget().newEditor.toggleComment()
+        self.tabEditorWidget.currentWidget().editor.toggleComment()
 
     def openScriptFileExtEditor(self):
         tabWidget = self.tabEditorWidget.currentWidget()
@@ -673,7 +673,7 @@ class PythonConsoleWidget(QWidget):
     def saveScriptFile(self):
         tabWidget = self.tabEditorWidget.currentWidget()
         try:
-            tabWidget.save()
+            tabWidget.editor.save()
         except (IOError, OSError) as error:
             msgText = QCoreApplication.translate('PythonConsole',
                                                  'The file <b>{0}</b> could not be saved. Error: {1}').format(tabWidget.path,

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -698,10 +698,10 @@ class EditorTabWidget(QTabWidget):
         nr = self.count()
         if not tabName:
             tabName = QCoreApplication.translate('PythonConsole', 'Untitled-{0}').format(nr)
-        self.tab = EditorTab(self, self.parent, filename, readOnly)
+        tab = EditorTab(self, self.parent, filename, readOnly)
         self.iconTab = QgsApplication.getThemeIcon('console/iconTabEditorConsole.svg')
-        self.addTab(self.tab, self.iconTab, tabName + ' (ro)' if readOnly else tabName)
-        self.setCurrentWidget(self.tab)
+        self.addTab(tab, self.iconTab, tabName + ' (ro)' if readOnly else tabName)
+        self.setCurrentWidget(tab)
         if filename:
             self.setTabToolTip(self.currentIndex(), filename)
         else:
@@ -712,14 +712,6 @@ class EditorTabWidget(QTabWidget):
         s = self.tabText(index)
         self.setTabTitle(index, '*{}'.format(s) if modified else re.sub(r'^(\*)', '', s))
         self.parent.saveFileButton.setEnabled(modified)
-
-    def closeTab(self, tab):
-        if self.count() < 2:
-            self.removeTab(self.indexOf(tab))
-            self.newTabEditor()
-        else:
-            self.removeTab(self.indexOf(tab))
-        self.currentWidget().setFocus(Qt.TabFocusReason)
 
     def setTabTitle(self, tab, title):
         self.setTabText(tab, title)
@@ -736,10 +728,10 @@ class EditorTabWidget(QTabWidget):
             res = QMessageBox.question(self, txtSaveOnRemove,
                                        txtMsgSaveOnRemove,
                                        QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
+            if res == QMessageBox.Cancel:
+                return
             if res == QMessageBox.Save:
                 tabWidget.save()
-            elif res == QMessageBox.Cancel:
-                return
             if tabWidget.path:
                 self.parent.updateTabListScript(tabWidget.path, action='remove')
             self.removeTab(tab)
@@ -753,6 +745,8 @@ class EditorTabWidget(QTabWidget):
                 self.newTabEditor()
             else:
                 self.removeTab(tab)
+
+        tabWidget.deleteLater()
         self.currentWidget().newEditor.setFocus(Qt.TabFocusReason)
 
     def buttonClosePressed(self):


### PR DESCRIPTION
Fixes #51732

## Description

When writting code in a Python Console Editor, pressing Ctrl+S triggers the Save Project action instead of the save script action.

This PR uses QEvent.ShortcutOverride to override the following shortcuts:
- **Ctrl+W**: close current tab
- **Ctrl+Shift+W**: close all tabs
- **Ctrl+S**: save current tab
- **Ctrl+Shift+S**: save current tab as
- **Ctrl+T**: open new tab
- **Ctrl+Tab**: Iter over tabs

Thus, when the Editor has focus, application QAction/QShortcut that share these KeySequences are ignored in favor of the Editor actions.
