### PR TITLE
Allow processing dialog to override default processing context settings

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -342,6 +342,15 @@ Returns ``True`` if the dialog is all finalized and can be safely deleted.
 .. versionadded:: 3.26
 %End
 
+    void applyContextOverrides( QgsProcessingContext *context );
+%Docstring
+Applies any defined overrides for Processing context settings to the specified ``context``.
+
+This allows the dialog to override default Processing settings for an individual algorithm execution.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void algorithmFinished( bool successful, const QVariantMap &result );

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -161,13 +161,14 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         if self.context is None:
             self.feedback = self.createFeedback()
             self.context = dataobjects.createContext(self.feedback)
-            self.context.setLogLevel(self.logLevel())
+
+        self.applyContextOverrides(self.context)
         return self.context
 
     def runAlgorithm(self):
         self.feedback = self.createFeedback()
         self.context = dataobjects.createContext(self.feedback)
-        self.context.setLogLevel(self.logLevel())
+        self.applyContextOverrides(self.context)
 
         checkCRS = ProcessingConfig.getSetting(ProcessingConfig.WARN_UNMATCHING_CRS)
         try:

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -26,6 +26,7 @@
 #include "qgsapplication.h"
 #include "qgspanelwidget.h"
 #include "qgsjsonutils.h"
+#include "qgsunittypes.h"
 #include <QToolButton>
 #include <QDesktopServices>
 #include <QScrollBar>
@@ -263,6 +264,8 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
             {
               mOverrideDefaultContextSettings = true;
               mGeometryCheck = mContextOptionsWidget->invalidGeometryCheck();
+              mDistanceUnits = mContextOptionsWidget->distanceUnit();
+              mAreaUnits = mContextOptionsWidget->areaUnit();
             } );
           }
         }
@@ -856,6 +859,8 @@ void QgsProcessingAlgorithmDialogBase::applyContextOverrides( QgsProcessingConte
   if ( mOverrideDefaultContextSettings )
   {
     context->setInvalidGeometryCheck( mGeometryCheck );
+    context->setDistanceUnit( mDistanceUnits );
+    context->setAreaUnit( mAreaUnits );
   }
 }
 
@@ -935,17 +940,67 @@ QgsProcessingContextOptionsWidget::QgsProcessingContextOptionsWidget( QWidget *p
   mComboInvalidFeatureFiltering->addItem( tr( "Skip (Ignore) Features with Invalid Geometries" ), QgsFeatureRequest::GeometrySkipInvalid );
   mComboInvalidFeatureFiltering->addItem( tr( "Stop Algorithm Execution When a Geometry is Invalid" ), QgsFeatureRequest::GeometryAbortOnInvalid );
 
+  mDistanceUnitsCombo->addItem( tr( "Default" ), QVariant::fromValue( Qgis::DistanceUnit::Unknown ) );
+  for ( Qgis::DistanceUnit unit :
+        {
+          Qgis::DistanceUnit::Meters,
+          Qgis::DistanceUnit::Kilometers,
+          Qgis::DistanceUnit::Centimeters,
+          Qgis::DistanceUnit::Millimeters,
+          Qgis::DistanceUnit::Feet,
+          Qgis::DistanceUnit::Miles,
+          Qgis::DistanceUnit::NauticalMiles,
+          Qgis::DistanceUnit::Yards,
+          Qgis::DistanceUnit::Degrees,
+        } )
+  {
+    mDistanceUnitsCombo->addItem( QgsUnitTypes::toString( unit ), QVariant::fromValue( unit ) );
+  }
+
+  mAreaUnitsCombo->addItem( tr( "Default" ), QVariant::fromValue( Qgis::AreaUnit::Unknown ) );
+  for ( Qgis::AreaUnit unit :
+        {
+          Qgis::AreaUnit::SquareMeters,
+          Qgis::AreaUnit::Hectares,
+          Qgis::AreaUnit::SquareKilometers,
+          Qgis::AreaUnit::SquareCentimeters,
+          Qgis::AreaUnit::SquareMillimeters,
+          Qgis::AreaUnit::SquareFeet,
+          Qgis::AreaUnit::SquareMiles,
+          Qgis::AreaUnit::SquareNauticalMiles,
+          Qgis::AreaUnit::SquareYards,
+          Qgis::AreaUnit::Acres,
+          Qgis::AreaUnit::SquareDegrees,
+        } )
+  {
+    mAreaUnitsCombo->addItem( QgsUnitTypes::toString( unit ), QVariant::fromValue( unit ) );
+  }
+
   connect( mComboInvalidFeatureFiltering, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
+  connect( mDistanceUnitsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
+  connect( mAreaUnitsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
 }
 
 void QgsProcessingContextOptionsWidget::setFromContext( const QgsProcessingContext *context )
 {
   whileBlocking( mComboInvalidFeatureFiltering )->setCurrentIndex( mComboInvalidFeatureFiltering->findData( static_cast< int >( context->invalidGeometryCheck() ) ) );
+  whileBlocking( mDistanceUnitsCombo )->setCurrentIndex( mDistanceUnitsCombo->findData( QVariant::fromValue( context->distanceUnit() ) ) );
+  whileBlocking( mAreaUnitsCombo )->setCurrentIndex( mAreaUnitsCombo->findData( QVariant::fromValue( context->areaUnit() ) ) );
 }
 
 QgsFeatureRequest::InvalidGeometryCheck QgsProcessingContextOptionsWidget::invalidGeometryCheck() const
 {
   return static_cast< QgsFeatureRequest::InvalidGeometryCheck >( mComboInvalidFeatureFiltering->currentData().toInt() );
+}
+
+Qgis::DistanceUnit QgsProcessingContextOptionsWidget::distanceUnit() const
+{
+  return mDistanceUnitsCombo->currentData().value< Qgis::DistanceUnit >();
+}
+
+Qgis::AreaUnit QgsProcessingContextOptionsWidget::areaUnit() const
+{
+  return mAreaUnitsCombo->currentData().value< Qgis::AreaUnit >();
 }
 
 ///@endcond

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -137,6 +137,34 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
       mAdvancedMenu = new QMenu( this );
       mAdvancedButton->setMenu( mAdvancedMenu );
 
+      mContextSettingsAction = new QAction( tr( "Algorithm Settings…" ), mAdvancedMenu );
+      mContextSettingsAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/settings.svg" ) ) );
+      mAdvancedMenu->addAction( mContextSettingsAction );
+
+      connect( mContextSettingsAction, &QAction::triggered, this, [this]
+      {
+        if ( QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( mMainWidget ) )
+        {
+          mTabWidget->setCurrentIndex( 0 );
+
+          if ( !mContextOptionsWidget )
+          {
+            mContextOptionsWidget = new QgsProcessingContextOptionsWidget();
+            mContextOptionsWidget->setFromContext( processingContext() );
+            panel->openPanel( mContextOptionsWidget );
+
+            connect( mContextOptionsWidget, &QgsPanelWidget::widgetChanged, this, [ = ]
+            {
+              mOverrideDefaultContextSettings = true;
+              mGeometryCheck = mContextOptionsWidget->invalidGeometryCheck();
+              mDistanceUnits = mContextOptionsWidget->distanceUnit();
+              mAreaUnits = mContextOptionsWidget->areaUnit();
+            } );
+          }
+        }
+      } );
+      mAdvancedMenu->addSeparator();
+
       QAction *copyAsPythonCommand = new QAction( tr( "Copy as Python Command" ), mAdvancedMenu );
       copyAsPythonCommand->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mIconPythonFile.svg" ) ) );
 
@@ -240,35 +268,6 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
         const QVariantMap preparedValues = QgsProcessingUtils::preprocessQgisProcessParameters( parameterValues, ok, error );
 
         setParameters( preparedValues );
-      } );
-
-      mAdvancedMenu->addSeparator();
-
-      mContextSettingsAction = new QAction( tr( "Algorithm Settings" ), mAdvancedMenu );
-      mContextSettingsAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/settings.svg" ) ) );
-      mAdvancedMenu->addAction( mContextSettingsAction );
-
-      connect( mContextSettingsAction, &QAction::triggered, this, [this]
-      {
-        if ( QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( mMainWidget ) )
-        {
-          mTabWidget->setCurrentIndex( 0 );
-
-          if ( !mContextOptionsWidget )
-          {
-            mContextOptionsWidget = new QgsProcessingContextOptionsWidget();
-            mContextOptionsWidget->setFromContext( processingContext() );
-            panel->openPanel( mContextOptionsWidget );
-
-            connect( mContextOptionsWidget, &QgsPanelWidget::widgetChanged, this, [ = ]
-            {
-              mOverrideDefaultContextSettings = true;
-              mGeometryCheck = mContextOptionsWidget->invalidGeometryCheck();
-              mDistanceUnits = mContextOptionsWidget->distanceUnit();
-              mAreaUnits = mContextOptionsWidget->areaUnit();
-            } );
-          }
-        }
       } );
 
       mButtonBox->addButton( mAdvancedButton, QDialogButtonBox::ResetRole );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -819,6 +819,14 @@ bool QgsProcessingAlgorithmDialogBase::isFinalized()
   return true;
 }
 
+void QgsProcessingAlgorithmDialogBase::applyContextOverrides( QgsProcessingContext *context )
+{
+  if ( !context )
+    return;
+
+  context->setLogLevel( logLevel() );
+}
+
 void QgsProcessingAlgorithmDialogBase::setInfo( const QString &message, bool isError, bool escapeHtml, bool isWarning )
 {
   constexpr int MESSAGE_COUNT_LIMIT = 10000;

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -954,7 +954,17 @@ QgsProcessingContextOptionsWidget::QgsProcessingContextOptionsWidget( QWidget *p
           Qgis::DistanceUnit::Degrees,
         } )
   {
-    mDistanceUnitsCombo->addItem( QgsUnitTypes::toString( unit ), QVariant::fromValue( unit ) );
+    QString title;
+    if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) )
+    {
+      title = QgsStringUtils::capitalize( QgsUnitTypes::toString( unit ), Qgis::Capitalization::TitleCase );
+    }
+    else
+    {
+      title = QgsUnitTypes::toString( unit );
+    }
+
+    mDistanceUnitsCombo->addItem( title, QVariant::fromValue( unit ) );
   }
 
   mAreaUnitsCombo->addItem( tr( "Default" ), QVariant::fromValue( Qgis::AreaUnit::Unknown ) );
@@ -973,7 +983,17 @@ QgsProcessingContextOptionsWidget::QgsProcessingContextOptionsWidget( QWidget *p
           Qgis::AreaUnit::SquareDegrees,
         } )
   {
-    mAreaUnitsCombo->addItem( QgsUnitTypes::toString( unit ), QVariant::fromValue( unit ) );
+    QString title;
+    if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) )
+    {
+      title = QgsStringUtils::capitalize( QgsUnitTypes::toString( unit ), Qgis::Capitalization::TitleCase );
+    }
+    else
+    {
+      title = QgsUnitTypes::toString( unit );
+    }
+
+    mAreaUnitsCombo->addItem( title, QVariant::fromValue( unit ) );
   }
 
   connect( mComboInvalidFeatureFiltering, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -472,6 +472,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     QPointer< QgsProcessingContextOptionsWidget > mContextOptionsWidget;
     bool mOverrideDefaultContextSettings = false;
     QgsFeatureRequest::InvalidGeometryCheck mGeometryCheck = QgsFeatureRequest::InvalidGeometryCheck::GeometryAbortOnInvalid;
+    Qgis::DistanceUnit mDistanceUnits = Qgis::DistanceUnit::Unknown;
+    Qgis::AreaUnit mAreaUnits = Qgis::AreaUnit::Unknown;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );
     void scrollToBottomOfLog();
@@ -545,6 +547,16 @@ class GUI_EXPORT QgsProcessingContextOptionsWidget : public QgsPanelWidget, priv
      * Returns the invalid geometry check selected in the widget.
      */
     QgsFeatureRequest::InvalidGeometryCheck invalidGeometryCheck() const;
+
+    /**
+     * Returns the distance unit selected in the widget.
+     */
+    Qgis::DistanceUnit distanceUnit() const;
+
+    /**
+     * Returns the area unit selected in the widget.
+     */
+    Qgis::AreaUnit areaUnit() const;
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -390,6 +390,15 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
      */
     virtual bool isFinalized();
 
+    /**
+     * Applies any defined overrides for Processing context settings to the specified \a context.
+     *
+     * This allows the dialog to override default Processing settings for an individual algorithm execution.
+     *
+     * \since QGIS 3.32
+     */
+    void applyContextOverrides( QgsProcessingContext *context );
+
   signals:
 
     /**

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -20,6 +20,7 @@
 #include "qgis_gui.h"
 #include "ui_qgsprocessingalgorithmdialogbase.h"
 #include "ui_qgsprocessingalgorithmprogressdialogbase.h"
+#include "ui_qgsprocessingcontextoptionsbase.h"
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingfeedback.h"
 #include "qgsprocessingwidgetwrapper.h"
@@ -29,6 +30,7 @@
 class QgsProcessingAlgorithm;
 class QToolButton;
 class QgsProcessingAlgorithmDialogBase;
+class QgsProcessingContextOptionsWidget;
 class QgsMessageBar;
 class QgsProcessingAlgRunnerTask;
 class QgsTask;
@@ -452,6 +454,7 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     QMenu *mAdvancedMenu = nullptr;
     QAction *mCopyAsQgisProcessCommand = nullptr;
     QAction *mPasteJsonAction = nullptr;
+    QAction *mContextSettingsAction = nullptr;
 
     bool mExecuted = false;
     bool mExecutedAnyResult = false;
@@ -465,6 +468,10 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     int mMessageLoggedCount = 0;
 
     QgsProcessingContext::LogLevel mLogLevel = QgsProcessingContext::DefaultLevel;
+
+    QPointer< QgsProcessingContextOptionsWidget > mContextOptionsWidget;
+    bool mOverrideDefaultContextSettings = false;
+    QgsFeatureRequest::InvalidGeometryCheck mGeometryCheck = QgsFeatureRequest::InvalidGeometryCheck::GeometryAbortOnInvalid;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );
     void scrollToBottomOfLog();
@@ -509,6 +516,35 @@ class QgsProcessingAlgorithmProgressDialog : public QDialog, private Ui::QgsProc
   public slots:
 
     void reject() override;
+
+};
+
+/**
+ * \ingroup gui
+ * \brief Widget for configuring settings for a Processing context.
+ * \note Not stable API
+ * \since QGIS 3.32
+ */
+class GUI_EXPORT QgsProcessingContextOptionsWidget : public QgsPanelWidget, private Ui::QgsProcessingContextOptionsBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingContextOptionsWidget, with the specified \a parent widget.
+     */
+    QgsProcessingContextOptionsWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Sets the widget state using the specified \a context.
+     */
+    void setFromContext( const QgsProcessingContext *context );
+
+    /**
+     * Returns the invalid geometry check selected in the widget.
+     */
+    QgsFeatureRequest::InvalidGeometryCheck invalidGeometryCheck() const;
 
 };
 

--- a/src/ui/processing/qgsprocessingcontextoptionsbase.ui
+++ b/src/ui/processing/qgsprocessingcontextoptionsbase.ui
@@ -47,14 +47,14 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Invalid feature filtering</string>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="mComboInvalidFeatureFiltering">
+         <property name="toolTip">
+          <string>If set, allows the default method for handling features with invalid geometries to be overridden</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -67,11 +67,40 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="mComboInvalidFeatureFiltering">
-         <property name="toolTip">
-          <string>If set, allows the default method for handling features with invalid geometries to be overridden</string>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Invalid feature filtering</string>
          </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Calculation Settings</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Distance units</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="mDistanceUnitsCombo"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Area units</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="mAreaUnitsCombo"/>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>

--- a/src/ui/processing/qgsprocessingcontextoptionsbase.ui
+++ b/src/ui/processing/qgsprocessingcontextoptionsbase.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsProcessingContextOptionsBase</class>
+ <widget class="QgsPanelWidget" name="QgsProcessingContextOptionsBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>448</width>
+    <height>197</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Processing Context Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QgsScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>448</width>
+        <height>197</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Invalid feature filtering</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="mComboInvalidFeatureFiltering">
+         <property name="toolTip">
+          <string>If set, allows the default method for handling features with invalid geometries to be overridden</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This adds a new "Algorithm Settings" action to the Advanced button. Selecting it shows a panel allowing users to control general processing settings which apply to that algorithm execution **only**. It's intended to be a place where a user can override their global processing settings on an ad-hoc basis without having to change their usual default settings.

Currently contains settings for:
- invalid geometry handling (Unlike the existing per-parameter setting override for this, setting the handling method here will apply to ALL inputs for the algorithm)
- distance unit and area units to use for distance/area measurements


https://user-images.githubusercontent.com/1829991/225210305-2c5daab0-6e40-453c-8260-996bf8cd5b75.mp4

