### PR TITLE
Refactor vector tiles layer/data provider

### DIFF
--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1363,7 +1363,7 @@ bool QgsVectorTileDataProvider::supportsAsync() const
   return false;
 }
 
-QNetworkRequest QgsVectorTileDataProvider::tileRequest( const QgsTileMatrix &, const QgsTileXYZ & ) const
+QNetworkRequest QgsVectorTileDataProvider::tileRequest( const QgsTileMatrix &, const QgsTileXYZ &, Qgis::RendererUsage ) const
 {
   return QNetworkRequest();
 }
@@ -1443,9 +1443,25 @@ QList<QgsVectorTileRawData> QgsXyzVectorTileDataProvider::readTiles( const QgsTi
   return rawTiles;
 }
 
-QNetworkRequest QgsXyzVectorTileDataProvider::tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const
+QNetworkRequest QgsXyzVectorTileDataProvider::tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const
 {
   QString urlTemplate = sourcePath();
+
+  if ( urlTemplate.contains( QLatin1String( "{usage}" ) ) )
+  {
+    switch ( usage )
+    {
+      case Qgis::RendererUsage::View:
+        urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
+        break;
+      case Qgis::RendererUsage::Export:
+        urlTemplate.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
+        break;
+      case Qgis::RendererUsage::Unknown:
+        urlTemplate.replace( QLatin1String( "{usage}" ), QString() );
+        break;
+    }
+  }
 
   const QString url = QgsVectorTileUtils::formatXYZUrlTemplate( urlTemplate, id, tileMatrix );
 

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1354,6 +1354,11 @@ bool QgsVectorTileDataProvider::renderInPreview( const PreviewContext &context )
   return context.lastRenderingTimeMs <= 1000;
 }
 
+bool QgsVectorTileDataProvider::supportsAsync() const
+{
+  return false;
+}
+
 //
 // QgsXyzVectorTileDataProvider
 //
@@ -1394,6 +1399,11 @@ QgsCoordinateReferenceSystem QgsXyzVectorTileDataProvider::crs() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
+}
+
+bool QgsXyzVectorTileDataProvider::supportsAsync() const
+{
+  return true;
 }
 
 QByteArray QgsXyzVectorTileDataProvider::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1372,6 +1372,15 @@ QgsXyzVectorTileDataProvider::QgsXyzVectorTileDataProvider( const QString &uri, 
 
 }
 
+QgsVectorTileDataProvider *QgsXyzVectorTileDataProvider::clone() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  ProviderOptions options;
+  options.transformContext = transformContext();
+  return new QgsXyzVectorTileDataProvider( dataSourceUri(), options, mReadFlags );
+}
+
 QString QgsXyzVectorTileDataProvider::sourcePath() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -1403,6 +1412,15 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
   : QgsVectorTileDataProvider( uri, providerOptions, flags )
 {
 
+}
+
+QgsVectorTileDataProvider *QgsMbTilesVectorTileDataProvider::clone() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  ProviderOptions options;
+  options.transformContext = transformContext();
+  return new QgsMbTilesVectorTileDataProvider( dataSourceUri(), options, mReadFlags );
 }
 
 QString QgsMbTilesVectorTileDataProvider::sourcePath() const
@@ -1438,6 +1456,15 @@ QgsVtpkVectorTileDataProvider::QgsVtpkVectorTileDataProvider( const QString &uri
 
 }
 
+QgsVectorTileDataProvider *QgsVtpkVectorTileDataProvider::clone() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  ProviderOptions options;
+  options.transformContext = transformContext();
+  return new QgsVtpkVectorTileDataProvider( dataSourceUri(), options, mReadFlags );
+}
+
 QString QgsVtpkVectorTileDataProvider::sourcePath() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -1470,6 +1497,15 @@ QgsArcGisVectorTileServiceDataProvider::QgsArcGisVectorTileServiceDataProvider( 
   , mSourcePath( sourcePath )
 {
 
+}
+
+QgsVectorTileDataProvider *QgsArcGisVectorTileServiceDataProvider::clone() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  ProviderOptions options;
+  options.transformContext = transformContext();
+  return new QgsArcGisVectorTileServiceDataProvider( dataSourceUri(), mSourcePath, options, mReadFlags );
 }
 
 QString QgsArcGisVectorTileServiceDataProvider::sourcePath() const

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1331,13 +1331,6 @@ QgsVectorTileDataProvider::QgsVectorTileDataProvider( const QString &uri,
   : QgsDataProvider( uri, options, flags )
 {}
 
-QgsCoordinateReferenceSystem QgsVectorTileDataProvider::crs() const
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
-}
-
 QString QgsVectorTileDataProvider::name() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -1395,6 +1388,13 @@ bool QgsXyzVectorTileDataProvider::isValid() const
   return true;
 }
 
+QgsCoordinateReferenceSystem QgsXyzVectorTileDataProvider::crs() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
+}
+
 //
 // QgsMbTilesVectorTileDataProvider
 //
@@ -1419,6 +1419,13 @@ bool QgsMbTilesVectorTileDataProvider::isValid() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return true;
+}
+
+QgsCoordinateReferenceSystem QgsMbTilesVectorTileDataProvider::crs() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
 }
 
 //
@@ -1447,6 +1454,13 @@ bool QgsVtpkVectorTileDataProvider::isValid() const
   return true;
 }
 
+QgsCoordinateReferenceSystem QgsVtpkVectorTileDataProvider::crs() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
+}
+
 //
 // QgsArcGisVectorTileServiceDataProvider
 //
@@ -1470,6 +1484,13 @@ bool QgsArcGisVectorTileServiceDataProvider::isValid() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return true;
+}
+
+QgsCoordinateReferenceSystem QgsArcGisVectorTileServiceDataProvider::crs() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
 }
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -904,21 +904,13 @@ QString QgsVectorTileLayer::sourcePath() const
 QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   QgsVectorTileDataProvider *vtProvider = qobject_cast< QgsVectorTileDataProvider * >( mDataProvider.get() );
   if ( !vtProvider )
     return QByteArray();
 
   const QgsTileMatrix tileMatrix = mMatrixSet.tileMatrix( tileID.zoomLevel() );
-  const QgsTileRange tileRange( tileID.column(), tileID.column(), tileID.row(), tileID.row() );
-
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( mDataSource );
-  const QString authcfg = dsUri.authConfigId();
-
-  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, vtProvider->sourcePath(), tileMatrix, QPointF(), tileRange, authcfg, dsUri.httpHeaders() );
-  if ( rawTiles.isEmpty() )
-    return QByteArray();
-  return rawTiles.first().data;
+  return vtProvider->readTile( tileMatrix, tileID );
 }
 
 void QgsVectorTileLayer::setRenderer( QgsVectorTileRenderer *r )
@@ -1404,6 +1396,26 @@ QgsCoordinateReferenceSystem QgsXyzVectorTileDataProvider::crs() const
   return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
 }
 
+QByteArray QgsXyzVectorTileDataProvider::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( dataSourceUri() );
+  const QString authcfg = dsUri.authConfigId();
+
+  const QgsTileRange tileRange( id.column(), id.column(), id.row(), id.row() );
+
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( QStringLiteral( "xyz" ),
+                                         dsUri.param( QStringLiteral( "url" ) ),
+                                         tileMatrix,
+                                         QPointF(),
+                                         tileRange,
+                                         authcfg,
+                                         dsUri.httpHeaders() );
+  if ( rawTiles.isEmpty() )
+    return QByteArray();
+  return rawTiles.first().data;
+}
+
 //
 // QgsMbTilesVectorTileDataProvider
 //
@@ -1444,6 +1456,26 @@ QgsCoordinateReferenceSystem QgsMbTilesVectorTileDataProvider::crs() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
+}
+
+QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( dataSourceUri() );
+  const QString authcfg = dsUri.authConfigId();
+
+  const QgsTileRange tileRange( id.column(), id.column(), id.row(), id.row() );
+
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( QStringLiteral( "mbtiles" ),
+                                         dsUri.param( QStringLiteral( "url" ) ),
+                                         tileMatrix,
+                                         QPointF(),
+                                         tileRange,
+                                         authcfg,
+                                         dsUri.httpHeaders() );
+  if ( rawTiles.isEmpty() )
+    return QByteArray();
+  return rawTiles.first().data;
 }
 
 //
@@ -1488,6 +1520,26 @@ QgsCoordinateReferenceSystem QgsVtpkVectorTileDataProvider::crs() const
   return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
 }
 
+QByteArray QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( dataSourceUri() );
+  const QString authcfg = dsUri.authConfigId();
+
+  const QgsTileRange tileRange( id.column(), id.column(), id.row(), id.row() );
+
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( QStringLiteral( "vtpk" ),
+                                         dsUri.param( QStringLiteral( "url" ) ),
+                                         tileMatrix,
+                                         QPointF(),
+                                         tileRange,
+                                         authcfg,
+                                         dsUri.httpHeaders() );
+  if ( rawTiles.isEmpty() )
+    return QByteArray();
+  return rawTiles.first().data;
+}
+
 //
 // QgsArcGisVectorTileServiceDataProvider
 //
@@ -1527,6 +1579,26 @@ QgsCoordinateReferenceSystem QgsArcGisVectorTileServiceDataProvider::crs() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) );
+}
+
+QByteArray QgsArcGisVectorTileServiceDataProvider::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( dataSourceUri() );
+  const QString authcfg = dsUri.authConfigId();
+
+  const QgsTileRange tileRange( id.column(), id.column(), id.row(), id.row() );
+
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( QStringLiteral( "xyz" ),
+                                         mSourcePath,
+                                         tileMatrix,
+                                         QPointF(),
+                                         tileRange,
+                                         authcfg,
+                                         dsUri.httpHeaders() );
+  if ( rawTiles.isEmpty() )
+    return QByteArray();
+  return rawTiles.first().data;
 }
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1359,13 +1359,6 @@ QgsRectangle QgsVectorTileDataProvider::extent() const
   return QgsRectangle();
 }
 
-bool QgsVectorTileDataProvider::isValid() const
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  return true;
-}
-
 bool QgsVectorTileDataProvider::renderInPreview( const PreviewContext &context )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -1388,9 +1381,18 @@ QgsXyzVectorTileDataProvider::QgsXyzVectorTileDataProvider( const QString &uri, 
 
 QString QgsXyzVectorTileDataProvider::sourcePath() const
 {
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( dataSourceUri() );
   return dsUri.param( QStringLiteral( "url" ) );
+}
+
+bool QgsXyzVectorTileDataProvider::isValid() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return true;
 }
 
 //
@@ -1405,9 +1407,18 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
 
 QString QgsMbTilesVectorTileDataProvider::sourcePath() const
 {
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( dataSourceUri() );
   return dsUri.param( QStringLiteral( "url" ) );
+}
+
+bool QgsMbTilesVectorTileDataProvider::isValid() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return true;
 }
 
 //
@@ -1422,9 +1433,18 @@ QgsVtpkVectorTileDataProvider::QgsVtpkVectorTileDataProvider( const QString &uri
 
 QString QgsVtpkVectorTileDataProvider::sourcePath() const
 {
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( dataSourceUri() );
   return dsUri.param( QStringLiteral( "url" ) );
+}
+
+bool QgsVtpkVectorTileDataProvider::isValid() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return true;
 }
 
 //
@@ -1440,7 +1460,16 @@ QgsArcGisVectorTileServiceDataProvider::QgsArcGisVectorTileServiceDataProvider( 
 
 QString QgsArcGisVectorTileServiceDataProvider::sourcePath() const
 {
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   return mSourcePath;
+}
+
+bool QgsArcGisVectorTileServiceDataProvider::isValid() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return true;
 }
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -1587,7 +1587,7 @@ QList<QgsVectorTileRawData> QgsMbTilesVectorTileDataProvider::readTiles( const Q
 QByteArray QgsMbTilesVectorTileDataProvider::loadFromMBTiles( QgsMbTiles &mbTileReader, const QgsTileXYZ &id, QgsFeedback *feedback )
 {
   // MBTiles uses TMS specs with Y starting at the bottom while XYZ uses Y starting at the top
-  int rowTMS = pow( 2, id.zoomLevel() ) - id.row() - 1;
+  const int rowTMS = static_cast<int>( pow( 2, id.zoomLevel() ) - id.row() - 1 );
   QByteArray gzippedTileData = mbTileReader.tileData( id.zoomLevel(), id.column(), rowTMS );
   if ( gzippedTileData.isEmpty() )
   {

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -25,6 +25,8 @@
 
 class QgsVectorTileLabeling;
 class QgsVectorTileRenderer;
+class QgsVectorTileRawData;
+class QgsVectorTileDataProvider;
 
 class QgsTileXYZ;
 class QgsFeature;
@@ -342,6 +344,45 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
 };
+
+class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
+{
+    Q_OBJECT
+
+  public:
+    QgsXyzVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+                                  QgsDataProvider::ReadFlags flags );
+
+};
+
+class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
+{
+    Q_OBJECT
+
+  public:
+    QgsMbTilesVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+                                      QgsDataProvider::ReadFlags flags );
+
+};
+
+class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
+{
+    Q_OBJECT
+
+  public:
+    QgsVtpkVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+                                   QgsDataProvider::ReadFlags flags );
+};
+
+class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
+{
+    Q_OBJECT
+
+  public:
+    QgsArcGisVectorTileServiceDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+                                            QgsDataProvider::ReadFlags flags );
+};
+
 ///@endcond
 #endif
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -362,7 +362,7 @@ class QgsVectorTileDataProvider : public QgsDataProvider
      *
      * The default implementation returns an invalid request.
      */
-    virtual QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const;
+    virtual QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const;
 };
 
 class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -381,7 +381,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     bool supportsAsync() const override;
     QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
-    QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
+    QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
 
   protected:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -335,7 +335,6 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     QgsVectorTileDataProvider( const QString &uri,
                                const QgsDataProvider::ProviderOptions &providerOptions,
                                QgsDataProvider::ReadFlags flags );
-    QgsCoordinateReferenceSystem crs() const override;
     QString name() const override;
     QString description() const override;
     QgsRectangle extent() const override;
@@ -356,6 +355,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
 
     QString sourcePath() const override;
     bool isValid() const override;
+    QgsCoordinateReferenceSystem crs() const override;
 };
 
 class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -369,7 +369,7 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
 
     QString sourcePath() const override;
     bool isValid() const override;
-
+    QgsCoordinateReferenceSystem crs() const override;
 };
 
 class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -383,6 +383,7 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
 
     QString sourcePath() const override;
     bool isValid() const override;
+    QgsCoordinateReferenceSystem crs() const override;
 };
 
 class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
@@ -396,6 +397,7 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
                                             QgsDataProvider::ReadFlags flags );
     QString sourcePath() const override;
     bool isValid() const override;
+    QgsCoordinateReferenceSystem crs() const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -188,7 +188,7 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     //! Returns type of the data source
     QString sourceType() const { return mSourceType; }
     //! Returns URL/path of the data source (syntax different to each data source type)
-    QString sourcePath() const { return mSourcePath; }
+    QString sourcePath() const;
 
     //! Returns minimum zoom level at which source has any valid tiles (negative = unconstrained)
     int sourceMinZoom() const { return mMatrixSet.minimumZoom(); }
@@ -290,8 +290,6 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
   private:
     //! Type of the data source
     QString mSourceType;
-    //! URL/Path of the data source
-    QString mSourcePath;
 
     QgsVectorTileMatrixSet mMatrixSet;
 
@@ -334,7 +332,8 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     Q_OBJECT
 
   public:
-    QgsVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+    QgsVectorTileDataProvider( const QString &uri,
+                               const QgsDataProvider::ProviderOptions &providerOptions,
                                QgsDataProvider::ReadFlags flags );
     QgsCoordinateReferenceSystem crs() const override;
     QString name() const override;
@@ -343,6 +342,8 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     bool isValid() const override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
+    virtual QString sourcePath() const = 0;
+
 };
 
 class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -350,8 +351,11 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     Q_OBJECT
 
   public:
-    QgsXyzVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+    QgsXyzVectorTileDataProvider( const QString &uri,
+                                  const QgsDataProvider::ProviderOptions &providerOptions,
                                   QgsDataProvider::ReadFlags flags );
+
+    QString sourcePath() const override;
 
 };
 
@@ -360,8 +364,11 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
     Q_OBJECT
 
   public:
-    QgsMbTilesVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+    QgsMbTilesVectorTileDataProvider( const QString &uri,
+                                      const QgsDataProvider::ProviderOptions &providerOptions,
                                       QgsDataProvider::ReadFlags flags );
+
+    QString sourcePath() const override;
 
 };
 
@@ -370,8 +377,11 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
     Q_OBJECT
 
   public:
-    QgsVtpkVectorTileDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+    QgsVtpkVectorTileDataProvider( const QString &uri,
+                                   const QgsDataProvider::ProviderOptions &providerOptions,
                                    QgsDataProvider::ReadFlags flags );
+
+    QString sourcePath() const override;
 };
 
 class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
@@ -379,8 +389,15 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
     Q_OBJECT
 
   public:
-    QgsArcGisVectorTileServiceDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+    QgsArcGisVectorTileServiceDataProvider( const QString &uri,
+                                            const QString &sourcePath,
+                                            const QgsDataProvider::ProviderOptions &providerOptions,
                                             QgsDataProvider::ReadFlags flags );
+    QString sourcePath() const override;
+
+  private:
+
+    QString mSourcePath;
 };
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -339,7 +339,6 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     QString name() const override;
     QString description() const override;
     QgsRectangle extent() const override;
-    bool isValid() const override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
     virtual QString sourcePath() const = 0;
@@ -356,7 +355,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
                                   QgsDataProvider::ReadFlags flags );
 
     QString sourcePath() const override;
-
+    bool isValid() const override;
 };
 
 class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -369,6 +368,7 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
                                       QgsDataProvider::ReadFlags flags );
 
     QString sourcePath() const override;
+    bool isValid() const override;
 
 };
 
@@ -382,6 +382,7 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
                                    QgsDataProvider::ReadFlags flags );
 
     QString sourcePath() const override;
+    bool isValid() const override;
 };
 
 class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
@@ -394,6 +395,7 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
                                             const QgsDataProvider::ProviderOptions &providerOptions,
                                             QgsDataProvider::ReadFlags flags );
     QString sourcePath() const override;
+    bool isValid() const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -32,6 +32,7 @@ class QgsTileXYZ;
 class QgsFeature;
 class QgsGeometry;
 class QgsSelectionContext;
+class QgsMbTiles;
 
 /**
  * \ingroup core
@@ -351,8 +352,10 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     virtual bool supportsAsync() const;
 
     //! Returns raw tile data for a single tile
-    virtual QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const = 0;
+    virtual QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const = 0;
 
+    //! Returns raw tile data for a range of tiles
+    virtual QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const = 0;
 };
 
 class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -369,7 +372,8 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
     bool supportsAsync() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 };
 
 class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -385,7 +389,14 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+
+  private:
+
+    //! Returns raw tile data for a single tile loaded from MBTiles file
+    static QByteArray loadFromMBTiles( QgsMbTiles &mbTileReader, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr );
+
 };
 
 class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -401,7 +412,9 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+
 };
 
 class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
@@ -417,7 +430,8 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -399,6 +399,8 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
 
 };
 
+class QgsVtpkTiles;
+
 class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
 {
     Q_OBJECT
@@ -414,6 +416,11 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
     QgsCoordinateReferenceSystem crs() const override;
     QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+
+  private:
+
+    //! Returns raw tile data for a single tile loaded from VTPK file
+    static QByteArray loadFromVtpk( QgsVtpkTiles &vtpkTileReader, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr );
 
 };
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -356,6 +356,13 @@ class QgsVectorTileDataProvider : public QgsDataProvider
 
     //! Returns raw tile data for a range of tiles
     virtual QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const = 0;
+
+    /**
+     * Returns a network request for a tile.
+     *
+     * The default implementation returns an invalid request.
+     */
+    virtual QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const;
 };
 
 class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -374,6 +381,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     bool supportsAsync() const override;
     QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+    QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 
   protected:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -341,6 +341,7 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
     virtual QString sourcePath() const = 0;
+    virtual QgsVectorTileDataProvider *clone() const = 0 SIP_FACTORY;
 
 };
 
@@ -353,6 +354,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
                                   const QgsDataProvider::ProviderOptions &providerOptions,
                                   QgsDataProvider::ReadFlags flags );
 
+    QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
@@ -367,6 +369,7 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
                                       const QgsDataProvider::ProviderOptions &providerOptions,
                                       QgsDataProvider::ReadFlags flags );
 
+    QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
@@ -381,6 +384,7 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
                                    const QgsDataProvider::ProviderOptions &providerOptions,
                                    QgsDataProvider::ReadFlags flags );
 
+    QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
@@ -395,6 +399,7 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
                                             const QString &sourcePath,
                                             const QgsDataProvider::ProviderOptions &providerOptions,
                                             QgsDataProvider::ReadFlags flags );
+    QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -343,6 +343,9 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     virtual QString sourcePath() const = 0;
     virtual QgsVectorTileDataProvider *clone() const = 0 SIP_FACTORY;
 
+    //! Returns raw tile data for a single tile
+    virtual QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const = 0;
+
 };
 
 class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -358,6 +361,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 };
 
 class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -373,6 +377,7 @@ class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 };
 
 class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -388,6 +393,7 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 };
 
 class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
@@ -403,6 +409,7 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
+    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -343,6 +343,13 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     virtual QString sourcePath() const = 0;
     virtual QgsVectorTileDataProvider *clone() const = 0 SIP_FACTORY;
 
+    /**
+     * Returns TRUE if the provider supports async tile reading.
+     *
+     * The default implementation returns FALSE.
+     */
+    virtual bool supportsAsync() const;
+
     //! Returns raw tile data for a single tile
     virtual QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const = 0;
 
@@ -361,6 +368,7 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     QString sourcePath() const override;
     bool isValid() const override;
     QgsCoordinateReferenceSystem crs() const override;
+    bool supportsAsync() const override;
     QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id ) const override;
 };
 

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -341,7 +341,10 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     QgsRectangle extent() const override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
+    //! Renders the source path for the data
     virtual QString sourcePath() const = 0;
+
+    //! Returns a clone of the data provider
     virtual QgsVectorTileDataProvider *clone() const = 0 SIP_FACTORY;
 
     /**

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -374,6 +374,22 @@ class QgsXyzVectorTileDataProvider : public QgsVectorTileDataProvider
     bool supportsAsync() const override;
     QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+
+  protected:
+
+    QString mAuthCfg;
+    QgsHttpHeaders mHeaders;
+
+  private:
+
+    //! Returns raw tile data for a single tile, doing a HTTP request. Block the caller until tile data are downloaded.
+    static QByteArray loadFromNetwork( const QgsTileXYZ &id,
+                                       const QgsTileMatrix &tileMatrix,
+                                       const QString &requestUrl,
+                                       const QString &authid,
+                                       const QgsHttpHeaders &headers,
+                                       QgsFeedback *feedback = nullptr );
+
 };
 
 class QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataProvider
@@ -424,7 +440,7 @@ class QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvider
 
 };
 
-class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
+class QgsArcGisVectorTileServiceDataProvider : public QgsXyzVectorTileDataProvider
 {
     Q_OBJECT
 
@@ -436,9 +452,6 @@ class QgsArcGisVectorTileServiceDataProvider : public QgsVectorTileDataProvider
     QgsVectorTileDataProvider *clone() const override;
     QString sourcePath() const override;
     bool isValid() const override;
-    QgsCoordinateReferenceSystem crs() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
-    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 
   private:
 

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -114,22 +114,6 @@ bool QgsVectorTileLayerRenderer::render()
     return true;   // nothing to do
   }
 
-  if ( mSourceType == QLatin1String( "xyz" ) && mSourcePath.contains( QLatin1String( "{usage}" ) ) )
-  {
-    switch ( renderContext()->rendererUsage() )
-    {
-      case Qgis::RendererUsage::View:
-        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
-        break;
-      case Qgis::RendererUsage::Export:
-        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
-        break;
-      case Qgis::RendererUsage::Unknown:
-        mSourcePath.replace( QLatin1String( "{usage}" ), QString() );
-        break;
-    }
-  }
-
   std::unique_ptr<QgsVectorTileLoader> asyncLoader;
   QList<QgsVectorTileRawData> rawTiles;
   if ( !mDataProvider->supportsAsync() )
@@ -142,7 +126,7 @@ bool QgsVectorTileLayerRenderer::render()
   }
   else
   {
-    asyncLoader.reset( new QgsVectorTileLoader( mDataProvider.get(), mTileMatrix, mTileRange, viewCenter, mFeedback.get() ) );
+    asyncLoader.reset( new QgsVectorTileLoader( mDataProvider.get(), mTileMatrix, mTileRange, viewCenter, mFeedback.get(), renderContext()->rendererUsage() ) );
     QObject::connect( asyncLoader.get(), &QgsVectorTileLoader::tileRequestFinished, asyncLoader.get(), [this]( const QgsVectorTileRawData & rawTile )
     {
       QgsDebugMsgLevel( QStringLiteral( "Got tile asynchronously: " ) + rawTile.id.toString(), 2 );

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -34,8 +34,6 @@
 
 QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
-  , mSourceType( layer->sourceType() )
-  , mSourcePath( layer->sourcePath() )
   , mDataProvider( qgis::down_cast< const QgsVectorTileDataProvider* >( layer->dataProvider() )->clone() )
   , mRenderer( layer->renderer()->clone() )
   , mDrawTileBoundaries( layer->isTileBorderRenderingEnabled() )
@@ -44,12 +42,6 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   , mLayerOpacity( layer->opacity() )
   , mTileMatrixSet( layer->tileMatrixSet() )
 {
-
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( layer->source() );
-  mAuthCfg = dsUri.authConfigId();
-  mHeaders = dsUri.httpHeaders();
-
   if ( QgsLabelingEngine *engine = context.labelingEngine() )
   {
     if ( layer->labeling() )

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -136,7 +136,7 @@ bool QgsVectorTileLayerRenderer::render()
   {
     QElapsedTimer tFetch;
     tFetch.start();
-    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, mTileMatrix, viewCenter, mTileRange, mAuthCfg, mHeaders, mFeedback.get() );
+    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mDataProvider.get(), mTileMatrix, viewCenter, mTileRange, mFeedback.get() );
     QgsDebugMsgLevel( QStringLiteral( "Tile fetching time: %1" ).arg( tFetch.elapsed() / 1000. ), 2 );
     QgsDebugMsgLevel( QStringLiteral( "Fetched tiles: %1" ).arg( rawTiles.count() ), 2 );
   }

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -142,7 +142,7 @@ bool QgsVectorTileLayerRenderer::render()
   }
   else
   {
-    asyncLoader.reset( new QgsVectorTileLoader( mSourcePath, mTileMatrix, mTileRange, viewCenter, mAuthCfg, mHeaders, mFeedback.get() ) );
+    asyncLoader.reset( new QgsVectorTileLoader( mDataProvider.get(), mTileMatrix, mTileRange, viewCenter, mFeedback.get() ) );
     QObject::connect( asyncLoader.get(), &QgsVectorTileLoader::tileRequestFinished, asyncLoader.get(), [this]( const QgsVectorTileRawData & rawTile )
     {
       QgsDebugMsgLevel( QStringLiteral( "Got tile asynchronously: " ) + rawTile.id.toString(), 2 );

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -16,6 +16,7 @@
 #include "qgsvectortilelayerrenderer.h"
 
 #include <QElapsedTimer>
+#include <QThread>
 
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeedback.h"
@@ -35,6 +36,7 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   : QgsMapLayerRenderer( layer->id(), &context )
   , mSourceType( layer->sourceType() )
   , mSourcePath( layer->sourcePath() )
+  , mDataProvider( qgis::down_cast< const QgsVectorTileDataProvider* >( layer->dataProvider() )->clone() )
   , mRenderer( layer->renderer()->clone() )
   , mDrawTileBoundaries( layer->isTileBorderRenderingEnabled() )
   , mFeedback( new QgsFeedback )
@@ -61,7 +63,11 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   }
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );
+
+  mDataProvider->moveToThread( nullptr );
 }
+
+QgsVectorTileLayerRenderer::~QgsVectorTileLayerRenderer() = default;
 
 bool QgsVectorTileLayerRenderer::render()
 {
@@ -69,6 +75,8 @@ bool QgsVectorTileLayerRenderer::render()
 
   if ( ctx.renderingStopped() )
     return false;
+
+  mDataProvider->moveToThread( QThread::currentThread() );
 
   const QgsScopedQPainterState painterState( ctx.painter() );
 
@@ -106,8 +114,6 @@ bool QgsVectorTileLayerRenderer::render()
     return true;   // nothing to do
   }
 
-  const bool isAsync = ( mSourceType == QLatin1String( "xyz" ) );
-
   if ( mSourceType == QLatin1String( "xyz" ) && mSourcePath.contains( QLatin1String( "{usage}" ) ) )
   {
     switch ( renderContext()->rendererUsage() )
@@ -126,7 +132,7 @@ bool QgsVectorTileLayerRenderer::render()
 
   std::unique_ptr<QgsVectorTileLoader> asyncLoader;
   QList<QgsVectorTileRawData> rawTiles;
-  if ( !isAsync )
+  if ( !mDataProvider->supportsAsync() )
   {
     QElapsedTimer tFetch;
     tFetch.start();
@@ -187,7 +193,7 @@ bool QgsVectorTileLayerRenderer::render()
     }
   }
 
-  if ( !isAsync )
+  if ( !mDataProvider->supportsAsync() )
   {
     for ( const QgsVectorTileRawData &rawTile : std::as_const( rawTiles ) )
     {

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -27,7 +27,6 @@ class QgsVectorTileDataProvider;
 
 #include "qgsvectortilerenderer.h"
 #include "qgsmapclippingregion.h"
-#include "qgshttpheaders.h"
 #include "qgsvectortilematrixset.h"
 
 /**
@@ -56,14 +55,6 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     void decodeAndDrawTile( const QgsVectorTileRawData &rawTile );
 
     // data coming from the vector tile layer
-
-    //! Type of the source from which we will be loading tiles (e.g. "xyz" or "mbtiles")
-    QString mSourceType;
-    //! Path/URL of the source. Format depends on source type
-    QString mSourcePath;
-
-    QString mAuthCfg;
-    QgsHttpHeaders mHeaders;
 
     std::unique_ptr< QgsVectorTileDataProvider > mDataProvider;
 

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -23,6 +23,7 @@
 class QgsVectorTileLayer;
 class QgsVectorTileRawData;
 class QgsVectorTileLabelProvider;
+class QgsVectorTileDataProvider;
 
 #include "qgsvectortilerenderer.h"
 #include "qgsmapclippingregion.h"
@@ -45,6 +46,7 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
   public:
     //! Creates the renderer. Always called from main thread, should copy whatever necessary from the layer
     QgsVectorTileLayerRenderer( QgsVectorTileLayer *layer, QgsRenderContext &context );
+    ~QgsVectorTileLayerRenderer() override;
 
     virtual bool render() override;
     virtual QgsFeedback *feedback() const override { return mFeedback.get(); }
@@ -62,6 +64,8 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
 
     QString mAuthCfg;
     QgsHttpHeaders mHeaders;
+
+    std::unique_ptr< QgsVectorTileDataProvider > mDataProvider;
 
     //! Tile renderer object to do rendering of individual tiles
     std::unique_ptr<QgsVectorTileRenderer> mRenderer;

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -242,26 +242,7 @@ QByteArray QgsVectorTileLoader::loadFromNetwork( const QgsTileXYZ &id, const Qgs
 
 QByteArray QgsVectorTileLoader::loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader, QgsFeedback *feedback )
 {
-  // MBTiles uses TMS specs with Y starting at the bottom while XYZ uses Y starting at the top
-  int rowTMS = pow( 2, id.zoomLevel() ) - id.row() - 1;
-  QByteArray gzippedTileData = mbTileReader.tileData( id.zoomLevel(), id.column(), rowTMS );
-  if ( gzippedTileData.isEmpty() )
-  {
-    return QByteArray();
-  }
 
-  if ( feedback && feedback->isCanceled() )
-    return QByteArray();
-
-  QByteArray data;
-  if ( !QgsZipUtils::decodeGzip( gzippedTileData, data ) )
-  {
-    QgsDebugMsg( QStringLiteral( "Failed to decompress tile " ) + id.toString() );
-    return QByteArray();
-  }
-
-  QgsDebugMsgLevel( QStringLiteral( "Tile blob size %1 -> uncompressed size %2" ).arg( gzippedTileData.size() ).arg( data.size() ), 2 );
-  return data;
 }
 
 QByteArray QgsVectorTileLoader::loadFromVtpk( const QgsTileXYZ &id, QgsVtpkTiles &vtpkTileReader )

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -25,7 +25,7 @@
 
 #include "qgstiledownloadmanager.h"
 
-QgsVectorTileLoader::QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter, QgsFeedback *feedback )
+QgsVectorTileLoader::QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter, QgsFeedback *feedback, Qgis::RendererUsage usage )
   : mEventLoop( new QEventLoop )
   , mFeedback( feedback )
 {
@@ -44,7 +44,7 @@ QgsVectorTileLoader::QgsVectorTileLoader( const QgsVectorTileDataProvider *provi
   QgsVectorTileUtils::sortTilesByDistanceFromCenter( tiles, viewCenter );
   for ( QgsTileXYZ id : std::as_const( tiles ) )
   {
-    loadFromNetworkAsync( id, tileMatrix, provider );
+    loadFromNetworkAsync( id, tileMatrix, provider, usage );
   }
 }
 
@@ -77,9 +77,9 @@ void QgsVectorTileLoader::downloadBlocking()
   Q_ASSERT( mReplies.isEmpty() );
 }
 
-void QgsVectorTileLoader::loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider )
+void QgsVectorTileLoader::loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider, Qgis::RendererUsage usage )
 {
-  QNetworkRequest request = provider->tileRequest( tileMatrix, id );
+  QNetworkRequest request = provider->tileRequest( tileMatrix, id, usage );
 
   QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
   connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsVectorTileLoader::tileReplyFinished );

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -77,7 +77,7 @@ class QgsVectorTileLoader : public QObject
 
     //! Constructs tile loader for doing asynchronous requests and starts network requests
     QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
-                         QgsFeedback *feedback );
+                         QgsFeedback *feedback, Qgis::RendererUsage usage );
     ~QgsVectorTileLoader();
 
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
@@ -87,7 +87,7 @@ class QgsVectorTileLoader : public QObject
     QString error() const;
 
   private:
-    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider );
+    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider, Qgis::RendererUsage usage );
 
   private slots:
     void tileReplyFinished();

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -18,10 +18,11 @@
 
 #define SIP_NO_FILE
 
-class QByteArray;
+#include "qgstiles.h"
 
-#include "qgsvectortilerenderer.h"
-#include "qgshttpheaders.h"
+class QByteArray;
+class QgsFeedback;
+
 
 /**
  * \ingroup core
@@ -75,8 +76,8 @@ class QgsVectorTileLoader : public QObject
     //
 
     //! Constructs tile loader for doing asynchronous requests and starts network requests
-    QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
-                         const QString &authid, const QgsHttpHeaders &headers, QgsFeedback *feedback );
+    QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
+                         QgsFeedback *feedback );
     ~QgsVectorTileLoader();
 
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
@@ -86,7 +87,7 @@ class QgsVectorTileLoader : public QObject
     QString error() const;
 
   private:
-    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl );
+    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider );
 
   private slots:
     void tileReplyFinished();
@@ -101,9 +102,6 @@ class QgsVectorTileLoader : public QObject
     std::unique_ptr<QEventLoop> mEventLoop;
     //! Feedback object that allows cancellation of pending requests
     QgsFeedback *mFeedback;
-
-    QString mAuthCfg;
-    QgsHttpHeaders mHeaders;
 
     //! Running tile requests
     QList<QgsTileDownloadManagerReply *> mReplies;

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -79,7 +79,6 @@ class QgsVectorTileLoader : public QObject
                                        const QString &authid,
                                        const QgsHttpHeaders &headers,
                                        QgsFeedback *feedback = nullptr );
-    //! Returns raw tile data for a single tile loaded from MBTiles file
     static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader, QgsFeedback *feedback = nullptr );
 
     //! Returns raw tile data for a single tile loaded from VTPK file

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -46,10 +46,10 @@ class QgsVectorTileRawData
 class QNetworkReply;
 class QEventLoop;
 
-class QgsMbTiles;
 class QgsVtpkTiles;
 
 class QgsTileDownloadManagerReply;
+class QgsVectorTileDataProvider;
 
 /**
  * \ingroup core
@@ -63,26 +63,12 @@ class QgsVectorTileLoader : public QObject
   public:
 
     //! Returns raw tile data for the specified range of tiles. Blocks the caller until all tiles are fetched.
-    static QList<QgsVectorTileRawData> blockingFetchTileRawData( const QString &sourceType,
-        const QString &sourcePath,
-        const QgsTileMatrix &tileMatrix,
-        const QPointF &viewCenter,
-        const QgsTileRange &range,
-        const QString &authid,
-        const QgsHttpHeaders &headers,
-        QgsFeedback *feedback = nullptr );
-
-    //! Returns raw tile data for a single tile, doing a HTTP request. Block the caller until tile data are downloaded.
-    static QByteArray loadFromNetwork( const QgsTileXYZ &id,
-                                       const QgsTileMatrix &tileMatrix,
-                                       const QString &requestUrl,
-                                       const QString &authid,
-                                       const QgsHttpHeaders &headers,
-                                       QgsFeedback *feedback = nullptr );
-    static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader, QgsFeedback *feedback = nullptr );
-
-    //! Returns raw tile data for a single tile loaded from VTPK file
-    static QByteArray loadFromVtpk( const QgsTileXYZ &id, QgsVtpkTiles &vtpkTileReader );
+    static QList<QgsVectorTileRawData> blockingFetchTileRawData(
+      const QgsVectorTileDataProvider *provider,
+      const QgsTileMatrix &tileMatrix,
+      const QPointF &viewCenter,
+      const QgsTileRange &range,
+      QgsFeedback *feedback = nullptr );
 
     //
     // non-static stuff


### PR DESCRIPTION
The vector tile layer class had originally been designed with a single source in mind -- xyz tile sources. It's since had a bunch of additional sources added (mbtiles, vtpk, arcgis vector tile services) and the code has become a mess of handling these different sources.

This PR refactors the vector tile classes to move source specific handling into QgsVectorTileDataProvider subclasses, just like we do for all the other layer types.

This is a refactor only, no new features -- but it's a precursor to some inbound new functionality which I don't want to add with the vector tile classes in their current state and further clutter the code!

(after this PR is merged I'll split all these classes out to separate files -- I've left them in their current locations for now to hopefully minimise the review effort)