### PR TITLE
[queued_ltr_backport] Use gdal::dataset_unique_ptr to store return of GDALOpenEx() (fixes #52052)

### DIFF
--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -216,7 +216,7 @@ QVector<QgsDataItem *> QgsGeoPackageCollectionItem::createChildren()
   {
     // sniff database to see if it's just empty, or if something went wrong
     // note that we HAVE to use update here, or GDAL won't open an empty database
-    gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( path.toUtf8().constData(), GDAL_OF_UPDATE | GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
+    gdal::dataset_unique_ptr hDS( GDALOpenEx( path.toUtf8().constData(), GDAL_OF_UPDATE | GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
     if ( !hDS )
     {
       QString errorMessage;

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -40,7 +40,7 @@
 // QgsOgrProviderResultIterator
 //
 
-QgsOgrProviderResultIterator::QgsOgrProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer )
+QgsOgrProviderResultIterator::QgsOgrProviderResultIterator( gdal::dataset_unique_ptr hDS, OGRLayerH ogrLayer )
   : mHDS( std::move( hDS ) )
   , mOgrLayer( ogrLayer )
 {
@@ -450,7 +450,7 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
   mCapabilities |= RenameField;
 #endif
 
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
   if ( !hDS )
   {
     // fallback to read only otherwise
@@ -459,18 +459,18 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
 
   if ( hDS )
   {
-    if ( OGR_DS_TestCapability( hDS.get(), ODsCCurveGeometries ) )
+    if ( GDALDatasetTestCapability( hDS.get(), ODsCCurveGeometries ) )
       mGeometryColumnCapabilities |= GeometryColumnCapability::Curves;
 
-    if ( OGR_DS_TestCapability( hDS.get(), ODsCMeasuredGeometries ) )
+    if ( GDALDatasetTestCapability( hDS.get(), ODsCMeasuredGeometries ) )
       mGeometryColumnCapabilities |= GeometryColumnCapability::M;
 
     if ( !mSingleTableDataset )
     {
-      if ( OGR_DS_TestCapability( hDS.get(), ODsCCreateLayer ) )
+      if ( GDALDatasetTestCapability( hDS.get(), ODsCCreateLayer ) )
         mCapabilities |= CreateVectorTable;
 
-      if ( OGR_DS_TestCapability( hDS.get(), ODsCDeleteLayer ) )
+      if ( GDALDatasetTestCapability( hDS.get(), ODsCDeleteLayer ) )
         mCapabilities |= DropVectorTable;
     }
   }
@@ -521,7 +521,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsOgrProviderConnection::exe
 
   QString errCause;
   // try first using an editable datasource
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
   if ( !hDS )
   {
     // fallback to read only otherwise
@@ -668,7 +668,7 @@ QList<QgsVectorDataProvider::NativeType> QgsOgrProviderConnection::nativeTypes()
 QStringList QgsOgrProviderConnection::fieldDomainNames() const
 {
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
   if ( !hDS )
   {
     // In some cases (empty geopackage for example), opening in read-only
@@ -730,7 +730,7 @@ QList<Qgis::FieldDomainType> QgsOgrProviderConnection::supportedFieldDomainTypes
 QgsFieldDomain *QgsOgrProviderConnection::fieldDomain( const QString &name ) const
 {
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,3,0)
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
   if ( !hDS )
   {
     // In some cases (empty geopackage for example), opening in read-only
@@ -808,7 +808,7 @@ void QgsOgrProviderConnection::addFieldDomain( const QgsFieldDomain &domain, con
     QgsMessageLog::logMessage( QStringLiteral( "Schema is not supported by OGR, ignoring" ), QStringLiteral( "OGR" ), Qgis::MessageLevel::Info );
   }
 
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
   if ( hDS )
   {
     if ( OGRFieldDomainH ogrDomain = QgsOgrUtils::convertFieldDomain( &domain ) )
@@ -914,7 +914,7 @@ QList<QgsWeakRelation> QgsOgrProviderConnection::relationships( const QString &s
   }
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
   if ( !hDS )
   {
     // In some cases (empty geopackage for example), opening in read-only

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -28,7 +28,7 @@
 struct QgsOgrProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
 {
 
-    QgsOgrProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer );
+    QgsOgrProviderResultIterator( gdal::dataset_unique_ptr hDS, OGRLayerH ogrLayer );
 
     ~QgsOgrProviderResultIterator();
 
@@ -38,7 +38,7 @@ struct QgsOgrProviderResultIterator: public QgsAbstractDatabaseProviderConnectio
 
   private:
 
-    gdal::ogr_datasource_unique_ptr mHDS;
+    gdal::dataset_unique_ptr mHDS;
     OGRLayerH mOgrLayer;
     QgsFields mFields;
     QVariantList mNextRow;

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -478,7 +478,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsSpatiaLiteProviderConnecti
   }
 
   QString errCause;
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( pathFromUri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
+  gdal::dataset_unique_ptr hDS( GDALOpenEx( pathFromUri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
   if ( hDS )
   {
 
@@ -584,7 +584,7 @@ void QgsSpatialiteProviderResultIterator::setFields( const QgsFields &fields )
 }
 
 
-QgsSpatialiteProviderResultIterator::QgsSpatialiteProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer )
+QgsSpatialiteProviderResultIterator::QgsSpatialiteProviderResultIterator( gdal::dataset_unique_ptr hDS, OGRLayerH ogrLayer )
   : mHDS( std::move( hDS ) )
   , mOgrLayer( ogrLayer )
 {

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -25,7 +25,7 @@
 
 struct QgsSpatialiteProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
 {
-    QgsSpatialiteProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer );
+    QgsSpatialiteProviderResultIterator( gdal::dataset_unique_ptr hDS, OGRLayerH ogrLayer );
 
     ~QgsSpatialiteProviderResultIterator();
 
@@ -35,7 +35,7 @@ struct QgsSpatialiteProviderResultIterator: public QgsAbstractDatabaseProviderCo
 
   private:
 
-    gdal::ogr_datasource_unique_ptr mHDS;
+    gdal::dataset_unique_ptr mHDS;
     OGRLayerH mOgrLayer;
     QgsFields mFields;
     QVariantList mNextRow;


### PR DESCRIPTION
This avoids an implicit case from OGRDataSourceH to GDALDatasetH, that doesn't work with all compilers

Backport of PR #52173
