### PR TITLE
Support `*.HEIC` HEIF format images in Processing `ImportPhotosAlgorithm`

### DIFF
--- a/src/analysis/processing/qgsalgorithmimportphotos.cpp
+++ b/src/analysis/processing/qgsalgorithmimportphotos.cpp
@@ -65,7 +65,7 @@ void QgsImportPhotosAlgorithm::initAlgorithm( const QVariantMap & )
 
 QString QgsImportPhotosAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Creates a point layer corresponding to the geotagged locations from JPEG images from a source folder. Optionally the folder can be recursively scanned.\n\n"
+  return QObject::tr( "Creates a point layer corresponding to the geotagged locations from JPEG or HEIF/HEIC images from a source folder. Optionally the folder can be recursively scanned.\n\n"
                       "The point layer will contain a single PointZ feature per input file from which the geotags could be read. Any altitude information from the geotags will be used "
                       "to set the point's Z value.\n\n"
                       "Optionally, a table of unreadable or non-geotagged photos can also be created." );
@@ -338,7 +338,7 @@ QVariantMap QgsImportPhotosAlgorithm::processAlgorithm( const QVariantMap &param
   QString invalidDest;
   std::unique_ptr< QgsFeatureSink > invalidSink( parameterAsSink( parameters, QStringLiteral( "INVALID" ), context, invalidDest, invalidFields ) );
 
-  const QStringList nameFilters { "*.jpeg", "*.jpg" };
+  const QStringList nameFilters { "*.jpeg", "*.jpg", "*.heic" };
   QStringList files;
 
   if ( !recurse )
@@ -397,7 +397,17 @@ QVariantMap QgsImportPhotosAlgorithm::processAlgorithm( const QVariantMap &param
       continue;
     }
 
-    if ( char **GDALmetadata = GDALGetMetadata( hDS.get(), nullptr ) )
+    char **GDALmetadata = GDALGetMetadata( hDS.get(), nullptr );
+    if ( ! GDALmetadata )
+    {
+      GDALmetadata = GDALGetMetadata( hDS.get(), "EXIF" );
+    }
+    if ( ! GDALmetadata )
+    {
+      feedback->reportError( QObject::tr( "No metadata found in %1" ).arg( QDir::toNativeSeparators( file ) ) );
+      saveInvalidFile( attributes, true );
+    }
+    else
     {
       if ( !outputSink )
         continue;
@@ -428,11 +438,6 @@ QVariantMap QgsImportPhotosAlgorithm::processAlgorithm( const QVariantMap &param
       f.setAttributes( attributes );
       if ( !outputSink->addFeature( f, QgsFeatureSink::FastInsert ) )
         throw QgsProcessingException( writeFeatureError( outputSink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
-    }
-    else
-    {
-      feedback->reportError( QObject::tr( "No metadata found in %1" ).arg( QDir::toNativeSeparators( file ) ) );
-      saveInvalidFile( attributes, true );
     }
   }
 


### PR DESCRIPTION
Minor changes to allow importing `*.heic` images with GDAL's HEIF image support. 

Firstly we add the file extension to our filter. I wanted to make this conditional on the GDAL driver being available, but our provider layer for GDAL does not seem to allow querying driver availability. Once the GDAL source is open, multiple metadata domains are available, we need to explicitly read the `EXIF` domain explicitly to find the usual GPS tags. 

Using a local build I confirmed with multiple images from an iOS device are imported, all the fields parse OK, attribute table looks good and markers plot correctly. The 'Map Tooltips' preview unfortunately cannot show thumbnails from HEIF format files, that would need some further investigation. 

First time contributor. Closes #51961 