### PR TITLE
CI: disable flaky clang-tidy test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -408,7 +408,9 @@ jobs:
           path: qgis_test_report
 
   clang-tidy:
-    if: github.event_name == 'pull_request'
+    #if: github.event_name == 'pull_request'
+    #  See https://github.com/qgis/QGIS/issues/51917
+    if: false
     runs-on: ubuntu-latest
     needs: build
 


### PR DESCRIPTION
References #51917

This is a spin-off of #51910 which cannot pass CI due to a possible bug in clang-tidy test as reported by the test author @troopa81 

@nyalldawson asked me to NOT include this change in the PR which is blocked by this bug so I'm creating a new PR.