### PR TITLE
[api] Add a new QgsZipUtils's files() function and a unzip() parameter to skip consistency check

### DIFF
--- a/python/core/auto_generated/qgsziputils.sip.in
+++ b/python/core/auto_generated/qgsziputils.sip.in
@@ -56,6 +56,13 @@ also returned.
 
 
 
+  const QStringList files( const QString &zip );
+%Docstring
+Returns the list of files within a ``zip`` file
+
+.. versionadded:: 3.30
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsziputils.sip.in
+++ b/python/core/auto_generated/qgsziputils.sip.in
@@ -25,12 +25,13 @@ extension, ``False`` otherwise.
 :return: ``True`` if the file is zipped, ``False`` otherwise
 %End
 
-  bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/ );
+  bool unzip( const QString &zip, const QString &dir, QStringList &files /Out/, bool checkConsistency = true );
 %Docstring
 Unzip a zip file in an output directory.
 
 :param zip: The zip filename
 :param dir: The output directory
+:param checkConsistency: Perform additional stricter consistency checks on the archive, and error if they fail (since QGIS 3.30)
 
 :return: - ``False`` if the zip filename does not exist, the output directory
          - files: The absolute path of unzipped files

--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -293,3 +293,35 @@ bool QgsZipUtils::encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut )
   deflateEnd( &strm );
   return true;
 }
+
+const QStringList QgsZipUtils::files( const QString &zip )
+{
+  if ( zip.isEmpty() && !QFileInfo::exists( zip ) )
+  {
+    return QStringList();
+  }
+  QStringList files;
+
+  int rc = 0;
+  const QByteArray fileNamePtr = zip.toUtf8();
+  struct zip *z = zip_open( fileNamePtr.constData(), 0, &rc );
+
+  if ( rc == ZIP_ER_OK && z )
+  {
+    const int count = zip_get_num_files( z );
+    if ( count != -1 )
+    {
+      struct zip_stat stat;
+
+      for ( int i = 0; i < count; i++ )
+      {
+        zip_stat_index( z, i, 0, &stat );
+        files << QString( stat.name );
+      }
+    }
+
+    zip_close( z );
+  }
+
+  return files;
+}

--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -34,7 +34,7 @@ bool QgsZipUtils::isZipFile( const QString &filename )
   return QFileInfo( filename ).suffix().compare( QLatin1String( "qgz" ), Qt::CaseInsensitive ) == 0;
 }
 
-bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QStringList &files )
+bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QStringList &files, bool checkConsistency )
 {
   files.clear();
 
@@ -66,7 +66,7 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
 
   int rc = 0;
   const QByteArray fileNamePtr = zipFilename.toUtf8();
-  struct zip *z = zip_open( fileNamePtr.constData(), ZIP_CHECKCONS, &rc );
+  struct zip *z = zip_open( fileNamePtr.constData(), checkConsistency ? ZIP_CHECKCONS : 0, &rc );
 
   if ( rc == ZIP_ER_OK && z )
   {

--- a/src/core/qgsziputils.h
+++ b/src/core/qgsziputils.h
@@ -84,6 +84,13 @@ namespace QgsZipUtils
    */
   CORE_EXPORT bool encodeGzip( const QByteArray &bytesIn, QByteArray &bytesOut ) SIP_SKIP;
 
+  /**
+   * Returns the list of files within a \a zip file
+   *
+   * \since QGIS 3.30
+   */
+  CORE_EXPORT const QStringList files( const QString &zip );
+
 };
 
 #endif //QGSZIPUTILS_H

--- a/src/core/qgsziputils.h
+++ b/src/core/qgsziputils.h
@@ -42,11 +42,12 @@ namespace QgsZipUtils
    * \param zip The zip filename
    * \param dir The output directory
    * \param files The absolute path of unzipped files
+   * \param checkConsistency Perform additional stricter consistency checks on the archive, and error if they fail (since QGIS 3.30)
    * \returns FALSE if the zip filename does not exist, the output directory
    * does not exist or is not writable.
    * \since QGIS 3.0
    */
-  CORE_EXPORT bool unzip( const QString &zip, const QString &dir, QStringList &files SIP_OUT );
+  CORE_EXPORT bool unzip( const QString &zip, const QString &dir, QStringList &files SIP_OUT, bool checkConsistency = true );
 
   /**
    * Zip the list of files in the zip file. If the zip file already exists or is

--- a/tests/src/python/test_qgsziputils.py
+++ b/tests/src/python/test_qgsziputils.py
@@ -121,6 +121,19 @@ class TestQgsZip(unittest.TestCase):
         self.assertTrue(rc)
         self.assertEqual(len(files), 3)
 
+    def test_zip_files(self):
+        zip = tmpPath()
+
+        f0 = os.path.join(unitTestDataPath(), 'multipoint.shp')
+        f1 = os.path.join(unitTestDataPath(), 'lines.shp')
+        f2 = os.path.join(unitTestDataPath(), 'joins.qgs')
+
+        rc = QgsZipUtils.zip(zip, [f0, f1, f2])
+        self.assertTrue(rc)
+
+        files = QgsZipUtils.files(zip)
+        self.assertEqual(files, ['multipoint.shp', 'lines.shp', 'joins.qgs'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Because libzip's consistency check fails with many, many zip archiver tool (e.g. gnome's very own archive manager), This PR adds a parameter to unzip() to skip the check so the class can be used outside of the narrower scope of handling libzip-produced .qgz.

PR also adds a useful files() function to list files within a ZIP archive without having to actually decompress its content.