### PR TITLE
Fix broken filter on Relation Editor

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -653,8 +653,14 @@ void QgsRelationEditorWidget::updateUiSingleEdit()
   }
   else
   {
+    mFeatureSelectionMgr = new QgsFilteredSelectionManager( layer, request, mDualView );
+    mDualView->setFeatureSelectionManager( mFeatureSelectionMgr );
+    connect( mFeatureSelectionMgr, &QgsIFeatureSelectionManager::selectionChanged, this, &QgsRelationEditorWidget::updateButtons );
+
     mDualView->setRequest( request );
     mDualView->masterModel()->loadLayer();
+
+    updateButtons();
   }
 }
 

--- a/tests/src/gui/testqgsrelationeditorwidget.cpp
+++ b/tests/src/gui/testqgsrelationeditorwidget.cpp
@@ -302,6 +302,7 @@ void TestQgsRelationEditorWidget::testUpdateUi()
 
   relationEditorWidget.setVisible( true );
 
+  //get feature with pk 10
   QgsFeature feat = mLayer2->getFeature( 1 );
   QVERIFY( feat.isValid() );
   relationEditorWidget.setFeature( feat );
@@ -312,8 +313,13 @@ void TestQgsRelationEditorWidget::testUpdateUi()
   QVERIFY( model );
 
   QCOMPARE( model->rowCount(), 1 );
+  //referencing feature on mLayer1 should be pk 0 (fid 1)
   QCOMPARE( model->data( model->index( 0, 0 ) ), 0 );
+  //as well be found with FilteredSelectionManager (fid 1)
+  relationEditorWidget.relation().referencingLayer()->selectAll();
+  QVERIFY( relationEditorWidget.selectedChildFeatureIds().contains( 1 ) );
 
+  //get feature with pk 11
   feat = mLayer2->getFeature( 2 );
   QVERIFY( feat.isValid() );
   relationEditorWidget.setFeature( feat );
@@ -321,26 +327,36 @@ void TestQgsRelationEditorWidget::testUpdateUi()
   // model hasn't changed (old one has not being destroyed)
   QVERIFY( model );
   QCOMPARE( model->rowCount(), 1 );
+  //referencing feature on mLayer1 should be pk 1 (fid 2)
   QCOMPARE( model->data( model->index( 0, 0 ) ), 1 );
+  //as well be found with FilteredSelectionManager (fid 2)
+  relationEditorWidget.relation().referencingLayer()->selectAll();
+  QVERIFY( relationEditorWidget.selectedChildFeatureIds().contains( 2 ) );
 
   // Now try with NM relations
   relationEditorWidget.setRelations( *mRelationNM, *mRelation1N );
   // model has not been destroyed (mLayer1 is still the displayed layer)
   QVERIFY( model );
 
+  //get feature with pk 10
   feat = mLayer2->getFeature( 1 );
   QVERIFY( feat.isValid() );
   relationEditorWidget.setFeature( feat );
 
   // model not destroyed, set request only
   QCOMPARE( model->rowCount(), 1 );
+  //referencing feature on mLayer1 should be pk 0 (fid 1)
   QCOMPARE( model->data( model->index( 0, 0 ) ), 0 );
+  //as well be found with FilteredSelectionManager (fid 1)
+  relationEditorWidget.nmRelation().referencedLayer()->selectAll();
+  QVERIFY( relationEditorWidget.selectedChildFeatureIds().contains( 1 ) );
 
   relationEditorWidget.setRelations( *mRelation1N, *mRelationNM );
   // model has been destroyed (mLayer2 is now the displayed layer)
   QVERIFY( !model );
   model = relationEditorWidget.mDualView->masterModel();
 
+  //get feature with pk 0
   feat = mLayer1->getFeature( 1 );
   QVERIFY( feat.isValid() );
   relationEditorWidget.setFeature( feat );
@@ -348,8 +364,15 @@ void TestQgsRelationEditorWidget::testUpdateUi()
   // model not destroyed, set request only
   QVERIFY( model );
   QCOMPARE( model->rowCount(), 2 );
+  //referencing feature on mLayer2 should be pk 10 (fid 1) and pk 11 (fid 2)
   QCOMPARE( model->data( model->index( 0, 0 ) ), 10 );
   QCOMPARE( model->data( model->index( 1, 0 ) ), 11 );
+
+  //as well be found with FilteredSelectionManager (fid 1 and fid 2)
+  relationEditorWidget.nmRelation().referencedLayer()->selectAll();
+  QVERIFY( relationEditorWidget.selectedChildFeatureIds().contains( 1 ) );
+  QVERIFY( relationEditorWidget.selectedChildFeatureIds().contains( 2 ) );
+
 }
 
 QGSTEST_MAIN( TestQgsRelationEditorWidget )


### PR DESCRIPTION
Recreates the `QgsFilteredSelectionManager` on request-change, when the layer persists. With this there is the current and valid `FeatureRequest` set on `QgsFilteredSelectionManager` and this fixes the broken filter in the Relation Editor.

### Bug

In the Attribute Table you could not select the child features anymore in the Relation Editor from the second feature.
![image](https://user-images.githubusercontent.com/28384354/219680627-9132255e-d3d0-4c4d-8247-18a822088e38.png)

Video: 
[selectionnotconsideredinfilter.webm](https://user-images.githubusercontent.com/28384354/219680698-0078ca02-d5a1-43a8-ba7c-c4aabcbf94a8.webm)

The feature got selected, but because it has not been considered in the QgsFilteredSelectionManager it was neither "yellow" nor the buttons reacted accordingly.

***LTR has not been affected***


