### PR TITLE
Greatly optimise legend filter by map hit test

### DIFF
--- a/python/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -306,21 +306,25 @@ used from subclasses to create SLD Rule elements following SLD v1.1 specs
 
     virtual bool legendSymbolItemsCheckable() const;
 %Docstring
-items of symbology items in legend should be checkable
+Returns ``True`` if symbology items in legend are checkable.
 
 .. versionadded:: 2.5
 %End
 
     virtual bool legendSymbolItemChecked( const QString &key );
 %Docstring
-items of symbology items in legend is checked
+Returns ``True`` if the legend symbology item with the specified ``key`` is checked.
+
+.. seealso:: :py:func:`checkLegendSymbolItem`
 
 .. versionadded:: 2.5
 %End
 
     virtual void checkLegendSymbolItem( const QString &key, bool state = true );
 %Docstring
-item in symbology was checked
+Sets whether the legend symbology item with the specified ``ley`` should be checked.
+
+.. seealso:: :py:func:`legendSymbolItemChecked`
 
 .. versionadded:: 2.5
 %End

--- a/python/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -304,6 +304,15 @@ the UserStyle element of a SLD style document
 used from subclasses to create SLD Rule elements following SLD v1.1 specs
 %End
 
+    QSet< QString > legendKeys() const;
+%Docstring
+Returns the set of all legend keys used by the renderer.
+
+.. seealso:: :py:func:`legendSymbolItems`
+
+.. versionadded:: 3.32
+%End
+
     virtual bool legendSymbolItemsCheckable() const;
 %Docstring
 Returns ``True`` if symbology items in legend are checkable.
@@ -317,6 +326,8 @@ Returns ``True`` if the legend symbology item with the specified ``key`` is chec
 
 .. seealso:: :py:func:`checkLegendSymbolItem`
 
+.. seealso:: :py:func:`legendKeys`
+
 .. versionadded:: 2.5
 %End
 
@@ -325,6 +336,8 @@ Returns ``True`` if the legend symbology item with the specified ``key`` is chec
 Sets whether the legend symbology item with the specified ``ley`` should be checked.
 
 .. seealso:: :py:func:`legendSymbolItemChecked`
+
+.. seealso:: :py:func:`legendKeys`
 
 .. versionadded:: 2.5
 %End
@@ -335,6 +348,8 @@ Sets the symbol to be used for a legend symbol item.
 
 :param key: rule key for legend symbol
 :param symbol: new symbol for legend item. Ownership is transferred to renderer.
+
+.. seealso:: :py:func:`legendKeys`
 
 .. versionadded:: 2.14
 %End
@@ -351,12 +366,17 @@ the features displayed using that key.
          - ok: will be set to ``True`` if legend key was successfully converted to a filter expression
 
 
+.. seealso:: :py:func:`legendKeys`
+
+
 .. versionadded:: 3.26
 %End
 
     virtual QgsLegendSymbolList legendSymbolItems() const;
 %Docstring
 Returns a list of symbology items for the legend
+
+.. seealso:: :py:func:`legendKeys`
 
 .. versionadded:: 2.6
 %End

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -109,6 +109,13 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
   const bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRenderer::MoreSymbolsPerFeature;
   r->startRender( context, vl->fields() );
 
+  // shortcut early if we know that there's nothing visible
+  if ( r->canSkipRender() )
+  {
+    r->stopRender( context );
+    return;
+  }
+
   QgsFeatureRequest request;
 
   const QString rendererFilterExpression = r->filter( vl->fields() );

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -116,6 +116,14 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
     return;
   }
 
+  // if there's no legend items for this layer, shortcut out early
+  QSet< QString > remainingKeysToFind = r->legendKeys();
+  if ( remainingKeysToFind.empty() )
+  {
+    r->stopRender( context );
+    return;
+  }
+
   QgsFeatureRequest request;
 
   const QString rendererFilterExpression = r->filter( vl->fields() );
@@ -168,8 +176,6 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
 
   usedSymbols.clear();
   usedSymbolsRuleKey.clear();
-
-  QSet< QString > remainingKeysToFind = r->legendKeys();
 
   QgsFeature f;
   while ( fi.nextFeature( f ) )

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -330,6 +330,19 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, Qgis::Geo
   return r;
 }
 
+QSet<QString> QgsFeatureRenderer::legendKeys() const
+{
+  // build up a list of unique legend keys
+  const QgsLegendSymbolList allLegendSymbols = legendSymbolItems();
+  QSet< QString > keys;
+  keys.reserve( allLegendSymbols.size() );
+  for ( const QgsLegendSymbolItem &symbol : allLegendSymbols )
+  {
+    keys.insert( symbol.ruleKey() );
+  }
+  return keys;
+}
+
 QDomElement QgsFeatureRenderer::writeSld( QDomDocument &doc, const QString &styleName, const QVariantMap &props ) const
 {
   QDomElement userStyleElem = doc.createElement( QStringLiteral( "UserStyle" ) );

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -340,19 +340,26 @@ class CORE_EXPORT QgsFeatureRenderer
     }
 
     /**
-     * items of symbology items in legend should be checkable
+     * Returns TRUE if symbology items in legend are checkable.
+     *
      * \since QGIS 2.5
      */
     virtual bool legendSymbolItemsCheckable() const;
 
     /**
-     * items of symbology items in legend is checked
+     * Returns TRUE if the legend symbology item with the specified \a key is checked.
+     *
+     * \see checkLegendSymbolItem()
+     *
      * \since QGIS 2.5
      */
     virtual bool legendSymbolItemChecked( const QString &key );
 
     /**
-     * item in symbology was checked
+     * Sets whether the legend symbology item with the specified \a ley should be checked.
+     *
+     * \see legendSymbolItemChecked()
+     *
      * \since QGIS 2.5
      */
     virtual void checkLegendSymbolItem( const QString &key, bool state = true );

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -340,6 +340,15 @@ class CORE_EXPORT QgsFeatureRenderer
     }
 
     /**
+     * Returns the set of all legend keys used by the renderer.
+     *
+     * \see legendSymbolItems()
+     *
+     * \since QGIS 3.32
+     */
+    QSet< QString > legendKeys() const;
+
+    /**
      * Returns TRUE if symbology items in legend are checkable.
      *
      * \since QGIS 2.5
@@ -350,6 +359,7 @@ class CORE_EXPORT QgsFeatureRenderer
      * Returns TRUE if the legend symbology item with the specified \a key is checked.
      *
      * \see checkLegendSymbolItem()
+     * \see legendKeys()
      *
      * \since QGIS 2.5
      */
@@ -359,6 +369,7 @@ class CORE_EXPORT QgsFeatureRenderer
      * Sets whether the legend symbology item with the specified \a ley should be checked.
      *
      * \see legendSymbolItemChecked()
+     * \see legendKeys()
      *
      * \since QGIS 2.5
      */
@@ -368,6 +379,9 @@ class CORE_EXPORT QgsFeatureRenderer
      * Sets the symbol to be used for a legend symbol item.
      * \param key rule key for legend symbol
      * \param symbol new symbol for legend item. Ownership is transferred to renderer.
+     *
+     * \see legendKeys()
+     *
      * \since QGIS 2.14
      */
     virtual void setLegendSymbolItem( const QString &key, QgsSymbol *symbol SIP_TRANSFER );
@@ -382,12 +396,17 @@ class CORE_EXPORT QgsFeatureRenderer
      *
      * \returns QGIS expression string for matching features with the specified key
      *
+     * \see legendKeys()
+     *
      * \since QGIS 3.26
      */
     virtual QString legendKeyToExpression( const QString &key, QgsVectorLayer *layer, bool &ok SIP_OUT ) const;
 
     /**
      * Returns a list of symbology items for the legend
+     *
+     * \see legendKeys()
+     *
      * \since QGIS 2.6
      */
     virtual QgsLegendSymbolList legendSymbolItems() const;

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -1152,6 +1152,33 @@ class TestQgsRuleBasedRenderer: public QgsTest
       QCOMPARE( counter->featureCount( "2" ), 1LL );
     }
 
+    void testLegendKeys()
+    {
+      QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
+      std::unique_ptr< QgsRuleBasedRenderer > renderer = std::make_unique< QgsRuleBasedRenderer >( rootRule );
+
+      QVERIFY( renderer->legendKeys().empty() );
+
+      QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( nullptr, 0, 0, "\"field_name\" = 5" );
+      QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( nullptr, 2000, 0, "\"field_name\" = 6" );
+      QgsRuleBasedRenderer::Rule *rule4 = new QgsRuleBasedRenderer::Rule( nullptr, 0, 1000, "\"field_name\" = 7" );
+      QgsRuleBasedRenderer::Rule *rule5 = new QgsRuleBasedRenderer::Rule( nullptr, 1000, 3000 );
+
+      rootRule->appendChild( rule2 );
+      rootRule->appendChild( rule3 );
+      rootRule->appendChild( rule4 );
+      rootRule->appendChild( rule5 );
+
+      QSet< QString > expected = QSet< QString >
+      {
+        rule2->ruleKey(),
+        rule3->ruleKey(),
+        rule4->ruleKey(),
+        rule5->ruleKey()
+      };
+      QCOMPARE( renderer->legendKeys(), expected );
+    }
+
     void testLegendKeyToExpression()
     {
       QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -412,6 +412,8 @@ class TestQgsCategorizedSymbolRenderer(unittest.TestCase):
         default_symbol.setColor(QColor(255, 255, 255))
         renderer.addCategory(QgsRendererCategory('', default_symbol, 'default'))
 
+        self.assertEqual(renderer.legendKeys(), {'0', '1', '2', '3', '4'})
+
         context = QgsRenderContext()
         context.setRendererScale(0)  # simulate counting
         renderer.startRender(context, fields)

--- a/tests/src/python/test_qgsgraduatedsymbolrenderer.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrenderer.py
@@ -482,6 +482,21 @@ class TestQgsGraduatedSymbolRenderer(unittest.TestCase):
         renderer.setClassAttribute("value - $area")
         self.assertTrue(renderer.filterNeedsGeometry())
 
+    def test_legend_keys(self):
+        renderer = QgsGraduatedSymbolRenderer()
+        renderer.setClassAttribute('field_name')
+
+        self.assertFalse(renderer.legendKeys())
+
+        symbol_a = createMarkerSymbol()
+        renderer.addClassRange(QgsRendererRange(1, 2, symbol_a, 'a'))
+        symbol_b = createMarkerSymbol()
+        renderer.addClassRange(QgsRendererRange(5, 6, symbol_b, 'b'))
+        symbol_c = createMarkerSymbol()
+        renderer.addClassRange(QgsRendererRange(15.5, 16.5, symbol_c, 'c', False))
+
+        self.assertEqual(renderer.legendKeys(), {'0', '1', '2'})
+
     def test_legend_key_to_expression(self):
         renderer = QgsGraduatedSymbolRenderer()
         renderer.setClassAttribute('field_name')

--- a/tests/src/python/test_qgsmergedfeaturerenderer.py
+++ b/tests/src/python/test_qgsmergedfeaturerenderer.py
@@ -47,6 +47,16 @@ class TestQgsMergedFeatureRenderer(unittest.TestCase):
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 
+    def test_legend_keys(self):
+        symbol1 = QgsFillSymbol()
+        symbol2 = QgsFillSymbol()
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+                                                            ])
+
+        renderer = QgsMergedFeatureRenderer(sub_renderer)
+        self.assertEqual(renderer.legendKeys(), {'0', '1'})
+
     def testSinglePolys(self):
         source = QgsVectorLayer(os.path.join(TEST_DATA_DIR, 'polys_overlapping.shp'))
         self.assertTrue(source.isValid())

--- a/tests/src/python/test_qgspointclusterrenderer.py
+++ b/tests/src/python/test_qgspointclusterrenderer.py
@@ -45,6 +45,8 @@ from qgis.core import (
     QgsSymbolLayer,
     QgsUnitTypes,
     QgsVectorLayer,
+    QgsCategorizedSymbolRenderer,
+    QgsRendererCategory
 )
 from qgis.testing import start_app, unittest
 
@@ -121,6 +123,18 @@ class TestQgsPointClusterRenderer(unittest.TestCase):
         elem = r.save(doc, QgsReadWriteContext())
         c = QgsPointClusterRenderer.create(elem, QgsReadWriteContext())
         self._checkProperties(c)
+
+    def test_legend_keys(self):
+        symbol1 = QgsMarkerSymbol()
+        symbol2 = QgsMarkerSymbol()
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+                                                            ])
+
+        renderer = QgsPointClusterRenderer()
+        renderer.setEmbeddedRenderer(sub_renderer)
+
+        self.assertEqual(renderer.legendKeys(), {'0', '1'})
 
     def testConvert(self):
         """ test renderer conversion """

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -485,6 +485,18 @@ class TestQgsPointDisplacementRenderer(unittest.TestCase):
         self.assertTrue(res)
         self._tearDown(layer)
 
+    def test_legend_keys(self):
+        symbol1 = QgsMarkerSymbol()
+        symbol2 = QgsMarkerSymbol()
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+                                                            ])
+
+        renderer = QgsPointDisplacementRenderer()
+        renderer.setEmbeddedRenderer(sub_renderer)
+
+        self.assertEqual(renderer.legendKeys(), {'0', '1'})
+
     def test_legend_key_to_expression(self):
         sym1 = QgsMarkerSymbol.createSimple({'color': '#fdbf6f', 'outline_color': 'black'})
         sub_renderer = QgsSingleSymbolRenderer(sym1)

--- a/tests/src/python/test_qgssinglesymbolrenderer.py
+++ b/tests/src/python/test_qgssinglesymbolrenderer.py
@@ -84,6 +84,12 @@ class TestQgsSingleSymbolRenderer(unittest.TestCase):
 
         self.assertCountEqual(self.renderer.usedAttributes(ctx), {})
 
+    def test_legend_keys(self):
+        sym1 = QgsFillSymbol.createSimple({'color': '#fdbf6f', 'outline_color': 'black'})
+        renderer = QgsSingleSymbolRenderer(sym1)
+
+        self.assertEqual(renderer.legendKeys(), {'0'})
+
     def test_legend_key_to_expression(self):
         sym1 = QgsFillSymbol.createSimple({'color': '#fdbf6f', 'outline_color': 'black'})
         renderer = QgsSingleSymbolRenderer(sym1)


### PR DESCRIPTION
Optimise legend filter by map test by finishing early when we have determined that all available legend symbols for a layer are visible in the map

Avoids a LOT of wasted time calculating visible symbols, especially for layers with a single symbol renderer. Also add a bunch of other shortcuts to the hit test when we know nothing is visible.

Refs https://github.com/qgis/QGIS/issues/51233
Refs https://github.com/qgis/QGIS/issues/48326
Refs https://github.com/qgis/QGIS/issues/51455
Refs https://github.com/qgis/QGIS/issues/51452