### PR TITLE
Move reformat/syntax checking to base QgsCodeEditor classes

### DIFF
--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -73,6 +73,9 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.parent = parent
         self.setupUi(self)
 
+        self.autopep8Level.setClearValue(1)
+        self.maxLineLength.setClearValue(80)
+
         # Set up the formatter combo box
         self.formatter.addItems(["autopep8", "black"])
 

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -212,11 +212,11 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/autoInsertImport", self.autoInsertImport.isChecked())
 
         settings.setValue("pythonConsole/formatOnSave", self.formatOnSave.isChecked())
-        settings.setValue("pythonConsole/sortImports", self.sortImports.isChecked())
-        settings.setValue("pythonConsole/formatter", self.formatter.currentText())
-        settings.setValue("pythonConsole/autopep8Level", self.autopep8Level.value())
-        settings.setValue("pythonConsole/blackNormalizeQuotes", self.blackNormalizeQuotes.isChecked())
-        settings.setValue("pythonConsole/maxLineLength", self.maxLineLength.value())
+        settings.setValue("gui/code-editor/python/sortImports", self.sortImports.isChecked())
+        settings.setValue("gui/code-editor/python/formatter", self.formatter.currentText())
+        settings.setValue("gui/code-editor/python/autopep8Level", self.autopep8Level.value())
+        settings.setValue("gui/code-editor/python/blackNormalizeQuotes", self.blackNormalizeQuotes.isChecked())
+        settings.setValue("gui/code-editor/python/maxLineLength", self.maxLineLength.value())
 
     def restoreSettings(self):
         settings = QgsSettings()
@@ -244,11 +244,11 @@ class ConsoleOptionsWidget(QWidget, Ui_SettingsDialogPythonConsole):
         self.autoInsertImport.setChecked(settings.value("pythonConsole/autoInsertImport", False, type=bool))
 
         self.formatOnSave.setChecked(settings.value("pythonConsole/formatOnSave", False, type=bool))
-        self.sortImports.setChecked(settings.value("pythonConsole/sortImports", True, type=bool))
-        self.formatter.setCurrentText(settings.value("pythonConsole/formatter", "autopep8", type=str))
-        self.autopep8Level.setValue(settings.value("pythonConsole/autopep8Level", 1, type=int))
-        self.blackNormalizeQuotes.setChecked(settings.value("pythonConsole/blackNormalizeQuotes", True, type=bool))
-        self.maxLineLength.setValue(settings.value("pythonConsole/maxLineLength", 80, type=int))
+        self.sortImports.setChecked(settings.value("gui/code-editor/python/sortImports", True, type=bool))
+        self.formatter.setCurrentText(settings.value("gui/code-editor/python/formatter", "autopep8", type=str))
+        self.autopep8Level.setValue(settings.value("gui/code-editor/python/autopep8Level", 1, type=int))
+        self.blackNormalizeQuotes.setChecked(settings.value("gui/code-editor/python/blackNormalizeQuotes", True, type=bool))
+        self.maxLineLength.setValue(settings.value("gui/code-editor/python/maxLineLength", 80, type=int))
 
         if settings.value("pythonConsole/autoCompleteSource") == 'fromDoc':
             self.autoCompFromDoc.setChecked(True)

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -24,7 +24,6 @@
   </property>
   <property name="font">
    <font>
-    <weight>50</weight>
     <bold>false</bold>
    </font>
   </property>
@@ -54,8 +53,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>789</width>
-        <height>860</height>
+        <width>775</width>
+        <height>879</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
@@ -474,7 +473,7 @@
            <number>2</number>
           </property>
           <item row="2" column="1">
-           <widget class="QSpinBox" name="maxLineLength">
+           <widget class="QgsSpinBox" name="maxLineLength">
             <property name="minimum">
              <number>60</number>
             </property>
@@ -539,7 +538,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QSpinBox" name="autopep8Level">
+           <widget class="QgsSpinBox" name="autopep8Level">
             <property name="maximum">
              <number>3</number>
             </property>
@@ -576,6 +575,11 @@
    <extends>QGroupBox</extends>
    <header>qgis.gui</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgis.gui</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2589,6 +2589,13 @@ Qgis.ScriptLanguage.__doc__ = 'Scripting languages.\n\n.. versionadded:: 3.30\n\
 # --
 Qgis.ScriptLanguage.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.ScriptLanguageCapability.Reformat.__doc__ = "Language supports automatic code reformatting"
+Qgis.ScriptLanguageCapability.__doc__ = 'Script language capabilities.\n\nThe flags reflect the support capabilities of a scripting language.\n\n.. versionadded:: 3.32\n\n' + '* ``Reformat``: ' + Qgis.ScriptLanguageCapability.Reformat.__doc__
+# --
+Qgis.ScriptLanguageCapability.baseClass = Qgis
+Qgis.ScriptLanguageCapabilities.baseClass = Qgis
+ScriptLanguageCapabilities = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.LayerTreeInsertionMethod.AboveInsertionPoint.__doc__ = "Layers are added in the tree above the insertion point"
 Qgis.LayerTreeInsertionMethod.TopOfTree.__doc__ = "Layers are added at the top of the layer tree"
 Qgis.LayerTreeInsertionMethod.OptimalInInsertionGroup.__doc__ = "Layers are added at optimal locations across the insertion point's group"

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2590,7 +2590,8 @@ Qgis.ScriptLanguage.__doc__ = 'Scripting languages.\n\n.. versionadded:: 3.30\n\
 Qgis.ScriptLanguage.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.ScriptLanguageCapability.Reformat.__doc__ = "Language supports automatic code reformatting"
-Qgis.ScriptLanguageCapability.__doc__ = 'Script language capabilities.\n\nThe flags reflect the support capabilities of a scripting language.\n\n.. versionadded:: 3.32\n\n' + '* ``Reformat``: ' + Qgis.ScriptLanguageCapability.Reformat.__doc__
+Qgis.ScriptLanguageCapability.CheckSyntax.__doc__ = "Language supports syntax checking"
+Qgis.ScriptLanguageCapability.__doc__ = 'Script language capabilities.\n\nThe flags reflect the support capabilities of a scripting language.\n\n.. versionadded:: 3.32\n\n' + '* ``Reformat``: ' + Qgis.ScriptLanguageCapability.Reformat.__doc__ + '\n' + '* ``CheckSyntax``: ' + Qgis.ScriptLanguageCapability.CheckSyntax.__doc__
 # --
 Qgis.ScriptLanguageCapability.baseClass = Qgis
 Qgis.ScriptLanguageCapabilities.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2591,7 +2591,8 @@ Qgis.ScriptLanguage.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.ScriptLanguageCapability.Reformat.__doc__ = "Language supports automatic code reformatting"
 Qgis.ScriptLanguageCapability.CheckSyntax.__doc__ = "Language supports syntax checking"
-Qgis.ScriptLanguageCapability.__doc__ = 'Script language capabilities.\n\nThe flags reflect the support capabilities of a scripting language.\n\n.. versionadded:: 3.32\n\n' + '* ``Reformat``: ' + Qgis.ScriptLanguageCapability.Reformat.__doc__ + '\n' + '* ``CheckSyntax``: ' + Qgis.ScriptLanguageCapability.CheckSyntax.__doc__
+Qgis.ScriptLanguageCapability.ToggleComment.__doc__ = "Language supports comment toggling"
+Qgis.ScriptLanguageCapability.__doc__ = 'Script language capabilities.\n\nThe flags reflect the support capabilities of a scripting language.\n\n.. versionadded:: 3.32\n\n' + '* ``Reformat``: ' + Qgis.ScriptLanguageCapability.Reformat.__doc__ + '\n' + '* ``CheckSyntax``: ' + Qgis.ScriptLanguageCapability.CheckSyntax.__doc__ + '\n' + '* ``ToggleComment``: ' + Qgis.ScriptLanguageCapability.ToggleComment.__doc__
 # --
 Qgis.ScriptLanguageCapability.baseClass = Qgis
 Qgis.ScriptLanguageCapabilities.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1589,6 +1589,14 @@ The development version
       Unknown,
     };
 
+    enum class ScriptLanguageCapability
+    {
+      Reformat,
+    };
+
+    typedef QFlags<Qgis::ScriptLanguageCapability> ScriptLanguageCapabilities;
+
+
     enum class LayerTreeInsertionMethod
     {
       AboveInsertionPoint,
@@ -2011,6 +2019,8 @@ QFlags<Qgis::MapLayerActionFlag> operator|(Qgis::MapLayerActionFlag f1, QFlags<Q
 QFlags<Qgis::RelationshipCapability> operator|(Qgis::RelationshipCapability f1, QFlags<Qgis::RelationshipCapability> f2);
 
 QFlags<Qgis::SettingsTreeNodeOption> operator|(Qgis::SettingsTreeNodeOption f1, QFlags<Qgis::SettingsTreeNodeOption> f2);
+
+QFlags<Qgis::ScriptLanguageCapability> operator|(Qgis::ScriptLanguageCapability f1, QFlags<Qgis::ScriptLanguageCapability> f2);
 
 
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1593,6 +1593,7 @@ The development version
     {
       Reformat,
       CheckSyntax,
+      ToggleComment,
     };
 
     typedef QFlags<Qgis::ScriptLanguageCapability> ScriptLanguageCapabilities;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1592,6 +1592,7 @@ The development version
     enum class ScriptLanguageCapability
     {
       Reformat,
+      CheckSyntax,
     };
 
     typedef QFlags<Qgis::ScriptLanguageCapability> ScriptLanguageCapabilities;

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -130,6 +130,13 @@ Returns the associated scripting language.
 .. versionadded:: 3.30
 %End
 
+    virtual Qgis::ScriptLanguageCapabilities languageCapabilities() const;
+%Docstring
+Returns the associated scripting language capabilities.
+
+.. versionadded:: 3.32
+%End
+
     static QString languageToString( Qgis::ScriptLanguage language );
 %Docstring
 Returns a user-friendly, translated name of the specified script ``language``.
@@ -414,6 +421,15 @@ Stores the commands executed in the editor to the persistent history file.
 .. versionadded:: 3.30
 %End
 
+    void reformatCode();
+%Docstring
+Applies code reformatting to the editor.
+
+This is only supported for editors which return the Qgis.ScriptLanguageCapability.Reformat capability from :py:func:`~QgsCodeEditor.languageCapabilities`.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void sessionHistoryCleared();
@@ -501,6 +517,15 @@ This method provides an opportunity for subclasses to add additional non-standar
 actions to the context menu.
 
 .. versionadded:: 3.30
+%End
+
+    virtual QString reformatCodeString( const QString &string, bool &ok /Out/, QString &error /Out/ ) const;
+%Docstring
+Applies code reformatting to a ``string`` and returns the result.
+
+This is only supported for editors which return the Qgis.ScriptLanguageCapability.Reformat capability from :py:func:`~QgsCodeEditor.languageCapabilities`.
+
+.. versionadded:: 3.32
 %End
 
 };

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -430,6 +430,15 @@ This is only supported for editors which return the Qgis.ScriptLanguageCapabilit
 .. versionadded:: 3.32
 %End
 
+    virtual bool checkSyntax();
+%Docstring
+Applies syntax checking to the editor.
+
+This is only supported for editors which return the Qgis.ScriptLanguageCapability.CheckSyntax capability from :py:func:`~QgsCodeEditor.languageCapabilities`.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void sessionHistoryCleared();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -519,11 +519,20 @@ actions to the context menu.
 .. versionadded:: 3.30
 %End
 
-    virtual QString reformatCodeString( const QString &string, bool &ok /Out/, QString &error /Out/ ) const;
+    virtual QString reformatCodeString( const QString &string );
 %Docstring
 Applies code reformatting to a ``string`` and returns the result.
 
 This is only supported for editors which return the Qgis.ScriptLanguageCapability.Reformat capability from :py:func:`~QgsCodeEditor.languageCapabilities`.
+
+.. versionadded:: 3.32
+%End
+
+    virtual void showMessage( const QString &title, const QString &message, Qgis::MessageLevel level );
+%Docstring
+Shows a user facing message (eg a warning message).
+
+The default implementation uses QMessageBox.
 
 .. versionadded:: 3.32
 %End

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -439,6 +439,15 @@ This is only supported for editors which return the Qgis.ScriptLanguageCapabilit
 .. versionadded:: 3.32
 %End
 
+    virtual void toggleComment();
+%Docstring
+Toggle comment for the selected text.
+
+This is only supported for editors which return the Qgis.ScriptLanguageCapability.ToggleComment capability from :py:func:`~QgsCodeEditor.languageCapabilities`.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void sessionHistoryCleared();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -80,6 +80,8 @@ A text editor based on QScintilla2.
 %End
   public:
 
+
+
     enum class Mode
     {
       ScriptEditor,

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -42,6 +42,8 @@ Construct a new Python editor.
 
     virtual Qgis::ScriptLanguage language() const;
 
+    virtual Qgis::ScriptLanguageCapabilities languageCapabilities() const;
+
 
     void loadAPIs( const QList<QString> &filenames );
 %Docstring
@@ -76,6 +78,13 @@ Returns the character after the cursor, or an empty string if the cursot is set 
 .. versionadded:: 3.30
 %End
 
+    void updateCapabilities();
+%Docstring
+Updates the editor capabilities.
+
+.. versionadded:: 3.32
+%End
+
   public slots:
 
     void searchSelectedTextInPyQGISDocs();
@@ -96,8 +105,9 @@ Toggle comment for the selected text.
 
     virtual void initializeLexer();
 
-
     virtual void keyPressEvent( QKeyEvent *event );
+    virtual QString reformatCodeString( const QString &string );
+
 
   protected slots:
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -85,6 +85,9 @@ Updates the editor capabilities.
 .. versionadded:: 3.32
 %End
 
+    virtual bool checkSyntax();
+
+
   public slots:
 
     void searchSelectedTextInPyQGISDocs();

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -97,7 +97,8 @@ Searches the selected text in the official PyQGIS online documentation.
 .. versionadded:: 3.16
 %End
 
-    void toggleComment();
+    virtual void toggleComment();
+
 %Docstring
 Toggle comment for the selected text.
 

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsCodeEditorPython : QgsCodeEditor
 {
 %Docstring(signature="appended")
@@ -27,6 +28,7 @@ code autocompletion.
 #include "qgscodeeditorpython.h"
 %End
   public:
+
 
     QgsCodeEditorPython( QWidget *parent /TransferThis/ = 0, const QList<QString> &filenames = QList<QString>(),
                          QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );

--- a/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
+++ b/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
@@ -23,6 +23,8 @@ __copyright__ = '(C) 2019, Nyall Dawson'
 
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import QgsProcessingAlgorithm, QgsProcessing, QgsApplication
+from qgis.utils import iface
+
 from processing.gui.ContextAction import ContextAction
 from processing.script.ScriptEditorDialog import ScriptEditorDialog
 
@@ -41,7 +43,7 @@ class ExportModelAsPythonScriptAction(ContextAction):
 
     def execute(self):
         alg = self.itemData
-        dlg = ScriptEditorDialog(None)
+        dlg = ScriptEditorDialog(parent=iface.mainWindow())
 
         dlg.editor.setText('\n'.join(alg.asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
         dlg.show()

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -392,7 +392,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         return QPointF(newX, newY)
 
     def exportAsScriptAlgorithm(self):
-        dlg = ScriptEditorDialog(None)
+        dlg = ScriptEditorDialog(parent=iface.mainWindow())
 
         dlg.editor.setText('\n'.join(self.model().asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
         dlg.show()

--- a/python/plugins/processing/script/AddScriptFromTemplateAction.py
+++ b/python/plugins/processing/script/AddScriptFromTemplateAction.py
@@ -26,7 +26,7 @@ import codecs
 
 from qgis.PyQt.QtCore import QCoreApplication
 
-from qgis.core import QgsApplication
+from qgis.utils import iface
 
 from processing.gui.ToolboxAction import ToolboxAction
 
@@ -40,7 +40,7 @@ class AddScriptFromTemplateAction(ToolboxAction):
         self.group = self.tr("Tools")
 
     def execute(self):
-        dlg = ScriptEditorDialog(None)
+        dlg = ScriptEditorDialog(parent=iface.mainWindow())
 
         pluginPath = os.path.split(os.path.dirname(__file__))[0]
         templatePath = os.path.join(

--- a/python/plugins/processing/script/CreateNewScriptAction.py
+++ b/python/plugins/processing/script/CreateNewScriptAction.py
@@ -25,7 +25,7 @@ import os
 
 from qgis.PyQt.QtCore import QCoreApplication
 
-from qgis.core import QgsApplication
+from qgis.utils import iface
 
 from processing.gui.ToolboxAction import ToolboxAction
 
@@ -39,5 +39,5 @@ class CreateNewScriptAction(ToolboxAction):
         self.group = self.tr("Tools")
 
     def execute(self):
-        dlg = ScriptEditorDialog(None)
+        dlg = ScriptEditorDialog(parent=iface.mainWindow())
         dlg.show()

--- a/python/plugins/processing/script/EditScriptAction.py
+++ b/python/plugins/processing/script/EditScriptAction.py
@@ -46,7 +46,7 @@ class EditScriptAction(ContextAction):
     def execute(self):
         filePath = ScriptUtils.findAlgorithmSource(self.itemData.name())
         if filePath is not None:
-            dlg = ScriptEditorDialog(filePath, iface.mainWindow())
+            dlg = ScriptEditorDialog(filePath, parent=iface.mainWindow())
             dlg.show()
         else:
             QMessageBox.warning(None,

--- a/python/plugins/processing/script/OpenScriptFromFileAction.py
+++ b/python/plugins/processing/script/OpenScriptFromFileAction.py
@@ -26,6 +26,7 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
 
 from qgis.core import QgsApplication, QgsSettings
+from qgis.utils import iface
 
 from processing.gui.ToolboxAction import ToolboxAction
 from processing.script.ScriptEditorDialog import ScriptEditorDialog
@@ -52,5 +53,5 @@ class OpenScriptFromFileAction(ToolboxAction):
             settings.setValue('Processing/lastScriptsDir',
                               QFileInfo(filename).absoluteDir().absolutePath())
 
-            dlg = ScriptEditorDialog(filePath=filename)
+            dlg = ScriptEditorDialog(filePath=filename, parent=iface.mainWindow())
             dlg.show()

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -122,7 +122,7 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.actionIncreaseFontSize.triggered.connect(self.editor.zoomIn)
         self.actionDecreaseFontSize.triggered.connect(self.editor.zoomOut)
         self.actionToggleComment.triggered.connect(self.editor.toggleComment)
-        self.editor.textChanged.connect(lambda: self.setHasChanged(True))
+        self.editor.textChanged.connect(self._on_text_modified)
 
         self.leFindText.returnPressed.connect(self.find)
         self.btnFind.clicked.connect(self.find)
@@ -228,6 +228,9 @@ class ScriptEditorDialog(BASE, WIDGET):
             self.setHasChanged(False)
 
         QgsApplication.processingRegistry().providerById("script").refreshAlgorithms()
+
+    def _on_text_modified(self):
+        self.setHasChanged(True)
 
     def setHasChanged(self, hasChanged):
         self.hasChanged = hasChanged

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -30,8 +30,11 @@ import warnings
 from qgis.PyQt import uic, sip
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QCursor
-from qgis.PyQt.QtWidgets import (QMessageBox,
-                                 QFileDialog)
+from qgis.PyQt.QtWidgets import (
+    QMessageBox,
+    QFileDialog,
+    QVBoxLayout
+)
 
 from qgis.gui import QgsGui, QgsErrorDialog
 from qgis.core import (QgsApplication,
@@ -44,6 +47,8 @@ from qgis.processing import alg as algfactory
 
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from processing.script import ScriptUtils
+
+from .ScriptEdit import ScriptEdit
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
@@ -62,6 +67,13 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.setAttribute(Qt.WA_DeleteOnClose)
 
         QgsGui.instance().enableAutoGeometryRestore(self)
+
+        vl = QVBoxLayout()
+        vl.setContentsMargins(0, 0, 0, 0)
+        self.editor_container.setLayout(vl)
+
+        self.editor = ScriptEdit()
+        vl.addWidget(self.editor)
 
         self.searchWidget.setVisible(False)
 

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -59,6 +59,7 @@ class ScriptEditorDialog(BASE, WIDGET):
     def __init__(self, filePath=None, parent=None):
         super(ScriptEditorDialog, self).__init__(parent)
         self.setupUi(self)
+        self.setAttribute(Qt.WA_DeleteOnClose)
 
         QgsGui.instance().enableAutoGeometryRestore(self)
 

--- a/python/plugins/processing/ui/DlgScriptEditor.ui
+++ b/python/plugins/processing/ui/DlgScriptEditor.ui
@@ -16,7 +16,7 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
-     <widget class="ScriptEdit" name="editor"/>
+     <widget class="QWidget" name="editor_container"/>
     </item>
     <item row="1" column="0">
      <widget class="QWidget" name="searchWidget" native="true">
@@ -255,13 +255,6 @@
    </property>
   </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>ScriptEdit</class>
-   <extends>QTextEdit</extends>
-   <header location="global">processing.script.ScriptEdit</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/app/options/qgscodeeditoroptions.cpp
+++ b/src/app/options/qgscodeeditoroptions.cpp
@@ -184,7 +184,7 @@ def somefunc(param1: str='', param2=0):
     '''A docstring'''
     if param1 > param2: # interesting
         print('Gre\'ater'.lower())
-    return (param2 - param1 + 1 + 0b10l) or None
+    return (param2 - param1 + 1 + 0b10) or None
 
 class SomeClass:
     """

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2736,6 +2736,7 @@ class CORE_EXPORT Qgis
     {
       Reformat = 1 << 0, //!< Language supports automatic code reformatting
       CheckSyntax = 1 << 1, //!< Language supports syntax checking
+      ToggleComment = 1 << 2, //!< Language supports comment toggling
     };
     Q_ENUM( ScriptLanguageCapability )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2735,6 +2735,7 @@ class CORE_EXPORT Qgis
     enum class ScriptLanguageCapability : int
     {
       Reformat = 1 << 0, //!< Language supports automatic code reformatting
+      CheckSyntax = 1 << 1, //!< Language supports syntax checking
     };
     Q_ENUM( ScriptLanguageCapability )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2726,6 +2726,27 @@ class CORE_EXPORT Qgis
     Q_ENUM( ScriptLanguage )
 
     /**
+     * Script language capabilities.
+     *
+     * The flags reflect the support capabilities of a scripting language.
+     *
+     * \since QGIS 3.32
+     */
+    enum class ScriptLanguageCapability : int
+    {
+      Reformat = 1 << 0, //!< Language supports automatic code reformatting
+    };
+    Q_ENUM( ScriptLanguageCapability )
+
+    /**
+     * Script language capabilities.
+     *
+     * \since QGIS 3.32
+     */
+    Q_DECLARE_FLAGS( ScriptLanguageCapabilities, ScriptLanguageCapability )
+    Q_FLAG( ScriptLanguageCapabilities )
+
+    /**
      * Layer tree insertion methods
      *
      * \since QGIS 3.30
@@ -3372,6 +3393,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerActionTargets )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerActionFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::RelationshipCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SettingsTreeNodeOptions )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ScriptLanguageCapabilities )
 
 
 // hack to workaround warnings when casting void pointers

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -193,13 +193,12 @@ int QgsStringUtils::levenshteinDistance( const QString &string1, const QString &
   }
 
   //levenshtein algorithm begins here
-  QVector< int > col;
-  col.fill( 0, length2 + 1 );
-  QVector< int > prevCol;
+  std::vector< int > col( length2 + 1, 0 );
+  std::vector< int > prevCol;
   prevCol.reserve( length2 + 1 );
   for ( int i = 0; i < length2 + 1; ++i )
   {
-    prevCol << i;
+    prevCol.emplace_back( i );
   }
   const QChar *s2start = s2Char;
   for ( int i = 0; i < length1; ++i )

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -224,14 +224,27 @@ void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )
       QMenu *menu = createStandardContextMenu();
       menu->setAttribute( Qt::WA_DeleteOnClose );
 
-      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat )
+      if ( ( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat ) ||
+           ( languageCapabilities() & Qgis::ScriptLanguageCapability::CheckSyntax ) )
       {
         menu->addSeparator();
+      }
 
+      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat )
+      {
         QAction *reformatAction = new QAction( tr( "Reformat Code" ), menu );
+        reformatAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "console/iconFormatCode.svg" ) ) );
         reformatAction->setEnabled( !isReadOnly() );
         connect( reformatAction, &QAction::triggered, this, &QgsCodeEditor::reformatCode );
         menu->addAction( reformatAction );
+      }
+
+      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat )
+      {
+        QAction *syntaxCheckAction = new QAction( tr( "Check Syntax" ), menu );
+        syntaxCheckAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "console/iconSyntaxErrorConsole.svg" ) ) );
+        connect( syntaxCheckAction, &QAction::triggered, this, &QgsCodeEditor::checkSyntax );
+        menu->addAction( syntaxCheckAction );
       }
 
       populateContextMenu( menu );
@@ -707,6 +720,11 @@ void QgsCodeEditor::reformatCode()
   setCursorPosition( line, index );
   verticalScrollBar()->setValue( oldScrollValue );
   endUndoAction();
+}
+
+bool QgsCodeEditor::checkSyntax()
+{
+  return true;
 }
 
 QStringList QgsCodeEditor::history() const

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -33,6 +33,7 @@
 #include <QMenu>
 #include <QClipboard>
 #include <QScrollBar>
+#include <QMessageBox>
 
 QMap< QgsCodeEditorColorScheme::ColorRole, QString > QgsCodeEditor::sColorRoleToSettingsKey
 {
@@ -575,10 +576,29 @@ void QgsCodeEditor::populateContextMenu( QMenu * )
 
 }
 
-QString QgsCodeEditor::reformatCodeString( const QString &string, bool &ok, QString & ) const
+QString QgsCodeEditor::reformatCodeString( const QString &string )
 {
-  ok = false;
   return string;
+}
+
+void QgsCodeEditor::showMessage( const QString &title, const QString &message, Qgis::MessageLevel level )
+{
+  switch ( level )
+  {
+    case Qgis::Info:
+    case Qgis::Success:
+    case Qgis::NoLevel:
+      QMessageBox::information( this, title, message );
+      break;
+
+    case Qgis::Warning:
+      QMessageBox::warning( this, title, message );
+      break;
+
+    case Qgis::Critical:
+      QMessageBox::critical( this, title, message );
+      break;
+  }
 }
 
 void QgsCodeEditor::updatePrompt()
@@ -670,16 +690,7 @@ void QgsCodeEditor::reformatCode()
 
   const QString originalText = text();
 
-  bool ok = false;
-  QString error;
-  const QString newText = reformatCodeString( originalText, ok, error );
-  if ( !ok )
-  {
-    if ( !error.isEmpty() )
-    {
-      // TODO raise
-    }
-  }
+  const QString newText = reformatCodeString( originalText );
 
   if ( originalText == newText )
     return;

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -239,7 +239,7 @@ void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )
         menu->addAction( reformatAction );
       }
 
-      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat )
+      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::CheckSyntax )
       {
         QAction *syntaxCheckAction = new QAction( tr( "Check Syntax" ), menu );
         syntaxCheckAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "console/iconSyntaxErrorConsole.svg" ) ) );

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -247,6 +247,15 @@ void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )
         menu->addAction( syntaxCheckAction );
       }
 
+      if ( languageCapabilities() & Qgis::ScriptLanguageCapability::ToggleComment )
+      {
+        QAction *toggleCommentAction = new QAction( tr( "Toggle Comment" ), menu );
+        toggleCommentAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "console/iconCommentEditorConsole.svg" ) ) );
+        toggleCommentAction->setEnabled( !isReadOnly() );
+        connect( toggleCommentAction, &QAction::triggered, this, &QgsCodeEditor::toggleComment );
+        menu->addAction( toggleCommentAction );
+      }
+
       populateContextMenu( menu );
 
       menu->exec( mapToGlobal( event->pos() ) );
@@ -725,6 +734,11 @@ void QgsCodeEditor::reformatCode()
 bool QgsCodeEditor::checkSyntax()
 {
   return true;
+}
+
+void QgsCodeEditor::toggleComment()
+{
+
 }
 
 QStringList QgsCodeEditor::history() const

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -455,6 +455,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     virtual bool checkSyntax();
 
+    /**
+     * Toggle comment for the selected text.
+     *
+     * This is only supported for editors which return the Qgis::ScriptLanguageCapability::ToggleComment capability from languageCapabilities().
+     *
+     * \since QGIS 3.32
+     */
+    virtual void toggleComment();
+
   signals:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -446,6 +446,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void reformatCode();
 
+    /**
+     * Applies syntax checking to the editor.
+     *
+     * This is only supported for editors which return the Qgis::ScriptLanguageCapability::CheckSyntax capability from languageCapabilities().
+     *
+     * \since QGIS 3.32
+     */
+    virtual bool checkSyntax();
+
   signals:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -20,6 +20,7 @@
 #include <QString>
 #include "qgscodeeditorcolorscheme.h"
 #include "qgis.h"
+#include "qgssettingstree.h"
 
 // qscintilla includes
 #include <Qsci/qsciapis.h>
@@ -94,6 +95,13 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     Q_OBJECT
 
   public:
+
+
+#ifndef SIP_RUN
+
+    static inline QgsSettingsTreeNode *sTreeCodeEditor = QgsSettingsTree::sTreeGui->createChildNode( QStringLiteral( "code-editor" ) );
+
+#endif
 
     /**
      * Code editor modes.

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -169,6 +169,13 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     virtual Qgis::ScriptLanguage language() const;
 
     /**
+     * Returns the associated scripting language capabilities.
+     *
+     * \since QGIS 3.32
+     */
+    virtual Qgis::ScriptLanguageCapabilities languageCapabilities() const;
+
+    /**
      * Returns a user-friendly, translated name of the specified script \a language.
      *
      * \since QGIS 3.30
@@ -430,6 +437,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     bool writeHistoryFile();
 
+    /**
+     * Applies code reformatting to the editor.
+     *
+     * This is only supported for editors which return the Qgis::ScriptLanguageCapability::Reformat capability from languageCapabilities().
+     *
+     * \since QGIS 3.32
+     */
+    void reformatCode();
+
   signals:
 
     /**
@@ -513,6 +529,15 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      * \since QGIS 3.30
      */
     virtual void populateContextMenu( QMenu *menu );
+
+    /**
+     * Applies code reformatting to a \a string and returns the result.
+     *
+     * This is only supported for editors which return the Qgis::ScriptLanguageCapability::Reformat capability from languageCapabilities().
+     *
+     * \since QGIS 3.32
+     */
+    virtual QString reformatCodeString( const QString &string, bool &ok SIP_OUT, QString &error SIP_OUT ) const;
 
   private:
 

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -537,7 +537,16 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      *
      * \since QGIS 3.32
      */
-    virtual QString reformatCodeString( const QString &string, bool &ok SIP_OUT, QString &error SIP_OUT ) const;
+    virtual QString reformatCodeString( const QString &string );
+
+    /**
+     * Shows a user facing message (eg a warning message).
+     *
+     * The default implementation uses QMessageBox.
+     *
+     * \since QGIS 3.32
+     */
+    virtual void showMessage( const QString &title, const QString &message, Qgis::MessageLevel level );
 
   private:
 

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -454,6 +454,12 @@ QString QgsCodeEditorPython::reformatCodeString( const QString &string )
   {
     const bool normalize = settings.value( QStringLiteral( "pythonConsole/blackNormalizeQuotes" ), true ).toBool();
 
+    if ( !checkSyntax() )
+    {
+      showMessage( tr( "Reformat Code" ), tr( "Code formatting failed -- the code contains syntax errors" ), Qgis::MessageLevel::Warning );
+      return newText;
+    }
+
     const QString defineReformat = QStringLiteral(
                                      "def __qgis_reformat(script):\n"
                                      "  try:\n"

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -622,7 +622,7 @@ QString QgsCodeEditorPython::characterAfterCursor() const
 
 void QgsCodeEditorPython::updateCapabilities()
 {
-  mCapabilities = Qgis::ScriptLanguageCapabilities();
+  mCapabilities = Qgis::ScriptLanguageCapability::ToggleComment;
 
   if ( !QgsPythonRunner::isValid() )
     return;

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -629,7 +629,7 @@ void QgsCodeEditorPython::updateCapabilities()
 
   mCapabilities |= Qgis::ScriptLanguageCapability::CheckSyntax;
 
-  // we could potentially check for autopep8/black import here and reflect the capabilty accordingly.
+  // we could potentially check for autopep8/black import here and reflect the capability accordingly.
   // (current approach is to to always indicate this capability and raise a user-friendly warning
   // when attempting to reformat if the libraries can't be imported)
   mCapabilities |= Qgis::ScriptLanguageCapability::Reformat;

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -21,6 +21,9 @@
 #include "qgis_gui.h"
 #include <Qsci/qscilexerpython.h>
 
+class QgsSettingsEntryInteger;
+class QgsSettingsEntryBool;
+
 SIP_IF_MODULE( HAVE_QSCI_SIP )
 
 #ifndef SIP_RUN
@@ -50,6 +53,46 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
     Q_OBJECT
 
   public:
+
+#ifndef SIP_RUN
+
+    static inline QgsSettingsTreeNode *sTreePythonCodeEditor = QgsCodeEditor::sTreeCodeEditor->createChildNode( QStringLiteral( "python" ) );
+
+    /**
+     * Code auto formatter.
+     *
+     * \since QGIS 3.32
+     */
+    static const QgsSettingsEntryString *settingCodeFormatter;
+
+    /**
+     * Maximum line length.
+     *
+     * \since QGIS 3.32
+     */
+    static const QgsSettingsEntryInteger *settingMaxLineLength;
+
+    /**
+     * Whether imports should be sorted when auto formatting code.
+     *
+     * \since QGIS 3.32
+     */
+    static const QgsSettingsEntryBool *settingSortImports;
+
+    /**
+     * Autopep8 aggressive level.
+     *
+     * \since QGIS 3.32
+     */
+    static const QgsSettingsEntryInteger *settingAutopep8Level;
+
+    /**
+     * Whether imports should be sorted when auto formatting code.
+     *
+     * \since QGIS 3.32
+     */
+    static const QgsSettingsEntryBool *settingBlackNormalizeQuotes;
+#endif
 
     /**
      * Construct a new Python editor.

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -63,6 +63,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
                          QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
 
     Qgis::ScriptLanguage language() const override;
+    Qgis::ScriptLanguageCapabilities languageCapabilities() const override;
 
     /**
      * Load APIs from one or more files
@@ -96,6 +97,13 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      */
     QString characterAfterCursor() const;
 
+    /**
+     * Updates the editor capabilities.
+     *
+     * \since QGIS 3.32
+     */
+    void updateCapabilities();
+
   public slots:
 
     /**
@@ -115,8 +123,8 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
   protected:
 
     void initializeLexer() override;
-
     virtual void keyPressEvent( QKeyEvent *event ) override;
+    QString reformatCodeString( const QString &string ) override;
 
   protected slots:
 
@@ -131,6 +139,8 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
 
     QList<QString> mAPISFilesList;
     QString mPapFile;
+
+    Qgis::ScriptLanguageCapabilities mCapabilities;
 
     static const QMap<QString, QString> sCompletionPairs;
 

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -104,6 +104,8 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      */
     void updateCapabilities();
 
+    bool checkSyntax() override;
+
   public slots:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -120,7 +120,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      *
      * \since QGIS 3.30
      */
-    void toggleComment();
+    void toggleComment() override;
 
   protected:
 


### PR DESCRIPTION
This follow up to https://github.com/qgis/QGIS/pull/51733 moves some of the reformat/syntax checking capabilities to the base QgsCodeEditorPython class and generalises them for potential use in other QgsCodeEditor subclasses.

This has two benefits:

1. ALL the python code editors used by QGIS can now reformat and check syntax of scripts via the right click menu (including Processing script editor, macro editor, etc), rather than just the python console script editor.
2. The generic API means we could add reformatting capabilities for other languages (eg a reformatter for QGIS expressions!! :partying_face: )

I haven't removed any of the code introduced by #51733 here, but that could be potentially removed in a follow up