### PR TITLE
[3D] prevent recreating an entity too many times on a renderer change

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -746,7 +746,6 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
   if ( layer->type() == Qgis::LayerType::PointCloud )
   {
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
-    connect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     connect( pclayer, &QgsPointCloudLayer::subsetStringChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 }
@@ -781,7 +780,6 @@ void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
   if ( layer->type() == Qgis::LayerType::PointCloud )
   {
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
-    disconnect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     disconnect( pclayer, &QgsPointCloudLayer::subsetStringChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
 }

--- a/src/app/mesh/qgsmeshelevationpropertieswidget.cpp
+++ b/src/app/mesh/qgsmeshelevationpropertieswidget.cpp
@@ -91,12 +91,20 @@ void QgsMeshElevationPropertiesWidget::apply()
     return;
 
   QgsMeshLayerElevationProperties *props = qgis::down_cast< QgsMeshLayerElevationProperties * >( mLayer->elevationProperties() );
+
+  const bool changed3DrelatedProperties = !qgsDoubleNear( mOffsetZSpinBox->value(), props->zOffset() )
+                                          || !qgsDoubleNear( mScaleZSpinBox->value(), props->zScale() );
+
   props->setZOffset( mOffsetZSpinBox->value() );
   props->setZScale( mScaleZSpinBox->value() );
   props->setProfileLineSymbol( mLineStyleButton->clonedSymbol< QgsLineSymbol >() );
   props->setProfileFillSymbol( mFillStyleButton->clonedSymbol< QgsFillSymbol >() );
   props->setProfileSymbology( static_cast< Qgis::ProfileSurfaceSymbology >( mStyleComboBox->currentData().toInt() ) );
-  mLayer->trigger3DUpdate();
+
+  if ( changed3DrelatedProperties )
+  {
+    mLayer->trigger3DUpdate();
+  }
 }
 
 void QgsMeshElevationPropertiesWidget::onChanged()

--- a/src/app/mesh/qgsmeshelevationpropertieswidget.cpp
+++ b/src/app/mesh/qgsmeshelevationpropertieswidget.cpp
@@ -141,4 +141,3 @@ QString QgsMeshElevationPropertiesWidgetFactory::layerPropertiesPagePositionHint
 {
   return QStringLiteral( "mOptsPage_Metadata" );
 }
-

--- a/src/app/raster/qgsrasterelevationpropertieswidget.cpp
+++ b/src/app/raster/qgsrasterelevationpropertieswidget.cpp
@@ -96,6 +96,12 @@ void QgsRasterElevationPropertiesWidget::apply()
     return;
 
   QgsRasterLayerElevationProperties *props = qgis::down_cast< QgsRasterLayerElevationProperties * >( mLayer->elevationProperties() );
+
+  const bool changed3DrelatedProperties = props->isEnabled() != mElevationGroupBox->isChecked()
+                                          || !qgsDoubleNear( mOffsetZSpinBox->value(), props->zOffset() )
+                                          || !qgsDoubleNear( mScaleZSpinBox->value(), props->zScale() )
+                                          || props->bandNumber() != mBandComboBox->currentBand();
+
   props->setEnabled( mElevationGroupBox->isChecked() );
   props->setZOffset( mOffsetZSpinBox->value() );
   props->setZScale( mScaleZSpinBox->value() );
@@ -103,7 +109,11 @@ void QgsRasterElevationPropertiesWidget::apply()
   props->setProfileFillSymbol( mFillStyleButton->clonedSymbol< QgsFillSymbol >() );
   props->setProfileSymbology( static_cast< Qgis::ProfileSurfaceSymbology >( mStyleComboBox->currentData().toInt() ) );
   props->setBandNumber( mBandComboBox->currentBand() );
-  mLayer->trigger3DUpdate();
+
+  if ( changed3DrelatedProperties )
+  {
+    mLayer->trigger3DUpdate();
+  }
 }
 
 void QgsRasterElevationPropertiesWidget::onChanged()

--- a/src/app/raster/qgsrasterelevationpropertieswidget.cpp
+++ b/src/app/raster/qgsrasterelevationpropertieswidget.cpp
@@ -148,4 +148,3 @@ QString QgsRasterElevationPropertiesWidgetFactory::layerPropertiesPagePositionHi
 {
   return QStringLiteral( "mOptsPage_Metadata" );
 }
-

--- a/src/app/vector/qgsvectorelevationpropertieswidget.cpp
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.cpp
@@ -202,6 +202,13 @@ void QgsVectorElevationPropertiesWidget::apply()
 
   QgsVectorLayerElevationProperties *props = qgis::down_cast< QgsVectorLayerElevationProperties * >( mLayer->elevationProperties() );
 
+  const bool changed3DrelatedProperties = !qgsDoubleNear( mOffsetZSpinBox->value(), props->zOffset() )
+                                          || !qgsDoubleNear( mScaleZSpinBox->value(), props->zScale() )
+                                          || static_cast< Qgis::AltitudeClamping >( mComboClamping->currentData().toInt() ) != props->clamping()
+                                          || static_cast< Qgis::AltitudeBinding >( mComboBinding->currentData().toInt() ) != props->binding()
+                                          || mExtrusionGroupBox->isChecked() != props->extrusionEnabled()
+                                          || mExtrusionSpinBox->value() != props->extrusionHeight();
+
   props->setZOffset( mOffsetZSpinBox->value() );
   props->setZScale( mScaleZSpinBox->value() );
   props->setType( static_cast< Qgis::VectorProfileType >( mTypeComboBox->currentData().toInt() ) );
@@ -230,7 +237,10 @@ void QgsVectorElevationPropertiesWidget::apply()
 
   props->setDataDefinedProperties( mPropertyCollection );
 
-  mLayer->trigger3DUpdate();
+  if ( changed3DrelatedProperties )
+  {
+    mLayer->trigger3DUpdate();
+  }
 }
 
 void QgsVectorElevationPropertiesWidget::onChanged()

--- a/src/app/vector/qgsvectorelevationpropertieswidget.cpp
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.cpp
@@ -417,4 +417,3 @@ QString QgsVectorElevationPropertiesWidgetFactory::layerPropertiesPagePositionHi
 {
   return QStringLiteral( "mOptsPage_Metadata" );
 }
-

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3357,7 +3357,7 @@ void QgsVectorLayer::setFieldAlias( int attIndex, const QString &aliasString )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  if ( attIndex < 0 || attIndex >= fields().count() )
+  if ( attIndex < 0 || attIndex >= fields().count() || mFields[ attIndex ].alias() == aliasString )
     return;
 
   QString name = fields().at( attIndex ).name();


### PR DESCRIPTION
## Description

### issue 

While looking at `Qgs3DMapScene::onLayerRenderer3DChanged()`, I realized that this function was called multiple times when updating a 3D renderer via the layer properties panel. This function can be triggered by the `layerModified`, `renderer3DChanged`  or `request3DUpdate` signals. 

It turns out that this these signals can be emitted by 3 different widgets in a Layer properties : 
- `Elevation` which calls `QgsMapLayer::trigger3DUpdate()` and then emits `QgsMapLayer::request3DUpdate` signal
- `the 3D rendered widget` with the `QgsMapLayer::setRenderer3D()` which calls `QgsMapLayer::trigger3DUpdate()` and emits `renderer3DChanged` 
- the fields widget for a vector layer (which is kinda weird) because `QgsVectorLayer::setFieldAlias()` emits `layerModified`

### solutions

Theses issues are solved with the following changes:

For the `elevation` widgets:  apply the logic already used in `QgsPointCloudElevationPropertiesWidget` which is to only call `QgsMapLayer::trigger3DUpdate()` if a relevant 3D property has changed

For the  `fields` widget: check if the alias has really changed. 
As a side note: I'm not sure this really makes sense to trigger a `layerModified` signal for an alias change. There is a TODO note: `// TODO[MD]: should have a different signal?` ;-)

`3D renderer` widget: no change

### limitations and questions

#### `3D renderer` widget

With the current logic, `QgsMapLayer::request3DUpdate` signal is emitted when clicking on the `apply` button even if there isn't any change. I have two ideas to solve this issue but I don't like any of them

1. use the same logic as elevation: check if any property has changed. There can be a lot of properties!
2. compare the previous renderer with the new one. This is already done in `QgsMapLayer::setRenderer3D` but it cannot work because there isn't any appropriate comparison operator on the renderer. The only solution I found would be to write `operator==` for the different renderers and then using dynamic cast in `setRenderer`. It really does not seem like a good idea...

### Is there a difference between `renderer3DChanged` and `request3DUpdate` signals ?

The `request3DUpdate` signal is emitted by `QgsMapLayer::trigger3DUpdate()`
The `renderer3DChanged` signal by `QgsMapLayer::setRenderer3D()`. But `setRenderer3D()` also calls `trigger3DUpdate()` which means that `setRenderer3D()` emits two signals: `renderer3DChanged` and `request3DUpdate`.

These different signals are consumed by `Qgs3DMapScene`. All the layers listen to `request3DUpdate` and only a pointcloud layer also listens to `renderer3DChanged` which is useless because it already listens to `request3DUpdate`

I don't have any pointcloud data to test it but I think one should need to:
- remove the connect(`renderer3DChanged` ) logic of a pointcloud in `Qgs3DMapScene`
- deprecate  `renderer3DChanged` signal because its logic is already covered by  `request3DUpdate`


@benoitdm-oslandia @wonder-sk any thougths ?