### PR TITLE
Fixes layer reprojection with curve geometries

### DIFF
--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -24,8 +24,14 @@ void QgsTransformAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "EPSG:4326" ) ) );
 
-  std::unique_ptr< QgsProcessingParameterCoordinateOperation > crsOpParam = std::make_unique< QgsProcessingParameterCoordinateOperation >( QStringLiteral( "OPERATION" ), QObject::tr( "Coordinate operation" ),
-      QVariant(), QStringLiteral( "INPUT" ), QStringLiteral( "TARGET_CRS" ), QVariant(), QVariant(), true );
+  // Convert curves to straight segments
+  auto convertCurvesParam = std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "CONVERT_CURVED_GEOMETRIES" ), QObject::tr( "Convert curved geometries to straight segments" ), false );
+  convertCurvesParam->setHelp( QObject::tr( "If checked, curved geometries will be converted to straight segments. Otherwise, they will be kept as curves. This can fix distortion issues." ) );
+  addParameter( convertCurvesParam.release() );
+
+  // Optional coordinate operation
+  auto crsOpParam = std::make_unique< QgsProcessingParameterCoordinateOperation >( QStringLiteral( "OPERATION" ), QObject::tr( "Coordinate operation" ),
+                    QVariant(), QStringLiteral( "INPUT" ), QStringLiteral( "TARGET_CRS" ), QVariant(), QVariant(), true );
   crsOpParam->setFlags( crsOpParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( crsOpParam.release() );
 }
@@ -87,6 +93,7 @@ bool QgsTransformAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
   prepareSource( parameters, context );
   mDestCrs = parameterAsCrs( parameters, QStringLiteral( "TARGET_CRS" ), context );
   mTransformContext = context.transformContext();
+  mConvertCurveToSegments = parameterAsBoolean( parameters, QStringLiteral( "CONVERT_CURVED_GEOMETRIES" ), context );
   mCoordOp = parameterAsString( parameters, QStringLiteral( "OPERATION" ), context );
   return true;
 }
@@ -107,8 +114,12 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
   if ( feature.hasGeometry() )
   {
     QgsGeometry g = feature.geometry();
-    // convert to straight segments to avoid issues with distorted curves
-    g.convertToStraightSegment();
+
+    if ( !mTransform.isShortCircuited() && mConvertCurveToSegments )
+    {
+      // convert to straight segments to avoid issues with distorted curves
+      g.convertToStraightSegment();
+    }
     try
     {
       if ( g.transform( mTransform ) == Qgis::GeometryOperationResult::Success )

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -107,6 +107,8 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
   if ( feature.hasGeometry() )
   {
     QgsGeometry g = feature.geometry();
+    // convert to straight segments to avoid issues with distorted curves
+    g.convertToStraightSegment();
     try
     {
       if ( g.transform( mTransform ) == Qgis::GeometryOperationResult::Success )

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -58,6 +58,7 @@ class QgsTransformAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsCoordinateReferenceSystem mDestCrs;
     QgsCoordinateTransform mTransform;
     QgsCoordinateTransformContext mTransformContext;
+    bool mConvertCurveToSegments = false;
     QString mCoordOp;
     bool mWarnedAboutFallbackTransform = false;
 


### PR DESCRIPTION
Fixes #25167 (conjointly with #51943 and #51931)

## Description

When reprojecting a layer containing curved geometries (`native:reprojectlayer`), the curves appear distorted.
This PR fix the issue by converting the geometries to straight segments prior to applying the transformation.

### Before
![reproject_bug](https://user-images.githubusercontent.com/9693475/220207072-00c1132f-690c-4bc8-99b8-bb04732406b2.gif)


### After
![reproject_fix](https://user-images.githubusercontent.com/9693475/220207080-b9a51e39-0b31-4624-8eed-44851c2d2c65.gif)

