### PR TITLE
Expose more vector tile properties for user control

### DIFF
--- a/python/gui/auto_generated/pointcloud/qgspointcloudrendererpropertieswidget.sip.in
+++ b/python/gui/auto_generated/pointcloud/qgspointcloudrendererpropertieswidget.sip.in
@@ -33,10 +33,8 @@ Constructor for QgsPointCloudRendererPropertiesWidget, associated with the speci
 Sets the ``context`` in which the widget is shown, e.g., the associated map canvas and expression contexts.
 %End
 
-    virtual void syncToLayer( QgsMapLayer *layer );
-
-    virtual void setDockMode( bool dockMode );
-
+    void syncToLayer( QgsMapLayer *layer ) final;
+    void setDockMode( bool dockMode ) final;
 
   public slots:
 

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -10,8 +10,6 @@
 
 
 
-
-
 class QgsVectorTileLayerProperties : QgsOptionsDialogBase
 {
 %Docstring(signature="appended")

--- a/src/app/3d/qgsmeshlayer3drendererwidget.h
+++ b/src/app/3d/qgsmeshlayer3drendererwidget.h
@@ -36,7 +36,7 @@ class QgsMeshLayer3DRendererWidget : public QgsMapLayerConfigWidget
   public:
     explicit QgsMeshLayer3DRendererWidget( QgsMeshLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
     //! no transfer of ownership
     void setRenderer( const QgsMeshLayer3DRenderer *renderer );

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.h
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.h
@@ -36,8 +36,8 @@ class QgsPointCloudLayer3DRendererWidget : public QgsMapLayerConfigWidget
   public:
     explicit QgsPointCloudLayer3DRendererWidget( QgsPointCloudLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
-    void setDockMode( bool dockMode ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
+    void setDockMode( bool dockMode ) final;
 
     //! no transfer of ownership
     void setRenderer( const QgsPointCloudLayer3DRenderer *renderer );

--- a/src/app/3d/qgsvectorlayer3drendererwidget.h
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.h
@@ -65,7 +65,7 @@ class QgsVectorLayer3DRendererWidget : public QgsMapLayerConfigWidget
   public:
     explicit QgsVectorLayer3DRendererWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
     void setDockMode( bool dockMode ) override;
 

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -33,9 +33,9 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public
     QgsAnnotationItemPropertiesWidget( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
     ~QgsAnnotationItemPropertiesWidget() override;
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
     void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
-    void setDockMode( bool dockMode ) override;
+    void setDockMode( bool dockMode ) final;
 
   public slots:
     void apply() override;

--- a/src/app/mesh/qgsmeshelevationpropertieswidget.h
+++ b/src/app/mesh/qgsmeshelevationpropertieswidget.h
@@ -30,7 +30,7 @@ class QgsMeshElevationPropertiesWidget : public QgsMapLayerConfigWidget, private
 
     QgsMeshElevationPropertiesWidget( QgsMeshLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
   public slots:
     void apply() override;

--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -14,10 +14,8 @@
  ***************************************************************************/
 
 #include "qgslayertreegrouppropertieswidget.h"
-#include "qgsstyle.h"
 #include "qgsapplication.h"
 #include "qgsmaplayer.h"
-#include "qgsgui.h"
 #include "qgspainteffect.h"
 #include "qgsmapcanvas.h"
 #include "qgspainteffectregistry.h"

--- a/src/app/qgslayertreegrouppropertieswidget.h
+++ b/src/app/qgslayertreegrouppropertieswidget.h
@@ -33,9 +33,9 @@ class QgsLayerTreeGroupPropertiesWidget : public QgsMapLayerConfigWidget, public
     QgsLayerTreeGroupPropertiesWidget( QgsMapCanvas *canvas, QWidget *parent );
     ~QgsLayerTreeGroupPropertiesWidget() override;
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
     void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
-    void setDockMode( bool dockMode ) override;
+    void setDockMode( bool dockMode ) final;
 
   public slots:
     void apply() override;

--- a/src/app/raster/qgsrasterelevationpropertieswidget.h
+++ b/src/app/raster/qgsrasterelevationpropertieswidget.h
@@ -30,7 +30,7 @@ class QgsRasterElevationPropertiesWidget : public QgsMapLayerConfigWidget, priva
 
     QgsRasterElevationPropertiesWidget( QgsRasterLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
   public slots:
     void apply() override;

--- a/src/app/vector/qgsvectorelevationpropertieswidget.h
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.h
@@ -32,7 +32,7 @@ class QgsVectorElevationPropertiesWidget : public QgsMapLayerConfigWidget, priva
 
     QgsVectorElevationPropertiesWidget( QgsVectorLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
     QgsExpressionContext createExpressionContext() const override;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -415,6 +415,9 @@ set(QGIS_GUI_SRCS
   providers/gdal/qgsgdalsourceselect.cpp
   providers/gdal/qgsgdalguiprovider.cpp
 
+  providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.cpp
+  providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.cpp
+
   providers/ogr/qgsogrguiprovider.cpp
   providers/ogr/qgsogrdbsourceselect.cpp
   providers/ogr/qgsogrdbtablemodel.cpp
@@ -423,6 +426,9 @@ set(QGIS_GUI_SRCS
   providers/ogr/qgsgeopackageitemguiprovider.cpp
   providers/ogr/qgsogritemguiprovider.cpp
   providers/ogr/qgsgeopackageprojectstorageguiprovider.cpp
+
+  providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.cpp
+  providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.cpp
 
   sensor/qgssensorguiregistry.cpp
   sensor/qgssensorwidget.cpp
@@ -1317,6 +1323,9 @@ set(QGIS_GUI_HDRS
   providers/gdal/qgsgdalguiprovider.h
   providers/gdal/qgsgdalsourceselect.h
 
+  providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.h
+  providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.h
+
   providers/ogr/qgsgeopackageitemguiprovider.h
   providers/ogr/qgsgeopackageprojectstoragedialog.h
   providers/ogr/qgsgeopackageprojectstorageguiprovider.h
@@ -1325,6 +1334,9 @@ set(QGIS_GUI_HDRS
   providers/ogr/qgsogrguiprovider.h
   providers/ogr/qgsogritemguiprovider.h
   providers/ogr/qgsogrsourceselect.h
+
+  providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.h
+  providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.h
 
   raster/qgsrasterattributetablewidget.h
   raster/qgscreaterasterattributetabledialog.h
@@ -1550,7 +1562,9 @@ target_include_directories(qgis_gui PUBLIC
   ${CMAKE_SOURCE_DIR}/src/gui/processing/models
   ${CMAKE_SOURCE_DIR}/src/gui/providers
   ${CMAKE_SOURCE_DIR}/src/gui/providers/gdal
+  ${CMAKE_SOURCE_DIR}/src/gui/providers/mbtilesvectortiles
   ${CMAKE_SOURCE_DIR}/src/gui/providers/ogr
+  ${CMAKE_SOURCE_DIR}/src/gui/providers/vtpkvectortiles
   ${CMAKE_SOURCE_DIR}/src/gui/pointcloud
   ${CMAKE_SOURCE_DIR}/src/gui/raster
   ${CMAKE_SOURCE_DIR}/src/gui/sensor

--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -18,11 +18,8 @@
 #include "qgis.h"
 #include "qgsmapcanvas.h"
 #include "qgsmeshlayer.h"
-#include "qgsmessagelog.h"
 #include "qgsmeshrendererscalarsettingswidget.h"
-#include "qgsmeshdatasetgrouptreeview.h"
 #include "qgsmeshrendereractivedatasetwidget.h"
-#include "qgsmeshlayerutils.h"
 #include "qgsproject.h"
 #include "qgsprojectutils.h"
 

--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.h
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsRendererMeshPropertiesWidget : public QgsMapLayerConfigWidge
      *
      * \since QGIS 3.22, replace syncToLayer() without argument
      */
-    void syncToLayer( QgsMapLayer *mapLayer ) override;
+    void syncToLayer( QgsMapLayer *mapLayer ) final;
 
   public slots:
     //! Applies the settings made in the dialog

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
@@ -51,8 +51,8 @@ class GUI_EXPORT QgsPointCloudRendererPropertiesWidget : public QgsMapLayerConfi
      */
     void setContext( const QgsSymbolWidgetContext &context );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
-    void setDockMode( bool dockMode ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
+    void setDockMode( bool dockMode ) final;
 
   public slots:
 

--- a/src/gui/providers/gdal/qgsgdalfilesourcewidget.cpp
+++ b/src/gui/providers/gdal/qgsgdalfilesourcewidget.cpp
@@ -20,7 +20,9 @@
 
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgsfilewidget.h"
 
+#include <QHBoxLayout>
 #include <gdal.h>
 
 QgsGdalFileSourceWidget::QgsGdalFileSourceWidget( QWidget *parent )

--- a/src/gui/providers/gdal/qgsgdalfilesourcewidget.h
+++ b/src/gui/providers/gdal/qgsgdalfilesourcewidget.h
@@ -17,10 +17,10 @@
 #ifndef QGGDALFILESOURCEWIDGET_H
 #define QGGDALFILESOURCEWIDGET_H
 
-#include "ui_qgsgdalsourceselectbase.h"
 #include "qgsprovidersourcewidget.h"
-#include "qgis_gui.h"
-#include "qgis_sip.h"
+#include <QVariantMap>
+
+class QgsFileWidget;
 
 ///@cond PRIVATE
 #define SIP_NO_FILE

--- a/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.cpp
+++ b/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+    qgsmbtilesvectortileguiprovider.cpp
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmbtilesvectortileguiprovider.h"
+///@cond PRIVATE
+
+#include <QList>
+#include <QAction>
+#include <QDesktopServices>
+#include <QMenu>
+#include <QMessageBox>
+
+#include "qgsmaplayer.h"
+#include "qgsmbtilesvectortilesourcewidget.h"
+#include "qgsproviderregistry.h"
+#include "qgsmbtilesvectortiledataprovider.h"
+
+
+//
+// QgsMbtilesVectorTileGuiProviderMetadata
+//
+
+QgsMbtilesVectorTileSourceWidgetProvider::QgsMbtilesVectorTileSourceWidgetProvider()
+{
+
+}
+
+QString QgsMbtilesVectorTileSourceWidgetProvider::providerKey() const
+{
+  return QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY;
+}
+
+bool QgsMbtilesVectorTileSourceWidgetProvider::canHandleLayer( QgsMapLayer *layer ) const
+{
+  if ( layer->providerType() != QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY )
+    return false;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri(
+                              QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY,
+                              layer->source() );
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return false;
+
+  return true;
+}
+
+QgsProviderSourceWidget *QgsMbtilesVectorTileSourceWidgetProvider::createWidget( QgsMapLayer *layer, QWidget *parent )
+{
+  if ( layer->providerType() != QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY )
+    return nullptr;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri(
+                              QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY,
+                              layer->source()
+                            );
+
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return nullptr;
+
+  return new QgsMbtilesVectorTileSourceWidget( parent );
+}
+
+
+//
+// QgsMbtilesVectorTileGuiProviderMetadata
+//
+QgsMbtilesVectorTileGuiProviderMetadata::QgsMbtilesVectorTileGuiProviderMetadata():
+  QgsProviderGuiMetadata( QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY )
+{
+}
+
+QList<QgsProviderSourceWidgetProvider *> QgsMbtilesVectorTileGuiProviderMetadata::sourceWidgetProviders()
+{
+  QList<QgsProviderSourceWidgetProvider *> providers;
+  providers << new QgsMbtilesVectorTileSourceWidgetProvider();
+  return providers;
+}
+
+///@endcond

--- a/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.h
+++ b/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+    qgsmbtilesvectortileguiprovider.h
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSMBTILESVECTORTILEGUIPROVIDER_H
+#define QGSMBTILESVECTORTILEGUIPROVIDER_H
+
+#include "qgsproviderguimetadata.h"
+#include "qgsprovidersourcewidgetprovider.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+class QgsMbtilesVectorTileSourceWidgetProvider : public QgsProviderSourceWidgetProvider
+{
+  public:
+    QgsMbtilesVectorTileSourceWidgetProvider();
+    QString providerKey() const override;
+    bool canHandleLayer( QgsMapLayer *layer ) const override;
+    QgsProviderSourceWidget *createWidget( QgsMapLayer *layer, QWidget *parent = nullptr ) override;
+};
+
+class QgsMbtilesVectorTileGuiProviderMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsMbtilesVectorTileGuiProviderMetadata();
+    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override;
+};
+
+///@endcond
+#endif // QGSMBTILESVECTORTILEGUIPROVIDER_H

--- a/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.cpp
+++ b/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+    qgsmbtilesvectortilesourcewidget.cpp
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmbtilesvectortilesourcewidget.h"
+///@cond PRIVATE
+
+#include "qgsproviderregistry.h"
+#include "qgsfilewidget.h"
+#include "qgsmbtilesvectortiledataprovider.h"
+
+#include <QHBoxLayout>
+
+
+QgsMbtilesVectorTileSourceWidget::QgsMbtilesVectorTileSourceWidget( QWidget *parent )
+  : QgsProviderSourceWidget( parent )
+{
+  QHBoxLayout *layout = new QHBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+
+  mFileWidget = new QgsFileWidget();
+  mFileWidget->setDialogTitle( tr( "Select Mbtiles Dataset" ) );
+  mFileWidget->setFilter( tr( "Mbtiles Files" ) + QStringLiteral( " (*.mbtiles *.MBTILES)" ) );
+  mFileWidget->setStorageMode( QgsFileWidget::GetFile );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
+  layout->addWidget( mFileWidget );
+
+  setLayout( layout );
+
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsMbtilesVectorTileSourceWidget::validate );
+}
+
+void QgsMbtilesVectorTileSourceWidget::setSourceUri( const QString &uri )
+{
+  mSourceParts = QgsProviderRegistry::instance()->decodeUri(
+                   QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY,
+                   uri
+                 );
+
+  mFileWidget->setFilePath( mSourceParts.value( QStringLiteral( "path" ) ).toString() );
+  mIsValid = true;
+}
+
+QString QgsMbtilesVectorTileSourceWidget::sourceUri() const
+{
+  QVariantMap parts = mSourceParts;
+  parts.insert( QStringLiteral( "path" ), mFileWidget->filePath() );
+  return QgsProviderRegistry::instance()->encodeUri(
+           QgsMbTilesVectorTileDataProvider::MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY,
+           parts
+         );
+}
+
+void QgsMbtilesVectorTileSourceWidget::validate()
+{
+  const bool valid = !mFileWidget->filePath().isEmpty();
+  if ( valid != mIsValid )
+    emit validChanged( valid );
+  mIsValid = valid;
+}
+
+
+///@endcond

--- a/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.h
+++ b/src/gui/providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+    qgsmbtilesvectortilesourcewidget.h
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSMBTILESKVECTORTILESOURCEWIDGET_H
+#define QGSMBTILESKVECTORTILESOURCEWIDGET_H
+
+#include "qgsprovidersourcewidget.h"
+#include <QVariantMap>
+
+class QgsFileWidget;
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+class QgsMbtilesVectorTileSourceWidget : public QgsProviderSourceWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsMbtilesVectorTileSourceWidget( QWidget *parent = nullptr );
+
+    void setSourceUri( const QString &uri ) override;
+    QString sourceUri() const override;
+
+  private slots:
+
+    void validate();
+
+  private:
+    QgsFileWidget *mFileWidget = nullptr;
+
+    QVariantMap mSourceParts;
+    bool mIsValid = false;
+};
+
+///@endcond
+#endif // QGSMBTILESKVECTORTILESOURCEWIDGET_H

--- a/src/gui/providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.cpp
+++ b/src/gui/providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+    qgsvtpkvectortileguiprovider.cpp
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvtpkvectortileguiprovider.h"
+///@cond PRIVATE
+
+#include <QList>
+#include <QAction>
+#include <QDesktopServices>
+#include <QMenu>
+#include <QMessageBox>
+
+#include "qgsmaplayer.h"
+#include "qgsvtpkvectortilesourcewidget.h"
+#include "qgsproviderregistry.h"
+#include "qgsvtpkvectortiledataprovider.h"
+
+
+//
+// QgsVtpkVectorTileSourceWidgetProvider
+//
+
+QgsVtpkVectorTileSourceWidgetProvider::QgsVtpkVectorTileSourceWidgetProvider()
+{
+
+}
+
+QString QgsVtpkVectorTileSourceWidgetProvider::providerKey() const
+{
+  return QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY;
+}
+
+bool QgsVtpkVectorTileSourceWidgetProvider::canHandleLayer( QgsMapLayer *layer ) const
+{
+  if ( layer->providerType() != QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY )
+    return false;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri(
+                              QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY,
+                              layer->source() );
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return false;
+
+  return true;
+}
+
+QgsProviderSourceWidget *QgsVtpkVectorTileSourceWidgetProvider::createWidget( QgsMapLayer *layer, QWidget *parent )
+{
+  if ( layer->providerType() != QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY )
+    return nullptr;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri(
+                              QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY,
+                              layer->source()
+                            );
+
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return nullptr;
+
+  return new QgsVtpkVectorTileSourceWidget( parent );
+}
+
+
+//
+// QgsVtpkVectorTileGuiProviderMetadata
+//
+QgsVtpkVectorTileGuiProviderMetadata::QgsVtpkVectorTileGuiProviderMetadata():
+  QgsProviderGuiMetadata( QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY )
+{
+}
+
+QList<QgsProviderSourceWidgetProvider *> QgsVtpkVectorTileGuiProviderMetadata::sourceWidgetProviders()
+{
+  QList<QgsProviderSourceWidgetProvider *> providers;
+  providers << new QgsVtpkVectorTileSourceWidgetProvider();
+  return providers;
+}
+
+///@endcond

--- a/src/gui/providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.h
+++ b/src/gui/providers/vtpkvectortiles/qgsvtpkvectortileguiprovider.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+    qgsvtpkvectortileguiprovider.h
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSVTPKVECTORTILEGUIPROVIDER_H
+#define QGSVTPKVECTORTILEGUIPROVIDER_H
+
+#include "qgsproviderguimetadata.h"
+#include "qgsprovidersourcewidgetprovider.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+class QgsVtpkVectorTileSourceWidgetProvider : public QgsProviderSourceWidgetProvider
+{
+  public:
+    QgsVtpkVectorTileSourceWidgetProvider();
+    QString providerKey() const override;
+    bool canHandleLayer( QgsMapLayer *layer ) const override;
+    QgsProviderSourceWidget *createWidget( QgsMapLayer *layer, QWidget *parent = nullptr ) override;
+};
+
+class QgsVtpkVectorTileGuiProviderMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsVtpkVectorTileGuiProviderMetadata();
+    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override;
+};
+
+///@endcond
+#endif // QGSVTPKVECTORTILEGUIPROVIDER_H

--- a/src/gui/providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.cpp
+++ b/src/gui/providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+    qgsvtpkvectortilesourcewidget.cpp
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvtpkvectortilesourcewidget.h"
+///@cond PRIVATE
+
+#include "qgsproviderregistry.h"
+#include "qgsfilewidget.h"
+#include "qgsvtpkvectortiledataprovider.h"
+
+#include <QHBoxLayout>
+
+
+QgsVtpkVectorTileSourceWidget::QgsVtpkVectorTileSourceWidget( QWidget *parent )
+  : QgsProviderSourceWidget( parent )
+{
+  QHBoxLayout *layout = new QHBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+
+  mFileWidget = new QgsFileWidget();
+  mFileWidget->setDialogTitle( tr( "Select VTPK Dataset" ) );
+  mFileWidget->setFilter( tr( "VTPK Files" ) + QStringLiteral( " (*.vtpk *.VTPK)" ) );
+  mFileWidget->setStorageMode( QgsFileWidget::GetFile );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
+  layout->addWidget( mFileWidget );
+
+  setLayout( layout );
+
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsVtpkVectorTileSourceWidget::validate );
+}
+
+void QgsVtpkVectorTileSourceWidget::setSourceUri( const QString &uri )
+{
+  mSourceParts = QgsProviderRegistry::instance()->decodeUri(
+                   QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY,
+                   uri
+                 );
+
+  mFileWidget->setFilePath( mSourceParts.value( QStringLiteral( "path" ) ).toString() );
+  mIsValid = true;
+}
+
+QString QgsVtpkVectorTileSourceWidget::sourceUri() const
+{
+  QVariantMap parts = mSourceParts;
+  parts.insert( QStringLiteral( "path" ), mFileWidget->filePath() );
+  return QgsProviderRegistry::instance()->encodeUri(
+           QgsVtpkVectorTileDataProvider::DATA_PROVIDER_KEY,
+           parts
+         );
+}
+
+void QgsVtpkVectorTileSourceWidget::validate()
+{
+  const bool valid = !mFileWidget->filePath().isEmpty();
+  if ( valid != mIsValid )
+    emit validChanged( valid );
+  mIsValid = valid;
+}
+
+
+///@endcond

--- a/src/gui/providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.h
+++ b/src/gui/providers/vtpkvectortiles/qgsvtpkvectortilesourcewidget.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+    qgsvtpkvectortilesourcewidget.h
+     --------------------------------------
+    Date                 : March 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSVTPKVECTORTILESOURCEWIDGET_H
+#define QGSVTPKVECTORTILESOURCEWIDGET_H
+
+#include "qgsprovidersourcewidget.h"
+#include <QVariantMap>
+
+class QgsFileWidget;
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+class QgsVtpkVectorTileSourceWidget : public QgsProviderSourceWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsVtpkVectorTileSourceWidget( QWidget *parent = nullptr );
+
+    void setSourceUri( const QString &uri ) override;
+    QString sourceUri() const override;
+
+  private slots:
+
+    void validate();
+
+  private:
+    QgsFileWidget *mFileWidget = nullptr;
+
+    QVariantMap mSourceParts;
+    bool mIsValid = false;
+};
+
+///@endcond
+#endif // QGSVTPKVECTORTILESOURCEWIDGET_H

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -29,6 +29,9 @@
 #include "qgspointcloudproviderguimetadata.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
 
+#include "qgsmbtilesvectortileguiprovider.h"
+#include "qgsvtpkvectortileguiprovider.h"
+
 #ifdef HAVE_EPT
 #include "qgseptproviderguimetadata.h"
 #endif
@@ -90,6 +93,12 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 
   QgsProviderGuiMetadata *vt = new QgsVectorTileProviderGuiMetadata();
   mProviders[ vt->key() ] = vt;
+
+  QgsProviderGuiMetadata *mbtilesVectorTiles = new QgsMbtilesVectorTileGuiProviderMetadata();
+  mProviders[ mbtilesVectorTiles->key() ] = mbtilesVectorTiles;
+
+  QgsProviderGuiMetadata *vtpkVectorTiles = new QgsVtpkVectorTileGuiProviderMetadata();
+  mProviders[ vtpkVectorTiles->key() ] = vtpkVectorTiles;
 
 #ifdef HAVE_EPT
   QgsProviderGuiMetadata *ept = new QgsEptProviderGuiMetadata();

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -47,7 +47,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr );
     ~QgsVectorTileBasicRendererWidget() override;
 
-    void setLayer( QgsVectorTileLayer *layer );
+    void syncToLayer( QgsMapLayer *mapLayer ) final;
 
   public slots:
     //! Applies the settings made in the dialog

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -216,7 +216,7 @@ void QgsVectorTileLayerProperties::syncToLayer()
   /*
    * Symbology Tab
    */
-  mRendererWidget->setLayer( mLayer );
+  mRendererWidget->syncToLayer( mLayer );
 
   /*
    * Labels Tab

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -59,6 +59,9 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsVectorTileLayerProperties::crsChanged );
 
+  // scale based layer visibility related widgets
+  mScaleRangeWidget->setMapCanvas( mMapCanvas );
+
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
   // switching vertical tabs between icon/text to icon-only modes (splitter collapsed to left),
   // and connecting QDialogButtonBox's accepted/rejected signals to dialog's accept/reject slots
@@ -149,6 +152,10 @@ void QgsVectorTileLayerProperties::apply()
   mRendererWidget->apply();
   mLabelingWidget->apply();
   mMetadataWidget->acceptMetadata();
+
+  mLayer->setScaleBasedVisibility( chkUseScaleDependentRendering->isChecked() );
+  mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
+  mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
 }
 
 void QgsVectorTileLayerProperties::onCancel()
@@ -215,6 +222,12 @@ void QgsVectorTileLayerProperties::syncToLayer()
    * Labels Tab
    */
   mLabelingWidget->setLayer( mLayer );
+
+  /*
+   * Rendering
+   */
+  chkUseScaleDependentRendering->setChecked( mLayer->hasScaleBasedVisibility() );
+  mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
 }
 
 

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -17,10 +17,8 @@
 #define QGSVECTORTILELAYERPROPERTIES_H
 
 #include "qgsoptionsdialogbase.h"
-
 #include "ui_qgsvectortilelayerpropertiesbase.h"
-
-#include "qgsmaplayerstylemanager.h"
+#include "qgsmaplayerstyle.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -29,6 +27,7 @@ class QgsVectorTileBasicLabelingWidget;
 class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileLayer;
 class QgsMetadataWidget;
+class QgsProviderSourceWidget;
 
 
 /**
@@ -57,6 +56,7 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     void saveMetadataAs();
     void showHelp();
     void urlClicked( const QUrl &url );
+    void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
@@ -77,6 +77,8 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
+
+    QgsProviderSourceWidget *mSourceWidget = nullptr;
 
     /**
      * Previous layer style. Used to reset style to previous state if new style

--- a/src/providers/postgres/raster/qgspostgresrastertemporalsettingswidget.cpp
+++ b/src/providers/postgres/raster/qgspostgresrastertemporalsettingswidget.cpp
@@ -17,12 +17,7 @@
 
 #include "qgspostgresrastertemporalsettingswidget.h"
 #include "qgsmaplayer.h"
-#include "qgsproject.h"
 #include "qgsrasterlayer.h"
-#include "qgsprojecttimesettings.h"
-#include "qgsrasterlayertemporalproperties.h"
-#include "qgsproviderregistry.h"
-#include "qgsprovidermetadata.h"
 
 QgsPostgresRasterTemporalSettingsWidget::QgsPostgresRasterTemporalSettingsWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )

--- a/src/providers/postgres/raster/qgspostgresrastertemporalsettingswidget.h
+++ b/src/providers/postgres/raster/qgspostgresrastertemporalsettingswidget.h
@@ -31,7 +31,7 @@ class QgsPostgresRasterTemporalSettingsWidget : public QgsMapLayerConfigWidget, 
   public:
     QgsPostgresRasterTemporalSettingsWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
     void apply() override;
   private slots:
 

--- a/src/providers/wms/qgswmstsettingswidget.h
+++ b/src/providers/wms/qgswmstsettingswidget.h
@@ -31,7 +31,7 @@ class QgsWmstSettingsWidget : public QgsMapLayerConfigWidget, private Ui::QgsWms
   public:
     QgsWmstSettingsWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
     void apply() override;
   private slots:
     void temporalPropertiesChange();

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -11,6 +11,18 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="bottomMargin">
@@ -122,13 +134,76 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="mActiveDatasetBlendingMode">
+     <property name="title">
+      <string>Layer Rendering</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <item row="1" column="1">
+       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Blending mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -148,6 +148,18 @@
          </item>
          <item>
           <property name="text">
+           <string>Rendering</string>
+          </property>
+          <property name="toolTip">
+           <string>Rendering</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Metadata</string>
           </property>
           <property name="toolTip">
@@ -363,6 +375,78 @@
          <widget class="QWidget" name="mOptsPage_Labeling">
           <layout class="QVBoxLayout" name="verticalLayout_4"/>
          </widget>
+         <widget class="QWidget" name="mOptsPage_Rendering">
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="chkUseScaleDependentRendering">
+             <property name="title">
+              <string>Scale Dependent Visibility</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <property name="syncGroup" stdset="0">
+              <string notr="true">rastergeneral</string>
+             </property>
+             <layout class="QGridLayout" name="_5">
+              <property name="leftMargin">
+               <number>11</number>
+              </property>
+              <property name="topMargin">
+               <number>11</number>
+              </property>
+              <property name="rightMargin">
+               <number>11</number>
+              </property>
+              <property name="bottomMargin">
+               <number>11</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>6</number>
+              </property>
+              <item row="0" column="0" colspan="2">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="whatsThis">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
          <widget class="QWidget" name="mOptsPage_Metadata">
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <property name="leftMargin">
@@ -462,6 +546,11 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsWebView</class>
    <extends>QWidget</extends>
    <header>qgswebview.h</header>
@@ -473,6 +562,7 @@
   <tabstop>mOptionsListWidget</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -112,6 +112,18 @@
          </item>
          <item>
           <property name="text">
+           <string>Source</string>
+          </property>
+          <property name="toolTip">
+           <string>Source</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Symbology</string>
           </property>
           <property name="toolTip">
@@ -206,6 +218,129 @@
            </property>
            <item>
             <widget class="QgsWebView" name="mMetadataViewer" native="true"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Source">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QgsScrollArea" name="scrollArea_3">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_3">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>661</width>
+                <height>507</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_7">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_14">
+                 <item>
+                  <widget class="QLabel" name="label_8">
+                   <property name="text">
+                    <string>Layer name</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="mLayerOrigNameLineEd"/>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mCrsGroupBox">
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
+                 <property name="title">
+                  <string>Assigned Coordinate Reference System (CRS)</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>false</bool>
+                 </property>
+                 <property name="syncGroup" stdset="0">
+                  <string notr="true">vectorgeneral</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_28">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <item>
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_17">
+                    <property name="text">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Changing this option does not modify the original data source or perform any reprojection of the vector tile layer. Rather, it can be used to override the layer's CRS within this project if it could not be detected or has been incorrectly detected.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="textFormat">
+                     <enum>Qt::RichText</enum>
+                    </property>
+                    <property name="wordWrap">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="Line" name="line_4">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mSourceGroupBox">
+                 <property name="title">
+                  <string>Layer Source</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Expanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>17</width>
+                   <height>111</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -304,9 +439,27 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsWebView</class>


### PR DESCRIPTION
This PR exposes some settings which are supported for vector tile layers, but have never been exposed for user control:

- layer opacity
- layer blend mode

Additionally it adds the standard "Source" and "Rendering" tabs to the vector tile layer properties dialog. The Rendering tab contains the layer's scale based visibility (just like for other layer types), and the source tab contains the layer name, crs override and provider-specific source controls.

I've also implemented source widgets for the vtpk and mbtiles vector tile providers, allowing control over the source vtpk/mbtiles file path.