### PR TITLE
Allow filter expressions to be set for vector sources

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -34,7 +34,7 @@ Encapsulates settings relating to a feature source input to a processing algorit
 
 
     QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false, long long featureLimit = -1,
-                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid );
+                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid, const QString &filterExpression = QString() );
 %Docstring
 Constructor for QgsProcessingFeatureSourceDefinition, accepting a static string ``source``.
 
@@ -43,6 +43,9 @@ If ``selectedFeaturesOnly`` is ``True``, then only selected features from the so
 The optional ``featureLimit`` can be set to a value > 0 to place a hard limit on the maximum number
 of features which will be read from the source.
 
+Since QGIS 3.32, the optional ``filterExpression`` argument can be used to specify a expression to use
+to filter the features read from the source.
+
 The ``flags`` argument can be used to specify flags which dictate the source behavior.
 
 If the QgsProcessingFeatureSourceDefinition.Flag.FlagOverrideDefaultGeometryCheck is set in ``flags``, then the value of ``geometryCheck`` will override
@@ -50,7 +53,7 @@ the default geometry check method (as dictated by :py:class:`QgsProcessingContex
 %End
 
     QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false, long long featureLimit = -1,
-                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid );
+                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid, const QString &filterExpression = QString() );
 %Docstring
 Constructor for QgsProcessingFeatureSourceDefinition, accepting a QgsProperty source.
 
@@ -58,6 +61,9 @@ If ``selectedFeaturesOnly`` is ``True``, then only selected features from the so
 
 The optional ``featureLimit`` can be set to a value > 0 to place a hard limit on the maximum number
 of features which will be read from the source.
+
+Since QGIS 3.32, the optional ``filterExpression`` argument can be used to specify a expression to use
+to filter the features read from the source.
 
 The ``flags`` argument can be used to specify flags which dictate the source behavior.
 
@@ -70,6 +76,8 @@ the default geometry check method (as dictated by :py:class:`QgsProcessingContex
     bool selectedFeaturesOnly;
 
     long long featureLimit;
+
+    QString filterExpression;
 
     Flags flags;
 

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -352,7 +352,9 @@ a specified ``algorithm``.
         const QStringList &compatibleFormats,
         const QString &preferredFormat,
         QgsProcessingContext &context,
-        QgsProcessingFeedback *feedback, long long featureLimit = -1 );
+        QgsProcessingFeedback *feedback,
+        long long featureLimit = -1,
+        const QString &filterExpression = QString() );
 %Docstring
 Converts a source vector ``layer`` to a file path of a vector layer of compatible format.
 
@@ -367,6 +369,9 @@ layer export is required. This defaults to shapefiles.
 
 The ``featureLimit`` argument can be used to specify a limit on the number of features read from the layer.
 
+Since QGIS 3.32, the optional ``filterExpression`` argument can be used to specify a expression to use
+to filter the features read from the layer.
+
 When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
 to use :py:func:`~QgsProcessingUtils.convertToCompatibleFormatAndLayerName` which may avoid conversion in more situations.
 
@@ -380,7 +385,9 @@ to use :py:func:`~QgsProcessingUtils.convertToCompatibleFormatAndLayerName` whic
         const QString &preferredFormat,
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback,
-        QString &layerName /Out/, long long featureLimit = -1 );
+        QString &layerName /Out/,
+        long long featureLimit = -1,
+        const QString &filterExpression = QString() );
 %Docstring
 Converts a source vector ``layer`` to a file path and layer name of a vector layer of compatible format.
 
@@ -406,10 +413,11 @@ a conversion in this case and will return the target layer name in the ``layerNa
 :param preferredFormat: preferred format extension to use if conversion if required
 :param context: processing context
 :param feedback: feedback object
+:param layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)
 :param featureLimit: can be used to place a limit on the maximum number of features read from the layer
+:param filterExpression: optional expression for filtering features read from the layer (since QGIS 3.32)
 
-:return: - path to source layer, or nearly converted compatible layer
-         - layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+:return: path to source layer, or nearly converted compatible layer
 
 
 .. seealso:: :py:func:`convertToCompatibleFormat`
@@ -531,7 +539,7 @@ results according to the settings in a :py:class:`QgsProcessingContext`.
 
 
     QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false,
-                                long long featureLimit = -1 );
+                                long long featureLimit = -1, const QString &filterExpression = QString() );
 %Docstring
 Constructor for QgsProcessingFeatureSource, accepting an original feature source ``originalSource``
 and processing ``context``.
@@ -541,6 +549,8 @@ If ``ownsOriginalSource`` is ``True``, then this object will take ownership of `
 
 If ``featureLimit`` is set to a value > 0, then a limit is placed on the maximum number of features which will be
 read from the source.
+
+Since QGIS 3.32, the optional ``filterExpression`` can be used to specify an expression based filter for the source.
 %End
 
     ~QgsProcessingFeatureSource();

--- a/src/analysis/processing/qgsalgorithmangletonearest.cpp
+++ b/src/analysis/processing/qgsalgorithmangletonearest.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmangletonearest.h"
-#include "qgsprocessingoutputs.h"
+#include "qgsspatialindex.h"
 #include "qgslinestring.h"
 #include "qgsvectorlayer.h"
 #include "qgsrenderer.h"

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsgeometryengine.h"
 #include "qgsdistancearea.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
@@ -18,6 +18,7 @@
 #include "qgsalgorithmdeleteduplicategeometries.h"
 #include "qgsvectorlayer.h"
 #include "qgsgeometryengine.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -17,7 +17,7 @@
 
 #include "qgsalgorithmdetectdatasetchanges.h"
 #include "qgsvectorlayer.h"
-#include "qgsgeometryengine.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -18,7 +18,7 @@
 #include "qgsalgorithmjoinbynearest.h"
 #include "qgsprocessingoutputs.h"
 #include "qgslinestring.h"
-
+#include "qgsspatialindex.h"
 #include <algorithm>
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmlinedensity.h
+++ b/src/analysis/processing/qgsalgorithmlinedensity.h
@@ -24,6 +24,7 @@
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 #include "qgsdistancearea.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsalgorithmlineintersection.h"
 #include "qgsgeometryengine.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
@@ -18,6 +18,7 @@
 #include "qgsalgorithmnearestneighbouranalysis.h"
 #include "qgsapplication.h"
 #include "qgsdistancearea.h"
+#include "qgsspatialindex.h"
 #include <QTextStream>
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmrandompointsextent.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsextent.cpp
@@ -18,7 +18,9 @@
 //Disclaimer: The algorithm optimizes the original Random points in extent algorithm, (C) Alexander Bruy, 2014
 
 #include "qgsalgorithmrandompointsextent.h"
-#include "random"
+#include "qgsspatialindex.h"
+
+#include <random>
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
@@ -17,6 +17,8 @@
 
 
 #include "qgsalgorithmrandompointsinpolygons.h"
+#include "qgsspatialindex.h"
+
 #include <random>
 
 // The algorithm parameter names:

--- a/src/analysis/processing/qgsalgorithmrandompointsonlines.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsonlines.cpp
@@ -17,7 +17,9 @@
 
 
 #include "qgsalgorithmrandompointsonlines.h"
-#include "random"
+#include "qgsspatialindex.h"
+
+#include <random>
 
 // The algorithm parameter names:
 static const QString INPUT = QStringLiteral( "INPUT" );

--- a/src/analysis/processing/qgsalgorithmshortestline.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestline.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsalgorithmshortestline.h"
 #include "qgsdistancearea.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -18,6 +18,8 @@
 #include "qgsalgorithmsplitwithlines.h"
 #include "qgsgeometryengine.h"
 #include "qgsvectorlayer.h"
+#include "qgsspatialindex.h"
+
 ///@cond PRIVATE
 
 QString QgsSplitWithLinesAlgorithm::name() const

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -20,6 +20,7 @@
 #include "qgsfeaturerequest.h"
 #include "qgsfeaturesource.h"
 #include "qgsprocessingcontext.h"
+#include "qgsspatialindex.h"
 
 ///@cond PRIVATE
 

--- a/src/core/classification/qgsclassificationmethod.cpp
+++ b/src/core/classification/qgsclassificationmethod.cpp
@@ -23,6 +23,7 @@
 #include "qgsapplication.h"
 #include "qgsclassificationmethodregistry.h"
 #include "qgsxmlutils.h"
+#include "qgsmessagelog.h"
 
 const int QgsClassificationMethod::MAX_PRECISION = 15;
 const int QgsClassificationMethod::MIN_PRECISION = -6;

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -19,6 +19,7 @@
 #include "qgsprocessingutils.h"
 #include "qgsunittypes.h"
 #include "qgsproviderregistry.h"
+#include "qgsprocessing.h"
 
 QgsProcessingContext::QgsProcessingContext()
   : mPreferredVectorFormat( QgsProcessingUtils::defaultVectorExtension() )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -76,16 +76,20 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
      * The optional \a featureLimit can be set to a value > 0 to place a hard limit on the maximum number
      * of features which will be read from the source.
      *
+     * Since QGIS 3.32, the optional \a filterExpression argument can be used to specify a expression to use
+     * to filter the features read from the source.
+     *
      * The \a flags argument can be used to specify flags which dictate the source behavior.
      *
      * If the QgsProcessingFeatureSourceDefinition::Flag::FlagOverrideDefaultGeometryCheck is set in \a flags, then the value of \a geometryCheck will override
      * the default geometry check method (as dictated by QgsProcessingContext) for this source.
      */
     QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false, long long featureLimit = -1,
-                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid )
+                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid, const QString &filterExpression = QString() )
       : source( QgsProperty::fromValue( source ) )
       , selectedFeaturesOnly( selectedFeaturesOnly )
       , featureLimit( featureLimit )
+      , filterExpression( filterExpression )
       , flags( flags )
       , geometryCheck( geometryCheck )
     {}
@@ -98,16 +102,20 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
      * The optional \a featureLimit can be set to a value > 0 to place a hard limit on the maximum number
      * of features which will be read from the source.
      *
+     * Since QGIS 3.32, the optional \a filterExpression argument can be used to specify a expression to use
+     * to filter the features read from the source.
+     *
      * The \a flags argument can be used to specify flags which dictate the source behavior.
      *
      * If the QgsProcessingFeatureSourceDefinition::Flag::FlagOverrideDefaultGeometryCheck is set in \a flags, then the value of \a geometryCheck will override
      * the default geometry check method (as dictated by QgsProcessingContext) for this source.
      */
     QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false, long long featureLimit = -1,
-                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid )
+                                          QgsProcessingFeatureSourceDefinition::Flags flags = QgsProcessingFeatureSourceDefinition::Flags(), QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid, const QString &filterExpression = QString() )
       : source( source )
       , selectedFeaturesOnly( selectedFeaturesOnly )
       , featureLimit( featureLimit )
+      , filterExpression( filterExpression )
       , flags( flags )
       , geometryCheck( geometryCheck )
     {}
@@ -129,6 +137,13 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
      * \since QGIS 3.14
      */
     long long featureLimit = -1;
+
+    /**
+     * Optional expression filter to use for filtering features which will be read from the source.
+     *
+     * \since QGIS 3.32
+     */
+    QString filterExpression;
 
     /**
      * Flags which dictate source behavior.
@@ -169,6 +184,7 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
       return source == other.source
              && selectedFeaturesOnly == other.selectedFeaturesOnly
              && featureLimit == other.featureLimit
+             && filterExpression == other.filterExpression
              && flags == other.flags
              && geometryCheck == other.geometryCheck;
     }

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -21,9 +21,6 @@
 #include "qgis_core.h"
 
 #include "qgsrasterlayer.h"
-#include "qgsmessagelog.h"
-#include "qgsspatialindex.h"
-#include "qgsprocessing.h"
 #include "qgsfeaturesink.h"
 #include "qgsfeaturesource.h"
 #include "qgsproxyfeaturesink.h"
@@ -376,6 +373,9 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * The \a featureLimit argument can be used to specify a limit on the number of features read from the layer.
      *
+     * Since QGIS 3.32, the optional \a filterExpression argument can be used to specify a expression to use
+     * to filter the features read from the layer.
+     *
      * When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
      * to use convertToCompatibleFormatAndLayerName() which may avoid conversion in more situations.
      *
@@ -387,7 +387,9 @@ class CORE_EXPORT QgsProcessingUtils
         const QStringList &compatibleFormats,
         const QString &preferredFormat,
         QgsProcessingContext &context,
-        QgsProcessingFeedback *feedback, long long featureLimit = -1 );
+        QgsProcessingFeedback *feedback,
+        long long featureLimit = -1,
+        const QString &filterExpression = QString() );
 
     /**
      * Converts a source vector \a layer to a file path and layer name of a vector layer of compatible format.
@@ -416,6 +418,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \param feedback feedback object
      * \param layerName will be set to the target layer name for multi-layer sources (e.g. Geopackage)
      * \param featureLimit can be used to place a limit on the maximum number of features read from the layer
+     * \param filterExpression optional expression for filtering features read from the layer (since QGIS 3.32)
      *
      * \returns path to source layer, or nearly converted compatible layer
      *
@@ -429,7 +432,9 @@ class CORE_EXPORT QgsProcessingUtils
         const QString &preferredFormat,
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback,
-        QString &layerName SIP_OUT, long long featureLimit = -1 );
+        QString &layerName SIP_OUT,
+        long long featureLimit = -1,
+        const QString &filterExpression = QString() );
 
     /**
      * Combines two field lists, avoiding duplicate field names (in a case-insensitive manner).
@@ -603,9 +608,11 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
      *
      * If \a featureLimit is set to a value > 0, then a limit is placed on the maximum number of features which will be
      * read from the source.
+     *
+     * Since QGIS 3.32, the optional \a filterExpression can be used to specify an expression based filter for the source.
      */
     QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false,
-                                long long featureLimit = -1 );
+                                long long featureLimit = -1, const QString &filterExpression = QString() );
 
     ~QgsProcessingFeatureSource() override;
 
@@ -655,6 +662,7 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
     std::function< void( const QgsFeature & ) > mInvalidGeometryCallbackAbort;
 
     long long mFeatureLimit = -1;
+    QString mFilterExpression;
 
 };
 

--- a/src/gui/processing/qgsprocessingfeaturesourceoptionswidget.cpp
+++ b/src/gui/processing/qgsprocessingfeaturesourceoptionswidget.cpp
@@ -34,6 +34,12 @@ QgsProcessingFeatureSourceOptionsWidget::QgsProcessingFeatureSourceOptionsWidget
 
   connect( mFeatureLimitSpinBox, qOverload<int>( &QSpinBox::valueChanged ), this, &QgsPanelWidget::widgetChanged );
   connect( mComboInvalidFeatureFiltering, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
+  connect( mFilterExpressionWidget, &QgsExpressionLineEdit::expressionChanged, this, &QgsPanelWidget::widgetChanged );
+}
+
+void QgsProcessingFeatureSourceOptionsWidget::setLayer( QgsVectorLayer *layer )
+{
+  mFilterExpressionWidget->setLayer( layer );
 }
 
 void QgsProcessingFeatureSourceOptionsWidget::setGeometryCheckMethod( bool isOverridden, QgsFeatureRequest::InvalidGeometryCheck check )
@@ -49,6 +55,11 @@ void QgsProcessingFeatureSourceOptionsWidget::setFeatureLimit( int limit )
   mFeatureLimitSpinBox->setValue( limit );
 }
 
+void QgsProcessingFeatureSourceOptionsWidget::setFilterExpression( const QString &expression )
+{
+  mFilterExpressionWidget->setExpression( expression );
+}
+
 QgsFeatureRequest::InvalidGeometryCheck QgsProcessingFeatureSourceOptionsWidget::geometryCheckMethod() const
 {
   return mComboInvalidFeatureFiltering->currentData().isValid() ? static_cast< QgsFeatureRequest::InvalidGeometryCheck >( mComboInvalidFeatureFiltering->currentData().toInt() ) : QgsFeatureRequest::GeometryAbortOnInvalid;
@@ -62,6 +73,11 @@ bool QgsProcessingFeatureSourceOptionsWidget::isOverridingInvalidGeometryCheck()
 int QgsProcessingFeatureSourceOptionsWidget::featureLimit() const
 {
   return mFeatureLimitSpinBox->value() > 0 ? mFeatureLimitSpinBox->value() : -1;
+}
+
+QString QgsProcessingFeatureSourceOptionsWidget::filterExpression() const
+{
+  return mFilterExpressionWidget->expression();
 }
 
 ///@endcond

--- a/src/gui/processing/qgsprocessingfeaturesourceoptionswidget.h
+++ b/src/gui/processing/qgsprocessingfeaturesourceoptionswidget.h
@@ -43,6 +43,11 @@ class GUI_EXPORT QgsProcessingFeatureSourceOptionsWidget : public QgsPanelWidget
     QgsProcessingFeatureSourceOptionsWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
+     * Sets a layer associated with the widget.
+     */
+    void setLayer( QgsVectorLayer *layer );
+
+    /**
      * Sets the geometry check method to use, and whether the default method is overridden.
      *
      * \see isOverridingInvalidGeometryCheck()
@@ -56,6 +61,13 @@ class GUI_EXPORT QgsProcessingFeatureSourceOptionsWidget : public QgsPanelWidget
      * \see featureLimit()
      */
     void setFeatureLimit( int limit );
+
+    /**
+     * Sets the filter \a expression for the source.
+     *
+     * \see filterExpression()
+     */
+    void setFilterExpression( const QString &expression );
 
     /**
      * Returns the selected geometry check method. Also check isOverridingInvalidGeometryCheck() to verify
@@ -79,6 +91,13 @@ class GUI_EXPORT QgsProcessingFeatureSourceOptionsWidget : public QgsPanelWidget
      * \see setFeatureLimit()
      */
     int featureLimit() const;
+
+    /**
+     * Returns the expression filter set in the widget, or an empty string if no filter is set.
+     *
+     * \see setFilterExpression()
+     */
+    QString filterExpression() const;
 
 };
 

--- a/src/gui/processing/qgsprocessingmaplayercombobox.h
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.h
@@ -146,6 +146,7 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
     QCheckBox *mUseSelectionCheckBox = nullptr;
     bool mDragActive = false;
     long long mFeatureLimit = -1;
+    QString mFilterExpression;
     bool mIsOverridingDefaultGeometryCheck = false;
     QgsFeatureRequest::InvalidGeometryCheck mGeometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;
     QPointer< QgsMapLayer> mPrevLayer;

--- a/src/ui/processing/qgsprocessingfeaturesourceoptionsbase.ui
+++ b/src/ui/processing/qgsprocessingfeaturesourceoptionsbase.ui
@@ -47,14 +47,14 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Invalid feature filtering</string>
+          <string>Limit features processed</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -66,6 +66,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Invalid feature filtering</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="1">
         <widget class="QComboBox" name="mComboInvalidFeatureFiltering">
@@ -84,10 +91,17 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="3" column="1">
+        <widget class="QgsExpressionLineEdit" name="mFilterExpressionWidget" native="true">
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Limit features processed</string>
+          <string>Feature filter</string>
          </property>
         </widget>
        </item>
@@ -98,6 +112,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
@@ -111,9 +130,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionlineedit.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -6048,6 +6048,12 @@ void TestProcessingGui::mapLayerComboBox()
   sourceDef.flags = QgsProcessingFeatureSourceDefinition::Flags();
   combo->setValue( sourceDef, context );
   QVERIFY( !( combo->value().value< QgsProcessingFeatureSourceDefinition >().flags & QgsProcessingFeatureSourceDefinition::Flag::FlagOverrideDefaultGeometryCheck ) );
+  sourceDef.filterExpression = QStringLiteral( "name='test'" );
+  combo->setValue( sourceDef, context );
+  QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().filterExpression, QStringLiteral( "name='test'" ) );
+  sourceDef.filterExpression = QString();
+  combo->setValue( sourceDef, context );
+  QCOMPARE( combo->value().value< QgsProcessingFeatureSourceDefinition >().filterExpression, QString() );
 
   combo.reset();
   param.reset();
@@ -9383,6 +9389,15 @@ void TestProcessingGui::testFeatureSourceOptionsWidget()
   w.setGeometryCheckMethod( false, QgsFeatureRequest::GeometryAbortOnInvalid );
   QVERIFY( !w.isOverridingInvalidGeometryCheck() );
   QCOMPARE( spy.count(), 5 );
+
+  w.setFilterExpression( QStringLiteral( "name='test'" ) );
+  QCOMPARE( spy.count(), 6 );
+  QCOMPARE( w.filterExpression(), QStringLiteral( "name='test'" ) );
+  w.setFilterExpression( QStringLiteral( "name='test'" ) );
+  QCOMPARE( spy.count(), 6 );
+  w.setFilterExpression( QString() );
+  QCOMPARE( spy.count(), 7 );
+  QCOMPARE( w.filterExpression(), QString() );
 }
 
 void TestProcessingGui::testVectorOutWrapper()


### PR DESCRIPTION
This change adds a new "feature filter" option alongside the existing feature limit and invalid geometry handling options available for all vector inputs to processing layers.

It allows users to enter an expression to subset the layer dynamically when running the tool, avoiding the need for separate steps to set layer filters or create layer subsets.

Sponsored by City of Canning

![image](https://user-images.githubusercontent.com/1829991/223615623-fad26517-e3ee-4186-8ccf-609e1e98f5ff.png)
