### PR TITLE
Provide a basic way to access open 3d scenes via PyQGIS

### DIFF
--- a/python/3d/3d_auto.sip
+++ b/python/3d/3d_auto.sip
@@ -1,9 +1,11 @@
 // Include auto-generated SIP files
 %Include auto_generated/processing/qgs3dalgorithms.sip
 %Include auto_generated/qgs3d.sip
+%Include auto_generated/qgs3dmapscene.sip
 %Include auto_generated/qgs3dmapsettings.sip
 %Include auto_generated/qgs3dtypes.sip
 %Include auto_generated/qgsabstractvectorlayer3drenderer.sip
+%Include auto_generated/qgscameracontroller.sip
 %Include auto_generated/qgscamerapose.sip
 %Include auto_generated/qgslayoutitem3dmap.sip
 %Include auto_generated/qgsrulebased3drenderer.sip

--- a/python/3d/auto_additions/qgscameracontroller.py
+++ b/python/3d/auto_additions/qgscameracontroller.py
@@ -1,3 +1,0 @@
-# The following has been generated automatically from src/3d/qgscameracontroller.h
-QgsCameraController.NavigationMode.baseClass = QgsCameraController
-QgsCameraController.VerticalAxisInversion.baseClass = QgsCameraController

--- a/python/3d/auto_additions/qgscameracontroller.py
+++ b/python/3d/auto_additions/qgscameracontroller.py
@@ -1,0 +1,3 @@
+# The following has been generated automatically from src/3d/qgscameracontroller.h
+QgsCameraController.NavigationMode.baseClass = QgsCameraController
+QgsCameraController.VerticalAxisInversion.baseClass = QgsCameraController

--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -1,0 +1,180 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgs3dmapscene.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+
+class Qgs3DMapScene : QObject
+{
+%Docstring(signature="appended")
+Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgs3dmapscene.h"
+%End
+  public:
+
+    QgsCameraController *cameraController();
+%Docstring
+Returns camera controller
+%End
+
+
+    void viewZoomFull();
+%Docstring
+Resets camera view to show the whole scene (top view)
+%End
+
+    void setViewFrom2DExtent( const QgsRectangle &extent );
+%Docstring
+Resets camera view to show the extent ``extent`` (top view)
+
+.. versionadded:: 3.26
+%End
+
+    QVector<QgsPointXY> viewFrustum2DExtent();
+%Docstring
+Calculates the 2D extent viewed by the 3D camera as the vertices of the viewed trapezoid
+
+.. versionadded:: 3.26
+%End
+
+    int terrainPendingJobsCount() const;
+%Docstring
+Returns number of pending jobs of the terrain entity
+%End
+
+    int totalPendingJobsCount() const;
+%Docstring
+Returns number of pending jobs for all chunked entities
+
+.. versionadded:: 3.12
+%End
+
+    enum SceneState
+    {
+      Ready,
+      Updating,
+    };
+
+    SceneState sceneState() const;
+%Docstring
+Returns the current state of the scene
+%End
+
+
+    float worldSpaceError( float epsilon, float distance );
+%Docstring
+Given screen error (in pixels) and distance from camera (in 3D world coordinates), this function
+estimates the error in world space. Takes into account camera's field of view and the screen (3D view) size.
+%End
+
+    void exportScene( const Qgs3DMapExportSettings &exportSettings );
+%Docstring
+Exports the scene according to the scene export settings
+%End
+
+
+    QgsRectangle sceneExtent();
+%Docstring
+Returns the scene extent in the map's CRS
+
+.. versionadded:: 3.20
+%End
+
+    QgsDoubleRange elevationRange() const;
+%Docstring
+Returns the scene's elevation range
+
+.. note::
+
+   Only terrain and point cloud layers are taken into account
+
+.. versionadded:: 3.30
+%End
+
+
+
+    static QMap< QString, Qgs3DMapScene * > openScenes();
+%Docstring
+Returns a map of 3D map scenes (by name) open in the QGIS application.
+
+.. note::
+
+   Only available from the QGIS desktop application.
+
+.. versionadded:: 3.30
+%End
+
+
+  signals:
+    void terrainEntityChanged();
+%Docstring
+Emitted when the current terrain entity is replaced by a new one
+%End
+    void terrainPendingJobsCountChanged();
+%Docstring
+Emitted when the number of terrain's pending jobs changes
+%End
+
+    void totalPendingJobsCountChanged();
+%Docstring
+Emitted when the total number of pending jobs changes
+
+.. versionadded:: 3.12
+%End
+    void sceneStateChanged();
+%Docstring
+Emitted when the scene's state has changed
+%End
+
+    void fpsCountChanged( float fpsCount );
+%Docstring
+Emitted when the FPS count changes
+%End
+    void fpsCounterEnabledChanged( bool fpsCounterEnabled );
+%Docstring
+Emitted when the FPS counter is activated or deactivated
+%End
+
+    void viewed2DExtentFrom3DChanged( QVector<QgsPointXY> extent );
+%Docstring
+Emitted when the viewed 2D extent seen by the 3D camera has changed
+
+.. versionadded:: 3.26
+%End
+
+  public slots:
+    void updateTemporal();
+%Docstring
+Updates the temporale entities
+%End
+
+  private:
+    Qgs3DMapScene();
+    Qgs3DMapScene( const Qgs3DMapScene &other );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgs3dmapscene.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -12,9 +12,6 @@
 
 
 
-
-
-
 class Qgs3DMapSettings : QObject, QgsTemporalRangeObject
 {
 %Docstring(signature="appended")

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -30,24 +30,10 @@ Object that controls camera movement based on user input
 %End
   public:
 
-    enum NavigationMode
-    {
-      TerrainBasedNavigation,
-      WalkNavigation
-    };
-
-    enum VerticalAxisInversion
-    {
-      Never,
-      WhenDragging,
-      Always,
-    };
-
-  public:
     ~QgsCameraController();
 
 
-    QgsCameraController::NavigationMode cameraNavigationMode() const;
+    Qgis::NavigationMode cameraNavigationMode() const;
 %Docstring
 Returns the navigation mode used by the camera controller.
 
@@ -68,14 +54,14 @@ Sets the camera movement speed
 .. versionadded:: 3.18
 %End
 
-    QgsCameraController::VerticalAxisInversion verticalAxisInversion() const;
+    Qgis::VerticalAxisInversion verticalAxisInversion() const;
 %Docstring
 Returns the vertical axis inversion behavior.
 
 .. versionadded:: 3.18
 %End
 
-    void setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion );
+    void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
 %Docstring
 Sets the vertical axis ``inversion`` behavior.
 
@@ -188,7 +174,7 @@ the controller ever receives it.
 
   public slots:
 
-    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+    void setCameraNavigationMode( Qgis::NavigationMode navigationMode );
 %Docstring
 Sets the navigation mode used by the camera controller.
 
@@ -211,7 +197,7 @@ Sets the depth buffer image used by the camera controller to calculate world pos
 Emitted when camera has been updated
 %End
 
-    void navigationModeChanged( QgsCameraController::NavigationMode mode );
+    void navigationModeChanged( Qgis::NavigationMode mode );
 %Docstring
 Emitted when the navigation mode is changed using the hotkey ctrl + ~
 %End

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -1,0 +1,252 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscameracontroller.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+
+class QgsCameraController : QObject
+{
+%Docstring(signature="appended")
+Object that controls camera movement based on user input
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgscameracontroller.h"
+%End
+  public:
+
+    enum NavigationMode
+    {
+      TerrainBasedNavigation,
+      WalkNavigation
+    };
+
+    enum VerticalAxisInversion
+    {
+      Never,
+      WhenDragging,
+      Always,
+    };
+
+  public:
+    ~QgsCameraController();
+
+
+    QgsCameraController::NavigationMode cameraNavigationMode() const;
+%Docstring
+Returns the navigation mode used by the camera controller.
+
+.. versionadded:: 3.18
+%End
+
+    double cameraMovementSpeed() const;
+%Docstring
+Returns the camera movement speed
+
+.. versionadded:: 3.18
+%End
+
+    void setCameraMovementSpeed( double movementSpeed );
+%Docstring
+Sets the camera movement speed
+
+.. versionadded:: 3.18
+%End
+
+    QgsCameraController::VerticalAxisInversion verticalAxisInversion() const;
+%Docstring
+Returns the vertical axis inversion behavior.
+
+.. versionadded:: 3.18
+%End
+
+    void setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion );
+%Docstring
+Sets the vertical axis ``inversion`` behavior.
+
+.. versionadded:: 3.18
+%End
+
+    void frameTriggered( float dt );
+%Docstring
+Called internally from 3D scene when a new frame is generated. Updates camera according to keyboard/mouse input
+%End
+
+    void resetView( float distance );
+%Docstring
+Move camera back to the initial position (looking down towards origin of world's coordinates)
+%End
+
+    void setViewFromTop( float worldX, float worldY, float distance, float yaw = 0 );
+%Docstring
+Sets camera to look down towards given point in world coordinate, in given distance from plane with zero elevation
+%End
+
+    QgsVector3D lookingAtPoint() const;
+%Docstring
+Returns the point in the world coordinates towards which the camera is looking
+%End
+
+    void setLookingAtPoint( const QgsVector3D &point, float distance, float pitch, float yaw );
+%Docstring
+Sets the complete camera configuration: the point towards it is looking (in 3D world coordinates), the distance
+of the camera from the point, pitch angle in degrees (0 = looking from the top, 90 = looking from the side) and
+yaw angle in degrees.
+
+.. versionadded:: 3.4
+%End
+
+    void setCameraPose( const QgsCameraPose &camPose );
+%Docstring
+Sets camera pose
+
+.. versionadded:: 3.4
+%End
+
+    QgsCameraPose cameraPose() const;
+%Docstring
+Returns camera pose
+
+.. versionadded:: 3.4
+%End
+
+    float distance() const;
+%Docstring
+Returns distance of the camera from the point it is looking at.
+The value should not be smaller than 10.
+
+.. versionadded:: 3.4
+%End
+
+    float pitch() const;
+%Docstring
+Returns pitch angle in degrees (0 = looking from the top, 90 = looking from the side).
+The angle should range from 0 to 180.
+
+.. versionadded:: 3.4
+%End
+
+    float yaw() const;
+%Docstring
+Returns yaw angle in degrees.  Yaw value of zero means the camera is pointing towards north.
+The angle should range from 0 to 360.
+
+.. versionadded:: 3.4
+%End
+
+    QDomElement writeXml( QDomDocument &doc ) const;
+%Docstring
+Writes camera configuration to the given DOM element
+%End
+    void readXml( const QDomElement &elem );
+%Docstring
+Reads camera configuration from the given DOM element
+%End
+
+    void zoom( float factor );
+%Docstring
+Zoom the map by ``factor``
+%End
+    void tiltUpAroundViewCenter( float deltaPitch );
+%Docstring
+Tilt up the view by ``deltaPitch`` around the view center (camera moves)
+%End
+    void rotateAroundViewCenter( float deltaYaw );
+%Docstring
+Rotate clockwise the view by ``deltaYaw`` around the view center (camera moves)
+%End
+    void setCameraHeadingAngle( float angle );
+%Docstring
+Set camera heading to ``angle`` (used for rotating the view)
+%End
+    void moveView( float tx, float ty );
+%Docstring
+Move the map by ``tx`` and ``ty``
+%End
+
+    bool willHandleKeyEvent( QKeyEvent *event );
+%Docstring
+Returns ``True`` if the camera controller will handle the specified key ``event``,
+preventing it from being instead handled by parents of the 3D window before
+the controller ever receives it.
+%End
+
+  public slots:
+
+    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+%Docstring
+Sets the navigation mode used by the camera controller.
+
+.. versionadded:: 3.18
+%End
+
+    void depthBufferCaptured( const QImage &depthImage );
+%Docstring
+Sets the depth buffer image used by the camera controller to calculate world position from a pixel's coordinates and depth
+
+.. versionadded:: 3.24
+%End
+
+  private:
+    QgsCameraController();
+    QgsCameraController( const QgsCameraController &other );
+  signals:
+    void cameraChanged();
+%Docstring
+Emitted when camera has been updated
+%End
+
+    void navigationModeChanged( QgsCameraController::NavigationMode mode );
+%Docstring
+Emitted when the navigation mode is changed using the hotkey ctrl + ~
+%End
+
+    void cameraMovementSpeedChanged( double speed );
+%Docstring
+Emitted whenever the camera movement speed is changed by the controller.
+%End
+
+    void setCursorPosition( QPoint point );
+%Docstring
+Emitted when the mouse cursor position should be moved to the specified ``point``
+on the map viewport.
+%End
+
+    void requestDepthBufferCapture();
+%Docstring
+Emitted to ask for the depth buffer image
+
+.. versionadded:: 3.24
+%End
+
+    void cameraRotationCenterChanged( QVector3D position );
+%Docstring
+Emitted when the camera rotation center changes
+
+.. versionadded:: 3.24
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscameracontroller.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2343,6 +2343,19 @@ Qgis.LightSourceType.__doc__ = 'Light source types for 3D scenes.\n\n.. versiona
 # --
 Qgis.LightSourceType.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.NavigationMode.TerrainBased.__doc__ = "The default navigation based on the terrain"
+Qgis.NavigationMode.Walk.__doc__ = "Uses WASD keys or arrows to navigate in walking (first person) manner"
+Qgis.NavigationMode.__doc__ = 'The navigation mode used by 3D cameras.\n\n.. versionadded:: 3.30\n\n' + '* ``TerrainBased``: ' + Qgis.NavigationMode.TerrainBased.__doc__ + '\n' + '* ``Walk``: ' + Qgis.NavigationMode.Walk.__doc__
+# --
+Qgis.NavigationMode.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.VerticalAxisInversion.Never.__doc__ = "Never invert vertical axis movements"
+Qgis.VerticalAxisInversion.WhenDragging.__doc__ = "Invert vertical axis movements when dragging in first person modes"
+Qgis.VerticalAxisInversion.Always.__doc__ = "Always invert vertical axis movements"
+Qgis.VerticalAxisInversion.__doc__ = 'Vertical axis inversion options for 3D views.\n\n.. versionadded:: 3.30\n\n' + '* ``Never``: ' + Qgis.VerticalAxisInversion.Never.__doc__ + '\n' + '* ``WhenDragging``: ' + Qgis.VerticalAxisInversion.WhenDragging.__doc__ + '\n' + '* ``Always``: ' + Qgis.VerticalAxisInversion.Always.__doc__
+# --
+Qgis.VerticalAxisInversion.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.ProfileSurfaceSymbology.Line.__doc__ = "The elevation surface will be rendered using a line symbol"
 Qgis.ProfileSurfaceSymbology.FillBelow.__doc__ = "The elevation surface will be rendered using a fill symbol below the surface level"
 Qgis.ProfileSurfaceSymbology.__doc__ = 'Surface symbology type for elevation profile plots.\n\n.. versionadded:: 3.26\n\n' + '* ``Line``: ' + Qgis.ProfileSurfaceSymbology.Line.__doc__ + '\n' + '* ``FillBelow``: ' + Qgis.ProfileSurfaceSymbology.FillBelow.__doc__

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1412,6 +1412,19 @@ The development version
       Directional,
     };
 
+    enum class NavigationMode
+    {
+      TerrainBased,
+      Walk
+    };
+
+    enum class VerticalAxisInversion
+    {
+      Never,
+      WhenDragging,
+      Always,
+    };
+
     enum class ProfileSurfaceSymbology
     {
       Line,

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -85,6 +85,8 @@
 #include "qgspointcloudlayer.h"
 #include "qgspointcloudlayerchunkloader_p.h"
 
+std::function< QMap< QString, Qgs3DMapScene * >() > Qgs3DMapScene::sOpenScenesFunction = [] { return QMap< QString, Qgs3DMapScene * >(); };
+
 Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine )
   : mMap( map )
   , mEngine( engine )
@@ -1243,6 +1245,11 @@ QgsDoubleRange Qgs3DMapScene::elevationRange() const
   const QgsDoubleRange yRange( std::min( yMin, std::numeric_limits<double>::max() ),
                                std::max( yMax, std::numeric_limits<double>::lowest() ) );
   return yRange;
+}
+
+QMap< QString, Qgs3DMapScene * > Qgs3DMapScene::openScenes()
+{
+  return sOpenScenesFunction();
 }
 
 void Qgs3DMapScene::addCameraRotationCenterEntity( QgsCameraController *controller )

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -65,15 +65,14 @@
 #include "qgssourcecache.h"
 #include "qgsterrainentity_p.h"
 #include "qgsterraingenerator.h"
-#include "qgstessellatedpolygongeometry.h"
+#include "qgsdirectionallightsettings.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3drenderer.h"
 #include "qgspoint3dbillboardmaterial.h"
 #include "qgsmaplayertemporalproperties.h"
-
+#include "qgsmaplayerelevationproperties.h"
 #include "qgslinematerial_p.h"
 #include "qgs3dsceneexporter.h"
-#include "qgsabstract3drenderer.h"
 #include "qgs3dmapexportsettings.h"
 #include "qgsmessageoutput.h"
 
@@ -81,9 +80,7 @@
 #include "qgsskyboxsettings.h"
 
 #include "qgswindow3dengine.h"
-#include "qgspointcloudlayerelevationproperties.h"
 #include "qgspointcloudlayer.h"
-#include "qgspointcloudlayerchunkloader_p.h"
 
 std::function< QMap< QString, Qgs3DMapScene * >() > Qgs3DMapScene::sOpenScenesFunction = [] { return QMap< QString, Qgs3DMapScene * >(); };
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -25,6 +25,7 @@
 #include "qgsray3d.h"
 #include "qgscameracontroller.h"
 
+#ifndef SIP_RUN
 namespace Qt3DRender
 {
   class QRenderSettings;
@@ -43,6 +44,8 @@ namespace Qt3DExtras
   class QForwardRenderer;
   class QSkyboxEntity;
 }
+#endif
+
 
 class Qgs3DAxis;
 class QgsAbstract3DEngine;
@@ -60,25 +63,33 @@ class QgsPostprocessingEntity;
 class QgsChunkNode;
 class QgsDoubleRange;
 
-#define SIP_NO_FILE
-
 /**
  * \ingroup 3d
  * \brief Entity that encapsulates our 3D scene - contains all other entities (such as terrain) as children.
  * \note Not available in Python bindings
  * \since QGIS 3.0
  */
+#ifndef SIP_RUN
 class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
 {
+#else
+class _3D_EXPORT Qgs3DMapScene : public QObject
+{
+#endif
+
     Q_OBJECT
   public:
     //! Constructs a 3D scene based on map settings and Qt 3D renderer configuration
-    Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine );
+    Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine ) SIP_SKIP;
 
     //! Returns camera controller
     QgsCameraController *cameraController() { return mCameraController; }
-    //! Returns terrain entity (may be temporarily NULLPTR)
-    QgsTerrainEntity *terrainEntity() { return mTerrain; }
+
+    /**
+     * Returns terrain entity (may be temporarily NULLPTR)
+     * \note Not available in Python bindings
+     */
+    QgsTerrainEntity *terrainEntity() SIP_SKIP { return mTerrain; }
 
     //! Resets camera view to show the whole scene (top view)
     void viewZoomFull();
@@ -117,9 +128,9 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     SceneState sceneState() const { return mSceneState; }
 
     //! Registers an object that will get results of pick events on 3D entities. Does not take ownership of the pick handler. Adds object picker components to 3D entities.
-    void registerPickHandler( Qgs3DMapScenePickHandler *pickHandler );
+    void registerPickHandler( Qgs3DMapScenePickHandler *pickHandler ) SIP_SKIP;
     //! Unregisters previously registered pick handler. Pick handler is not deleted. Also removes object picker components from 3D entities.
-    void unregisterPickHandler( Qgs3DMapScenePickHandler *pickHandler );
+    void unregisterPickHandler( Qgs3DMapScenePickHandler *pickHandler ) SIP_SKIP;
 
     /**
      * Given screen error (in pixels) and distance from camera (in 3D world coordinates), this function
@@ -157,14 +168,28 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
      *
      * \since QGIS 3.26
      */
-    Qgs3DAxis *get3DAxis() { return m3DAxis; }
+    Qgs3DAxis *get3DAxis() SIP_SKIP { return m3DAxis; }
 
     /**
      * Returns the abstract 3D engine
      *
      * \since QGIS 3.26
      */
-    QgsAbstract3DEngine *engine() { return mEngine; }
+    QgsAbstract3DEngine *engine() SIP_SKIP { return mEngine; }
+
+    /**
+     * Returns a map of 3D map scenes (by name) open in the QGIS application.
+     *
+     * \note Only available from the QGIS desktop application.
+     *
+     * \since QGIS 3.30
+     */
+    static QMap< QString, Qgs3DMapScene * > openScenes();
+
+#ifndef SIP_RUN
+    //! Static function for returning open 3D map scenes
+    static std::function< QMap< QString, Qgs3DMapScene * >() > sOpenScenesFunction;
+#endif
 
   signals:
     //! Emitted when the current terrain entity is replaced by a new one
@@ -223,6 +248,11 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     bool updateCameraNearFarPlanes();
 
   private:
+#ifdef SIP_RUN
+    Qgs3DMapScene();
+    Qgs3DMapScene( const Qgs3DMapScene &other );
+#endif
+
     void addLayerEntity( QgsMapLayer *layer );
     void removeLayerEntity( QgsMapLayer *layer );
     void addCameraViewCenterEntity( Qt3DRender::QCamera *camera );

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -26,12 +26,15 @@
 #include "qgspointcloudlayer3drenderer.h"
 #include "qgsprojectelevationproperties.h"
 #include "qgsterrainprovider.h"
+#include "qgslightsource.h"
+#include "qgssymbollayerutils.h"
+#include "qgsrasterlayer.h"
+#include "qgspointlightsettings.h"
+#include "qgsdirectionallightsettings.h"
 
 #include <QDomDocument>
 #include <QDomElement>
 
-#include "qgssymbollayerutils.h"
-#include "qgsrasterlayer.h"
 
 Qgs3DMapSettings::Qgs3DMapSettings()
   : QObject( nullptr )
@@ -151,9 +154,9 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     mProjectionType = static_cast< Qt3DRender::QCameraLens::ProjectionType >( elemCamera.attribute( QStringLiteral( "projection-type" ), QStringLiteral( "1" ) ).toInt() );
     QString cameraNavigationMode = elemCamera.attribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "basic-navigation" ) );
     if ( cameraNavigationMode == QLatin1String( "terrain-based-navigation" ) )
-      mCameraNavigationMode = QgsCameraController::NavigationMode::TerrainBasedNavigation;
+      mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
     else if ( cameraNavigationMode == QLatin1String( "walk-navigation" ) )
-      mCameraNavigationMode = QgsCameraController::NavigationMode::WalkNavigation;
+      mCameraNavigationMode = Qgis::NavigationMode::Walk;
     mCameraMovementSpeed = elemCamera.attribute( QStringLiteral( "camera-movement-speed" ), QStringLiteral( "5.0" ) ).toDouble();
   }
 
@@ -368,10 +371,10 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemCamera.setAttribute( QStringLiteral( "projection-type" ), static_cast< int >( mProjectionType ) );
   switch ( mCameraNavigationMode )
   {
-    case QgsCameraController::TerrainBasedNavigation:
+    case Qgis::NavigationMode::TerrainBased:
       elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "terrain-based-navigation" ) );
       break;
-    case QgsCameraController::WalkNavigation:
+    case Qgis::NavigationMode::Walk:
       elemCamera.setAttribute( QStringLiteral( "camera-navigation-mode" ), QStringLiteral( "walk-navigation" ) );
       break;
   }
@@ -903,7 +906,7 @@ void Qgs3DMapSettings::setProjectionType( const Qt3DRender::QCameraLens::Project
   emit projectionTypeChanged();
 }
 
-void Qgs3DMapSettings::setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode )
+void Qgs3DMapSettings::setCameraNavigationMode( Qgis::NavigationMode navigationMode )
 {
   if ( mCameraNavigationMode == navigationMode )
     return;

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -25,25 +25,19 @@
 
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmaplayerref.h"
-#include "qgsmesh3dsymbol.h"
 #include "qgsphongmaterialsettings.h"
-#include "qgspointlightsettings.h"
-#include "qgsdirectionallightsettings.h"
 #include "qgsterraingenerator.h"
 #include "qgsvector3d.h"
 #include "qgs3daxissettings.h"
 #include "qgsskyboxsettings.h"
 #include "qgsshadowsettings.h"
-#include "qgscameracontroller.h"
 #include "qgstemporalrangeobject.h"
 #include "qgsambientocclusionsettings.h"
 
 class QgsMapLayer;
 class QgsRasterLayer;
-
+class QgsLightSource;
 class QgsAbstract3DRenderer;
-
-
 class QgsReadWriteContext;
 class QgsProject;
 
@@ -500,13 +494,13 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      * Returns the navigation mode used by the camera
      * \since QGIS 3.18
      */
-    QgsCameraController::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
+    Qgis::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
 
     /**
      * Sets the navigation mode for the camera
      * \since QGIS 3.18
      */
-    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+    void setCameraNavigationMode( Qgis::NavigationMode navigationMode );
 #endif
 
     /**
@@ -926,7 +920,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QList< QgsLightSource * > mLightSources; //!< List of light sources in the scene (owned by the settings)
     float mFieldOfView = 45.0f; //<! Camera lens field of view value
     Qt3DRender::QCameraLens::ProjectionType mProjectionType = Qt3DRender::QCameraLens::PerspectiveProjection;  //<! Camera lens projection type
-    QgsCameraController::NavigationMode mCameraNavigationMode = QgsCameraController::NavigationMode::TerrainBasedNavigation;
+    Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
     double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -24,19 +24,11 @@
 #include "qgsvectorlayer.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeedback.h"
-#include "qgsexpression.h"
-#include "qgsexpressionutils.h"
 #include "qgsoffscreen3dengine.h"
-
 #include "qgs3dmapscene.h"
 #include "qgsabstract3dengine.h"
 #include "qgsterraingenerator.h"
 #include "qgscameracontroller.h"
-
-#include "qgsline3dsymbol.h"
-#include "qgspoint3dsymbol.h"
-#include "qgspolygon3dsymbol.h"
-
 #include "qgspointcloudrenderer.h"
 #include "qgspointcloud3dsymbol.h"
 #include "qgspointcloudlayer3drenderer.h"

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -16,8 +16,6 @@
 #ifndef QGS3DUTILS_H
 #define QGS3DUTILS_H
 
-#include "qgis_sip.h"
-
 class QgsLineString;
 class QgsPolygon;
 class QgsFeedback;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -68,6 +68,8 @@ QgsCameraController::QgsCameraController( Qgs3DMapScene *scene )
   mFpsNavTimer->start();
 }
 
+QgsCameraController::~QgsCameraController() = default;
+
 QWindow *QgsCameraController::window() const
 {
   QgsWindow3DEngine *windowEngine = qobject_cast<QgsWindow3DEngine *>( mScene->engine() );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -14,13 +14,12 @@
  ***************************************************************************/
 
 #include "qgscameracontroller.h"
-#include "qgsterrainentity_p.h"
 #include "qgsvector3d.h"
-#include "qgs3dutils.h"
 #include "qgswindow3dengine.h"
 #include "qgs3dmapscene.h"
-
+#include "qgsterrainentity_p.h"
 #include "qgis.h"
+#include "qgs3dutils.h"
 
 #include <QDomDocument>
 #include <Qt3DRender/QCamera>
@@ -76,7 +75,7 @@ QWindow *QgsCameraController::window() const
   return windowEngine ? windowEngine->window() : nullptr;
 }
 
-void QgsCameraController::setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode )
+void QgsCameraController::setCameraNavigationMode( Qgis::NavigationMode navigationMode )
 {
   if ( navigationMode == mCameraNavigationMode )
     return;
@@ -95,7 +94,7 @@ void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
   emit cameraMovementSpeedChanged( mCameraMovementSpeed );
 }
 
-void QgsCameraController::setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion )
+void QgsCameraController::setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion )
 {
   mVerticalAxisInversion = inversion;
 }
@@ -272,11 +271,11 @@ void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
 {
   switch ( mCameraNavigationMode )
   {
-    case TerrainBasedNavigation:
+    case Qgis::NavigationMode::TerrainBased:
       onPositionChangedTerrainNavigation( mouse );
       break;
 
-    case WalkNavigation:
+    case Qgis::NavigationMode::Walk:
       onPositionChangedFlyNavigation( mouse );
       break;
   }
@@ -580,14 +579,14 @@ void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
 {
   switch ( mCameraNavigationMode )
   {
-    case QgsCameraController::WalkNavigation:
+    case Qgis::NavigationMode::Walk:
     {
       const float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) != 0 ? 0.1f : 1.0f ) / 1000.f;
       setCameraMovementSpeed( mCameraMovementSpeed + mCameraMovementSpeed * scaling * wheel->angleDelta().y() );
       break;
     }
 
-    case TerrainBasedNavigation:
+    case Qgis::NavigationMode::TerrainBased:
     {
 
       const float scaling = ( ( wheel->modifiers() & Qt::ControlModifier ) != 0 ? 0.5f : 5.f );
@@ -689,11 +688,11 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
     // switch navigation mode
     switch ( mCameraNavigationMode )
     {
-      case NavigationMode::WalkNavigation:
-        setCameraNavigationMode( NavigationMode::TerrainBasedNavigation );
+      case Qgis::NavigationMode::Walk:
+        setCameraNavigationMode( Qgis::NavigationMode::TerrainBased );
         break;
-      case NavigationMode::TerrainBasedNavigation:
-        setCameraNavigationMode( NavigationMode::WalkNavigation );
+      case Qgis::NavigationMode::TerrainBased:
+        setCameraNavigationMode( Qgis::NavigationMode::Walk );
         break;
     }
     return;
@@ -701,13 +700,13 @@ void QgsCameraController::onKeyPressed( Qt3DInput::QKeyEvent *event )
 
   switch ( mCameraNavigationMode )
   {
-    case WalkNavigation:
+    case Qgis::NavigationMode::Walk:
     {
       onKeyPressedFlyNavigation( event );
       break;
     }
 
-    case TerrainBasedNavigation:
+    case Qgis::NavigationMode::TerrainBased:
     {
       onKeyPressedTerrainNavigation( event );
       break;
@@ -914,12 +913,12 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
       float diffPitch = -0.2f * dy;
       switch ( mVerticalAxisInversion )
       {
-        case Always:
+        case Qgis::VerticalAxisInversion::Always:
           diffPitch *= -1;
           break;
 
-        case WhenDragging:
-        case Never:
+        case Qgis::VerticalAxisInversion::WhenDragging:
+        case Qgis::VerticalAxisInversion::Never:
           break;
       }
 
@@ -931,12 +930,12 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
       float diffPitch = -0.2f * dy;
       switch ( mVerticalAxisInversion )
       {
-        case Always:
-        case WhenDragging:
+        case Qgis::VerticalAxisInversion::Always:
+        case Qgis::VerticalAxisInversion::WhenDragging:
           diffPitch *= -1;
           break;
 
-        case Never:
+        case Qgis::VerticalAxisInversion::Never:
           break;
       }
       const float diffYaw = - 0.2f * dx;
@@ -1011,7 +1010,7 @@ bool QgsCameraController::willHandleKeyEvent( QKeyEvent *event )
 
   switch ( mCameraNavigationMode )
   {
-    case WalkNavigation:
+    case Qgis::NavigationMode::Walk:
     {
       switch ( event->key() )
       {
@@ -1040,7 +1039,7 @@ bool QgsCameraController::willHandleKeyEvent( QKeyEvent *event )
       break;
     }
 
-    case TerrainBasedNavigation:
+    case Qgis::NavigationMode::TerrainBased:
     {
       switch ( event->key() )
       {

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -22,6 +22,7 @@
 #include <Qt3DInput/QMouseEvent>
 #include <QImage>
 
+#ifndef SIP_RUN
 namespace Qt3DInput
 {
   class QKeyEvent;
@@ -36,6 +37,8 @@ namespace Qt3DRender
   class QCamera;
 }
 
+#endif
+
 #include "qgscamerapose.h"
 
 class QDomDocument;
@@ -46,16 +49,20 @@ class QgsVector3D;
 class QgsWindow3DEngine;
 class Qgs3DMapScene;
 
-#define SIP_NO_FILE
-
 /**
  * \ingroup 3d
  * \brief Object that controls camera movement based on user input
  * \note Not available in Python bindings
  * \since QGIS 3.0
  */
+#ifndef SIP_RUN
 class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 {
+#else
+class _3D_EXPORT QgsCameraController : public QObject
+{
+#endif
+
     Q_OBJECT
   public:
 
@@ -78,10 +85,17 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
   public:
     //! Constructs the camera controller with optional parent node that will take ownership
-    QgsCameraController( Qgs3DMapScene *scene );
+    QgsCameraController( Qgs3DMapScene *scene ) SIP_SKIP;
+    ~QgsCameraController() override;
 
-    //! Returns camera that is being controlled
+#ifndef SIP_RUN
+
+    /**
+     * Returns camera that is being controlled
+     * \note Not available in Python bindings
+     */
     Qt3DRender::QCamera *camera() const { return mCamera; }
+#endif
 
     /**
      * Returns the navigation mode used by the camera controller.
@@ -204,6 +218,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void depthBufferCaptured( const QImage &depthImage );
 
   private:
+#ifdef SIP_RUN
+    QgsCameraController();
+    QgsCameraController( const QgsCameraController &other );
+#endif
+
     void rotateCamera( float diffPitch, float diffYaw );
     void updateCameraFromPose();
     void moveCameraPositionBy( const QVector3D &posDiff );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -66,24 +66,6 @@ class _3D_EXPORT QgsCameraController : public QObject
     Q_OBJECT
   public:
 
-    //! The navigation mode used by the camera
-    enum NavigationMode
-    {
-      TerrainBasedNavigation, //!< The default navigation based on the terrain
-      WalkNavigation //!< Uses WASD keys or arrows to navigate in walking (first person) manner
-    };
-    Q_ENUM( NavigationMode )
-
-    //! Vertical axis inversion options
-    enum VerticalAxisInversion
-    {
-      Never, //!< Never invert vertical axis movements
-      WhenDragging, //!< Invert vertical axis movements when dragging in first person modes
-      Always, //!< Always invert vertical axis movements
-    };
-    Q_ENUM( VerticalAxisInversion )
-
-  public:
     //! Constructs the camera controller with optional parent node that will take ownership
     QgsCameraController( Qgs3DMapScene *scene ) SIP_SKIP;
     ~QgsCameraController() override;
@@ -101,7 +83,7 @@ class _3D_EXPORT QgsCameraController : public QObject
      * Returns the navigation mode used by the camera controller.
      * \since QGIS 3.18
      */
-    QgsCameraController::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
+    Qgis::NavigationMode cameraNavigationMode() const { return mCameraNavigationMode; }
 
     /**
      * Returns the camera movement speed
@@ -119,13 +101,13 @@ class _3D_EXPORT QgsCameraController : public QObject
      * Returns the vertical axis inversion behavior.
      * \since QGIS 3.18
      */
-    QgsCameraController::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversion; }
+    Qgis::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversion; }
 
     /**
      * Sets the vertical axis \a inversion behavior.
      * \since QGIS 3.18
      */
-    void setVerticalAxisInversion( QgsCameraController::VerticalAxisInversion inversion );
+    void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
 
     //! Called internally from 3D scene when a new frame is generated. Updates camera according to keyboard/mouse input
     void frameTriggered( float dt );
@@ -209,7 +191,7 @@ class _3D_EXPORT QgsCameraController : public QObject
      * Sets the navigation mode used by the camera controller.
      * \since QGIS 3.18
      */
-    void setCameraNavigationMode( QgsCameraController::NavigationMode navigationMode );
+    void setCameraNavigationMode( Qgis::NavigationMode navigationMode );
 
     /**
      * Sets the depth buffer image used by the camera controller to calculate world position from a pixel's coordinates and depth
@@ -234,7 +216,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     void cameraChanged();
 
     //! Emitted when the navigation mode is changed using the hotkey ctrl + ~
-    void navigationModeChanged( QgsCameraController::NavigationMode mode );
+    void navigationModeChanged( Qgis::NavigationMode mode );
 
     /**
      * Emitted whenever the camera movement speed is changed by the controller.
@@ -323,8 +305,8 @@ class _3D_EXPORT QgsCameraController : public QObject
 
     Qt3DInput::QMouseHandler *mMouseHandler = nullptr;
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
-    NavigationMode mCameraNavigationMode = NavigationMode::TerrainBasedNavigation;
-    VerticalAxisInversion mVerticalAxisInversion = WhenDragging;
+    Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
+    Qgis::VerticalAxisInversion mVerticalAxisInversion = Qgis::VerticalAxisInversion::WhenDragging;
     double mCameraMovementSpeed = 5.0;
 
     QSet< int > mDepressedKeys;

--- a/src/3d/symbols/qgspoint3dbillboardmaterial.cpp
+++ b/src/3d/symbols/qgspoint3dbillboardmaterial.cpp
@@ -81,6 +81,8 @@ QgsPoint3DBillboardMaterial::QgsPoint3DBillboardMaterial()
   setEffect( effect );
 }
 
+QgsPoint3DBillboardMaterial::~QgsPoint3DBillboardMaterial() = default;
+
 void QgsPoint3DBillboardMaterial::setSize( const QSizeF size )
 {
   mSize->setValue( size );

--- a/src/3d/symbols/qgspoint3dbillboardmaterial.h
+++ b/src/3d/symbols/qgspoint3dbillboardmaterial.h
@@ -24,6 +24,8 @@
 
 #define SIP_NO_FILE
 
+class QgsMarkerSymbol;
+
 /**
  * \ingroup 3d
  * \brief Material of the billboard rendering for points in 3D map view.
@@ -38,6 +40,7 @@ class QgsPoint3DBillboardMaterial : public Qt3DRender::QMaterial
 
   public:
     QgsPoint3DBillboardMaterial();
+    ~QgsPoint3DBillboardMaterial() override;
 
     //! Set the billboard size.
     void setSize( const QSizeF size );

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -21,23 +21,14 @@
 #include <Qt3DLogic/QFrameAction>
 #include <QMouseEvent>
 
-
 #include "qgscameracontroller.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dmapscene.h"
 #include "qgs3dmaptool.h"
 #include "qgswindow3dengine.h"
 #include "qgs3dnavigationwidget.h"
-#include "qgsproject.h"
-#include "qgsprojectviewsettings.h"
 #include "qgssettings.h"
 #include "qgstemporalcontroller.h"
-#include "qgsflatterraingenerator.h"
-#include "qgsonlineterraingenerator.h"
-#include "qgsray3d.h"
-#include "qgs3dutils.h"
-#include "qgsoffscreen3dengine.h"
-#include "qgscoordinatetransform.h"
 
 Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
   : QWidget( parent )
@@ -296,7 +287,7 @@ QSize Qgs3DMapCanvas::windowSize() const
   return mEngine->size();
 }
 
-void Qgs3DMapCanvas::onNavigationModeChanged( QgsCameraController::NavigationMode mode )
+void Qgs3DMapCanvas::onNavigationModeChanged( Qgis::NavigationMode mode )
 {
   mMap->setCameraNavigationMode( mode );
 }

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -149,7 +149,7 @@ class Qgs3DMapCanvas : public QWidget
 
   private slots:
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
-    void onNavigationModeChanged( QgsCameraController::NavigationMode mode );
+    void onNavigationModeChanged( Qgis::NavigationMode mode );
 
   protected:
     void resizeEvent( QResizeEvent *ev ) override;

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -21,22 +21,17 @@
 #include "qgsonlineterraingenerator.h"
 #include "qgsmeshterraingenerator.h"
 #include "qgs3dutils.h"
-
 #include "qgsguiutils.h"
 #include "qgsmapcanvas.h"
-#include "qgsmapthemecollection.h"
 #include "qgsrasterlayer.h"
 #include "qgsmeshlayer.h"
 #include "qgsproject.h"
-#include "qgsprojectviewsettings.h"
 #include "qgsmesh3dsymbolwidget.h"
 #include "qgssettings.h"
 #include "qgsskyboxrenderingsettingswidget.h"
 #include "qgsshadowrenderingsettingswidget.h"
 #include "qgsambientocclusionsettingswidget.h"
 #include "qgs3dmapcanvas.h"
-#include "qgs3dmapscene.h"
-#include "qgs3daxis.h"
 
 Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas *mainCanvas, Qgs3DMapCanvas *mapCanvas3D, QWidget *parent )
   : QWidget( parent )
@@ -54,8 +49,8 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   const int iconSize = QgsGuiUtils::scaleIconSize( 20 );
   m3DOptionsListWidget->setIconSize( QSize( iconSize, iconSize ) ) ;
 
-  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QgsCameraController::TerrainBasedNavigation );
-  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QgsCameraController::WalkNavigation );
+  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QVariant::fromValue( Qgis::NavigationMode::TerrainBased ) );
+  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QVariant::fromValue( Qgis::NavigationMode::Walk ) );
 
   // get rid of annoying outer focus rect on Mac
   m3DOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
@@ -143,7 +138,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   spinCameraFieldOfView->setValue( mMap->fieldOfView() );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( mMap->projectionType() ) );
-  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( mMap->cameraNavigationMode() ) );
+  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( mMap->cameraNavigationMode() ) ) );
   mCameraMovementSpeed->setValue( mMap->cameraMovementSpeed() );
   spinTerrainScale->setValue( mMap->terrainVerticalScale() );
   spinMapResolution->setValue( mMap->mapTileResolution() );
@@ -345,7 +340,7 @@ void Qgs3DMapConfigWidget::apply()
 
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
   mMap->setProjectionType( cboCameraProjectionType->currentData().value< Qt3DRender::QCameraLens::ProjectionType >() );
-  mMap->setCameraNavigationMode( static_cast<QgsCameraController::NavigationMode>( mCameraNavigationModeCombo->currentData().toInt() ) );
+  mMap->setCameraNavigationMode( mCameraNavigationModeCombo->currentData().value< Qgis::NavigationMode>() );
   mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );
   mMap->setMapTileResolution( spinMapResolution->value() );

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -17,8 +17,6 @@
 #include "qgsapplication.h"
 #include "qgssettings.h"
 #include "qgis.h"
-#include "qgsgui.h"
-#include "qgscameracontroller.h"
 #include <Qt3DRender/QCamera>
 
 //
@@ -32,25 +30,25 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
 
   layout()->setContentsMargins( 0, 0, 0, 0 );
 
-  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QgsCameraController::TerrainBasedNavigation );
-  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QgsCameraController::WalkNavigation );
+  mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QVariant::fromValue( Qgis::NavigationMode::TerrainBased ) );
+  mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QVariant::fromValue( Qgis::NavigationMode::Walk ) );
 
   cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
   cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
 
-  mInvertVerticalAxisCombo->addItem( tr( "Never" ), QgsCameraController::Never );
-  mInvertVerticalAxisCombo->addItem( tr( "Only When Dragging" ), QgsCameraController::WhenDragging );
-  mInvertVerticalAxisCombo->addItem( tr( "Always" ), QgsCameraController::Always );
+  mInvertVerticalAxisCombo->addItem( tr( "Never" ), QVariant::fromValue( Qgis::VerticalAxisInversion::Never ) );
+  mInvertVerticalAxisCombo->addItem( tr( "Only When Dragging" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenDragging ) );
+  mInvertVerticalAxisCombo->addItem( tr( "Always" ), QVariant::fromValue( Qgis::VerticalAxisInversion::Always ) );
 
   mCameraMovementSpeed->setClearValue( 4 );
   spinCameraFieldOfView->setClearValue( 45.0 );
 
   QgsSettings settings;
-  const QgsCameraController::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), QgsCameraController::TerrainBasedNavigation, QgsSettings::App );
-  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( static_cast< int >( defaultNavMode ) ) );
+  const Qgis::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), Qgis::NavigationMode::TerrainBased, QgsSettings::App );
+  mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( defaultNavMode ) ) );
 
-  const QgsCameraController::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), QgsCameraController::WhenDragging, QgsSettings::App );
-  mInvertVerticalAxisCombo->setCurrentIndex( mInvertVerticalAxisCombo->findData( static_cast< int >( axisInversion ) ) );
+  const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
+  mInvertVerticalAxisCombo->setCurrentIndex( mInvertVerticalAxisCombo->findData( QVariant::fromValue( axisInversion ) ) );
 
   const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( QStringLiteral( "map3d/defaultProjection" ), Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast< int >( defaultProjection ) ) );
@@ -62,8 +60,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
 void Qgs3DOptionsWidget::apply()
 {
   QgsSettings settings;
-  settings.setValue( QStringLiteral( "map3d/defaultNavigation" ), static_cast< QgsCameraController::NavigationMode >( mCameraNavigationModeCombo->currentData().toInt() ), QgsSettings::App );
-  settings.setValue( QStringLiteral( "map3d/axisInversion" ), static_cast< QgsCameraController::VerticalAxisInversion >( mInvertVerticalAxisCombo->currentData().toInt() ), QgsSettings::App );
+  settings.setEnumValue( QStringLiteral( "map3d/defaultNavigation" ), mCameraNavigationModeCombo->currentData().value< Qgis::NavigationMode >(), QgsSettings::App );
+  settings.setEnumValue( QStringLiteral( "map3d/axisInversion" ), mInvertVerticalAxisCombo->currentData().value< Qgis::VerticalAxisInversion >(), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultProjection" ), static_cast< Qt3DRender::QCameraLens::ProjectionType >( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultMovementSpeed" ), mCameraMovementSpeed->value(), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultFieldOfView" ), spinCameraFieldOfView->value(), QgsSettings::App );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -148,6 +148,7 @@
 #include "qgs3doptions.h"
 #include "qgsmapviewsmanager.h"
 #include "qgs3dmapcanvaswidget.h"
+#include "qgs3dmapscene.h"
 #endif
 
 #ifdef HAVE_GEOREFERENCER
@@ -1817,6 +1818,11 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
 
 #ifdef HAVE_3D
   connect( QgsProject::instance()->viewsManager(), &QgsMapViewsManager::views3DListChanged, this, &QgisApp::views3DMenuAboutToShow );
+
+  Qgs3DMapScene::sOpenScenesFunction = [this]() -> QMap< QString, Qgs3DMapScene * >
+  {
+    return map3DScenes();
+  };
 #endif
 
   setupDuplicateFeaturesAction();
@@ -9412,6 +9418,18 @@ QList<QgsMapCanvas *> QgisApp::mapCanvases()
     return !canvas || canvas->property( "browser_canvas" ).toBool();
   } ), canvases.end() );
   return canvases;
+}
+
+QMap< QString, Qgs3DMapScene * > QgisApp::map3DScenes()
+{
+  QMap< QString, Qgs3DMapScene * > res;
+#ifdef HAVE_3D
+  for ( Qgs3DMapCanvasWidget *canvas3D : std::as_const( mOpen3DMapViews ) )
+  {
+    res.insert( canvas3D->canvasName(), canvas3D->mapCanvas3D()->scene() );
+  }
+#endif
+  return res;
 }
 
 void QgisApp::removeAnnotationItems()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -149,6 +149,7 @@
 #include "qgsmapviewsmanager.h"
 #include "qgs3dmapcanvaswidget.h"
 #include "qgs3dmapscene.h"
+#include "qgsdirectionallightsettings.h"
 #endif
 
 #ifdef HAVE_GEOREFERENCER
@@ -13170,7 +13171,7 @@ void QgisApp::new3DMapCanvas()
     map->setLayers( mMapCanvas->layers( true ) );
     map->setTemporalRange( mMapCanvas->temporalRange() );
 
-    const QgsCameraController::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), QgsCameraController::TerrainBasedNavigation, QgsSettings::App );
+    const Qgis::NavigationMode defaultNavMode = settings.enumValue( QStringLiteral( "map3d/defaultNavigation" ), Qgis::NavigationMode::TerrainBased, QgsSettings::App );
     map->setCameraNavigationMode( defaultNavMode );
 
     map->setCameraMovementSpeed( settings.value( QStringLiteral( "map3d/defaultMovementSpeed" ), 5, QgsSettings::App ).toDouble() );
@@ -13200,7 +13201,7 @@ void QgisApp::new3DMapCanvas()
     float dist = static_cast< float >( std::max( extent.width(), extent.height() ) );
     canvasWidget->mapCanvas3D()->setViewFromTop( mMapCanvas->extent().center(), dist, static_cast< float >( mMapCanvas->rotation() ) );
 
-    const QgsCameraController::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), QgsCameraController::WhenDragging, QgsSettings::App );
+    const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
     if ( canvasWidget->mapCanvas3D()->cameraController() )
       canvasWidget->mapCanvas3D()->cameraController()->setVerticalAxisInversion( axisInversion );
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -159,6 +159,7 @@ class QgsScreenHelper;
 class QgsAppGpsConnection;
 class QgsGpsToolBar;
 class QgsAppGpsSettingsMenu;
+class Qgs3DMapScene;
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -264,6 +265,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Returns a list of all map canvases open in the app.
      */
     QList< QgsMapCanvas * > mapCanvases();
+
+    /**
+     * Returns a map of all 3D map scenes (by name) open in the app.
+     */
+    QMap<QString, Qgs3DMapScene *> map3DScenes();
 
     /**
      * Create a new map canvas with the specified unique \a name.

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2385,6 +2385,31 @@ class CORE_EXPORT Qgis
     Q_ENUM( LightSourceType )
 
     /**
+     * The navigation mode used by 3D cameras.
+     *
+     * \since QGIS 3.30
+     */
+    enum class NavigationMode : int
+    {
+      TerrainBased, //!< The default navigation based on the terrain
+      Walk //!< Uses WASD keys or arrows to navigate in walking (first person) manner
+    };
+    Q_ENUM( NavigationMode )
+
+    /**
+     * Vertical axis inversion options for 3D views.
+     *
+     * \since QGIS 3.30
+     */
+    enum class VerticalAxisInversion : int
+    {
+      Never, //!< Never invert vertical axis movements
+      WhenDragging, //!< Invert vertical axis movements when dragging in first person modes
+      Always, //!< Always invert vertical axis movements
+    };
+    Q_ENUM( VerticalAxisInversion )
+
+    /**
      * Surface symbology type for elevation profile plots.
      *
      * \since QGIS 3.26


### PR DESCRIPTION
Qgs3DMapScene.openScenes() will now return a map of open Qgs3DMapScene objects (by name) visible in the app. Various basic properties of the scene are exposed, including the camera controller, allowing access to navigate 3d scenes via python