### PR TITLE
fix add new mesh face with undo

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -356,9 +356,16 @@ Adds point to the CAD point list
 
     void removePreviousPoint();
 %Docstring
-Remove previous point in the CAD point list
+Removes previous point in the CAD point list
 
 .. versionadded:: 3.8
+%End
+
+    void updateCurrentPoint( const QgsPointXY &point );
+%Docstring
+Updates the current ``point`` in the CAD point list
+
+.. versionadded:: 3.30.2
 %End
 
     void setPoints( const QList<QgsPointXY> &points );

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -361,7 +361,7 @@ Removes previous point in the CAD point list
 .. versionadded:: 3.8
 %End
 
-    void updateCurrentPoint( const QgsPointXY &point );
+    void updateCurrentPoint( const QgsPoint &point );
 %Docstring
 Updates the current ``point`` in the CAD point list
 

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1626,7 +1626,7 @@ bool QgsMapToolEditMeshFrame::isFaceSelected( int faceIndex )
   return true;
 }
 
-void QgsMapToolEditMeshFrame::setSelectedVertices( const QList<int> newSelectedVertices, Qgis::SelectBehavior behavior )
+void QgsMapToolEditMeshFrame::setSelectedVertices( const QList<int> &newSelectedVertices, Qgis::SelectBehavior behavior )
 {
   if ( mSelectedVertices.isEmpty() )
   {
@@ -1662,7 +1662,7 @@ void QgsMapToolEditMeshFrame::setSelectedVertices( const QList<int> newSelectedV
   prepareSelection();
 }
 
-void QgsMapToolEditMeshFrame::setSelectedFaces( const QList<int> newSelectedFaces, Qgis::SelectBehavior behavior )
+void QgsMapToolEditMeshFrame::setSelectedFaces( const QList<int> &newSelectedFaces, Qgis::SelectBehavior behavior )
 {
   bool removeFaces = false;
 
@@ -1948,7 +1948,6 @@ void QgsMapToolEditMeshFrame::onUndoRedo()
       mCadDockWidget->setEnabledZ( mCadDockWidget->cadEnabled() );
       break;
     case ForceByLines:
-      break;
     case Selecting:
     case SelectingByPolygon:
       break;

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -948,7 +948,7 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           addVertexToFaceCanditate( mCurrentVertexIndex );
           // Advanced digitizing base class adds a point at map point not at vertex position
           // so we need to replace it by the position of the vertex
-          const QgsPointXY &currentPoint = mapVertexXY( mCurrentVertexIndex );
+          const QgsPoint &currentPoint = mapVertex( mCurrentVertexIndex );
           cadDockWidget()->updateCurrentPoint( currentPoint );
           cadDockWidget()->removePreviousPoint();
           cadDockWidget()->addPoint( currentPoint );
@@ -1236,6 +1236,7 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
         mNewFaceBand->reset( Qgis::GeometryType::Polygon );
         mNewFaceCandidate.clear();
         mNewVerticesForNewFaceCandidate.clear();
+        mCadDockWidget->clearPoints();
         mCurrentState = Digitizing;
         consumned = true;
       }

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1248,7 +1248,7 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
     }
     break;
     case MovingSelection:
-      if ( e->key() == Qt:: Key_Escape )
+      if ( e->key() == Qt::Key_Escape )
       {
         mCurrentState = Digitizing;
         mMovingEdgesRubberband->reset( Qgis::GeometryType::Line );

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -986,6 +986,7 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       const QgsGeometry selectionGeom = mSelectionBand->asGeometry();
       selectByGeometry( selectionGeom, e->modifiers() );
       mSelectionBand->reset( Qgis::GeometryType::Polygon );
+      mCadDockWidget->clearPoints();
       mCurrentState = Digitizing;
     }
     break;
@@ -1236,14 +1237,13 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
         mNewFaceBand->reset( Qgis::GeometryType::Polygon );
         mNewFaceCandidate.clear();
         mNewVerticesForNewFaceCandidate.clear();
-        mCadDockWidget->clearPoints();
         mCurrentState = Digitizing;
         consumned = true;
       }
     }
     break;
     case MovingSelection:
-      if ( e->key() == Qt::Key_Escape )
+      if ( e->key() == Qt:: Key_Escape )
       {
         mCurrentState = Digitizing;
         mMovingEdgesRubberband->reset( Qgis::GeometryType::Line );
@@ -1274,6 +1274,9 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
       }
       break;
   }
+
+  if ( e->key() == Qt::Key_Escape )
+    mCadDockWidget->clearPoints();
 
   if ( !consumned && mZValueWidget )
     QgsApplication::sendEvent( mZValueWidget->keyboardEntryWidget(), e );

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -920,6 +920,7 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
                   mCurrentEdge.first != -1 && mCurrentEdge.second != -1 )  // flip edge
         {
           clearSelection();
+          mCadDockWidget->clearPoints();
           const QVector<int> edgeVert = edgeVertices( mCurrentEdge );
           mCurrentEditor->flipEdge( edgeVert.at( 0 ), edgeVert.at( 1 ) );
           mCurrentEdge = {-1, -1};
@@ -930,13 +931,17 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
                   mCurrentEdge.first != -1 && mCurrentEdge.second != -1 ) // merge two faces
         {
           clearSelection();
+          mCadDockWidget->clearPoints();
           const QVector<int> edgeVert = edgeVertices( mCurrentEdge );
           mCurrentEditor->merge( edgeVert.at( 0 ), edgeVert.at( 1 ) );
           mCurrentEdge = {-1, -1};
           highLight( mapPoint );
         }
         else
+        {
           select( mapPoint, e->modifiers(), tolerance );
+          mCadDockWidget->clearPoints();
+        }
       }
       break;
     case AddingNewFace:

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -946,8 +946,12 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         if ( mCurrentVertexIndex != -1 )
         {
           addVertexToFaceCanditate( mCurrentVertexIndex );
-          const QgsPointXY currentPoint = mapVertexXY( mCurrentVertexIndex );
-          cadDockWidget()->setPoints( QList<QgsPointXY>() << currentPoint << currentPoint );
+          // Advanced digitizing base class adds a point at map point not at vertex position
+          // so we need to replace it by the position of the vertex
+          const QgsPointXY &currentPoint = mapVertexXY( mCurrentVertexIndex );
+          cadDockWidget()->updateCurrentPoint( currentPoint );
+          cadDockWidget()->removePreviousPoint();
+          cadDockWidget()->addPoint( currentPoint );
         }
         else
         {
@@ -962,8 +966,6 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           if ( acceptPoint )
           {
             addVertexToFaceCanditate( mapPoint );
-            const QgsPointXY currentPoint( mapPoint );
-            cadDockWidget()->setPoints( QList<QgsPointXY>() << currentPoint << currentPoint );
           }
         }
       }
@@ -1223,6 +1225,8 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
         }
         if ( mNewFaceCandidate.isEmpty() )
           mCurrentState = Digitizing;
+
+        mCadDockWidget->removePreviousPoint();
 
         consumned = true;
       }
@@ -1939,6 +1943,7 @@ void QgsMapToolEditMeshFrame::onUndoRedo()
       mNewFaceCandidate.clear();
       mNewVerticesForNewFaceCandidate.clear();
       mCurrentState = Digitizing;
+      mCadDockWidget->clearPoints();
       break;
     case MovingSelection:
       mCurrentState = Digitizing;
@@ -1946,6 +1951,7 @@ void QgsMapToolEditMeshFrame::onUndoRedo()
       mMovingFacesRubberband->reset( Qgis::GeometryType::Polygon );
       mMovingFreeVertexRubberband->reset( Qgis::GeometryType::Point );
       mCadDockWidget->setEnabledZ( mCadDockWidget->cadEnabled() );
+      mCadDockWidget->clearPoints();
       break;
     case ForceByLines:
     case Selecting:

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -229,8 +229,8 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     void addNewSelectedVertex( int vertexIndex );
     void removeFromSelection( int vertexIndex );
     bool isFaceSelected( int faceIndex );
-    void setSelectedVertices( const QList<int> newSelectedVertices,  Qgis::SelectBehavior behavior );
-    void setSelectedFaces( const QList<int> newSelectedFaces,  Qgis::SelectBehavior behavior );
+    void setSelectedVertices( const QList<int> &newSelectedVertices,  Qgis::SelectBehavior behavior );
+    void setSelectedFaces( const QList<int> &newSelectedFaces,  Qgis::SelectBehavior behavior );
     void selectByGeometry( const QgsGeometry &geometry,  Qt::KeyboardModifiers modifiers );
     void selectTouchedByGeometry( const QgsGeometry &geometry, Qgis::SelectBehavior behavior );
     void selectContainedByGeometry( const QgsGeometry &geometry, Qgis::SelectBehavior behavior );

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -165,6 +165,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     void selectByExpression( const QString &textExpression, Qgis::SelectBehavior behavior, QgsMesh::ElementType elementType );
     void onZoomToSelected();
     void reindexMesh();
+    void onUndoRedo();
 
   private:
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1745,6 +1745,11 @@ void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPoint &point 
   updateCadPaintItem();
 }
 
+void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPointXY &point )
+{
+  updateCurrentPoint( QgsPoint( point ) );
+}
+
 
 void QgsAdvancedDigitizingDockWidget::CadConstraint::setLockMode( LockMode mode )
 {

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1745,12 +1745,6 @@ void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPoint &point 
   updateCadPaintItem();
 }
 
-void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPointXY &point )
-{
-  updateCurrentPoint( QgsPoint( point ) );
-}
-
-
 void QgsAdvancedDigitizingDockWidget::CadConstraint::setLockMode( LockMode mode )
 {
   mLockMode = mode;

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -356,10 +356,16 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void addPoint( const QgsPointXY &point );
 
     /**
-     * Remove previous point in the CAD point list
+     * Removes previous point in the CAD point list
      * \since QGIS 3.8
      */
     void removePreviousPoint();
+
+    /**
+     * Updates the current \a point in the CAD point list
+     * \since QGIS 3.30.2
+     */
+    void updateCurrentPoint( const QgsPointXY &point );
 
     /**
      * Configures list of current CAD points

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -365,7 +365,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Updates the current \a point in the CAD point list
      * \since QGIS 3.30.2
      */
-    void updateCurrentPoint( const QgsPointXY &point );
+    void updateCurrentPoint( const QgsPoint &point );
 
     /**
      * Configures list of current CAD points
@@ -932,10 +932,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * \param snapped if given, determines if a segment has been snapped
      */
     QList<QgsPointXY> snapSegmentToAllLayers( const QgsPointXY &originalMapPoint, bool *snapped = nullptr ) const;
-
-    //! update the current point in the CAD point list
-    void updateCurrentPoint( const QgsPoint &point );
-
 
     /**
      * filters key press


### PR DESCRIPTION
During mesh editing, especially adding new faces, if the user use undo, the map tool take an inconsistent state.
This PR fixes this issue (fix #51530)
