### PR TITLE
[vector tile] Fix tile background edge artifacts by using a buffered polygon

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -161,6 +161,8 @@ Constructs renderer with no styles
 
     virtual void stopRender( QgsRenderContext &context );
 
+    virtual void renderBackground( QgsRenderContext &context );
+
     virtual void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context );
 
     virtual void renderSelectedFeatures( const QList< QgsFeature > &selection, QgsRenderContext &context );

--- a/python/core/auto_generated/vectortile/qgsvectortilerenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilerenderer.sip.in
@@ -126,6 +126,11 @@ An empty string present in the list indicates that all layer in the tiles are re
 Finishes rendering and cleans up any resources
 %End
 
+    virtual void renderBackground( QgsRenderContext &context ) = 0;
+%Docstring
+Renders the background if defined
+%End
+
     virtual void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context ) = 0;
 %Docstring
 Renders given vector tile. Must be called between startRender/stopRender.

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -169,9 +169,6 @@ void QgsVectorTileBasicRenderer::renderBackground( QgsRenderContext &context )
     if ( !layerStyle.symbol() || layerStyle.layerName() != QLatin1String( "background" ) )
       continue;
 
-    QgsExpression filterExpression( layerStyle.filterExpression() );
-    filterExpression.prepare( &context.expressionContext() );
-
     QgsSymbol *sym = layerStyle.symbol();
     sym->startRender( context, QgsFields() );
 

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -185,7 +185,15 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
     {
       QgsFillSymbol *fillSym = dynamic_cast<QgsFillSymbol *>( sym );
       if ( fillSym )
-        fillSym->renderPolygon( tile.tilePolygon(), nullptr, nullptr, context );
+      {
+        QPolygon tilePolygon = tile.tilePolygon();
+        // Order of points set in QgsVectorTileUtils::tilePolygon
+        tilePolygon.setPoint( 0, QPoint( tilePolygon.point( 0 ).x() - 10, tilePolygon.point( 0 ).y() + 10 ) );
+        tilePolygon.setPoint( 1, QPoint( tilePolygon.point( 1 ).x() - 10, tilePolygon.point( 1 ).y() - 10 ) );
+        tilePolygon.setPoint( 2, QPoint( tilePolygon.point( 2 ).x() + 10, tilePolygon.point( 2 ).y() - 10 ) );
+        tilePolygon.setPoint( 3, QPoint( tilePolygon.point( 3 ).x() + 10, tilePolygon.point( 3 ).y() + 10 ) );
+        fillSym->renderPolygon( tilePolygon, nullptr, nullptr, context );
+      }
     }
     else if ( layerStyle.layerName().isEmpty() )
     {

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -162,6 +162,34 @@ void QgsVectorTileBasicRenderer::stopRender( QgsRenderContext &context )
   Q_UNUSED( context )
 }
 
+void QgsVectorTileBasicRenderer::renderBackground( QgsRenderContext &context )
+{
+  for ( const QgsVectorTileBasicRendererStyle &layerStyle : std::as_const( mStyles ) )
+  {
+    if ( !layerStyle.symbol() || layerStyle.layerName() != QLatin1String( "background" ) )
+      continue;
+
+    QgsExpression filterExpression( layerStyle.filterExpression() );
+    filterExpression.prepare( &context.expressionContext() );
+
+    QgsSymbol *sym = layerStyle.symbol();
+    sym->startRender( context, QgsFields() );
+
+    QgsFillSymbol *fillSym = dynamic_cast<QgsFillSymbol *>( sym );
+    if ( fillSym )
+    {
+      QPolygon polygon;
+      polygon << QPoint( 0, 0 );
+      polygon << QPoint( 0, context.outputSize().height() );
+      polygon << QPoint( context.outputSize().width(), context.outputSize().height() );
+      polygon << QPoint( context.outputSize().width(), 0 );
+      fillSym->renderPolygon( polygon, nullptr, nullptr, context );
+    }
+    sym->stopRender( context );
+    break;
+  }
+}
+
 void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context )
 {
   const QgsVectorTileFeatures tileData = tile.features();
@@ -169,7 +197,7 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
 
   for ( const QgsVectorTileBasicRendererStyle &layerStyle : std::as_const( mStyles ) )
   {
-    if ( !layerStyle.isActive( zoomLevel ) || !layerStyle.symbol() )
+    if ( !layerStyle.isActive( zoomLevel ) || !layerStyle.symbol() || layerStyle.layerName() == QLatin1String( "background" ) )
       continue;
 
     QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Layer" ) ); // will be deleted by popper
@@ -181,21 +209,7 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
 
     QgsSymbol *sym = layerStyle.symbol();
     sym->startRender( context, QgsFields() );
-    if ( layerStyle.layerName() == QLatin1String( "background" ) )
-    {
-      QgsFillSymbol *fillSym = dynamic_cast<QgsFillSymbol *>( sym );
-      if ( fillSym )
-      {
-        QPolygon tilePolygon = tile.tilePolygon();
-        // Order of points set in QgsVectorTileUtils::tilePolygon
-        tilePolygon.setPoint( 0, QPoint( tilePolygon.point( 0 ).x() - 10, tilePolygon.point( 0 ).y() + 10 ) );
-        tilePolygon.setPoint( 1, QPoint( tilePolygon.point( 1 ).x() - 10, tilePolygon.point( 1 ).y() - 10 ) );
-        tilePolygon.setPoint( 2, QPoint( tilePolygon.point( 2 ).x() + 10, tilePolygon.point( 2 ).y() - 10 ) );
-        tilePolygon.setPoint( 3, QPoint( tilePolygon.point( 3 ).x() + 10, tilePolygon.point( 3 ).y() + 10 ) );
-        fillSym->renderPolygon( tilePolygon, nullptr, nullptr, context );
-      }
-    }
-    else if ( layerStyle.layerName().isEmpty() )
+    if ( layerStyle.layerName().isEmpty() )
     {
       // matching all layers
       for ( const auto &features : tileData )

--- a/src/core/vectortile/qgsvectortilebasicrenderer.h
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.h
@@ -136,6 +136,7 @@ class CORE_EXPORT QgsVectorTileBasicRenderer : public QgsVectorTileRenderer
     QMap<QString, QSet<QString> > usedAttributes( const QgsRenderContext & ) override SIP_SKIP;
     QSet< QString > requiredLayers( QgsRenderContext &context, int tileZoom ) const override;
     void stopRender( QgsRenderContext &context ) override;
+    void renderBackground( QgsRenderContext &context ) override;
     void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context ) override;
     void renderSelectedFeatures( const QList< QgsFeature > &selection, QgsRenderContext &context ) override;
     bool willRenderFeature( const QgsFeature &feature, int tileZoom, const QString &layerName, QgsRenderContext &context ) override;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -21,6 +21,7 @@
 #include "qgsfeedback.h"
 #include "qgslogger.h"
 
+#include "qgsvectortilebasicrenderer.h"
 #include "qgsvectortilemvtdecoder.h"
 #include "qgsvectortilelayer.h"
 #include "qgsvectortileloader.h"
@@ -155,6 +156,9 @@ bool QgsVectorTileLayerRenderer::render()
   const QgsExpressionContextScopePopper popper( ctx.expressionContext(), scope );
 
   mRenderer->startRender( *renderContext(), mTileZoom, mTileRange );
+
+  // Draw background style if present
+  mRenderer->renderBackground( ctx );
 
   QMap<QString, QSet<QString> > requiredFields = mRenderer->usedAttributes( ctx );
 

--- a/src/core/vectortile/qgsvectortilerenderer.h
+++ b/src/core/vectortile/qgsvectortilerenderer.h
@@ -135,6 +135,9 @@ class CORE_EXPORT QgsVectorTileRenderer
     //! Finishes rendering and cleans up any resources
     virtual void stopRender( QgsRenderContext &context ) = 0;
 
+    //! Renders the background if defined
+    virtual void renderBackground( QgsRenderContext &context ) = 0;
+
     //! Renders given vector tile. Must be called between startRender/stopRender.
     virtual void renderTile( const QgsVectorTileRendererData &tile, QgsRenderContext &context ) = 0;
 


### PR DESCRIPTION
## Description

This PR improves the rendering of vector tile backgrounds by rendering the background only *once* (covering the whole output size) to avoid artifacts at tiles' edges. Spotted those recently while working with rotated map canvases (but _also impacts non-rotated map canvases exported via layout prints :scream:_)

Image of the issue against a map canvas with a 45 degree rotation:
![Screenshot from 2023-03-14 16-48-27](https://user-images.githubusercontent.com/1728657/224982301-df4314a6-ed60-44bf-9998-dfc09ca9cbb5.png)

Same map canvas, same rotation, with the PR fix applied:
![Screenshot from 2023-03-14 16-48-02](https://user-images.githubusercontent.com/1728657/224982470-85e76ca3-12ec-40be-ad09-8318fc9258b6.png)

Bingo! :)

This was pretty bad, and also affected raster exports of print layouts (left is without the fix, right is rendered with fix):
![image](https://user-images.githubusercontent.com/1728657/224982911-0882b035-1624-477f-b9bb-96adf4d4de5f.png)

By rendering the background only *once*, benefits include:
- micro optimization, only renders once instead being rendered at the bottom of every single tile
- removes bad artifacts on PDF exports
- looks much better during progressive renderings