### PR TITLE
Add some context to obscure warning, reduce message logs noise

### DIFF
--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -355,7 +355,10 @@ void QgsLayoutItemPicture::refreshPicture( const QgsExpressionContext *context )
     {
       mHasExpressionError = true;
       source = QString();
-      QgsMessageLog::logMessage( tr( "Picture expression eval error" ) );
+      if ( scopedContext.feature().isValid() )
+      {
+        QgsMessageLog::logMessage( QStringLiteral( "%1: %2" ).arg( tr( "Picture expression eval error" ), sourceProperty.asExpression() ) );
+      }
     }
     else if ( source.type() != QVariant::ByteArray )
     {


### PR DESCRIPTION
## Description

This PR adds a bit of context to an obscure _Picture expression eval error_ message log (by appending the layout image item's data defined property's expression string), it should help users figure out where this warning comes from.

In addition, the warning will only show is an atlas feature is present in the context. This is meant to avoid the noise on project load when layouts are loaded without an active atlas feature leading to a bunch of warnings.