### PR TITLE
Fix locator customization

### DIFF
--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -37,6 +37,7 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
   , mLineEdit( new QgsLocatorLineEdit( this ) )
   , mResultsView( new QgsLocatorResultsView() )
 {
+  setObjectName( QStringLiteral( "LocatorWidget" ) );
   mLineEdit->setShowClearButton( true );
 #ifdef Q_OS_MACX
   mLineEdit->setPlaceholderText( tr( "Type to locate (⌘K)" ) );

--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -59,6 +59,7 @@ void QgsStatusBar::addPermanentWidget( QWidget *widget, int stretch, Anchor anch
 void QgsStatusBar::removeWidget( QWidget *widget )
 {
   mLayout->removeWidget( widget );
+  widget->hide();
 }
 
 QString QgsStatusBar::currentMessage() const


### PR DESCRIPTION
- Fixes #25675

## Description

This PR adds the possibility to hide the Locator widget with the Customization

- Set an object name on the `QgsLocatorWidget`, which make it appear in the `QgsCustomization`
- Fix the `QgsStatusBar::removeWidget` method to also hide the widget (like `QStatusBar` do) so that the locator is actually hidden when it is unchecked in the customization dialog.