### PR TITLE
[server/OAPIF] Fix prev/next links

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1399,7 +1399,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       if ( offset != 0 )
       {
         json prevLink = selfLink;
-        prevLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, limit - offset ) ).arg( limit ).toStdString();
+        prevLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
         prevLink["rel"] = "prev";
         prevLink["title"] = "Previous page";
         data["links"].push_back( prevLink );

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1383,6 +1383,10 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       {
         cleanedUrlAsString += '?';
       }
+      else
+      {
+        cleanedUrlAsString += '&';
+      }
 
       // Get the self link
       json selfLink;
@@ -1399,7 +1403,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       if ( offset != 0 )
       {
         json prevLink = selfLink;
-        prevLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
+        prevLink["href"] = QStringLiteral( "%1offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
         prevLink["rel"] = "prev";
         prevLink["title"] = "Previous page";
         data["links"].push_back( prevLink );
@@ -1408,7 +1412,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       if ( limit + offset < matchedFeaturesCount )
       {
         json nextLink = selfLink;
-        nextLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
+        nextLink["href"] = QStringLiteral( "%1offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
         nextLink["rel"] = "next";
         nextLink["title"] = "Next page";
         data["links"].push_back( nextLink );

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1401,7 +1401,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
         json prevLink = selfLink;
         prevLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, limit - offset ) ).arg( limit ).toStdString();
         prevLink["rel"] = "prev";
-        prevLink["name"] = "Previous page";
+        prevLink["title"] = "Previous page";
         data["links"].push_back( prevLink );
       }
 
@@ -1410,7 +1410,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
         json nextLink = selfLink;
         nextLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
         nextLink["rel"] = "next";
-        nextLink["name"] = "Next page";
+        nextLink["title"] = "Next page";
         data["links"].push_back( nextLink );
       }
 

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1403,7 +1403,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       if ( offset != 0 )
       {
         json prevLink = selfLink;
-        prevLink["href"] = QStringLiteral( "%1offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
+        prevLink["href"] = cleanedUrlAsString.toStdString() + QStringLiteral( "offset=%1&limit=%2" ).arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
         prevLink["rel"] = "prev";
         prevLink["title"] = "Previous page";
         data["links"].push_back( prevLink );
@@ -1412,7 +1412,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       if ( limit + offset < matchedFeaturesCount )
       {
         json nextLink = selfLink;
-        nextLink["href"] = QStringLiteral( "%1offset=%2&limit=%3" ).arg( cleanedUrlAsString ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
+        nextLink["href"] = cleanedUrlAsString.toStdString() + QStringLiteral( "offset=%1&limit=%2" ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
         nextLink["rel"] = "next";
         nextLink["title"] = "Next page";
         data["links"].push_back( nextLink );

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -627,6 +627,15 @@ class QgsServerAPITest(QgsServerAPITestBase):
         self.assertEqual(response.body(),
                          b'[{"code":"Bad request error","description":"Argument \'limit\' is not valid. Number of features to retrieve [0-10000]"}]')  # Bad request
 
+    def test_wfs3_collection_items_limit_offset_2(self):
+        """Test WFS3 API offset 2"""
+        project = QgsProject()
+        project.read(os.path.join(self.temporary_path, 'qgis_server', 'test_project_api.qgs'))
+        request = QgsBufferServerRequest(
+            'http://server.qgis.org/wfs3/collections/testlayer%20èé/items?limit=1&offset=2')
+        self.compareApi(
+            request, project, 'test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json')
+
     def test_wfs3_collection_items_bbox(self):
         """Test WFS3 API bbox"""
         project = QgsProject()

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
@@ -986,9 +986,8 @@ Content-Type: application/geo+json
     },
     {
       "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http10A10F10Fwww.opengis.net10Fdef10Fcrs10FEPSG10F010F3857&offset=10&limit=10",
-      "name": "Next page",
       "rel": "next",
-      "title": "Retrieve the features of the collection as GEOJSON",
+      "title": "Next page",
       "type": "application/geo+json"
     }
   ],

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
@@ -985,7 +985,7 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http10A10F10Fwww.opengis.net10Fdef10Fcrs10FEPSG10F010F3857&offset=10&limit=10",
+      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857&offset=10&limit=10",
       "rel": "next",
       "title": "Next page",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
@@ -986,9 +986,8 @@ Content-Type: application/geo+json
     },
     {
       "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http10A10F10Fwww.opengis.net10Fdef10Fcrs10FEPSG10F010F4326&offset=10&limit=10",
-      "name": "Next page",
       "rel": "next",
-      "title": "Retrieve the features of the collection as GEOJSON",
+      "title": "Next page",
       "type": "application/geo+json"
     }
   ],

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
@@ -985,7 +985,7 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http10A10F10Fwww.opengis.net10Fdef10Fcrs10FEPSG10F010F4326&offset=10&limit=10",
+      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F4326&offset=10&limit=10",
       "rel": "next",
       "title": "Next page",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
@@ -33,7 +33,7 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=1&limit=1",
+      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=1&limit=1",
       "rel": "next",
       "title": "Next page",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
@@ -34,9 +34,8 @@ Content-Type: application/geo+json
     },
     {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=1&limit=1",
-      "name": "Next page",
       "rel": "next",
-      "title": "Retrieve the features of the collection as GEOJSON",
+      "title": "Next page",
       "type": "application/geo+json"
     }
   ],

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
@@ -34,16 +34,14 @@ Content-Type: application/geo+json
     },
     {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=0&limit=1",
-      "name": "Previous page",
       "rel": "prev",
-      "title": "Retrieve the features of the collection as GEOJSON",
+      "title": "Previous page",
       "type": "application/geo+json"
     },
     {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=2&limit=1",
-      "name": "Next page",
       "rel": "next",
-      "title": "Retrieve the features of the collection as GEOJSON",
+      "title": "Next page",
       "type": "application/geo+json"
     }
   ],

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
@@ -33,13 +33,13 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=0&limit=1",
+      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=0&limit=1",
       "rel": "prev",
       "title": "Previous page",
       "type": "application/geo+json"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=2&limit=1",
+      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=2&limit=1",
       "rel": "next",
       "title": "Next page",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
@@ -1,0 +1,46 @@
+Content-Type: application/geo+json
+
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          8.203459,
+          44.901395
+        ],
+        "type": "Point"
+      },
+      "id": "2",
+      "properties": {
+        "id": 3,
+        "name": "three",
+        "utf8nameè": "three èé↓"
+      },
+      "type": "Feature"
+    }
+  ],
+  "links": [
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson?limit=1&offset=2",
+      "rel": "self",
+      "title": "Retrieve the features of the collection as GEOJSON",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html?limit=1&offset=2",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as HTML",
+      "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=1&limit=1",
+      "rel": "prev",
+      "title": "Previous page",
+      "type": "application/geo+json"
+    }
+  ],
+  "numberMatched": 3,
+  "numberReturned": 1,
+  "timeStamp": "2019-07-05T12:27:07Z",
+  "type": "FeatureCollection"
+}

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
@@ -33,7 +33,7 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?&offset=1&limit=1",
+      "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=1&limit=1",
       "rel": "prev",
       "title": "Previous page",
       "type": "application/geo+json"


### PR DESCRIPTION
Fixes various unreported issues related to OAPIF prev/next links:

- fix `title` key for prev/next links (before a `name` key was created)
- fix offset calculation for prev link
- avoid `?&` for prev/next links query string
- fix unintended replacement of percent encoded URL parts,<br>e.g. CRS query parameter values like `http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857`

Updated/added tests accordingly.