### PR TITLE
Fix lost index on selection change in Attribute Table

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -234,6 +234,8 @@ class GUI_EXPORT QgsFeatureListView : public QListView
   private:
     void selectRow( const QModelIndex &index, bool anchor );
 
+    void updateEditSelection( bool inSelection = false );
+
     enum PositionInList
     {
       First,
@@ -264,7 +266,8 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     int mRowAnchor = 0;
     QItemSelectionModel::SelectionFlags mCtrlDragSelectionFlag;
 
-    QTimer mUpdateEditSelectionTimer;
+    QTimer mUpdateEditSelectionTimerWithSelection;
+    QTimer mUpdateEditSelectionTimerWithoutSelection;
 
     friend class QgsDualView;
 };

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -853,7 +853,7 @@ void TestQgsAttributeTable::testEnsureEditSelection()
 
   std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( layer.get() ) );
 
-  //since the update is done by timer we need to wait for update (at least one milisecond)
+  //since the update is done by timer, we have to wait for the update (at least one millisecond)
   QEventLoop loop;
 
   // we set the index to ft3


### PR DESCRIPTION
Issue was that the index always jumps to the first position when I make a feature selection (yellow):

[IndexLostOnSelection.webm](https://user-images.githubusercontent.com/28384354/220962054-75aac73a-cff1-4c3f-ab99-abfda614849b.webm)


The original implementation intended that the index jumps to the first feature in the made selection (in case the indexed feature is currently not in the selection - otherwise the index should presist). **But this did not work:** Problem was that when the connection to the lambda updating the index has the parameter of it's initialization. Means `inSelection` was always `false` and with this the index received 0 (first position).

This fix decapsulates the update function from where the timer to trigger starts. Since we cannot pass the parameter `inSelection` because of the timer I created two timer (and with it two connections). 

I decided against a quick fix with deconnect/connect the lambda function on every `ensureEditSelection` because of the fragility of those triggers in the attribute table. The proposed sollution is in my opinion more secure.

Fixed sollution looks like this:

[selectiontakesindex.webm](https://user-images.githubusercontent.com/28384354/221605303-734a6f39-c04a-401e-8406-f7db1ae259b0.webm)
 