### PR TITLE
fix  void context menu of map canvas

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1208,6 +1208,9 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
     if ( !mapTool()->populateContextMenuWithEvent( &menu, event ) )
       mMapTool->populateContextMenu( &menu );
 
+  if ( menu.isEmpty() ) // menu can be empty after populateContextMenu()
+    return;
+
   emit contextMenuAboutToShow( &menu, event );
 
   menu.exec( event->globalPos() );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1208,12 +1208,10 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
     if ( !mapTool()->populateContextMenuWithEvent( &menu, event ) )
       mMapTool->populateContextMenu( &menu );
 
-  if ( menu.isEmpty() ) // menu can be empty after populateContextMenu()
-    return;
-
   emit contextMenuAboutToShow( &menu, event );
 
-  menu.exec( event->globalPos() );
+  if ( !menu.isEmpty() ) // menu can be empty after populateContextMenu() and contextMenuAboutToShow()
+    menu.exec( event->globalPos() );
 }
 
 void QgsMapCanvas::notifyRendererErrors( const QgsMapRendererJob::Errors &errors )


### PR DESCRIPTION
Without this fix, if the map tool empties the context menu, calling exec() with a void menu create an impression  of QGIS freezing that can only  be exited by escape key or by clicking somewhere. Indeed the context menu is executed but not visible.