### PR TITLE
[settings] fix missing current option for OWS connections

### DIFF
--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsOwsConnection : public QObject
 
 #ifndef SIP_RUN
     static inline QgsSettingsTreeNamedListNode *sTtreeOwsServices = QgsSettingsTree::sTreeConnections->createNamedListNode( QStringLiteral( "ows" ) );
-    static inline QgsSettingsTreeNamedListNode *sTreeOwsConnections = sTtreeOwsServices->createNamedListNode( QStringLiteral( "connections" ) );
+    static inline QgsSettingsTreeNamedListNode *sTreeOwsConnections = sTtreeOwsServices->createNamedListNode( QStringLiteral( "connections" ), Qgis::SettingsTreeNodeOption::NamedListSelectedItemSetting );
 
     static const QgsSettingsEntryString *settingsUrl;
     static const QgsSettingsEntryVariantMap *settingsHeaders;


### PR DESCRIPTION
@nyalldawson it was not catch until you fixed the flag value in https://github.com/qgis/QGIS/pull/51959/commits/b5d5fb9fd774bd86687670cab8d7cb7d618fb804