### PR TITLE
Fix missing #include in qgsarcgisrestutils.cpp

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -43,6 +43,7 @@
 #include "qgsvariantutils.h"
 
 #include <QRegularExpression>
+#include <QUrl>
 
 QVariant::Type QgsArcGisRestUtils::convertFieldType( const QString &esriFieldType )
 {


### PR DESCRIPTION
## Description

@nyalldawson , tiny followup to https://github.com/nirvn/QGIS/commit/f3065469160a5bb0987dda79fefeaae98bc0a2c3 needed to fix compilation under vcpkg.