### PR TITLE
qgs3dmapscene: Do not create a terrain entity if there is no raster

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -119,13 +119,13 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
   addCameraRotationCenterEntity( mCameraController );
   updateLights();
 
-  connect( &map, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::terrainGeneratorChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::mapTileResolutionChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::maxTerrainScreenErrorChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::maxTerrainGroundErrorChanged, this, &Qgs3DMapScene::createTerrain );
-  connect( &map, &Qgs3DMapSettings::terrainShadingChanged, this, &Qgs3DMapScene::createTerrain );
+  connect( &map, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::terrainGeneratorChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::mapTileResolutionChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::maxTerrainScreenErrorChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::maxTerrainGroundErrorChanged, this, &Qgs3DMapScene::updateTerrain );
+  connect( &map, &Qgs3DMapSettings::terrainShadingChanged, this, &Qgs3DMapScene::updateTerrain );
   connect( &map, &Qgs3DMapSettings::lightSourcesChanged, this, &Qgs3DMapScene::updateLights );
   connect( &map, &Qgs3DMapSettings::showLightSourceOriginsChanged, this, &Qgs3DMapScene::updateLights );
   connect( &map, &Qgs3DMapSettings::fieldOfViewChanged, this, &Qgs3DMapScene::updateCameraLens );
@@ -559,7 +559,7 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
   }
 }
 
-void Qgs3DMapScene::createTerrain()
+void Qgs3DMapScene::updateTerrain()
 {
   if ( mTerrain )
   {
@@ -572,7 +572,7 @@ void Qgs3DMapScene::createTerrain()
   if ( !mTerrainUpdateScheduled )
   {
     // defer re-creation of terrain: there may be multiple invocations of this slot, so create the new entity just once
-    QTimer::singleShot( 0, this, &Qgs3DMapScene::createTerrainDeferred );
+    QTimer::singleShot( 0, this, &Qgs3DMapScene::updateTerrainDeferred );
     mTerrainUpdateScheduled = true;
     setSceneState( Updating );
   }
@@ -582,7 +582,7 @@ void Qgs3DMapScene::createTerrain()
   }
 }
 
-void Qgs3DMapScene::createTerrainDeferred()
+void Qgs3DMapScene::updateTerrainDeferred()
 {
   bool hasValidTerrainRenderer = false;
   if ( mMap.terrainRenderingEnabled() && mMap.terrainGenerator() )
@@ -837,7 +837,7 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
   // create the terrain
   if ( !mTerrain && layer->type() == Qgis::LayerType::Raster )
   {
-    createTerrain();
+    updateTerrain();
   }
 }
 
@@ -878,7 +878,7 @@ void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
   // remove the terrain
   if ( mTerrain && layer->type() == Qgis::LayerType::Raster )
   {
-    createTerrain();
+    updateTerrain();
   }
 }
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -231,10 +231,10 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
   private slots:
     void onCameraChanged();
     void onFrameTriggered( float dt );
-    void createTerrain();
+    void updateTerrain();
     void onLayerRenderer3DChanged();
     void onLayersChanged();
-    void createTerrainDeferred();
+    void updateTerrainDeferred();
     void onBackgroundColorChanged();
     void onLayerEntityPickedObject( Qt3DRender::QPickEvent *pickEvent, QgsFeatureId fid );
     void updateLights();


### PR DESCRIPTION
## Description

From the main commit:

The logic to create the initial scene is handled by `createTerrainDeferred` which creates a Terrain entity (`mTerrain`) and then creates an entity for all the layers which have a renderer. However, this can result in a bad rendering if there is no layer associated with a terrain. Indeed, in that case, the terrain entity has a texture which has the same color as the background and this can hide objects below the terrain.

This issue is fixed by only creating `mTerrain` if necessary. The initial entity creation logic is now handled by calling `onLayersChanged` instead of `createTerrainDeferred`. Then, `addLayerEntity` and `removeLayerEntity` checks if a layer is suitable to be displayed as a terrain and calls `createTerrain` to create or remove mTerrain accordingly.


Current behavior:

![Capture d’écran du 2023-03-07 18-53-31](https://user-images.githubusercontent.com/497207/223510714-2beb15f0-5656-4c15-bc09-2896694cffa9.png)

New behavior:

![Capture d’écran du 2023-03-07 18-54-08](https://user-images.githubusercontent.com/497207/223510762-92f03b56-1309-431c-acfd-da241107c271.png)


cc @benoitdm-oslandia @wonder-sk 