### PR TITLE
Fix Circle Shape tool when layer crs != map crs

### DIFF
--- a/src/app/maptools/qgsmaptoolshapecircleabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircleabstract.cpp
@@ -33,12 +33,12 @@ void QgsMapToolShapeCircleAbstract::addCircleToParentTool()
   mParentTool->clearCurve();
 
   // Check whether to draw the circle as a polygon or a circular string
-  auto layerCrs = mParentTool->layer()->crs();
-  auto mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
-  bool drawAsPolygon = layerCrs != mapCrs;
+  const QgsCoordinateReferenceSystem layerCrs = mParentTool->layer()->crs();
+  const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
+  const bool drawAsPolygon = layerCrs != mapCrs;
   if ( drawAsPolygon )
   {
-    int segments = QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg->value() * 12;
+    const int segments = QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg->value() * 12;
     std::unique_ptr<QgsLineString> ls( mCircle.toLineString( segments ) );
     mParentTool->addCurve( ls.release() );
   }

--- a/src/app/maptools/qgsmaptoolshapecircleabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircleabstract.cpp
@@ -15,6 +15,9 @@
 
 #include "qgsmaptoolshapecircleabstract.h"
 #include "qgsmaptoolcapture.h"
+#include "qgsmapcanvas.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 
 void QgsMapToolShapeCircleAbstract::clean()
 {
@@ -29,7 +32,19 @@ void QgsMapToolShapeCircleAbstract::addCircleToParentTool()
 
   mParentTool->clearCurve();
 
-  std::unique_ptr<QgsCircularString> lineString( mCircle.toCircularString() );
-
-  mParentTool->addCurve( lineString.release() );
+  // Check whether to draw the circle as a polygon or a circular string
+  auto layerCrs = mParentTool->layer()->crs();
+  auto mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
+  bool drawAsPolygon = layerCrs != mapCrs;
+  if ( drawAsPolygon )
+  {
+    int segments = QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg->value() * 12;
+    std::unique_ptr<QgsLineString> ls( mCircle.toLineString( segments ) );
+    mParentTool->addCurve( ls.release() );
+  }
+  else
+  {
+    std::unique_ptr<QgsCircularString> ls( mCircle.toCircularString() );
+    mParentTool->addCurve( ls.release() );
+  }
 }


### PR DESCRIPTION
Partially addresses #25167 (reprojection and curve tools are still an issue)
Fixes #38212
Fixes #38493
Fixes #38830
Fixes #44600
Fixes #51926

Many duplicates for this one...

## Description

The Circle Shape digitizing tools use `QgsCircularStrings` to draw the shape on the canvas AND to define the resulting feature in the layer coordinates. The problem is that in layer coordinates, the resulting shape is not always a circle, and `QgsCircularStrings` cannot be used to draw an ellipse. When mixing EPSG:4326 and EPSG:2857 for instance, the tools produces shapes like these:

![weird_shape](https://user-images.githubusercontent.com/15817745/91759721-1fdb9380-eba0-11ea-9c3a-2a2ffcd59559.png) 
![weird_shape2](https://user-images.githubusercontent.com/15817745/91760122-caec4d00-eba0-11ea-92ed-892f7613853e.png)

This PR aims to fix this with the following behavior:
- When map crs == layer crs, use QgsCircularStrings to draw the circle (as before)
- When map crs != layer crs, convert the curved geometry to a polygon, using the same number of segments as the ellipse tool.


###  Demonstration
![circle_tool](https://user-images.githubusercontent.com/9693475/219984261-df27a62b-3a27-4823-860b-2bc8aa00fc9c.gif)

Note the difference between the curved geometries (only 4 vertices) and the polygon geometries (many vertices) at the end of the recording.
