### PR TITLE
qgs3dmapcanvaswidget: Allow to draw the extent on the 2D map canvas

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -682,6 +682,22 @@ This parameter is transient. It is not saved in the project parameters.
 .. versionadded:: 3.26
 %End
 
+    bool showExtentIn2DView() const;
+%Docstring
+Returns whether the extent is displayed on the main 2D map canvas
+
+.. seealso:: :py:func:`setShowExtentIn2DView`
+
+.. versionadded:: 3.32
+%End
+
+    void setShowExtentIn2DView( bool show );
+%Docstring
+Sets whether the extent is displayed on the main 2D map canvas
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void settingsChanged();
@@ -934,6 +950,15 @@ Emitted when the 3d view's 2d extent has changed
 .. seealso:: :py:func:`setExtent`
 
 .. versionadded:: 3.30
+%End
+
+    void showExtentIn2DViewChanged();
+%Docstring
+Emitted when the parameter to display 3d view's extent in the 2D canvas has changed
+
+.. seealso:: :py:func:`setShowExtentIn2DView`
+
+.. versionadded:: 3.32
 %End
 
   private:

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -99,6 +99,7 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , m3dAxisSettings( other.m3dAxisSettings )
   , mIsDebugOverlayEnabled( other.mIsDebugOverlayEnabled )
   , mExtent( other.mExtent )
+  , mShowExtentIn2DView( other.mShowExtentIn2DView )
 {
   for ( QgsAbstract3DRenderer *renderer : std::as_const( other.mRenderers ) )
   {
@@ -141,6 +142,8 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
                 elemExtent.attribute( QStringLiteral( "yMin" ) ).toDouble(),
                 elemExtent.attribute( QStringLiteral( "xMax" ) ).toDouble(),
                 elemExtent.attribute( QStringLiteral( "yMax" ) ).toDouble() );
+
+    mShowExtentIn2DView = elemExtent.attribute( QStringLiteral( "showIn2dView" ), QStringLiteral( "0" ) ).toInt();
   }
   else
   {
@@ -364,6 +367,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemExtent.setAttribute( QStringLiteral( "yMin" ), mExtent.yMinimum() );
   elemExtent.setAttribute( QStringLiteral( "xMax" ), mExtent.xMaximum() );
   elemExtent.setAttribute( QStringLiteral( "yMax" ), mExtent.yMaximum() );
+  elemExtent.setAttribute( QStringLiteral( "showIn2dView" ), mShowExtentIn2DView );
   elem.appendChild( elemExtent );
 
   QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
@@ -1016,6 +1020,7 @@ void Qgs3DMapSettings::connectChangedSignalsToSettingsChanged()
   connect( this, &Qgs3DMapSettings::axisSettingsChanged, this, &Qgs3DMapSettings::settingsChanged );
   connect( this, &Qgs3DMapSettings::ambientOcclusionSettingsChanged, this, &Qgs3DMapSettings::settingsChanged );
   connect( this, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapSettings::settingsChanged );
+  connect( this, &Qgs3DMapSettings::showExtentIn2DViewChanged, this, &Qgs3DMapSettings::settingsChanged );
 }
 
 
@@ -1036,4 +1041,13 @@ void Qgs3DMapSettings::set3DAxisSettings( const Qgs3DAxisSettings &axisSettings,
     m3dAxisSettings = axisSettings;
     emit axisSettingsChanged();
   }
+}
+
+void Qgs3DMapSettings::setShowExtentIn2DView( bool show )
+{
+  if ( show == mShowExtentIn2DView )
+    return;
+
+  mShowExtentIn2DView = show;
+  emit showExtentIn2DViewChanged();
 }

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -681,6 +681,19 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setIsDebugOverlayEnabled( bool debugOverlayEnabled );
 
+    /**
+     * Returns whether the extent is displayed on the main 2D map canvas
+     * \see setShowExtentIn2DView()
+     * \since QGIS 3.32
+     */
+    bool showExtentIn2DView() const { return mShowExtentIn2DView; }
+
+    /**
+     * Sets whether the extent is displayed on the main 2D map canvas
+     * \since QGIS 3.32
+     */
+    void setShowExtentIn2DView( bool show );
+
   signals:
 
     /**
@@ -887,6 +900,13 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void extentChanged();
 
+    /**
+     * Emitted when the parameter to display 3d view's extent in the 2D canvas has changed
+     * \see setShowExtentIn2DView()
+     * \since QGIS 3.32
+     */
+    void showExtentIn2DViewChanged();
+
   private:
 #ifdef SIP_RUN
     Qgs3DMapSettings &operator=( const Qgs3DMapSettings & );
@@ -960,6 +980,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     bool mIsDebugOverlayEnabled = false;
 
     QgsRectangle mExtent; //!< 2d extent used to limit the 3d view
+
+    bool mShowExtentIn2DView = false;
 
 };
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -371,6 +371,9 @@ void Qgs3DMapCanvasWidget::setMapSettings( Qgs3DMapSettings *map )
   mLabelFpsCounter->setVisible( map->isFpsCounterEnabled() );
 
   connect( map, &Qgs3DMapSettings::viewFrustumVisualizationEnabledChanged, this, &Qgs3DMapCanvasWidget::onViewFrustumVisualizationEnabledChanged );
+  connect( map, &Qgs3DMapSettings::extentChanged, this, &Qgs3DMapCanvasWidget::onExtentChanged );
+  connect( map, &Qgs3DMapSettings::showExtentIn2DViewChanged, this, &Qgs3DMapCanvasWidget::onExtentChanged );
+  onExtentChanged();
 }
 
 void Qgs3DMapCanvasWidget::setMainCanvas( QgsMapCanvas *canvas )
@@ -385,6 +388,12 @@ void Qgs3DMapCanvasWidget::setMainCanvas( QgsMapCanvas *canvas )
   {
     mViewFrustumHighlight.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
     mViewFrustumHighlight->setColor( QColor::fromRgba( qRgba( 0, 0, 255, 50 ) ) );
+  }
+
+  if ( !mViewExtentHighlight )
+  {
+    mViewExtentHighlight.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
+    mViewExtentHighlight->setColor( QColor::fromRgba( qRgba( 255, 0, 0, 50 ) ) );
   }
 }
 
@@ -616,5 +625,20 @@ void Qgs3DMapCanvasWidget::onViewFrustumVisualizationEnabledChanged()
       mViewFrustumHighlight->addPoint( pt, false );
     }
     mViewFrustumHighlight->closePoints();
+  }
+}
+
+void Qgs3DMapCanvasWidget::onExtentChanged()
+{
+  Qgs3DMapSettings *mapSettings = mCanvas->map();
+  mViewExtentHighlight->reset( Qgis::GeometryType::Polygon );
+  if ( mapSettings->showExtentIn2DView() )
+  {
+    QgsRectangle extent = mapSettings->extent();
+    mViewExtentHighlight->addPoint( QgsPointXY( extent.xMinimum(), extent.yMinimum() ), false );
+    mViewExtentHighlight->addPoint( QgsPointXY( extent.xMinimum(), extent.yMaximum() ), false );
+    mViewExtentHighlight->addPoint( QgsPointXY( extent.xMaximum(), extent.yMaximum() ), false );
+    mViewExtentHighlight->addPoint( QgsPointXY( extent.xMaximum(), extent.yMinimum() ), false );
+    mViewExtentHighlight->closePoints();
   }
 }

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -55,7 +55,6 @@
 Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   : QWidget( nullptr )
   , mCanvasName( name )
-  , mViewFrustumHighlight( nullptr )
 {
   const QgsSettings setting;
 
@@ -272,8 +271,6 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 Qgs3DMapCanvasWidget::~Qgs3DMapCanvasWidget()
 {
   delete mDockableWidgetHelper;
-  if ( mViewFrustumHighlight )
-    delete mViewFrustumHighlight;
 }
 
 void Qgs3DMapCanvasWidget::resizeEvent( QResizeEvent *event )
@@ -384,10 +381,11 @@ void Qgs3DMapCanvasWidget::setMainCanvas( QgsMapCanvas *canvas )
   connect( mMainCanvas, &QgsMapCanvas::canvasColorChanged, this, &Qgs3DMapCanvasWidget::onMainCanvasColorChanged );
   connect( mMainCanvas, &QgsMapCanvas::extentsChanged, this, &Qgs3DMapCanvasWidget::onMainMapCanvasExtentChanged );
 
-  if ( mViewFrustumHighlight )
-    delete mViewFrustumHighlight;
-  mViewFrustumHighlight = new QgsRubberBand( canvas, Qgis::GeometryType::Polygon );
-  mViewFrustumHighlight->setColor( QColor::fromRgba( qRgba( 0, 0, 255, 50 ) ) );
+  if ( !mViewFrustumHighlight )
+  {
+    mViewFrustumHighlight.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
+    mViewFrustumHighlight->setColor( QColor::fromRgba( qRgba( 0, 0, 255, 50 ) ) );
+  }
 }
 
 void Qgs3DMapCanvasWidget::resetView()

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -19,6 +19,7 @@
 #include "qmenu.h"
 #include "qgsdockwidget.h"
 #include "qgis_app.h"
+#include "qobjectuniqueptr.h"
 #include "qtoolbutton.h"
 #include "qgsrectangle.h"
 
@@ -116,7 +117,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QAction *mShowFrustumPolyogon = nullptr;
     QToolButton *mBtnOptions = nullptr;
     QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
-    QgsRubberBand *mViewFrustumHighlight = nullptr;
+    QObjectUniquePtr< QgsRubberBand > mViewFrustumHighlight;
     QPointer<QDialog> mConfigureDialog;
 };
 

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -92,6 +92,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void onMainMapCanvasExtentChanged();
     void onViewed2DExtentFrom3DChanged( QVector<QgsPointXY> extent );
     void onViewFrustumVisualizationEnabledChanged();
+    void onExtentChanged();
 
   private:
     QString mCanvasName;
@@ -118,6 +119,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QToolButton *mBtnOptions = nullptr;
     QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
     QObjectUniquePtr< QgsRubberBand > mViewFrustumHighlight;
+    QObjectUniquePtr< QgsRubberBand > mViewExtentHighlight;
     QPointer<QDialog> mConfigureDialog;
 };
 

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -252,6 +252,11 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   groupExtent->setCurrentExtent( mMap->extent(), mMap->crs() );
   groupExtent->setOutputExtentFromCurrent();
   groupExtent->setMapCanvas( mMainCanvas );
+
+  // checkbox to display the extent in the 2D Map View
+  mShowExtentIn2DViewCheckbox = new QCheckBox( tr( "Show in 2D map view" ) );
+  mShowExtentIn2DViewCheckbox->setChecked( map->showExtentIn2DView() );
+  groupExtent->layout()->addWidget( mShowExtentIn2DViewCheckbox );
 }
 
 Qgs3DMapConfigWidget::~Qgs3DMapConfigWidget()
@@ -264,6 +269,7 @@ Qgs3DMapConfigWidget::~Qgs3DMapConfigWidget()
 void Qgs3DMapConfigWidget::apply()
 {
   mMap->setExtent( groupExtent->outputExtent() );
+  mMap->setShowExtentIn2DView( mShowExtentIn2DViewCheckbox->isChecked() );
 
   const QgsTerrainGenerator::Type terrainType = static_cast<QgsTerrainGenerator::Type>( cboTerrainType->currentData().toInt() );
 

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -20,6 +20,7 @@
 
 #include <ui_map3dconfigwidget.h>
 
+class QCheckBox;
 class Qgs3DMapSettings;
 class QgsMapCanvas;
 class QgsMesh3dSymbolWidget;
@@ -57,6 +58,7 @@ class Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigWidget
     QgsMesh3dSymbolWidget *mMeshSymbolWidget = nullptr;
     QgsSkyboxRenderingSettingsWidget *mSkyboxSettingsWidget = nullptr;
     QgsShadowRenderingSettingsWidget *mShadowSettingsWidget = nullptr;
+    QCheckBox *mShowExtentIn2DViewCheckbox = nullptr;
 
     void init3DAxisPage();
 };

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -803,21 +803,21 @@
                   <item row="0" column="0">
                    <widget class="QCheckBox" name="mSync2DTo3DCheckbox">
                     <property name="text">
-                     <string>2D Map View Follows 3D Camera</string>
+                     <string>2D map view follows 3D camera</string>
                     </property>
                    </widget>
                   </item>
                   <item row="1" column="0">
                    <widget class="QCheckBox" name="mSync3DTo2DCheckbox">
                     <property name="text">
-                     <string>3D Camera Follows 2D Map View</string>
+                     <string>3D camera follows 2D map view</string>
                     </property>
                    </widget>
                   </item>
                   <item row="2" column="0">
                    <widget class="QCheckBox" name="mVisualizeExtentCheckBox">
                     <property name="text">
-                     <string>Show Visible Camera Area in 2D Map View</string>
+                     <string>Show visible camera area in 2D map view</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
This adds a QgsRubberband in the 2D map canvas similar to the one used to display the Frustum.

The option can be enabled in the General section of the 3D configuration widget.

The option 
![Capture d’écran du 2023-03-07 12-41-20](https://user-images.githubusercontent.com/497207/224727615-8ab70f61-b5e3-4e1d-9234-01de958df725.png)

Result on the 2D Map Canvas

![Capture d’écran du 2023-03-07 12-41-29](https://user-images.githubusercontent.com/497207/224727708-d2cd48b7-1520-4264-86e3-5f1aa5000627.png)

Extent and Frustum combined


![Capture d’écran du 2023-03-07 12-41-59](https://user-images.githubusercontent.com/497207/224727792-f867452c-57e1-490e-a82c-239a828a2640.png)


cc @benoitdm-oslandia @wonder-sk 