### PR TITLE
Fix Split settings - Add non translatable option page identifier

### DIFF
--- a/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
@@ -96,7 +96,7 @@ Sets the dialog ``page`` (by object name) to show.
 .. versionadded:: 3.14
 %End
 
-    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QStringList &path = QStringList() );
+    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QStringList &path = QStringList(), const QString &key = QString() );
 %Docstring
 Adds a new page to the dialog pages.
 
@@ -107,12 +107,15 @@ The page content is specified via the ``widget`` argument. Ownership of ``widget
 Since QGIS 3.22, the optional ``path`` argument can be used to set the path of the item's entry in the tree view
 (for dialogs which show a tree view of options pages only).
 
+Since QGIS 3.32, the optional ``key`` argument can be used to set an untranslated key that ``path`` can refer to
+in following calls. Default to ``title``.
+
 .. seealso:: :py:func:`insertPage`
 
 .. versionadded:: 3.14
 %End
 
-    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QString &before, const QStringList &path = QStringList() );
+    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QString &before, const QStringList &path = QStringList(), const QString &key = QString() );
 %Docstring
 Inserts a new page into the dialog pages.
 
@@ -125,6 +128,9 @@ before the matching page.
 
 Since QGIS 3.22, the optional ``path`` argument can be used to set the path of the item's entry in the tree view
 (for dialogs which show a tree view of options pages only).
+
+Since QGIS 3.32, the optional ``key`` argument can be used to set an untranslated key that ``path`` can refer to
+in following calls. Default to ``title``.
 
 .. seealso:: :py:func:`addPage`
 

--- a/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -82,7 +82,7 @@ class QgsOptionsWidgetFactory : QObject
 Constructor
 %End
 
-    QgsOptionsWidgetFactory( const QString &title, const QIcon &icon );
+    QgsOptionsWidgetFactory( const QString &title, const QIcon &icon, const QString &key = QString() );
 %Docstring
 Constructor
 %End
@@ -115,6 +115,22 @@ The title of the panel.
 Set the ``title`` for the interface.
 
 .. seealso:: :py:func:`title`
+%End
+
+    virtual QString key() const;
+%Docstring
+The key of the panel (untranslated title).
+
+.. seealso:: :py:func:`setKey`
+
+.. versionadded:: 3.32
+%End
+
+    void setKey( const QString &key );
+%Docstring
+Set the ``key`` for the interface.
+
+.. seealso:: :py:func:`key`
 %End
 
     virtual QString pagePositionHint() const;

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -72,7 +72,7 @@ void Qgs3DOptionsWidget::apply()
 // Qgs3DOptionsFactory
 //
 Qgs3DOptionsFactory::Qgs3DOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "3D" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "3D" ), QIcon(), QStringLiteral( "3d" ) )
 {
 
 }

--- a/src/app/options/qgsadvancedoptions.cpp
+++ b/src/app/options/qgsadvancedoptions.cpp
@@ -54,7 +54,7 @@ QgsSettingsTreeWidget *QgsAdvancedSettingsWidget::settingsTree()
 // QgsAdvancedSettingsOptionsFactory
 //
 QgsAdvancedSettingsOptionsFactory::QgsAdvancedSettingsOptionsFactory()
-  : QgsOptionsWidgetFactory( QCoreApplication::translate( "QgsOptionsBase", "Advanced" ), QIcon() )
+  : QgsOptionsWidgetFactory( QCoreApplication::translate( "QgsOptionsBase", "Advanced" ), QIcon(), QStringLiteral( "advanced" ) )
 {
 
 }

--- a/src/app/options/qgscodeeditoroptions.cpp
+++ b/src/app/options/qgscodeeditoroptions.cpp
@@ -364,7 +364,7 @@ void QgsCodeEditorOptionsWidget::updatePreview()
 // QgsCodeEditorOptionsFactory
 //
 QgsCodeEditorOptionsFactory::QgsCodeEditorOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Code Editor" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "Code Editor" ), QIcon(), QStringLiteral("code_editor") )
 {
 
 }

--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -429,7 +429,7 @@ QString QgsCustomProjectionOptionsWidget::helpKey() const
 // QgsCustomProjectionOptionsFactory
 //
 QgsCustomProjectionOptionsFactory::QgsCustomProjectionOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "User Defined CRS" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "User Defined CRS" ), QIcon(), QStringLiteral( "user_defined_crs" ) )
 {
 
 }

--- a/src/app/options/qgsfontoptions.cpp
+++ b/src/app/options/qgsfontoptions.cpp
@@ -140,7 +140,7 @@ void QgsFontOptionsWidget::apply()
 // QgsFontOptionsFactory
 //
 QgsFontOptionsFactory::QgsFontOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Fonts" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "Fonts" ), QIcon(), QStringLiteral( "fonts" ) )
 {
 }
 

--- a/src/app/options/qgsgpsdeviceoptions.cpp
+++ b/src/app/options/qgsgpsdeviceoptions.cpp
@@ -231,7 +231,7 @@ void QgsGpsDeviceOptionsWidget::renameCurrentDevice()
 // QgsGpsDeviceOptionsFactory
 //
 QgsGpsDeviceOptionsFactory::QgsGpsDeviceOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "GPSBabel" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "GPSBabel" ), QIcon(), QStringLiteral( "gpsbabel" ) )
 {
 
 }

--- a/src/app/options/qgsgpsoptions.cpp
+++ b/src/app/options/qgsgpsoptions.cpp
@@ -438,7 +438,7 @@ void QgsGpsOptionsWidget::updateTimeZones()
 // QgsGpsOptionsFactory
 //
 QgsGpsOptionsFactory::QgsGpsOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "GPS" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "GPS" ), QIcon(), QStringLiteral( "gps" ) )
 {
 
 }

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1157,9 +1157,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     mAdditionalOptionWidgets << page;
     const QString beforePage = factory->pagePositionHint();
     if ( beforePage.isEmpty() )
-      addPage( factory->title(), factory->title(), factory->icon(), page, factory->path() );
+      addPage( factory->title(), factory->title(), factory->icon(), page, factory->path(), factory->key() );
     else
-      insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage, factory->path() );
+      insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage, factory->path(), factory->key() );
 
     if ( QgsAdvancedSettingsWidget *advancedPage = qobject_cast< QgsAdvancedSettingsWidget * >( page ) )
     {

--- a/src/app/options/qgsrasterrenderingoptions.cpp
+++ b/src/app/options/qgsrasterrenderingoptions.cpp
@@ -159,7 +159,7 @@ void QgsRasterRenderingOptionsWidget::saveMinMaxLimits( QComboBox *cbox, const Q
 // QgsRasterRenderingOptionsFactory
 //
 QgsRasterRenderingOptionsFactory::QgsRasterRenderingOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Raster" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "Raster" ), QIcon(), QStringLiteral( "raster" ) )
 {
 
 }

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -77,7 +77,7 @@ void QgsRenderingOptionsWidget::apply()
 // QgsRenderingOptionsFactory
 //
 QgsRenderingOptionsFactory::QgsRenderingOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Rendering" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "Rendering" ), QIcon(),   QStringLiteral( "rendering" ) )
 {
 }
 

--- a/src/app/options/qgsvectorrenderingoptions.cpp
+++ b/src/app/options/qgsvectorrenderingoptions.cpp
@@ -102,7 +102,7 @@ void QgsVectorRenderingOptionsWidget::apply()
 // QgsVectorRenderingOptionsFactory
 //
 QgsVectorRenderingOptionsFactory::QgsVectorRenderingOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Vector" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "Vector" ), QIcon(), QStringLiteral( "vector" ) )
 {
 
 }

--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -160,7 +160,7 @@ bool QgsProjectElevationSettingsWidget::isValid()
 //
 
 QgsProjectElevationSettingsWidgetFactory::QgsProjectElevationSettingsWidgetFactory( QObject *parent )
-  : QgsOptionsWidgetFactory( tr( "Terrain" ), QgsApplication::getThemeIcon( QStringLiteral( "mLayoutItem3DMap.svg" ) ) )
+  : QgsOptionsWidgetFactory( tr( "Terrain" ), QgsApplication::getThemeIcon( QStringLiteral( "mLayoutItem3DMap.svg" ) ), QStringLiteral( "terrain" ) )
 {
   setParent( parent );
 }

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -325,7 +325,7 @@ void QgsOptionsDialogBase::setCurrentPage( const QString &page )
   }
 }
 
-void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QStringList &path )
+void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QStringList &path, const QString &key )
 {
   int newPage = -1;
 
@@ -341,6 +341,10 @@ void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip
   {
     QStandardItem *item = new QStandardItem( icon, title );
     item->setToolTip( tooltip );
+    if ( !key.isEmpty() )
+    {
+      item->setData( key );
+    }
 
     QModelIndex parent;
     QStandardItem *parentItem = nullptr;
@@ -399,7 +403,7 @@ void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip
     mOptStackedWidget->insertWidget( newPage, widget );
 }
 
-void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QString &before, const QStringList &path )
+void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QString &before, const QStringList &path, const QString &key )
 {
   //find the page with a matching widget name
   for ( int page = 0; page < mOptStackedWidget->count(); ++page )
@@ -470,6 +474,10 @@ void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tool
 
         QStandardItem *item = new QStandardItem( icon, title );
         item->setToolTip( tooltip );
+        if ( !key.isEmpty() )
+        {
+          item->setData( key );
+        }
         if ( parentItem )
         {
           if ( sourceBeforeIndices.empty() )

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -152,10 +152,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      * Since QGIS 3.22, the optional \a path argument can be used to set the path of the item's entry in the tree view
      * (for dialogs which show a tree view of options pages only).
      *
+     * Since QGIS 3.32, the optional \a key argument can be used to set an untranslated key that \a path can refer to
+     * in following calls. Default to \a title.
+     *
      * \see insertPage()
      * \since QGIS 3.14
      */
-    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QStringList &path = QStringList() );
+    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QStringList &path = QStringList(), const QString &key = QString() );
 
     /**
      * Inserts a new page into the dialog pages.
@@ -170,10 +173,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      * Since QGIS 3.22, the optional \a path argument can be used to set the path of the item's entry in the tree view
      * (for dialogs which show a tree view of options pages only).
      *
+     * Since QGIS 3.32, the optional \a key argument can be used to set an untranslated key that \a path can refer to
+     * in following calls. Default to \a title.
+     *
      * \see addPage()
      * \since QGIS 3.14
      */
-    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QString &before, const QStringList &path = QStringList() );
+    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QString &before, const QStringList &path = QStringList(), const QString &key = QString() );
 
   public slots:
 

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -113,9 +113,10 @@ class GUI_EXPORT QgsOptionsWidgetFactory : public QObject
     QgsOptionsWidgetFactory() = default;
 
     //! Constructor
-    QgsOptionsWidgetFactory( const QString &title, const QIcon &icon )
+    QgsOptionsWidgetFactory( const QString &title, const QIcon &icon, const QString &key = QString() )
       : mTitle( title )
       , mIcon( icon )
+      , mKey( key )
     {}
 
     /**
@@ -142,6 +143,20 @@ class GUI_EXPORT QgsOptionsWidgetFactory : public QObject
      * \see title()
      */
     void setTitle( const QString &title ) { mTitle = title; }
+
+    /**
+     * The key of the panel (untranslated title).
+     * \see setKey()
+     *
+     * \since QGIS 3.32
+     */
+    virtual QString key() const { return mKey; }
+
+    /**
+     * Set the \a key for the interface.
+     * \see key()
+     */
+    void setKey( const QString &key ) { mKey = key; }
 
     /**
      * Returns a tab name hinting at where this page should be inserted into the
@@ -178,6 +193,7 @@ class GUI_EXPORT QgsOptionsWidgetFactory : public QObject
   private:
     QString mTitle;
     QIcon mIcon;
+    QString mKey;
 
 
 };


### PR DESCRIPTION
- Fixes #50657

## Description

When nesting option pages, the title of the parent page was used to find out where to insert the child option page. In non-english setups, when one of these strings was not translated, the page was not found, causing a duplicated entry to appear in the settings dialog (see #50657)

![duplicated](https://user-images.githubusercontent.com/39594821/197348958-52eebefc-7121-4136-ad6c-75e7b72c6ca2.png)

This PR adds a new `key` parameter to the `QgsOptionsWidgetFactory`, which is a non translatable `QString` that can be used to define the page hierarchy.

![fixed](https://user-images.githubusercontent.com/9693475/221382010-43ba0615-6c53-4d63-9b94-60557456dd9f.png)

