### PR TITLE
Measure tool copy coordinates

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -59,6 +59,7 @@
 #include "options/qgsadvancedoptions.h"
 #include "qgssettingsentryimpl.h"
 #include "qgssettingsentryenumflag.h"
+#include "qgsmeasuredialog.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -649,9 +650,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   // set the measure tool copy settings
   connect( mSeparatorOther, &QRadioButton::toggled, mSeparatorCustom, &QLineEdit::setEnabled );
-  bool includeHeader = mSettings->value( QStringLiteral( "qgis/measure/clipboard_header" ), false ).toBool();
-  mIncludeHeader->setChecked( includeHeader );
-  const QString sep = mSettings->value( QStringLiteral( "qgis/measure/clipboard_separator" ), QStringLiteral( "\t" ) ).toString();
+  mIncludeHeader->setChecked( QgsMeasureDialog::settingClipboardHeader->value() );
+
+  const QString sep = QgsMeasureDialog::settingClipboardSeparator->value();
 
   if ( sep.isEmpty() || sep == QStringLiteral( "\t" ) )
     mSeparatorTab->setChecked( true );
@@ -1682,7 +1683,7 @@ void QgsOptions::saveOptions()
   bool baseUnit = mKeepBaseUnitCheckBox->isChecked();
   mSettings->setValue( QStringLiteral( "/qgis/measure/keepbaseunit" ), baseUnit );
 
-  mSettings->setValue( QStringLiteral( "/qgis/measure/clipboard_header" ), mIncludeHeader->isChecked() );
+  QgsMeasureDialog::settingClipboardHeader->setValue( mIncludeHeader->isChecked() );
   QString separator;
   if ( mSeparatorTab->isChecked() )
     separator = QStringLiteral( "\t" );
@@ -1696,7 +1697,8 @@ void QgsOptions::saveOptions()
     separator = QStringLiteral( ":" );
   else
     separator = mSeparatorCustom->text();
-  mSettings->setValue( QStringLiteral( "/qgis/measure/clipboard_separator" ), separator );
+
+  QgsMeasureDialog::settingClipboardSeparator->setValue( separator );
 
   //set the color for selections
   QColor myColor = pbnSelectionColor->color();

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -643,16 +643,33 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   // set if base unit of measure tool should be changed
   bool baseUnit = mSettings->value( QStringLiteral( "qgis/measure/keepbaseunit" ), true ).toBool();
-  if ( baseUnit )
-  {
-    mKeepBaseUnitCheckBox->setChecked( true );
-  }
-  else
-  {
-    mKeepBaseUnitCheckBox->setChecked( false );
-  }
+  mKeepBaseUnitCheckBox->setChecked( baseUnit );
+
   mPlanimetricMeasurementsComboBox->setChecked( mSettings->value( QStringLiteral( "measure/planimetric" ), false, QgsSettings::Core ).toBool() );
 
+  // set the measure tool copy settings
+  connect( mSeparatorOther, &QRadioButton::toggled, mSeparatorCustom, &QLineEdit::setEnabled );
+  bool includeHeader = mSettings->value( QStringLiteral( "qgis/measure/clipboard_header" ), false ).toBool();
+  mIncludeHeader->setChecked( includeHeader );
+  const QString sep = mSettings->value( QStringLiteral( "qgis/measure/clipboard_separator" ), QStringLiteral( "\t" ) ).toString();
+
+  if ( sep.isEmpty() || sep == QStringLiteral( "\t" ) )
+    mSeparatorTab->setChecked( true );
+  else if ( sep == QStringLiteral( "," ) )
+    mSeparatorComma->setChecked( true );
+  else if ( sep == QStringLiteral( ";" ) )
+    mSeparatorSemicolon->setChecked( true );
+  else if ( sep == QStringLiteral( " " ) )
+    mSeparatorSpace->setChecked( true );
+  else if ( sep == QStringLiteral( ":" ) )
+    mSeparatorColon->setChecked( true );
+  else
+  {
+    mSeparatorOther->setChecked( true );
+    mSeparatorCustom->setText( sep );
+  }
+
+  // set the default icon size
   cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "qgis/iconSize" ), QGIS_ICON_SIZE ).toString() ) );
 
   // set font size and family
@@ -1664,6 +1681,22 @@ void QgsOptions::saveOptions()
 
   bool baseUnit = mKeepBaseUnitCheckBox->isChecked();
   mSettings->setValue( QStringLiteral( "/qgis/measure/keepbaseunit" ), baseUnit );
+
+  mSettings->setValue( QStringLiteral( "/qgis/measure/clipboard_header" ), mIncludeHeader->isChecked() );
+  QString separator;
+  if ( mSeparatorTab->isChecked() )
+    separator = QStringLiteral( "\t" );
+  else if ( mSeparatorComma->isChecked() )
+    separator = QStringLiteral( "," );
+  else if ( mSeparatorSemicolon->isChecked() )
+    separator = QStringLiteral( ";" );
+  else if ( mSeparatorSpace->isChecked() )
+    separator = QStringLiteral( " " );
+  else if ( mSeparatorColon->isChecked() )
+    separator = QStringLiteral( ":" );
+  else
+    separator = mSeparatorCustom->text();
+  mSettings->setValue( QStringLiteral( "/qgis/measure/clipboard_separator" ), separator );
 
   //set the color for selections
   QColor myColor = pbnSelectionColor->color();

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "qgisapp.h"
+#include "qgsmessagebar.h"
 #include "qgsmeasuredialog.h"
 #include "qgsmeasuretool.h"
 #include "qgsdistancearea.h"
@@ -56,9 +57,15 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
 
   if ( !mMeasureArea )
   {
+    QAction *copyAction = new QAction( tr( "Copy &All" ), this );
     QPushButton *cpb = new QPushButton( tr( "Copy &All" ) );
     buttonBox->addButton( cpb, QDialogButtonBox::ActionRole );
-    connect( cpb, &QAbstractButton::clicked, this, &QgsMeasureDialog::copyMeasurements );
+    connect( cpb, &QAbstractButton::clicked, copyAction, &QAction::trigger );
+    connect( copyAction, &QAction::triggered, this, &QgsMeasureDialog::copyMeasurements );
+
+    // Add context menu in the table
+    mTable->setContextMenuPolicy( Qt::ActionsContextMenu );
+    mTable->addAction( copyAction );
   }
   else
   {
@@ -754,6 +761,9 @@ void QgsMeasureDialog::copyMeasurements()
   }
 
   clipboard->setText( text );
+
+  // Display a message to the user
+  QgisApp::instance()->messageBar()->pushInfo( tr( "Measure" ), tr( "Measurements copied to clipboard" ) );
 }
 
 void QgsMeasureDialog::reject()

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -57,8 +57,8 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
 
   if ( !mMeasureArea )
   {
-    QAction *copyAction = new QAction( tr( "Copy &All" ), this );
-    QPushButton *cpb = new QPushButton( tr( "Copy &All" ) );
+    QAction *copyAction = new QAction( tr( "Copy" ), this );
+    QPushButton *cpb = new QPushButton( tr( "Copy" ) );
     buttonBox->addButton( cpb, QDialogButtonBox::ActionRole );
     connect( cpb, &QAbstractButton::clicked, copyAction, &QAction::trigger );
     connect( copyAction, &QAction::triggered, this, &QgsMeasureDialog::copyMeasurements );

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -67,10 +67,6 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
     mTable->setContextMenuPolicy( Qt::ActionsContextMenu );
     mTable->addAction( copyAction );
   }
-  else
-  {
-    mCopySettingsGroupBox->hide();
-  }
 
   repopulateComboBoxUnits( mMeasureArea );
   if ( mMeasureArea )
@@ -724,22 +720,12 @@ double QgsMeasureDialog::convertArea( double area, Qgis::AreaUnit toUnit ) const
 
 void QgsMeasureDialog::copyMeasurements()
 {
-  bool includeHeader = mIncludeHeader->isChecked();
+  bool includeHeader = QgsSettings().value( QStringLiteral( "qgis/measure/clipboard_header" ), false ).toBool();
 
   // Get the separator
-  QString separator;
-  if ( mSeparatorTab->isChecked() )
+  QString separator = QgsSettings().value( QStringLiteral( "qgis/measure/clipboard_separator" ), QStringLiteral( "\t" ) ).toString();
+  if ( separator.isEmpty() )
     separator = QStringLiteral( "\t" );
-  else if ( mSeparatorComma->isChecked() )
-    separator = QStringLiteral( "," );
-  else if ( mSeparatorSemicolon->isChecked() )
-    separator = QStringLiteral( ";" );
-  else if ( mSeparatorSpace->isChecked() )
-    separator = QStringLiteral( " " );
-  else if ( mSeparatorColon->isChecked() )
-    separator = QStringLiteral( ":" );
-  else
-    separator = mSeparatorCustom->text();
 
   QClipboard *clipboard = QApplication::clipboard();
   QString text;

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -24,12 +24,19 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsunittypes.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingstree.h"
 #include "qgsgui.h"
 
 #include <QClipboard>
 #include <QCloseEvent>
 #include <QLocale>
 #include <QPushButton>
+
+
+const QgsSettingsEntryBool *QgsMeasureDialog::settingClipboardHeader = new QgsSettingsEntryBool( QStringLiteral( "clipboard-header" ), QgsSettingsTree::sTreeMeasure, false, QObject::tr( "Whether the header should be copied to the cliboard along the coordinates, distances" ) );
+
+const QgsSettingsEntryString *QgsMeasureDialog::settingClipboardSeparator = new QgsSettingsEntryString( QStringLiteral( "clipboard-separator" ), QgsSettingsTree::sTreeMeasure, QStringLiteral( "\t" ), QObject::tr( "Separator between the measure columns copied to the clipboard" ) );
 
 
 QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
@@ -713,10 +720,10 @@ double QgsMeasureDialog::convertArea( double area, Qgis::AreaUnit toUnit ) const
 
 void QgsMeasureDialog::copyMeasurements()
 {
-  bool includeHeader = QgsSettings().value( QStringLiteral( "qgis/measure/clipboard_header" ), false ).toBool();
+  bool includeHeader = settingClipboardHeader->value();
 
   // Get the separator
-  QString separator = QgsSettings().value( QStringLiteral( "qgis/measure/clipboard_separator" ), QStringLiteral( "\t" ) ).toString();
+  QString separator = settingClipboardSeparator->value();
   if ( separator.isEmpty() )
     separator = QStringLiteral( "\t" );
 

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -70,14 +70,29 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Open configuration tab
     void openConfigTab();
 
-    //! Copy measurements to the clipboard
-    void copyMeasurements();
+    /**
+     * Copy measurements to the clipboard
+     * \param copyCoordinates \since QGIS 3.32 set to TRUE to also copy coordinates to clipboard
+     */
+    void copyMeasurements( bool copyCoordinates = false );
+
+    void showCoordinatesChanged();
 
     void crsChanged();
 
     void projChanged();
 
   private:
+
+    //! \since QGIS 3.32 columns
+    enum Columns
+    {
+      StartX = 0,
+      StartY,
+      EndX,
+      EndY,
+      Distance,
+    };
 
     //! formats distance to most appropriate units
     QString formatDistance( double distance, bool convertUnits = true ) const;
@@ -111,6 +126,9 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     //! Number of decimal places we want.
     int mDecimalPlaces = 3;
+
+    //! Number of decimal places we want for the coordinates.
+    int mDecimalPlacesCoordinates = 3;
 
     //! Current unit for input values
     Qgis::DistanceUnit mCanvasUnits = Qgis::DistanceUnit::Unknown;

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -70,11 +70,8 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Open configuration tab
     void openConfigTab();
 
-    /**
-     * Copy measurements to the clipboard
-     * \param copyCoordinates \since QGIS 3.32 set to TRUE to also copy coordinates to clipboard
-     */
-    void copyMeasurements( bool copyCoordinates = false, QString separator = QStringLiteral( "\t" ) );
+    //! Copy measurements to the clipboard
+    void copyMeasurements();
 
     void showCoordinatesChanged();
 

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -74,7 +74,7 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
      * Copy measurements to the clipboard
      * \param copyCoordinates \since QGIS 3.32 set to TRUE to also copy coordinates to clipboard
      */
-    void copyMeasurements( bool copyCoordinates = false );
+    void copyMeasurements( bool copyCoordinates = false, QString separator = QStringLiteral( "\t" ) );
 
     void showCoordinatesChanged();
 
@@ -87,10 +87,8 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! \since QGIS 3.32 columns
     enum Columns
     {
-      StartX = 0,
-      StartY,
-      EndX,
-      EndY,
+      X = 0,
+      Y,
       Distance,
     };
 

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -73,8 +73,6 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Copy measurements to the clipboard
     void copyMeasurements();
 
-    void showCoordinatesChanged();
-
     void crsChanged();
 
     void projChanged();

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -27,12 +27,17 @@
 class QCloseEvent;
 class QgsMeasureTool;
 class QgsMapCanvas;
+class QgsSettingsEntryBool;
+class QgsSettingsEntryString;
 
 class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 {
     Q_OBJECT
 
   public:
+
+    static const QgsSettingsEntryBool *settingClipboardHeader;
+    static const QgsSettingsEntryString *settingClipboardSeparator;
 
     //! Constructor
     QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f = Qt::WindowFlags() );

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -36,8 +36,6 @@ QgsMeasureTool::QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea )
   mRubberBand = new QgsRubberBand( canvas, mMeasureArea ? Qgis::GeometryType::Polygon : Qgis::GeometryType::Line );
   mRubberBandPoints = new QgsRubberBand( canvas, Qgis::GeometryType::Point );
 
-  // Append point we will move
-  mPoints.append( QgsPointXY( 0, 0 ) );
   mDestinationCrs = canvas->mapSettings().destinationCrs();
 
   mDialog = new QgsMeasureDialog( this );

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -95,17 +95,6 @@ void QgsMeasureTool::deactivate()
   mDialog->hide();
   mRubberBand->hide();
   mRubberBandPoints->hide();
-
-  // Deactivating the tool does not reset the measure.
-  // Remove the last temporary point as to not duplicate it when
-  // the tool is re activated
-  int nbTempVertices = mRubberBand->numberOfVertices();
-  int nbVertices = mRubberBandPoints->numberOfVertices();
-  if ( nbTempVertices > nbVertices )
-  {
-    mRubberBand->removeLastPoint();
-  }
-
   QgsMapTool::deactivate();
 }
 
@@ -161,18 +150,20 @@ void QgsMeasureTool::updateSettings()
     }
 
     mRubberBand->updatePosition();
-    mRubberBand->update();
     mRubberBandPoints->updatePosition();
-    mRubberBandPoints->update();
   }
   mDestinationCrs = mCanvas->mapSettings().destinationCrs();
 
+  // Update the dialog. This will clear then re-populate the table
   mDialog->updateSettings();
 
-  if ( !mDone && mRubberBand->size() > 0 )
+  int nbTempVertices = mRubberBand->numberOfVertices();
+  int nbVertices = mRubberBandPoints->numberOfVertices();
+
+  // Add a temporary point to the rubber band if the user is currently measuring
+  if ( !mDone && mRubberBand->size() > 0  && nbTempVertices <= nbVertices )
   {
     mRubberBand->addPoint( mPoints.last() );
-    mDialog->addPoint();
   }
   if ( mRubberBand->size() > 0 )
   {

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -61,6 +61,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeRendering = treeRoot()->createChildNode( QStringLiteral( "rendering" ) );
     static inline QgsSettingsTreeNode *sTreeSvg = treeRoot()->createChildNode( QStringLiteral( "svg" ) );
     static inline QgsSettingsTreeNode *sTreeWms = treeRoot()->createChildNode( QStringLiteral( "wms" ) );
+    static inline QgsSettingsTreeNode *sTreeMeasure = treeRoot()->createChildNode( QStringLiteral( "measure" ) );
 
 #endif
 

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -48,29 +48,19 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>5</number>
+      <number>3</number>
      </property>
      <attribute name="headerDefaultSectionSize">
-      <number>85</number>
+      <number>100</number>
      </attribute>
      <column>
       <property name="text">
-       <string>x1</string>
+       <string>x</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>y1</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>x2</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>y2</string>
+       <string>y</string>
       </property>
      </column>
      <column>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -48,8 +48,31 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>1</number>
+      <number>5</number>
      </property>
+     <attribute name="headerDefaultSectionSize">
+      <number>85</number>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>x1</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>y1</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>x2</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>y2</string>
+      </property>
+     </column>
      <column>
       <property name="text">
        <string>Segments</string>
@@ -186,6 +209,13 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QCheckBox" name="mShowCoordinates">
+     <property name="text">
+      <string>Show coordinates</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>443</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="baseSize">
@@ -58,13 +58,78 @@
      </layout>
     </widget>
    </item>
+   <item row="9" column="0" colspan="4">
+    <spacer name="mSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0">
+    <widget class="QRadioButton" name="mCartesian">
+     <property name="text">
+      <string>Cartesian</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QLineEdit" name="editHorizontalTotal">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="3">
     <widget class="QComboBox" name="mUnitsCombo"/>
    </item>
-   <item row="11" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+   <item row="7" column="2">
+    <widget class="QRadioButton" name="mEllipsoidal">
+     <property name="text">
+      <string>Ellipsoidal</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="editTotal">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="totalHorizontalDistanceLabel">
+     <property name="text">
+      <string>Total Horizontal Distance</string>
      </property>
     </widget>
    </item>
@@ -102,29 +167,6 @@
      </column>
     </widget>
    </item>
-   <item row="9" column="0" colspan="4">
-    <spacer name="mSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="0">
-    <widget class="QRadioButton" name="mCartesian">
-     <property name="text">
-      <string>Cartesian</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="1">
     <spacer>
      <property name="orientation">
@@ -151,152 +193,11 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="totalHorizontalDistanceLabel">
-     <property name="text">
-      <string>Total Horizontal Distance</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLineEdit" name="editHorizontalTotal">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="editTotal">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QRadioButton" name="mEllipsoidal">
-     <property name="text">
-      <string>Ellipsoidal</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="10" column="0" colspan="4">
-    <widget class="QgsCollapsibleGroupBox" name="mCopySettingsGroupBox">
-     <property name="title">
-      <string>Copy settings</string>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
      </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Include header</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="mIncludeHeader">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Separator</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QRadioButton" name="mSeparatorComma">
-          <property name="text">
-           <string>Comma</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QRadioButton" name="mSeparatorSpace">
-          <property name="text">
-           <string>Space</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QRadioButton" name="mSeparatorColon">
-          <property name="text">
-           <string>Colon</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QRadioButton" name="mSeparatorSemicolon">
-          <property name="text">
-           <string>Semicolon</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QRadioButton" name="mSeparatorTab">
-          <property name="text">
-           <string>Tab</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QRadioButton" name="mSeparatorOther">
-            <property name="text">
-             <string>Other</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="mSeparatorCustom">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maxLength">
-             <number>3</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>
@@ -317,32 +218,7 @@
   <tabstop>mUnitsCombo</tabstop>
   <tabstop>editHorizontalTotal</tabstop>
   <tabstop>mCartesian</tabstop>
-  <tabstop>mIncludeHeader</tabstop>
-  <tabstop>mSeparatorComma</tabstop>
-  <tabstop>mSeparatorSemicolon</tabstop>
-  <tabstop>mSeparatorTab</tabstop>
-  <tabstop>mSeparatorColon</tabstop>
-  <tabstop>mSeparatorSpace</tabstop>
-  <tabstop>mSeparatorOther</tabstop>
-  <tabstop>mSeparatorCustom</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>mSeparatorOther</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSeparatorCustom</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>311</x>
-     <y>464</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>381</x>
-     <y>464</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>472</height>
+    <height>443</height>
    </rect>
   </property>
   <property name="baseSize">
@@ -39,6 +39,35 @@
    <property name="spacing">
     <number>6</number>
    </property>
+   <item row="8" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="title">
+      <string>Info</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="mNotesLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QComboBox" name="mUnitsCombo"/>
+   </item>
+   <item row="11" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0" colspan="4">
     <widget class="QTreeWidget" name="mTable">
      <property name="editTriggers">
@@ -73,36 +102,7 @@
      </column>
     </widget>
    </item>
-   <item row="7" column="2">
-    <widget class="QRadioButton" name="mEllipsoidal">
-     <property name="text">
-      <string>Ellipsoidal</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="9" column="0" colspan="4">
-    <widget class="QgsCollapsibleGroupBox" name="groupBox">
-     <property name="title">
-      <string>Info</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QLabel" name="mNotesLabel">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="4">
     <spacer name="mSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -115,31 +115,15 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="editTotal">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+   <item row="7" column="0">
+    <widget class="QRadioButton" name="mCartesian">
+     <property name="text">
+      <string>Cartesian</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="checked">
+      <bool>false</bool>
      </property>
     </widget>
-   </item>
-   <item row="12" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QComboBox" name="mUnitsCombo"/>
    </item>
    <item row="4" column="1">
     <spacer>
@@ -156,6 +140,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="totalDistanceLabel">
+     <property name="text">
+      <string>Total</string>
+     </property>
+     <property name="buddy">
+      <cstring>editTotal</cstring>
+     </property>
+    </widget>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="totalHorizontalDistanceLabel">
@@ -180,27 +174,33 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="totalDistanceLabel">
-     <property name="text">
-      <string>Total</string>
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="editTotal">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="buddy">
-      <cstring>editTotal</cstring>
+     <property name="alignment">
+      <set>Qt::AlignRight</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QRadioButton" name="mCartesian">
+   <item row="7" column="2">
+    <widget class="QRadioButton" name="mEllipsoidal">
      <property name="text">
-      <string>Cartesian</string>
+      <string>Ellipsoidal</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="4">
+   <item row="10" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="mCopySettingsGroupBox">
      <property name="title">
       <string>Copy settings</string>
@@ -299,13 +299,6 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0" colspan="4">
-    <widget class="QCheckBox" name="mShowCoordinates">
-     <property name="text">
-      <string>Show coordinates</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -324,7 +317,6 @@
   <tabstop>mUnitsCombo</tabstop>
   <tabstop>editHorizontalTotal</tabstop>
   <tabstop>mCartesian</tabstop>
-  <tabstop>mShowCoordinates</tabstop>
   <tabstop>mIncludeHeader</tabstop>
   <tabstop>mSeparatorComma</tabstop>
   <tabstop>mSeparatorSemicolon</tabstop>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>376</height>
+    <width>430</width>
+    <height>472</height>
    </rect>
   </property>
   <property name="baseSize">
@@ -73,15 +73,73 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="totalDistanceLabel">
+   <item row="7" column="2">
+    <widget class="QRadioButton" name="mEllipsoidal">
      <property name="text">
-      <string>Total</string>
+      <string>Ellipsoidal</string>
      </property>
-     <property name="buddy">
-      <cstring>editTotal</cstring>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
+   </item>
+   <item row="9" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="title">
+      <string>Info</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="mNotesLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="4">
+    <spacer name="mSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="editTotal">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QComboBox" name="mUnitsCombo"/>
    </item>
    <item row="4" column="1">
     <spacer>
@@ -122,13 +180,13 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <widget class="QRadioButton" name="mEllipsoidal">
+   <item row="4" column="0">
+    <widget class="QLabel" name="totalDistanceLabel">
      <property name="text">
-      <string>Ellipsoidal</string>
+      <string>Total</string>
      </property>
-     <property name="checked">
-      <bool>true</bool>
+     <property name="buddy">
+      <cstring>editTotal</cstring>
      </property>
     </widget>
    </item>
@@ -142,63 +200,104 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="4">
-    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+   <item row="11" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="mCopySettingsGroupBox">
      <property name="title">
-      <string>Info</string>
+      <string>Copy settings</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QLabel" name="mNotesLabel">
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+         <string>Include header</string>
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="mIncludeHeader">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Separator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="mSeparatorComma">
+          <property name="text">
+           <string>Comma</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QRadioButton" name="mSeparatorSpace">
+          <property name="text">
+           <string>Space</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QRadioButton" name="mSeparatorColon">
+          <property name="text">
+           <string>Colon</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QRadioButton" name="mSeparatorSemicolon">
+          <property name="text">
+           <string>Semicolon</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="mSeparatorTab">
+          <property name="text">
+           <string>Tab</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QRadioButton" name="mSeparatorOther">
+            <property name="text">
+             <string>Other</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="mSeparatorCustom">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maxLength">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QComboBox" name="mUnitsCombo"/>
-   </item>
-   <item row="11" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="editTotal">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight</set>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="4">
-    <spacer name="mSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="8" column="0" colspan="4">
     <widget class="QCheckBox" name="mShowCoordinates">
@@ -221,7 +320,37 @@
  <tabstops>
   <tabstop>mTable</tabstop>
   <tabstop>editTotal</tabstop>
+  <tabstop>mEllipsoidal</tabstop>
+  <tabstop>mUnitsCombo</tabstop>
+  <tabstop>editHorizontalTotal</tabstop>
+  <tabstop>mCartesian</tabstop>
+  <tabstop>mShowCoordinates</tabstop>
+  <tabstop>mIncludeHeader</tabstop>
+  <tabstop>mSeparatorComma</tabstop>
+  <tabstop>mSeparatorSemicolon</tabstop>
+  <tabstop>mSeparatorTab</tabstop>
+  <tabstop>mSeparatorColon</tabstop>
+  <tabstop>mSeparatorSpace</tabstop>
+  <tabstop>mSeparatorOther</tabstop>
+  <tabstop>mSeparatorCustom</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>mSeparatorOther</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mSeparatorCustom</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>311</x>
+     <y>464</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>381</x>
+     <y>464</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1029</width>
-    <height>744</height>
+    <height>734</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -122,7 +122,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>7</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -151,8 +151,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>856</width>
-                <height>1223</height>
+                <width>675</width>
+                <height>963</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -940,8 +940,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>617</width>
-                <height>1135</height>
+                <width>578</width>
+                <height>1069</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1479,8 +1479,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
-                <height>575</height>
+                <width>611</width>
+                <height>465</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1723,8 +1723,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>648</width>
-                <height>118</height>
+                <width>596</width>
+                <height>105</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1806,8 +1806,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>702</width>
-                <height>895</height>
+                <width>637</width>
+                <height>746</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2205,8 +2205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>447</width>
-                <height>431</height>
+                <width>457</width>
+                <height>419</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -2426,8 +2426,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>523</width>
-                <height>435</height>
+                <width>508</width>
+                <height>482</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2555,40 +2555,39 @@
                  <layout class="QGridLayout" name="gridLayout_35">
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_15">
-                   <property name="text">
+                    <property name="text">
                      <string>Double-click action in legend</string>
-                   </property>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
                    <widget class="QComboBox" name="cmbLegendDoubleClickAction">
                     <item>
-                      <property name="text">
+                     <property name="text">
                       <string>Open layer properties</string>
-                      </property>
+                     </property>
                     </item>
                     <item>
-                      <property name="text">
+                     <property name="text">
                       <string>Open attribute table</string>
-                      </property>
+                     </property>
                     </item>
                     <item>
-                      <property name="text">
+                     <property name="text">
                       <string>Open layer styling dock</string>
-                      </property>
+                     </property>
                     </item>
                    </widget>
                   </item>
                   <item row="1" column="0">
-                    <widget class="QLabel" name="mLayerTreeInsertionMethodLabel">
+                   <widget class="QLabel" name="mLayerTreeInsertionMethodLabel">
                     <property name="text">
-                      <string>Behavior used when adding new layers</string>
+                     <string>Behavior used when adding new layers</string>
                     </property>
-                    </widget>
+                   </widget>
                   </item>
                   <item row="1" column="1">
-                    <widget class="QComboBox" name="mLayerTreeInsertionMethod">
-                    </widget>
+                   <widget class="QComboBox" name="mLayerTreeInsertionMethod"/>
                   </item>
                   <item row="2" column="0" colspan="2">
                    <widget class="QCheckBox" name="mShowFeatureCountByDefaultCheckBox">
@@ -2607,103 +2606,103 @@
                   <item row="4" column="0">
                    <widget class="QLabel" name="label_58">
                     <property name="text">
-                      <string>WMS getLegendGraphic resolution</string>
+                     <string>WMS getLegendGraphic resolution</string>
                     </property>
                    </widget>
                   </item>
                   <item row="4" column="1">
-                    <widget class="QgsSpinBox" name="mLegendGraphicResolutionSpinBox">
-                     <property name="toolTip">
-                       <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
-                     </property>
-                     <property name="whatsThis">
-                       <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
-                     </property>
-                     <property name="suffix">
-                       <string> dpi</string>
-                     </property>
-                     <property name="minimum">
-                       <number>0</number>
-                     </property>
-                     <property name="maximum">
-                       <number>1000000</number>
-                     </property>
-                    </widget>
+                   <widget class="QgsSpinBox" name="mLegendGraphicResolutionSpinBox">
+                    <property name="toolTip">
+                     <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
+                    </property>
+                    <property name="whatsThis">
+                     <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
+                    </property>
+                    <property name="suffix">
+                     <string> dpi</string>
+                    </property>
+                    <property name="minimum">
+                     <number>0</number>
+                    </property>
+                    <property name="maximum">
+                     <number>1000000</number>
+                    </property>
+                   </widget>
                   </item>
                   <item row="5" column="0">
-                    <widget class="QLabel" name="labelLegendSymbolMinimumSize">
+                   <widget class="QLabel" name="labelLegendSymbolMinimumSize">
                     <property name="text">
-                      <string>Minimum legend symbol size</string>
+                     <string>Minimum legend symbol size</string>
                     </property>
-                    </widget>
+                   </widget>
                   </item>
                   <item row="5" column="1">
                    <widget class="QgsDoubleSpinBox" name="mLegendSymbolMinimumSizeSpinBox">
                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
-                      </sizepolicy>
+                     </sizepolicy>
                     </property>
                     <property name="toolTip">
-                      <string extracomment="(set value to 0 to skip minimum size)"/>
+                     <string extracomment="(set value to 0 to skip minimum size)"/>
                     </property>
                     <property name="suffix">
-                      <string> mm</string>
+                     <string> mm</string>
                     </property>
                     <property name="decimals">
-                      <number>2</number>
+                     <number>2</number>
                     </property>
                     <property name="maximum">
-                      <double>999.000000000000000</double>
+                     <double>999.000000000000000</double>
                     </property>
                     <property name="singleStep">
-                      <double>0.200000000000000</double>
+                     <double>0.200000000000000</double>
                     </property>
                     <property name="value">
-                      <double>0.100000000000000</double>
+                     <double>0.100000000000000</double>
                     </property>
                     <property name="showClearButton" stdset="0">
-                      <bool>true</bool>
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
                   <item row="6" column="0">
-                    <widget class="QLabel" name="labelLegendSymbolMaximumSize">
+                   <widget class="QLabel" name="labelLegendSymbolMaximumSize">
                     <property name="text">
-                      <string>Maximum legend symbol size</string>
+                     <string>Maximum legend symbol size</string>
                     </property>
-                    </widget>
+                   </widget>
                   </item>
                   <item row="6" column="1">
                    <widget class="QgsDoubleSpinBox" name="mLegendSymbolMaximumSizeSpinBox">
-                   <property name="sizePolicy">
+                    <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
                      </sizepolicy>
-                   </property>
-                   <property name="toolTip">
+                    </property>
+                    <property name="toolTip">
                      <string extracomment="(set value to 0 to skip maximum size)"/>
-                   </property>
-                   <property name="suffix">
+                    </property>
+                    <property name="suffix">
                      <string> mm</string>
-                   </property>
-                   <property name="decimals">
+                    </property>
+                    <property name="decimals">
                      <number>2</number>
-                   </property>
-                   <property name="maximum">
+                    </property>
+                    <property name="maximum">
                      <double>999.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
+                    </property>
+                    <property name="singleStep">
                      <double>0.200000000000000</double>
-                   </property>
-                   <property name="value">
+                    </property>
+                    <property name="value">
                      <double>20.000000000000000</double>
-                   </property>
-                   <property name="showClearButton" stdset="0">
+                    </property>
+                    <property name="showClearButton" stdset="0">
                      <bool>true</bool>
-                   </property>
+                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -2808,9 +2807,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>678</width>
-                <height>850</height>
+                <y>-210</y>
+                <width>843</width>
+                <height>895</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -2968,50 +2967,27 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_6">
+                <widget class="QgsCollapsibleGroupBox" name="mMeasureToolGroupBox">
                  <property name="title">
                   <string>Measure Tool</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_21">
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="textLabel1_11">
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="mAngleUnitsLabel">
                     <property name="text">
-                     <string>Preferred distance units</string>
+                     <string>Preferred angle units</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="1" colspan="3">
-                   <widget class="QComboBox" name="mAreaUnitsComboBox"/>
-                  </item>
-                  <item row="3" column="1" colspan="3">
-                   <widget class="QComboBox" name="mDistanceUnitsComboBox"/>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_13">
-                    <property name="toolTip">
-                     <string>If unchecked large numbers will be converted from m. to km. and from ft. to miles</string>
-                    </property>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="textLabel1_14">
                     <property name="text">
-                     <string>Keep base unit</string>
+                     <string>Preferred area units</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1">
-                   <widget class="QgsSpinBox" name="mDecimalPlacesSpinBox"/>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_12">
-                    <property name="text">
-                     <string>Decimal places</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="textLabel1_10">
-                    <property name="text">
-                     <string>Rubberband color</string>
-                    </property>
-                   </widget>
+                  <item row="5" column="1" colspan="3">
+                   <widget class="QComboBox" name="mAngleUnitsComboBox"/>
                   </item>
                   <item row="0" column="2" colspan="2">
                    <spacer>
@@ -3026,29 +3002,15 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="textLabel1_14">
+                  <item row="3" column="1" colspan="3">
+                   <widget class="QComboBox" name="mDistanceUnitsComboBox"/>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="textLabel1_10">
                     <property name="text">
-                     <string>Preferred area units</string>
+                     <string>Rubberband color</string>
                     </property>
                    </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QCheckBox" name="mKeepBaseUnitCheckBox">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="mAngleUnitsLabel">
-                    <property name="text">
-                     <string>Preferred angle units</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1" colspan="3">
-                   <widget class="QComboBox" name="mAngleUnitsComboBox"/>
                   </item>
                   <item row="0" column="1">
                    <widget class="QgsColorButton" name="pbnMeasureColor">
@@ -3074,6 +3036,145 @@
                      <string/>
                     </property>
                    </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="textLabel1_11">
+                    <property name="text">
+                     <string>Preferred distance units</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="mKeepBaseUnitCheckBox">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_12">
+                    <property name="text">
+                     <string>Decimal places</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_13">
+                    <property name="toolTip">
+                     <string>If unchecked large numbers will be converted from m. to km. and from ft. to miles</string>
+                    </property>
+                    <property name="text">
+                     <string>Keep base unit</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QgsSpinBox" name="mDecimalPlacesSpinBox"/>
+                  </item>
+                  <item row="4" column="1" colspan="3">
+                   <widget class="QComboBox" name="mAreaUnitsComboBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mMeasureToolCopySettingsGroupBox">
+                 <property name="title">
+                  <string>Measure Tool Copy Settings</string>
+                 </property>
+                 <layout class="QFormLayout" name="formLayout">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_22">
+                    <property name="toolTip">
+                     <string>C</string>
+                    </property>
+                    <property name="text">
+                     <string>Include header</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="mIncludeHeader">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_23">
+                    <property name="text">
+                     <string>Separator</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <layout class="QGridLayout" name="gridLayout_6">
+                    <item row="0" column="0">
+                     <widget class="QRadioButton" name="mSeparatorComma">
+                      <property name="text">
+                       <string>Comma</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QRadioButton" name="mSeparatorSpace">
+                      <property name="text">
+                       <string>Space</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QRadioButton" name="mSeparatorColon">
+                      <property name="text">
+                       <string>Colon</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QRadioButton" name="mSeparatorSemicolon">
+                      <property name="text">
+                       <string>Semicolon</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QRadioButton" name="mSeparatorTab">
+                      <property name="text">
+                       <string>Tab</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <layout class="QHBoxLayout" name="horizontalLayout_3">
+                      <item>
+                       <widget class="QRadioButton" name="mSeparatorOther">
+                        <property name="text">
+                         <string>Other</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="mSeparatorCustom">
+                        <property name="enabled">
+                         <bool>false</bool>
+                        </property>
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maxLength">
+                         <number>3</number>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>
@@ -3154,7 +3255,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_10">
+                <widget class="QgsCollapsibleGroupBox" name="mZoomingGroupBox">
                  <property name="title">
                   <string>Zooming</string>
                  </property>
@@ -3210,7 +3311,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_15">
+                <widget class="QgsCollapsibleGroupBox" name="mPredefinedScalesGroupBox">
                  <property name="title">
                   <string>Predefined Scales</string>
                  </property>
@@ -3354,8 +3455,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>608</width>
-                <height>1229</height>
+                <width>551</width>
+                <height>1000</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4057,8 +4158,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>139</width>
-                <height>255</height>
+                <width>147</width>
+                <height>251</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4237,8 +4338,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>546</width>
-                <height>606</height>
+                <width>482</width>
+                <height>539</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4569,8 +4670,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>712</width>
-                <height>828</height>
+                <width>657</width>
+                <height>669</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5050,8 +5151,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
- Fixes #50292
- Fixes #52532

## Description

This PR extend the `QgsMeasureDialog` with X and Y coordinates.
- Adds X an Y columns
- Adds a first row in the table that contains only the coordinates (no distance)
- Display a message when the copy has succeeded
- Adds the `Copy all` action in a context menu in the table
- Fixes some bugs when changing settings while measuring


![new_measure_tool](https://user-images.githubusercontent.com/9693475/229810370-54b91816-9ad8-419a-9d1b-a2103cc8fd03.gif)


Additional settings (separator, include header) control the "Copy All" button behavior. This can be used to copy the data (X, Y and dist) to a raw csv, to an excel table etc.

![measure_tool_copy_settings](https://user-images.githubusercontent.com/9693475/229810537-463c2e59-86b6-42ee-aaef-2e6788f1d32b.png)
