### PR TITLE
Server - Add display name in GetFeatureInfo response

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -538,6 +538,11 @@ namespace QgsWms
                                        QVariant( false ) );
     save( pWithMapTip );
 
+    const QgsWmsParameter pWithDisplayName( QgsWmsParameter::WITH_DISPLAY_NAME,
+                                            QVariant::Bool,
+                                            QVariant( false ) );
+    save( pWithDisplayName );
+
     const QgsWmsParameter pWmtver( QgsWmsParameter::WMTVER );
     save( pWmtver );
 
@@ -2095,6 +2100,11 @@ namespace QgsWms
   bool QgsWmsParameters::withMapTip() const
   {
     return mWmsParameters.value( QgsWmsParameter::WITH_MAPTIP ).toBool();
+  }
+
+  bool QgsWmsParameters::withDisplayName() const
+  {
+    return mWmsParameters.value( QgsWmsParameter::WITH_DISPLAY_NAME ).toBool();
   }
 
   QString QgsWmsParameters::wmtver() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -181,6 +181,7 @@ namespace QgsWms
         GRID_INTERVAL_Y,
         WITH_GEOMETRY,
         WITH_MAPTIP,
+        WITH_DISPLAY_NAME,
         WMTVER,
         ATLAS_PK,
         FORMAT_OPTIONS,
@@ -1286,6 +1287,13 @@ namespace QgsWms
        * \returns TRUE if maptip information is requested for feature info response
        */
       bool withMapTip() const;
+
+      /**
+       * \brief withDisplayName
+       * \returns TRUE if the display name is requested for feature info response
+       * \since QGIS 3.32
+       */
+      bool withDisplayName() const;
 
       /**
        * Returns WMTVER parameter or an empty string if not defined.

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1867,6 +1867,18 @@ namespace QgsWms
           featureElement.appendChild( maptipElem );
         }
 
+        QgsExpression displayExpression = layer->displayExpression();
+        if ( displayExpression.isValid() && mWmsParameters.withDisplayName() )
+        {
+          QDomElement displayElem = infoDocument.createElement( QStringLiteral( "Attribute" ) );
+          displayElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "displayName" ) );
+          QgsExpressionContext context { renderContext.expressionContext() };
+          context.appendScope( QgsExpressionContextUtils::layerScope( layer ) );
+          displayExpression.prepare( &context );
+          displayElem.setAttribute( QStringLiteral( "value" ),  displayExpression.evaluate( &context ).toString() );
+          featureElement.appendChild( displayElem );
+        }
+
         //append feature bounding box to feature info xml
         if ( QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) &&
              layer->wkbType() != Qgis::WkbType::NoGeometry && hasGeometry )

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -116,23 +116,25 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'with_geometry=true',
                                  'wms_getfeatureinfo-text-html-geometry')
 
-        # Test getfeatureinfo response html with maptip
+        # Test getfeatureinfo response html with maptip and display name
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fhtml&transparent=true&' +
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_display_name=true&' +
                                  'with_maptip=true',
                                  'wms_getfeatureinfo-text-html-maptip')
 
-        # Test getfeatureinfo response html with maptip in text mode
+        # Test getfeatureinfo response html with maptip and display name in text mode
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fplain&transparent=true&' +
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_display_name=true&' +
                                  'with_maptip=true',
                                  'wms_getfeatureinfo-text-html-maptip-plain')
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
@@ -9,4 +9,5 @@ id = '3'
 name = 'three'
 utf8nameè = 'three èé↓'
 maptip = 'Name: three'
+displayName = 'three'
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
@@ -14,6 +14,7 @@ Content-Type: text/html; charset=utf-8
 <TR><TH>name</TH><TD>three</TD></TR>
 <TR><TH>utf8nameè</TH><TD>three èé↓</TD></TR>
 <TR><TH>maptip</TH><TD>Name: three</TD></TR>
+<TR><TH>displayName</TH><TD>three</TD></TR>
 </TABLE>
 </BR>
 </TABLE>


### PR DESCRIPTION
Add the display name in GetFeatureInfo response if needed thanks to `WITH_DISPLAY_NAME`, similar to the existing `WITH_MAPTIP`.

Funded by 3liz.com https://3liz.com