### PR TITLE
Don't use scientific notation when generating gdal_translate command from georeferencer

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -57,6 +57,7 @@
 #include "qgsgeoreftooldeletepoint.h"
 #include "qgsgeoreftoolmovepoint.h"
 #include "qgsgcpcanvasitem.h"
+#include "qgscoordinateutils.h"
 
 #include "qgsgcplistwidget.h"
 
@@ -2131,12 +2132,16 @@ QString QgsGeoreferencerMainWindow::generateGDALtranslateCommand( bool generateT
     gdalCommand << QStringLiteral( "-co TFW=YES" );
   }
 
+  const int precision = QgsCoordinateUtils::calculateCoordinatePrecision( mTargetCrs );
   for ( QgsGeorefDataPoint *pt : std::as_const( mPoints ) )
   {
     const QgsPointXY pixel = mGeorefTransform.toSourcePixel( pt->sourcePoint() );
     const QgsPointXY transformedDestinationPoint = pt->transformedDestinationPoint( mTargetCrs, QgsProject::instance()->transformContext() );
-    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pixel.x() ).arg( -pixel.y() )
-                .arg( transformedDestinationPoint.x() ).arg( transformedDestinationPoint.y() );
+    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg(
+                  qgsDoubleToString( pixel.x(), 3 ),
+                  qgsDoubleToString( -pixel.y(), 3 ),
+                  qgsDoubleToString( transformedDestinationPoint.x(), precision ),
+                  qgsDoubleToString( transformedDestinationPoint.y(), precision ) );
   }
 
   QFileInfo rasterFileInfo( mFileName );
@@ -2151,11 +2156,17 @@ QString QgsGeoreferencerMainWindow::generateGDALogr2ogrCommand() const
   QStringList gdalCommand;
   gdalCommand << QStringLiteral( "ogr2ogr" );
 
+  const int sourcePrecision = QgsCoordinateUtils::calculateCoordinatePrecision( mLayer->crs() );
+  const int destPrecision = QgsCoordinateUtils::calculateCoordinatePrecision( mTargetCrs );
+
   for ( QgsGeorefDataPoint *pt : std::as_const( mPoints ) )
   {
     const QgsPointXY dest = pt->transformedDestinationPoint( mTargetCrs, QgsProject::instance()->transformContext() );
-    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pt->sourcePoint().x() ).arg( pt->sourcePoint().y() )
-                .arg( dest.x() ).arg( dest.y() );
+    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg(
+                  qgsDoubleToString( pt->sourcePoint().x(), sourcePrecision ),
+                  qgsDoubleToString( pt->sourcePoint().y(), sourcePrecision ),
+                  qgsDoubleToString( dest.x(), destPrecision ),
+                  qgsDoubleToString( dest.y(), destPrecision ) );
   }
 
   switch ( mTransformMethod )

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -96,6 +96,11 @@ int QgsCoordinateUtils::calculateCoordinatePrecisionForCrs( const QgsCoordinateR
     return prj->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 6 );
   }
 
+  return calculateCoordinatePrecision( crs );
+}
+
+int QgsCoordinateUtils::calculateCoordinatePrecision( const QgsCoordinateReferenceSystem &crs )
+{
   const Qgis::DistanceUnit unit = crs.mapUnits();
   if ( unit == Qgis::DistanceUnit::Degrees )
   {

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -62,13 +62,27 @@ class CORE_EXPORT QgsCoordinateUtils
     Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project = nullptr );
 
     /**
-     * Calculates coordinate precision for a CRS / Project. Considers CRS units and project settings
+     * Calculates coordinate precision for a \a crs and \a project.
+     *
+     * This method checks whether the \a project has explicit precision settings, and if not
+     * calculates a precision based on CRS units.
+     *
      * \param crs Coordinate system
      * \param project QGIS project. Takes QgsProject::instance() if NULL
+     *
      * \returns number of decimal places behind the dot
      * \since QGIS 3.18
      */
     Q_INVOKABLE static int calculateCoordinatePrecisionForCrs( const QgsCoordinateReferenceSystem &crs, QgsProject *project = nullptr );
+
+    /**
+     * Calculates a reasonable coordinate precision for a \a crs.
+     *
+     * This method considers the CRS units only.
+     *
+     * \since QGIS 3.30
+     */
+    Q_INVOKABLE static int calculateCoordinatePrecision( const QgsCoordinateReferenceSystem &crs );
 
     /**
      * Formats a \a point coordinate for use with the specified \a project, respecting the project's

--- a/tests/src/app/testqgsgeoreferencer.cpp
+++ b/tests/src/app/testqgsgeoreferencer.cpp
@@ -848,17 +848,32 @@ void TestQgsGeoreferencer::testGdalCommands()
   QgsGeoreferencerMainWindow window;
   window.openLayer( Qgis::LayerType::Raster, QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ) );
 
-  window.addPoint( QgsPointXY( 783414, 3350122 ), QgsPointXY( 783414, 3350122 ), QgsCoordinateReferenceSystem() );
+  window.addPoint( QgsPointXY( 783414, 3350122 ), QgsPointXY( 783414.001234567, 3350122.002345678 ), QgsCoordinateReferenceSystem() );
   window.addPoint( QgsPointXY( 791344, 3349795 ), QgsPointXY( 791344, 33497952 ), QgsCoordinateReferenceSystem() );
   window.addPoint( QgsPointXY( 783077, 334093 ), QgsPointXY( 783077, 334093 ), QgsCoordinateReferenceSystem() );
   window.addPoint( QgsPointXY( 791134, 3341401 ), QgsPointXY( 791134, 3341401 ), QgsCoordinateReferenceSystem() );
 
   QString command = window.generateGDALtranslateCommand();
   // gdal_translate command must use source pixels, not geographic coordinates
-  QCOMPARE( command, QStringLiteral( "gdal_translate -of GTiff -co TFW=YES -gcp 30.7303 14.0548 783414 3.35012e+06 -gcp 169.853 19.7917 791344 3.3498e+07 -gcp 24.818 52926.8 783077 334093 -gcp 166.169 167.055 791134 3.3414e+06 \"%1\" \"%2\"" ).arg(
+  QCOMPARE( command, QStringLiteral( "gdal_translate -of GTiff -co TFW=YES -gcp 30.73 14.055 783414.001 3350122.002 -gcp 169.853 19.792 791344 33497952 -gcp 24.818 52926.844 783077 334093 -gcp 166.169 167.055 791134 3341401 \"%1\" \"%2\"" ).arg(
               QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ),
               QDir::tempPath() + QStringLiteral( "/landsat.tif" ) ) );
 
+  command = window.generateGDALogr2ogrCommand();
+  QCOMPARE( command, QStringLiteral( "ogr2ogr -gcp 783414 3350122 783414.001 3350122.002 -gcp 791344 3349795 791344 33497952 -gcp 783077 334093 783077 334093 -gcp 791134 3341401 791134 3341401 -tps -t_srs EPSG:32633 \"\" \"%1\"" ).arg(
+              QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ) ) );
+
+  window.mTargetCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  command = window.generateGDALtranslateCommand();
+  QgsDebugMsg( command );
+  QCOMPARE( command, QStringLiteral( "gdal_translate -of GTiff -co TFW=YES -gcp 30.73 14.055 783414.00123457 3350122.00234568 -gcp 169.853 19.792 791344 33497952 -gcp 24.818 52926.844 783077 334093 -gcp 166.169 167.055 791134 3341401 \"%1\" \"%2\"" ).arg(
+              QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ),
+              QDir::tempPath() + QStringLiteral( "/landsat.tif" ) ) );
+
+  command = window.generateGDALogr2ogrCommand();
+  QgsDebugMsg( command );
+  QCOMPARE( command, QStringLiteral( "ogr2ogr -gcp 783414 3350122 783414.00123457 3350122.00234568 -gcp 791344 3349795 791344 33497952 -gcp 783077 334093 783077 334093 -gcp 791134 3341401 791134 3341401 -tps -t_srs EPSG:4326 \"\" \"%1\"" ).arg(
+              QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsGeoreferencer )

--- a/tests/src/core/testqgscoordinateutils.cpp
+++ b/tests/src/core/testqgscoordinateutils.cpp
@@ -24,6 +24,7 @@ class TestQgsCoordinateUtils : public QObject
     Q_OBJECT
   private slots:
 
+    void testPrecisionForCrs();
     void testDegreeWithSuffix();
     void testLocale();
     void initTestCase();
@@ -40,6 +41,16 @@ void TestQgsCoordinateUtils::initTestCase()
 void TestQgsCoordinateUtils::cleanupTestCase()
 {
   QgsApplication::exitQgis();
+}
+
+void TestQgsCoordinateUtils::testPrecisionForCrs()
+{
+  // 8 decimal places for degrees based crs
+  QCOMPARE( QgsCoordinateUtils::calculateCoordinatePrecision( QgsCoordinateReferenceSystem( "EPSG:4326" ) ), 8 );
+  // 3 decimal places for others
+  QCOMPARE( QgsCoordinateUtils::calculateCoordinatePrecision( QgsCoordinateReferenceSystem( "EPSG:3857" ) ), 3 );
+  QCOMPARE( QgsCoordinateUtils::calculateCoordinatePrecision( QgsCoordinateReferenceSystem( "EPSG:3111" ) ), 3 );
+  QCOMPARE( QgsCoordinateUtils::calculateCoordinatePrecision( QgsCoordinateReferenceSystem() ), 3 );
 }
 
 void TestQgsCoordinateUtils::testDegreeWithSuffix()


### PR DESCRIPTION
Fixes #51813
