### PR TITLE
Making `session_role` in a vector layer affect rendering (issue #52085)

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -41,6 +41,21 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
   if ( !source->mTransactionConnection )
   {
     mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.timeout(), request.requestMayBeNested() );
+
+    const QString sessionRoleKey = QStringLiteral( "session_role" );
+    if ( uri.hasParam( sessionRoleKey ) )
+    {
+      const QString sessionRole = uri.param( sessionRoleKey );
+      if ( !sessionRole.isEmpty() )
+      {
+        conn->setSessionRole( sessionRole )
+      }
+    }
+    else
+    {
+      conn->resetSessionRole();
+    }
+
     mIsTransactionConnection = false;
   }
   else
@@ -1080,6 +1095,7 @@ QgsPostgresFeatureSource::QgsPostgresFeatureSource( const QgsPostgresProvider *p
   , mPrimaryKeyType( p->mPrimaryKeyType )
   , mPrimaryKeyAttrs( p->mPrimaryKeyAttrs )
   , mQuery( p->mQuery )
+  , mUri( p->mUri )
   , mCrs( p->crs() )
   , mShared( p->mShared )
   , mTopoLayerInfo( p->mTopoLayerInfo )

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -43,17 +43,17 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.timeout(), request.requestMayBeNested() );
 
     const QString sessionRoleKey = QStringLiteral( "session_role" );
-    if ( uri.hasParam( sessionRoleKey ) )
+    if ( mSource->mUri.hasParam( sessionRoleKey ) )
     {
-      const QString sessionRole = uri.param( sessionRoleKey );
+      const QString sessionRole = mSource->mUri.param( sessionRoleKey );
       if ( !sessionRole.isEmpty() )
       {
-        conn->setSessionRole( sessionRole )
+        mConn->setSessionRole( sessionRole );
       }
     }
     else
     {
-      conn->resetSessionRole();
+      mConn->resetSessionRole();
     }
 
     mIsTransactionConnection = false;

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -51,6 +51,7 @@ class QgsPostgresFeatureSource final: public QgsAbstractFeatureSource
     QgsPostgresPrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;
     QString mQuery;
+    QgsDataSourceUri mUri;
     // TODO: loadFields()
     QgsCoordinateReferenceSystem mCrs;
 


### PR DESCRIPTION
## Description

Implementing the feature proposed in #52085 (full description of the problem and solution in the issue).

Making `QgsPostgresFeatureIterator` change the `session_role` of the postgres connection. Uses the session_role value of the layers `QgsPostgresProvider`.
