### PR TITLE
Secondary canvas extent options should be checkboxes, not radio buttons

### DIFF
--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -122,29 +122,34 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   mActionShowLabels->setChecked( true );
   connect( mActionShowLabels, &QAction::toggled, this, &QgsMapCanvasDockWidget::showLabels );
 
-
-  mSyncExtentRadio = settingsAction->syncExtentRadio();
-  mSyncSelectionRadio = settingsAction->syncSelectionRadio();
+  mSyncExtentCheck = settingsAction->syncExtentCheck();
+  mSyncSelectionCheck = settingsAction->syncSelectionCheck();
   mScaleCombo = settingsAction->scaleCombo();
   mRotationEdit = settingsAction->rotationSpinBox();
   mMagnificationEdit = settingsAction->magnifierSpinBox();
   mSyncScaleCheckBox = settingsAction->syncScaleCheckBox();
   mScaleFactorWidget = settingsAction->scaleFactorSpinBox();
 
-  connect( mSyncSelectionRadio, &QRadioButton::toggled, this, [ = ]( bool checked )
+  connect( mSyncSelectionCheck, &QCheckBox::toggled, this, [ = ]( bool checked )
   {
     autoZoomToSelection( checked );
     if ( checked )
     {
       syncSelection();
+
+      // sync extent and selection options are mutually exclusive
+      whileBlocking( mSyncExtentCheck )->setChecked( false );
     }
   } );
 
-  connect( mSyncExtentRadio, &QRadioButton::toggled, this, [ = ]( bool checked )
+  connect( mSyncExtentCheck, &QCheckBox::toggled, this, [ = ]( bool checked )
   {
     if ( checked )
     {
       syncViewCenter( mMainCanvas );
+
+      // sync extent and selection options are mutually exclusive
+      whileBlocking( mSyncSelectionCheck )->setChecked( false );
     }
   } );
 
@@ -221,7 +226,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   connect( &mResizeTimer, &QTimer::timeout, this, [ = ]
   {
     mBlockExtentSync = false;
-    if ( mSyncExtentRadio->isChecked() )
+    if ( mSyncExtentCheck->isChecked() )
       syncViewCenter( mMainCanvas );
   } );
 
@@ -256,22 +261,22 @@ QgsMapCanvas *QgsMapCanvasDockWidget::mapCanvas()
 
 void QgsMapCanvasDockWidget::setViewCenterSynchronized( bool enabled )
 {
-  mSyncExtentRadio->setChecked( enabled );
+  mSyncExtentCheck->setChecked( enabled );
 }
 
 bool QgsMapCanvasDockWidget::isViewCenterSynchronized() const
 {
-  return mSyncExtentRadio->isChecked();
+  return mSyncExtentCheck->isChecked();
 }
 
 bool QgsMapCanvasDockWidget::isAutoZoomToSelected() const
 {
-  return mSyncSelectionRadio->isChecked();
+  return mSyncSelectionCheck->isChecked();
 }
 
 void QgsMapCanvasDockWidget::setAutoZoomToSelected( bool autoZoom )
 {
-  mSyncSelectionRadio->setChecked( autoZoom );
+  mSyncSelectionCheck->setChecked( autoZoom );
 }
 
 void QgsMapCanvasDockWidget::setCursorMarkerVisible( bool visible )
@@ -391,7 +396,7 @@ void QgsMapCanvasDockWidget::mapExtentChanged()
     mScaleFactorWidget->setValue( newScaleFactor );
   }
 
-  if ( mSyncExtentRadio->isChecked() )
+  if ( mSyncExtentCheck->isChecked() )
     syncViewCenter( sourceCanvas );
 }
 
@@ -536,11 +541,11 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   QGridLayout *gLayout = new QGridLayout();
   gLayout->setContentsMargins( 3, 2, 3, 2 );
 
-  mSyncExtentRadio = new QRadioButton( tr( "Synchronize View Center with Main Map" ) );
-  gLayout->addWidget( mSyncExtentRadio, 0, 0, 1, 2 );
+  mSyncExtentCheck = new QCheckBox( tr( "Synchronize View Center with Main Map" ) );
+  gLayout->addWidget( mSyncExtentCheck, 0, 0, 1, 2 );
 
-  mSyncSelectionRadio = new QRadioButton( tr( "Synchronize View to Selection" ) );
-  gLayout->addWidget( mSyncSelectionRadio, 1, 0, 1, 2 );
+  mSyncSelectionCheck = new QCheckBox( tr( "Synchronize View to Selection" ) );
+  gLayout->addWidget( mSyncSelectionCheck, 1, 0, 1, 2 );
 
   QLabel *label = new QLabel( tr( "Scale" ) );
   gLayout->addWidget( label, 2, 0 );

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -173,8 +173,8 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapCanvas *mMainCanvas = nullptr;
     QMenu *mMenu = nullptr;
     QList<QAction *> mMenuPresetActions;
-    QRadioButton *mSyncExtentRadio = nullptr;
-    QRadioButton *mSyncSelectionRadio = nullptr;
+    QCheckBox *mSyncExtentCheck = nullptr;
+    QCheckBox *mSyncSelectionCheck = nullptr;
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationEdit = nullptr;
     QgsDoubleSpinBox *mMagnificationEdit = nullptr;
@@ -206,8 +206,8 @@ class QgsMapSettingsAction: public QWidgetAction
 
     QgsMapSettingsAction( QWidget *parent = nullptr );
 
-    QRadioButton *syncExtentRadio() { return mSyncExtentRadio; }
-    QRadioButton *syncSelectionRadio() { return mSyncSelectionRadio; }
+    QCheckBox *syncExtentCheck() { return mSyncExtentCheck; }
+    QCheckBox *syncSelectionCheck() { return mSyncSelectionCheck; }
     QgsScaleComboBox *scaleCombo() { return mScaleCombo; }
     QgsDoubleSpinBox *rotationSpinBox() { return mRotationWidget; }
     QgsDoubleSpinBox *magnifierSpinBox() { return mMagnifierWidget; }
@@ -215,8 +215,8 @@ class QgsMapSettingsAction: public QWidgetAction
     QCheckBox *syncScaleCheckBox() { return mSyncScaleCheckBox; }
 
   private:
-    QRadioButton *mSyncSelectionRadio = nullptr;
-    QRadioButton *mSyncExtentRadio = nullptr;
+    QCheckBox *mSyncSelectionCheck = nullptr;
+    QCheckBox *mSyncExtentCheck = nullptr;
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationWidget = nullptr;
     QgsDoubleSpinBox *mMagnifierWidget = nullptr;


### PR DESCRIPTION
Otherwise it is IMPOSSIBLE to disable one of the "sync extent" options after enabling them!
