### PR TITLE
Update pdal_wrench and PDAL Processing provider

### DIFF
--- a/external/pdal_wrench/vpc.hpp
+++ b/external/pdal_wrench/vpc.hpp
@@ -26,11 +26,23 @@ void buildVpc(std::vector<std::string> args);
 
 struct VirtualPointCloud
 {
+    struct SchemaItem
+    {
+      SchemaItem(const std::string &n, const std::string &t, int s): name(n), type(t), size(s) {}
+
+      std::string name;
+      std::string type;
+      int size;
+    };
+
     struct File
     {
         std::string filename;
         point_count_t count;
         BOX3D bbox;
+        std::string crsWkt;
+        std::string datetime;  // RFC 3339 encoded date/time - e.g. 2023-01-01T12:00:00Z
+        std::vector<SchemaItem> schema;  // we're not using it, just for STAC export
     };
 
     std::vector<File> files;

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -921,9 +921,10 @@ Evaluates the parameter with matching ``name`` to a matrix/table of values.
 Tables are collapsed to a 1 dimensional list.
 %End
 
-    QList< QgsMapLayer *> parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QList< QgsMapLayer *> parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of map layers.
+The ``flags`` are used to set options for loading layers (e.g. skip index generation).
 %End
 
     QStringList parameterAsFileList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1434,14 +1434,16 @@ Tables are collapsed to a 1 dimensional list.
 .. versionadded:: 3.4
 %End
 
-    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of map layers.
+The ``flags`` are used to set options for loading layers (e.g. skip index generation).
 %End
 
-    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context );
+    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to a list of map layers.
+The ``flags`` are used to set options for loading layers (e.g. skip index generation).
 
 .. versionadded:: 3.4
 %End

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -424,7 +424,7 @@ if (WITH_PDAL AND PDAL_2_5_OR_HIGHER)
     processing/pdal/qgspdalalgorithmbase.cpp
 
     processing/pdal/qgsalgorithmpdalboundary.cpp
-    #processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+    processing/pdal/qgsalgorithmpdalbuildvpc.cpp
     processing/pdal/qgsalgorithmpdalclip.cpp
     processing/pdal/qgsalgorithmpdalconvertformat.cpp
     processing/pdal/qgsalgorithmpdaldensity.cpp

--- a/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
@@ -69,7 +69,7 @@ QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &pa
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
@@ -67,7 +67,7 @@ QStringList QgsPdalBuildVpcAlgorithm::createArgumentLists( const QVariantMap &pa
 {
   Q_UNUSED( feedback );
 
-  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context );
+  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( layers.empty() )
   {
     feedback->reportError( QObject::tr( "No layers selected" ), true );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -67,7 +67,7 @@ void QgsPdalClipAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
@@ -67,7 +67,7 @@ QStringList QgsPdalConvertFormatAlgorithm::createArgumentLists( const QVariantMa
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
@@ -77,7 +77,7 @@ QStringList QgsPdalDensityAlgorithm::createArgumentLists( const QVariantMap &par
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -93,7 +93,7 @@ QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -77,7 +77,7 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
@@ -83,7 +83,7 @@ QStringList QgsPdalExportVectorAlgorithm::createArgumentLists( const QVariantMap
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -68,7 +68,7 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfixprojection.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfixprojection.cpp
@@ -68,7 +68,7 @@ QStringList QgsPdalFixProjectionAlgorithm::createArgumentLists( const QVariantMa
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalinformation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalinformation.cpp
@@ -131,7 +131,7 @@ QStringList QgsPdalInformationAlgorithm::createArgumentLists( const QVariantMap 
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -67,7 +67,7 @@ QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &param
 {
   Q_UNUSED( feedback );
 
-  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context );
+  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( layers.empty() )
   {
     feedback->reportError( QObject::tr( "No layers selected" ), true );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
@@ -74,7 +74,7 @@ QStringList QgsPdalReprojectAlgorithm::createArgumentLists( const QVariantMap &p
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
@@ -69,7 +69,7 @@ QStringList QgsPdalThinAlgorithm::createArgumentLists( const QVariantMap &parame
 {
   Q_UNUSED( feedback );
 
-  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context );
+  QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, QStringLiteral( "INPUT" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
@@ -74,7 +74,7 @@ QStringList QgsPdalTileAlgorithm::createArgumentLists( const QVariantMap &parame
 {
   Q_UNUSED( feedback );
 
-  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context );
+  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( layers.empty() )
   {
     feedback->reportError( QObject::tr( "No layers selected" ), true );

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -83,7 +83,7 @@ QStringList QgsPdalAlgorithms::supportedOutputRasterLayerExtensions() const
 
 QStringList QgsPdalAlgorithms::supportedOutputPointCloudLayerExtensions() const
 {
-  return QStringList() << QStringLiteral( "las" ) << QStringLiteral( "laz" );
+  return QStringList() << QStringLiteral( "las" ) << QStringLiteral( "laz" ) << QStringLiteral( "copc.laz" );
 }
 
 void QgsPdalAlgorithms::loadAlgorithms()

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -20,7 +20,7 @@
 #include "qgsapplication.h"
 
 #include "qgsalgorithmpdalboundary.h"
-//#include "qgsalgorithmpdalbuildvpc.h"
+#include "qgsalgorithmpdalbuildvpc.h"
 #include "qgsalgorithmpdalclip.h"
 #include "qgsalgorithmpdalconvertformat.h"
 #include "qgsalgorithmpdaldensity.h"
@@ -91,7 +91,7 @@ void QgsPdalAlgorithms::loadAlgorithms()
   const QgsScopedRuntimeProfile profile( QObject::tr( "QGIS PDAL provider" ) );
 
   addAlgorithm( new QgsPdalBoundaryAlgorithm() );
-  //addAlgorithm( new QgsPdalBuildVpcAlgorithm() );
+  addAlgorithm( new QgsPdalBuildVpcAlgorithm() );
   addAlgorithm( new QgsPdalClipAlgorithm() );
   addAlgorithm( new QgsPdalConvertFormatAlgorithm() );
   addAlgorithm( new QgsPdalDensityAlgorithm() );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -820,9 +820,9 @@ QVariantList QgsProcessingAlgorithm::parameterAsMatrix( const QVariantMap &param
   return QgsProcessingParameters::parameterAsMatrix( parameterDefinition( name ), parameters, context );
 }
 
-QList<QgsMapLayer *> QgsProcessingAlgorithm::parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
+QList<QgsMapLayer *> QgsProcessingAlgorithm::parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags ) const
 {
-  return QgsProcessingParameters::parameterAsLayerList( parameterDefinition( name ), parameters, context );
+  return QgsProcessingParameters::parameterAsLayerList( parameterDefinition( name ), parameters, context, flags );
 }
 
 QStringList QgsProcessingAlgorithm::parameterAsFileList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -925,8 +925,9 @@ class CORE_EXPORT QgsProcessingAlgorithm
 
     /**
      * Evaluates the parameter with matching \a name to a list of map layers.
+     * The \a flags are used to set options for loading layers (e.g. skip index generation).
      */
-    QList< QgsMapLayer *> parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QList< QgsMapLayer *> parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
 
     /**
      * Evaluates the parameter with matching \a name to a list of files (for QgsProcessingParameterMultipleLayers in QgsProcessing:TypeFile mode).

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1774,7 +1774,7 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
   QList<QgsMapLayer *> layers;
 
   std::function< void( const QVariant &var ) > processVariant;
-  processVariant = [ &layers, &context, &definition, &processVariant, flags ]( const QVariant & var )
+  processVariant = [ &layers, &context, &definition, flags, &processVariant]( const QVariant & var )
   {
     if ( var.type() == QVariant::List )
     {
@@ -1810,7 +1810,7 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
     }
     else
     {
-      QgsMapLayer *alayer = QgsProcessingUtils::mapLayerFromString( var.toString(), context, flags );
+      QgsMapLayer *alayer = QgsProcessingUtils::mapLayerFromString( var.toString(), context, true, QgsProcessingUtils::LayerHint::UnknownType, flags );
       if ( alayer )
         layers << alayer;
     }
@@ -4242,7 +4242,7 @@ QString QgsProcessingParameterMultipleLayers::valueAsPythonString( const QVarian
   {
     QVariantMap p;
     p.insert( name(), value );
-    const QList<QgsMapLayer *> list = QgsProcessingParameters::parameterAsLayerList( this, p, context );
+    const QList<QgsMapLayer *> list = QgsProcessingParameters::parameterAsLayerList( this, p, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
     if ( !list.isEmpty() )
     {
       QStringList parts;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1752,15 +1752,15 @@ QVariantList QgsProcessingParameters::parameterAsMatrix( const QgsProcessingPara
   return result;
 }
 
-QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context )
+QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags )
 {
   if ( !definition )
     return QList<QgsMapLayer *>();
 
-  return parameterAsLayerList( definition, parameters.value( definition->name() ), context );
+  return parameterAsLayerList( definition, parameters.value( definition->name() ), context, flags );
 }
 
-QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context )
+QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags )
 {
   if ( !definition )
     return QList<QgsMapLayer *>();
@@ -1774,7 +1774,7 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
   QList<QgsMapLayer *> layers;
 
   std::function< void( const QVariant &var ) > processVariant;
-  processVariant = [ &layers, &context, &definition, &processVariant ]( const QVariant & var )
+  processVariant = [ &layers, &context, &definition, &processVariant, flags ]( const QVariant & var )
   {
     if ( var.type() == QVariant::List )
     {
@@ -1810,7 +1810,7 @@ QList<QgsMapLayer *> QgsProcessingParameters::parameterAsLayerList( const QgsPro
     }
     else
     {
-      QgsMapLayer *alayer = QgsProcessingUtils::mapLayerFromString( var.toString(), context );
+      QgsMapLayer *alayer = QgsProcessingUtils::mapLayerFromString( var.toString(), context, flags );
       if ( alayer )
         layers << alayer;
     }
@@ -4156,7 +4156,7 @@ bool QgsProcessingParameterMultipleLayers::checkValueIsAcceptable( const QVarian
       return true;
 
     if ( mLayerType != QgsProcessing::TypeFile )
-      return QgsProcessingUtils::mapLayerFromString( input.toString(), *context );
+      return QgsProcessingUtils::mapLayerFromString( input.toString(), *context, true, QgsProcessingUtils::LayerHint::UnknownType, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
     else
       return true;
   }
@@ -4179,7 +4179,7 @@ bool QgsProcessingParameterMultipleLayers::checkValueIsAcceptable( const QVarian
         if ( qobject_cast< QgsMapLayer * >( qvariant_cast<QObject *>( v ) ) )
           continue;
 
-        if ( !QgsProcessingUtils::mapLayerFromString( v.toString(), *context ) )
+        if ( !QgsProcessingUtils::mapLayerFromString( v.toString(), *context, true, QgsProcessingUtils::LayerHint::UnknownType, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration ) )
           return false;
       }
     }
@@ -4201,7 +4201,7 @@ bool QgsProcessingParameterMultipleLayers::checkValueIsAcceptable( const QVarian
       const auto constToStringList = input.toStringList();
       for ( const QString &v : constToStringList )
       {
-        if ( !QgsProcessingUtils::mapLayerFromString( v, *context ) )
+        if ( !QgsProcessingUtils::mapLayerFromString( v, *context, true, QgsProcessingUtils::LayerHint::UnknownType, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration ) )
           return false;
       }
     }

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1535,14 +1535,16 @@ class CORE_EXPORT QgsProcessingParameters
 
     /**
      * Evaluates the parameter with matching \a definition to a list of map layers.
+     * The \a flags are used to set options for loading layers (e.g. skip index generation).
      */
-    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 
     /**
      * Evaluates the parameter with matching \a definition and \a value to a list of map layers.
+     * The \a flags are used to set options for loading layers (e.g. skip index generation).
      * \since QGIS 3.4
      */
-    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context );
+    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 
     /**
      * Evaluates the parameter with matching \a definition to a list of files (for QgsProcessingParameterMultipleLayers in QgsProcessing:TypeFile mode).

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -35,7 +35,7 @@ class TestQgsProcessingPdalAlgs: public QObject
     void cleanup() {} // will be called after every testfunction.
 
     void boundary();
-    //void buildVpc();
+    void buildVpc();
     void clip();
     void convertFormat();
     void density();
@@ -716,7 +716,6 @@ void TestQgsProcessingPdalAlgs::merge()
           );
 }
 
-/*
 void TestQgsProcessingPdalAlgs::buildVpc()
 {
   QgsPdalAlgorithmBase *alg = const_cast<QgsPdalAlgorithmBase *>( static_cast< const QgsPdalAlgorithmBase * >( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "pdal:virtualpointcloud" ) ) ) );
@@ -760,7 +759,6 @@ void TestQgsProcessingPdalAlgs::buildVpc()
             << pointCloud2
           );
 }
-*/
 
 void TestQgsProcessingPdalAlgs::clip()
 {


### PR DESCRIPTION
## Description

- Update pdal_wrench to the latest revision.
- Do not index input point clouds in Processing provider.
- Enable "Build virtual point cloud" algorithm. Virtual point cloud (VPC) is similar to GDAL's VRT — it is a single file referring to other files that contain actual data. Software then may handle all data as a single dataset. pdal_wrench uses STAC ItemCollection for virtual point cloud format.

Funded by: [Point cloud processing and 3D data enhancements crowdfunding](https://www.lutraconsulting.co.uk/crowdfunding/pointcloud-processing-qgis/)