### PR TITLE
Toggle selected symbols

### DIFF
--- a/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
@@ -83,6 +83,14 @@ transferred to the renderer.
 
     void clearFeatureCounts();
 
+  signals:
+    void toggleSelectedSymbols( const bool state );
+%Docstring
+Signals emitted when a modified key is held and the state is toggled.
+
+.. versionadded:: 3.32
+%End
+
   protected:
 };
 

--- a/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
@@ -84,6 +84,7 @@ transferred to the renderer.
     void clearFeatureCounts();
 
   signals:
+
     void toggleSelectedSymbols( const bool state );
 %Docstring
 Signals emitted when a modified key is held and the state is toggled.

--- a/src/gui/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.h
@@ -91,8 +91,18 @@ class GUI_EXPORT QgsRuleBasedLabelingModel : public QAbstractItemModel
      */
     void finishedAddingRules(); // call endInsertRows
 
+  signals:
+    /**
+     * Signals emitted when a modified key is held and the state is toggled.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
+
+
   protected:
     QgsRuleBasedLabeling::Rule *mRootRule = nullptr;
+
 };
 
 
@@ -128,7 +138,12 @@ class GUI_EXPORT QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui:
     void paste();
     void ruleWidgetPanelAccepted( QgsPanelWidget *panel );
     void liveUpdateRuleFromPanel();
-
+    /**
+     * Slot used to change the state of all selected items.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
   private:
     QgsRuleBasedLabeling::Rule *currentRule();
 

--- a/src/gui/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.h
@@ -92,13 +92,13 @@ class GUI_EXPORT QgsRuleBasedLabelingModel : public QAbstractItemModel
     void finishedAddingRules(); // call endInsertRows
 
   signals:
+
     /**
      * Signals emitted when a modified key is held and the state is toggled.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
-
 
   protected:
     QgsRuleBasedLabeling::Rule *mRootRule = nullptr;
@@ -138,12 +138,14 @@ class GUI_EXPORT QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui:
     void paste();
     void ruleWidgetPanelAccepted( QgsPanelWidget *panel );
     void liveUpdateRuleFromPanel();
+
     /**
      * Slot used to change the state of all selected items.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
+
   private:
     QgsRuleBasedLabeling::Rule *currentRule();
 

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -621,21 +621,21 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
     const QModelIndexList selected = selectionModel()->selectedIndexes();
     if ( ! selected.isEmpty() )
     {
-      QModelIndex layerTreeIndex = mProxyModel->mapToSource( selected.at( 0 ) );
-      bool isFirstNodeChecked;
+      const QModelIndex firstLayerTreeIndex = mProxyModel->mapToSource( selected.at( 0 ) );
+      bool isFirstNodeChecked = false;
 
-      if ( QgsLayerTreeNode *node = layerTreeModel()->index2node( layerTreeIndex ) )
+      if ( QgsLayerTreeNode *node = layerTreeModel()->index2node( firstLayerTreeIndex ) )
       {
         isFirstNodeChecked = node->itemVisibilityChecked();
       }
-      else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( layerTreeIndex ) )
+      else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( firstLayerTreeIndex ) )
       {
          isFirstNodeChecked = legendNode->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
       }
 
       for ( const QModelIndex &index : selected )
       {
-        layerTreeIndex = mProxyModel->mapToSource( index );
+        const QModelIndex layerTreeIndex = mProxyModel->mapToSource( index );
         if ( QgsLayerTreeNode *node = layerTreeModel()->index2node( layerTreeIndex ) )
         {
           node->setItemVisibilityChecked( ! isFirstNodeChecked );

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -620,7 +620,7 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
   {
     const QModelIndexList selected = selectionModel()->selectedIndexes();
     if ( ! selected.isEmpty() )
-    {    
+    {
       QModelIndex layerTreeIndex = mProxyModel->mapToSource( selected.at( 0 ) );
       bool isFirstNodeChecked;
 
@@ -630,9 +630,9 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
       }
       else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( layerTreeIndex ) )
       {
-         isFirstNodeChecked = legendNode->isVisibile(); // TO IMPLEMENT
+         isFirstNodeChecked = legendNode->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
       }
- 
+
       for ( const QModelIndex &index : selected )
       {
         layerTreeIndex = mProxyModel->mapToSource( index );
@@ -642,7 +642,7 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
         }
         else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( layerTreeIndex ) )
         {
-          legendNode->setVisibility( ! isFirstNodeChecked ); // TO IMPLEMENT
+          legendNode->setData( isFirstNodeChecked ? Qt::Unchecked : Qt::Checked, Qt::CheckStateRole );
         }
       }
       // if we call the original keyPress handler, the current item will be checked to the original state yet again

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -618,16 +618,33 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
 {
   if ( event->key() == Qt::Key_Space )
   {
-    const QList<QgsLayerTreeNode *> constSelectedNodes = selectedNodes();
+    const QModelIndexList selected = selectionModel()->selectedIndexes();
+    if ( ! selected.isEmpty() )
+    {    
+      QModelIndex layerTreeIndex = mProxyModel->mapToSource( selected.at( 0 ) );
+      bool isFirstNodeChecked;
 
-    if ( !constSelectedNodes.isEmpty() )
-    {
-      const bool isFirstNodeChecked = constSelectedNodes[0]->itemVisibilityChecked();
-      for ( QgsLayerTreeNode *node : constSelectedNodes )
+      if ( QgsLayerTreeNode *node = layerTreeModel()->index2node( layerTreeIndex ) )
       {
-        node->setItemVisibilityChecked( ! isFirstNodeChecked );
+        isFirstNodeChecked = node->itemVisibilityChecked();
       }
-
+      else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( layerTreeIndex ) )
+      {
+         isFirstNodeChecked = legendNode->isVisibile(); // TO IMPLEMENT
+      }
+ 
+      for ( const QModelIndex &index : selected )
+      {
+        layerTreeIndex = mProxyModel->mapToSource( index );
+        if ( QgsLayerTreeNode *node = layerTreeModel()->index2node( layerTreeIndex ) )
+        {
+          node->setItemVisibilityChecked( ! isFirstNodeChecked );
+        }
+        else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( layerTreeIndex ) )
+        {
+          legendNode->setVisibility( ! isFirstNodeChecked ); // TO IMPLEMENT
+        }
+      }
       // if we call the original keyPress handler, the current item will be checked to the original state yet again
       return;
     }

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -630,7 +630,7 @@ void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
       }
       else if ( QgsLayerTreeModelLegendNode *legendNode = layerTreeModel()->index2legendNode( firstLayerTreeIndex ) )
       {
-         isFirstNodeChecked = legendNode->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
+        isFirstNodeChecked = legendNode->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
       }
 
       for ( const QModelIndex &index : selected )

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
@@ -188,7 +188,12 @@ bool QgsPointCloudClassifiedRendererModel::setData( const QModelIndex &index, co
 
   if ( index.column() == 0 && role == Qt::CheckStateRole )
   {
-    mCategories[ index.row() ].setRenderState( value == Qt::Checked );
+    if ( QGuiApplication::keyboardModifiers() == Qt::ShiftModifier || QGuiApplication::keyboardModifiers() == Qt::ControlModifier )
+    {
+      toggleSelectedSymbols( value == Qt::Checked );
+    }
+    else
+      mCategories[ index.row() ].setRenderState( value == Qt::Checked );
     emit dataChanged( index, index );
     emit categoriesChanged();
     return true;
@@ -421,7 +426,7 @@ QgsPointCloudClassifiedRendererWidget::QgsPointCloudClassifiedRendererWidget( Qg
   connect( btnDeleteCategories, &QAbstractButton::clicked, this, &QgsPointCloudClassifiedRendererWidget::deleteCategories );
   connect( btnDeleteAllCategories, &QAbstractButton::clicked, this, &QgsPointCloudClassifiedRendererWidget::deleteAllCategories );
   connect( btnAddCategory, &QAbstractButton::clicked, this, &QgsPointCloudClassifiedRendererWidget::addCategory );
-
+  connect( mModel, &QgsPointCloudClassifiedRendererModel::toggleSelectedSymbols, this, &QgsPointCloudClassifiedRendererWidget::toggleSelectedSymbols );
 }
 
 QgsPointCloudRendererWidget *QgsPointCloudClassifiedRendererWidget::create( QgsPointCloudLayer *layer, QgsStyle *style, QgsPointCloudRenderer * )
@@ -668,4 +673,24 @@ void QgsPointCloudClassifiedRendererWidget::updateCategoriesPercentages()
   }
   mModel->updateCategoriesPercentages( percentages );
 }
+
+void QgsPointCloudClassifiedRendererWidget::toggleSelectedSymbols( const bool state )
+{
+  QModelIndexList selectedIndexes = viewCategories->selectionModel()->selectedRows();
+  if ( !selectedIndexes.isEmpty() && mModel )
+  {
+    const auto constSelectedIndexes = selectedIndexes;
+    for ( const QModelIndex &idx : constSelectedIndexes )
+    {
+      if ( idx.isValid() )
+      {
+        mModel->category( idx ).setRenderState( state );
+        viewCategories->update( idx );
+      }
+    }
+  emit widgetChanged();
+  }
+}
+
+
 ///@endcond

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.cpp
@@ -688,7 +688,7 @@ void QgsPointCloudClassifiedRendererWidget::toggleSelectedSymbols( const bool st
         viewCategories->update( idx );
       }
     }
-  emit widgetChanged();
+    emit widgetChanged();
   }
 }
 

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
@@ -71,7 +71,7 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererModel : public QAbstractItemMode
 
     /**
      * Signals emitted when a modified key is held and the state is toggled.
-     * 
+     *
      * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
@@ -129,6 +129,7 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererWidget: public QgsPointCloudRend
     void deleteCategories();
     void deleteAllCategories();
     void attributeChanged();
+
     /**
      * Slot used to change the state of all selected items.
      *

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererModel : public QAbstractItemMode
     /**
      * Signals emitted when a modified key is held and the state is toggled.
      * 
-     * \since QGIS 3.28
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 
@@ -131,8 +131,8 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererWidget: public QgsPointCloudRend
     void attributeChanged();
     /**
      * Slot used to change the state of all selected items.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
   private:

--- a/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
+++ b/src/gui/pointcloud/qgspointcloudclassifiedrendererwidget.h
@@ -69,6 +69,13 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererModel : public QAbstractItemMode
   signals:
     void categoriesChanged();
 
+    /**
+     * Signals emitted when a modified key is held and the state is toggled.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
+
   private:
     QgsPointCloudCategoryList mCategories;
     QMap< int, float > mPercentages;
@@ -122,6 +129,12 @@ class GUI_EXPORT QgsPointCloudClassifiedRendererWidget: public QgsPointCloudRend
     void deleteCategories();
     void deleteAllCategories();
     void attributeChanged();
+    /**
+     * Slot used to change the state of all selected items.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
   private:
     //! Sets default category and available classes
     void initialize();

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -63,6 +63,13 @@ class GUI_EXPORT QgsCategorizedSymbolRendererModel : public QAbstractItemModel
   signals:
     void rowsMoved();
 
+    /**
+     * Signals emitted when a modified key is held and the state is toggled.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
+
   private:
     QgsCategorizedSymbolRenderer *mRenderer = nullptr;
     QString mMimeFormat;
@@ -212,6 +219,13 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void showContextMenu( QPoint p );
 
     void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
+
+    /**
+     * Slot used to change the state of all selected items.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
 
   protected:
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -65,8 +65,8 @@ class GUI_EXPORT QgsCategorizedSymbolRendererModel : public QAbstractItemModel
 
     /**
      * Signals emitted when a modified key is held and the state is toggled.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 
@@ -223,7 +223,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     /**
      * Slot used to change the state of all selected items.
      * 
-     * \since QGIS 3.28
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -222,7 +222,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     /**
      * Slot used to change the state of all selected items.
-     * 
+     *
      * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -67,6 +67,13 @@ class GUI_EXPORT QgsGraduatedSymbolRendererModel : public QAbstractItemModel
   signals:
     void rowsMoved();
 
+    /**
+     * Signals emitted when a modified key is held and the state is toggled.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
+
   private:
     QgsGraduatedSymbolRenderer *mRenderer = nullptr;
     QString mMimeFormat;
@@ -150,6 +157,12 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
     void symmetryPointEditingFinished();
     void classifyGraduatedImpl();
+    /**
+     * Slot used to change the state of all selected items.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
 
   protected slots:
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -69,8 +69,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererModel : public QAbstractItemModel
 
     /**
      * Signals emitted when a modified key is held and the state is toggled.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 
@@ -159,8 +159,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void classifyGraduatedImpl();
     /**
      * Slot used to change the state of all selected items.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -157,6 +157,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
     void symmetryPointEditingFinished();
     void classifyGraduatedImpl();
+
     /**
      * Slot used to change the state of all selected items.
      *

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -100,6 +100,14 @@ class GUI_EXPORT QgsRuleBasedRendererModel : public QAbstractItemModel
     void setFeatureCounts( const QHash<QgsRuleBasedRenderer::Rule *, QgsRuleBasedRendererCount> &countMap ) SIP_SKIP;
     void clearFeatureCounts();
 
+  signals:
+    /**
+     * Signals emitted when a modified key is held and the state is toggled.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
+
   protected:
     QgsRuleBasedRenderer *mR = nullptr;
     QHash<QgsRuleBasedRenderer::Rule *, QgsRuleBasedRendererCount> mFeatureCountMap;
@@ -186,6 +194,12 @@ class GUI_EXPORT QgsRuleBasedRendererWidget : public QgsRendererWidget, private 
     void ruleWidgetPanelAccepted( QgsPanelWidget *panel );
     void liveUpdateRuleFromPanel();
     void showContextMenu( QPoint p );
+    /**
+     * Slot used to change the state of all selected items.
+     * 
+     * \since QGIS 3.28
+     */
+    void toggleSelectedSymbols( const bool state );
 };
 
 ///////

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -101,10 +101,11 @@ class GUI_EXPORT QgsRuleBasedRendererModel : public QAbstractItemModel
     void clearFeatureCounts();
 
   signals:
+
     /**
      * Signals emitted when a modified key is held and the state is toggled.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 
@@ -194,10 +195,11 @@ class GUI_EXPORT QgsRuleBasedRendererWidget : public QgsRendererWidget, private 
     void ruleWidgetPanelAccepted( QgsPanelWidget *panel );
     void liveUpdateRuleFromPanel();
     void showContextMenu( QPoint p );
+
     /**
      * Slot used to change the state of all selected items.
-     * 
-     * \since QGIS 3.28
+     *
+     * \since QGIS 3.32
      */
     void toggleSelectedSymbols( const bool state );
 };


### PR DESCRIPTION
## Description

I've been sitting on this one for a while. Allows to toggle multiple symbols with a shift click in the symbology widgets and the spacebar (as currently possible) in the layertree.

It should slightly speed up toggling layers and allow symbols to be selected (I couldn't see a downside to allowing this).

![mass_symbol_toggle](https://user-images.githubusercontent.com/12854129/227596340-cc077a8e-ff56-4e26-93cb-51723585f936.gif)

