### PR TITLE
fix mesh traces without feedback in the render context

### DIFF
--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -398,7 +398,9 @@ void QgsMeshStreamField::addRandomTraces()
 {
   if ( mMaximumMagnitude > 0 )
     while ( ( mPixelFillingCount < mMaxPixelFillingCount ) &&
-            mRenderContext.feedback() && !mRenderContext.feedback()->isCanceled() )
+            ( !mRenderContext.feedback() ||
+              !mRenderContext.feedback()->isCanceled() ||
+              !mRenderContext.renderingStopped() ) )
       addRandomTrace();
 }
 


### PR DESCRIPTION
Allow mesh traces rendering even a feedback is not provided in the render context
