### PR TITLE
Show a "time" column in db query logger, with color coded bars illustrating the most costly queries logged

### DIFF
--- a/src/app/devtools/qgsdevtoolsmodelnode.h
+++ b/src/app/devtools/qgsdevtoolsmodelnode.h
@@ -41,6 +41,7 @@ class QgsDevToolsModelNode
       RoleId, //!< Request ID role
       RoleElapsedTime, //!< Elapsed time
       RoleMaximumTime, //!< Maximum encountered elapsed time
+      RoleSort, //!< Sort order role
     };
 
     virtual ~QgsDevToolsModelNode();

--- a/src/app/devtools/qgsdevtoolsmodelnode.h
+++ b/src/app/devtools/qgsdevtoolsmodelnode.h
@@ -39,6 +39,8 @@ class QgsDevToolsModelNode
     {
       RoleStatus = Qt::UserRole + 1, //!< Request status role
       RoleId, //!< Request ID role
+      RoleElapsedTime, //!< Elapsed time
+      RoleMaximumTime, //!< Maximum encountered elapsed time
     };
 
     virtual ~QgsDevToolsModelNode();

--- a/src/app/devtools/querylogger/qgsappquerylogger.cpp
+++ b/src/app/devtools/querylogger/qgsappquerylogger.cpp
@@ -74,7 +74,7 @@ void QgsAppQueryLogger::queryFinished( const QgsDatabaseQueryLogEntry &query )
     queryGroup->setSql( query.query );
   }
 
-  const long long newMaxCost = std::max< long long >( query.finishedTime - query.startedTime, mMaxCost );
+  const long long newMaxCost = std::max< long long >( static_cast< long long >( query.finishedTime - query.startedTime ), mMaxCost );
 
   // Calculate the number of children: if error or not fetched rows 1 row is added else 2 rows are added
   beginInsertRows( requestIndex, queryGroup->childCount(), queryGroup->childCount() + ( query.fetchedRows != -1 ? 1 : 0 ) );
@@ -217,8 +217,6 @@ QVariant QgsAppQueryLogger::data( const QModelIndex &index, int role ) const
       switch ( role )
       {
         case Qt::DisplayRole:
-          return node->data( QgsDevToolsModelNode::RoleElapsedTime );
-
         case QgsDevToolsModelNode::RoleElapsedTime:
           return node->data( QgsDevToolsModelNode::RoleElapsedTime );
 
@@ -307,10 +305,10 @@ bool QgsDatabaseQueryLoggerProxyModel::filterAcceptsRow( int source_row, const Q
 // QueryCostDelegate
 //
 
-QueryCostDelegate::QueryCostDelegate( quint32 sortRole, quint32 totalCostRole, QObject *parent )
+QueryCostDelegate::QueryCostDelegate( int sortRole, int totalCostRole, QObject *parent )
   : QStyledItemDelegate( parent )
-  , m_sortRole( sortRole )
-  , m_totalCostRole( totalCostRole )
+  , mSortRole( sortRole )
+  , mTotalCostRole( totalCostRole )
 {
 }
 
@@ -318,18 +316,18 @@ QueryCostDelegate::~QueryCostDelegate() = default;
 
 void QueryCostDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
-  const auto cost = index.data( m_sortRole ).toDouble();
+  const auto cost = index.data( mSortRole ).toDouble();
   if ( cost <= 0 )
   {
     QStyledItemDelegate::paint( painter, option, index );
     return;
   }
 
-  const auto totalCost = index.data( m_totalCostRole ).toDouble();
+  const auto totalCost = index.data( mTotalCostRole ).toDouble();
   const auto fraction = std::abs( float( cost ) / totalCost );
 
   auto rect = option.rect;
-  rect.setWidth( rect.width() * fraction );
+  rect.setWidth( static_cast< int >( rect.width() * fraction ) );
 
   const auto &brush = painter->brush();
   const auto &pen = painter->pen();
@@ -344,7 +342,7 @@ void QueryCostDelegate::paint( QPainter *painter, const QStyleOptionViewItem &op
     painter->drawRect( option.rect );
   }
 
-  const auto color = QColor::fromHsv( 120 - fraction * 120, 255, 255, ( -( ( fraction - 1 ) * ( fraction - 1 ) ) ) * 120 + 120 );
+  const auto color = QColor::fromHsv( static_cast< int >( 120 - fraction * 120 ), 255, 255, static_cast< int >( ( -( ( fraction - 1 ) * ( fraction - 1 ) ) ) * 120 + 120 ) );
   painter->setBrush( color );
   painter->drawRect( rect );
 

--- a/src/app/devtools/querylogger/qgsappquerylogger.cpp
+++ b/src/app/devtools/querylogger/qgsappquerylogger.cpp
@@ -218,6 +218,7 @@ QVariant QgsAppQueryLogger::data( const QModelIndex &index, int role ) const
       {
         case Qt::DisplayRole:
         case QgsDevToolsModelNode::RoleElapsedTime:
+        case QgsDevToolsModelNode::RoleSort:
           return node->data( QgsDevToolsModelNode::RoleElapsedTime );
 
         case QgsDevToolsModelNode::RoleMaximumTime:

--- a/src/app/devtools/querylogger/qgsappquerylogger.h
+++ b/src/app/devtools/querylogger/qgsappquerylogger.h
@@ -141,14 +141,14 @@ class QueryCostDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
   public:
-    explicit QueryCostDelegate( quint32 sortRole, quint32 totalCostRole, QObject *parent = nullptr );
+    explicit QueryCostDelegate( int sortRole, int totalCostRole, QObject *parent = nullptr );
     ~QueryCostDelegate();
 
     void paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
 
   private:
-    quint32 m_sortRole;
-    quint32 m_totalCostRole;
+    int mSortRole = 0;
+    int mTotalCostRole = 0;
 };
 
 #endif // QGSAPPQUERYLOGGER_H

--- a/src/app/devtools/querylogger/qgsappquerylogger.h
+++ b/src/app/devtools/querylogger/qgsappquerylogger.h
@@ -20,6 +20,7 @@
 #include <QElapsedTimer>
 #include "qgsdbquerylog.h"
 #include <memory>
+#include <QStyledItemDelegate>
 
 class QgsDevToolsModelNode;
 class QgsDevToolsModelGroup;
@@ -99,6 +100,7 @@ class QgsAppQueryLogger : public QAbstractItemModel
     QModelIndex indexOfParentLayerTreeNode( QgsDevToolsModelNode *parentNode ) const;
 
     std::unique_ptr< QgsDatabaseQueryLoggerRootNode > mRootNode;
+    long long mMaxCost = 0;
 
     QHash< int, QgsDatabaseQueryLoggerQueryGroup * > mQueryGroups;
 
@@ -133,6 +135,20 @@ class QgsDatabaseQueryLoggerProxyModel : public QSortFilterProxyModel
     QgsAppQueryLogger *mLogger = nullptr;
 
     QString mFilterString;
+};
+
+class QueryCostDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+  public:
+    explicit QueryCostDelegate( quint32 sortRole, quint32 totalCostRole, QObject *parent = nullptr );
+    ~QueryCostDelegate();
+
+    void paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+
+  private:
+    quint32 m_sortRole;
+    quint32 m_totalCostRole;
 };
 
 #endif // QGSAPPQUERYLOGGER_H

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
@@ -205,7 +205,7 @@ void QgsDatabaseQueryLoggerQueryGroup::setFinished( const QgsDatabaseQueryLogEnt
   if ( query.error.isEmpty() )
   {
     mStatus = query.canceled ? Status::Canceled : Status::Complete;
-    mElapsed = query.finishedTime - query.startedTime;
+    mElapsed = static_cast<qint64>( query.finishedTime - query.startedTime );
     addKeyValueNode( QObject::tr( "Total time (ms)" ), QLocale().toString( mElapsed ) );
     if ( query.fetchedRows != -1 )
     {

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
@@ -91,6 +91,9 @@ QVariant QgsDatabaseQueryLoggerQueryGroup::data( int role ) const
       return QStringLiteral( "%1 %2" ).arg( QString::number( mQueryId ),
                                             mSql );
 
+    case QgsDevToolsModelNode::RoleSort:
+      return mQueryId;
+
     case Qt::ToolTipRole:
     {
       // Show no more than 255 characters

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
@@ -124,6 +124,9 @@ QVariant QgsDatabaseQueryLoggerQueryGroup::data( int role ) const
     case RoleId:
       return mQueryId;
 
+    case RoleElapsedTime:
+      return mElapsed;
+
     case Qt::ForegroundRole:
     {
       switch ( mStatus )
@@ -202,7 +205,8 @@ void QgsDatabaseQueryLoggerQueryGroup::setFinished( const QgsDatabaseQueryLogEnt
   if ( query.error.isEmpty() )
   {
     mStatus = query.canceled ? Status::Canceled : Status::Complete;
-    addKeyValueNode( QObject::tr( "Total time (ms)" ), QLocale().toString( query.finishedTime - query.startedTime ) );
+    mElapsed = query.finishedTime - query.startedTime;
+    addKeyValueNode( QObject::tr( "Total time (ms)" ), QLocale().toString( mElapsed ) );
     if ( query.fetchedRows != -1 )
     {
       addKeyValueNode( QObject::tr( "Row count" ), QLocale().toString( query.fetchedRows ) );

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.h
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.h
@@ -120,6 +120,7 @@ class QgsDatabaseQueryLoggerQueryGroup final : public QgsDevToolsModelGroup
     int mQueryId = 0;
     QByteArray mData;
     Status mStatus = Status::Pending;
+    qint64 mElapsed = -1;
 };
 
 #endif // QGSDBQUERYLOGGERNODE_H

--- a/src/app/devtools/querylogger/qgsqueryloggerpanelwidget.cpp
+++ b/src/app/devtools/querylogger/qgsqueryloggerpanelwidget.cpp
@@ -45,6 +45,7 @@ QgsDatabaseQueryLoggerTreeView::QgsDatabaseQueryLoggerTreeView( QgsAppQueryLogge
   setFont( QFontDatabase::systemFont( QFontDatabase::FixedFont ) );
 
   mProxyModel = new QgsDatabaseQueryLoggerProxyModel( mLogger, this );
+  mProxyModel->setSortRole( QgsDevToolsModelNode::RoleSort );
   setModel( mProxyModel );
 
   connect( mProxyModel, &QAbstractItemModel::rowsInserted, this, [this]( const QModelIndex & parent, int first, int last )
@@ -169,6 +170,7 @@ QgsDatabaseQueryLoggerPanelWidget::QgsDatabaseQueryLoggerPanelWidget( QgsAppQuer
   mTreeView = new QgsDatabaseQueryLoggerTreeView( mLogger );
   mTreeView->setItemDelegateForColumn( 1, new QueryCostDelegate( QgsDevToolsModelNode::RoleElapsedTime, QgsDevToolsModelNode::RoleMaximumTime, mTreeView ) );
   mTreeView->setSortingEnabled( true );
+  mTreeView->sortByColumn( 0, Qt::SortOrder::AscendingOrder );
 
   verticalLayout->addWidget( mTreeView );
   mToolbar->setIconSize( QgsGuiUtils::iconSize( true ) );

--- a/src/app/devtools/querylogger/qgsqueryloggerpanelwidget.cpp
+++ b/src/app/devtools/querylogger/qgsqueryloggerpanelwidget.cpp
@@ -168,6 +168,7 @@ QgsDatabaseQueryLoggerPanelWidget::QgsDatabaseQueryLoggerPanelWidget( QgsAppQuer
 
   mTreeView = new QgsDatabaseQueryLoggerTreeView( mLogger );
   mTreeView->setItemDelegateForColumn( 1, new QueryCostDelegate( QgsDevToolsModelNode::RoleElapsedTime, QgsDevToolsModelNode::RoleMaximumTime, mTreeView ) );
+  mTreeView->setSortingEnabled( true );
 
   verticalLayout->addWidget( mTreeView );
   mToolbar->setIconSize( QgsGuiUtils::iconSize( true ) );


### PR DESCRIPTION
Brings this helpful visualisation technique from the startup profiler over to the db query log, so that you can easily identify the slowest queries when a whole bunch of queries are recorded.

![image](https://user-images.githubusercontent.com/1829991/226504199-5db81e94-140a-488f-9697-0e9e3cd5e685.png)