### PR TITLE
Relation Reference: Remove broken (unused) setting for "Order by value"

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -104,14 +104,6 @@ determines if the widget offers the possibility to select the related feature on
 %End
     void setAllowMapIdentification( bool allowMapIdentification );
 
-    bool orderByValue();
-%Docstring
-If the widget will order the combobox entries by value
-%End
-    void setOrderByValue( bool orderByValue );
-%Docstring
-Sets if the widget will order the combobox entries by value
-%End
     void setFilterFields( const QStringList &filterFields );
 %Docstring
 Sets the fields for which filter comboboxes will be created

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -55,7 +55,6 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
   }
 
   connect( mCbxAllowNull, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
-  connect( mCbxOrderByValue, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxShowForm, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxShowOpenFormButton, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxMapIdentification, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
@@ -99,7 +98,6 @@ void QgsRelationReferenceConfigDlg::mEditExpression_clicked()
 void QgsRelationReferenceConfigDlg::setConfig( const QVariantMap &config )
 {
   mCbxAllowNull->setChecked( config.value( QStringLiteral( "AllowNULL" ), false ).toBool() );
-  mCbxOrderByValue->setChecked( config.value( QStringLiteral( "OrderByValue" ), false ).toBool() );
   mCbxShowForm->setChecked( config.value( QStringLiteral( "ShowForm" ), false ).toBool() );
   mCbxShowOpenFormButton->setChecked( config.value( QStringLiteral( "ShowOpenFormButton" ), true ).toBool() );
 
@@ -166,7 +164,6 @@ QVariantMap QgsRelationReferenceConfigDlg::config()
 {
   QVariantMap myConfig;
   myConfig.insert( QStringLiteral( "AllowNULL" ), mCbxAllowNull->isChecked() );
-  myConfig.insert( QStringLiteral( "OrderByValue" ), mCbxOrderByValue->isChecked() );
   myConfig.insert( QStringLiteral( "ShowForm" ), mCbxShowForm->isChecked() );
   myConfig.insert( QStringLiteral( "ShowOpenFormButton" ), mCbxShowOpenFormButton->isChecked() );
   myConfig.insert( QStringLiteral( "MapIdentification" ), mCbxMapIdentification->isEnabled() && mCbxMapIdentification->isChecked() );

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -209,7 +209,6 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
   mWidget->setEmbedForm( false );
   mWidget->setReadOnlySelector( false );
   mWidget->setAllowMapIdentification( config( QStringLiteral( "MapIdentification" ), false ).toBool() );
-  mWidget->setOrderByValue( config( QStringLiteral( "OrderByValue" ), false ).toBool() );
   mWidget->setAllowAddFeatures( false );
   mWidget->setOpenFormButtonVisible( false );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -365,11 +365,6 @@ void QgsRelationReferenceWidget::setAllowMapIdentification( bool allowMapIdentif
   mAllowMapIdentification = allowMapIdentification;
 }
 
-void QgsRelationReferenceWidget::setOrderByValue( bool orderByValue )
-{
-  mOrderByValue = orderByValue;
-}
-
 void QgsRelationReferenceWidget::setFilterFields( const QStringList &filterFields )
 {
   mFilterFields = filterFields;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -131,10 +131,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool allowMapIdentification() { return mAllowMapIdentification; }
     void setAllowMapIdentification( bool allowMapIdentification );
 
-    //! If the widget will order the combobox entries by value
-    bool orderByValue() { return mOrderByValue; }
-    //! Sets if the widget will order the combobox entries by value
-    void setOrderByValue( bool orderByValue );
     //! Sets the fields for which filter comboboxes will be created
     void setFilterFields( const QStringList &filterFields );
 
@@ -337,7 +333,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool mEmbedForm = false;
     bool mReadOnlySelector = false;
     bool mAllowMapIdentification = false;
-    bool mOrderByValue = false;
     bool mOpenFormButtonVisible = true;
     bool mChainFilters = false;
     bool mAllowAddFeatures = false;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -51,13 +51,11 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   const bool showForm = config( QStringLiteral( "ShowForm" ), false ).toBool();
   const bool mapIdent = config( QStringLiteral( "MapIdentification" ), false ).toBool();
   const bool readOnlyWidget = config( QStringLiteral( "ReadOnly" ), false ).toBool();
-  const bool orderByValue = config( QStringLiteral( "OrderByValue" ), false ).toBool();
   const bool showOpenFormButton = config( QStringLiteral( "ShowOpenFormButton" ), true ).toBool();
 
   mWidget->setEmbedForm( showForm );
   mWidget->setReadOnlySelector( readOnlyWidget );
   mWidget->setAllowMapIdentification( mapIdent );
-  mWidget->setOrderByValue( orderByValue );
   mWidget->setOpenFormButtonVisible( showOpenFormButton );
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -7,76 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>470</width>
-    <height>540</height>
+    <height>553</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxShowForm">
-     <property name="text">
-      <string>Show embedded form</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxShowOpenFormButton">
-     <property name="text">
-      <string>Show open form button</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboRelation">
-     <property name="toolTip">
-      <string>The generated relations for a polymorphic relation cannot be used.</string>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxAllowNull">
-     <property name="text">
-      <string>Allow NULL value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxReadOnly">
      <property name="text">
       <string>Use a read-only line edit instead of a combobox</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Relation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="mCbxOrderByValue">
-     <property name="text">
-      <string>Order by value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCbxMapIdentification">
-     <property name="text">
-      <string>On map identification (for geometric layers only)</string>
      </property>
     </widget>
    </item>
@@ -90,7 +31,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mFilterGroupBox">
      <property name="title">
       <string>Filters</string>
@@ -207,10 +148,62 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxShowOpenFormButton">
+     <property name="text">
+      <string>Show open form button</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Relation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxAllowNull">
+     <property name="text">
+      <string>Allow NULL value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxMapIdentification">
+     <property name="text">
+      <string>On map identification (for geometric layers only)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboRelation">
+     <property name="toolTip">
+      <string>The generated relations for a polymorphic relation cannot be used.</string>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxAllowAddFeatures">
      <property name="text">
       <string>Allow adding new features</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxShowForm">
+     <property name="text">
+      <string>Show embedded form</string>
      </property>
     </widget>
    </item>
@@ -234,7 +227,6 @@
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>mComboRelation</tabstop>
   <tabstop>mCbxAllowNull</tabstop>
-  <tabstop>mCbxOrderByValue</tabstop>
   <tabstop>mCbxShowForm</tabstop>
   <tabstop>mCbxShowOpenFormButton</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
@@ -250,6 +242,7 @@
   <tabstop>mFilterExpression</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION

The setting for "Order by value" has been brocken for at least 5 years now. Apparently noone missed it. It always sorted according to the display expression.

Compared to the Value Relation Widget (where "Order by value" would sort the `value` and otherwise the `key`) it's not really clear what order would be expected in the RelationReference widget anyway. Maybe the `referencedField` set in the relation?

I suggest it to remove it until someone misses it.

Resolves #26468