### PR TITLE
Sensors UI/UX improvements

### DIFF
--- a/python/core/auto_generated/sensor/qgsabstractsensor.sip.in
+++ b/python/core/auto_generated/sensor/qgsabstractsensor.sip.in
@@ -116,6 +116,11 @@ Returns the latest captured data from the sensor.
 Sets the latest captured data from the sensor.
 %End
 
+    QString errorString() const;
+%Docstring
+Returns the last error message.
+%End
+
     bool writeXml( QDomElement &parentElement, QDomDocument &document ) const;
 %Docstring
 Write generic sensor properties into a DOM element.
@@ -163,6 +168,11 @@ Emitted when the sensor status has changed.
     void dataChanged();
 %Docstring
 Emitted when the captured sensor data has changed.
+%End
+
+    void errorOccurred( const QString &errorString );
+%Docstring
+Emitted when an error has occurred. The ``errorString`` describes the error.
 %End
 
   protected:

--- a/python/core/auto_generated/sensor/qgssensormanager.sip.in
+++ b/python/core/auto_generated/sensor/qgssensormanager.sip.in
@@ -133,6 +133,11 @@ Emitted when a sensor status has changed.
 Emitted when newly captured data from a sensor has occurred.
 %End
 
+    void sensorErrorOccurred( const QString &id );
+%Docstring
+Emitted when a sensor error has occurred.
+%End
+
 };
 
 /************************************************************************

--- a/src/app/sensor/qgsprojectsensorsettingswidget.cpp
+++ b/src/app/sensor/qgsprojectsensorsettingswidget.cpp
@@ -41,6 +41,14 @@ QgsProjectSensorSettingsWidget::QgsProjectSensorSettingsWidget( QWidget *parent 
       mConnectedSensors << sensor->id();
     }
   }
+
+  connect( QgsProject::instance()->sensorManager(), &QgsSensorManager::sensorErrorOccurred, this, [ = ]( const QString & id )
+  {
+    if ( QgsAbstractSensor *sensor = QgsProject::instance()->sensorManager()->sensor( id ) )
+    {
+      mMessageBar->pushCritical( tr( "Sensor Error" ), QStringLiteral( "%1: %2" ).arg( sensor->name(), sensor->errorString() ) );
+    }
+  } );
 }
 
 void QgsProjectSensorSettingsWidget::cancel()

--- a/src/app/sensor/qgsprojectsensorsettingswidget.cpp
+++ b/src/app/sensor/qgsprojectsensorsettingswidget.cpp
@@ -29,6 +29,11 @@ QgsProjectSensorSettingsWidget::QgsProjectSensorSettingsWidget( QWidget *parent 
 
   QgsSensorTableWidget *widget = new QgsSensorTableWidget( this );
   mPanelStack->setMainPanel( widget );
+  connect( widget, &QgsPanelWidget::showPanel, this, [ = ]( QgsPanelWidget * panel )
+  {
+    mSensorIntroductionLabel->setVisible( false );
+    connect( panel, &QgsPanelWidget::panelAccepted, this, [ = ]() { mSensorIntroductionLabel->setVisible( true ); } );
+  } );
 
   QDomElement sensorElem = QgsProject::instance()->sensorManager()->writeXml( mPreviousSensors );
   mPreviousSensors.appendChild( sensorElem );

--- a/src/app/sensor/qgssensortablewidget.cpp
+++ b/src/app/sensor/qgssensortablewidget.cpp
@@ -55,6 +55,7 @@ QgsSensorSettingsWidget::QgsSensorSettingsWidget( QgsAbstractSensor *sensor, QWi
   mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( false );
   connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, [ = ]()
   {
+    mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( false );
     apply();
   } );
 

--- a/src/core/sensor/qgsabstractsensor.cpp
+++ b/src/core/sensor/qgsabstractsensor.cpp
@@ -63,6 +63,11 @@ void QgsAbstractSensor::setData( const QgsAbstractSensor::SensorData &data )
   emit dataChanged();
 }
 
+QString QgsAbstractSensor::errorString() const
+{
+  return mErrorString;
+}
+
 void QgsAbstractSensor::connectSensor()
 {
   setStatus( Qgis::DeviceConnectionStatus::Connecting );

--- a/src/core/sensor/qgsabstractsensor.h
+++ b/src/core/sensor/qgsabstractsensor.h
@@ -144,6 +144,11 @@ class CORE_EXPORT QgsAbstractSensor : public QObject
     void setData( const QgsAbstractSensor::SensorData &data );
 
     /**
+     * Returns the last error message.
+     */
+    QString errorString() const;
+
+    /**
      * Write generic sensor properties into a DOM element.
      * \param parentElement parent DOM element (e.g 'Sensors' element)
      * \param document DOM document
@@ -182,6 +187,9 @@ class CORE_EXPORT QgsAbstractSensor : public QObject
     //! Emitted when the captured sensor data has changed.
     void dataChanged();
 
+    //! Emitted when an error has occurred. The \a errorString describes the error.
+    void errorOccurred( const QString &errorString );
+
   protected:
 
     /**
@@ -197,6 +205,7 @@ class CORE_EXPORT QgsAbstractSensor : public QObject
     virtual void handleDisconnect() = 0;
 
     QgsAbstractSensor::SensorData mData;
+    QString mErrorString;
 
   private:
 

--- a/src/core/sensor/qgsiodevicesensor.h
+++ b/src/core/sensor/qgsiodevicesensor.h
@@ -135,7 +135,8 @@ class CORE_EXPORT QgsTcpSocketSensor : public QgsIODeviceSensor
 
   private slots:
 
-    virtual void socketStateChanged( const QAbstractSocket::SocketState socketState );
+    void socketStateChanged( const QAbstractSocket::SocketState socketState );
+    void handleError( QAbstractSocket::SocketError error );
 
   private:
 
@@ -205,7 +206,8 @@ class CORE_EXPORT QgsUdpSocketSensor : public QgsIODeviceSensor
 
   private slots:
 
-    virtual void socketStateChanged( const QAbstractSocket::SocketState socketState );
+    void socketStateChanged( const QAbstractSocket::SocketState socketState );
+    void handleError( QAbstractSocket::SocketError error );
 
   private:
 
@@ -265,6 +267,10 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
 
     void handleConnect() override;
     void handleDisconnect() override;
+
+  private slots:
+
+    void handleError( QSerialPort::SerialPortError error );
 
   private:
 

--- a/src/core/sensor/qgssensormanager.cpp
+++ b/src/core/sensor/qgssensormanager.cpp
@@ -88,6 +88,7 @@ void QgsSensorManager::addSensor( QgsAbstractSensor *sensor )
   connect( sensor, &QgsAbstractSensor::nameChanged, this, &QgsSensorManager::handleSensorNameChanged );
   connect( sensor, &QgsAbstractSensor::statusChanged, this, &QgsSensorManager::handleSensorStatusChanged );
   connect( sensor, &QgsAbstractSensor::dataChanged, this, &QgsSensorManager::captureSensorData );
+  connect( sensor, &QgsAbstractSensor::errorOccurred, this, &QgsSensorManager::handleSensorErrorOccurred );
   mSensors << sensor;
 
   emit sensorAdded( sensor->id() );
@@ -145,6 +146,15 @@ void QgsSensorManager::captureSensorData()
 
   mSensorsData.insert( sensor->name(), sensor->data() );
   emit sensorDataCaptured( sensor->id() );
+}
+
+void QgsSensorManager::handleSensorErrorOccurred( const QString & )
+{
+  const QgsAbstractSensor *sensor = qobject_cast<QgsAbstractSensor *>( sender() );
+  if ( !sensor )
+    return;
+
+  emit sensorErrorOccurred( sensor->id() );
 }
 
 bool QgsSensorManager::readXml( const QDomElement &element, const QDomDocument &document )

--- a/src/core/sensor/qgssensormanager.h
+++ b/src/core/sensor/qgssensormanager.h
@@ -131,11 +131,15 @@ class CORE_EXPORT QgsSensorManager : public QObject
     //! Emitted when newly captured data from a sensor has occurred.
     void sensorDataCaptured( const QString &id );
 
+    //! Emitted when a sensor error has occurred.
+    void sensorErrorOccurred( const QString &id );
+
   private slots:
 
     void handleSensorNameChanged();
     void handleSensorStatusChanged();
     void captureSensorData();
+    void handleSensorErrorOccurred( const QString &errorMessage );
 
   private:
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -2854,21 +2854,6 @@ Shift+click to snap rotation to 45 degree steps.</string>
     <string>Show Statistical Summary</string>
    </property>
   </action>
-  <action name="mActionSensorDock">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mSensorDock.svg</normaloff>:/images/themes/default/mSensorDock.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Sensors</string>
-   </property>
-   <property name="toolTip">
-    <string>Show Sensors</string>
-   </property>
-  </action>
   <action name="mActionShowAlignRasterTool">
    <property name="text">
     <string>Align Rasters…</string>

--- a/src/ui/sensor/qgsprojectsensorettingswidgetbase.ui
+++ b/src/ui/sensor/qgsprojectsensorettingswidgetbase.ui
@@ -27,6 +27,9 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Sensors</string>
@@ -45,6 +48,12 @@
    <class>QgsPanelWidgetStack</class>
    <extends>QWidget</extends>
    <header>qgspanelwidgetstack.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/sensor/qgsprojectsensorettingswidgetbase.ui
+++ b/src/ui/sensor/qgsprojectsensorettingswidgetbase.ui
@@ -38,6 +38,16 @@
       <item>
        <widget class="QgsPanelWidgetStack" name="mPanelStack" native="true"/>
       </item>
+      <item>
+       <widget class="QLabel" name="mSensorIntroductionLabel">
+        <property name="text">
+         <string>When connected, a sensor will passively capture data in the background. The latest captured data can be accessed within expressions using the &lt;i&gt;sensor_data('sensor name')&lt;/i&gt; function.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This PR improves the handling of sensors UI/UX by doing the following:
- adds an errorOccured signal to sensors which the project properties' sensor panel uses to inform users when and why a failing sensor connection occurred
- a sensor introductory label was added in the project properties' sensor panel
- the sensor settings widget's apply button gets disabled once settings are applied to make it extra clear hitting apply on subsequent changes is required

How the panel now looks with an error message being displayed:
![Screenshot from 2023-04-01 14-07-38](https://user-images.githubusercontent.com/1728657/229271471-c0a5ef87-7763-451a-83ae-8a9d54c8fc98.png)
