### PR TITLE
qgs3daxis: Fix label transparency issues by using a sort policy

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -38,6 +38,7 @@ typedef Qt3DCore::QBuffer Qt3DQBuffer;
 #include <Qt3DRender/QLayer>
 #include <Qt3DRender/QLayerFilter>
 #include <Qt3DRender/QPointLight>
+#include <Qt3DRender/QSortPolicy>
 #include <QWidget>
 #include <QScreen>
 #include <QShortcut>
@@ -307,7 +308,14 @@ Qt3DRender::QViewport *Qgs3DAxis::constructAxisViewport( Qt3DCore::QEntity *pare
   axisCameraSelector->setParent( axisLayerFilter );
   axisCameraSelector->setCamera( mAxisCamera );
 
-  Qt3DRender::QClearBuffers *clearBuffers = new Qt3DRender::QClearBuffers( axisCameraSelector );
+  // This ensures to have the labels (Text2DEntity) rendered after the other objects and therefore
+  // avoid any transparency issue on the labels.
+  Qt3DRender::QSortPolicy *sortPolicy = new Qt3DRender::QSortPolicy( axisCameraSelector );
+  QVector<Qt3DRender::QSortPolicy::SortType> sortTypes = QVector<Qt3DRender::QSortPolicy::SortType>();
+  sortTypes << Qt3DRender::QSortPolicy::BackToFront;
+  sortPolicy->setSortTypes( sortTypes );
+
+  Qt3DRender::QClearBuffers *clearBuffers = new Qt3DRender::QClearBuffers( sortPolicy );
   clearBuffers->setBuffers( Qt3DRender::QClearBuffers::DepthBuffer );
 
   // cppcheck-suppress memleak
@@ -348,7 +356,14 @@ Qt3DRender::QViewport *Qgs3DAxis::constructLabelViewport( Qt3DCore::QEntity *par
   twoDCameraSelector->setParent( twoDLayerFilter );
   twoDCameraSelector->setCamera( mTwoDLabelCamera );
 
-  Qt3DRender::QClearBuffers *clearBuffers = new Qt3DRender::QClearBuffers( twoDCameraSelector );
+  // this ensures to have the labels (Text2DEntity) rendered after the other objects and therefore
+  // avoid any transparency issue on the labels.
+  Qt3DRender::QSortPolicy *sortPolicy = new Qt3DRender::QSortPolicy( twoDCameraSelector );
+  QVector<Qt3DRender::QSortPolicy::SortType> sortTypes = QVector<Qt3DRender::QSortPolicy::SortType>();
+  sortTypes << Qt3DRender::QSortPolicy::BackToFront;
+  sortPolicy->setSortTypes( sortTypes );
+
+  Qt3DRender::QClearBuffers *clearBuffers = new Qt3DRender::QClearBuffers( sortPolicy );
   clearBuffers->setBuffers( Qt3DRender::QClearBuffers::DepthBuffer );
 
   // cppcheck-suppress memleak


### PR DESCRIPTION
This ensures to have the labels (Text2DEntity) rendered after the other objects and therefore avoiding any transparency issues on the labels.


This fixes these kind of issues: sometimes the background of the labels becomes opaque: 

![Capture d’écran du 2023-03-02 19-20-26](https://user-images.githubusercontent.com/497207/222518182-1feb79b3-9d2a-46b7-817c-80278e6de344.png)
