### PR TITLE
QML fix for Qgis class and vcpkg #include fix

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -21,6 +21,8 @@
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 
+#include <QLocale>
+
 ///@cond PRIVATE
 
 QString QgsPackageAlgorithm::name() const

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -54,6 +54,8 @@ int QgisEvent = QEvent::User + 1;
 class CORE_EXPORT Qgis
 {
     Q_GADGET
+    Q_CLASSINFO( "RegisterEnumClassesUnscoped", "false" )
+
   public:
 
     /**

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -13,6 +13,7 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsrasterattributetable.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsogrprovider.h"
@@ -22,6 +23,9 @@
 #include "qgssinglebandpseudocolorrenderer.h"
 #include "qgsrastershader.h"
 #include "qgsrastershaderfunction.h"
+
+#include <QLocale>
+
 #include <mutex>
 #include <cmath>
 


### PR DESCRIPTION
## Description

Regarding the Q_CLASSINFO commit, see https://bugreports.qt.io/browse/QTBUG-73394 , it is added to remove the following errors when registering Qgis in a QML environment:
![image](https://user-images.githubusercontent.com/1728657/221096171-e5f3446b-b71d-4006-b97d-d56a12fb2c13.png)

The missing include fixes a compilation error on vcpkg.