### PR TITLE
Allow Python console to be toggled between a doc  widget and a full main window dialog

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -120,10 +120,6 @@ class PythonConsole(QgsCodeEditorDockWidget):
         self.setLayout(vl)
         self.setFocusProxy(self.console)
 
-        # try to restore position from stored main window state
-        #if iface and not iface.mainWindow().restoreDockWidget(self):
-        #    iface.mainWindow().addDockWidget(Qt.BottomDockWidgetArea, self)
-
         # closeEvent is not always called for this widget -- so we also trigger a settings
         # save on application exit
         QgsApplication.instance().aboutToQuit.connect(self.on_app_exit)

--- a/python/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditordockwidget.sip.in
@@ -1,0 +1,81 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/codeeditors/qgscodeeditordockwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsCodeEditorDockWidget : QWidget
+{
+%Docstring(signature="appended")
+A custom dock widget for code editors.
+
+.. warning::
+
+   Exposed to Python for internal use only -- this class is not considered stable API.
+
+.. versionadded:: 3.32
+%End
+
+%TypeHeaderCode
+#include "qgscodeeditordockwidget.h"
+%End
+  public:
+
+    QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+%Docstring
+Constructor for QgsCodeEditorDockWidget, with the specified window geometry settings key.
+
+If ``usePersistentWidget`` is ``True`` then the widget (either as a dock or window) cannot be destroyed and must be hidden instead.
+%End
+    ~QgsCodeEditorDockWidget();
+
+    void setTitle( const QString &title );
+%Docstring
+Sets the title to use for the code editor dock widget or window.
+%End
+
+    QToolButton *dockToggleButton();
+%Docstring
+Returns the dock toggle button for the widget, which is used to toggle between dock or full window mode.
+%End
+
+    void setDockObjectName( const QString &name );
+%Docstring
+Sets the object name of the dock widget
+%End
+
+    bool isUserVisible() const;
+%Docstring
+Returns ``True`` if the widget is user visible.
+%End
+
+  public slots:
+
+    void setUserVisible( bool visible );
+%Docstring
+Sets whether the editor is user visible.
+%End
+
+  signals:
+
+    void visibilityChanged( bool isVisible );
+%Docstring
+Emitted when the editor's visibility is changed.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/codeeditors/qgscodeeditordockwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -285,6 +285,7 @@
 %If ( HAVE_QSCI_SIP )
 %Include auto_generated/codeeditors/qgscodeeditorcss.sip
 %End
+%Include auto_generated/codeeditors/qgscodeeditordockwidget.sip
 %If ( HAVE_QSCI_SIP )
 %Include auto_generated/codeeditors/qgscodeeditorexpression.sip
 %End

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -74,7 +74,6 @@ set(QGIS_APP_SRCS
   qgsrecentprojectsitemsmodel.cpp
   qgsvectorlayerdigitizingproperties.cpp
   qgswelcomepage.cpp
-  qgsdockablewidgethelper.cpp
 
   qgsmaptooladdfeature.cpp
   qgsmaptooladdpart.cpp

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -128,6 +128,8 @@
 
 #include "canvas/qgscanvasrefreshblocker.h"
 
+#include "qgsdockablewidgethelper.h"
+
 #ifdef HAVE_3D
 #include "qgs3d.h"
 #include "qgs3danimationsettings.h"
@@ -972,6 +974,15 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   mScreenHelper = new QgsScreenHelper( this );
 
   setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
+
+  QgsDockableWidgetHelper::sAddTabifiedDockWidgetFunction = []( Qt::DockWidgetArea dockArea, QDockWidget * dock, const QStringList & tabSiblings, bool raiseTab )
+  {
+    QgisApp::instance()->addTabifiedDockWidget( dockArea, dock, tabSiblings, raiseTab );
+  };
+  QgsDockableWidgetHelper::sAppStylesheetFunction = []()->QString
+  {
+    return QgisApp::instance()->styleSheet();
+  };
 
   //////////
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -983,6 +983,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   {
     return QgisApp::instance()->styleSheet();
   };
+  QgsDockableWidgetHelper::sOwnerWindow = QgisApp::instance();
 
   //////////
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -497,6 +497,7 @@ set(QGIS_GUI_SRCS
   qgsdial.cpp
   qgsdialog.cpp
   qgsdirectionallightwidget.cpp
+  qgsdockablewidgethelper.cpp
   qgsdoublevalidator.cpp
   qgsdockwidget.cpp
   qgsencodingfiledialog.cpp
@@ -766,6 +767,7 @@ set(QGIS_GUI_HDRS
   qgsdial.h
   qgsdialog.h
   qgsdirectionallightwidget.h
+  qgsdockablewidgethelper.h
   qgsdockwidget.h
   qgsdoublevalidator.h
   qgsencodingfiledialog.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -141,6 +141,7 @@ set(QGIS_GUI_SRCS
   codeeditors/qgscodeeditorcolorscheme.cpp
   codeeditors/qgscodeeditorcolorschemeregistry.cpp
   codeeditors/qgscodeeditorcss.cpp
+  codeeditors/qgscodeeditordockwidget.cpp
   codeeditors/qgscodeeditorhistorydialog.cpp
   codeeditors/qgscodeeditorhtml.cpp
   codeeditors/qgscodeeditorjs.cpp
@@ -1033,6 +1034,7 @@ set(QGIS_GUI_HDRS
   codeeditors/qgscodeeditorcolorscheme.h
   codeeditors/qgscodeeditorcolorschemeregistry.h
   codeeditors/qgscodeeditorcss.h
+  codeeditors/qgscodeeditordockwidget.h
   codeeditors/qgscodeeditorexpression.h
   codeeditors/qgscodeeditorhistorydialog.h
   codeeditors/qgscodeeditorhtml.h

--- a/src/gui/codeeditors/qgscodeeditordockwidget.cpp
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+  qgscodeeditordockwidget.cpp
+  --------------------------------------
+  Date                 : March 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscodeeditordockwidget.h"
+#include "qgsdockablewidgethelper.h"
+
+QgsCodeEditorDockWidget::QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey, bool usePersistentWidget )
+  : QWidget( nullptr )
+{
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( true, tr( "Code Editor" ),
+      this, QgsDockableWidgetHelper::sOwnerWindow, Qt::BottomDockWidgetArea, QStringList(), true, windowGeometrySettingsKey, usePersistentWidget );
+
+  mDockToggleButton = mDockableWidgetHelper->createDockUndockToolButton();
+  mDockToggleButton->setToolTip( tr( "Dock Code Editor" ) );
+  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [ = ]()
+  {
+    close();
+  } );
+
+  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::visibilityChanged, this, &QgsCodeEditorDockWidget::visibilityChanged );
+}
+
+QgsCodeEditorDockWidget::~QgsCodeEditorDockWidget()
+{
+  delete mDockableWidgetHelper;
+}
+
+void QgsCodeEditorDockWidget::setTitle( const QString &title )
+{
+  mDockableWidgetHelper->setWindowTitle( title );
+}
+
+QToolButton *QgsCodeEditorDockWidget::dockToggleButton()
+{
+  return mDockToggleButton;
+}
+
+void QgsCodeEditorDockWidget::setDockObjectName( const QString &name )
+{
+  mDockableWidgetHelper->setDockObjectName( name );
+}
+
+bool QgsCodeEditorDockWidget::isUserVisible() const
+{
+  return mDockableWidgetHelper->isUserVisible();
+}
+
+void QgsCodeEditorDockWidget::setUserVisible( bool visible )
+{
+  mDockableWidgetHelper->setUserVisible( visible );
+}

--- a/src/gui/codeeditors/qgscodeeditordockwidget.h
+++ b/src/gui/codeeditors/qgscodeeditordockwidget.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+  qgscodeeditordockwidget.h
+  --------------------------------------
+  Date                 : March 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCODEEDITORDOCKWIDGET_H
+#define QGSCODEEDITORDOCKWIDGET_H
+
+#include "qgis_gui.h"
+
+#include <QWidget>
+
+class QgsDockableWidgetHelper;
+class QToolButton;
+
+
+/**
+ * A custom dock widget for code editors.
+ *
+ * \warning Exposed to Python for internal use only -- this class is not considered stable API.
+ *
+ * \ingroup gui
+ * \since QGIS 3.32
+ */
+class GUI_EXPORT QgsCodeEditorDockWidget : public QWidget
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsCodeEditorDockWidget, with the specified window geometry settings key.
+     *
+     * If \a usePersistentWidget is TRUE then the widget (either as a dock or window) cannot be destroyed and must be hidden instead.
+     */
+    QgsCodeEditorDockWidget( const QString &windowGeometrySettingsKey = QString(), bool usePersistentWidget = false );
+    ~QgsCodeEditorDockWidget() override;
+
+    /**
+     * Sets the title to use for the code editor dock widget or window.
+     */
+    void setTitle( const QString &title );
+
+    /**
+     * Returns the dock toggle button for the widget, which is used to toggle between dock or full window mode.
+     */
+    QToolButton *dockToggleButton();
+
+    //! Sets the object name of the dock widget
+    void setDockObjectName( const QString &name );
+
+    /**
+     * Returns TRUE if the widget is user visible.
+     */
+    bool isUserVisible() const;
+
+  public slots:
+
+    /**
+     * Sets whether the editor is user visible.
+     */
+    void setUserVisible( bool visible );
+
+  signals:
+
+    /**
+     * Emitted when the editor's visibility is changed.
+     */
+    void visibilityChanged( bool isVisible );
+
+  private:
+
+    QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
+    QToolButton *mDockToggleButton = nullptr;
+
+
+};
+
+#endif // QGSCODEEDITORDOCKWIDGET_H

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -57,10 +57,13 @@ QgsDockableWidgetHelper::~QgsDockableWidgetHelper()
   {
     mDockGeometry = mDock->geometry();
     mIsDockFloating = mDock->isFloating();
-    mDockArea = mOwnerWindow->dockWidgetArea( mDock );
+    if ( mOwnerWindow )
+      mDockArea = mOwnerWindow->dockWidgetArea( mDock );
 
     mDock->setWidget( nullptr );
-    mOwnerWindow->removeDockWidget( mDock );
+
+    if ( mOwnerWindow )
+      mOwnerWindow->removeDockWidget( mDock );
     mDock->deleteLater();
     mDock = nullptr;
   }
@@ -88,7 +91,8 @@ void QgsDockableWidgetHelper::writeXml( QDomElement &viewDom )
   {
     mDockGeometry = mDock->geometry();
     mIsDockFloating = mDock->isFloating();
-    mDockArea = mOwnerWindow->dockWidgetArea( mDock );
+    if ( mOwnerWindow )
+      mDockArea = mOwnerWindow->dockWidgetArea( mDock );
   }
 
   viewDom.setAttribute( QStringLiteral( "x" ), mDockGeometry.x() );
@@ -101,7 +105,7 @@ void QgsDockableWidgetHelper::writeXml( QDomElement &viewDom )
 
   if ( mDock )
   {
-    const QList<QDockWidget * > tabSiblings = mOwnerWindow->tabifiedDockWidgets( mDock );
+    const QList<QDockWidget * > tabSiblings = mOwnerWindow ? mOwnerWindow->tabifiedDockWidgets( mDock ) : QList<QDockWidget * >();
     QDomElement tabSiblingsElement = viewDom.ownerDocument().createElement( QStringLiteral( "tab_siblings" ) );
     for ( QDockWidget *dock : tabSiblings )
     {
@@ -171,7 +175,7 @@ void QgsDockableWidgetHelper::readXml( const QDomElement &viewDom )
 void QgsDockableWidgetHelper::setWidget( QWidget *widget )
 {
   // Make sure the old mWidget is not stuck as a child of mDialog or mDock
-  if ( mWidget )
+  if ( mWidget && mOwnerWindow )
   {
     mWidget->setParent( mOwnerWindow );
   }
@@ -201,7 +205,7 @@ QDialog *QgsDockableWidgetHelper::dialog()
 void QgsDockableWidgetHelper::toggleDockMode( bool docked )
 {
   // Make sure the old mWidget is not stuck as a child of mDialog or mDock
-  if ( mWidget )
+  if ( mWidget && mOwnerWindow )
   {
     mWidget->setParent( mOwnerWindow );
   }
@@ -211,10 +215,12 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
   {
     mDockGeometry = mDock->geometry();
     mIsDockFloating = mDock->isFloating();
-    mDockArea = mOwnerWindow->dockWidgetArea( mDock );
+    if ( mOwnerWindow )
+      mDockArea = mOwnerWindow->dockWidgetArea( mDock );
 
     mDock->setWidget( nullptr );
-    mOwnerWindow->removeDockWidget( mDock );
+    if ( mOwnerWindow )
+      mOwnerWindow->removeDockWidget( mDock );
     delete mDock;
     mDock = nullptr;
   }
@@ -254,7 +260,8 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     {
       mDockGeometry = mDock->geometry();
       mIsDockFloating = mDock->isFloating();
-      mDockArea = mOwnerWindow->dockWidgetArea( mDock );
+      if ( mOwnerWindow )
+        mDockArea = mOwnerWindow->dockWidgetArea( mDock );
       emit closed();
     } );
 
@@ -380,7 +387,7 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
     return;
 
   mDock->setFloating( mIsDockFloating );
-  if ( mDockGeometry.isEmpty() )
+  if ( mDockGeometry.isEmpty() && mOwnerWindow )
   {
     const QFontMetrics fm( mOwnerWindow->font() );
     const int initialDockSize = fm.horizontalAdvance( '0' ) * 50;
@@ -396,7 +403,7 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
   {
     sAddTabifiedDockWidgetFunction( mDockArea, mDock, mTabifyWith, mRaiseTab );
   }
-  else
+  else if ( mOwnerWindow )
   {
     mOwnerWindow->addDockWidget( mDockArea, mDock );
   }

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -17,9 +17,17 @@
 
 #include "qgsdockwidget.h"
 #include "qgsapplication.h"
-#include "qgisapp.h"
+#include "qgssettings.h"
+
 #include <QLayout>
 #include <QAction>
+#include <QUuid>
+
+///@cond PRIVATE
+
+
+std::function< void( Qt::DockWidgetArea, QDockWidget *, const QStringList &, bool ) > QgsDockableWidgetHelper::sAddTabifiedDockWidgetFunction = []( Qt::DockWidgetArea, QDockWidget *, const QStringList &, bool ) {};
+std::function< QString( ) > QgsDockableWidgetHelper::sAppStylesheetFunction = [] { return QString(); };
 
 QgsDockableWidgetHelper::QgsDockableWidgetHelper( bool isDocked, const QString &windowTitle, QWidget *widget, QMainWindow *ownerWindow,
     Qt::DockWidgetArea defaultDockArea,
@@ -243,7 +251,7 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     // note -- we explicitly DO NOT set the parent for the dialog, as we want these treated as
     // proper top level windows and have their own taskbar entries. See https://github.com/qgis/QGIS/issues/49286
     mDialog = new QDialog( nullptr, Qt::Window );
-    mDialog->setStyleSheet( QgisApp::instance()->styleSheet() );
+    mDialog->setStyleSheet( sAppStylesheetFunction() );
 
     mDialog->setWindowTitle( mWindowTitle );
     QVBoxLayout *vl = new QVBoxLayout();
@@ -304,11 +312,11 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
   }
   if ( !tabSiblings.isEmpty() )
   {
-    QgisApp::instance()->addTabifiedDockWidget( mDockArea, mDock, tabSiblings, false );
+    sAddTabifiedDockWidgetFunction( mDockArea, mDock, tabSiblings, false );
   }
   else if ( mRaiseTab )
   {
-    QgisApp::instance()->addTabifiedDockWidget( mDockArea, mDock, mTabifyWith, mRaiseTab );
+    sAddTabifiedDockWidgetFunction( mDockArea, mDock, mTabifyWith, mRaiseTab );
   }
   else
   {
@@ -341,3 +349,5 @@ QAction *QgsDockableWidgetHelper::createDockUndockAction( const QString &title, 
   connect( toggleAction, &QAction::toggled, this, &QgsDockableWidgetHelper::toggleDockMode );
   return toggleAction;
 }
+
+///@endcond

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -52,7 +52,6 @@ QgsDockableWidgetHelper::QgsDockableWidgetHelper( bool isDocked, const QString &
 
 QgsDockableWidgetHelper::~QgsDockableWidgetHelper()
 {
-  setWidget( nullptr );
   if ( mDock )
   {
     mDockGeometry = mDock->geometry();

--- a/src/gui/qgsdockablewidgethelper.h
+++ b/src/gui/qgsdockablewidgethelper.h
@@ -16,7 +16,7 @@
 #ifndef QGSDOCKABLEWIDGETHELPER_H
 #define QGSDOCKABLEWIDGETHELPER_H
 
-#include "qgis_app.h"
+#include "qgis_gui.h"
 
 #include <QDialog>
 #include <QToolButton>
@@ -27,14 +27,19 @@
 
 class QgsDockWidget;
 
+///@cond PRIVATE
+
 /**
  * This class is responible of displaying a QWidget inside a top level window or a dock widget (only one of the 2 is alive at most).
  * The widget is not owned by this class and its ownership is passed to the owner window before this class's object is deleted or
  * another widget is set using setWidget() function
  *
+ * \note Not available from Python bindings
+ *
+ * \ingroup gui
  * \since QGIS 3.24
  */
-class APP_EXPORT QgsDockableWidgetHelper : public QObject
+class GUI_EXPORT QgsDockableWidgetHelper : public QObject
 {
     Q_OBJECT
   public:
@@ -79,6 +84,9 @@ class APP_EXPORT QgsDockableWidgetHelper : public QObject
      */
     QAction *createDockUndockAction( const QString &title, QWidget *parent );
 
+    static std::function< void( Qt::DockWidgetArea, QDockWidget *, const QStringList &, bool ) > sAddTabifiedDockWidgetFunction;
+    static std::function< QString( ) > sAppStylesheetFunction;
+
   signals:
     void closed();
 
@@ -112,5 +120,7 @@ class APP_EXPORT QgsDockableWidgetHelper : public QObject
     // Unique identifier of dock
     QString mUuid;
 };
+
+///@endcond
 
 #endif // QGSDOCKABLEWIDGETHELPER_H


### PR DESCRIPTION
Adds the same toggle button as we use for 3d map canvases and attribute tables to make it super-easy to switch the Python console to a full main window.