### PR TITLE
Map tip preview

### DIFF
--- a/python/gui/auto_generated/qgsmaptip.sip.in
+++ b/python/gui/auto_generated/qgsmaptip.sip.in
@@ -69,6 +69,22 @@ Clear the current maptip if it exists
 Apply font family and size to match user settings
 %End
 
+    static QString vectorMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *mapCanvas, const QString &mapTemplate, const QString &displayExpression );
+%Docstring
+Returns the html that would be displayed in a maptip for a given layer. If the layer has features, the first feature is used
+to evaluate the expressions.
+
+.. versionadded:: 3.32
+%End
+
+    static QString rasterMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *mapCanvas, const QString &mapTemplate );
+%Docstring
+Returns the html that would be displayed in a maptip for a given layer. The center pixel of the raster is used to
+evaluate the expressions.
+
+.. versionadded:: 3.32
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -46,6 +46,9 @@ Adds a properties page factory to the raster layer properties dialog.
     virtual QgsExpressionContext createExpressionContext() const;
 
 
+    virtual bool eventFilter( QObject *obj, QEvent *ev );
+
+
   protected slots:
 
 };

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -27,6 +27,9 @@ class QgsVectorLayerProperties : QgsOptionsDialogBase
 Adds a properties page factory to the vector layer properties dialog.
 %End
 
+    virtual bool eventFilter( QObject *obj, QEvent *ev );
+
+
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -75,11 +75,12 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   // Do not render a new map tip when the mouse hovers an existing one
   if ( mWidget && mWidget->underMouse() )
+  {
     return;
+  }
 
   // Show the maptip on the canvas
-  QString tipText, lastTipText, tipHtml, bodyStyle, containerStyle,
-          backgroundColor, strokeColor, textColor;
+  QString tipText, lastTipText, tipHtml, backgroundColor, strokeColor;
 
   if ( ! mWidget )
   {
@@ -193,11 +194,15 @@ void QgsMapTip::resizeContent()
 void QgsMapTip::clear( QgsMapCanvas *, int msDelay )
 {
   if ( !mMapTipVisible )
+  {
     return;
+  }
 
   // Skip clearing the map tip if the user interacts with it or the timer still runs
   if ( mDelayedClearTimer.isActive() || mWidget->underMouse() )
+  {
     return;
+  }
 
   if ( msDelay > 0 )
   {
@@ -215,7 +220,9 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer || !vlayer->isSpatial() )
+  {
     return QString();
+  }
 
   if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) ||
        ( mapCanvas->mapSettings().isTemporal() && !layer->temporalProperties()->isVisibleInTemporalRange( mapCanvas->temporalRange() ) ) )
@@ -239,7 +246,9 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
 
   const QString canvasFilter = QgsMapCanvasUtils::filterForLayer( mapCanvas, vlayer );
   if ( canvasFilter ==  QLatin1String( "FALSE" ) )
+  {
     return QString();
+  }
 
   const QString mapTip = vlayer->mapTipTemplate();
   QString tipString;
@@ -250,7 +259,9 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
   request.setFilterRect( r );
   request.setFlags( QgsFeatureRequest::ExactIntersect );
   if ( !canvasFilter.isEmpty() )
+  {
     request.setFilterExpression( canvasFilter );
+  }
 
   if ( mapTip.isEmpty() )
   {
@@ -307,7 +318,9 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
   }
 
   if ( renderer )
+  {
     renderer->stopRender( renderCtx );
+  }
 
   return tipString;
 }
@@ -316,19 +329,27 @@ QString QgsMapTip::fetchRaster( QgsMapLayer *layer, QgsPointXY &mapPosition, Qgs
 {
   QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer );
   if ( !rlayer )
+  {
     return QString();
+  }
 
   if ( !layer->isInScaleRange( mapCanvas->mapSettings().scale() ) ||
        ( mapCanvas->mapSettings().isTemporal() && !layer->temporalProperties()->isVisibleInTemporalRange( mapCanvas->temporalRange() ) ) )
+  {
     return QString();
+  }
 
   if ( rlayer->mapTipTemplate().isEmpty() )
+  {
     return QString();
+  }
 
   const QgsPointXY mappedPosition { mapCanvas->mapSettings().mapToLayerCoordinates( layer, mapPosition ) };
 
   if ( ! layer->extent().contains( mappedPosition ) )
-    return QString( );
+  {
+    return QString();
+  }
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
   context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
@@ -385,7 +406,7 @@ QString QgsMapTip::vectorMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *ma
 {
   // Only spatial layers can have map tips
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !vlayer || !vlayer->isSpatial() )
+  if ( !mapCanvas || !vlayer || !vlayer->isSpatial() )
     return QString();
 
   // If no map tip template or display expression is set, return an empty string
@@ -430,8 +451,10 @@ QString QgsMapTip::vectorMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *ma
 QString QgsMapTip::rasterMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *mapCanvas, const QString &mapTemplate )
 {
   QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer );
-  if ( !rlayer || mapTemplate.isEmpty() )
+  if ( !mapCanvas || !rlayer || mapTemplate.isEmpty() )
+  {
     return QString();
+  }
 
   // Create an expression context
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -102,8 +102,8 @@ class GUI_EXPORT QgsMapTip : public QWidget
                          QgsPointXY &mapPosition,
                          QgsMapCanvas *mapCanvas );
 
-    QString replaceText(
-      QString displayText, QgsVectorLayer *layer, QgsFeature &feat );
+    // Insert the raw map tip text into an HTML template and return the result
+    static QString htmlText( const QString &text );
 
     // Flag to indicate if a maptip is currently being displayed
     bool mMapTipVisible;

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -86,6 +86,20 @@ class GUI_EXPORT QgsMapTip : public QWidget
      */
     void applyFontSettings();
 
+    /**
+     * Returns the html that would be displayed in a maptip for a given layer. If the layer has features, the first feature is used
+     * to evaluate the expressions.
+     * \since QGIS 3.32
+     */
+    static QString vectorMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *mapCanvas, const QString &mapTemplate, const QString &displayExpression );
+
+    /**
+     * Returns the html that would be displayed in a maptip for a given layer. The center pixel of the raster is used to
+     * evaluate the expressions.
+     * \since QGIS 3.32
+     */
+    static QString rasterMapTipPreviewText( QgsMapLayer *layer, QgsMapCanvas *mapCanvas, const QString &mapTemplate );
+
   private slots:
     void onLinkClicked( const QUrl &url );
     void resizeContent();

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -63,6 +63,11 @@
 #include "qgsrasterattributetablewidget.h"
 #include "qgsrasterlayertemporalpropertieswidget.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsmaptip.h"
+#include "qgswebframe.h"
+#if WITH_QTWEBKIT
+#include <QWebElement>
+#endif
 
 #include <QDesktopServices>
 #include <QTableWidgetItem>
@@ -222,7 +227,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mRasterTransparencyWidget->pbnDefaultValues->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTable.svg" ) ) );
   mRasterTransparencyWidget->pbnImportTransparentPixelValues->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFileOpen.svg" ) ) );
   mRasterTransparencyWidget->pbnExportTransparentPixelValues->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFileSave.svg" ) ) );
-
+  initMapTipPreview();
 
   if ( !mRasterLayer )
   {
@@ -1920,4 +1925,90 @@ void QgsRasterLayerProperties::updateGammaSpinBox( int value )
 void QgsRasterLayerProperties::updateGammaSlider( double value )
 {
   whileBlocking( mSliderGamma )->setValue( value * 100 );
+}
+
+
+bool QgsRasterLayerProperties::eventFilter( QObject *obj, QEvent *ev )
+{
+  // If the map tip preview container is resized, resize the map tip
+  if ( obj == mMapTipPreviewContainer && ev->type() == QEvent::Resize )
+  {
+    resizeMapTip();
+  }
+  return QgsOptionsDialogBase::eventFilter( obj, ev );
+}
+
+void QgsRasterLayerProperties::initMapTipPreview()
+{
+  // HTML editor and preview are in a splitter. By default, the editor takes 2/3 of the space
+  mMapTipSplitter->setSizes( { 400, 200 } );
+  // Event filter is used to resize the map tip when the container is resized
+  mMapTipPreviewContainer->installEventFilter( this );
+
+  // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
+  // Create and style the map tip frame
+  mMapTipPreviewWidget = new QWidget( mMapTipPreviewContainer );
+  mMapTipPreviewWidget->setContentsMargins( MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE );
+  const QString backgroundColor = mMapTipPreviewWidget->palette().base().color().name();
+  const QString strokeColor = mMapTipPreviewWidget->palette().shadow().color().name();
+  mMapTipPreviewWidget->setStyleSheet( QString(
+                                         ".QWidget{"
+                                         "border: 1px solid %1;"
+                                         "background-color: %2;}" ).arg(
+                                         strokeColor, backgroundColor ) );
+
+  // Create the WebView
+  mMapTipPreview = new QgsWebView( mMapTipPreviewWidget );
+
+#if WITH_QTWEBKIT
+  mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
+  mMapTipPreview->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
+  connect( mMapTipPreview, &QWebView::loadFinished, this, &QgsRasterLayerProperties::resizeMapTip );
+#endif
+
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
+
+  // Disable scrollbars, avoid random resizing issues
+  mMapTipPreview->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
+  mMapTipPreview->page()->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
+
+  QHBoxLayout *hlayout = new QHBoxLayout;
+  hlayout->setContentsMargins( 0, 0, 0, 0 );
+  hlayout->addWidget( mMapTipPreview );
+
+  mMapTipPreviewWidget->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+  mMapTipPreviewWidget->setLayout( hlayout );
+
+  // Update the map tip preview when the expression or the map tip template changes
+  connect( mMapTipWidget, &QgsCodeEditorHTML::textChanged, this, &QgsRasterLayerProperties::updateMapTipPreview );
+}
+
+void QgsRasterLayerProperties::updateMapTipPreview()
+{
+  mMapTipPreviewWidget->setMaximumSize( mMapTipPreviewContainer->width(), mMapTipPreviewContainer->height() );
+  const QString htmlContent = QgsMapTip::rasterMapTipPreviewText( mRasterLayer, mMapCanvas, mMapTipWidget->text() );
+  mMapTipPreview->setHtml( htmlContent );
+}
+
+void QgsRasterLayerProperties::resizeMapTip()
+{
+  // Ensure the map tip is not bigger than the container
+  mMapTipPreviewWidget->setMaximumSize( mMapTipPreviewContainer->width(), mMapTipPreviewContainer->height() );
+#if WITH_QTWEBKIT
+  // Get the content size
+  const QWebElement container = mMapTipPreview->page()->mainFrame()->findFirstElement(
+                                  QStringLiteral( "#QgsWebViewContainer" ) );
+  const int width = container.geometry().width() + MARGIN_VALUE * 2;
+  const int height = container.geometry().height() + MARGIN_VALUE * 2;
+  mMapTipPreviewWidget->resize( width, height );
+
+  // Move the map tip to the center of the container
+  mMapTipPreviewWidget->move( ( mMapTipPreviewContainer->width() - mMapTipPreviewWidget->width() ) / 2,
+                              ( mMapTipPreviewContainer->height() - mMapTipPreviewWidget->height() ) / 2 );
+
+#else
+  mMapTipPreview->adjustSize();
+#endif
 }

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -318,6 +318,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     QWidget *mMapTipPreviewWidget = nullptr;
     QgsWebView *mMapTipPreview = nullptr;
-    const int MARGIN_VALUE = 5;
+    static const int MARGIN_VALUE = 5;
 };
 #endif

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -48,6 +48,7 @@ class QgsMapLayerConfigWidget;
 class QgsPropertyOverrideButton;
 class QgsRasterTransparencyWidget;
 class QgsRasterAttributeTableWidget;
+class QgsWebView;
 
 
 /**
@@ -91,6 +92,8 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     QgsExpressionContext createExpressionContext() const override;
+
+    bool eventFilter( QObject *obj, QEvent *ev ) override;
 
   protected slots:
     //! \brief auto slot executed when the active page in the main widget stack is changed
@@ -199,6 +202,11 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     void urlClicked( const QUrl &url );
 
+    // Update the preview of the map tip
+    void updateMapTipPreview();
+    // Resize the map tip preview
+    void resizeMapTip();
+
   private:
     QPushButton *mBtnStyle = nullptr;
     QPushButton *mBtnMetadata = nullptr;
@@ -305,5 +313,11 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QgsCoordinateReferenceSystem mBackupCrs;
 
     QgsRasterAttributeTableWidget *mRasterAttributeTableWidget = nullptr;
+
+    void initMapTipPreview();
+
+    QWidget *mMapTipPreviewWidget = nullptr;
+    QgsWebView *mMapTipPreview = nullptr;
+    const int MARGIN_VALUE = 5;
 };
 #endif

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -66,6 +66,12 @@
 #include "qgsproviderregistry.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgslayertreemodel.h"
+#include "qgsmaptip.h"
+#include "qgswebview.h"
+#include "qgswebframe.h"
+#if WITH_QTWEBKIT
+#include <QWebElement>
+#endif
 
 #include <QDesktopServices>
 #include <QMessageBox>
@@ -162,6 +168,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mMapTipExpressionFieldWidget->registerExpressionContextGenerator( this );
   mDisplayExpressionWidget->setLayer( lyr );
   mDisplayExpressionWidget->registerExpressionContextGenerator( this );
+  initMapTipPreview();
 
   connect( mInsertExpressionButton, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::insertFieldOrExpression );
 
@@ -2247,4 +2254,90 @@ void QgsVectorLayerProperties::deleteAuxiliaryField( int index )
     const QString msg = QObject::tr( "Unable to remove auxiliary field (%1)" ).arg( errors );
     mMessageBar->pushMessage( title, msg, Qgis::MessageLevel::Warning );
   }
+}
+
+bool QgsVectorLayerProperties::eventFilter( QObject *obj, QEvent *ev )
+{
+  // If the map tip preview container is resized, resize the map tip
+  if ( obj == mMapTipPreviewContainer && ev->type() == QEvent::Resize )
+  {
+    resizeMapTip();
+  }
+  return QgsOptionsDialogBase::eventFilter( obj, ev );
+}
+
+void QgsVectorLayerProperties::initMapTipPreview()
+{
+  // HTML editor and preview are in a splitter. By default, the editor takes 2/3 of the space
+  mMapTipSplitter->setSizes( { 400, 200 } );
+  // Event filter is used to resize the map tip when the container is resized
+  mMapTipPreviewContainer->installEventFilter( this );
+
+  // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
+  // Create and style the map tip frame
+  mMapTipPreviewWidget = new QWidget( mMapTipPreviewContainer );
+  mMapTipPreviewWidget->setContentsMargins( MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE, MARGIN_VALUE );
+  const QString backgroundColor = mMapTipPreviewWidget->palette().base().color().name();
+  const QString strokeColor = mMapTipPreviewWidget->palette().shadow().color().name();
+  mMapTipPreviewWidget->setStyleSheet( QString(
+                                         ".QWidget{"
+                                         "border: 1px solid %1;"
+                                         "background-color: %2;}" ).arg(
+                                         strokeColor, backgroundColor ) );
+
+  // Create the WebView
+  mMapTipPreview = new QgsWebView( mMapTipPreviewWidget );
+
+#if WITH_QTWEBKIT
+  mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
+  mMapTipPreview->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
+  connect( mMapTipPreview, &QWebView::loadFinished, this, &QgsVectorLayerProperties::resizeMapTip );
+#endif
+
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
+  mMapTipPreview->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
+
+  // Disable scrollbars, avoid random resizing issues
+  mMapTipPreview->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
+  mMapTipPreview->page()->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
+
+  QHBoxLayout *hlayout = new QHBoxLayout;
+  hlayout->setContentsMargins( 0, 0, 0, 0 );
+  hlayout->addWidget( mMapTipPreview );
+
+  mMapTipPreviewWidget->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+  mMapTipPreviewWidget->setLayout( hlayout );
+
+  // Update the map tip preview when the expression or the map tip template changes
+  connect( mMapTipWidget, &QgsCodeEditorHTML::textChanged, this, &QgsVectorLayerProperties::updateMapTipPreview );
+  connect( mDisplayExpressionWidget, qOverload< const QString & >( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsVectorLayerProperties::updateMapTipPreview );
+}
+
+void QgsVectorLayerProperties::updateMapTipPreview()
+{
+  mMapTipPreviewWidget->setMaximumSize( mMapTipPreviewContainer->width(), mMapTipPreviewContainer->height() );
+  const QString htmlContent = QgsMapTip::vectorMapTipPreviewText( mLayer, mCanvas, mMapTipWidget->text(), mDisplayExpressionWidget->asExpression() );
+  mMapTipPreview->setHtml( htmlContent );
+}
+
+void QgsVectorLayerProperties::resizeMapTip()
+{
+  // Ensure the map tip is not bigger than the container
+  mMapTipPreviewWidget->setMaximumSize( mMapTipPreviewContainer->width(), mMapTipPreviewContainer->height() );
+#if WITH_QTWEBKIT
+  // Get the content size
+  const QWebElement container = mMapTipPreview->page()->mainFrame()->findFirstElement(
+                                  QStringLiteral( "#QgsWebViewContainer" ) );
+  const int width = container.geometry().width() + MARGIN_VALUE * 2;
+  const int height = container.geometry().height() + MARGIN_VALUE * 2;
+  mMapTipPreviewWidget->resize( width, height );
+
+  // Move the map tip to the center of the container
+  mMapTipPreviewWidget->move( ( mMapTipPreviewContainer->width() - mMapTipPreviewWidget->width() ) / 2,
+                              ( mMapTipPreviewContainer->height() - mMapTipPreviewWidget->height() ) / 2 );
+
+#else
+  mMapTipPreview->adjustSize();
+#endif
 }

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -49,6 +49,7 @@ class QgsDoubleSpinBox;
 class QgsMaskingWidget;
 class QgsVectorLayerTemporalPropertiesWidget;
 class QgsProviderSourceWidget;
+class QgsWebView;
 
 /**
  * \ingroup gui
@@ -74,6 +75,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     //! Adds a properties page factory to the vector layer properties dialog.
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
+
+    bool eventFilter( QObject *obj, QEvent *ev ) override;
 
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
@@ -161,6 +164,11 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void onAuxiliaryLayerAddField();
 
     void urlClicked( const QUrl &url );
+
+    // Update the preview of the map tip
+    void updateMapTipPreview();
+    // Resize the map tip preview
+    void resizeMapTip();
 
   private:
 
@@ -254,6 +262,12 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsProviderSourceWidget *mSourceWidget = nullptr;
 
     QgsCoordinateReferenceSystem mBackupCrs;
+
+    void initMapTipPreview();
+
+    QWidget *mMapTipPreviewWidget = nullptr;
+    QgsWebView *mMapTipPreview = nullptr;
+    const int MARGIN_VALUE = 5;
 
   private slots:
     void openPanel( QgsPanelWidget *panel );

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -267,7 +267,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QWidget *mMapTipPreviewWidget = nullptr;
     QgsWebView *mMapTipPreview = nullptr;
-    const int MARGIN_VALUE = 5;
+    static const int MARGIN_VALUE = 5;
 
   private slots:
     void openPanel( QgsPanelWidget *panel );

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1487,8 +1487,46 @@ p, li { white-space: pre-wrap; }
                 <property name="title">
                  <string>HTML Map Tip</string>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_81">
-                 <item row="1" column="2">
+                <layout class="QGridLayout" name="gridLayout_8">
+                 <item row="0" column="0" colspan="2">
+                  <widget class="QSplitter" name="mMapTipSplitter">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>100</width>
+                      <height>100</height>
+                     </size>
+                    </property>
+                   </widget>
+                   <widget class="QGroupBox" name="mMapTipPreviewContainer">
+                    <property name="minimumSize">
+                     <size>
+                      <width>100</width>
+                      <height>100</height>
+                     </size>
+                    </property>
+                    <property name="title">
+                     <string>Preview</string>
+                    </property>
+                   </widget>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
                   <widget class="QPushButton" name="mInsertExpressionButton">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1504,39 +1542,23 @@ p, li { white-space: pre-wrap; }
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="0" colspan="3">
-                  <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
+                 <item row="2" column="0" colspan="2">
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
                    </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>100</height>
-                    </size>
+                   <property name="wordWrap">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
-                 <item row="1" column="0" colspan="2">
+                 <item row="1" column="0">
                   <widget class="QgsExpressionLineEdit" name="mMapTipExpressionWidget" native="true">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
                    <property name="toolTip">
                     <string>The valid attribute names for this layer</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0" colspan="3">
-                  <widget class="QLabel" name="labelMapTipInfo">
-                   <property name="text">
-                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -363,7 +363,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>11</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>239</width>
-                <height>480</height>
+                <width>336</width>
+                <height>562</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>110</width>
-                <height>87</height>
+                <width>164</width>
+                <height>103</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1460,7 +1460,45 @@
                  <string>HTML Map Tip</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_8">
-                 <item row="1" column="2">
+                 <item row="0" column="0" colspan="2">
+                  <widget class="QSplitter" name="mMapTipSplitter">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>100</width>
+                      <height>100</height>
+                     </size>
+                    </property>
+                   </widget>
+                   <widget class="QGroupBox" name="mMapTipPreviewContainer">
+                    <property name="minimumSize">
+                     <size>
+                      <width>100</width>
+                      <height>100</height>
+                     </size>
+                    </property>
+                    <property name="title">
+                     <string>Preview</string>
+                    </property>
+                   </widget>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
                   <widget class="QPushButton" name="mInsertExpressionButton">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1476,39 +1514,23 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="0" colspan="3">
-                  <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>100</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0" colspan="2">
-                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget" native="true">
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="toolTip">
-                    <string>The valid attribute names for this layer</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0" colspan="3">
+                 <item row="2" column="0" colspan="2">
                   <widget class="QLabel" name="labelMapTipInfo">
                    <property name="text">
                     <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget" native="true">
+                   <property name="focusPolicy">
+                    <enum>Qt::StrongFocus</enum>
+                   </property>
+                   <property name="toolTip">
+                    <string>The valid attribute names for this layer</string>
                    </property>
                   </widget>
                  </item>
@@ -1547,8 +1569,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>493</width>
-                <height>473</height>
+                <width>695</width>
+                <height>552</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -2106,8 +2128,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>263</width>
-                <height>713</height>
+                <width>374</width>
+                <height>815</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">


### PR DESCRIPTION
## Description

Adds a map tip preview in the Raster and Vector layer properties dialog.
This makes it easier to design map tips.

![map_tip_preview](https://user-images.githubusercontent.com/9693475/228259974-06dd13fb-9237-42be-bd63-cce9f6bfdeab.gif)
