### PR TITLE
Preview of layers in dxf import dialog

### DIFF
--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -463,13 +463,16 @@ QList<QgsVectorLayer *> QgsDwgImportDialog::createLayers( const QStringList &lay
     layers.append( l );
   }
 
-  l = createLayer( layerFilter, QStringLiteral( "inserts" ) );
-  if ( l && l->renderer() )
+  if ( !cbExpandInserts->isChecked() )
   {
-    QgsSingleSymbolRenderer *ssr = dynamic_cast<QgsSingleSymbolRenderer *>( l->renderer() );
-    if ( ssr && ssr->symbol() && ssr->symbol()->symbolLayer( 0 ) )
-      ssr->symbol()->symbolLayer( 0 )->setDataDefinedProperty( QgsSymbolLayer::PropertyAngle, QgsProperty::fromExpression( QStringLiteral( "180-angle*180.0/pi()" ) ) );
-    layers.append( l );
+    l = createLayer( layerFilter, QStringLiteral( "inserts" ) );
+    if ( l && l->renderer() )
+    {
+      QgsSingleSymbolRenderer *ssr = dynamic_cast<QgsSingleSymbolRenderer *>( l->renderer() );
+      if ( ssr && ssr->symbol() && ssr->symbol()->symbolLayer( 0 ) )
+        ssr->symbol()->symbolLayer( 0 )->setDataDefinedProperty( QgsSymbolLayer::PropertyAngle, QgsProperty::fromExpression( QStringLiteral( "180-angle*180.0/pi()" ) ) );
+      layers.append( l );
+    }
   }
 
   return layers;

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -57,9 +57,9 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   mDatabaseFileWidget->setStorageMode( QgsFileWidget::SaveFile );
   mDatabaseFileWidget->setConfirmOverwrite( false );
 
-  mBlockModeComboBox->addItem( tr( "Expand block geometries" ), static_cast<int>( BlockImportFlag::BlockImportExpandGeometry ) );
-  mBlockModeComboBox->addItem( tr( "Expand block geometries and add insert points" ), static_cast<int>( BlockImportFlag::BlockImportExpandGeometry ) | static_cast<int>( BlockImportFlag::BlockImportAddInsertPoints ) );
-  mBlockModeComboBox->addItem( tr( "Add only insert points" ), static_cast<int>( BlockImportFlag::BlockImportAddInsertPoints ) );
+  mBlockModeComboBox->addItem( tr( "Expand Block Geometries" ), static_cast<int>( BlockImportFlag::BlockImportExpandGeometry ) );
+  mBlockModeComboBox->addItem( tr( "Expand Block Geometries and Add Insert Points" ), static_cast<int>( BlockImportFlag::BlockImportExpandGeometry ) | static_cast<int>( BlockImportFlag::BlockImportAddInsertPoints ) );
+  mBlockModeComboBox->addItem( tr( "Add Only Insert Points" ), static_cast<int>( BlockImportFlag::BlockImportAddInsertPoints ) );
 
   const QgsSettings s;
   int index = mBlockModeComboBox->findData( s.value( QStringLiteral( "/DwgImport/lastBlockImportFlags" ), static_cast<int>( BlockImportFlag::BlockImportExpandGeometry ) ) );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -463,6 +463,15 @@ QList<QgsVectorLayer *> QgsDwgImportDialog::createLayers( const QStringList &lay
     layers.append( l );
   }
 
+  l = createLayer( layerFilter, QStringLiteral( "inserts" ) );
+  if ( l && l->renderer() )
+  {
+    QgsSingleSymbolRenderer *ssr = dynamic_cast<QgsSingleSymbolRenderer *>( l->renderer() );
+    if ( ssr && ssr->symbol() && ssr->symbol()->symbolLayer( 0 ) )
+      ssr->symbol()->symbolLayer( 0 )->setDataDefinedProperty( QgsSymbolLayer::PropertyAngle, QgsProperty::fromExpression( QStringLiteral( "180-angle*180.0/pi()" ) ) );
+    layers.append( l );
+  }
+
   return layers;
 }
 

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -478,7 +478,7 @@ QList<QgsVectorLayer *> QgsDwgImportDialog::createLayers( const QStringList &lay
 void QgsDwgImportDialog::createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible )
 {
   QgsLayerTreeGroup *layerGroup = group->addGroup( name );
-  QgsDebugMsgLevel( QStringLiteral( " %1" ).arg( name ) ) ;
+  QgsDebugMsgLevel( QStringLiteral( " %1" ).arg( name ), 2 ) ;
   Q_ASSERT( layerGroup );
 
   const QList<QgsVectorLayer *> layersList = createLayers( layers );

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -23,6 +23,7 @@
 
 class QgsVectorLayer;
 class QgsLayerTreeGroup;
+class QgsMapToolPan;
 
 class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
 {
@@ -56,6 +57,8 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
     void updateUI();
     void expandInserts();
     void updateCheckState( Qt::CheckState state );
+
+    QgsMapToolPan *mPanTool;
 };
 
 #endif // QGSDWGIMPORTDIALOG_H

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -44,6 +44,8 @@ class APP_EXPORT QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBa
     void leLayerGroup_textChanged( const QString &text );
     void showHelp();
     void layersClicked( QTableWidgetItem *item );
+    void blockModeCurrentIndexChanged();
+    void useCurvesClicked();
 
   private:
 
@@ -52,6 +54,13 @@ class APP_EXPORT QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBa
       Name = 0,
       Visibility = 1
     };
+
+    enum BlockImportFlag
+    {
+      BlockImportExpandGeometry = 1 << 0,
+      BlockImportAddInsertPoints = 1 << 1
+    };
+    Q_DECLARE_FLAGS( BlockImportFlags, BlockImportFlag )
 
     QgsVectorLayer *createLayer( const QString &layer, const QString &table );
     QList<QgsVectorLayer *> createLayers( const QStringList &layerNames );

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -42,7 +42,7 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
     void mDatabaseFileWidget_textChanged( const QString &filename );
     void leLayerGroup_textChanged( const QString &text );
     void showHelp();
-    void layers_clicked( QTableWidgetItem *item );
+    void layersClicked( QTableWidgetItem *item );
 
   private:
 
@@ -52,13 +52,13 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
       Visibility = 1
     };
 
-    QgsVectorLayer *layer( QgsLayerTreeGroup *layerGroup, const QString &layer, const QString &table );
-    void createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible );
+    QgsVectorLayer *layer( QgsLayerTreeGroup *layerGroup, const QString &layer, const QString &table, bool addToProject );
+    void createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible, bool addToProject );
     void updateUI();
     void expandInserts();
     void updateCheckState( Qt::CheckState state );
 
-    QgsMapToolPan *mPanTool;
+    QgsMapToolPan *mPanTool = nullptr;
 };
 
 #endif // QGSDWGIMPORTDIALOG_H

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -41,8 +41,16 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
     void mDatabaseFileWidget_textChanged( const QString &filename );
     void leLayerGroup_textChanged( const QString &text );
     void showHelp();
+    void layers_clicked( QTableWidgetItem *item );
 
   private:
+
+    enum class ColumnIndex : int
+    {
+      Name = 0,
+      Visibility = 1
+    };
+
     QgsVectorLayer *layer( QgsLayerTreeGroup *layerGroup, const QString &layer, const QString &table );
     void createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible );
     void updateUI();

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -20,12 +20,13 @@
 
 #include "ui_qgsdwgimportbase.h"
 #include "qgshelp.h"
+#include "qgis_app.h"
 
 class QgsVectorLayer;
 class QgsLayerTreeGroup;
 class QgsMapToolPan;
 
-class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
+class APP_EXPORT QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
 {
     Q_OBJECT
   public:
@@ -61,6 +62,8 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
 
     QgsMapToolPan *mPanTool = nullptr;
     QList<QgsVectorLayer *> mPreviewLayers;
+
+    friend class TestQgsDwgImportDialog;
 };
 
 #endif // QGSDWGIMPORTDIALOG_H

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -52,13 +52,15 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
       Visibility = 1
     };
 
-    QgsVectorLayer *layer( QgsLayerTreeGroup *layerGroup, const QString &layer, const QString &table, bool addToProject );
-    void createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible, bool addToProject );
+    QgsVectorLayer *createLayer( const QString &layer, const QString &table );
+    QList<QgsVectorLayer *> createLayers( const QStringList &layerNames );
+    void createGroup( QgsLayerTreeGroup *group, const QString &name, const QStringList &layers, bool visible );
     void updateUI();
     void expandInserts();
     void updateCheckState( Qt::CheckState state );
 
     QgsMapToolPan *mPanTool = nullptr;
+    QList<QgsVectorLayer *> mPreviewLayers;
 };
 
 #endif // QGSDWGIMPORTDIALOG_H

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -113,11 +113,7 @@
       <item row="7" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QCheckBox" name="cbExpandInserts">
-          <property name="text">
-           <string>Expand block references</string>
-          </property>
-         </widget>
+         <widget class="QComboBox" name="mBlockModeComboBox"/>
         </item>
         <item>
          <widget class="QCheckBox" name="cbUseCurves">
@@ -282,7 +278,7 @@
   <tabstop>leDrawing</tabstop>
   <tabstop>pbImportDrawing</tabstop>
   <tabstop>pbBrowseDrawing</tabstop>
-  <tabstop>cbExpandInserts</tabstop>
+  <tabstop>mBlockModeComboBox</tabstop>
   <tabstop>cbUseCurves</tabstop>
   <tabstop>leLayerGroup</tabstop>
   <tabstop>mLayers</tabstop>

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -6,115 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>497</width>
-    <height>415</height>
+    <width>935</width>
+    <height>705</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>DWG/DXF Import</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="8" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,10,0">
+   <item row="0" column="0">
+    <widget class="QgsMessageBar" name="bar" native="true"/>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="mGroupBox">
-     <property name="title">
-      <string>Layers to Import into Project</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0" colspan="3">
-       <widget class="QTableWidget" name="mLayers">
-        <property name="alternatingRowColors">
-         <bool>true</bool>
-        </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
-        </property>
-        <column>
-         <property name="text">
-          <string>Layer</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Visible</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLineEdit" name="leLayerGroup"/>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Group name</string>
-        </property>
-        <property name="buddy">
-         <cstring>leLayerGroup</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QCheckBox" name="cbMergeLayers">
-          <property name="text">
-           <string>Merge layers</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pbDeselectAll">
-          <property name="text">
-           <string>Deselect All</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pbSelectAll">
-          <property name="text">
-           <string>Select All</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Import Drawing into GeoPackage</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="1" column="1">
-       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
@@ -175,11 +85,11 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QgsFileWidget" name="mDatabaseFileWidget">
-          <property name="dialogTitle">
+         <widget class="QgsFileWidget" name="mDatabaseFileWidget" native="true">
+          <property name="dialogTitle" stdset="0">
            <string>Select GeoPackage Database</string>
           </property>
-          <property name="filter">
+          <property name="filter" stdset="0">
            <string notr="true">*.gpkg;;*.GPKG</string>
           </property>
          </widget>
@@ -221,8 +131,130 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QgsMessageBar" name="bar" native="true"/>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Layers to import into the project</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <widget class="QWidget" name="gridLayoutWidget">
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0" colspan="2">
+           <widget class="QTableWidget" name="mLayers">
+            <property name="alternatingRowColors">
+             <bool>true</bool>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <column>
+             <property name="text">
+              <string>Layer</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Visible</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="leLayerGroup"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Group name</string>
+            </property>
+            <property name="buddy">
+             <cstring>leLayerGroup</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QCheckBox" name="cbMergeLayers">
+              <property name="text">
+               <string>Merge layers</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbDeselectAll">
+              <property name="text">
+               <string>Deselect All</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbSelectAll">
+              <property name="text">
+               <string>Select All</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="verticalLayoutWidget">
+         <layout class="QVBoxLayout" name="verticalLayout" stretch="0,50">
+          <item>
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Preview</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QgsPixmapLabel" name="mLabelLayerPreview" native="true">
+            <property name="text" stdset="0">
+             <string>Select a layer to display a preview</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -243,6 +275,11 @@
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPixmapLabel</class>
+   <extends>QWidget</extends>
+   <header>qgspixmaplabel.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -230,14 +230,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QgsPixmapLabel" name="mLabelLayerPreview" native="true">
-            <property name="text" stdset="0">
-             <string>Select a layer to display a preview</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignHCenter|Qt::AlignHCenter</set>
-            </property>
-           </widget>
+           <widget class="QgsMapCanvas" name="mMapCanvas"/>
           </item>
          </layout>
         </widget>
@@ -277,9 +270,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPixmapLabel</class>
-   <extends>QWidget</extends>
-   <header>qgspixmaplabel.h</header>
+   <class>QgsMapCanvas</class>
+   <extends>QGraphicsView</extends>
+   <header>qgsmapcanvas.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
   testqgsattributetable.cpp
   testqgsapplocatorfilters.cpp
   testqgsdecorationscalebar.cpp
+  testqgsdwgimportdialog.cpp
   testqgsfieldcalculator.cpp
   testqgsmapcanvasdockwidget.cpp
   testqgsmaptooleditannotation.cpp

--- a/tests/src/app/testqgsdwgimportdialog.cpp
+++ b/tests/src/app/testqgsdwgimportdialog.cpp
@@ -104,7 +104,7 @@ void TestQgsDwgImportDialog::importDxfDocument()
   layerNames = QStringList() << "hatches"
                << "lines"
                << "polylines";
-  const auto layerTreeLayersGruen = group0->findLayers();
+  const auto layerTreeLayersGruen = groupGruen->findLayers();
   for ( QgsLayerTreeLayer *layerTreeLayer : layerTreeLayersGruen )
     QVERIFY2( layerNames.removeOne( layerTreeLayer->name() ), QString( "Unexpected layer name: '%1'" ).arg( layerTreeLayer->name() ).toLatin1() );
 

--- a/tests/src/app/testqgsdwgimportdialog.cpp
+++ b/tests/src/app/testqgsdwgimportdialog.cpp
@@ -33,7 +33,7 @@ class TestQgsDwgImportDialog : public QObject
     void cleanupTestCase() {} // will be called after the last testfunction was executed.
     void cleanup(); // will be called after every testfunction.
 
-    void importDxfDocument();
+    void importDwgDocument();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -56,7 +56,7 @@ void TestQgsDwgImportDialog::cleanup()
   QgsProject::instance()->removeAllMapLayers();
 }
 
-void TestQgsDwgImportDialog::importDxfDocument()
+void TestQgsDwgImportDialog::importDwgDocument()
 {
 
   QgsDwgImportDialog dwgImportDialog( nullptr, Qt::WindowFlags() );

--- a/tests/src/app/testqgsdwgimportdialog.cpp
+++ b/tests/src/app/testqgsdwgimportdialog.cpp
@@ -30,8 +30,8 @@ class TestQgsDwgImportDialog : public QObject
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
-    void cleanupTestCase() {} // will be called after the last testfunction was executed.
-    void cleanup(); // will be called after every testfunction.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void cleanup() {} // will be called after every testfunction.
 
     void importDwgDocument();
 
@@ -51,14 +51,13 @@ void TestQgsDwgImportDialog::initTestCase()
   mDataDir += "/dwg";
 }
 
-void TestQgsDwgImportDialog::cleanup()
+void TestQgsDwgImportDialog::cleanupTestCase()
 {
   QgsProject::instance()->removeAllMapLayers();
 }
 
 void TestQgsDwgImportDialog::importDwgDocument()
 {
-
   QgsDwgImportDialog dwgImportDialog( nullptr, Qt::WindowFlags() );
 
   // Set target gpkg
@@ -69,6 +68,9 @@ void TestQgsDwgImportDialog::importDwgDocument()
   QString uri = QString( mDataDir + "/entities.dwg" );
   dwgImportDialog.leDrawing->setText( uri );
   dwgImportDialog.pbImportDrawing_clicked();
+
+  // Set Expand Inserts checkbox
+  dwgImportDialog.cbExpandInserts->setChecked( false );
 
   // Check that a default group name was assigned
   QCOMPARE( dwgImportDialog.leLayerGroup->text(), "entities" );

--- a/tests/src/app/testqgsdwgimportdialog.cpp
+++ b/tests/src/app/testqgsdwgimportdialog.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+  testqgsdwgimportdialog.cpp
+
+ ---------------------
+ begin                : 23.5.2023
+ copyright            : (C) 2023 by Damiano Lombardi
+ email                : damiano@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgisapp.h"
+#include "testqgsmaptoolutils.h"
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
+#include "qgsdwgimportdialog.h"
+
+class TestQgsDwgImportDialog : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsDwgImportDialog() = default;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase() {} // will be called after the last testfunction was executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void importDxfDocument();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+    QString mDataDir;
+};
+
+
+//runs before all tests
+void TestQgsDwgImportDialog::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  mQgisApp = new QgisApp();
+  mDataDir = QString( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  mDataDir += "/dwg";
+}
+
+void TestQgsDwgImportDialog::cleanup()
+{
+  QgsProject::instance()->removeAllMapLayers();
+}
+
+void TestQgsDwgImportDialog::importDxfDocument()
+{
+
+  QgsDwgImportDialog dwgImportDialog( nullptr, Qt::WindowFlags() );
+
+  // Set target gpkg
+  QTemporaryDir temporaryDir;
+  dwgImportDialog.mDatabaseFileWidget->setFilePath( temporaryDir.filePath( "entities.gpkg" ) );
+
+  // Set source drawing and import
+  QString uri = QString( mDataDir + "/entities.dwg" );
+  dwgImportDialog.leDrawing->setText( uri );
+  dwgImportDialog.pbImportDrawing_clicked();
+
+  // Check that a default group name was assigned
+  QCOMPARE( dwgImportDialog.leLayerGroup->text(), "entities" );
+
+  dwgImportDialog.buttonBox_accepted();
+
+  QgsLayerTreeGroup *rootGroup = QgsLayerTree::toGroup( QgisApp::instance()->layerTreeView()->layerTreeModel()->rootGroup() );
+  QVERIFY( rootGroup );
+
+  QgsLayerTreeGroup *groupEntities = rootGroup->findGroup( "entities" );
+  QVERIFY( groupEntities );
+
+  // Group 0
+  QgsLayerTreeGroup *group0 = groupEntities->findGroup( "0" );
+  QVERIFY( group0 );
+
+  QStringList layerNames = QStringList() << "hatches"
+                           << "lines"
+                           << "polylines"
+                           << "texts"
+                           << "points"
+                           << "inserts";
+  const auto layerTreeLayers0 = group0->findLayers();
+  for ( QgsLayerTreeLayer *layerTreeLayer : layerTreeLayers0 )
+    QVERIFY2( layerNames.removeOne( layerTreeLayer->name() ), QString( "Unexpected layer name: '%1'" ).arg( layerTreeLayer->name() ).toLatin1() );
+
+  QVERIFY2( layerNames.isEmpty(), QString( "Missing layers in group '0': '%1'" ).arg( layerNames.join( ", " ) ).toLatin1() );
+
+  // Group grün
+  QgsLayerTreeGroup *groupGruen = groupEntities->findGroup( "grün" );
+  QVERIFY( groupGruen );
+
+  layerNames = QStringList() << "hatches"
+               << "lines"
+               << "polylines";
+  const auto layerTreeLayersGruen = group0->findLayers();
+  for ( QgsLayerTreeLayer *layerTreeLayer : layerTreeLayersGruen )
+    QVERIFY2( layerNames.removeOne( layerTreeLayer->name() ), QString( "Unexpected layer name: '%1'" ).arg( layerTreeLayer->name() ).toLatin1() );
+
+  QVERIFY2( layerNames.isEmpty(), QString( "Missing layers in group 'grün': '%1'" ).arg( layerNames.join( ", " ) ).toLatin1() );
+}
+
+QGSTEST_MAIN( TestQgsDwgImportDialog )
+#include "testqgsdwgimportdialog.moc"


### PR DESCRIPTION
Add a preview when clicking on layers in the dxf/dwg import dialog and some other small UI improvements:
- Automatically fill the main group name line edit using the document file name
- Use `WaitCursor` instead of `BusyCursor` during long lasting operations 

![Peek 2023-03-31 11-05](https://user-images.githubusercontent.com/9881900/229078707-a68eeb9e-0ad6-4903-81e2-34c9e3331c96.gif)
