### PR TITLE
Mesh layer style following dataset group name

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -682,9 +682,24 @@ Sets new edge mesh renderer settings
 %Docstring
 Returns renderer settings
 %End
+
     void setScalarSettings( int groupIndex, const QgsMeshRendererScalarSettings &settings );
 %Docstring
 Sets new renderer settings
+%End
+
+    bool hasScalarSettings( int groupIndex ) const;
+%Docstring
+Returns whether ``groupIndex`` has existing scalar settings
+
+.. versionadded:: 3.30.1
+%End
+
+    bool removeScalarSettings( int groupIndex );
+%Docstring
+Removes scalar settings with ``groupIndex``
+
+.. versionadded:: 3.30.1
 %End
 
     QgsMeshRendererVectorSettings vectorSettings( int groupIndex ) const;
@@ -694,6 +709,20 @@ Returns renderer settings
     void setVectorSettings( int groupIndex, const QgsMeshRendererVectorSettings &settings );
 %Docstring
 Sets new renderer settings
+%End
+
+    bool hasVectorSettings( int groupIndex ) const;
+%Docstring
+Returns whether ``groupIndex`` has existing vector settings
+
+.. versionadded:: 3.30.1
+%End
+
+    bool removeVectorSettings( int groupIndex );
+%Docstring
+Removes vector settings for ``groupIndex``
+
+.. versionadded:: 3.30.1
 %End
 
     QgsMesh3dAveragingMethod *averagingMethod() const;

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -692,14 +692,14 @@ Sets new renderer settings
 %Docstring
 Returns whether ``groupIndex`` has existing scalar settings
 
-.. versionadded:: 3.30.1
+.. versionadded:: 3.30.2
 %End
 
     bool removeScalarSettings( int groupIndex );
 %Docstring
 Removes scalar settings with ``groupIndex``
 
-.. versionadded:: 3.30.1
+.. versionadded:: 3.30.2
 %End
 
     QgsMeshRendererVectorSettings vectorSettings( int groupIndex ) const;
@@ -715,14 +715,14 @@ Sets new renderer settings
 %Docstring
 Returns whether ``groupIndex`` has existing vector settings
 
-.. versionadded:: 3.30.1
+.. versionadded:: 3.30.2
 %End
 
     bool removeVectorSettings( int groupIndex );
 %Docstring
 Removes vector settings for ``groupIndex``
 
-.. versionadded:: 3.30.1
+.. versionadded:: 3.30.2
 %End
 
     QgsMesh3dAveragingMethod *averagingMethod() const;

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -392,6 +392,16 @@ int QgsMeshDatasetGroupStore::globalDatasetGroupIndexInSource( QgsMeshDatasetSou
   return -1;
 }
 
+int QgsMeshDatasetGroupStore::indexFromGroupName( const QString &groupName ) const
+{
+  return mGroupNameToGlobalIndex.value( groupName, -1 );
+}
+
+QString QgsMeshDatasetGroupStore::groupName( int groupIndex ) const
+{
+  return  datasetGroupMetadata( groupIndex ).name();
+}
+
 bool QgsMeshDatasetGroupStore::saveDatasetGroup( QString filePath, int groupIndex, QString driver )
 {
   DatasetGroup group = datasetGroup( groupIndex );

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -230,14 +230,14 @@ class QgsMeshDatasetGroupStore: public QObject
     /**
      * Returns the global dataset group index of the dataset with name \a groupName
      *
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     int indexFromGroupName( const QString &groupName ) const;
 
     /**
      * Returns the name of the dataset group with global index \a groupIndex
      *
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     QString groupName( int groupIndex ) const;
 

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -125,7 +125,7 @@ class QgsMeshDatasetGroupStore: public QObject
 
   public:
     //! Constructor
-    QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
+    explicit QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
 
     //!  Sets the persistent mesh data provider with the path of its extra dataset to be loaded by the provider
     void setPersistentProvider( QgsMeshDataProvider *provider, const QStringList &extraDatasetUri );
@@ -203,7 +203,7 @@ class QgsMeshDatasetGroupStore: public QObject
     /**
      * Returns the global dataset index of the dataset int the dataset group with \a groupIndex, that is between relative times \a time1 and \a time2
      *
-     * Since QGIS 3.22
+     * \since QGIS 3.22
      */
     QList<QgsMeshDatasetIndex> datasetIndexInTimeInterval( qint64 time1, qint64 time2, int groupIndex ) const;
 
@@ -223,9 +223,23 @@ class QgsMeshDatasetGroupStore: public QObject
      * Returns the global dataset group index of the dataset group with native index \a nativeGroupIndex in the \a source
      * Returns -1 if the group or the source is not registered
      *
-     * Since QGIS 3.22
+     * \since QGIS 3.22
      */
     int globalDatasetGroupIndexInSource( QgsMeshDatasetSourceInterface *source, int nativeGroupIndex ) const;
+
+    /**
+     * Returns the global dataset group index of the dataset with name \a groupName
+     *
+     * \since QGIS 3.30.1
+     */
+    int indexFromGroupName( const QString &groupName ) const;
+
+    /**
+     * Returns the name of the dataset group with global index \a groupIndex
+     *
+     * \since QGIS 3.30.1
+     */
+    QString groupName( int groupIndex ) const;
 
   signals:
     //! Emitted after dataset groups are added

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1390,7 +1390,7 @@ QgsMeshRendererSettings QgsMeshLayer::accordSymbologyWithGroupName( const QgsMes
   int activeScalar = consistentSettings.activeScalarDatasetGroup();
   int activeVector = consistentSettings.activeScalarDatasetGroup();
 
-  for ( auto it = nameToIndex.constBegin(); it != nameToIndex.cend(); ++it )
+  for ( auto it = nameToIndex.constBegin(); it != nameToIndex.constEnd(); ++it )
   {
     int index = it.value();
     const QString name = it.key() ;
@@ -1701,7 +1701,7 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
   QDomElement nameToIndexElem = elem.firstChildElement( "name-to-global-index" );
   while ( !nameToIndexElem.isNull() )
   {
-    QString name = nameToIndexElem.attribute( QStringLiteral( "name" ) );
+    const QString name = nameToIndexElem.attribute( QStringLiteral( "name" ) );
     int globalIndex = nameToIndexElem.attribute( QStringLiteral( "global-index" ) ).toInt();
     groupNameToGlobalIndex.insert( name, globalIndex );
     nameToIndexElem = nameToIndexElem.nextSiblingElement( QStringLiteral( "name-to-global-index" ) );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1382,6 +1382,64 @@ void QgsMeshLayer::updateActiveDatasetGroups()
     emit activeVectorDatasetGroupChanged( settings.activeVectorDatasetGroup() );
 }
 
+QgsMeshRendererSettings QgsMeshLayer::accordSymbologyWithGroupName( const QgsMeshRendererSettings &settings, const QMap<QString, int> &nameToIndex )
+{
+  QString activeScalarName;
+  QString activeVectorName;
+  QgsMeshRendererSettings consistentSettings = settings;
+  int activeScalar = consistentSettings.activeScalarDatasetGroup();
+  int activeVector = consistentSettings.activeScalarDatasetGroup();
+
+  for ( auto it = nameToIndex.constBegin(); it != nameToIndex.cend(); ++it )
+  {
+    int index = it.value();
+    const QString name = it.key() ;
+    int globalIndex = mDatasetGroupStore->indexFromGroupName( name );
+    if ( globalIndex >= 0 )
+    {
+      QgsMeshRendererScalarSettings scalarSettings = settings.scalarSettings( index );
+      consistentSettings.setScalarSettings( globalIndex, scalarSettings );
+      if ( settings.hasVectorSettings( it.value() ) && mDatasetGroupStore->datasetGroupMetadata( globalIndex ).isVector() )
+      {
+        QgsMeshRendererVectorSettings vectorSettings = settings.vectorSettings( index );
+        consistentSettings.setVectorSettings( globalIndex, vectorSettings );
+      }
+    }
+    else
+    {
+      consistentSettings.removeScalarSettings( index );
+      if ( settings.hasVectorSettings( it.value() ) )
+        consistentSettings.removeVectorSettings( index );
+    }
+
+    if ( index == activeScalar )
+      activeScalarName = name;
+    if ( index == activeVector )
+      activeVectorName = name;
+  }
+
+  const QList<int> globalIndexes = datasetGroupsIndexes();
+  for ( int globalIndex : globalIndexes )
+  {
+    const QString name = mDatasetGroupStore->groupName( globalIndex );
+    if ( !nameToIndex.contains( name ) )
+    {
+      consistentSettings.setScalarSettings( globalIndex, mRendererSettings.scalarSettings( globalIndex ) );
+      if ( mDatasetGroupStore->datasetGroupMetadata( globalIndex ).isVector() )
+      {
+        consistentSettings.setVectorSettings( globalIndex, mRendererSettings.vectorSettings( globalIndex ) );
+      }
+    }
+  }
+
+  if ( !activeScalarName.isEmpty() )
+    consistentSettings.setActiveScalarDatasetGroup( mDatasetGroupStore->indexFromGroupName( activeScalarName ) );
+  if ( activeVectorName.isEmpty() )
+    consistentSettings.setActiveVectorDatasetGroup( mDatasetGroupStore->indexFromGroupName( activeVectorName ) );
+
+  return consistentSettings;
+}
+
 void QgsMeshLayer::setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -1634,9 +1692,22 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
 
   readCommonStyle( elem, context, categories );
 
+  QgsMeshRendererSettings rendererSettings;
   const QDomElement elemRendererSettings = elem.firstChildElement( "mesh-renderer-settings" );
   if ( !elemRendererSettings.isNull() )
-    mRendererSettings.readXml( elemRendererSettings, context );
+    rendererSettings.readXml( elemRendererSettings, context );
+
+  QMap<QString, int> groupNameToGlobalIndex;
+  QDomElement nameToIndexElem = elem.firstChildElement( "name-to-global-index" );
+  while ( !nameToIndexElem.isNull() )
+  {
+    QString name = nameToIndexElem.attribute( QStringLiteral( "name" ) );
+    int globalIndex = nameToIndexElem.attribute( QStringLiteral( "global-index" ) ).toInt();
+    groupNameToGlobalIndex.insert( name, globalIndex );
+    nameToIndexElem = nameToIndexElem.nextSiblingElement( QStringLiteral( "name-to-global-index" ) );
+  }
+
+  mRendererSettings = accordSymbologyWithGroupName( rendererSettings, groupNameToGlobalIndex );
 
   checkSymbologyConsistency();
 
@@ -1680,6 +1751,16 @@ bool QgsMeshLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString &e
 
   const QDomElement elemRendererSettings = mRendererSettings.writeXml( doc, context );
   elem.appendChild( elemRendererSettings );
+
+  const QList<int> groupIndexes = datasetGroupsIndexes();
+  // we store the relation between name and indexes to be able to retrieve the consistency between name and symbology
+  for ( int index : groupIndexes )
+  {
+    QDomElement elemNameToIndex = doc.createElement( QStringLiteral( "name-to-global-index" ) );
+    elemNameToIndex.setAttribute( QStringLiteral( "name" ), mDatasetGroupStore->groupName( index ) );
+    elemNameToIndex.setAttribute( QStringLiteral( "global-index" ), index );
+    elem.appendChild( elemNameToIndex );
+  }
 
   const QDomElement elemSimplifySettings = mSimplificationSettings.writeXml( doc, context );
   elem.appendChild( elemSimplifySettings );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -1004,6 +1004,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
 
     void updateActiveDatasetGroups();
 
+    QgsMeshRendererSettings accordSymbologyWithGroupName( const QgsMeshRendererSettings &settings, const QMap<QString, int> &nameToIndex );
     void checkSymbologyConsistency();
 
     void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -624,7 +624,7 @@ class CORE_EXPORT QgsMeshRendererSettings
     void setScalarSettings( int groupIndex, const QgsMeshRendererScalarSettings &settings ) { mRendererScalarSettings[groupIndex] = settings; }
 
     /**
-     * Returns whether \a groupIndex has exisiting scalar settings
+     * Returns whether \a groupIndex has existing scalar settings
      * \since QGIS 3.30.1
      */
     bool hasScalarSettings( int groupIndex ) const {return mRendererScalarSettings.contains( groupIndex );}
@@ -641,7 +641,7 @@ class CORE_EXPORT QgsMeshRendererSettings
     void setVectorSettings( int groupIndex, const QgsMeshRendererVectorSettings &settings ) { mRendererVectorSettings[groupIndex] = settings; }
 
     /**
-     * Returns whether \a groupIndex has exisiting vector settings
+     * Returns whether \a groupIndex has existing vector settings
      * \since QGIS 3.30.1
      */
     bool hasVectorSettings( int groupIndex ) const {return mRendererVectorSettings.contains( groupIndex );}

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -625,13 +625,13 @@ class CORE_EXPORT QgsMeshRendererSettings
 
     /**
      * Returns whether \a groupIndex has existing scalar settings
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     bool hasScalarSettings( int groupIndex ) const {return mRendererScalarSettings.contains( groupIndex );}
 
     /**
      * Removes scalar settings with \a groupIndex
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     bool removeScalarSettings( int groupIndex )  {return mRendererScalarSettings.remove( groupIndex );}
 
@@ -642,13 +642,13 @@ class CORE_EXPORT QgsMeshRendererSettings
 
     /**
      * Returns whether \a groupIndex has existing vector settings
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     bool hasVectorSettings( int groupIndex ) const {return mRendererVectorSettings.contains( groupIndex );}
 
     /**
      * Removes vector settings for \a groupIndex
-     * \since QGIS 3.30.1
+     * \since QGIS 3.30.2
      */
     bool removeVectorSettings( int groupIndex )  {return mRendererVectorSettings.remove( groupIndex );}
 

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -619,13 +619,38 @@ class CORE_EXPORT QgsMeshRendererSettings
 
     //! Returns renderer settings
     QgsMeshRendererScalarSettings scalarSettings( int groupIndex ) const { return mRendererScalarSettings.value( groupIndex ); }
+
     //! Sets new renderer settings
     void setScalarSettings( int groupIndex, const QgsMeshRendererScalarSettings &settings ) { mRendererScalarSettings[groupIndex] = settings; }
+
+    /**
+     * Returns whether \a groupIndex has exisiting scalar settings
+     * \since QGIS 3.30.1
+     */
+    bool hasScalarSettings( int groupIndex ) const {return mRendererScalarSettings.contains( groupIndex );}
+
+    /**
+     * Removes scalar settings with \a groupIndex
+     * \since QGIS 3.30.1
+     */
+    bool removeScalarSettings( int groupIndex )  {return mRendererScalarSettings.remove( groupIndex );}
 
     //! Returns renderer settings
     QgsMeshRendererVectorSettings vectorSettings( int groupIndex ) const { return mRendererVectorSettings.value( groupIndex ); }
     //! Sets new renderer settings
     void setVectorSettings( int groupIndex, const QgsMeshRendererVectorSettings &settings ) { mRendererVectorSettings[groupIndex] = settings; }
+
+    /**
+     * Returns whether \a groupIndex has exisiting vector settings
+     * \since QGIS 3.30.1
+     */
+    bool hasVectorSettings( int groupIndex ) const {return mRendererVectorSettings.contains( groupIndex );}
+
+    /**
+     * Removes vector settings for \a groupIndex
+     * \since QGIS 3.30.1
+     */
+    bool removeVectorSettings( int groupIndex )  {return mRendererVectorSettings.remove( groupIndex );}
 
     /**
      * Returns averaging method for conversion of 3d stacked mesh data to 2d data


### PR DESCRIPTION
For mesh layer, rendering style of dataset groups are linked to an internal group index. When loading a QGIS project, copy/paste style or save/load qml file, the style of a dataset group is retrieved following this group index. This approach leads to inconsistent rendering, especially when copy/paste style or saving/loading qml file because, equivalent dataset group may not have the same index from layer to layer.

To fix these issues, this PR add a link between dataset group style and dataset group name when writing/reading XML. So, when applying a XML style on a mesh layer, style of each dataset group are retrieved from their name, not directly from the index anymore.