### PR TITLE
[processing] Don't raise uncaught exceptions when trying to generate GDAL commands for invalid layers

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
@@ -33,8 +33,11 @@ from qgis.PyQt.QtWidgets import (QWidget,
                                  QSizePolicy,
                                  QDialogButtonBox)
 
-from qgis.core import (QgsProcessingFeedback,
-                       QgsProcessingParameterDefinition)
+from qgis.core import (
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProcessingParameterDefinition
+)
 from qgis.gui import (QgsMessageBar,
                       QgsProjectionSelectionWidget,
                       QgsProcessingAlgorithmDialogBase,
@@ -140,9 +143,12 @@ class GdalParametersPanel(ParametersPanel):
                     self.text.setPlainText('')
                     return
 
-            commands = self.algorithm().getConsoleCommands(parameters, context, feedback, executing=False)
-            commands = [c for c in commands if c not in ['cmd.exe', '/C ']]
-            self.text.setPlainText(" ".join(commands))
+            try:
+                commands = self.algorithm().getConsoleCommands(parameters, context, feedback, executing=False)
+                commands = [c for c in commands if c not in ['cmd.exe', '/C ']]
+                self.text.setPlainText(" ".join(commands))
+            except QgsProcessingException as e:
+                self.text.setPlainText(str(e))
         except AlgorithmDialogBase.InvalidParameterValue as e:
             self.text.setPlainText(self.tr("Invalid value for parameter '{0}'").format(e.parameter.description()))
         except AlgorithmDialogBase.InvalidOutputExtension as e:


### PR DESCRIPTION
This is a partial fix, which at least removes the uncaught exception. Ideally we'd gracefully fall back to using the layer's source (even if it doesn't exist!) in the generated GDAL commands. But that's far from trivial to do.

Fixes #51958
