### PR TITLE
Reenable MSYS2 CI

### DIFF
--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -1,4 +1,4 @@
-name: 🪟 MSYS2 MinGW-w64 Windows 64bit Build
+name: MSYS2 MinGW-w64 Windows 64bit Build
 
 on:
   push:
@@ -95,3 +95,4 @@ jobs:
       - name: Build QGIS
         run: |
           cmake --build build
+          ccache -s


### PR DESCRIPTION
## Description

Reenable MSYS2 CI, It was broken because of an issue the latest cmake 3.26.1, the issue was identified and fixed.