### PR TITLE
[OAPIF provider] OGC API features 2 / CRS related fixes (fixes #52228)

### DIFF
--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -26,6 +26,7 @@ set(WFS_SRCS
   oapif/qgsoapiflandingpagerequest.cpp
   oapif/qgsoapifapirequest.cpp
   oapif/qgsoapifcollection.cpp
+  oapif/qgsoapifconformancerequest.cpp
   oapif/qgsoapifitemsrequest.cpp
   oapif/qgsoapifprovider.cpp
   oapif/qgsoapifutils.cpp

--- a/src/providers/wfs/oapif/qgsoapifcollection.h
+++ b/src/providers/wfs/oapif/qgsoapifcollection.h
@@ -39,14 +39,20 @@ struct QgsOapifCollection
   //! Description
   QString mDescription;
 
-  //! Bounding box (in CRS84)
+  //! Bounding box
   QgsRectangle mBbox;
+
+  //! Bounding box Crs
+  QgsCoordinateReferenceSystem mBboxCrs;
+
+  //! List of available CRS
+  QList<QString> mCrsList;
 
   //! Layer metadata
   QgsLayerMetadata mLayerMetadata;
 
   //! Fills a collection from its JSON serialization
-  bool deserialize( const json &j );
+  bool deserialize( const json &j, const json &jCollections );
 };
 
 //! Manages the /collections request

--- a/src/providers/wfs/oapif/qgsoapifconformancerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifconformancerequest.cpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+    qgsoapifconformancerequest.cpp
+    ------------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgslogger.h"
+#include "qgsoapifconformancerequest.h"
+#include "qgsoapifutils.h"
+#include "qgswfsconstants.h"
+
+#include <QTextCodec>
+
+QgsOapifConformanceRequest::QgsOapifConformanceRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+  // Using Qt::DirectConnection since the download might be running on a different thread.
+  // In this case, the request was sent from the main thread and is executed with the main
+  // thread being blocked in future.waitForFinished() so we can run code on this object which
+  // lives in the main thread without risking havoc.
+  connect( this, &QgsBaseNetworkRequest::downloadFinished, this, &QgsOapifConformanceRequest::processReply, Qt::DirectConnection );
+}
+
+QStringList QgsOapifConformanceRequest::conformanceClasses( const QUrl &conformanceUrl )
+{
+  sendGET( conformanceUrl, QString( "application/json" ), /*synchronous=*/true, /*forceRefresh=*/false );
+  return mConformanceClasses;
+}
+
+QString QgsOapifConformanceRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Download of conformance classes failed: %1" ).arg( reason );
+}
+
+void QgsOapifConformanceRequest::processReply()
+{
+  if ( mErrorCode != QgsBaseNetworkRequest::NoError )
+  {
+    return;
+  }
+  const QByteArray &buffer = mResponse;
+  if ( buffer.isEmpty() )
+  {
+    mErrorMessage = tr( "empty response" );
+    mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
+    return;
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "parsing Conformance response: " ) + buffer, 4 );
+
+  QTextCodec::ConverterState state;
+  QTextCodec *codec = QTextCodec::codecForName( "UTF-8" );
+  Q_ASSERT( codec );
+
+  const QString utf8Text = codec->toUnicode( buffer.constData(), buffer.size(), &state );
+  if ( state.invalidChars != 0 )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Invalid UTF-8 content" ) );
+    return;
+  }
+
+  try
+  {
+    const json j = json::parse( utf8Text.toStdString() );
+
+    if ( j.is_object() && j.contains( "conformsTo" ) )
+    {
+      const json jConformsTo = j["conformsTo"];
+      if ( jConformsTo.is_array() )
+      {
+        for ( const auto &subj : jConformsTo )
+        {
+          if ( subj.is_string() )
+          {
+            mConformanceClasses.append( QString::fromStdString( subj.get<std::string>() ) );
+          }
+        }
+      }
+    }
+  }
+  catch ( const json::parse_error &ex )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Cannot decode JSON document: %1" ).arg( QString::fromStdString( ex.what() ) ) );
+    return;
+  }
+}

--- a/src/providers/wfs/oapif/qgsoapifconformancerequest.h
+++ b/src/providers/wfs/oapif/qgsoapifconformancerequest.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+    qgsoapifconformancerequest.h
+    -----------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFCONFORMANCEREQUEST_H
+#define QGSOAPIFCONFORMANCEREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsbasenetworkrequest.h"
+
+//! Manages the conformance request
+class QgsOapifConformanceRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifConformanceRequest( const QgsDataSourceUri &uri );
+
+    //! Issue the request synchronously and return conformance classes
+    QStringList conformanceClasses( const QUrl &conformanceUrl );
+
+  private slots:
+    void processReply();
+
+  private:
+    QStringList mConformanceClasses;
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFCONFORMANCEREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapiflandingpagerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapiflandingpagerequest.cpp
@@ -124,6 +124,8 @@ void QgsOapifLandingPageRequest::processReply()
                         apiTypes );
     }
 #endif
+
+    mConformanceUrl = QgsOAPIFJson::findLink( links, QStringLiteral( "conformance" ) );
   }
   catch ( const json::parse_error &ex )
   {

--- a/src/providers/wfs/oapif/qgsoapiflandingpagerequest.h
+++ b/src/providers/wfs/oapif/qgsoapiflandingpagerequest.h
@@ -45,8 +45,11 @@ class QgsOapifLandingPageRequest : public QgsBaseNetworkRequest
     //! Return URL of the api endpoint
     const QString &apiUrl() const { return mApiUrl; }
 
-    //! Return URL of the api endpoint
+    //! Return URL of the collections endpoint
     const QString &collectionsUrl() const { return mCollectionsUrl; }
+
+    //! Return URL of the conformance endpoint
+    const QString &conformanceUrl() const { return mConformanceUrl; }
 
   signals:
     //! emitted when the capabilities have been fully parsed, or an error occurred
@@ -66,6 +69,9 @@ class QgsOapifLandingPageRequest : public QgsBaseNetworkRequest
 
     //! URL of the collections endpoint.
     QString mCollectionsUrl;
+
+    //! URL of the conformance endpoint.
+    QString mConformanceUrl;
 
     ApplicationLevelError mAppLevelError = ApplicationLevelError::NoError;
 

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -122,12 +122,6 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     }
 #endif
 
-    // For REST API using URL subpaths, normalize the subpaths
-    const int afterEndpointStartPos = modifiedUrlString.indexOf( "fake_qgis_http_endpoint" ) + strlen( "fake_qgis_http_endpoint" );
-    QString afterEndpointStart = modifiedUrlString.mid( afterEndpointStartPos );
-    afterEndpointStart.replace( QLatin1String( "/" ), QLatin1String( "_" ) );
-    modifiedUrlString = modifiedUrlString.mid( 0, afterEndpointStartPos ) + afterEndpointStart;
-
     if ( !acceptHeader.isEmpty() )
     {
       if ( modifiedUrlString.indexOf( '?' ) > 0 )
@@ -139,6 +133,13 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
         modifiedUrlString += QStringLiteral( "?Accept=" ) + acceptHeader;
       }
     }
+
+    // For REST API using URL subpaths, normalize the subpaths
+    const int afterEndpointStartPos = static_cast<int>( modifiedUrlString.indexOf( "fake_qgis_http_endpoint" ) + strlen( "fake_qgis_http_endpoint" ) );
+    QString afterEndpointStart = modifiedUrlString.mid( afterEndpointStartPos );
+    afterEndpointStart.replace( QLatin1String( "/" ), QLatin1String( "_" ) );
+    modifiedUrlString = modifiedUrlString.mid( 0, afterEndpointStartPos ) + afterEndpointStart;
+
     const auto posQuotationMark = modifiedUrlString.indexOf( '?' );
     if ( posQuotationMark > 0 )
     {

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -380,6 +380,7 @@ void QgsWFSSourceSelect::oapifCollectionsReplyFinished()
     return;
   }
 
+  mAvailableCRS.clear();
   for ( const auto &collection : mOAPIFCollections->collections() )
   {
     // insert the typenames, titles and abstracts into the tree view
@@ -393,8 +394,8 @@ void QgsWFSSourceSelect::oapifCollectionsReplyFinished()
     typedef QList< QStandardItem * > StandardItemList;
     mModel->appendRow( StandardItemList() << titleItem << nameItem << abstractItem << filterItem );
 
-    gbCRS->setEnabled( false );
-    labelCoordRefSys->setText( collection.mLayerMetadata.crs().authid() );
+    // insert the available CRS into mAvailableCRS
+    mAvailableCRS.insert( collection.mId, collection.mCrsList );
   }
 
   if ( !mOAPIFCollections->nextUrl().isEmpty() )

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -176,35 +176,33 @@ void QgsWFSSourceSelect::populateConnectionList()
   changeConnection();
 }
 
-QString QgsWFSSourceSelect::getPreferredCrs( const QSet<QString> &crsSet ) const
+QString QgsWFSSourceSelect::getPreferredCrs( const QList<QString> &crsList ) const
 {
-  if ( crsSet.size() < 1 )
+  if ( crsList.size() < 1 )
   {
     return QString();
   }
 
-  //first: project CRS
-  QgsCoordinateReferenceSystem projectRefSys = QgsProject::instance()->crs();
-  //convert to EPSG
-  QString ProjectCRS;
-  if ( projectRefSys.isValid() )
+  //first: project CRS (if the project is not empty)
+  QgsProject *project = QgsProject::instance();
+  if ( !project->mapLayers().isEmpty() )
   {
-    ProjectCRS = projectRefSys.authid();
+    QgsCoordinateReferenceSystem projectRefSys = QgsProject::instance()->crs();
+    //convert to EPSG
+    QString projectCRS;
+    if ( projectRefSys.isValid() )
+    {
+      projectCRS = projectRefSys.authid();
+    }
+
+    if ( !projectCRS.isEmpty() && crsList.contains( projectCRS ) )
+    {
+      return projectCRS;
+    }
   }
 
-  if ( !ProjectCRS.isEmpty() && crsSet.contains( ProjectCRS ) )
-  {
-    return ProjectCRS;
-  }
-
-  //second: WGS84
-  if ( crsSet.contains( geoEpsgCrsAuthId() ) )
-  {
-    return geoEpsgCrsAuthId();
-  }
-
-  //third: first entry in set
-  return *( crsSet.constBegin() );
+  //otherwise: first entry in set
+  return crsList[0];
 }
 
 void QgsWFSSourceSelect::refresh()
@@ -705,7 +703,7 @@ void QgsWFSSourceSelect::changeCRSFilter()
       mProjectionSelector = new QgsProjectionSelectionDialog( this );
 
       mProjectionSelector->setOgcWmsCrsFilter( crsNames );
-      QString preferredCRS = getPreferredCrs( crsNames ); //get preferred EPSG system
+      QString preferredCRS = getPreferredCrs( *crsIterator ); //get preferred EPSG system
       if ( !preferredCRS.isEmpty() )
       {
         QgsCoordinateReferenceSystem refSys = QgsCoordinateReferenceSystem::fromOgcWmsCrs( preferredCRS );

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -80,15 +80,14 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
     QString mVersion;
 
     /**
-     * Returns the best suited CRS from a set of authority ids
+     * Returns the best suited CRS from a list of authority ids
      *
-     * 1. project CRS if contained in the set
-     * 2. WGS84 if contained in the set
-     * 3. the first entry in the set else
+     * 1. project CRS if contained in the list and the project is not empty
+     * 2. the first entry in the list else
      *
      * \returns the authority id of the crs or an empty string in case of error
     */
-    QString getPreferredCrs( const QSet<QString> &crsSet ) const;
+    QString getPreferredCrs( const QList<QString> &crsList ) const;
 
     void showHelp();
 

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -65,6 +65,7 @@ def GDAL_COMPUTE_VERSION(maj, min, rev):
 ACCEPT_LANDING = 'Accept=application/json'
 ACCEPT_API = 'Accept=application/vnd.oai.openapi+json;version=3.0, application/openapi+json;version=3.0, application/json'
 ACCEPT_COLLECTION = 'Accept=application/json'
+ACCEPT_CONFORMANCE = 'Accept=application/json'
 ACCEPT_ITEMS = 'Accept=application/geo+json, application/json'
 
 
@@ -86,7 +87,8 @@ def create_landing_page_api_collection(endpoint,
         f.write(json.dumps({
             "links": [
                 {"href": "http://" + endpoint + "/api" + questionmark_extraparam, "rel": "service-desc"},
-                {"href": "http://" + endpoint + "/collections" + questionmark_extraparam, "rel": "data"}
+                {"href": "http://" + endpoint + "/collections" + questionmark_extraparam, "rel": "data"},
+                {"href": "http://" + endpoint + "/conformance" + questionmark_extraparam, "rel": "conformance"},
             ]}).encode('UTF-8'))
 
     # API
@@ -102,6 +104,12 @@ def create_landing_page_api_collection(endpoint,
                     }
                 }
             }
+        }).encode('UTF-8'))
+
+    # conformance
+    with open(sanitize(endpoint, '/conformance?' + add_params(extraparam, ACCEPT_CONFORMANCE)), 'wb') as f:
+        f.write(json.dumps({
+            "conformsTo": ["http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"]
         }).encode('UTF-8'))
 
     # collection
@@ -859,6 +867,13 @@ class TestPyQgsOapifProvider(unittest.TestCase, ProviderTestCase):
         source = vl.dataProvider()
 
         self.assertEqual(source.sourceCrs().authid(), 'EPSG:2056')
+
+        # Test srsname parameter overrides default CRS
+        vl = QgsVectorLayer("url='http://" + endpoint + "' typename='mycollection' srsname='OGC:CRS84'", 'test', 'OAPIF')
+        assert vl.isValid()
+        source = vl.dataProvider()
+
+        self.assertEqual(source.sourceCrs().authid(), 'OGC:CRS84')
 
     def testFeatureCountFallback(self):
 


### PR DESCRIPTION
[OAPIF provider] OGC API features 2 / CRS related fixes (fixes #52228)

- Takes into account storageCrs in /collection response to get the
  default crs in priority
- Append &crs=... to /items requests when the crs is not OGC:CRS84
- Make sure geometry axis order is flipped to easting/northing or
  long/lat when reading geometries from a CRS with inverted axis order
- Report the list of available CRS in the dialog box where one can
  select one
- Resolve "#/crs"

[WFS/OGCAPI] In source select dialog box, better handle list of CRS]

- Use an orderered list instead of a set, so that the first element
  is really the preferred one
- Do not trust the project CRS if the project has no layers: it is
  better to rely on the preferred CRS of the source instead