### PR TITLE
Welcome 3.30, bye bye 3.22 docker build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ ^refs/tags ]]; then
             echo "matrix={\"branch\":[\"${GITHUB_REF##*/}\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"branch\":[\"master\", \"release-3_30\", \"release-3_28\"]}"  >> $GITHUB_OUTPUT
+            echo "matrix={\"branch\":[\"master\", \"release-3_30\", \"release-3_28\"]}" >> $GITHUB_OUTPUT
           fi
 
   build-docker:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,9 +32,9 @@ jobs:
       - id: matrix
         run: |
           if [[ "${GITHUB_REF}" =~ ^refs/tags ]]; then
-            echo "::set-output name=matrix::{\"branch\":[\"${GITHUB_REF##*/}\"]}"
+            echo "matrix={\"branch\":[\"${GITHUB_REF##*/}\"]}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=matrix::{\"branch\":[\"master\", \"release-3_22\", \"release-3_28\"]}"
+            echo "matrix={\"branch\":[\"master\", \"release-3_30\", \"release-3_28\"]}"  >> $GITHUB_OUTPUT
           fi
 
   build-docker:

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -66,7 +66,7 @@ jobs:
           NUMBER_OF_PRS=$(echo "${PRS_TO_PROCESS}" | jq -s '. | length')
           echo "NUMBER_OF_PRS: ${NUMBER_OF_PRS}"
           # early exit
-          [[ ${NUMBER_OF_PRS} == 0 ]] && echo "::set-output name=has_milestone_to_set::0" && exit 0
+          [[ ${NUMBER_OF_PRS} == 0 ]] && echo "has_milestone_to_set=0" >> $GITHUB_OUTPUT && exit 0
 
           # Take the first
           PR_NUMBER=$(echo "${PRS_TO_PROCESS}" | jq -s '. | first')
@@ -100,11 +100,11 @@ jobs:
           HAS_MILESTONE_TO_CREATE=$([[ -z ${MILESTONE_NUMBER} ]] && echo "1" || echo "0" )
           echo "HAS_MILESTONE_TO_CREATE: ${HAS_MILESTONE_TO_CREATE}"
 
-          echo "::set-output name=has_milestone_to_set::1"
-          echo "::set-output name=pr_number::${PR_NUMBER}"
-          echo "::set-output name=milestone_title::${MILESTONE_TITLE}"
-          echo "::set-output name=milestone_number::${MILESTONE_NUMBER}"
-          echo "::set-output name=has_milestone_to_create::${HAS_MILESTONE_TO_CREATE}"
+          echo "has_milestone_to_set=1" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "milestone_title=${MILESTONE_TITLE}" >> $GITHUB_OUTPUT
+          echo "milestone_number=${MILESTONE_NUMBER}" >> $GITHUB_OUTPUT
+          echo "has_milestone_to_create=${HAS_MILESTONE_TO_CREATE}" >> $GITHUB_OUTPUT
 
       # create the milestone if needed
       - name: Create milestone if needed
@@ -127,7 +127,7 @@ jobs:
         run: |
           FINAL_MILESTONE_NUMBER=$([[ -n ${MILESTONE_NUMBER_EXISTING} ]] && echo "${MILESTONE_NUMBER_EXISTING}" || echo $(echo "${MILESTONE_NUMBER_CREATED_JSON}" | jq .number ))
           echo "FINAL_MILESTONE_NUMBER: ${FINAL_MILESTONE_NUMBER}"
-          echo "::set-output name=milestone_number::${FINAL_MILESTONE_NUMBER}"
+          echo "milestone_number=${FINAL_MILESTONE_NUMBER}" >> $GITHUB_OUTPUT
 
       # update PR with milestone
       - name: update PR milestone

--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           LABEL=$(sed -r 's/^([[:digit:]]\.[[:digit:]]+)(\.[[:digit:]]+)?$/\1/' <<< ${MILESTONE})
           echo ${LABEL}
-          echo "::set-output name=label::${LABEL}"
+          echo "label=${LABEL}" >> $GITHUB_OUTPUT
             # get the PR body
 
       # get the PR body
@@ -92,7 +92,7 @@ jobs:
           JSON_DATA: ${{ steps.get_pr_commits.outputs.data }}
         run: |
           COMMITS_MESSAGES=$(echo ${JSON_DATA} | jq '.[].commit.message | select( . |test("\\[(feature|needs?.doc(umentation)?s?)\\]"; "i")) | sub("\\[needs?.doc(umentation)?s?\\]"; "\n\n\n\n"; "i")')
-          echo "::set-output name=commits::$(echo ${COMMITS_MESSAGES} | tr -d '\n' )"
+          echo "commits=$(echo ${COMMITS_MESSAGES} | tr -d '\n' )" >> $GITHUB_OUTPUT
 
       # create the documentation issue
       - name: Create Documentation issue


### PR DESCRIPTION
Also get rid of the [deprecated ::set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in the action _assuming that I correctly understand their changes_