### PR TITLE
expose Qgs3dMapCanvas in app lib

### DIFF
--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -20,6 +20,8 @@
 #include <Qt3DRender/QRenderCapture>
 #include <QSplitter>
 
+#include "qgis_app.h"
+
 #include "qgsrange.h"
 #include "qgscameracontroller.h"
 #include "qgsrectangle.h"
@@ -43,7 +45,7 @@ class Qgs3DNavigationWidget;
 class QgsTemporalController;
 class QgsRubberBand;
 
-class Qgs3DMapCanvas : public QWidget
+class APP_EXPORT Qgs3DMapCanvas : public QWidget
 {
     Q_OBJECT
   public:

--- a/tests/src/3d/sandbox/CMakeLists.txt
+++ b/tests/src/3d/sandbox/CMakeLists.txt
@@ -24,8 +24,6 @@ include_directories(SYSTEM
 
 add_executable(qgis_3d_sandbox
   qgis_3d_sandbox.cpp
-  ${CMAKE_SOURCE_DIR}/src/app/3d/qgs3dmapcanvas.cpp
-  ${CMAKE_SOURCE_DIR}/src/app/3d/qgs3dnavigationwidget.cpp
 )
 # require c++17
 target_compile_features(qgis_3d_sandbox PRIVATE cxx_std_17)
@@ -43,4 +41,5 @@ target_link_libraries(qgis_3d_sandbox
   ${QWT_LIBRARY}
   qgis_core
   qgis_3d
-  qgis_native)
+  qgis_native
+  qgis_app)


### PR DESCRIPTION
To expose the Qgs3dMapCanvas from the app lib. Not useful in QGIS, but allows to access this class from a stand alone application.