### PR TITLE
Fix broken layer support for vtpk/mbtile vector tile layers, show vtpk files in browser

### DIFF
--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -883,24 +883,6 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
       }
     }
   }
-  else if ( fileName.endsWith( QStringLiteral( ".vtpk" ), Qt::CaseInsensitive ) )
-  {
-    // these are vector tiles
-    QUrlQuery uq;
-    uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "vtpk" ) );
-    uq.addQueryItem( QStringLiteral( "url" ), fileName );
-    const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
-    std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
-    if ( vtLayer->isValid() )
-    {
-      openedLayers << vtLayer.get();
-      QgsAppLayerHandling::postProcessAddedLayer( vtLayer.get() );
-      QgsProject::instance()->addMapLayer( vtLayer.release(), addToLegend );
-      postProcessAddedLayers();
-      ok = true;
-      return openedLayers;
-    }
-  }
 
   QList< QgsProviderSublayerModel::NonLayerItem > nonLayerItems;
   if ( QgsProjectStorage *ps = QgsApplication::projectStorageRegistry()->projectStorageFromUri( fileName ) )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7521,8 +7521,21 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
     const QString path = sourceParts.value( QStringLiteral( "path" ) ).toString();
     const QString closestPath = QFile::exists( path ) ? path : QgsFileUtils::findClosestExistingPath( path );
     dlg.expandPath( closestPath );
-    source.replace( path, QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( closestPath ).toString(),
-                    path ) );
+    if ( source.contains( path ) )
+    {
+      source.replace( path, QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( closestPath ).toString(),
+                      path ) );
+    }
+    else
+    {
+      // source might contain the original path using a "QUrl::FullyEncoded" encoding
+      const QString uriEncodedPath = QUrl( path ).toString( QUrl::FullyEncoded );
+      if ( source.contains( uriEncodedPath ) )
+      {
+        source.replace( uriEncodedPath, QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( closestPath ).toString(),
+                        uriEncodedPath ) );
+      }
+    }
   }
   dlg.setDescription( tr( "Original source URI: %1" ).arg( source ) );
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -53,6 +53,10 @@
 #include "qgsmeshlayer.h"
 #include "qgsmapcanvasutils.h"
 #include "qgsmaplayeraction.h"
+#include "qgsvectortilelayer.h"
+#include "qgsvectortiledataprovider.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
 
 QgsAppLayerTreeViewMenuProvider::QgsAppLayerTreeViewMenuProvider( QgsLayerTreeView *view, QgsMapCanvas *canvas )
   : mView( view )
@@ -157,6 +161,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
       QgsPointCloudLayer *pcLayer = qobject_cast<QgsPointCloudLayer * >( layer );
       QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer * >( layer );
+      QgsVectorTileLayer *vectorTileLayer = qobject_cast<QgsVectorTileLayer * >( layer );
 
       if ( layer && layer->isSpatial() )
       {
@@ -381,8 +386,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( tr( "&Filter…" ), QgisApp::instance(), qOverload<>( &QgisApp::layerSubsetString ) );
       }
 
-      // change data source is only supported for vectors, rasters, point clouds, mesh
-      if ( vlayer || rlayer || pcLayer || meshLayer )
+      // change data source is only supported for vectors, rasters, point clouds, mesh, some vector tile layers
+      bool supportsChangeDataSource = vlayer || rlayer || pcLayer || meshLayer;
+      if ( vectorTileLayer )
+      {
+        if ( const QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( vectorTileLayer->providerType() ) )
+        {
+          supportsChangeDataSource = metadata->providerCapabilities() & QgsProviderMetadata::FileBasedUris;
+        }
+      }
+      if ( supportsChangeDataSource )
       {
 
         QAction *a = new QAction( layer->isValid() ? tr( "C&hange Data Source…" ) : tr( "Repair Data Source…" ), menu );

--- a/src/app/qgslayertreeviewindicatorprovider.cpp
+++ b/src/app/qgslayertreeviewindicatorprovider.cpp
@@ -22,6 +22,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
 #include "qgspointcloudlayer.h"
+#include "qgsvectortilelayer.h"
 #include "qgsmeshlayer.h"
 #include "qgisapp.h"
 #include "qgsapplication.h"
@@ -102,7 +103,8 @@ void QgsLayerTreeViewIndicatorProvider::onLayerLoaded()
   if ( !( qobject_cast<QgsVectorLayer *>( layerNode->layer() ) ||
           qobject_cast<QgsRasterLayer *>( layerNode->layer() ) ||
           qobject_cast<QgsMeshLayer *>( layerNode->layer() ) ||
-          qobject_cast<QgsPointCloudLayer *>( layerNode->layer() ) ) )
+          qobject_cast<QgsPointCloudLayer *>( layerNode->layer() ) ||
+          qobject_cast<QgsVectorTileLayer *>( layerNode->layer() ) ) )
     return;
 
   if ( QgsMapLayer *mapLayer = layerNode->layer() )
@@ -129,7 +131,8 @@ void QgsLayerTreeViewIndicatorProvider::connectSignals( QgsMapLayer *layer )
   if ( !( qobject_cast<QgsVectorLayer *>( layer )
           || qobject_cast<QgsRasterLayer *>( layer )
           || qobject_cast<QgsMeshLayer *>( layer )
-          || qobject_cast<QgsPointCloudLayer *>( layer ) ) )
+          || qobject_cast<QgsPointCloudLayer *>( layer )
+          || qobject_cast<QgsVectorTileLayer *>( layer ) ) )
     return;
 
   QgsMapLayer *mapLayer = layer;
@@ -141,7 +144,8 @@ void QgsLayerTreeViewIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
   if ( !( qobject_cast<QgsVectorLayer *>( layer )
           || qobject_cast<QgsRasterLayer *>( layer )
           || qobject_cast<QgsMeshLayer *>( layer )
-          || qobject_cast<QgsPointCloudLayer *>( layer ) ) )
+          || qobject_cast<QgsPointCloudLayer *>( layer )
+          || qobject_cast<QgsVectorTileLayer *>( layer ) ) )
     return;
   QgsMapLayer *mapLayer = layer;
   disconnect( mapLayer, &QgsMapLayer::dataSourceChanged, this, &QgsLayerTreeViewIndicatorProvider::onLayerChanged );

--- a/src/core/browser/qgslayeritem.cpp
+++ b/src/core/browser/qgslayeritem.cpp
@@ -201,9 +201,15 @@ QString QgsLayerItem::iconName( Qgis::BrowserLayerType layerType )
       return QStringLiteral( "/mIconMeshLayer.svg" );
     case Qgis::BrowserLayerType::PointCloud:
       return QStringLiteral( "/mIconPointCloudLayer.svg" );
-    default:
-      return QStringLiteral( "/mIconLayer.png" );
+    case Qgis::BrowserLayerType::VectorTile:
+      return QStringLiteral( "/mIconVectorTileLayer.svg" );
+
+    case Qgis::BrowserLayerType::NoType:
+    case Qgis::BrowserLayerType::Database:
+    case Qgis::BrowserLayerType::Plugin:
+      return QStringLiteral( "/mIconLayer.png" );;
   }
+  BUILTIN_UNREACHABLE
 }
 
 bool QgsLayerItem::deleteLayer()

--- a/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
+++ b/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
@@ -341,26 +341,13 @@ QgsArcGisVectorTileServiceDataProvider *QgsArcGisVectorTileServiceDataProviderMe
 
 QVariantMap QgsArcGisVectorTileServiceDataProviderMetadata::decodeUri( const QString &uri ) const
 {
-  // TODO -- carefully thin out options which don't apply to arcgis vector tile services
-
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
   uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
-    uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
-
-  if ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "mbtiles" ) ||
-       ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "xyz" ) &&
-         !dsUri.param( QStringLiteral( "url" ) ).startsWith( QLatin1String( "http" ) ) ) )
-  {
-    uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
-  else
-  {
-    uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
+  uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
+  uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
 
   if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
     uriComponents.insert( QStringLiteral( "zmin" ), dsUri.param( QStringLiteral( "zmin" ) ) );
@@ -381,13 +368,10 @@ QVariantMap QgsArcGisVectorTileServiceDataProviderMetadata::decodeUri( const QSt
 
 QString QgsArcGisVectorTileServiceDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  // TODO -- carefully thin out options which don't apply to arcgis vector tile services
-
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
-  if ( parts.contains( QStringLiteral( "serviceType" ) ) )
-    dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
-  dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
+  dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
+  dsUri.setParam( QStringLiteral( "url" ), parts.value( QStringLiteral( "url" ) ).toString() );
 
   if ( parts.contains( QStringLiteral( "zmin" ) ) )
     dsUri.setParam( QStringLiteral( "zmin" ), parts[ QStringLiteral( "zmin" ) ].toString() );

--- a/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
+++ b/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
@@ -345,8 +345,8 @@ QVariantMap QgsArcGisVectorTileServiceDataProviderMetadata::decodeUri( const QSt
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
-  uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
+  uriComponents.insert( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  uriComponents.insert( QStringLiteral( "serviceType" ), QStringLiteral( "arcgis" ) );
   uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
 
   if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
@@ -369,8 +369,8 @@ QVariantMap QgsArcGisVectorTileServiceDataProviderMetadata::decodeUri( const QSt
 QString QgsArcGisVectorTileServiceDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
   QgsDataSourceUri dsUri;
-  dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
-  dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
+  dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  dsUri.setParam( QStringLiteral( "serviceType" ), QStringLiteral( "arcgis" ) );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( QStringLiteral( "url" ) ).toString() );
 
   if ( parts.contains( QStringLiteral( "zmin" ) ) )

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -240,7 +240,7 @@ QVariantMap QgsMbTilesVectorTileDataProviderMetadata::decodeUri( const QString &
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
-  uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
+  uriComponents.insert( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
   uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
 
   return uriComponents;
@@ -249,7 +249,7 @@ QVariantMap QgsMbTilesVectorTileDataProviderMetadata::decodeUri( const QString &
 QString QgsMbTilesVectorTileDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
   QgsDataSourceUri dsUri;
-  dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
+  dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
   return dsUri.encodedUri();
 }

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -236,94 +236,42 @@ QgsProviderMetadata::ProviderCapabilities QgsMbTilesVectorTileDataProviderMetada
 
 QVariantMap QgsMbTilesVectorTileDataProviderMetadata::decodeUri( const QString &uri ) const
 {
-  // TODO -- carefully thin out options which don't apply to mbtiles
-
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
   uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
-    uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
-
-  if ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "mbtiles" ) ||
-       ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "xyz" ) &&
-         !dsUri.param( QStringLiteral( "url" ) ).startsWith( QLatin1String( "http" ) ) ) )
-  {
-    uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
-  else
-  {
-    uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
-
-  if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
-    uriComponents.insert( QStringLiteral( "zmin" ), dsUri.param( QStringLiteral( "zmin" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "zmax" ) ) )
-    uriComponents.insert( QStringLiteral( "zmax" ), dsUri.param( QStringLiteral( "zmax" ) ) );
-
-  dsUri.httpHeaders().updateMap( uriComponents );
-
-  if ( dsUri.hasParam( QStringLiteral( "styleUrl" ) ) )
-    uriComponents.insert( QStringLiteral( "styleUrl" ), dsUri.param( QStringLiteral( "styleUrl" ) ) );
-
-  const QString authcfg = dsUri.authConfigId();
-  if ( !authcfg.isEmpty() )
-    uriComponents.insert( QStringLiteral( "authcfg" ), authcfg );
+  uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
 
   return uriComponents;
 }
 
 QString QgsMbTilesVectorTileDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  // TODO -- carefully thin out options which don't apply to mbtiles
-
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
-  if ( parts.contains( QStringLiteral( "serviceType" ) ) )
-    dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
-
-  if ( parts.contains( QStringLiteral( "zmin" ) ) )
-    dsUri.setParam( QStringLiteral( "zmin" ), parts[ QStringLiteral( "zmin" ) ].toString() );
-  if ( parts.contains( QStringLiteral( "zmax" ) ) )
-    dsUri.setParam( QStringLiteral( "zmax" ), parts[ QStringLiteral( "zmax" ) ].toString() );
-
-  dsUri.httpHeaders().setFromMap( parts );
-
-  if ( parts.contains( QStringLiteral( "styleUrl" ) ) )
-    dsUri.setParam( QStringLiteral( "styleUrl" ), parts[ QStringLiteral( "styleUrl" ) ].toString() );
-
-  if ( parts.contains( QStringLiteral( "authcfg" ) ) )
-    dsUri.setAuthConfigId( parts[ QStringLiteral( "authcfg" ) ].toString() );
-
   return dsUri.encodedUri();
 }
 
 QString QgsMbTilesVectorTileDataProviderMetadata::absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const
 {
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( uri );
+  QVariantMap parts = decodeUri( uri );
 
-  QString sourcePath = dsUri.param( QStringLiteral( "url" ) );
+  const QString originalPath = parts.value( QStringLiteral( "path" ) ).toString();
+  parts.insert( QStringLiteral( "path" ), context.pathResolver().writePath( originalPath ) );
 
-  sourcePath = context.pathResolver().writePath( sourcePath );
-  dsUri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
-  dsUri.setParam( QStringLiteral( "url" ), sourcePath );
-  return dsUri.encodedUri();
+  return encodeUri( parts );
 }
 
 QString QgsMbTilesVectorTileDataProviderMetadata::relativeToAbsoluteUri( const QString &uri, const QgsReadWriteContext &context ) const
 {
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( uri );
+  QVariantMap parts = decodeUri( uri );
 
-  QString sourcePath = dsUri.param( QStringLiteral( "url" ) );
+  const QString originalPath = parts.value( QStringLiteral( "path" ) ).toString();
+  parts.insert( QStringLiteral( "path" ), context.pathResolver().readPath( originalPath ) );
 
-  sourcePath = context.pathResolver().readPath( sourcePath );
-  dsUri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
-  dsUri.setParam( QStringLiteral( "url" ), sourcePath );
-  return dsUri.encodedUri();
+  return encodeUri( parts );
 }
 
 QList<Qgis::LayerType> QgsMbTilesVectorTileDataProviderMetadata::supportedLayerTypes() const

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -429,7 +429,7 @@ bool QgsVectorTileLayer::loadDefaultStyleAndSubLayersPrivate( QString &error, QS
       styleDefinition = QgsJsonUtils::parseJson( content.content() ).toMap();
     }
 
-    if ( styleDefinition.contains( QStringLiteral( "sprite" ) ) )
+    if ( styleDefinition.contains( QStringLiteral( "sprite" ) ) && ( context.spriteDefinitions().empty() || context.spriteImage().isNull() ) )
     {
       // retrieve sprite definition
       QString spriteUriBase;

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -112,7 +112,7 @@ bool QgsVectorTileLayer::loadDataSource()
     setExtent( mDataProvider->extent() );
   }
 
-  return true;
+  return mDataProvider && mDataProvider->isValid();
 }
 
 QgsVectorTileLayer::~QgsVectorTileLayer() = default;

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -242,94 +242,42 @@ QgsProviderMetadata::ProviderCapabilities QgsVtpkVectorTileDataProviderMetadata:
 
 QVariantMap QgsVtpkVectorTileDataProviderMetadata::decodeUri( const QString &uri ) const
 {
-  // TODO -- carefully thin out options which don't apply to vtpk
-
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
   uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
-    uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
-
-  if ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "mbtiles" ) ||
-       ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "xyz" ) &&
-         !dsUri.param( QStringLiteral( "url" ) ).startsWith( QLatin1String( "http" ) ) ) )
-  {
-    uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
-  else
-  {
-    uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
-  }
-
-  if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
-    uriComponents.insert( QStringLiteral( "zmin" ), dsUri.param( QStringLiteral( "zmin" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "zmax" ) ) )
-    uriComponents.insert( QStringLiteral( "zmax" ), dsUri.param( QStringLiteral( "zmax" ) ) );
-
-  dsUri.httpHeaders().updateMap( uriComponents );
-
-  if ( dsUri.hasParam( QStringLiteral( "styleUrl" ) ) )
-    uriComponents.insert( QStringLiteral( "styleUrl" ), dsUri.param( QStringLiteral( "styleUrl" ) ) );
-
-  const QString authcfg = dsUri.authConfigId();
-  if ( !authcfg.isEmpty() )
-    uriComponents.insert( QStringLiteral( "authcfg" ), authcfg );
+  uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
 
   return uriComponents;
 }
 
 QString QgsVtpkVectorTileDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  // TODO -- carefully thin out options which don't apply to vtpk
-
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
-  if ( parts.contains( QStringLiteral( "serviceType" ) ) )
-    dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
-
-  if ( parts.contains( QStringLiteral( "zmin" ) ) )
-    dsUri.setParam( QStringLiteral( "zmin" ), parts[ QStringLiteral( "zmin" ) ].toString() );
-  if ( parts.contains( QStringLiteral( "zmax" ) ) )
-    dsUri.setParam( QStringLiteral( "zmax" ), parts[ QStringLiteral( "zmax" ) ].toString() );
-
-  dsUri.httpHeaders().setFromMap( parts );
-
-  if ( parts.contains( QStringLiteral( "styleUrl" ) ) )
-    dsUri.setParam( QStringLiteral( "styleUrl" ), parts[ QStringLiteral( "styleUrl" ) ].toString() );
-
-  if ( parts.contains( QStringLiteral( "authcfg" ) ) )
-    dsUri.setAuthConfigId( parts[ QStringLiteral( "authcfg" ) ].toString() );
-
   return dsUri.encodedUri();
 }
 
 QString QgsVtpkVectorTileDataProviderMetadata::absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const
 {
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( uri );
+  QVariantMap parts = decodeUri( uri );
 
-  QString sourcePath = dsUri.param( QStringLiteral( "url" ) );
+  const QString originalPath = parts.value( QStringLiteral( "path" ) ).toString();
+  parts.insert( QStringLiteral( "path" ), context.pathResolver().writePath( originalPath ) );
 
-  sourcePath = context.pathResolver().writePath( sourcePath );
-  dsUri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
-  dsUri.setParam( QStringLiteral( "url" ), sourcePath );
-  return dsUri.encodedUri();
+  return encodeUri( parts );
 }
 
 QString QgsVtpkVectorTileDataProviderMetadata::relativeToAbsoluteUri( const QString &uri, const QgsReadWriteContext &context ) const
 {
-  QgsDataSourceUri dsUri;
-  dsUri.setEncodedUri( uri );
+  QVariantMap parts = decodeUri( uri );
 
-  QString sourcePath = dsUri.param( QStringLiteral( "url" ) );
+  const QString originalPath = parts.value( QStringLiteral( "path" ) ).toString();
+  parts.insert( QStringLiteral( "path" ), context.pathResolver().readPath( originalPath ) );
 
-  sourcePath = context.pathResolver().readPath( sourcePath );
-  dsUri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
-  dsUri.setParam( QStringLiteral( "url" ), sourcePath );
-  return dsUri.encodedUri();
+  return encodeUri( parts );
 }
 
 QList<Qgis::LayerType> QgsVtpkVectorTileDataProviderMetadata::supportedLayerTypes() const

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -85,9 +85,13 @@ class QgsVtpkVectorTileDataProviderMetadata : public QgsProviderMetadata
     Q_OBJECT
   public:
     QgsVtpkVectorTileDataProviderMetadata();
+    QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     QgsVtpkVectorTileDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     QIcon icon() const override;
     ProviderCapabilities providerCapabilities() const override;
+    QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+    int priorityForUri( const QString &uri ) const override;
+    QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QString absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const override;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -178,7 +178,7 @@ QVariantMap QgsXyzVectorTileDataProviderMetadata::decodeUri( const QString &uri 
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
-  uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
+  uriComponents.insert( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
 
   if ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "mbtiles" ) ||
        ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "xyz" ) &&
@@ -211,7 +211,7 @@ QVariantMap QgsXyzVectorTileDataProviderMetadata::decodeUri( const QString &uri 
 QString QgsXyzVectorTileDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
   QgsDataSourceUri dsUri;
-  dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
+  dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
 
   if ( parts.contains( QStringLiteral( "zmin" ) ) )

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -174,15 +174,11 @@ QgsProviderMetadata::ProviderCapabilities QgsXyzVectorTileDataProviderMetadata::
 
 QVariantMap QgsXyzVectorTileDataProviderMetadata::decodeUri( const QString &uri ) const
 {
-  // TODO -- carefully thin out options which don't apply to xyz vector tile services
-
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( uri );
 
   QVariantMap uriComponents;
   uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
-    uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
 
   if ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "mbtiles" ) ||
        ( uriComponents[ QStringLiteral( "type" ) ] == QLatin1String( "xyz" ) &&
@@ -214,12 +210,8 @@ QVariantMap QgsXyzVectorTileDataProviderMetadata::decodeUri( const QString &uri 
 
 QString QgsXyzVectorTileDataProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
-  // TODO -- carefully thin out options which don't apply to xyz vector tile services
-
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
-  if ( parts.contains( QStringLiteral( "serviceType" ) ) )
-    dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
 
   if ( parts.contains( QStringLiteral( "zmin" ) ) )

--- a/tests/src/core/testqgsvectortilelayer.cpp
+++ b/tests/src/core/testqgsvectortilelayer.cpp
@@ -354,12 +354,10 @@ void TestQgsVectorTileLayer::test_absoluteRelativeUriVtpk()
   QgsDataSourceUri dsAbs;
   dsAbs.setParam( "type", "vtpk" );
   dsAbs.setParam( "url", QString( "%1/testvtpk.vtpk" ).arg( TEST_DATA_DIR ) );
-  dsAbs.setParam( "zmax", "1" );
 
   QgsDataSourceUri dsRel;
   dsRel.setParam( "type", "vtpk" );
   dsRel.setParam( "url", "./testvtpk.vtpk" );
-  dsRel.setParam( "zmax", "1" );
 
   QString absoluteUri = dsAbs.encodedUri();
   QString relativeUri = dsRel.encodedUri();

--- a/tests/src/core/testqgsvectortilelayer.cpp
+++ b/tests/src/core/testqgsvectortilelayer.cpp
@@ -250,12 +250,10 @@ void TestQgsVectorTileLayer::test_absoluteRelativeUriMbTiles()
   QgsDataSourceUri dsAbs;
   dsAbs.setParam( "type", "mbtiles" );
   dsAbs.setParam( "url", QString( "%1/vector_tile/mbtiles_vt.mbtiles" ).arg( TEST_DATA_DIR ) );
-  dsAbs.setParam( "zmax", "1" );
 
   QgsDataSourceUri dsRel;
   dsRel.setParam( "type", "mbtiles" );
   dsRel.setParam( "url", "./vector_tile/mbtiles_vt.mbtiles" );
-  dsRel.setParam( "zmax", "1" );
 
   QString absoluteUri = dsAbs.encodedUri();
   QString relativeUri = dsRel.encodedUri();


### PR DESCRIPTION
This PR ensures that vector tile layers expose all the required API for supporting the broken layer handling and discovery like other layer types. Additionally, by implementing the modern provider metadata APIs for the VTPK provider we ensure that VTPK files are shown in the browser panel for easy discovery.

Funded by Landesamt für Vermessung und Geoinformation, Feldkirch, Austria