### PR TITLE
[3d] Add walkView() and expose rotateCamera() functions within QgsCameraController

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -111,6 +111,13 @@ Returns the scene's elevation range
 
 
 
+    Qgs3DMapSettings *mapSettings() const;
+%Docstring
+Returns the 3D map settings.
+
+.. versionadded:: 3.30
+%End
+
     static QMap< QString, Qgs3DMapScene * > openScenes();
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -164,6 +164,10 @@ Set camera heading to ``angle`` (used for rotating the view)
 %Docstring
 Move the map by ``tx`` and ``ty``
 %End
+    void walkView( float tx, float ty, float tz );
+%Docstring
+Walk into the map by ``tx``, ``ty``, and ``tz``
+%End
 
     bool willHandleKeyEvent( QKeyEvent *event );
 %Docstring

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -164,9 +164,22 @@ Set camera heading to ``angle`` (used for rotating the view)
 %Docstring
 Move the map by ``tx`` and ``ty``
 %End
+
     void walkView( float tx, float ty, float tz );
 %Docstring
-Walk into the map by ``tx``, ``ty``, and ``tz``
+Walks into the map by ``tx``, ``ty``, and ``tz``
+
+.. versionadded:: 3.30
+%End
+
+    void rotateCamera( float diffPitch, float diffYaw );
+%Docstring
+Rotates the camera on itself.
+
+:param diffPitch: the pitch difference
+:param diffYaw: the yaw difference
+
+.. versionadded:: 3.30
 %End
 
     bool willHandleKeyEvent( QKeyEvent *event );

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -165,7 +165,7 @@ Set camera heading to ``angle`` (used for rotating the view)
 Move the map by ``tx`` and ``ty``
 %End
 
-    void walkView( float tx, float ty, float tz );
+    void walkView( double tx, double ty, double tz );
 %Docstring
 Walks into the map by ``tx``, ``ty``, and ``tz``
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -178,6 +178,13 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     QgsAbstract3DEngine *engine() SIP_SKIP { return mEngine; }
 
     /**
+     * Returns the 3D map settings.
+     *
+     * \since QGIS 3.30
+     */
+    Qgs3DMapSettings *mapSettings() const { return &mMap; }
+
+    /**
      * Returns a map of 3D map scenes (by name) open in the QGIS application.
      *
      * \note Only available from the QGIS desktop application.

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -817,7 +817,7 @@ void QgsCameraController::onKeyPressedFlyNavigation( Qt3DInput::QKeyEvent *event
   mDepressedKeys.insert( event->key() );
 }
 
-void QgsCameraController::walkView( float tx, float ty, float tz )
+void QgsCameraController::walkView( double tx, double ty, double tz )
 {
   const QVector3D cameraUp = mCamera->upVector().normalized();
   const QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
@@ -850,9 +850,9 @@ void QgsCameraController::applyFlyModeKeyMovements()
   const double movementSpeed = mCameraMovementSpeed * ( shiftPressed ? 2 : 1 ) * ( ctrlPressed ? 0.1 : 1 );
 
   bool changed = false;
-  float x = 0.0;
-  float y = 0.0;
-  float z = 0.0;
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
   if ( mDepressedKeys.contains( Qt::Key_Left ) || mDepressedKeys.contains( Qt::Key_A ) )
   {
     changed = true;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -182,7 +182,7 @@ class _3D_EXPORT QgsCameraController : public QObject
      * Walks into the map by \a tx, \a ty, and \a tz
      * \since QGIS 3.30
      */
-    void walkView( float tx, float ty, float tz );
+    void walkView( double tx, double ty, double tz );
 
     /**
      * Rotates the camera on itself.

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -177,6 +177,8 @@ class _3D_EXPORT QgsCameraController : public QObject
     void setCameraHeadingAngle( float angle );
     //! Move the map by \a tx and \a ty
     void moveView( float tx, float ty );
+    //! Walk into the map by \a tx, \a ty, and \a tz
+    void walkView( float tx, float ty, float tz );
 
     /**
      * Returns TRUE if the camera controller will handle the specified key \a event,

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -177,8 +177,20 @@ class _3D_EXPORT QgsCameraController : public QObject
     void setCameraHeadingAngle( float angle );
     //! Move the map by \a tx and \a ty
     void moveView( float tx, float ty );
-    //! Walk into the map by \a tx, \a ty, and \a tz
+
+    /**
+     * Walks into the map by \a tx, \a ty, and \a tz
+     * \since QGIS 3.30
+     */
     void walkView( float tx, float ty, float tz );
+
+    /**
+     * Rotates the camera on itself.
+     * \param diffPitch the pitch difference
+     * \param diffYaw the yaw difference
+     * \since QGIS 3.30
+     */
+    void rotateCamera( float diffPitch, float diffYaw );
 
     /**
      * Returns TRUE if the camera controller will handle the specified key \a event,
@@ -207,7 +219,6 @@ class _3D_EXPORT QgsCameraController : public QObject
     QgsCameraController( const QgsCameraController &other );
 #endif
 
-    void rotateCamera( float diffPitch, float diffYaw );
     void updateCameraFromPose();
     void moveCameraPositionBy( const QVector3D &posDiff );
     //! Returns a pointer to the scene's engine's window or nullptr if engine is QgsOffscreen3DEngine


### PR DESCRIPTION
## Description

Nothing much happening other than exposing a bit of functionality to the (newly-exposed) QgsCameraController python binding. These functions are needed to provide needed flexibility to control camera movement.

E.g., with these functions exposed to the python API, it is possible to use external controllers to come up with really nice navigation functionality:

https://user-images.githubusercontent.com/1728657/221410151-475c5714-f976-4b32-b832-4ef290dfef45.mp4

_It might not be obvious here but no mouse nor keyboard was involved in recording this video :wink:_
