### PR TITLE
Datetime Widget Config: "Protect" field format change possiblities

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -392,6 +392,16 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
   connect( mDisplayFormatEdit, &QLineEdit::textChanged, this, &QgsEditorConfigWidget::changed );
   connect( mCalendarPopupCheckBox, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mAllowNullCheckBox, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
+  connect( mFieldFormatGroupBox, &QGroupBox::toggled, this, [ = ]( bool checked )
+  {
+    //reset to default value when unchecking
+    if ( !checked )
+    {
+      const QgsField fieldDef = layer()->fields().at( field() );
+      const QString fieldFormat = QgsDateTimeFieldFormatter::defaultFormat( fieldDef.type() );
+      setFieldFormatCombo( fieldFormat );
+    }
+  } );
 
   // initialize
   updateFieldFormat( mFieldFormatComboBox->currentIndex() );
@@ -488,6 +498,7 @@ QVariantMap QgsDateTimeEditConfig::config()
 {
   QVariantMap myConfig;
 
+  myConfig.insert( QStringLiteral( "field_format_overwrite" ), mFieldFormatGroupBox->isChecked() );
   myConfig.insert( QStringLiteral( "field_iso_format" ), mFieldFormatEdit->text() == QgsDateTimeFieldFormatter::QT_ISO_FORMAT );
   myConfig.insert( QStringLiteral( "field_format" ), mFieldFormatEdit->text() );
   myConfig.insert( QStringLiteral( "display_format" ), mDisplayFormatEdit->text() );
@@ -499,19 +510,10 @@ QVariantMap QgsDateTimeEditConfig::config()
 
 void QgsDateTimeEditConfig::setConfig( const QVariantMap &config )
 {
+  mFieldFormatGroupBox->setChecked( config.value( QStringLiteral( "field_format_overwrite" ), false ).toBool() );
   const QgsField fieldDef = layer()->fields().at( field() );
   const QString fieldFormat = config.value( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( fieldDef.type() ) ).toString();
-  mFieldFormatEdit->setText( fieldFormat );
-
-  const int idx = mFieldFormatComboBox->findData( fieldFormat );
-  if ( idx >= 0 )
-  {
-    mFieldFormatComboBox->setCurrentIndex( idx );
-  }
-  else
-  {
-    mFieldFormatComboBox->setCurrentIndex( 4 );
-  }
+  setFieldFormatCombo( fieldFormat );
 
   const QString displayFormat = config.value( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::defaultDisplayFormat( fieldDef.type() ) ).toString();
   mDisplayFormatEdit->setText( displayFormat );
@@ -526,4 +528,19 @@ void QgsDateTimeEditConfig::setConfig( const QVariantMap &config )
 
   mCalendarPopupCheckBox->setChecked( config.value( QStringLiteral( "calendar_popup" ), true ).toBool() );
   mAllowNullCheckBox->setChecked( config.value( QStringLiteral( "allow_null" ), true ).toBool() );
+}
+
+void QgsDateTimeEditConfig::setFieldFormatCombo( const QString &fieldFormat )
+{
+  mFieldFormatEdit->setText( fieldFormat );
+
+  const int idx = mFieldFormatComboBox->findData( fieldFormat );
+  if ( idx >= 0 )
+  {
+    mFieldFormatComboBox->setCurrentIndex( idx );
+  }
+  else
+  {
+    mFieldFormatComboBox->setCurrentIndex( 4 );
+  }
 }

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.h
@@ -42,6 +42,9 @@ class GUI_EXPORT QgsDateTimeEditConfig : public QgsEditorConfigWidget, private U
     void updateDisplayFormat( const QString &fieldFormat );
     void displayFormatChanged( int idx );
     void showHelp( bool buttonChecked );
+
+  private:
+    void setFieldFormatCombo( const QString &fieldFormat );
 };
 
 #endif // QGSDATETIMEEDITCONFIG_H

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -161,7 +161,7 @@
    <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type (like e.g. QDate).&lt;/p&gt;&lt;p&gt;For the display format of the date, use the Widget Display above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date, use the Widget Display above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
       <string>Overwrite Field Format</string>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -161,7 +161,7 @@
    <item row="4" column="0">
     <widget class="QGroupBox" name="mFieldFormatGroupBox">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;usually&lt;/span&gt; intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date widget, use the section above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The field format allows to customize the format in which the date will be stored in the datasource. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Overwriting the field format is&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;usually&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date widget, use the section above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
       <string>Overwrite Field Format</string>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -60,9 +60,9 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="mDisplayFormatGroupBox">
      <property name="title">
-      <string>Widget Display</string>
+      <string>Display Format</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="3">
@@ -159,9 +159,9 @@
     </spacer>
    </item>
    <item row="4" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="mFieldFormatGroupBox">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date, use the Widget Display above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;usually&lt;/span&gt; intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date widget, use the section above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
       <string>Overwrite Field Format</string>
@@ -173,19 +173,19 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QComboBox" name="mFieldFormatComboBox">
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="mFieldHelpToolButton">
+        <property name="text">
+         <string>…</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mFieldFormatEdit">
-        <property name="enabled">
+        <property name="icon">
+         <iconset resource="../../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionHelpContents.svg</normaloff>:/images/themes/default/mActionHelpContents.svg</iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
          <bool>false</bool>
         </property>
        </widget>
@@ -203,20 +203,20 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="2">
-       <widget class="QToolButton" name="mFieldHelpToolButton">
-        <property name="text">
-         <string>…</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../images/images.qrc">
-          <normaloff>:/images/themes/default/mActionHelpContents.svg</normaloff>:/images/themes/default/mActionHelpContents.svg</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mFieldFormatEdit">
+        <property name="enabled">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QComboBox" name="mFieldFormatComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
         </property>
        </widget>
       </item>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -161,7 +161,7 @@
    <item row="4" column="0">
     <widget class="QGroupBox" name="mFieldFormatGroupBox">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The field format allows to customize the format in which the date will be stored in the datasource. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Overwriting the field format is&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;usually&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date widget, use the section above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The field format allows customizing the format in which the date will be stored in the datasource. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Overwriting the field format is&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;usually&lt;span style=&quot; font-weight:600; font-style:italic;&quot;/&gt;intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type.&lt;/p&gt;&lt;p&gt;For the display format of the date widget, use the section above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
       <string>Overwrite Field Format</string>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -14,7 +14,14 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
+   <item row="9" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
     <widget class="QgsScrollArea" name="mHelpScrollArea">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
@@ -30,8 +37,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>478</width>
-        <height>971</height>
+        <width>484</width>
+        <height>68</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
@@ -50,82 +57,6 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="8" column="0">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Field Format</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QComboBox" name="mFieldFormatComboBox">
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mFieldFormatEdit">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="2">
-       <widget class="QToolButton" name="mFieldHelpToolButton">
-        <property name="text">
-         <string>…</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../images/images.qrc">
-          <normaloff>:/images/themes/default/mActionHelpContents.svg</normaloff>:/images/themes/default/mActionHelpContents.svg</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="2" column="0">
@@ -214,7 +145,79 @@
      </layout>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="11" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="toolTip">
+      <string>The field format is intended for fields that are not of a date type and should otherwise be left at the default value. For the display of the date use the Widget Display. </string>
+     </property>
+     <property name="title">
+      <string>Field Format</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QComboBox" name="mFieldFormatComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mFieldFormatEdit">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="mFieldHelpToolButton">
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionHelpContents.svg</normaloff>:/images/themes/default/mActionHelpContents.svg</iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="label">
@@ -257,6 +260,7 @@
   <tabstop>mHelpScrollArea</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -161,10 +161,16 @@
    <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="toolTip">
-      <string>The field format is intended for fields that are not of a date type and should otherwise be left at the default value. For the display of the date use the Widget Display. </string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overwriting the field format is intended for fields that are &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;not&lt;/span&gt; of a date type (like e.g. QDate).&lt;/p&gt;&lt;p&gt;For the display format of the date, use the Widget Display above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
-      <string>Field Format</string>
+      <string>Overwrite Field Format</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
@@ -180,7 +186,7 @@
       <item row="0" column="1">
        <widget class="QLineEdit" name="mFieldFormatEdit">
         <property name="enabled">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
User often confuses field format with display widget format. Mostly the user does not want to change the field format but thinks it needs to be aligned to the widget display format. After making there wrong settings, filtering does not work anymore etc.

### Changes:

![image](https://user-images.githubusercontent.com/28384354/222679257-8fc11a55-6003-4b8e-8349-691d4667e941.png)

- "Field Format" settings are now below "Display Format".
- "Widget Display" is now called "Display Format" (IMO Widget Display does not make much sense for users).
- "Field Format" is now in a checkable group box "Overwrite Field Format". User needs to activate it, to overwrite the default value. 
- When "Overwrite Field Format" gets unchecked again, the Field Format Combobox resets back to "Default" (this to avoid that user could think the custom value is taken, but just not enabled to edit it).
- The checked state of "Overwrite Field Format" is keeped in the config.
- Tooltip on "Overwrite Field Format" box: 
   > The field format allows to customize the format in which the date will be stored in the datasource. 
   > Overwriting the field format is usually intended for fields that are **_not_** of a date type.
   > For the display format of the date widget, use the section above.

Resolves confusion at #43177