### PR TITLE
Fix #51940 Refactor Field Source Expression cursor moves at end

### DIFF
--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -284,12 +284,11 @@ QWidget *QgsFieldMappingExpressionDelegate::createEditor( QWidget *parent, const
 
   editor->setField( index.model()->data( index, Qt::DisplayRole ).toString() );
   connect( editor,
-           qOverload<const  QString &, bool >( &QgsFieldExpressionWidget::fieldChanged ),
+           qOverload<const  QString & >( &QgsFieldExpressionWidget::fieldChanged ),
            this,
-           [ = ]( const QString & fieldName, bool isValid )
+           [ = ]( const QString & fieldName )
   {
     Q_UNUSED( fieldName )
-    Q_UNUSED( isValid )
     const_cast< QgsFieldMappingExpressionDelegate *>( this )->emit commitData( editor );
   } );
   return editor;


### PR DESCRIPTION
- Fix #51940

## Description

When editing an expression directly in the expression box of the Source Expression, any keystroke will trigger a validation of the expression and move the cursor to the end of the line

![](https://user-images.githubusercontent.com/12854129/220186960-ce54196a-b5bf-49f9-9cd8-9ab915adac7a.gif)

Seem like the wrong signal overload was connected, causing the data to be committed while the user was typing inside the lineEdit.