### PR TITLE
qgs3dmapscene: remove unnecessary onRenderersChanged logic

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -326,15 +326,6 @@ Empty map theme name means that the map theme is not overridden and the current 
 %End
 
 
-    void setRenderers( const QList<QgsAbstract3DRenderer *> &renderers /Transfer/ );
-%Docstring
-Sets list of extra 3D renderers to use in the scene. Takes ownership of the objects.
-%End
-    QList<QgsAbstract3DRenderer *> renderers() const;
-%Docstring
-Returns list of extra 3D renderers
-%End
-
     void setShowTerrainBoundingBoxes( bool enabled );
 %Docstring
 Sets whether to display bounding boxes of terrain tiles (for debugging)

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -133,7 +133,6 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
   connect( &map, &Qgs3DMapSettings::showLightSourceOriginsChanged, this, &Qgs3DMapScene::updateLights );
   connect( &map, &Qgs3DMapSettings::fieldOfViewChanged, this, &Qgs3DMapScene::updateCameraLens );
   connect( &map, &Qgs3DMapSettings::projectionTypeChanged, this, &Qgs3DMapScene::updateCameraLens );
-  connect( &map, &Qgs3DMapSettings::renderersChanged, this, &Qgs3DMapScene::onRenderersChanged );
   connect( &map, &Qgs3DMapSettings::skyboxSettingsChanged, this, &Qgs3DMapScene::onSkyboxSettingsChanged );
   connect( &map, &Qgs3DMapSettings::shadowSettingsChanged, this, &Qgs3DMapScene::onShadowSettingsChanged );
   connect( &map, &Qgs3DMapSettings::ambientOcclusionSettingsChanged, this, &Qgs3DMapScene::onAmbientOcclusionSettingsChanged );
@@ -183,10 +182,6 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
       }
     }
   } );
-
-  // create entities of renderers
-
-  onRenderersChanged();
 
   // listen to changes of layers in order to add/remove 3D renderer entities
   connect( &map, &Qgs3DMapSettings::layersChanged, this, &Qgs3DMapScene::onLayersChanged );
@@ -682,26 +677,6 @@ void Qgs3DMapScene::updateCameraLens()
   mEngine->camera()->lens()->setFieldOfView( mMap.fieldOfView() );
   mEngine->camera()->lens()->setProjectionType( mMap.projectionType() );
   onCameraChanged();
-}
-
-void Qgs3DMapScene::onRenderersChanged()
-{
-  // remove entities (if any)
-  qDeleteAll( mRenderersEntities );
-  mRenderersEntities.clear();
-
-  // re-add entities from new set of renderers
-  const QList<QgsAbstract3DRenderer *> renderers = mMap.renderers();
-  for ( const QgsAbstract3DRenderer *renderer : renderers )
-  {
-    Qt3DCore::QEntity *newEntity = renderer->createEntity( mMap );
-    if ( newEntity )
-    {
-      newEntity->setParent( this );
-      finalizeNewEntity( newEntity );
-      mRenderersEntities[renderer] = newEntity;
-    }
-  }
 }
 
 void Qgs3DMapScene::onLayerRenderer3DChanged()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -232,7 +232,6 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void onLayerEntityPickedObject( Qt3DRender::QPickEvent *pickEvent, QgsFeatureId fid );
     void updateLights();
     void updateCameraLens();
-    void onRenderersChanged();
     void onSkyboxSettingsChanged();
     void onShadowSettingsChanged();
     void onAmbientOcclusionSettingsChanged();
@@ -275,7 +274,6 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     Qt3DCore::QEntity *mEntityCameraViewCenter = nullptr;
     //! Keeps track of entities that belong to a particular layer
     QMap<QgsMapLayer *, Qt3DCore::QEntity *> mLayerEntities;
-    QMap<const QgsAbstract3DRenderer *, Qt3DCore::QEntity *> mRenderersEntities;
     bool mTerrainUpdateScheduled = false;
     SceneState mSceneState = Ready;
     //! List of currently registered pick handlers (used by identify tool)

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -339,11 +339,6 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     // misc configuration
     //
 
-    //! Sets list of extra 3D renderers to use in the scene. Takes ownership of the objects.
-    void setRenderers( const QList<QgsAbstract3DRenderer *> &renderers SIP_TRANSFER );
-    //! Returns list of extra 3D renderers
-    QList<QgsAbstract3DRenderer *> renderers() const { return mRenderers; }
-
     //! Sets whether to display bounding boxes of terrain tiles (for debugging)
     void setShowTerrainBoundingBoxes( bool enabled );
     //! Returns whether to display bounding boxes of terrain tiles (for debugging)
@@ -923,7 +918,6 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
     double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
-    QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object
     //! Coordinate transform context
     QgsCoordinateTransformContext mTransformContext;
     QgsPathResolver mPathResolver;


### PR DESCRIPTION
## Description

This logic is already handled by `onLayersChanged` and
`onLayerRenderer3DChanged`:

- `onLayersChanged` creates or remove an entity when a layer is added or removed
- `onLayerRenderer3DChanged` recreates an entity when a layer's renderer is changed

cc @benoitdm-oslandia @wonder-sk 

## Update

### 2023-02-27

- Removed the `renderers` storage logic in `Qgs3DMapSettings` this is never used as mentionned by @uclaros 