### PR TITLE
Python console UX tweaks

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -137,7 +137,11 @@ class PythonInterpreter(QgsCodeInterpreter, code.InteractiveInterpreter):
 class ShellScintilla(QgsCodeEditorPython):
 
     def __init__(self, parent=None):
-        super().__init__(parent, [], QgsCodeEditor.Mode.CommandInput)
+        # We set the ImmediatelyUpdateHistory flag here, as users can easily
+        # crash QGIS by entering a Python command, and we don't want the
+        # history leading to the crash lost..
+        super().__init__(parent, [], QgsCodeEditor.Mode.CommandInput,
+                         flags=QgsCodeEditor.Flags(QgsCodeEditor.Flag.CodeFolding | QgsCodeEditor.Flag.ImmediatelyUpdateHistory))
 
         self.parent = parent
         self._interpreter = PythonInterpreter()

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -303,7 +303,7 @@ class ShellScintilla(QgsCodeEditorPython):
 
         try:
             # Run the file
-            self.runCommand("exec(Path('{0}').read_text())".format(filename))
+            self.runCommand("exec(Path('{0}').read_text())".format(filename), skipHistory=True)
         finally:
             # Remove the directory from the path and delete the __file__ variable
             self._interpreter.execCommandImpl("del __file__", False)

--- a/python/gui/auto_additions/qgscodeeditor.py
+++ b/python/gui/auto_additions/qgscodeeditor.py
@@ -21,7 +21,8 @@ QgsCodeEditor.MarginRole.__doc__ = 'Margin roles.\n\nThis enum contains the role
 QgsCodeEditor.MarginRole.baseClass = QgsCodeEditor
 # monkey patching scoped based enum
 QgsCodeEditor.Flag.CodeFolding.__doc__ = "Indicates that code folding should be enabled for the editor"
-QgsCodeEditor.Flag.__doc__ = 'Flags controlling behavior of code editor\n\n.. versionadded:: 3.28\n\n' + '* ``CodeFolding``: ' + QgsCodeEditor.Flag.CodeFolding.__doc__
+QgsCodeEditor.Flag.ImmediatelyUpdateHistory.__doc__ = "Indicates that the history file should be immediately updated whenever a command is executed, instead of the default behavior of only writing the history on widget close. Since QGIS 3.32."
+QgsCodeEditor.Flag.__doc__ = 'Flags controlling behavior of code editor\n\n.. versionadded:: 3.28\n\n' + '* ``CodeFolding``: ' + QgsCodeEditor.Flag.CodeFolding.__doc__ + '\n' + '* ``ImmediatelyUpdateHistory``: ' + QgsCodeEditor.Flag.ImmediatelyUpdateHistory.__doc__
 # --
 QgsCodeEditor.Flag.baseClass = QgsCodeEditor
 QgsCodeEditor.Flags.baseClass = QgsCodeEditor

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -99,6 +99,7 @@ A text editor based on QScintilla2.
     enum class Flag
     {
       CodeFolding,
+      ImmediatelyUpdateHistory,
     };
 
     typedef QFlags<QgsCodeEditor::Flag> Flags;

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -329,11 +329,14 @@ is in the QgsCodeEditor.Mode.CommandInput mode.
 
   public slots:
 
-    void runCommand( const QString &command );
+    void runCommand( const QString &command, bool skipHistory = false );
 %Docstring
 Runs a command in the editor.
 
 An :py:func:`~QgsCodeEditor.interpreter` must be set.
+
+Since QGIS 3.32, if ``skipHistory`` is ``True`` then the command will not be automatically
+added to the widget's history.
 
 .. versionadded:: 3.30
 %End

--- a/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -31,13 +31,14 @@ code autocompletion.
 
 
     QgsCodeEditorPython( QWidget *parent /TransferThis/ = 0, const QList<QString> &filenames = QList<QString>(),
-                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
+                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor, QgsCodeEditor::Flags flags = QgsCodeEditor::Flag::CodeFolding );
 %Docstring
 Construct a new Python editor.
 
 :param parent: The parent QWidget
 :param filenames: The list of apis files to load for the Python lexer
 :param mode: code editor mode (since QGIS 3.30)
+:param flags: code editor flags (since QGIS 3.32)
 
 .. versionadded:: 2.6
 %End

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -758,9 +758,10 @@ QStringList QgsCodeEditor::history() const
   return mHistory;
 }
 
-void QgsCodeEditor::runCommand( const QString &command )
+void QgsCodeEditor::runCommand( const QString &command, bool skipHistory )
 {
-  updateHistory( { command } );
+  if ( !skipHistory )
+    updateHistory( { command } );
 
   if ( mInterpreter )
     mInterpreter->exec( command );

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -761,7 +761,11 @@ QStringList QgsCodeEditor::history() const
 void QgsCodeEditor::runCommand( const QString &command, bool skipHistory )
 {
   if ( !skipHistory )
+  {
     updateHistory( { command } );
+    if ( mFlags & QgsCodeEditor::Flag::ImmediatelyUpdateHistory )
+      writeHistoryFile();
+  }
 
   if ( mInterpreter )
     mInterpreter->exec( command );

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -366,9 +366,12 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      *
      * An interpreter() must be set.
      *
+     * Since QGIS 3.32, if \a skipHistory is TRUE then the command will not be automatically
+     * added to the widget's history.
+     *
      * \since QGIS 3.30
      */
-    void runCommand( const QString &command );
+    void runCommand( const QString &command, bool skipHistory = false );
 
     /**
      * Moves the cursor to the start of the document and scrolls to ensure

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -139,6 +139,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     enum class Flag : int
     {
       CodeFolding = 1 << 0, //!< Indicates that code folding should be enabled for the editor
+      ImmediatelyUpdateHistory = 1 << 1, //!< Indicates that the history file should be immediately updated whenever a command is executed, instead of the default behavior of only writing the history on widget close. Since QGIS 3.32.
     };
     Q_ENUM( Flag )
 

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -51,12 +51,13 @@ const QgsSettingsEntryBool *QgsCodeEditorPython::settingBlackNormalizeQuotes = n
 ///@endcond PRIVATE
 
 
-QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> &filenames, Mode mode )
+QgsCodeEditorPython::QgsCodeEditorPython( QWidget *parent, const QList<QString> &filenames, Mode mode, Flags flags )
   : QgsCodeEditor( parent,
                    QString(),
                    false,
                    false,
-                   QgsCodeEditor::Flag::CodeFolding, mode )
+                   flags,
+                   mode )
   , mAPISFilesList( filenames )
 {
   if ( !parent )

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -71,10 +71,11 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
      * \param parent The parent QWidget
      * \param filenames The list of apis files to load for the Python lexer
      * \param mode code editor mode (since QGIS 3.30)
+     * \param flags code editor flags (since QGIS 3.32)
      * \since QGIS 2.6
      */
     QgsCodeEditorPython( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QList<QString> &filenames = QList<QString>(),
-                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor );
+                         QgsCodeEditor::Mode mode = QgsCodeEditor::Mode::ScriptEditor, QgsCodeEditor::Flags flags = QgsCodeEditor::Flag::CodeFolding );
 
     Qgis::ScriptLanguage language() const override;
     Qgis::ScriptLanguageCapabilities languageCapabilities() const override;


### PR DESCRIPTION
- Don't add 'exec(Path(...))' entries to console history when running scripts. These just clutter the history.
- Immediately write out the console history file BEFORE running commands. This prevents loss of history when a user enters a Python command which results in a QGIS crash