### PR TITLE
[Python Console] Fix duplicated newline on save (windows)

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -301,7 +301,9 @@ class Editor(QgsCodeEditorPython):
 
     def createTempFile(self):
         name = tempfile.NamedTemporaryFile(delete=False).name
-        Path(name).write_text(self.text(), encoding='utf-8')
+        # Need to use newline='' to avoid adding extra \r characters on Windows
+        with open(name, 'w', encoding='utf-8', newline='') as f:
+            f.write(self.text())
         return name
 
     def runScriptCode(self):
@@ -427,7 +429,9 @@ class Editor(QgsCodeEditorPython):
             self.pythonconsole.callWidgetMessageBarEditor(msgText, 0, True)
 
         # Save the new contents
-        Path(self.path).write_text(self.text(), encoding='utf-8')
+        # Need to use newline='' to avoid adding extra \r characters on Windows
+        with open(self.path, 'w', encoding='utf-8', newline='') as f:
+            f.write(self.text())
         tabwidget.setTabTitle(index, Path(self.path).name)
         tabwidget.setTabToolTip(index, self.path)
         self.setModified(False)


### PR DESCRIPTION
## Description

When saving a python script on Windows, newlines are duplicated.
This was introduced by #51913

On Windows, QScintilla inserts `\r\n` whenever the enter key is pressed. Code was previously reliant on the `codecs.open`, whose default handling of newlines differs from the way `io.open`, `open`, or `Path` does it.

This PR replaces the calls to

```Python
Path(name).write_text(text, encoding='utf-8')
```

```Python
with open(name, 'w', encoding='utf-8', newline='') as f:
   f.write(text)
```

**Note**: Path did not introduce the [`newline`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_text) argument until Python 3.10  so we cannnot use it in this case.