### PR TITLE
Fix handling of additional C++ plugins paths (Fix #52041)

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -357,10 +357,11 @@ void QgsPluginManager::getCppPluginsMetadata()
   QStringList myPathList( pr->libraryDirectory().path() );
 
   const QgsSettings settings;
-  const QString myPaths = settings.value( QStringLiteral( "plugins/searchPathsForPlugins" ), "" ).toString();
+  const QStringList myPaths = settings.value( QStringLiteral( "plugins/searchPathsForPlugins" ) ).toStringList();
   if ( !myPaths.isEmpty() )
   {
-    myPathList.append( myPaths.split( '|' ) );
+    myPathList.append( myPaths );
+    myPathList.removeDuplicates();
   }
 
   for ( int j = 0; j < myPathList.size(); ++j )
@@ -371,7 +372,7 @@ void QgsPluginManager::getCppPluginsMetadata()
     if ( pluginDir.count() == 0 )
     {
       QMessageBox::information( this, tr( "No Plugins" ), tr( "No QGIS plugins found in %1" ).arg( myPluginDir ) );
-      return;
+      continue;
     }
 
     for ( uint i = 0; i < pluginDir.count(); i++ )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1604,10 +1604,10 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
     QgsPluginRegistry::instance()->restoreSessionPlugins( QgsApplication::pluginPath() );
 
     // Also restore plugins from user specified plugin directories
-    QString myPaths = settings.value( QStringLiteral( "plugins/searchPathsForPlugins" ), "" ).toString();
-    if ( !myPaths.isEmpty() )
+    QStringList myPathList = settings.value( QStringLiteral( "plugins/searchPathsForPlugins" ) ).toStringList();
+    if ( !myPathList.isEmpty() )
     {
-      QStringList myPathList = myPaths.split( '|' );
+      myPathList.removeDuplicates();
       QgsPluginRegistry::instance()->restoreSessionPlugins( myPathList );
     }
   }


### PR DESCRIPTION
## Description

Fixes an issue (probably an oversight in https://github.com/qgis/QGIS/pull/3917) that prevents the correct handling of the additional C++ plugins paths stored in the `plugins/searchPathsForPlugins` setting as QStringList.

Fixes https://github.com/qgis/QGIS/issues/52041.

This PR needs to be backported.

NOTE: I would also like to change the "No QGIS plugins found in path" notification of the Plugin Manager, from the current use of a QMessageBox
https://github.com/qgis/QGIS/blob/0ebc409f11de7cb3663ae659a1d7c723e7d51ff0/src/app/pluginmanager/qgspluginmanager.cpp#L373

to a less annoying QgsMessageLog warning in the Plugins tab, to avoid the multiple display of message box windows if multiple paths don't contain plugins:

```c++
      QgsMessageLog::logMessage( tr( "No QGIS plugins found in \"%1\"" ).arg( myPluginDir ), tr( "Plugins" ) );
```
Does it make sense?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
