### PR TITLE
[3d] Fix map theme layer visibility not respected

### DIFF
--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -183,7 +183,7 @@ QgsMapSettings QgsTerrainTextureGenerator::baseMapSettings()
   }
   layers.erase( std::remove_if( layers.begin(),
                                 layers.end(),
-  []( const QgsMapLayer * layer ) { return layer->renderer3D() != nullptr; } ),
+  []( const QgsMapLayer * layer ) { return layer->renderer3D(); } ),
   layers.end() );
   mapSettings.setLayers( layers );
 


### PR DESCRIPTION
## Description

By taking the layers list from mMap.layers(), the terrain texture generator cancelled the map theme layer visibility override which had taken place when creating the mapSettings. This meant that setting a map theme for a 3D map scene would only apply layer styling, not layer visibility.

This PR fixes the above, and we get beautiful map themes in 3D map canvases. 