### PR TITLE
Fix #52098 Capture tool technique button disabled

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -70,6 +70,13 @@ Sets the current capture if it is supported by the map tool
 .. versionadded:: 3.26
 %End
 
+    Qgis::CaptureTechnique currentCaptureTechnique() const;
+%Docstring
+Returns the active capture technique
+
+.. versionadded:: 3.32
+%End
+
 
     virtual void activate();
 

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
@@ -93,22 +93,7 @@ void QgsMapToolsDigitizingTechniqueManager::setupToolBars()
 
   mDigitizeModeToolButton->setMenu( digitizeMenu );
 
-  const Qgis::CaptureTechnique technique = settingsDigitizingTechnique->value();
-  switch ( technique )
-  {
-    case Qgis::CaptureTechnique::StraightSegments:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithSegment );
-      break;
-    case Qgis::CaptureTechnique::CircularString:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithCurve );
-      break;
-    case Qgis::CaptureTechnique::Streaming:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionStreamDigitize );
-      break;
-    case Qgis::CaptureTechnique::Shape:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeShape );
-      break;
-  }
+  updateDigitizeModeButton( settingsDigitizingTechnique->value() );
 
   QgisApp::instance()->mDigitizeToolBar->insertWidget( QgisApp::instance()->mDigitizeToolBar->actions().at( 3 ), mDigitizeModeToolButton );
 
@@ -163,21 +148,7 @@ void QgsMapToolsDigitizingTechniqueManager::setCaptureTechnique( Qgis::CaptureTe
 
   mTechniqueActions.value( technique )->setChecked( true );
 
-  switch ( technique )
-  {
-    case Qgis::CaptureTechnique::StraightSegments:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithSegment );
-      break;
-    case Qgis::CaptureTechnique::CircularString:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithCurve );
-      break;
-    case Qgis::CaptureTechnique::Streaming:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionStreamDigitize );
-      break;
-    case Qgis::CaptureTechnique::Shape:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeShape );
-      break;
-  }
+  updateDigitizeModeButton( technique );
 
   // QgisApp::captureTools returns all registered capture tools + the eventual current capture tool
   const QList< QgsMapToolCapture * > tools = QgisApp::instance()->captureTools();
@@ -263,6 +234,25 @@ void QgsMapToolsDigitizingTechniqueManager::setupTool( QgsMapToolCapture *tool )
   } );
 }
 
+void QgsMapToolsDigitizingTechniqueManager::updateDigitizeModeButton( const Qgis::CaptureTechnique technique )
+{
+  switch ( technique )
+  {
+    case Qgis::CaptureTechnique::StraightSegments:
+      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithSegment );
+      break;
+    case Qgis::CaptureTechnique::CircularString:
+      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithCurve );
+      break;
+    case Qgis::CaptureTechnique::Streaming:
+      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionStreamDigitize );
+      break;
+    case Qgis::CaptureTechnique::Shape:
+      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeShape );
+      break;
+  }
+}
+
 void QgsMapToolsDigitizingTechniqueManager::enableDigitizingTechniqueActions( bool enabled, QAction *triggeredFromToolAction )
 {
   QgsSettings settings;
@@ -303,21 +293,7 @@ void QgsMapToolsDigitizingTechniqueManager::enableDigitizingTechniqueActions( bo
   }
 
   // Ensure the digitizing mode tool button is set to the correct action
-  switch ( actualCurrentTechnique )
-  {
-    case Qgis::CaptureTechnique::StraightSegments:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithSegment );
-      break;
-    case Qgis::CaptureTechnique::CircularString:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeWithCurve );
-      break;
-    case Qgis::CaptureTechnique::Streaming:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionStreamDigitize );
-      break;
-    case Qgis::CaptureTechnique::Shape:
-      mDigitizeModeToolButton->setDefaultAction( QgisApp::instance()->mActionDigitizeShape );
-      break;
-  }
+  updateDigitizeModeButton( actualCurrentTechnique );
 
   QMap<Qgis::CaptureTechnique, QAction *>::const_iterator cit = mTechniqueActions.constBegin();
   for ( ; cit != mTechniqueActions.constEnd(); ++ cit )

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
@@ -74,6 +74,8 @@ class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
   private:
     void setupTool( QgsMapToolCapture *tool );
 
+    void updateDigitizeModeButton( const Qgis::CaptureTechnique technique );
+
     QMap<Qgis::CaptureTechnique, QAction *> mTechniqueActions;
     QHash<QString, QAction *> mShapeActions;
     QMap<QgsMapToolShapeAbstract::ShapeCategory, QToolButton *> mShapeCategoryButtons;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -94,6 +94,12 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     void setCurrentCaptureTechnique( Qgis::CaptureTechnique technique );
 
     /**
+     * Returns the active capture technique
+     * \since QGIS 3.32
+     */
+    Qgis::CaptureTechnique currentCaptureTechnique() const { return mCurrentCaptureTechnique; }
+
+    /**
      * Sets the current shape tool
      * \see QgsMapToolShapeRegistry
      * \since QGIS 3.26


### PR DESCRIPTION
Fixes #52098 
Partially adresses #51014
## Description

This PR ensures the capture technique button is not disabled when the new map tool does not support the previous digitization technique. The previous digitization is still kept in the settings, and it is restored if the user switch to another tool that supports it.

### Previous behavior
![bug_capture_technique](https://user-images.githubusercontent.com/9693475/222931189-915c0b81-3ab4-44bb-833e-88b15e9049bd.gif)

### Fixed beahavior
![fixed_capture_technique](https://user-images.githubusercontent.com/9693475/222930979-d62a4adf-303b-4206-b1e3-0f44d93642e0.gif)
