### PR TITLE
Update code_layout action

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -144,13 +144,12 @@ jobs:
           sudo apt install -y \
               expect \
               silversearcher-ag
-      - uses: trilom/file-changes-action@v1.2.4
+      - uses: tj-actions/changed-files@v35
         id: changed_files
         with:
-          output: ' '
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          separator: ' '
       - name: Spell Test
-        run: ./scripts/spell_check/check_spelling.sh -r ${{ steps.changed_files.outputs.files_modified }} ${{ steps.changed_files.outputs.files_added }}
+        run: ./scripts/spell_check/check_spelling.sh -r ${{ steps.changed_files.outputs.all_changed_files }}
 
   sip_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
in order to satisfy https://github.com/qgis/QGIS/actions/runs/4344779295
- Replace inactive [trilom/file-changes-action](https://github.com/trilom/file-changes-action) with [tj-actions/changed-files](https://github.com/tj-actions/changed-files) for spell check. The former repository looks inactive for almost 3 years, and uses dependencies deprecated by github soon. Please check if I cover the full list of expected output files.
~~- Run ccpcheck test under ubuntu 22.04~~ reverted, for #52122
