### PR TITLE
Html editor toggle comment

### DIFF
--- a/python/gui/auto_generated/codeeditors/qgscodeeditorhtml.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditorhtml.sip.in
@@ -37,6 +37,17 @@ Constructor for QgsCodeEditorHTML
     virtual Qgis::ScriptLanguageCapabilities languageCapabilities() const;
 
 
+  public slots:
+
+    virtual void toggleComment();
+
+%Docstring
+Toggle comment for the selected text.
+
+.. versionadded:: 3.32
+%End
+
+
   protected:
     virtual void initializeLexer();
 

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -216,10 +216,19 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
 
   // Ctrl+Alt+F: reformat code
   const bool canReformat = languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat;
-  if ( canReformat && ctrlModifier && altModifier && event->key() == Qt::Key_F )
+  if ( !isReadOnly() && canReformat && ctrlModifier && altModifier && event->key() == Qt::Key_F )
   {
     event->accept();
     reformatCode();
+    return;
+  }
+
+  // Toggle comment when user presses  Ctrl+:
+  const bool canToggle = languageCapabilities() & Qgis::ScriptLanguageCapability::ToggleComment;
+  if ( !isReadOnly() && canToggle && ctrlModifier && event->key() == Qt::Key_Colon )
+  {
+    event->accept();
+    toggleComment();
     return;
   }
 

--- a/src/gui/codeeditors/qgscodeeditorhtml.cpp
+++ b/src/gui/codeeditors/qgscodeeditorhtml.cpp
@@ -194,7 +194,7 @@ void QgsCodeEditorHTML::toggleComment()
   const bool commented = startLineTrimmed.startsWith( commentStart ) && endLineTrimmed.endsWith( commentEnd );
 
   // Special case, selected text is <!--> or <!--->
-  if ( commented && startLine == endLine && text( endLine ).trimmed() < commentStart.size() + commentEnd.size() )
+  if ( commented && startLine == endLine && text( endLine ).trimmed().size() < commentStart.size() + commentEnd.size() )
   {
     return;
   }

--- a/src/gui/codeeditors/qgscodeeditorhtml.h
+++ b/src/gui/codeeditors/qgscodeeditorhtml.h
@@ -41,6 +41,16 @@ class GUI_EXPORT QgsCodeEditorHTML : public QgsCodeEditor
     Qgis::ScriptLanguage language() const override;
     Qgis::ScriptLanguageCapabilities languageCapabilities() const override;
 
+  public slots:
+
+    /**
+     * Toggle comment for the selected text.
+     *
+     * \since QGIS 3.32
+     */
+    void toggleComment() override;
+
+
   protected:
     void initializeLexer() override;
     QString reformatCodeString( const QString &string ) override;

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -220,15 +220,6 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
   {
     return QgsCodeEditor::keyPressEvent( event );
   }
-  const bool ctrlModifier = event->modifiers() & Qt::ControlModifier;
-
-  // Toggle comment when user presses  Ctrl+:
-  if ( ctrlModifier && event->key() == Qt::Key_Colon )
-  {
-    event->accept();
-    toggleComment();
-    return;
-  }
 
   const QgsSettings settings;
 


### PR DESCRIPTION
## Description

Add toggle comment capability to the `QgsCodeEditorHTML` (`Ctrl+:` shortcut)

![toggleFormat](https://user-images.githubusercontent.com/9693475/228366726-29ef8f07-3111-4970-97ed-500be7ed5467.gif)
