### PR TITLE
Expose option to load vector tile sources from files in Data Source Manager

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -946,6 +946,34 @@ QgsPalLayerSettings.MultiJustify.__doc__ = "Justified"
 Qgis.LabelMultiLineAlignment.__doc__ = 'Text alignment for multi-line labels.\n\n.. note::\n\n   Prior to QGIS 3.26 this was available as :py:class:`QgsPalLayerSettings`.MultiLineAlign\n\n.. versionadded:: 3.26\n\n' + '* ``MultiLeft``: ' + Qgis.LabelMultiLineAlignment.Left.__doc__ + '\n' + '* ``MultiCenter``: ' + Qgis.LabelMultiLineAlignment.Center.__doc__ + '\n' + '* ``MultiRight``: ' + Qgis.LabelMultiLineAlignment.Right.__doc__ + '\n' + '* ``MultiFollowPlacement``: ' + Qgis.LabelMultiLineAlignment.FollowPlacement.__doc__ + '\n' + '* ``MultiJustify``: ' + Qgis.LabelMultiLineAlignment.Justify.__doc__
 # --
 Qgis.LabelMultiLineAlignment.baseClass = Qgis
+QgsProviderMetadata.FilterType = Qgis.FileFilterType
+# monkey patching scoped based enum
+QgsProviderMetadata.FilterVector = Qgis.FileFilterType.Vector
+QgsProviderMetadata.FilterType.FilterVector = Qgis.FileFilterType.Vector
+QgsProviderMetadata.FilterVector.is_monkey_patched = True
+QgsProviderMetadata.FilterVector.__doc__ = "Vector layers"
+QgsProviderMetadata.FilterRaster = Qgis.FileFilterType.Raster
+QgsProviderMetadata.FilterType.FilterRaster = Qgis.FileFilterType.Raster
+QgsProviderMetadata.FilterRaster.is_monkey_patched = True
+QgsProviderMetadata.FilterRaster.__doc__ = "Raster layers"
+QgsProviderMetadata.FilterMesh = Qgis.FileFilterType.Mesh
+QgsProviderMetadata.FilterType.FilterMesh = Qgis.FileFilterType.Mesh
+QgsProviderMetadata.FilterMesh.is_monkey_patched = True
+QgsProviderMetadata.FilterMesh.__doc__ = "Mesh layers"
+QgsProviderMetadata.FilterMeshDataset = Qgis.FileFilterType.MeshDataset
+QgsProviderMetadata.FilterType.FilterMeshDataset = Qgis.FileFilterType.MeshDataset
+QgsProviderMetadata.FilterMeshDataset.is_monkey_patched = True
+QgsProviderMetadata.FilterMeshDataset.__doc__ = "Mesh datasets"
+QgsProviderMetadata.FilterPointCloud = Qgis.FileFilterType.PointCloud
+QgsProviderMetadata.FilterType.FilterPointCloud = Qgis.FileFilterType.PointCloud
+QgsProviderMetadata.FilterPointCloud.is_monkey_patched = True
+QgsProviderMetadata.FilterPointCloud.__doc__ = "Point clouds (since QGIS 3.18)"
+QgsProviderMetadata.VectorTile = Qgis.FileFilterType.VectorTile
+QgsProviderMetadata.VectorTile.is_monkey_patched = True
+QgsProviderMetadata.VectorTile.__doc__ = "Vector tile layers (since QGIS 3.32)"
+Qgis.FileFilterType.__doc__ = 'Type of file filters\n\nPrior to QGIS 3.32 this was available as :py:class:`QgsProviderMetadata`.FilterType\n\n.. versionadded:: 3.32\n\n' + '* ``FilterVector``: ' + Qgis.FileFilterType.Vector.__doc__ + '\n' + '* ``FilterRaster``: ' + Qgis.FileFilterType.Raster.__doc__ + '\n' + '* ``FilterMesh``: ' + Qgis.FileFilterType.Mesh.__doc__ + '\n' + '* ``FilterMeshDataset``: ' + Qgis.FileFilterType.MeshDataset.__doc__ + '\n' + '* ``FilterPointCloud``: ' + Qgis.FileFilterType.PointCloud.__doc__ + '\n' + '* ``VectorTile``: ' + Qgis.FileFilterType.VectorTile.__doc__
+# --
+Qgis.FileFilterType.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.SublayerQueryFlag.FastScan.__doc__ = "Indicates that the provider must scan for sublayers using the fastest possible approach -- e.g. by first checking that a uri has an extension which is known to be readable by the provider"
 Qgis.SublayerQueryFlag.ResolveGeometryType.__doc__ = "Attempt to resolve the geometry type for vector sublayers"

--- a/python/core/auto_additions/qgsprovidermetadata.py
+++ b/python/core/auto_additions/qgsprovidermetadata.py
@@ -2,11 +2,3 @@
 QgsMeshDriverMetadata.MeshDriverCapability.baseClass = QgsMeshDriverMetadata
 QgsMeshDriverMetadata.MeshDriverCapabilities.baseClass = QgsMeshDriverMetadata
 MeshDriverCapabilities = QgsMeshDriverMetadata  # dirty hack since SIP seems to introduce the flags in module
-# monkey patching scoped based enum
-QgsProviderMetadata.FilterType.FilterVector.__doc__ = "Vector layers"
-QgsProviderMetadata.FilterType.FilterRaster.__doc__ = "Raster layers"
-QgsProviderMetadata.FilterType.FilterMesh.__doc__ = "Mesh layers"
-QgsProviderMetadata.FilterType.FilterMeshDataset.__doc__ = "Mesh datasets"
-QgsProviderMetadata.FilterType.FilterPointCloud.__doc__ = "Point clouds (since QGIS 3.18)"
-QgsProviderMetadata.FilterType.__doc__ = 'Type of file filters\n\n.. versionadded:: 3.10\n\n' + '* ``FilterVector``: ' + QgsProviderMetadata.FilterType.FilterVector.__doc__ + '\n' + '* ``FilterRaster``: ' + QgsProviderMetadata.FilterType.FilterRaster.__doc__ + '\n' + '* ``FilterMesh``: ' + QgsProviderMetadata.FilterType.FilterMesh.__doc__ + '\n' + '* ``FilterMeshDataset``: ' + QgsProviderMetadata.FilterType.FilterMeshDataset.__doc__ + '\n' + '* ``FilterPointCloud``: ' + QgsProviderMetadata.FilterType.FilterPointCloud.__doc__
-# --

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -275,16 +275,7 @@ Cleanup the provider
 .. versionadded:: 3.10
 %End
 
-    enum class FilterType
-    {
-      FilterVector,
-      FilterRaster,
-      FilterMesh,
-      FilterMeshDataset,
-      FilterPointCloud,
-    };
-
-    virtual QString filters( FilterType type );
+    virtual QString filters( Qgis::FileFilterType type );
 %Docstring
 Builds the list of file filter strings (supported formats)
 

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -617,6 +617,8 @@ supported by all data providers.
 .. seealso:: :py:func:`fileMeshFilters`
 
 .. seealso:: :py:func:`filePointCloudFilters`
+
+.. seealso:: :py:func:`fileVectorTileFilters`
 %End
 
     QString fileRasterFilters() const;
@@ -635,6 +637,8 @@ supported by all data providers.
 .. seealso:: :py:func:`fileMeshFilters`
 
 .. seealso:: :py:func:`filePointCloudFilters`
+
+.. seealso:: :py:func:`fileVectorTileFilters`
 %End
 
     QString fileMeshFilters() const;
@@ -651,6 +655,8 @@ supported by all data providers.
 .. seealso:: :py:func:`fileVectorFilters`
 
 .. seealso:: :py:func:`filePointCloudFilters`
+
+.. seealso:: :py:func:`fileVectorTileFilters`
 
 .. versionadded:: 3.6
 %End
@@ -680,7 +686,27 @@ supported by all data providers.
 
 .. seealso:: :py:func:`fileVectorFilters`
 
+.. seealso:: :py:func:`fileVectorTileFilters`
+
 .. versionadded:: 3.18
+%End
+
+    QString fileVectorTileFilters() const;
+%Docstring
+Returns a file filter string for supported vector tile files.
+
+Returns a string suitable for a QFileDialog of vector tile file formats
+supported by all data providers.
+
+.. seealso:: :py:func:`fileMeshFilters`
+
+.. seealso:: :py:func:`fileRasterFilters`
+
+.. seealso:: :py:func:`fileVectorFilters`
+
+.. seealso:: :py:func:`filePointCloudFilters`
+
+.. versionadded:: 3.32
 %End
 
     QString databaseDrivers() const;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -523,6 +523,16 @@ The development version
       Justify,
     };
 
+    enum class FileFilterType
+      {
+      Vector,
+      Raster,
+      Mesh,
+      MeshDataset,
+      PointCloud,
+      VectorTile,
+    };
+
     enum class SublayerQueryFlag
     {
       FastScan,

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -270,15 +270,17 @@ void QgsHandleBadLayers::browseClicked()
     const QString provider = mLayerList->item( row, 0 )->data( static_cast< int >( CustomRoles::Provider ) ).toString();
 
     QString fileFilter;
+    QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( provider );
+
     switch ( layerType )
     {
       case Qgis::LayerType::Vector:
         memoryQualifier = QStringLiteral( "lastVectorFileFilter" );
-        fileFilter = QgsProviderRegistry::instance()->providerMetadata( provider )->filters( QgsProviderMetadata::FilterType::FilterVector );
+        fileFilter = metadata->filters( Qgis::FileFilterType::Vector );
         break;
       case Qgis::LayerType::Raster:
         memoryQualifier = QStringLiteral( "lastRasterFileFilter" );
-        fileFilter = QgsProviderRegistry::instance()->providerMetadata( provider )->filters( QgsProviderMetadata::FilterType::FilterRaster );
+        fileFilter = metadata->filters( Qgis::FileFilterType::Raster );
         break;
       case Qgis::LayerType::Mesh:
         memoryQualifier = QStringLiteral( "lastMeshFileFilter" );
@@ -286,12 +288,11 @@ void QgsHandleBadLayers::browseClicked()
         break;
       case Qgis::LayerType::VectorTile:
         memoryQualifier = QStringLiteral( "lastVectorTileFileFilter" );
-        // not quite right -- but currently there's no generic method to get vector tile filters...
-        fileFilter = QgsProviderRegistry::instance()->fileVectorFilters();
+        fileFilter = metadata ? metadata->filters( Qgis::FileFilterType::VectorTile ) : QObject::tr( "All files (*.*)" );
         break;
       case Qgis::LayerType::PointCloud:
         memoryQualifier = QStringLiteral( "lastPointCloudFileFilter" );
-        fileFilter = QgsProviderRegistry::instance()->providerMetadata( provider )->filters( QgsProviderMetadata::FilterType::FilterPointCloud );
+        fileFilter = metadata->filters( Qgis::FileFilterType::PointCloud );
         break;
 
       case Qgis::LayerType::Annotation:

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -22,6 +22,7 @@
 #include "qgsgeometryengine.h"
 #include "qgsmeshadvancedediting.h"
 #include "qgsgeometryutils.h"
+#include "qgspolygon.h"
 
 #include <poly2tri.h>
 

--- a/src/core/providers/copc/qgscopcprovider.cpp
+++ b/src/core/providers/copc/qgscopcprovider.cpp
@@ -16,8 +16,6 @@
  ***************************************************************************/
 
 #include "qgis.h"
-#include "qgslogger.h"
-#include "qgsproviderregistry.h"
 #include "qgscopcprovider.h"
 #include "qgscopcpointcloudindex.h"
 #include "qgsremotecopcpointcloudindex.h"
@@ -204,17 +202,18 @@ QVariantMap QgsCopcProviderMetadata::decodeUri( const QString &uri ) const
   return uriComponents;
 }
 
-QString QgsCopcProviderMetadata::filters( QgsProviderMetadata::FilterType type )
+QString QgsCopcProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterVector:
-    case QgsProviderMetadata::FilterType::FilterRaster:
-    case QgsProviderMetadata::FilterType::FilterMesh:
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
 
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::PointCloud:
       return QObject::tr( "COPC Point Clouds" ) + QStringLiteral( " (*.copc.laz *.COPC.LAZ)" );
   }
   return QString();

--- a/src/core/providers/copc/qgscopcprovider.h
+++ b/src/core/providers/copc/qgscopcprovider.h
@@ -74,7 +74,7 @@ class QgsCopcProviderMetadata : public QgsProviderMetadata
     QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QVariantMap decodeUri( const QString &uri ) const override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
     QList< Qgis::LayerType > supportedLayerTypes() const override;
 };

--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -209,17 +209,18 @@ QVariantMap QgsEptProviderMetadata::decodeUri( const QString &uri ) const
   return uriComponents;
 }
 
-QString QgsEptProviderMetadata::filters( QgsProviderMetadata::FilterType type )
+QString QgsEptProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterVector:
-    case QgsProviderMetadata::FilterType::FilterRaster:
-    case QgsProviderMetadata::FilterType::FilterMesh:
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
 
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::PointCloud:
       return QObject::tr( "Entwine Point Clouds" ) + QStringLiteral( " (ept.json EPT.JSON)" );
   }
   return QString();

--- a/src/core/providers/ept/qgseptprovider.h
+++ b/src/core/providers/ept/qgseptprovider.h
@@ -71,7 +71,7 @@ class QgsEptProviderMetadata : public QgsProviderMetadata
     bool uriIsBlocklisted( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QVariantMap decodeUri( const QString &uri ) const override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
     QList< Qgis::LayerType > supportedLayerTypes() const override;
 };

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3966,11 +3966,11 @@ bool QgsGdalProvider::remove()
  * that contains this list that is suitable for use in a
  * QFileDialog::getOpenFileNames() call.
 */
-QString QgsGdalProviderMetadata::filters( FilterType type )
+QString QgsGdalProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterRaster:
+    case Qgis::FileFilterType::Raster:
     {
       QString fileFiltersString;
       QStringList exts;
@@ -3979,10 +3979,11 @@ QString QgsGdalProviderMetadata::filters( FilterType type )
       return fileFiltersString;
     }
 
-    case QgsProviderMetadata::FilterType::FilterVector:
-    case QgsProviderMetadata::FilterType::FilterMesh:
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::PointCloud:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
   }
   return QString();

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -394,7 +394,7 @@ class QgsGdalProviderMetadata final: public QgsProviderMetadata
       double *geoTransform,
       const QgsCoordinateReferenceSystem &crs,
       const QStringList &createOptions ) override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     QList<QPair<QString, QString> > pyramidResamplingMethods() override;
     QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     ProviderCapabilities providerCapabilities() const override;

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -1141,17 +1141,18 @@ QIcon QgsOgrProviderMetadata::icon() const
   return QgsApplication::getThemeIcon( QStringLiteral( "mIconVector.svg" ) );
 }
 
-QString QgsOgrProviderMetadata::filters( FilterType type )
+QString QgsOgrProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterVector:
+    case Qgis::FileFilterType::Vector:
       return QgsOgrProviderUtils::fileVectorFilters();
 
-    case QgsProviderMetadata::FilterType::FilterRaster:
-    case QgsProviderMetadata::FilterType::FilterMesh:
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::PointCloud:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
   }
   return QString();

--- a/src/core/providers/ogr/qgsogrprovidermetadata.h
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.h
@@ -43,7 +43,7 @@ class QgsOgrProviderMetadata final: public QgsProviderMetadata
     QString encodeUri( const QVariantMap &parts ) const override;
     QString absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const override;
     QString relativeToAbsoluteUri( const QString &uri, const QgsReadWriteContext &context ) const override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     ProviderCapabilities providerCapabilities() const override;
     bool uriIsBlocklisted( const QString &uri ) const override;

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -97,7 +97,7 @@ void QgsProviderMetadata::cleanupProvider()
 
 }
 
-QString QgsProviderMetadata::filters( FilterType )
+QString QgsProviderMetadata::filters( Qgis::FileFilterType )
 {
   return QString();
 }

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -32,9 +32,7 @@
 #include "qgis_core.h"
 #include <functional>
 #include "qgsabstractproviderconnection.h"
-#include "qgsabstractlayermetadataprovider.h"
 #include "qgsfields.h"
-#include "qgsexception.h"
 
 class QgsDataItem;
 class QgsDataItemProvider;
@@ -343,26 +341,13 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     virtual void cleanupProvider();
 
     /**
-     * Type of file filters
-     * \since QGIS 3.10
-     */
-    enum class FilterType
-    {
-      FilterVector = 1, //!< Vector layers
-      FilterRaster, //!< Raster layers
-      FilterMesh, //!< Mesh layers
-      FilterMeshDataset, //!< Mesh datasets
-      FilterPointCloud, //!< Point clouds (since QGIS 3.18)
-    };
-
-    /**
      * Builds the list of file filter strings (supported formats)
      *
      * Suitable for use in a QFileDialog::getOpenFileNames() call.
      *
      * \since QGIS 3.10
      */
-    virtual QString filters( FilterType type );
+    virtual QString filters( Qgis::FileFilterType type );
 
     /**
      * Builds the list of available mesh drivers metadata

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -351,6 +351,9 @@ void QgsProviderRegistry::init()
   QStringList pointCloudWildcards;
   QStringList pointCloudFilters;
 
+  QStringList vectorTileWildcards;
+  QStringList vectorTileFilters;
+
   // now initialize all providers
   for ( Providers::const_iterator it = mProviders.begin(); it != mProviders.end(); ++it )
   {
@@ -361,7 +364,7 @@ void QgsProviderRegistry::init()
     QgsProviderMetadata *meta = it->second;
 
     // now get vector file filters, if any
-    const QString fileVectorFilters = meta->filters( QgsProviderMetadata::FilterType::FilterVector );
+    const QString fileVectorFilters = meta->filters( Qgis::FileFilterType::Vector );
     if ( !fileVectorFilters.isEmpty() )
     {
       mVectorFileFilters += fileVectorFilters;
@@ -369,7 +372,7 @@ void QgsProviderRegistry::init()
     }
 
     // now get raster file filters, if any
-    const QString fileRasterFilters = meta->filters( QgsProviderMetadata::FilterType::FilterRaster );
+    const QString fileRasterFilters = meta->filters( Qgis::FileFilterType::Raster );
     if ( !fileRasterFilters.isEmpty() )
     {
       QgsDebugMsgLevel( "raster filters: " + fileRasterFilters, 2 );
@@ -378,7 +381,7 @@ void QgsProviderRegistry::init()
     }
 
     // now get mesh file filters, if any
-    const QString fileMeshFilters = meta->filters( QgsProviderMetadata::FilterType::FilterMesh );
+    const QString fileMeshFilters = meta->filters( Qgis::FileFilterType::Mesh );
     if ( !fileMeshFilters.isEmpty() )
     {
       mMeshFileFilters += fileMeshFilters;
@@ -386,7 +389,7 @@ void QgsProviderRegistry::init()
 
     }
 
-    const QString fileMeshDatasetFilters = meta->filters( QgsProviderMetadata::FilterType::FilterMeshDataset );
+    const QString fileMeshDatasetFilters = meta->filters( Qgis::FileFilterType::MeshDataset );
     if ( !fileMeshDatasetFilters.isEmpty() )
     {
       mMeshDatasetFileFilters += fileMeshDatasetFilters;
@@ -394,7 +397,7 @@ void QgsProviderRegistry::init()
     }
 
     // now get point cloud file filters, if any
-    const QString filePointCloudFilters = meta->filters( QgsProviderMetadata::FilterType::FilterPointCloud );
+    const QString filePointCloudFilters = meta->filters( Qgis::FileFilterType::PointCloud );
     if ( !filePointCloudFilters.isEmpty() )
     {
       QgsDebugMsgLevel( "point cloud filters: " + filePointCloudFilters, 2 );
@@ -411,6 +414,24 @@ void QgsProviderRegistry::init()
       }
     }
 
+    // now get vector tile file filters, if any
+    const QString fileVectorTileFilters = meta->filters( Qgis::FileFilterType::VectorTile );
+    if ( !fileVectorTileFilters.isEmpty() )
+    {
+      QgsDebugMsgLevel( "vector tile filters: " + fileVectorTileFilters, 2 );
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+      const QStringList filters = fileVectorTileFilters.split( QStringLiteral( ";;" ), QString::SkipEmptyParts );
+#else
+      const QStringList filters = fileVectorTileFilters.split( QStringLiteral( ";;" ), Qt::SkipEmptyParts );
+#endif
+      for ( const QString &filter : filters )
+      {
+        vectorTileFilters.append( filter );
+        vectorTileWildcards.append( QgsFileUtils::wildcardsFromFilter( filter ).split( ' ' ) );
+      }
+    }
+
     // call initProvider() - allows provider to register its services to QGIS
     meta->initProvider();
   }
@@ -420,6 +441,13 @@ void QgsProviderRegistry::init()
     pointCloudFilters.insert( 0, QObject::tr( "All Supported Files" ) + QStringLiteral( " (%1)" ).arg( pointCloudWildcards.join( ' ' ) ) );
     pointCloudFilters.insert( 1, QObject::tr( "All Files" ) + QStringLiteral( " (*.*)" ) );
     mPointCloudFileFilters = pointCloudFilters.join( QLatin1String( ";;" ) );
+  }
+
+  if ( !vectorTileFilters.empty() )
+  {
+    vectorTileFilters.insert( 0, QObject::tr( "All Supported Files" ) + QStringLiteral( " (%1)" ).arg( vectorTileWildcards.join( ' ' ) ) );
+    vectorTileFilters.insert( 1, QObject::tr( "All Files" ) + QStringLiteral( " (*.*)" ) );
+    mVectorTileFileFilters = vectorTileFilters.join( QLatin1String( ";;" ) );
   }
 
   // load database drivers (only OGR)
@@ -886,6 +914,11 @@ QString QgsProviderRegistry::fileMeshDatasetFilters() const
 QString QgsProviderRegistry::filePointCloudFilters() const
 {
   return mPointCloudFileFilters;
+}
+
+QString QgsProviderRegistry::fileVectorTileFilters() const
+{
+  return mVectorTileFileFilters;
 }
 
 QString QgsProviderRegistry::databaseDrivers() const

--- a/src/core/providers/qgsproviderregistry.h
+++ b/src/core/providers/qgsproviderregistry.h
@@ -629,6 +629,7 @@ class CORE_EXPORT QgsProviderRegistry
      * \see fileRasterFilters()
      * \see fileMeshFilters()
      * \see filePointCloudFilters()
+     * \see fileVectorTileFilters()
      */
     QString fileVectorFilters() const;
 
@@ -643,6 +644,7 @@ class CORE_EXPORT QgsProviderRegistry
      * \see fileVectorFilters()
      * \see fileMeshFilters()
      * \see filePointCloudFilters()
+     * \see fileVectorTileFilters()
      */
     QString fileRasterFilters() const;
 
@@ -656,6 +658,7 @@ class CORE_EXPORT QgsProviderRegistry
      * \see fileRasterFilters()
      * \see fileVectorFilters()
      * \see filePointCloudFilters()
+     * \see fileVectorTileFilters()
      *
      * \since QGIS 3.6
      */
@@ -682,10 +685,26 @@ class CORE_EXPORT QgsProviderRegistry
      * \see fileMeshFilters()
      * \see fileRasterFilters()
      * \see fileVectorFilters()
+     * \see fileVectorTileFilters()
      *
      * \since QGIS 3.18
      */
     QString filePointCloudFilters() const;
+
+    /**
+     * Returns a file filter string for supported vector tile files.
+     *
+     * Returns a string suitable for a QFileDialog of vector tile file formats
+     * supported by all data providers.
+     *
+     * \see fileMeshFilters()
+     * \see fileRasterFilters()
+     * \see fileVectorFilters()
+     * \see filePointCloudFilters()
+     *
+     * \since QGIS 3.32
+     */
+    QString fileVectorTileFilters() const;
 
     //! Returns a string containing the available database drivers
     QString databaseDrivers() const;
@@ -757,6 +776,11 @@ class CORE_EXPORT QgsProviderRegistry
      * File filter string for point cloud files
      */
     QString mPointCloudFileFilters;
+
+    /**
+     * File filter string for vector tile files
+     */
+    QString mVectorTileFileFilters;
 
     /**
      * Available database drivers string for vector databases

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -835,6 +835,23 @@ class CORE_EXPORT Qgis
     Q_ENUM( LabelMultiLineAlignment )
 
     /**
+     * Type of file filters
+     *
+     * Prior to QGIS 3.32 this was available as QgsProviderMetadata::FilterType
+     * \since QGIS 3.32
+     */
+    enum class FileFilterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProviderMetadata, FilterType ) : int
+      {
+      Vector SIP_MONKEYPATCH_COMPAT_NAME( FilterVector ) = 1, //!< Vector layers
+      Raster SIP_MONKEYPATCH_COMPAT_NAME( FilterRaster ), //!< Raster layers
+      Mesh SIP_MONKEYPATCH_COMPAT_NAME( FilterMesh ), //!< Mesh layers
+      MeshDataset SIP_MONKEYPATCH_COMPAT_NAME( FilterMeshDataset ), //!< Mesh datasets
+      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( FilterPointCloud ), //!< Point clouds (since QGIS 3.18)
+      VectorTile, //!< Vector tile layers (since QGIS 3.32)
+    };
+    Q_ENUM( FileFilterType )
+
+    /**
      * Flags which control how data providers will scan for sublayers in a dataset.
      *
      * \since QGIS 3.22

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -234,6 +234,23 @@ QgsProviderMetadata::ProviderCapabilities QgsMbTilesVectorTileDataProviderMetada
   return FileBasedUris;
 }
 
+QString QgsMbTilesVectorTileDataProviderMetadata::filters( Qgis::FileFilterType type )
+{
+  switch ( type )
+  {
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::PointCloud:
+      return QString();
+
+    case Qgis::FileFilterType::VectorTile:
+      return QObject::tr( "Mbtiles Vector Tiles" ) + QStringLiteral( " (*.mbtiles *.MBTILES)" );
+  }
+  return QString();
+}
+
 QVariantMap QgsMbTilesVectorTileDataProviderMetadata::decodeUri( const QString &uri ) const
 {
   QgsDataSourceUri dsUri;

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -73,10 +73,14 @@ class QgsMbTilesVectorTileDataProviderMetadata : public QgsProviderMetadata
     Q_OBJECT
   public:
     QgsMbTilesVectorTileDataProviderMetadata();
+    QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     QgsMbTilesVectorTileDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     QIcon icon() const override;
     ProviderCapabilities providerCapabilities() const override;
     QString filters( Qgis::FileFilterType type ) override;
+    int priorityForUri( const QString &uri ) const override;
+    QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;
+
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QString absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const override;

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -76,6 +76,7 @@ class QgsMbTilesVectorTileDataProviderMetadata : public QgsProviderMetadata
     QgsMbTilesVectorTileDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     QIcon icon() const override;
     ProviderCapabilities providerCapabilities() const override;
+    QString filters( Qgis::FileFilterType type ) override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QString absoluteToRelativeUri( const QString &uri, const QgsReadWriteContext &context ) const override;

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -250,6 +250,23 @@ QgsProviderMetadata::ProviderCapabilities QgsVtpkVectorTileDataProviderMetadata:
   return FileBasedUris;
 }
 
+QString QgsVtpkVectorTileDataProviderMetadata::filters( Qgis::FileFilterType type )
+{
+  switch ( type )
+  {
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::PointCloud:
+      return QString();
+
+    case Qgis::FileFilterType::VectorTile:
+      return QObject::tr( "VTPK Vector Tiles" ) + QStringLiteral( " (*.vtpk *.VTPK)" );
+  }
+  return QString();
+}
+
 QList<QgsProviderSublayerDetails> QgsVtpkVectorTileDataProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags, QgsFeedback * ) const
 {
   QString fileName;

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -89,6 +89,7 @@ class QgsVtpkVectorTileDataProviderMetadata : public QgsProviderMetadata
     QgsVtpkVectorTileDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     QIcon icon() const override;
     ProviderCapabilities providerCapabilities() const override;
+    QString filters( Qgis::FileFilterType type ) override;
     QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
     int priorityForUri( const QString &uri ) const override;
     QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -87,7 +87,7 @@ QgsVectorTileSourceSelect::QgsVectorTileSourceSelect( QWidget *parent, Qt::Windo
   mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {
-    emit enableButtons( ! path.isEmpty() );
+    emit enableButtons( !path.isEmpty() );
   } );
 }
 

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -36,8 +36,6 @@ QgsVectorTileSourceSelect::QgsVectorTileSourceSelect( QWidget *parent, Qt::Windo
 {
   setupUi( this );
 
-  mConnectionDetailsGroupBox->hide();
-
   setWindowTitle( tr( "Add Vector Tile Layer" ) );
   mConnectionsGroupBox->setTitle( tr( "Vector Tile Connections" ) );
 

--- a/src/gui/vectortile/qgsvectortilesourceselect.h
+++ b/src/gui/vectortile/qgsvectortilesourceselect.h
@@ -22,7 +22,7 @@
 #define SIP_NO_FILE
 
 #include "qgsabstractdatasourcewidget.h"
-#include "ui_qgstilesourceselectbase.h"
+#include "ui_qgsvectortilesourceselectbase.h"
 
 /*!
  * \brief   Dialog to create connections to vector tile servers.
@@ -33,7 +33,7 @@
  * The user can then connect and add layers from the vector tile server
  * to the map canvas.
  */
-class QgsVectorTileSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsTileSourceSelectBase
+class QgsVectorTileSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsVectorTileSourceSelectBase
 {
     Q_OBJECT
 

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -1246,18 +1246,18 @@ QList<Qgis::LayerType> QgsMdalProviderMetadata::supportedLayerTypes() const
   return { Qgis::LayerType::Mesh };
 }
 
-QString QgsMdalProviderMetadata::filters( FilterType type )
+QString QgsMdalProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterMesh:
+    case Qgis::FileFilterType::Mesh:
     {
       QString fileMeshFiltersString;
       QString fileMeshDatasetFiltersString;
       QgsMdalProvider::fileMeshFilters( fileMeshFiltersString, fileMeshDatasetFiltersString );
       return fileMeshFiltersString;
     }
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
+    case Qgis::FileFilterType::MeshDataset:
     {
       QString fileMeshFiltersString;
       QString fileMeshDatasetFiltersString;
@@ -1265,9 +1265,10 @@ QString QgsMdalProviderMetadata::filters( FilterType type )
       return fileMeshDatasetFiltersString;
     }
 
-    case QgsProviderMetadata::FilterType::FilterRaster:
-    case QgsProviderMetadata::FilterType::FilterVector:
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::PointCloud:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
   }
   return QString();

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -145,7 +145,7 @@ class QgsMdalProviderMetadata: public QgsProviderMetadata
   public:
     QgsMdalProviderMetadata();
     QIcon icon() const override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     QList<QgsMeshDriverMetadata> meshDriversMetadata() override;
     QgsMdalProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     bool createMeshData( const QgsMesh &mesh,

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -411,17 +411,18 @@ QList<QgsProviderSublayerDetails> QgsPdalProviderMetadata::querySublayers( const
   }
 }
 
-QString QgsPdalProviderMetadata::filters( QgsProviderMetadata::FilterType type )
+QString QgsPdalProviderMetadata::filters( Qgis::FileFilterType type )
 {
   switch ( type )
   {
-    case QgsProviderMetadata::FilterType::FilterVector:
-    case QgsProviderMetadata::FilterType::FilterRaster:
-    case QgsProviderMetadata::FilterType::FilterMesh:
-    case QgsProviderMetadata::FilterType::FilterMeshDataset:
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::VectorTile:
       return QString();
 
-    case QgsProviderMetadata::FilterType::FilterPointCloud:
+    case Qgis::FileFilterType::PointCloud:
       buildSupportedPointCloudFileFilterAndExtensions();
 
       return sFilterString;

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -80,7 +80,7 @@ class QgsPdalProviderMetadata : public QgsProviderMetadata
     int priorityForUri( const QString &uri ) const override;
     QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;
     QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
-    QString filters( FilterType type ) override;
+    QString filters( Qgis::FileFilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
     QList< Qgis::LayerType > supportedLayerTypes() const override;
 

--- a/src/ui/qgsvectortilesourceselectbase.ui
+++ b/src/ui/qgsvectortilesourceselectbase.ui
@@ -6,12 +6,240 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>558</width>
-    <height>259</height>
+    <width>553</width>
+    <height>383</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="srcGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Source Type</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout1">
+      <item>
+       <widget class="QRadioButton" name="mRadioSourceFile">
+        <property name="text">
+         <string>F&amp;ile</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="mRadioSourceService">
+        <property name="text">
+         <string>Service</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="fileGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Source</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Vector tile dataset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="mConnectionsGroupBox">
+         <property name="title">
+          <string>Connections</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0" colspan="7">
+           <widget class="QComboBox" name="cmbConnections"/>
+          </item>
+          <item row="1" column="5">
+           <widget class="QToolButton" name="btnLoad">
+            <property name="toolTip">
+             <string>Load connections from file</string>
+            </property>
+            <property name="text">
+             <string>Load</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>171</width>
+              <height>30</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="2">
+           <widget class="QToolButton" name="btnEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Edit selected service connection</string>
+            </property>
+            <property name="text">
+             <string>Edit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QToolButton" name="btnDelete">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Remove connection to selected service</string>
+            </property>
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QToolButton" name="btnNew">
+            <property name="toolTip">
+             <string>Create a new service connection</string>
+            </property>
+            <property name="text">
+             <string>&amp;New</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QToolButton" name="btnSave">
+            <property name="toolTip">
+             <string>Save connections to file</string>
+            </property>
+            <property name="text">
+             <string>Save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -21,105 +249,15 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="mConnectionsGroupBox">
-     <property name="title">
-      <string>Connections</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="4">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>171</width>
-          <height>30</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="0" colspan="7">
-       <widget class="QComboBox" name="cmbConnections"/>
-      </item>
-      <item row="1" column="2">
-       <widget class="QToolButton" name="btnEdit">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Edit selected service connection</string>
-        </property>
-        <property name="text">
-         <string>Edit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QToolButton" name="btnDelete">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Remove connection to selected service</string>
-        </property>
-        <property name="text">
-         <string>Remove</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="5">
-       <widget class="QToolButton" name="btnLoad">
-        <property name="toolTip">
-         <string>Load connections from file</string>
-        </property>
-        <property name="text">
-         <string>Load</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="6">
-       <widget class="QToolButton" name="btnSave">
-        <property name="toolTip">
-         <string>Save connections to file</string>
-        </property>
-        <property name="text">
-         <string>Save</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QToolButton" name="btnNew">
-        <property name="toolTip">
-         <string>Create a new service connection</string>
-        </property>
-        <property name="text">
-         <string>&amp;New</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbConnections</tabstop>
   <tabstop>btnNew</tabstop>

--- a/src/ui/qgsvectortilesourceselectbase.ui
+++ b/src/ui/qgsvectortilesourceselectbase.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTileSourceSelectBase</class>
+ <widget class="QDialog" name="QgsVectorTileSourceSelectBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>558</width>
+    <height>259</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="mConnectionsGroupBox">
+     <property name="title">
+      <string>Connections</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="4">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>171</width>
+          <height>30</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" colspan="7">
+       <widget class="QComboBox" name="cmbConnections"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="btnEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Edit selected service connection</string>
+        </property>
+        <property name="text">
+         <string>Edit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QToolButton" name="btnDelete">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Remove connection to selected service</string>
+        </property>
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <widget class="QToolButton" name="btnLoad">
+        <property name="toolTip">
+         <string>Load connections from file</string>
+        </property>
+        <property name="text">
+         <string>Load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QToolButton" name="btnSave">
+        <property name="toolTip">
+         <string>Save connections to file</string>
+        </property>
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QToolButton" name="btnNew">
+        <property name="toolTip">
+         <string>Create a new service connection</string>
+        </property>
+        <property name="text">
+         <string>&amp;New</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>cmbConnections</tabstop>
+  <tabstop>btnNew</tabstop>
+  <tabstop>btnEdit</tabstop>
+  <tabstop>btnDelete</tabstop>
+  <tabstop>btnLoad</tabstop>
+  <tabstop>btnSave</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/src/core/testqgsvectortilelayer.cpp
+++ b/tests/src/core/testqgsvectortilelayer.cpp
@@ -62,6 +62,8 @@ class TestQgsVectorTileLayer : public QgsTest
     void test_render();
     void test_render_withClip();
     void test_labeling();
+
+    void testMbtilesProviderMetadata();
     void test_relativePathsMbTiles();
     void test_absoluteRelativeUriMbTiles();
 
@@ -215,6 +217,18 @@ void TestQgsVectorTileLayer::test_labeling()
   QVERIFY( res );
 }
 
+void TestQgsVectorTileLayer::testMbtilesProviderMetadata()
+{
+  QgsProviderMetadata *vectorTileMetadata = QgsProviderRegistry::instance()->providerMetadata( "mbtilesvectortiles" );
+  QVERIFY( vectorTileMetadata );
+
+  QCOMPARE( vectorTileMetadata->filters( Qgis::FileFilterType::VectorTile ), QStringLiteral( "Mbtiles Vector Tiles (*.mbtiles *.MBTILES)" ) );
+  QCOMPARE( vectorTileMetadata->filters( Qgis::FileFilterType::PointCloud ), QString() );
+
+  const QString registryPointCloudFilters = QgsProviderRegistry::instance()->fileVectorTileFilters();
+  QVERIFY( registryPointCloudFilters.contains( "(*.mbtiles *.MBTILES)" ) );
+}
+
 void TestQgsVectorTileLayer::test_relativePathsMbTiles()
 {
   QgsReadWriteContext contextRel;
@@ -352,6 +366,13 @@ void TestQgsVectorTileLayer::testVtpkProviderMetadata()
   QCOMPARE( sublayers.at( 0 ).name(), QStringLiteral( "testvtpk" ) );
   QCOMPARE( sublayers.at( 0 ).uri(), QStringLiteral( "type=vtpk&url=%1/testvtpk.vtpk" ).arg( TEST_DATA_DIR ) );
   QCOMPARE( sublayers.at( 0 ).type(), Qgis::LayerType::VectorTile );
+
+
+  QCOMPARE( vectorTileMetadata->filters( Qgis::FileFilterType::VectorTile ), QStringLiteral( "VTPK Vector Tiles (*.vtpk *.VTPK)" ) );
+  QCOMPARE( vectorTileMetadata->filters( Qgis::FileFilterType::PointCloud ), QString() );
+
+  const QString registryPointCloudFilters = QgsProviderRegistry::instance()->fileVectorTileFilters();
+  QVERIFY( registryPointCloudFilters.contains( "(*.vtpk *.VTPK)" ) );
 }
 
 void TestQgsVectorTileLayer::test_relativePathsVtpk()

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -113,8 +113,8 @@ void TestQgsCopcProvider::filters()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "copc" ) );
   QVERIFY( metadata );
 
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud ), QStringLiteral( "COPC Point Clouds (*.copc.laz *.COPC.LAZ)" ) );
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterVector ), QString() );
+  QCOMPARE( metadata->filters( Qgis::FileFilterType::PointCloud ), QStringLiteral( "COPC Point Clouds (*.copc.laz *.COPC.LAZ)" ) );
+  QCOMPARE( metadata->filters( Qgis::FileFilterType::Vector ), QString() );
 
   const QString registryPointCloudFilters = QgsProviderRegistry::instance()->filePointCloudFilters();
   QVERIFY( registryPointCloudFilters.contains( "(*.copc.laz *.COPC.LAZ)" ) );

--- a/tests/src/providers/testqgseptprovider.cpp
+++ b/tests/src/providers/testqgseptprovider.cpp
@@ -106,8 +106,8 @@ void TestQgsEptProvider::filters()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ept" ) );
   QVERIFY( metadata );
 
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud ), QStringLiteral( "Entwine Point Clouds (ept.json EPT.JSON)" ) );
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterVector ), QString() );
+  QCOMPARE( metadata->filters( Qgis::FileFilterType::PointCloud ), QStringLiteral( "Entwine Point Clouds (ept.json EPT.JSON)" ) );
+  QCOMPARE( metadata->filters( Qgis::FileFilterType::Vector ), QString() );
 
   const QString registryPointCloudFilters = QgsProviderRegistry::instance()->filePointCloudFilters();
   QVERIFY( registryPointCloudFilters.contains( "(ept.json EPT.JSON)" ) );

--- a/tests/src/providers/testqgspdalprovider.cpp
+++ b/tests/src/providers/testqgspdalprovider.cpp
@@ -89,13 +89,13 @@ void TestQgsPdalProvider::filters()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
   QVERIFY( metadata );
 
-  const QString metadataFilters = metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud );
+  const QString metadataFilters = metadata->filters( Qgis::FileFilterType::PointCloud );
   QVERIFY( metadataFilters.contains( "*.laz" ) );
   QVERIFY( metadataFilters.contains( "*.las" ) );
   QVERIFY( metadataFilters.contains( "*.LAZ" ) );
   QVERIFY( metadataFilters.contains( "*.LAS" ) );
 
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterVector ), QString() );
+  QCOMPARE( metadata->filters( Qgis::FileFilterType::Vector ), QString() );
 
   const QString registryPointCloudFilters = QgsProviderRegistry::instance()->filePointCloudFilters();
   QVERIFY( registryPointCloudFilters.contains( "*.laz" ) );


### PR DESCRIPTION
The Vector Tile tab now includes choices for selecting from a "Service" (the existing, connection based approach for adding
vector tiles from online sources) or "File" (the new option which allows directly adding VTPK or MBTiles vector tile files)

https://user-images.githubusercontent.com/1829991/229019730-664efa91-41a4-4dc6-ba34-6ab573979047.mp4

Funded by Landesamt für Vermessung und Geoinformation, Feldkirch, Austria