### PR TITLE
Add a save button in layer style panel

### DIFF
--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -42,6 +42,34 @@ Adds properties page from a factory
 .. versionadded:: 3.16
 %End
 
+    void loadDefaultStyle();
+%Docstring
+Loads the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveDefaultStyle();
+%Docstring
+Saves the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void loadStyle();
+%Docstring
+Loads a saved style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveStyleAs();
+%Docstring
+Saves a style when appriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
   protected slots:
 
 };

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -49,6 +49,34 @@ Adds a properties page factory to the raster layer properties dialog.
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 
+    void loadDefaultStyle();
+%Docstring
+Loads the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveDefaultStyle();
+%Docstring
+Saves the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void loadStyle();
+%Docstring
+Loads a saved style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveStyleAs();
+%Docstring
+Saves a style when appriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
   protected slots:
 
 };

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -30,6 +30,34 @@ Adds a properties page factory to the vector layer properties dialog.
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 
+    void loadDefaultStyle();
+%Docstring
+Loads the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveDefaultStyle();
+%Docstring
+Saves the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void loadStyle();
+%Docstring
+Loads a saved style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveStyleAs();
+%Docstring
+Saves a style when appriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
 

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -27,6 +27,34 @@ Vectortile layer properties dialog
 Constructor
 %End
 
+    void loadDefaultStyle();
+%Docstring
+Loads the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveDefaultStyle();
+%Docstring
+Saves the default style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void loadStyle();
+%Docstring
+Loads a saved style when appropriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
+    void saveStyleAs();
+%Docstring
+Saves a style when appriate button is pressed
+
+.. versionadded:: 3.30
+%End
+
   protected slots:
 
 };

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -97,14 +97,38 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
+    /**
+     * Loads the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadDefaultStyle();
+
+    /**
+     * Saves the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveDefaultStyle();
+
+    /**
+     * Loads a saved style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadStyle();
+
+    /**
+     * Saves a style when appriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveStyleAs();
+
   private slots:
     void apply();
     void onCancel();
 
-    void loadDefaultStyle();
-    void saveDefaultStyle();
-    void loadStyle();
-    void saveStyleAs();
     void aboutToShowStyleMenu();
     void loadMetadata();
     void saveMetadataAs();

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -901,9 +901,9 @@ bool QgsLayerStyleManagerWidgetFactory::supportsLayer( QgsMapLayer *layer ) cons
     case Qgis::LayerType::Vector:
     case Qgis::LayerType::Raster:
     case Qgis::LayerType::Mesh:
+    case Qgis::LayerType::VectorTile:
       return true;
 
-    case Qgis::LayerType::VectorTile:
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Annotation:

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -259,6 +259,7 @@ void QgsMeshLayerProperties::loadDefaultStyle()
   if ( defaultLoadedFlag )
   {
     syncToLayer();
+    apply();
   }
   else
   {
@@ -318,6 +319,7 @@ void QgsMeshLayerProperties::loadStyle()
   {
     settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( fileName ).absolutePath() );
     syncToLayer();
+    apply();
   }
   else
   {

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -65,6 +65,34 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
      */
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
+    /**
+     * Loads the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadDefaultStyle();
+
+    /**
+     * Saves the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveDefaultStyle();
+
+    /**
+     * Loads a saved style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadStyle();
+
+    /**
+     * Saves a style when appriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveStyleAs();
+
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
@@ -78,14 +106,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void syncAndRepaint();
     //! Changes layer coordinate reference system
     void changeCrs( const QgsCoordinateReferenceSystem &crs );
-    //! Loads the default style when appropriate button is pressed
-    void loadDefaultStyle();
-    //! Saves the default style when appropriate button is pressed
-    void saveDefaultStyle();
-    //! Loads a saved style when appropriate button is pressed
-    void loadStyle();
-    //! Saves a style when appriate button is pressed
-    void saveStyleAs();
     //! Prepares style menu
     void aboutToShowStyleMenu();
     //! Reloads temporal properties from the provider

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -168,21 +168,9 @@ void QgsMapLayerStyleManagerWidget::addStyle()
 void QgsMapLayerStyleManagerWidget::removeStyle()
 {
   const QString current = mLayer->styleManager()->currentStyle();
-  const QList<QStandardItem *> items = mModel->findItems( current );
-  if ( items.isEmpty() )
-    return;
-
-  QStandardItem *item = items.at( 0 );
   const bool res = mLayer->styleManager()->removeStyle( current );
-  if ( res )
-  {
-    mModel->removeRow( item->row() );
-  }
-  else
-  {
+  if ( !res )
     QgsDebugMsg( QStringLiteral( "Failed to remove current style" ) );
-  }
-
 }
 
 void QgsMapLayerStyleManagerWidget::renameStyle( QStandardItem *item )

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -132,11 +132,11 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
-  menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle_clicked );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs_clicked );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle_clicked );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultStyle_clicked );
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsRasterLayerProperties::aboutToShowStyleMenu );
   buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
@@ -1604,7 +1604,7 @@ void QgsRasterLayerProperties::removeSelectedMetadataUrl()
 // Next four methods for saving and restoring qml style state
 //
 //
-void QgsRasterLayerProperties::loadDefaultStyle_clicked()
+void QgsRasterLayerProperties::loadDefaultStyle()
 {
   bool defaultLoadedFlag = false;
   QString myMessage = mRasterLayer->loadDefaultStyle( defaultLoadedFlag );
@@ -1623,7 +1623,7 @@ void QgsRasterLayerProperties::loadDefaultStyle_clicked()
   }
 }
 
-void QgsRasterLayerProperties::saveDefaultStyle_clicked()
+void QgsRasterLayerProperties::saveDefaultStyle()
 {
 
   apply(); // make sure the style to save is up-to-date
@@ -1648,7 +1648,7 @@ void QgsRasterLayerProperties::saveDefaultStyle_clicked()
 }
 
 
-void QgsRasterLayerProperties::loadStyle_clicked()
+void QgsRasterLayerProperties::loadStyle()
 {
   QgsSettings settings;
   QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
@@ -1681,7 +1681,7 @@ void QgsRasterLayerProperties::loadStyle_clicked()
 }
 
 
-void QgsRasterLayerProperties::saveStyleAs_clicked()
+void QgsRasterLayerProperties::saveStyleAs()
 {
   QgsSettings settings;
   QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -95,6 +95,34 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     bool eventFilter( QObject *obj, QEvent *ev ) override;
 
+    /**
+     * Loads the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadDefaultStyle();
+
+    /**
+     * Saves the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveDefaultStyle();
+
+    /**
+     * Loads a saved style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadStyle();
+
+    /**
+     * Saves a style when appriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveStyleAs();
+
   protected slots:
     //! \brief auto slot executed when the active page in the main widget stack is changed
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
@@ -156,17 +184,8 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     void updateGammaSlider( double value );
 
     void mRenderTypeComboBox_currentIndexChanged( int index );
-    //! Load the default style when appropriate button is pressed.
-    void loadDefaultStyle_clicked();
-    //! Save the default style when appropriate button is pressed.
-    void saveDefaultStyle_clicked();
-    //! Load a saved style when appropriate button is pressed.
-    void loadStyle_clicked();
-    //! Save a style when appriate button is pressed.
-    void saveStyleAs_clicked();
     //! Restore dialog modality and focus, usually after a pixel clicked to pick transparency color
     void restoreWindowModality();
-
 
     //! Load a saved metadata file.
     void loadMetadata();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -975,7 +975,7 @@ void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateRefer
   mMetadataWidget->crsChanged();
 }
 
-void QgsVectorLayerProperties::loadDefaultStyle_clicked()
+void QgsVectorLayerProperties::loadDefaultStyle()
 {
   QString msg;
   bool defaultLoadedFlag = false;
@@ -1036,7 +1036,7 @@ void QgsVectorLayerProperties::loadDefaultStyle_clicked()
   }
 }
 
-void QgsVectorLayerProperties::saveDefaultStyle_clicked()
+void QgsVectorLayerProperties::saveDefaultStyle()
 {
   apply();
   QString errorMsg;
@@ -1452,8 +1452,8 @@ void QgsVectorLayerProperties::aboutToShowStyleMenu()
   }
 
   m->addSeparator();
-  m->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultStyle_clicked );
-  m->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultStyle_clicked );
+  m->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultStyle );
+  m->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultStyle );
 
   // re-add style manager actions!
   m->addSeparator();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1011,6 +1011,7 @@ void QgsVectorLayerProperties::loadDefaultStyle_clicked()
         else
         {
           syncToLayer();
+          apply();
         }
 
         return;
@@ -1026,6 +1027,7 @@ void QgsVectorLayerProperties::loadDefaultStyle_clicked()
   {
     // all worked OK so no need to inform user
     syncToLayer();
+    apply();
   }
   else
   {
@@ -1494,6 +1496,7 @@ void QgsVectorLayerProperties::loadStyle()
         if ( defaultLoadedFlag )
         {
           syncToLayer();
+          apply();
         }
         else
         {
@@ -1519,6 +1522,7 @@ void QgsVectorLayerProperties::loadStyle()
         if ( mLayer->importNamedStyle( myDocument, errorMsg, categories ) )
         {
           syncToLayer();
+          apply();
         }
         else
         {
@@ -1535,6 +1539,7 @@ void QgsVectorLayerProperties::loadStyle()
         if ( defaultLoadedFlag )
         {
           syncToLayer();
+          apply();
         }
         else
         {

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -78,6 +78,34 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     bool eventFilter( QObject *obj, QEvent *ev ) override;
 
+    /**
+     * Loads the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadDefaultStyle();
+
+    /**
+     * Saves the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveDefaultStyle();
+
+    /**
+     * Loads a saved style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadStyle();
+
+    /**
+     * Saves a style when appriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveStyleAs();
+
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
 
@@ -104,8 +132,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void pbnQueryBuilder_clicked();
     void pbnIndex_clicked();
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
-    void loadDefaultStyle_clicked();
-    void saveDefaultStyle_clicked();
     void loadMetadata();
     void saveMetadataAs();
     void saveDefaultMetadata();
@@ -137,14 +163,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     //! Toggle editing of layer
     void toggleEditing();
 
-    //! Save the style
-    void saveStyleAs();
-
     //! Save multiple styles
     void saveMultipleStylesAs();
-
-    //! Load the style
-    void loadStyle();
 
     void aboutToShowStyleMenu();
 

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -43,14 +43,38 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     //! Constructor
     QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 
+    /**
+     * Loads the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadDefaultStyle();
+
+    /**
+     * Saves the default style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveDefaultStyle();
+
+    /**
+     * Loads a saved style when appropriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void loadStyle();
+
+    /**
+     * Saves a style when appriate button is pressed
+     *
+     * \since QGIS 3.30
+     */
+    void saveStyleAs();
+
   private slots:
     void apply();
     void onCancel();
 
-    void loadDefaultStyle();
-    void saveDefaultStyle();
-    void loadStyle();
-    void saveStyleAs();
     void aboutToShowStyleMenu();
     void loadMetadata();
     void saveMetadataAs();


### PR DESCRIPTION
## Description

Saving layer style QML file is already available at 2 places in QGIS, with code duplication:

- The contextual menu of the layer in the layer tree view (code in qgisapp.cpp)
![image](https://user-images.githubusercontent.com/34267385/221554547-92d9d7b4-a798-4645-909c-23727528b0da.png)
- Each of the dedicated layer properties classes, for the layer properties dialogs
![image](https://user-images.githubusercontent.com/34267385/221557079-8858693c-3def-4aac-8f4f-cac266d88973.png)

For the purpose of #51515 a third place of code duplication was going to appear:
- in the layer style panel
![image](https://user-images.githubusercontent.com/34267385/221557617-5135638f-7589-458a-b214-206334d3c61d.png)

To remove code duplication, I had to choose between:
- putting the loading methods of each layer properties classes as `public`
- putting the classes that need to use this method as `friend`

I propose the `friend` option because looking into the code of the style panel, I was able to remove dupllicate code for the saving, saving as default, and open buttons, which mean more methods to change to `public`, where I just needed to add one `friend` statement. This is debatable, and I ask for opinions.

### Testing

I spent time on writing a unit test, but on GUI it's terribly difficult here because it's all about pop-up, and I ended with using QTimers and singleShots to mock user clicks, but it's really unstable (crashes QGIS when the test fails... and stops all the unit test run...).

Here the addition relies on calling code from the layer properties, which is tested, so I think that it's sufficient.

### Other QGIS crash found and fixed

To reproduce:
- Add a new style
- Delete a style
- QGIS crashes

![image](https://user-images.githubusercontent.com/34267385/221559588-a4a511c0-1a95-4890-8709-98c352214228.png)


Reason: the item of the QStandardItemModel was removed twice.

