### PR TITLE
Relation Reference: Limit number of entries (resp. unlimit it) per widget

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -237,6 +237,21 @@ Set the name of the referenced layer to ``referencedLayerName``
 .. versionadded:: 3.12
 %End
 
+    int fetchLimit() const;
+%Docstring
+Returns the limit of fetched features (0 means all features)
+
+.. versionadded:: 3.30
+%End
+
+    void setFetchLimit( int fetchLimit );
+%Docstring
+Set the limit of fetched features (0 means all features)
+
+.. versionadded:: 3.30
+%End
+
+
   public slots:
     void openForm();
 %Docstring

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -241,14 +241,14 @@ Set the name of the referenced layer to ``referencedLayerName``
 %Docstring
 Returns the limit of fetched features (0 means all features)
 
-.. versionadded:: 3.30
+.. versionadded:: 3.32
 %End
 
     void setFetchLimit( int fetchLimit );
 %Docstring
 Set the limit of fetched features (0 means all features)
 
-.. versionadded:: 3.30
+.. versionadded:: 3.32
 %End
 
 

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -137,6 +137,17 @@ Determines if a NULL value should be available in the list.
 Determines if a NULL value should be available in the list.
 %End
 
+    int fetchLimit() const;
+%Docstring
+Returns the feature request fetch limit
+%End
+
+    void setFetchLimit( int fetchLimit );
+%Docstring
+Defines the feature request fetch limit
+If set to 0, no limit is applied when fetching
+%End
+
  QString identifierField() const /Deprecated/;
 %Docstring
 Field name that will be used to uniquely identify the current feature.

--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -140,12 +140,16 @@ Determines if a NULL value should be available in the list.
     int fetchLimit() const;
 %Docstring
 Returns the feature request fetch limit
+
+.. versionadded:: 3.32
 %End
 
     void setFetchLimit( int fetchLimit );
 %Docstring
 Defines the feature request fetch limit
 If set to 0, no limit is applied when fetching
+
+.. versionadded:: 3.32
 %End
 
  QString identifierField() const /Deprecated/;

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -592,6 +592,8 @@ void QgsFeaturePickerModelBase::setFetchLimit( int fetchLimit )
 
   mFetchLimit = fetchLimit;
   emit fetchLimitChanged();
+
+  reload();
 }
 
 

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -84,7 +84,7 @@ void QgsRelationReferenceConfigDlg::mEditExpression_clicked()
 
   context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) << QStringLiteral( "current_parent_value" ) );
   context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
-                                   << QStringLiteral( "cumaximumDoubleSpinBox->setMaximum( std::numeric_limits<double>::max() );rrent_feature" )
+                                   << QStringLiteral( "current_feature" )
                                    << QStringLiteral( "form_mode" )
                                    << QStringLiteral( "current_parent_geometry" )
                                    << QStringLiteral( "current_parent_feature" ) );

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -27,6 +27,9 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
 
 {
   setupUi( this );
+
+  mFetchLimit->setMaximum( std::numeric_limits<int>::max() );
+
   connect( mAddFilterButton, &QToolButton::clicked, this, &QgsRelationReferenceConfigDlg::mAddFilterButton_clicked );
   connect( mRemoveFilterButton, &QToolButton::clicked, this, &QgsRelationReferenceConfigDlg::mRemoveFilterButton_clicked );
 
@@ -81,7 +84,7 @@ void QgsRelationReferenceConfigDlg::mEditExpression_clicked()
 
   context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) << QStringLiteral( "current_parent_value" ) );
   context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
-                                   << QStringLiteral( "current_feature" )
+                                   << QStringLiteral( "cumaximumDoubleSpinBox->setMaximum( std::numeric_limits<double>::max() );rrent_feature" )
                                    << QStringLiteral( "form_mode" )
                                    << QStringLiteral( "current_parent_geometry" )
                                    << QStringLiteral( "current_parent_feature" ) );
@@ -110,6 +113,8 @@ void QgsRelationReferenceConfigDlg::setConfig( const QVariantMap &config )
   mCbxMapIdentification->setChecked( config.value( QStringLiteral( "MapIdentification" ), false ).toBool() );
   mCbxAllowAddFeatures->setChecked( config.value( QStringLiteral( "AllowAddFeatures" ), false ).toBool() );
   mCbxReadOnly->setChecked( config.value( QStringLiteral( "ReadOnly" ), false ).toBool() );
+  mFetchLimitGroupBox->setChecked( config.value( QStringLiteral( "FetchLimitActive" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ).toInt() > 0 ).toBool() );
+  mFetchLimit->setValue( config.value( QStringLiteral( "FetchLimitNumber" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ) ).toInt() );
   mFilterExpression->setPlainText( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
 
   if ( config.contains( QStringLiteral( "FilterFields" ) ) )
@@ -170,6 +175,8 @@ QVariantMap QgsRelationReferenceConfigDlg::config()
   myConfig.insert( QStringLiteral( "ReadOnly" ), mCbxReadOnly->isChecked() );
   myConfig.insert( QStringLiteral( "Relation" ), mComboRelation->currentData() );
   myConfig.insert( QStringLiteral( "AllowAddFeatures" ), mCbxAllowAddFeatures->isChecked() );
+  myConfig.insert( QStringLiteral( "FetchLimitActive" ), mFetchLimitGroupBox->isChecked() );
+  myConfig.insert( QStringLiteral( "FetchLimitNumber" ), mFetchLimit->value() );
 
   if ( mFilterGroupBox->isChecked() )
   {

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -217,10 +217,6 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   {
     mWidget->setFetchLimit( config( QStringLiteral( "FetchLimitNumber" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ) ).toInt() );
   }
-  else
-  {
-    mWidget->setFetchLimit( 0 );
-  }
 
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -212,6 +212,16 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   mWidget->setAllowAddFeatures( false );
   mWidget->setOpenFormButtonVisible( false );
 
+  const bool fetchLimitActive = config( QStringLiteral( "FetchLimitActive" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ).toInt() > 0 ).toBool();
+  if ( fetchLimitActive )
+  {
+    mWidget->setFetchLimit( config( QStringLiteral( "FetchLimitNumber" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ) ).toInt() );
+  }
+  else
+  {
+    mWidget->setFetchLimit( 0 );
+  }
+
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {
     mWidget->setFilterFields( config( QStringLiteral( "FilterFields" ) ).toStringList() );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -187,6 +187,7 @@ void QgsRelationReferenceWidget::setRelation( const QgsRelation &relation, bool 
       mComboBox->setSourceLayer( mReferencedLayer );
       mComboBox->setIdentifierFields( mReferencedFields );
       mComboBox->setFilterExpression( mFilterExpression );
+      mComboBox->setFetchLimit( mFetchLimit );
     }
     mAttributeEditorFrame->setObjectName( QStringLiteral( "referencing/" ) + relation.name() );
 
@@ -474,6 +475,7 @@ void QgsRelationReferenceWidget::init()
     mComboBox->setDisplayExpression( mReferencedLayer->displayExpression() );
     mComboBox->setAllowNull( mAllowNull );
     mComboBox->setIdentifierFields( mReferencedFields );
+    mComboBox->setFetchLimit( mFetchLimit );
 
     if ( ! mFilterExpression.isEmpty() )
       mComboBox->setFilterExpression( mFilterExpression );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -251,6 +251,19 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
      */
     void setReferencedLayerName( const QString &referencedLayerName );
 
+    /**
+     * Returns the limit of fetched features (0 means all features)
+     * \since QGIS 3.30
+     */
+    int fetchLimit() const {return mFetchLimit; }
+
+    /**
+     * Set the limit of fetched features (0 means all features)
+     * \since QGIS 3.30
+     */
+    void setFetchLimit( int fetchLimit ) {mFetchLimit = fetchLimit; }
+
+
   public slots:
     //! open the form of the related feature in a new dialog
     void openForm();
@@ -328,6 +341,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QStringList mFilterFields;
     QMap<QString, QMap<QString, QSet<QString> > > mFilterCache;
     bool mInitialized = false;
+    int mFetchLimit = 0;
 
     // Q_PROPERTY
     bool mEmbedForm = false;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -253,13 +253,13 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 
     /**
      * Returns the limit of fetched features (0 means all features)
-     * \since QGIS 3.30
+     * \since QGIS 3.32
      */
     int fetchLimit() const {return mFetchLimit; }
 
     /**
      * Set the limit of fetched features (0 means all features)
-     * \since QGIS 3.30
+     * \since QGIS 3.32
      */
     void setFetchLimit( int fetchLimit ) {mFetchLimit = fetchLimit; }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -63,10 +63,6 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   {
     mWidget->setFetchLimit( config( QStringLiteral( "FetchLimitNumber" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ) ).toInt() );
   }
-  else
-  {
-    mWidget->setFetchLimit( 0 );
-  }
 
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -57,6 +57,17 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   mWidget->setReadOnlySelector( readOnlyWidget );
   mWidget->setAllowMapIdentification( mapIdent );
   mWidget->setOpenFormButtonVisible( showOpenFormButton );
+
+  const bool fetchLimitActive = config( QStringLiteral( "FetchLimitActive" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ).toInt() > 0 ).toBool();
+  if ( fetchLimitActive )
+  {
+    mWidget->setFetchLimit( config( QStringLiteral( "FetchLimitNumber" ), QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ) ).toInt() );
+  }
+  else
+  {
+    mWidget->setFetchLimit( 0 );
+  }
+
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {
     mWidget->setFilterFields( config( QStringLiteral( "FilterFields" ) ).toStringList() );

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -241,6 +241,16 @@ void QgsFeatureListComboBox::setAllowNull( bool allowNull )
   mLineEdit->setClearMode( allowNull ? QgsFilterLineEdit::ClearToNull : QgsFilterLineEdit::ClearToDefault );
 }
 
+int QgsFeatureListComboBox::fetchLimit() const
+{
+  return mModel->fetchLimit();
+}
+
+void QgsFeatureListComboBox::setFetchLimit( int fetchLimit )
+{
+  mModel->setFetchLimit( fetchLimit );
+}
+
 QVariant QgsFeatureListComboBox::identifierValue() const
 {
   Q_NOWARN_DEPRECATED_PUSH

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -156,12 +156,14 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
 
     /**
      * Returns the feature request fetch limit
+     * \since QGIS 3.32
      */
     int fetchLimit() const;
 
     /**
      * Defines the feature request fetch limit
      * If set to 0, no limit is applied when fetching
+     * \since QGIS 3.32
      */
     void setFetchLimit( int fetchLimit );
 

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -155,6 +155,17 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
     void setAllowNull( bool allowNull );
 
     /**
+     * Returns the feature request fetch limit
+     */
+    int fetchLimit() const;
+
+    /**
+     * Defines the feature request fetch limit
+     * If set to 0, no limit is applied when fetching
+     */
+    void setFetchLimit( int fetchLimit );
+
+    /**
      * Field name that will be used to uniquely identify the current feature.
      * Normally the primary key of the layer.
      * \deprecated since QGIS 3.10

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -7,17 +7,31 @@
     <x>0</x>
     <y>0</y>
     <width>470</width>
-    <height>553</height>
+    <height>601</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxReadOnly">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Use a read-only line edit instead of a combobox</string>
+      <string>Relation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxAllowAddFeatures">
+     <property name="text">
+      <string>Allow adding new features</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxAllowNull">
+     <property name="text">
+      <string>Allow NULL value</string>
      </property>
     </widget>
    </item>
@@ -28,6 +42,37 @@
      </property>
      <property name="text">
       <string>Display expression Ⓘ</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxReadOnly">
+     <property name="text">
+      <string>Use a read-only line edit instead of a combobox</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxMapIdentification">
+     <property name="text">
+      <string>On map identification (for geometric layers only)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboRelation">
+     <property name="toolTip">
+      <string>The generated relations for a polymorphic relation cannot be used.</string>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
@@ -148,56 +193,29 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxShowOpenFormButton">
-     <property name="text">
-      <string>Show open form button</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Relation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxAllowNull">
-     <property name="text">
-      <string>Allow NULL value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxMapIdentification">
-     <property name="text">
-      <string>On map identification (for geometric layers only)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboRelation">
-     <property name="toolTip">
-      <string>The generated relations for a polymorphic relation cannot be used.</string>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxAllowAddFeatures">
-     <property name="text">
-      <string>Allow adding new features</string>
+    <widget class="QGroupBox" name="mFetchLimitGroupBox">
+     <property name="toolTip">
+      <string>If no limit is set, all entries are loaded.</string>
      </property>
+     <property name="title">
+      <string>Limit number of entries</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_fetchLimit">
+        <property name="text">
+         <string>Maximum number of entries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsSpinBox" name="mFetchLimit"/>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="3" column="0" colspan="2">
@@ -222,13 +240,17 @@
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>mComboRelation</tabstop>
   <tabstop>mCbxAllowNull</tabstop>
   <tabstop>mCbxShowForm</tabstop>
-  <tabstop>mCbxShowOpenFormButton</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
   <tabstop>mCbxReadOnly</tabstop>
   <tabstop>mCbxAllowAddFeatures</tabstop>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxAllowAddFeatures">
      <property name="text">
       <string>Allow adding new features</string>
@@ -45,14 +45,14 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxReadOnly">
      <property name="text">
       <string>Use a read-only line edit instead of a combobox</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxMapIdentification">
      <property name="text">
       <string>On map identification (for geometric layers only)</string>
@@ -76,7 +76,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mFilterGroupBox">
      <property name="title">
       <string>Filters</string>
@@ -193,7 +193,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QGroupBox" name="mFetchLimitGroupBox">
      <property name="toolTip">
       <string>If no limit is set, all entries are loaded.</string>
@@ -225,6 +225,13 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxShowOpenFormButton">
+     <property name="text">
+      <string>Show open form button</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -251,6 +258,7 @@
   <tabstop>mComboRelation</tabstop>
   <tabstop>mCbxAllowNull</tabstop>
   <tabstop>mCbxShowForm</tabstop>
+  <tabstop>mCbxShowOpenFormButton</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
   <tabstop>mCbxReadOnly</tabstop>
   <tabstop>mCbxAllowAddFeatures</tabstop>

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -818,31 +818,58 @@ void TestQgsRelationReferenceWidget::testComboLimit()
   QEventLoop loop;
   connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
   w.setRelation( mRelation, false );
-  w.init();
   loop.exec();
   QVERIFY( w.relation().isValid() );
 
+  // check fetch limit of combobox directly
   QSignalSpy spy( w.mComboBox, &QgsFeatureListComboBox::modelUpdated );
 
-  w.mComboBox->setFetchLimit( 200 );
-  spy.wait( 1000 );
-  QCOMPARE( w.mComboBox->count(), 200 );
-
   w.mComboBox->setFetchLimit( 20 );
-  spy.wait( 1000 );
+  spy.wait();
   QCOMPARE( w.mComboBox->count(), 20 );
 
   w.mComboBox->setFetchLimit( -1 );
-  spy.wait( 1000 );
+  spy.wait();
   QCOMPARE( w.mComboBox->count(), 200 );
 
+  w.mComboBox->setFetchLimit( 120 );
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 120 );
+
   w.mComboBox->setFetchLimit( 0 );
-  spy.wait( 1000 );
+  spy.wait();
   QCOMPARE( w.mComboBox->count(), 200 );
 
   w.mComboBox->setFetchLimit( 300 );
-  spy.wait( 1000 );
+  spy.wait();
   QCOMPARE( w.mComboBox->count(), 200 );
+
+  // check the setting in relation reference
+  w.setFetchLimit( 22 );
+  w.init();
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 22 );
+
+  w.setFetchLimit( -1 );
+  w.init();
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 200 );
+
+  w.setFetchLimit( 122 );
+  w.init();
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 122 );
+
+  w.setFetchLimit( 0 );
+  w.setRelation( mRelation, false );
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 200 );
+
+  w.setFetchLimit( 300 );
+  w.setRelation( mRelation, true );
+  spy.wait();
+  QCOMPARE( w.mComboBox->count(), 201 );
+
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
Possiblity to set the limit of values in the Relation Reference Widget:

![image](https://user-images.githubusercontent.com/28384354/225290839-ba8bdd43-857d-43b5-840c-c74a3d2a9670.png)

Before the limit of the RelationReference could have been configured over the very hidden Advanced Settings and has been set per QGIS Profile (local) and generally for all RelationReference widgets (and the example drop-down in the Expression Builder).
![image](https://user-images.githubusercontent.com/28384354/225290545-2c28cb3c-b770-47fc-95e3-6d844509201a.png)

Means, when no setting has been done yet (on new or old projects), the value from the local Advanced Setting is read into the widget settings (on opening the configuration) and the option to set a limit is activated

### Backwards compatibilty:
As mentioned: When no setting has been done yet (on new or old projects), the value from the local Advanced Setting is read into the widget settings (on opening the configuration) and the option to set a limit is activated. After storing, this value is considered (even when the user changes the value of the Advanced Setting). When deactivating the "Limit number of entries", the limit is not considered (fetchLimit is set to 0), but the value in the setting persists in case of activating it again. On doing no configuration at all, the setting from the Advanced Setting is considered as well.

