### PR TITLE
Layout Item 3D Map Widget change

### DIFF
--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -316,17 +316,31 @@ void QgsLayoutItem3DMap::setSettingsFromXml( const QDomElement &elem )
 {
   QgsReadWriteContext readWriteContext;
   readWriteContext.setPathResolver( QgsProject::instance()->pathResolver() );
-  mSettings.reset( new Qgs3DMapSettings );
 
-  mSettings->readXml( elem, readWriteContext );
-  // move to 3d map settings loadProjectSettings
   readPropertiesFromElement( elem, QDomDocument(), readWriteContext );
+
+  loadProjectSettings();
+  update();
+}
+
+void QgsLayoutItem3DMap::setCameraPoseFromXml( const QDomElement &elem )
+{
+  // create camera pose from camera controller settings saved on 3DViewSettings
+  // look in QgsCameraController::writeXml for explanation
+  QgsCameraPose pose;
+  pose.setCenterPoint( QgsVector3D( elem.attribute( "x" ).toDouble(),
+                                    elem.attribute( "elev" ).toDouble(),
+                                    elem.attribute( "y" ).toDouble() ) );
+  pose.setDistanceFromCenterPoint( elem.attribute( "dist" ).toDouble() );
+  pose.setHeadingAngle( elem.attribute( "yaw" ).toDouble() );
+  pose.setPitchAngle( elem.attribute( "pitch" ).toDouble() );
+
+  setCameraPose( pose );
+}
+
+void QgsLayoutItem3DMap::loadProjectSettings()
+{
   mSettings->setSelectionColor( QgsProject::instance()->selectionColor() );
   mSettings->setBackgroundColor( QgsProject::instance()->backgroundColor() );
   mSettings->setOutputDpi( QGuiApplication::primaryScreen()->logicalDotsPerInch() );
-}
-void QgsLayoutItem3DMap::setCameraControllerFromXml( const QDomElement &elem )
-{
-  mScene->cameraController()->readXml( elem );
-  setCameraPose( mScene->cameraController()->cameraPose() );
 }

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -15,6 +15,9 @@
 
 #include "qgslayoutitem3dmap.h"
 
+#include <QGuiApplication>
+#include <QScreen>
+
 #include "qgs3dmapscene.h"
 #include "qgs3dutils.h"
 #include "qgscameracontroller.h"
@@ -23,6 +26,7 @@
 #include "qgslayoutitemregistry.h"
 #include "qgsoffscreen3dengine.h"
 #include "qgslayoutrendercontext.h"
+
 
 QgsLayoutItem3DMap::QgsLayoutItem3DMap( QgsLayout *layout )
   : QgsLayoutItem( layout )
@@ -306,4 +310,23 @@ void QgsLayoutItem3DMap::setCameraPose( const QgsCameraPose &pose )
   mCameraPose = pose;
   mCapturedImage = QImage();
   update();
+}
+
+void QgsLayoutItem3DMap::setSettingsFromXml( const QDomElement &elem )
+{
+  QgsReadWriteContext readWriteContext;
+  readWriteContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  mSettings.reset( new Qgs3DMapSettings );
+
+  mSettings->readXml( elem, readWriteContext );
+  // move to 3d map settings loadProjectSettings
+  readPropertiesFromElement( elem, QDomDocument(), readWriteContext );
+  mSettings->setSelectionColor( QgsProject::instance()->selectionColor() );
+  mSettings->setBackgroundColor( QgsProject::instance()->backgroundColor() );
+  mSettings->setOutputDpi( QGuiApplication::primaryScreen()->logicalDotsPerInch() );
+}
+void QgsLayoutItem3DMap::setCameraControllerFromXml( const QDomElement &elem )
+{
+  mScene->cameraController()->readXml( elem );
+  setCameraPose( mScene->cameraController()->cameraPose() );
 }

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -340,7 +340,9 @@ void QgsLayoutItem3DMap::setCameraPoseFromXml( const QDomElement &elem )
 
 void QgsLayoutItem3DMap::loadProjectSettings()
 {
-  mSettings->setSelectionColor( QgsProject::instance()->selectionColor() );
-  mSettings->setBackgroundColor( QgsProject::instance()->backgroundColor() );
-  mSettings->setOutputDpi( QGuiApplication::primaryScreen()->logicalDotsPerInch() );
+  QgsProject* project = layout() ? layout()->project() : nullptr;
+  if ( !project )
+    return;
+  mSettings->setSelectionColor( project->selectionColor() );
+  mSettings->setBackgroundColor( project->backgroundColor() );
 }

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -340,7 +340,7 @@ void QgsLayoutItem3DMap::setCameraPoseFromXml( const QDomElement &elem )
 
 void QgsLayoutItem3DMap::loadProjectSettings()
 {
-  QgsProject* project = layout() ? layout()->project() : nullptr;
+  QgsProject *project = layout() ? layout()->project() : nullptr;
   if ( !project )
     return;
   mSettings->setSelectionColor( project->selectionColor() );

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -107,6 +107,11 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
 
     void finalizeRestoreFromXml() override;
 
+    void setSettingsFromXml( const QDomElement &elem );
+
+    void setCameraControllerFromXml( const QDomElement &elem );
+
+
   public slots:
     void refresh() override;
 

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -109,7 +109,7 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
 
     void setSettingsFromXml( const QDomElement &elem );
 
-    void setCameraControllerFromXml( const QDomElement &elem );
+    void setCameraPoseFromXml( const QDomElement &elem );
 
 
   public slots:
@@ -128,6 +128,8 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
   private:
     //! Resets the item tooltip to reflect current map id
     void updateToolTip();
+    // load 3DMapSettings that are only stored in the project
+    void loadProjectSettings();
 
   private:
     std::unique_ptr<Qgs3DMapSettings> mSettings;

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -108,18 +108,18 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
     void finalizeRestoreFromXml() override;
 
     /**
-     * @brief Set 3D view settings from XML element
+     * \brief Set 3D view settings from XML element
      *
-     * @param elem DOM element representing the settings of the 3D view
+     * \param elem DOM element representing the settings of the 3D view
      *
      * \since QGIS 3.34
      */
     void setSettingsFromXml( const QDomElement &elem );
 
     /**
-     * @brief Set 3D view camera position settings from XML element
+     * \brief Set 3D view camera position settings from XML element
      *
-     * @param elem DOM element representing the settings of the camera
+     * \param elem DOM element representing the settings of the camera
      *
      * \since QGIS 3.34
      */

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -128,7 +128,7 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
   private:
     //! Resets the item tooltip to reflect current map id
     void updateToolTip();
-    // load 3DMapSettings that are only stored in the project
+    //! load 3DMapSettings that are only stored in the project
     void loadProjectSettings();
 
   private:

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -107,8 +107,22 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRa
 
     void finalizeRestoreFromXml() override;
 
+    /**
+     * @brief Set 3D view settings from XML element
+     *
+     * @param elem DOM element representing the settings of the 3D view
+     *
+     * \since QGIS 3.34
+     */
     void setSettingsFromXml( const QDomElement &elem );
 
+    /**
+     * @brief Set 3D view camera position settings from XML element
+     *
+     * @param elem DOM element representing the settings of the camera
+     *
+     * \since QGIS 3.34
+     */
     void setCameraPoseFromXml( const QDomElement &elem );
 
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -31,7 +31,8 @@ float _normalizedAngle( float x )
   if ( x < 0 ) x += 360;
   return x;
 }
-void _prepare3DViewsMenu( QMenu *menu, QgsLayout3DMapWidget *w, const std::function< void( const QDomElement &) > &slot )
+
+void _prepare3DViewsMenu( QMenu *menu, QgsLayout3DMapWidget *w, const std::function< void( const QDomElement & ) > &slot )
 {
   QObject::connect( menu, &QMenu::aboutToShow, w, [menu, slot]
   {
@@ -74,14 +75,14 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
 
   mMenu3DCanvases = new QMenu( this );
   mCopySettingsButton->setMenu( mMenu3DCanvases );
-  _prepare3DViewsMenu( mMenu3DCanvases, this, [ = ](  const QDomElement &elem3DMap )
+  _prepare3DViewsMenu( mMenu3DCanvases, this, [ = ]( const QDomElement & elem3DMap )
   {
     copy3DMapSettings( elem3DMap );
   } );
 
   mMenu3DCanvasesPose = new QMenu( this );
   mPoseFromViewButton->setMenu( mMenu3DCanvasesPose );
-  _prepare3DViewsMenu( mMenu3DCanvasesPose, this, [ = ]( const QDomElement &elem3DMap ) { copyCameraPose( elem3DMap ); } );
+  _prepare3DViewsMenu( mMenu3DCanvasesPose, this, [ = ]( const QDomElement & elem3DMap ) { copyCameraPose( elem3DMap ); } );
 
   QList<QgsDoubleSpinBox *> lst;
   lst << mCenterXSpinBox << mCenterYSpinBox << mCenterZSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
@@ -112,7 +113,7 @@ void QgsLayout3DMapWidget::copy3DMapSettings( const QDomElement &elem3DMap )
 {
   QDomElement elem3D = elem3DMap.firstChildElement( QStringLiteral( "qgis3d" ) );
 
-  if (elem3D.isNull())
+  if ( elem3D.isNull() )
   {
     return;
   }
@@ -120,8 +121,8 @@ void QgsLayout3DMapWidget::copy3DMapSettings( const QDomElement &elem3DMap )
   QgsReadWriteContext readWriteContext;
   readWriteContext.setPathResolver( QgsProject::instance()->pathResolver() );
 
-  Qgs3DMapSettings * settings= new Qgs3DMapSettings();
-  settings->readXml(elem3D, readWriteContext);
+  Qgs3DMapSettings *settings = new Qgs3DMapSettings();
+  settings->readXml( elem3D, readWriteContext );
   settings->resolveReferences( *QgsProject::instance() );
   settings->setTransformContext( QgsProject::instance()->transformContext() );
   settings->setPathResolver( QgsProject::instance()->pathResolver() );
@@ -131,7 +132,7 @@ void QgsLayout3DMapWidget::copy3DMapSettings( const QDomElement &elem3DMap )
   settings->setBackgroundColor( QgisApp::instance()->mapCanvas()->canvasColor() );
   settings->setOutputDpi( QGuiApplication::primaryScreen()->logicalDotsPerInch() );
 
-  mMap3D->setMapSettings(settings);
+  mMap3D->setMapSettings( settings );
 }
 
 void QgsLayout3DMapWidget::copyCameraPose( const QDomElement &elem3DMap )
@@ -156,7 +157,7 @@ void QgsLayout3DMapWidget::copyCameraPose( const QDomElement &elem3DMap )
   cameraPose.setPitchAngle( pitch );
   cameraPose.setHeadingAngle( yaw );
 
-  mMap3D->setCameraPose(cameraPose);
+  mMap3D->setCameraPose( cameraPose );
   updateCameraPoseWidgetsFromItem();
 }
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -24,7 +24,6 @@
 #include "qgisapp.h"
 #include "qscreen.h"
 #include "qgsmapcanvas.h"
-#include "qgisapp.h"
 
 float _normalizedAngle( float x )
 {
@@ -120,10 +119,10 @@ void QgsLayout3DMapWidget::copyCameraPose( const QString &viewName )
 {
   QDomElement elem3DViewSettings = QgsProject::instance()->viewsManager()->get3DViewSettings( viewName );
 
-  if (QgsProject::instance()->viewsManager()->is3DViewOpen(viewName))
+  if ( QgsProject::instance()->viewsManager()->is3DViewOpen( viewName ) )
   {
     Qgs3DMapCanvasWidget *map3Dwidget = QgisApp::instance()->get3DMapView( viewName );
-    mMap3D->setCameraPose(map3Dwidget->mapCanvas3D()->cameraController()->cameraPose());
+    mMap3D->setCameraPose( map3Dwidget->mapCanvas3D()->cameraController()->cameraPose() );
   }
   else
   {

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -124,7 +124,7 @@ void QgsLayout3DMapWidget::copyCameraPose( const QDomElement &elem3DViewSettings
     return;
   }
 
-  mMap3D->setCameraControllerFromXml( elemCamera );
+  mMap3D->setCameraPoseFromXml( elemCamera );
   updateCameraPoseWidgetsFromItem();
 }
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -22,8 +22,6 @@
 #include "qgs3dmapcanvaswidget.h"
 #include "qgsmapviewsmanager.h"
 #include "qgisapp.h"
-#include "qscreen.h"
-#include "qgsmapcanvas.h"
 
 float _normalizedAngle( float x )
 {

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -23,6 +23,7 @@
 
 class QgsLayoutItem3DMap;
 class Qgs3DMapCanvasWidget;
+class Qgs3DScene;
 
 class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayout3DMapWidgetBase
 {
@@ -39,8 +40,8 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
     void updateCameraPoseWidgetsFromItem();
 
   private slots:
-    void copy3DMapSettings( Qgs3DMapCanvasWidget *widget );
-    void copyCameraPose( Qgs3DMapCanvasWidget *widget );
+    void copy3DMapSettings( Qgs3DMapScene *scene );
+    void copyCameraPose( Qgs3DMapScene *scene );
     void updateCameraPose();
 
   private:

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -40,8 +40,8 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
     void updateCameraPoseWidgetsFromItem();
 
   private slots:
-    void copy3DMapSettings( const QDomElement &elem3DViewSettings );
-    void copyCameraPose( const QDomElement &elem3DViewSettings );
+    void copy3DMapSettings( const QString &viewName );
+    void copyCameraPose( const QString &viewName );
     void updateCameraPose();
 
   private:

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -40,8 +40,8 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
     void updateCameraPoseWidgetsFromItem();
 
   private slots:
-    void copy3DMapSettings( const QDomElement &elem3DMap );
-    void copyCameraPose( const QDomElement &elem3DMap );
+    void copy3DMapSettings( const QDomElement &elem3DViewSettings );
+    void copyCameraPose( const QDomElement &elem3DViewSettings );
     void updateCameraPose();
 
   private:

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -23,7 +23,7 @@
 
 class QgsLayoutItem3DMap;
 class Qgs3DMapCanvasWidget;
-class Qgs3DScene;
+class QDomElement;
 
 class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayout3DMapWidgetBase
 {
@@ -40,8 +40,8 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
     void updateCameraPoseWidgetsFromItem();
 
   private slots:
-    void copy3DMapSettings( Qgs3DMapScene *scene );
-    void copyCameraPose( Qgs3DMapScene *scene );
+    void copy3DMapSettings( const QDomElement &elem3DMap );
+    void copyCameraPose( const QDomElement &elem3DMap );
     void updateCameraPose();
 
   private:

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -23,7 +23,6 @@
 
 class QgsLayoutItem3DMap;
 class Qgs3DMapCanvasWidget;
-class QDomElement;
 
 class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayout3DMapWidgetBase
 {


### PR DESCRIPTION
## Description

This PR allows `QgsLayout3DMapWidget` to copy 3D Map Settings and Camera Pose from `3D View` that are not currently open as QGIS `3D Map View`. The widget will now list all existing `3D Views` in menus (in contrast to only listing opened 3D Views Widgets) for copying 3D scenes settings and camera positions.

This should be useful when working on Layout where user wants to add 3D Maps, which are not currently open (and in fact do not need to open). 