### PR TITLE
Fix Random Extract duplicates features

### DIFF
--- a/src/analysis/processing/qgsalgorithmrandomextract.cpp
+++ b/src/analysis/processing/qgsalgorithmrandomextract.cpp
@@ -124,12 +124,13 @@ QVariantMap QgsRandomExtractAlgorithm::processAlgorithm( const QVariantMap &para
 
   // If the number of features to select is greater than half the total number of features
   // we will instead randomly select features to *exclude* from the output layer
+  size_t actualFeatureCount = allFeats.size();
   size_t shuffledFeatureCount = number;
-  bool invertSelection = number > count / 2;
+  bool invertSelection = static_cast< size_t>( number ) > actualFeatureCount / 2;
   if ( invertSelection )
-    shuffledFeatureCount = count - number;
+    shuffledFeatureCount = actualFeatureCount - number;
 
-  size_t nb = count;
+  size_t nb = actualFeatureCount;
 
   // Shuffle <number> features at the start of the iterator
   feedback->pushInfo( QObject::tr( "Randomly select %1 features" ).arg( number ) );


### PR DESCRIPTION
- Fixes #52114

## Description

The Random Extract algorithm randomly selects n integers from 0 to featureCount, and uses these as a list of feature ids. However, feature ids are not guaranteed to be in this range (it will notably not be the case if some feature were deleted in the current session). Besides, id 0 will typicaly be an invalid feature (this PR set the range to 1->featureCount). 

With this PR, the algorithm builds the list of the actual ids before selecting them to fix this issue. It then performs a modified [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) to select the ids. This performs the C++ equivalent of Python's `random.sample`


