### PR TITLE
Don't allow users to set maximum thread count for rendering to 1

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -695,7 +695,7 @@ Set maximum concurrent thread count
 
 .. note::
 
-   must be between 1 and \#cores, -1 means use all available cores
+   must be between 2 and \#cores, -1 means use all available cores
 
 .. versionadded:: 2.4
 %End

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -32,8 +32,8 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
   QgsSettings settings;
   chkAddedVisibility->setChecked( settings.value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool() );
 
-  spinMaxThreads->setRange( 0, QThread::idealThreadCount() );
-  spinMaxThreads->setClearValue( 0, tr( "All Available (%1)" ).arg( QThread::idealThreadCount() ) );
+  spinMaxThreads->setRange( 1, QThread::idealThreadCount() );
+  spinMaxThreads->setClearValue( 1, tr( "All Available (%1)" ).arg( QThread::idealThreadCount() ) );
   if ( QgsApplication::maxThreads() != -1 )
     spinMaxThreads->setValue( QgsApplication::maxThreads() );
   else

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -2351,9 +2351,12 @@ void QgsApplication::setMaxThreads( int maxThreads )
   QgsDebugMsgLevel( QStringLiteral( "maxThreads: %1" ).arg( maxThreads ), 2 );
 
   // make sure value is between 1 and #cores, if not set to -1 (use #cores)
-  // 0 could be used to disable any parallel processing
   if ( maxThreads < 1 || maxThreads > QThread::idealThreadCount() )
     maxThreads = -1;
+
+  // force at least 2 threads -- anything less risks deadlocks within Qt itself (e.g in QImage internal mutexes)
+  if ( maxThreads > 0 && maxThreads < 2 )
+    maxThreads = 2;
 
   // save value
   ABISYM( sMaxThreads ) = maxThreads;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -670,7 +670,7 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     /**
      * Set maximum concurrent thread count
-     * \note must be between 1 and \#cores, -1 means use all available cores
+     * \note must be between 2 and \#cores, -1 means use all available cores
      * \since QGIS 2.4
     */
     static void setMaxThreads( int maxThreads );


### PR DESCRIPTION
(This setting can sometimes unwantedly occur when using the same profile across sessions of newer to very old QGIS versions)

The option is a misleading, as it's actually setting the global thread limit for the entire QGIS application. If we allow this to be set to a limit of 1 thread, then deadlocks occur from the QImage internals in unpredictable ways.


I've been chasing down unpredictable deadlocks in QImage handling for months now, and had attributed this incorrectly to a upstream bug (or Fedora packaging bug). Turns out it was due to this setting getting stuck at a maximum of 1 thread (I test a lot of older QGIS versions!) :scream_cat: 

