### PR TITLE
Attribute Dialog moving on screen

### DIFF
--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -87,6 +87,14 @@ void QgsAttributeDialog::accept()
 void QgsAttributeDialog::show()
 {
   QDialog::show();
+
+  // We cannot call restoreGeometry() in the constructor or init because the dialog is not yet visible
+  // and the geometry restoration will not take the window decorations (frame) into account.
+  if ( mFirstShow )
+  {
+    mFirstShow = false;
+    restoreGeometry();
+  }
   raise();
   activateWindow();
 }
@@ -133,8 +141,6 @@ void QgsAttributeDialog::init( QgsVectorLayer *layer, QgsFeature *feature, const
     mMenuBar->addMenu( mMenu );
     layout()->setMenuBar( mMenuBar );
   }
-
-  restoreGeometry();
   focusNextChild();
 }
 

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -136,6 +136,7 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog, public QgsMapLayerActionCo
 
     static int sFormCounter;
 
+    bool mFirstShow = true;
     void saveGeometry();
     void restoreGeometry();
 };


### PR DESCRIPTION
- fix #44050 

## Description

On some platform (eg Ubuntu), calling restoreGeometry on an unshown QDialog do not correctly handle the dialog frame, causing the dialog to drift downward.
