### PR TITLE
[server][getPrint] Use default extent instead of fail

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -665,26 +665,22 @@ namespace QgsWms
 
       if ( !atlasPrint || !map->atlasDriven() ) //No need to extent, scal, rotation set with atlas feature
       {
-        //map extent is mandatory
-        if ( !cMapParams.mHasExtent )
+        if ( cMapParams.mHasExtent )
         {
-          //remove map from composition if not referenced by the request
-          c->removeLayoutItem( map );
-          continue;
-        }
-        // Change CRS of map set to "project CRS" to match requested CRS
-        // (if map has a valid preset crs then we keep this crs and don't use the
-        // requested crs for this map item)
-        if ( mapSettings.destinationCrs().isValid() && !map->presetCrs().isValid() )
-          map->setCrs( mapSettings.destinationCrs() );
+          // Change CRS of map set to "project CRS" to match requested CRS
+          // (if map has a valid preset crs then we keep this crs and don't use the
+          // requested crs for this map item)
+          if ( mapSettings.destinationCrs().isValid() && !map->presetCrs().isValid() )
+            map->setCrs( mapSettings.destinationCrs() );
 
-        QgsRectangle r( cMapParams.mExtent );
-        if ( mWmsParameters.versionAsNumber() >= QgsProjectVersion( 1, 3, 0 ) &&
-             mapSettings.destinationCrs().hasAxisInverted() )
-        {
-          r.invert();
+          QgsRectangle r( cMapParams.mExtent );
+          if ( mWmsParameters.versionAsNumber() >= QgsProjectVersion( 1, 3, 0 ) &&
+               mapSettings.destinationCrs().hasAxisInverted() )
+          {
+            r.invert();
+          }
+          map->setExtent( r );
         }
-        map->setExtent( r );
 
         // scale
         if ( cMapParams.mScale > 0 )


### PR DESCRIPTION
## Description
In QGIS server, there is a GetPrint request used to get composer layout outputs.

The extent parameter is now optional, if no extent is specified in the request, the extent from the layout map is used.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
