### PR TITLE
wmsgetcapabilities: Do not set a dimension default value if there are none

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1237,11 +1237,11 @@ namespace QgsWms
               {
                 dimElem.setAttribute( QStringLiteral( "unitSymbol" ), dim.unitSymbol );
               }
-              if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MinValue )
+              if ( !values.isEmpty() && dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MinValue )
               {
                 dimElem.setAttribute( QStringLiteral( "default" ), values.first().toString() );
               }
-              else if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MaxValue )
+              else if ( !values.isEmpty() && dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MaxValue )
               {
                 dimElem.setAttribute( QStringLiteral( "default" ), values.last().toString() );
               }


### PR DESCRIPTION
## Description

The WMS getCapabilities response tries to set a default value on multi-dimensional data. However, if the `values` list is empty, this can result in a segmentation fault because it can call `values.first()` or `values.last()` which is non valid for an empty list.

This issue is fixed by checking if `values` list is empty before calling `values.first()` and `values.last()`.

According to the WMS specification, the default parameter is optional. Therefore, in this case, the response is still valid.
