### PR TITLE
qgs3daxis: Fix camera conf by taking into account terrain offset

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -745,7 +745,7 @@ void Qgs3DAxis::onCameraViewChange( float pitch, float yaw )
       QgsDebugMsgLevel( "Unable to obtain elevation from terrain", 2 );
 
   }
-  pos.set( pos.x(), elevation, pos.z() );
+  pos.set( pos.x(), elevation + mMapSettings->terrainElevationOffset(), pos.z() );
 
   mCameraController->setLookingAtPoint( pos, ( mCameraController->camera()->position() - pos.toVector3D() ).length(),
                                         pitch, yaw );


### PR DESCRIPTION
This was found by Stefanos Natsis.

This is factored out from https://github.com/qgis/QGIS/pull/52208

cc @benoitdm-oslandia @uclaros 