### PR TITLE
Fix index lost on reload in Attribute Table

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -185,9 +185,13 @@ void QgsFeatureListView::editSelectionChanged( const QItemSelection &selected, c
 
   if ( !selected.isEmpty() )
   {
-    QgsFeature selectedFeature;
-    mModel->featureByIndex( mModel->mapFromMaster( selected.indexes().first() ), selectedFeature );
-    mLastEditSelectionFid = selectedFeature.id();
+    const QModelIndexList indexList = selected.indexes();
+    if ( !indexList.isEmpty() )
+    {
+      QgsFeature selectedFeature;
+      mModel->featureByIndex( mModel->mapFromMaster( indexList.first() ), selectedFeature );
+      mLastEditSelectionFid = selectedFeature.id();
+    }
   }
 
   const QItemSelection currentSelection = mCurrentEditSelectionModel->selection();

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -174,7 +174,7 @@ void QgsFeatureListView::mousePressEvent( QMouseEvent *event )
   }
 }
 
-void QgsFeatureListView::editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected )
+void QgsFeatureListView::editSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   if ( isVisible() && updatesEnabled() )
   {

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -183,6 +183,7 @@ void QgsFeatureListView::editSelectionChanged( const QItemSelection &selected, c
     viewport()->update( visualRegionForSelection( localDeselected ) | visualRegionForSelection( localSelected ) );
   }
 
+  mLastEditSelectionFid = QgsFeatureId();
   if ( !selected.isEmpty() )
   {
     const QModelIndexList indexList = selected.indexes();

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -269,6 +269,8 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     QTimer mUpdateEditSelectionTimerWithSelection;
     QTimer mUpdateEditSelectionTimerWithoutSelection;
 
+    QgsFeatureId mLastEditSelectionFid;
+
     friend class QgsDualView;
 };
 

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -221,7 +221,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
 
 
   private slots:
-    void editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected );
+    void editSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
 
     /**
      * Make sure, there is an edit selection. If there is none, choose the first item.

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -891,9 +891,8 @@ void TestQgsAttributeTable::testEnsureEditSelection()
   // we reload the layer
   layer->reload();
   spy.wait( 1 );
-  // ... and the currentEditSelection jumps to the first one (instead of staying at 2, since it's NOT persistend)
-  QVERIFY( dlg->mMainView->mFeatureListView->currentEditSelection().contains( 1 ) );
-
+  // ... and the currentEditSelection stays on 2 (since lastEditSelectionFid is persisted)
+  QVERIFY( dlg->mMainView->mFeatureListView->currentEditSelection().contains( 2 ) );
 }
 
 QGSTEST_MAIN( TestQgsAttributeTable )


### PR DESCRIPTION
On layer refresh the last index was never concerned. This leaded to confusion when working in the attribute table with relation editors and dependencies:
- Working on form of feature x - working on relation editor, doing a save (on child layer)
- Index lost and is now on the first feature - user is confused since he/she does not noticed the index jump and continues working on the first feature (instead of feature x) - and user breaks his/her data See #43902

In this implementation the member variable `mLastEditSelectionFid? keeping it. See

This implementation fixes #43902

***This PR is based on the branch of #52045***