### PR TITLE
Add a way to disable map tips for a specific layer

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1563,6 +1563,22 @@ It may also contain embedded expressions.
 .. versionadded:: 3.30
 %End
 
+    void setMapTipsEnabled( bool enabled );
+%Docstring
+Enable or disable map tips for this layer
+
+:param enabled: Whether map tips are enabled for this layer
+
+.. versionadded:: 3.32
+%End
+
+    bool mapTipsEnabled() const;
+%Docstring
+Returns true if map tips are enabled for this layer
+
+.. versionadded:: 3.32
+%End
+
   public slots:
 
     void setMinimumScale( double scale );
@@ -1912,6 +1928,15 @@ Emitted when the map tip template changes
    this method was only available for vector layers since QGIS 3.0
 
 .. versionadded:: 3.30
+%End
+
+    void mapTipsEnabledChanged();
+%Docstring
+Emitted when map tips are enabled or disabled for the layer.
+
+.. seealso:: :py:func:`setMapTipsEnabled`
+
+.. versionadded:: 3.32
 %End
 
   protected:

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -912,6 +912,24 @@ void QgsMapLayer::setMapTipTemplate( const QString &mapTip )
   emit mapTipTemplateChanged();
 }
 
+void QgsMapLayer::setMapTipsEnabled( bool enabled )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( mMapTipsEnabled == enabled )
+    return;
+
+  mMapTipsEnabled = enabled;
+  emit mapTipsEnabledChanged();
+}
+
+bool QgsMapLayer::mapTipsEnabled() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mMapTipsEnabled;
+}
+
 bool QgsMapLayer::isValid() const
 {
   // because QgsVirtualLayerProvider is not anywhere NEAR thread safe:
@@ -2479,7 +2497,7 @@ bool QgsMapLayer::hasMapTips() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return !mMapTipTemplate.isEmpty();
+  return mapTipsEnabled() && !mMapTipTemplate.isEmpty();
 }
 
 void QgsMapLayer::setProviderType( const QString &providerType )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -81,6 +81,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_PROPERTY( bool isValid READ isValid NOTIFY isValidChanged )
     Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
     Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
+    Q_PROPERTY( bool mapTipsEnabled READ mapTipsEnabled WRITE setMapTipsEnabled NOTIFY mapTipsEnabledChanged )
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
@@ -1571,6 +1572,20 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void setMapTipTemplate( const QString &mapTipTemplate );
 
+    /**
+     *  Enable or disable map tips for this layer
+     *
+     *  \param enabled Whether map tips are enabled for this layer
+     *  \since QGIS 3.32
+     */
+    void setMapTipsEnabled( bool enabled );
+
+    /**
+     *  Returns true if map tips are enabled for this layer
+     *  \since QGIS 3.32
+     */
+    bool mapTipsEnabled() const;
+
   public slots:
 
     /**
@@ -1862,6 +1877,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.30
      */
     void mapTipTemplateChanged();
+
+    /**
+     * Emitted when map tips are enabled or disabled for the layer.
+     *
+     * \see setMapTipsEnabled()
+     * \since QGIS 3.32
+     */
+    void mapTipsEnabledChanged();
 
   private slots:
 
@@ -2185,6 +2208,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Maptip template
     QString mMapTipTemplate;
+
+    //! Flag indicating whether map tips are enabled for this layer or not
+    bool mMapTipsEnabled = true;
 
     friend class QgsVectorLayer;
     friend class TestQgsMapLayer;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -173,6 +173,7 @@ QgsRasterLayer *QgsRasterLayer::clone() const
   layer->mElevationProperties = mElevationProperties->clone();
   layer->mElevationProperties->setParent( layer );
   layer->setMapTipTemplate( mapTipTemplate() );
+  layer->setMapTipsEnabled( mapTipsEnabled() );
 
   // do not clone data provider which is the first element in pipe
   for ( int i = 1; i < mPipe->size(); i++ )
@@ -2262,7 +2263,11 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     mPipe->dataDefinedProperties().readXml( elemDataDefinedProperties, QgsRasterPipe::propertyDefinitions() );
 
   if ( categories.testFlag( MapTips ) )
-    setMapTipTemplate( layer_node.namedItem( QStringLiteral( "mapTip" ) ).toElement().text() );
+  {
+    QDomElement mapTipElem = layer_node.namedItem( QStringLiteral( "mapTip" ) ).toElement();
+    setMapTipTemplate( mapTipElem.text() );
+    setMapTipsEnabled( mapTipElem.attribute( QStringLiteral( "enabled" ), QStringLiteral( "1" ) ).toInt() == 1 );
+  }
 
   readCustomProperties( layer_node );
 
@@ -2474,6 +2479,7 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
   if ( categories.testFlag( MapTips ) )
   {
     QDomElement mapTipElem = document.createElement( QStringLiteral( "mapTip" ) );
+    mapTipElem.setAttribute( QStringLiteral( "enabled" ), mapTipsEnabled() );
     QDomText mapTipText = document.createTextNode( mapTipTemplate() );
     mapTipElem.appendChild( mapTipText );
     layer_node.toElement().appendChild( mapTipElem );

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -310,6 +310,7 @@ QgsVectorLayer *QgsVectorLayer::clone() const
     layer->setProviderEncoding( mDataProvider->encoding() );
   layer->setDisplayExpression( displayExpression() );
   layer->setMapTipTemplate( mapTipTemplate() );
+  layer->setMapTipsEnabled( mapTipsEnabled() );
   layer->setReadOnly( isReadOnly() );
   layer->selectByIds( selectedFeatureIds() );
   layer->setAttributeTableConfig( attributeTableConfig() );
@@ -2313,7 +2314,11 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
   readStyle( layerNode, errorMessage, context, categories );
 
   if ( categories.testFlag( MapTips ) )
-    mMapTipTemplate = layerNode.namedItem( QStringLiteral( "mapTip" ) ).toElement().text();
+  {
+    QDomElement mapTipElem = layerNode.namedItem( QStringLiteral( "mapTip" ) ).toElement();
+    setMapTipTemplate( mapTipElem.text() );
+    setMapTipsEnabled( mapTipElem.attribute( QStringLiteral( "enabled" ), QStringLiteral( "1" ) ).toInt() == 1 );
+  }
 
   if ( categories.testFlag( LayerConfiguration ) )
     mDisplayExpression = layerNode.namedItem( QStringLiteral( "previewExpression" ) ).toElement().text();
@@ -2994,6 +2999,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
   if ( categories.testFlag( MapTips ) )
   {
     QDomElement mapTipElem = doc.createElement( QStringLiteral( "mapTip" ) );
+    mapTipElem.setAttribute( QStringLiteral( "enabled" ), mapTipsEnabled() );
     QDomText mapTipText = doc.createTextNode( mMapTipTemplate );
     mapTipElem.appendChild( mapTipText );
     node.toElement().appendChild( mapTipElem );
@@ -3952,7 +3958,7 @@ bool QgsVectorLayer::hasMapTips() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   // display expressions are used as a fallback when no explicit map tip template is set
-  return !mapTipTemplate().isEmpty() || !displayExpression().isEmpty();
+  return mapTipsEnabled() && ( !mapTipTemplate().isEmpty() || !displayExpression().isEmpty() );
 }
 
 bool QgsVectorLayer::isEditable() const

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -219,7 +219,7 @@ void QgsMapTip::clear( QgsMapCanvas *, int msDelay )
 QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, QgsMapCanvas *mapCanvas )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !vlayer || !vlayer->isSpatial() )
+  if ( !vlayer || !vlayer->isSpatial() || !vlayer->mapTipsEnabled() )
   {
     return QString();
   }
@@ -328,7 +328,7 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
 QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, QgsMapCanvas *mapCanvas )
 {
   QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer );
-  if ( !rlayer )
+  if ( !rlayer || !rlayer->mapTipsEnabled() )
   {
     return QString();
   }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -234,6 +234,9 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     return;
   }
 
+  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
+  mEnableMapTips->setChecked( mRasterLayer->mapTipsEnabled() );
+
   updateRasterAttributeTableOptionsPage();
 
   connect( mRasterLayer, &QgsRasterLayer::rendererChanged, this, &QgsRasterLayerProperties::updateRasterAttributeTableOptionsPage );
@@ -867,6 +870,7 @@ void QgsRasterLayerProperties::sync()
   mLayerLegendUrlLineEdit->setText( mRasterLayer->legendUrl() );
   mLayerLegendUrlFormatComboBox->setCurrentIndex( mLayerLegendUrlFormatComboBox->findText( mRasterLayer->legendUrlFormat() ) );
 
+  mEnableMapTips->setChecked( mRasterLayer->mapTipsEnabled() );
   mMapTipWidget->setText( mRasterLayer->mapTipTemplate() );
 
   //WMS print layer
@@ -1126,6 +1130,7 @@ void QgsRasterLayerProperties::apply()
 
   mRasterLayer->pipe()->setDataDefinedProperties( mPropertyCollection );
 
+  mRasterLayer->setMapTipsEnabled( mEnableMapTips->isChecked() );
   mRasterLayer->setMapTipTemplate( mMapTipWidget->text() );
 
   // Force a redraw of the legend

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -175,6 +175,9 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   if ( !mLayer )
     return;
 
+  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
+  mEnableMapTips->setChecked( mLayer->mapTipsEnabled() );
+
   QVBoxLayout *layout = nullptr;
 
   if ( mLayer->isSpatial() )
@@ -557,8 +560,9 @@ void QgsVectorLayerProperties::syncToLayer()
   txtSubsetSQL->setCaretLineVisible( false );
   setPbnQueryBuilderEnabled();
 
-  mMapTipWidget->setText( mLayer->mapTipTemplate() );
   mDisplayExpressionWidget->setField( mLayer->displayExpression() );
+  mEnableMapTips->setChecked( mLayer->mapTipsEnabled() );
+  mMapTipWidget->setText( mLayer->mapTipTemplate() );
 
   // set up the scale based layer visibility stuff....
   mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
@@ -718,6 +722,7 @@ void QgsVectorLayerProperties::apply()
   }
 
   mLayer->setDisplayExpression( mDisplayExpressionWidget->asExpression() );
+  mLayer->setMapTipsEnabled( mEnableMapTips->isChecked() );
   mLayer->setMapTipTemplate( mMapTipWidget->text() );
 
   mLayer->actions()->clearActions();

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1477,7 +1477,20 @@ p, li { white-space: pre-wrap; }
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QGroupBox" name="groupBox_2">
+               <widget class="QCheckBox" name="mEnableMapTips">
+                <property name="toolTip">
+                 <string>Indicates whether map tips are displayed for this layer or not</string>
+                </property>
+                <property name="text">
+                 <string>Enable map tips</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1449,7 +1449,20 @@
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QGroupBox" name="groupBox_2">
+               <widget class="QCheckBox" name="mEnableMapTips">
+                <property name="toolTip">
+                 <string>Indicates whether map tips are displayed for this layer or not</string>
+                </property>
+                <property name="text">
+                 <string>Enable map tips</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>


### PR DESCRIPTION
- fix #23400

## Description

This PR add a `mapTipsEnabled` Q_PROPERTY in the `QgsMapLayer` which allows disabling mapTips for a specific layer.

![disable_map_tips](https://user-images.githubusercontent.com/9693475/227073513-279a7943-33d4-4a34-b0ec-f5ea8aa9cbeb.gif)

