### PR TITLE
Renamed the QgsPenStyleComboBox Qt::NoPen entry to "No Line"

### DIFF
--- a/src/gui/symbology/qgspenstylecombobox.cpp
+++ b/src/gui/symbology/qgspenstylecombobox.cpp
@@ -29,7 +29,7 @@ QgsPenStyleComboBox::QgsPenStyleComboBox( QWidget *parent )
 {
   QList < QPair<Qt::PenStyle, QString> > styles;
   styles << qMakePair( Qt::SolidLine, tr( "Solid Line" ) )
-         << qMakePair( Qt::NoPen, tr( "No Pen" ) )
+         << qMakePair( Qt::NoPen, tr( "No Line" ) )
          << qMakePair( Qt::DashLine, tr( "Dash Line" ) )
          << qMakePair( Qt::DotLine, tr( "Dot Line" ) )
          << qMakePair( Qt::DashDotLine, tr( "Dash Dot Line" ) )


### PR DESCRIPTION
## Description

All QgsPenStyleComboBox entries mention a "line", with one exception: theentry related to the `Qt::NoPen` enum.

For consistency with other entries, this PR renames "No Pen" to "No Line".


| Before | After |
|---------|------|
| ![grafik](https://user-images.githubusercontent.com/1404870/221838557-1f773961-f1c9-4684-8557-332a589dfc22.png) | ![grafik](https://user-images.githubusercontent.com/1404870/222060679-8fe1b891-e35f-4b2f-8f7f-91ec792e43f0.png) |





