### PR TITLE
Add clear recently used crs button

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1123,6 +1123,20 @@ Pushes a recently used CRS to the top of the recent CRS list.
 .. versionadded:: 3.10.3
 %End
 
+    static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Removes a CRS from the list of recently used CRS.
+
+.. versionadded:: 3.32
+%End
+
+    static void clearRecentCoordinateReferenceSystems();
+%Docstring
+Cleans the list of recently used CRS.
+
+.. versionadded:: 3.32
+%End
+
 
     static void invalidateCache();
 %Docstring

--- a/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
@@ -155,6 +155,14 @@ Marks the current selected projection for push to front of recent projections li
    Has no effect since QGIS 3.20
 %End
 
+
+    void clearRecentCrs();
+%Docstring
+Clear the list of recent projections.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void crsSelected();

--- a/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
@@ -198,6 +198,9 @@ Emitted when the selection in the tree is changed from a valid selection to an i
     virtual void resizeEvent( QResizeEvent *event );
 
 
+    virtual bool eventFilter( QObject *obj, QEvent *ev );
+
+
 };
 
 /************************************************************************

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2942,6 +2942,40 @@ void QgsCoordinateReferenceSystem::pushRecentCoordinateReferenceSystem( const Qg
   settings.setValue( QStringLiteral( "UI/recentProjectionsProj4" ), proj );
 }
 
+
+void QgsCoordinateReferenceSystem::removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs )
+{
+  if ( crs.srsid() == 0 || !crs.isValid() )
+    return;
+
+  QList<QgsCoordinateReferenceSystem> recent = recentCoordinateReferenceSystems();
+  recent.removeAll( crs );
+  QStringList authids;
+  authids.reserve( recent.size() );
+  QStringList proj;
+  proj.reserve( recent.size() );
+  QStringList wkt;
+  wkt.reserve( recent.size() );
+  for ( const QgsCoordinateReferenceSystem &c : std::as_const( recent ) )
+  {
+    authids << c.authid();
+    proj << c.toProj();
+    wkt << c.toWkt( WKT_PREFERRED );
+  }
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "UI/recentProjectionsAuthId" ), authids );
+  settings.setValue( QStringLiteral( "UI/recentProjectionsWkt" ), wkt );
+  settings.setValue( QStringLiteral( "UI/recentProjectionsProj4" ), proj );
+}
+
+void QgsCoordinateReferenceSystem::clearRecentCoordinateReferenceSystems()
+{
+  QgsSettings settings;
+  settings.remove( QStringLiteral( "UI/recentProjectionsAuthId" ) );
+  settings.remove( QStringLiteral( "UI/recentProjectionsWkt" ) );
+  settings.remove( QStringLiteral( "UI/recentProjectionsProj4" ) );
+}
+
 void QgsCoordinateReferenceSystem::invalidateCache( bool disableCache )
 {
   sSrIdCacheLock()->lockForWrite();

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -1063,6 +1063,18 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     static void pushRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs );
 
+    /**
+     * Removes a CRS from the list of recently used CRS.
+     * \since QGIS 3.32
+     */
+    static void removeRecentCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Cleans the list of recently used CRS.
+     * \since QGIS 3.32
+     */
+    static void clearRecentCoordinateReferenceSystems();
+
 #ifndef SIP_RUN
 
     /**

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -88,7 +88,7 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
     QTreeWidgetItem *currentItem = lstRecent->itemAt( pos );
     if ( currentItem )
     {
-      QAction *clearSelected = menu.addAction( QgsApplication::getThemeIcon( "/mIconClearItem.svg" ),  tr( "Clear selected CRS from recently used CRS" ) );
+      QAction *clearSelected = menu.addAction( QgsApplication::getThemeIcon( "/mIconClearItem.svg" ),  tr( "Remove selected CRS from recently used CRS" ) );
       connect( clearSelected, &QAction::triggered, this, [this, currentItem ] { removeRecentCrsItem( currentItem ); } );
       menu.addSeparator();
     }
@@ -290,7 +290,7 @@ void QgsProjectionSelectionTreeWidget::insertRecent( const QgsCoordinateReferenc
   QToolButton *clearButton = new QToolButton();
   clearButton->setIcon( QgsApplication::getThemeIcon( "/mIconClearItem.svg" ) );
   clearButton->setAutoRaise( true );
-  clearButton->setToolTip( tr( "Clear from recently used CRS" ) );
+  clearButton->setToolTip( tr( "Remove from recently used CRS" ) );
   connect( clearButton, &QToolButton::clicked, this, [this, item] { removeRecentCrsItem( item ); } );
   lstRecent->setItemWidget( item, ClearColumn, clearButton );
 

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -29,6 +29,7 @@
 
 //qt includes
 #include <QAction>
+#include <QToolButton>
 #include <QMenu>
 #include <QFileInfo>
 #include <QHeaderView>
@@ -53,7 +54,6 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   connect( lstRecent, &QTreeWidget::currentItemChanged, this, &QgsProjectionSelectionTreeWidget::lstRecent_currentItemChanged );
   connect( cbxHideDeprecated, &QCheckBox::stateChanged, this, &QgsProjectionSelectionTreeWidget::updateFilter );
   connect( leSearch, &QgsFilterLineEdit::textChanged, this, &QgsProjectionSelectionTreeWidget::updateFilter );
-  connect( mClearRecentCrs, &QToolButton::clicked, this, &QgsProjectionSelectionTreeWidget::clearRecentCrs );
 
   mAreaCanvas->setVisible( mShowMap );
 

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -1117,6 +1117,19 @@ void QgsProjectionSelectionTreeWidget::showDBMissingWarning( const QString &file
 
 void QgsProjectionSelectionTreeWidget::clearRecentCrs()
 {
+  // If the list is empty, there is nothing to do
+  if ( lstRecent->topLevelItemCount() == 0 )
+  {
+    return;
+  }
+
+  // Ask for confirmation
+  if ( QMessageBox::question( this, tr( "Clear Recent CRS" ),
+                              tr( "Are you sure you want to clear the list of recently used coordinate reference system?" ),
+                              QMessageBox::Yes | QMessageBox::No ) != QMessageBox::Yes )
+  {
+    return;
+  }
   QgsCoordinateReferenceSystem::clearRecentCoordinateReferenceSystems();
   lstRecent->clear();
 }

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -98,6 +98,9 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
     menu.exec( lstRecent->viewport()->mapToGlobal( pos ) );
   } );
 
+  // Install event fiter to catch delete key press on the recent crs list
+  lstRecent->installEventFilter( this );
+
   mRecentProjections = QgsCoordinateReferenceSystem::recentCoordinateReferenceSystems();
 
   mCheckBoxNoProjection->setHidden( true );
@@ -172,6 +175,25 @@ void QgsProjectionSelectionTreeWidget::showEvent( QShowEvent *event )
   // Pass up the inheritance hierarchy
   QWidget::showEvent( event );
   mInitialized = true;
+}
+
+
+bool QgsProjectionSelectionTreeWidget::eventFilter( QObject *obj, QEvent *ev )
+{
+  if ( obj != lstRecent )
+    return false;
+
+  if ( ev->type() != QEvent::KeyPress )
+    return false;
+
+  QKeyEvent *keyEvent = static_cast<QKeyEvent *>( ev );
+  if ( keyEvent->matches( QKeySequence::Delete ) )
+  {
+    removeRecentCrsItem( lstRecent->currentItem() );
+    return true;
+  }
+
+  return false;
 }
 
 QString QgsProjectionSelectionTreeWidget::ogcWmsCrsFilterAsSqlExpression( QSet<QString> *crsFilter )

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -145,6 +145,14 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
      */
     Q_DECL_DEPRECATED void pushProjectionToFront() SIP_DEPRECATED;
 
+
+    /**
+     * Clear the list of recent projections.
+     *
+     * \since QGIS 3.32
+     */
+    void clearRecentCrs();
+
   signals:
 
     /**
@@ -236,12 +244,11 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
      */
     void applySelection( int column = QgsProjectionSelectionTreeWidget::None, QString value = QString() );
 
-    /**
-       * \brief gets an arbitrary sqlite3 expression from the selection
-       *
-       * \param e The sqlite3 expression (typically "srid" or "sridid")
-       */
-    QString getSelectedExpression( const QString &e ) const;
+    //! gets an arbitrary sqlite3 expression from the given item
+    QString expressionForItem( QTreeWidgetItem *item, const QString &expression ) const;
+
+    //! Returns the CRS of the given item
+    QgsCoordinateReferenceSystem crsForItem( QTreeWidgetItem *item ) const;
 
     QString selectedName();
 
@@ -290,7 +297,7 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     //! Has the Recent Projection List been populated?
     bool mRecentProjListDone = false;
 
-    enum Columns { NameColumn, AuthidColumn, QgisCrsIdColumn, None };
+    enum Columns { NameColumn, AuthidColumn, QgisCrsIdColumn, ClearColumn, None };
     int mSearchColumn = QgsProjectionSelectionTreeWidget::None;
     QString mSearchValue;
 
@@ -320,6 +327,8 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     void lstCoordinateSystems_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
     void lstRecent_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
     void updateFilter();
+
+    void removeRecentCrsItem( QTreeWidgetItem *item );
 };
 
 #endif

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -186,6 +186,9 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     // Used to manage column sizes
     void resizeEvent( QResizeEvent *event ) override;
 
+    // Used to catch key presses on the recent projections list
+    bool eventFilter( QObject *obj, QEvent *ev ) override;
+
   private:
 
     /**

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -82,17 +82,51 @@
        </layout>
       </item>
       <item>
-       <widget class="QLabel" name="label_3">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Recently Used Coordinate Reference Systems</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Recently Used Coordinate Reference Systems</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mClearRecentCrs">
+          <property name="toolTip">
+           <string>Clear all recently used coordinate reference systems</string>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
+          </property>
+          <property name="autoRaise">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QSplitter" name="mSplitter">
@@ -125,7 +159,7 @@
           <bool>true</bool>
          </property>
          <property name="columnCount">
-          <number>3</number>
+          <number>4</number>
          </property>
          <column>
           <property name="text">
@@ -142,8 +176,13 @@
            <string>ID</string>
           </property>
          </column>
+         <column>
+          <property name="text">
+           <string/>
+          </property>
+         </column>
         </widget>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <layout class="QGridLayout" name="gridLayout">
           <property name="horizontalSpacing">
            <number>0</number>
@@ -223,7 +262,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="topMargin">
            <number>0</number>
@@ -314,6 +353,8 @@
   <tabstop>cbxHideDeprecated</tabstop>
   <tabstop>lstCoordinateSystems</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>578</width>
-    <height>654</height>
+    <height>650</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -95,36 +95,6 @@
            <string>Recently Used Coordinate Reference Systems</string>
           </property>
          </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="mClearRecentCrs">
-          <property name="toolTip">
-           <string>Clear all recently used CRS</string>
-          </property>
-          <property name="text">
-           <string>Clear</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
        </layout>
       </item>
@@ -262,7 +232,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="layoutWidget">
+        <widget class="QWidget" name="layoutWidget_2">
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="topMargin">
            <number>0</number>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -99,7 +99,7 @@
         <item>
          <widget class="QToolButton" name="mClearRecentCrs">
           <property name="toolTip">
-           <string>Clear all recently used coordinate reference systems</string>
+           <string>Clear all recently used CRS</string>
           </property>
           <property name="text">
            <string>Clear</string>


### PR DESCRIPTION
Fixes #21473

## Description

- Adds a column in the recent crs table with a button to clear individual CRS
- Adds a context menu (right click) with two actions:
  - Clear selected (Same as button)
  - Clear all recent CRS (prompt user for confirmation)
- Pressing the Del key while the list of recently used crs has focus remove the selected CRS

![clear_crs](https://user-images.githubusercontent.com/9693475/234017205-ef637fb2-67d3-4932-aa60-4a5e2ed37c80.gif)