### PR TITLE
Add skip/src/dstnodata params to gdal2xyz

### DIFF
--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2533,7 +2533,47 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['gdal2xyz.py',
                  '-band 1 -csv ' +
                  source + ' ' +
-                 outsource])
+                    outsource])
+
+            if GdalUtils.version() >= 3030000:
+                # skip nodata output
+                self.assertEqual(
+                    alg.getConsoleCommands({'INPUT': source,
+                                            'BAND': 1,
+                                            'CSV': False,
+                                            'SKIPNODATA': True,
+                                            'OUTPUT': outsource}, context, feedback),
+                    ['gdal2xyz.py',
+                     '-band 1 -skipnodata ' +
+                     source + ' ' +
+                     outsource])
+
+            if GdalUtils.version() > 3060300:
+                # srcnodata output
+                self.assertEqual(
+                    alg.getConsoleCommands({'INPUT': source,
+                                            'BAND': 1,
+                                            'CSV': False,
+                                            'SRCNODATA': -999,
+                                            'SKIPNODATA': False,
+                                            'OUTPUT': outsource}, context, feedback),
+                    ['gdal2xyz.py',
+                     '-band 1 -srcnodata -999 ' +
+                     source + ' ' +
+                     outsource])
+
+                # dstnodata output
+                self.assertEqual(
+                    alg.getConsoleCommands({'INPUT': source,
+                                            'BAND': 1,
+                                            'CSV': False,
+                                            'DSTNODATA': -999,
+                                            'SKIPNODATA': False,
+                                            'OUTPUT': outsource}, context, feedback),
+                    ['gdal2xyz.py',
+                     '-band 1 -dstnodata -999 ' +
+                     source + ' ' +
+                     outsource])
 
     def testGdalPolygonize(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2541,7 +2541,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                     alg.getConsoleCommands({'INPUT': source,
                                             'BAND': 1,
                                             'CSV': False,
-                                            'SKIPNODATA': True,
+                                            'SKIP_NODATA': True,
                                             'OUTPUT': outsource}, context, feedback),
                     ['gdal2xyz.py',
                      '-band 1 -skipnodata ' +
@@ -2554,8 +2554,8 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                     alg.getConsoleCommands({'INPUT': source,
                                             'BAND': 1,
                                             'CSV': False,
-                                            'SRCNODATA': -999,
-                                            'SKIPNODATA': False,
+                                            'NODATA_INPUT': -999,
+                                            'SKIP_NODATA': False,
                                             'OUTPUT': outsource}, context, feedback),
                     ['gdal2xyz.py',
                      '-band 1 -srcnodata -999 ' +
@@ -2567,8 +2567,8 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                     alg.getConsoleCommands({'INPUT': source,
                                             'BAND': 1,
                                             'CSV': False,
-                                            'DSTNODATA': -999,
-                                            'SKIPNODATA': False,
+                                            'NODATA_OUTPUT': -999,
+                                            'SKIP_NODATA': False,
                                             'OUTPUT': outsource}, context, feedback),
                     ['gdal2xyz.py',
                      '-band 1 -dstnodata -999 ' +


### PR DESCRIPTION
## Description

Adds `-skipnodata` and `-src/dstnodata` parameters to GDAL provider gdal2xyz processing algorithm. These parameters were added to GDAL's gdal2xyz.py utilitues as of GDAL 3.3, though the `-src/dstnodata` params are [broken as of GDAL 3.6](https://github.com/OSGeo/gdal/issues/7410).

Suggested help in [QGIS-Documentation gdal2xyz_params branch](https://github.com/lpinner/QGIS-Documentation/blob/gdal2xyz_params/docs/user_manual/processing_algs/gdal/rasterconversion.rst) (PR: [#8097](https://github.com/qgis/QGIS-Documentation/pull/8097))