### PR TITLE
Don't handle valueChanged for each duplicate widget

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1081,7 +1081,12 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
   {
     if ( formEditorWidget->editorWidget() == eww )
       continue;
+
+    // formEditorWidget and eww points to the same field, so block signals
+    // as there is no need to handle valueChanged again for each duplicate
+    formEditorWidget->editorWidget()->blockSignals( true );
     formEditorWidget->editorWidget()->setValue( value );
+    formEditorWidget->editorWidget()->blockSignals( false );
   }
 
   if ( !signalEmitted )


### PR DESCRIPTION
Currently in the attribute form, if more widgets points to the same field, when one of them change value all the duplicates are updated in `onAttributeChanged`. During update they send the same valueChanged signal and `onAttributeChanged` is called again and again with the same value and field that was already handled.

This P.R. will block duplicate widgets from sending `valueChanged` signal in this context.
This fixes https://github.com/qgis/QGIS/issues/50859