### PR TITLE
Add a "contextMenuAboutToShow" signal to QgsLayerTreeView 

### DIFF
--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -363,7 +363,7 @@ Emitted when datasets are dropped onto the layer tree view
 %Docstring
 Emitted when the context menu is about to show.
 
-Allows customisation of the menu.
+Allows customization of the menu.
 
 .. versionadded:: 3.32
 %End

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -359,6 +359,15 @@ Emitted when a current layer is changed
 Emitted when datasets are dropped onto the layer tree view
 %End
 
+    void contextMenuAboutToShow( QMenu *menu );
+%Docstring
+Emitted when the context menu is about to show.
+
+Allows customisation of the menu.
+
+.. versionadded:: 3.32
+%End
+
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -143,6 +143,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       menu->addSeparator();
 
       QMenu *menuExportGroup = new QMenu( tr( "E&xport" ), menu );
+      menuExportGroup->setObjectName( QStringLiteral( "exportMenu" ) );
       QAction *actionSaveAsDefinitionGroup = new QAction( tr( "Save as Layer &Definition File…" ), menuExportGroup );
       connect( actionSaveAsDefinitionGroup, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
       menuExportGroup->addAction( actionSaveAsDefinitionGroup );
@@ -539,6 +540,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
               }
               // save as vector file
               QMenu *menuExportVector = new QMenu( tr( "E&xport" ), menu );
+              menuExportVector->setObjectName( QStringLiteral( "exportMenu" ) );
               QAction *actionSaveAs = new QAction( tr( "Save Features &As…" ), menuExportVector );
               connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
               actionSaveAs->setEnabled( vlayer->isValid() );
@@ -568,6 +570,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             bool enableSaveAs = ( pcLayer && pcLayer->isValid() ) ||
                                 ( rlayer && rlayer->isValid() );
             QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
+            menuExportRaster->setObjectName( QStringLiteral( "exportMenu" ) );
             QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
             QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
             QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -179,9 +179,14 @@ void QgsLayerTreeView::contextMenuEvent( QContextMenuEvent *event )
     setCurrentIndex( QModelIndex() );
 
   QMenu *menu = mMenuProvider->createContextMenu();
-  if ( menu && menu->actions().count() != 0 )
-    menu->exec( mapToGlobal( event->pos() ) );
-  delete menu;
+  if ( menu )
+  {
+    emit contextMenuAboutToShow( menu );
+
+    if ( menu->actions().count() != 0 )
+      menu->exec( mapToGlobal( event->pos() ) );
+    delete menu;
+  }
 }
 
 

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -354,6 +354,15 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     //! Emitted when datasets are dropped onto the layer tree view
     void datasetsDropped( QDropEvent *event );
 
+    /**
+     * Emitted when the context menu is about to show.
+     *
+     * Allows customisation of the menu.
+     *
+     * \since QGIS 3.32
+     */
+    void contextMenuAboutToShow( QMenu *menu );
+
   protected:
     void contextMenuEvent( QContextMenuEvent *event ) override;
 

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -357,7 +357,7 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     /**
      * Emitted when the context menu is about to show.
      *
-     * Allows customisation of the menu.
+     * Allows customization of the menu.
      *
      * \since QGIS 3.32
      */


### PR DESCRIPTION
Allows plugins to hook into this menu and add custom entries and customise the standard entries

I'd ideally like to backport to 3.30 and 3.28