### PR TITLE
fix displaying of the enum parameter options in static strings mode

### DIFF
--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -4911,7 +4911,7 @@ QString QgsProcessingParameterEnum::valueAsPythonString( const QVariant &value, 
 
   if ( mUsesStaticStrings )
   {
-    if ( value.type() == QVariant::StringList )
+    if ( value.type() == QVariant::List || value.type() == QVariant::StringList )
     {
       QStringList parts;
       const QStringList constList = value.toStringList();

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2445,8 +2445,19 @@ void QgsProcessingEnumPanelWidget::showDialog()
   if ( mParam )
   {
     availableOptions.reserve( mParam->options().size() );
-    for ( int i = 0; i < mParam->options().count(); ++i )
-      availableOptions << i;
+
+    if ( mParam->usesStaticStrings() )
+    {
+      for ( QString o : mParam->options() )
+      {
+        availableOptions << o;
+      }
+    }
+    else
+    {
+      for ( int i = 0; i < mParam->options().count(); ++i )
+        availableOptions << i;
+    }
   }
 
   const QStringList options = mParam ? mParam->options() : QStringList();


### PR DESCRIPTION
If Processing enum parameter uses static strings mode and multiple selection is allowed, option list shows empty items instead of actual values. Also improves conversion to Python string by considering not only `QStringList` as a possible value but also `QList`.

Should be backported.