### PR TITLE
Fix circular string digitizing tool

### DIFF
--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -198,6 +198,7 @@ void QgsMapToolShapeCircularStringAbstract::addCurveToParentTool()
   {
     std::unique_ptr<QgsLineString> ls( c->curveToLine( ) );
     mParentTool->addCurve( ls.release() );
+    delete c;
   }
   else
   {

--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -194,7 +194,7 @@ void QgsMapToolShapeCircularStringAbstract::addCurveToParentTool()
   // Check whether to draw the circle as a polygon or a circular string
   bool drawAsPolygon = false;
 
-  if ( QgsMapLayer* layer = mParentTool->layer() )
+  if ( QgsMapLayer *layer = mParentTool->layer() )
   {
     const QgsCoordinateReferenceSystem layerCrs = layer->crs();
     const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();

--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -20,8 +20,9 @@
 #include "qgsgeometryrubberband.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
-#include "qgspoint.h"
+#include "qgsmapcanvas.h"
 #include "qgsmaptoolcapture.h"
+#include "qgspoint.h"
 
 QgsMapToolShapeCircularStringAbstract::QgsMapToolShapeCircularStringAbstract( const QString &id, QgsMapToolCapture *parentTool )
   : QgsMapToolShapeAbstract( id, parentTool )

--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -192,9 +192,15 @@ void QgsMapToolShapeCircularStringAbstract::addCurveToParentTool()
   c->setPoints( mPoints );
 
   // Check whether to draw the circle as a polygon or a circular string
-  const QgsCoordinateReferenceSystem layerCrs = mParentTool->layer()->crs();
-  const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
-  const bool drawAsPolygon = layerCrs != mapCrs;
+  bool drawAsPolygon = false;
+
+  if ( mParentTool->layer() )
+  {
+    const QgsCoordinateReferenceSystem layerCrs = mParentTool->layer()->crs();
+    const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
+    drawAsPolygon = layerCrs != mapCrs;
+  }
+
   if ( drawAsPolygon )
   {
     std::unique_ptr<QgsLineString> ls( c->curveToLine( ) );

--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -189,7 +189,20 @@ void QgsMapToolShapeCircularStringAbstract::addCurveToParentTool()
 {
   QgsCircularString *c = new QgsCircularString();
   c->setPoints( mPoints );
-  mParentTool->addCurve( c );
+
+  // Check whether to draw the circle as a polygon or a circular string
+  const QgsCoordinateReferenceSystem layerCrs = mParentTool->layer()->crs();
+  const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
+  const bool drawAsPolygon = layerCrs != mapCrs;
+  if ( drawAsPolygon )
+  {
+    std::unique_ptr<QgsLineString> ls( c->curveToLine( ) );
+    mParentTool->addCurve( ls.release() );
+  }
+  else
+  {
+    mParentTool->addCurve( c );
+  }
 }
 
 void QgsMapToolShapeCircularStringAbstract::clean()

--- a/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircularstringabstract.cpp
@@ -194,9 +194,9 @@ void QgsMapToolShapeCircularStringAbstract::addCurveToParentTool()
   // Check whether to draw the circle as a polygon or a circular string
   bool drawAsPolygon = false;
 
-  if ( mParentTool->layer() )
+  if ( QgsMapLayer* layer = mParentTool->layer() )
   {
-    const QgsCoordinateReferenceSystem layerCrs = mParentTool->layer()->crs();
+    const QgsCoordinateReferenceSystem layerCrs = layer->crs();
     const QgsCoordinateReferenceSystem mapCrs = mParentTool->canvas()->mapSettings().destinationCrs();
     drawAsPolygon = layerCrs != mapCrs;
   }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -806,20 +806,28 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
     mTempRubberBand->addPoint( endPt ); //add last point of c
   }
 
-  //transform back to layer CRS in case map CRS and layer CRS are different
-  const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( layer() );
-  if ( ct.isValid() )
-  {
-    c->transform( ct, Qgis::TransformDirection::Reverse );
-  }
   const int countBefore = mCaptureCurve.vertexCount();
   //if there is only one point, this the first digitized point that are in the this first curve added --> remove the point
   if ( mCaptureCurve.numPoints() == 1 )
     mCaptureCurve.removeCurve( 0 );
 
-  // we set the extendPrevious option to true to avoid creating compound curves with many 2 vertex linestrings -- instead we prefer
-  // to extend linestring curves so that they continue the previous linestring wherever possible...
-  mCaptureCurve.addCurve( c, !mStartNewCurve );
+  // Transform back to layer CRS in case map CRS and layer CRS are different
+  const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( layer() );
+  if ( ct.isValid() && !ct.isShortCircuited() )
+  {
+    QgsLineString *segmented = c->curveToLine();
+    segmented->transform( ct, Qgis::TransformDirection::Reverse );
+    // Curve geometries will be converted to segments, so we explicitly set extentPrevious to false
+    // to be able to remove the whole curve in undo
+    mCaptureCurve.addCurve( segmented, false );
+  }
+  else
+  {
+    // we set the extendPrevious option to true to avoid creating compound curves with many 2 vertex linestrings -- instead we prefer
+    // to extend linestring curves so that they continue the previous linestring wherever possible...
+    mCaptureCurve.addCurve( c, !mStartNewCurve );
+  }
+
   mStartNewCurve = false;
 
   const int countAfter = mCaptureCurve.vertexCount();
@@ -872,6 +880,13 @@ void QgsMapToolCapture::undo( bool isAutoRepeat )
     vertexToRemove.part = 0;
     vertexToRemove.ring = 0;
     vertexToRemove.vertex = size() - 1;
+
+    // If the geometry was reprojected, remove the entire last curve.
+    const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( layer() );
+    if ( ct.isValid() && !ct.isShortCircuited() )
+    {
+      mCaptureCurve.removeCurve( mCaptureCurve.nCurves() - 1 );
+    }
     if ( mCaptureCurve.numPoints() == 2 && mCaptureCurve.nCurves() == 1 )
     {
       // store the first vertex to restore if after deleting the curve

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -820,6 +820,7 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
     // Curve geometries will be converted to segments, so we explicitly set extentPrevious to false
     // to be able to remove the whole curve in undo
     mCaptureCurve.addCurve( segmented, false );
+    delete c;
   }
   else
   {


### PR DESCRIPTION
Fixes #51936
Partially adresses #25167

## Description

Circular strings do not play well with different crs between map and layer and the resulting shape can be funky.

This PR completes #51931 

- Fixes `QgsMapToolShapeCircularStringRadius` "Circular string by radius" ![](https://raw.githubusercontent.com/qgis/QGIS/master/images/themes/default/mActionCircularStringRadius.svg)


![circular_by_radius](https://user-images.githubusercontent.com/9693475/220201485-d8d0b9e1-9736-484d-9f3b-3bb1b8fdcac0.gif)

- Fixes the Curve mode of the `QgsMapToolCapture` (used to create new Line/Polygon features, add rings, reshape features...) 

![menu](https://user-images.githubusercontent.com/9693475/220204561-19cb1bbe-9b04-4995-a9cf-f5d5851d4330.png)


![capture_tool](https://user-images.githubusercontent.com/9693475/220201506-154c4e99-e0be-47c2-bfc5-61493787970c.gif)


