### PR TITLE
Avoid loss of text in code editors when certain modifiers are pressed

### DIFF
--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -483,6 +483,8 @@ Returns ``True`` if a ``font`` is a fixed pitch font.
 
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
+    virtual bool eventFilter( QObject *watched, QEvent *event );
+
 
     virtual void initializeLexer();
 %Docstring

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -138,6 +138,10 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
       break;
     }
   }
+
+#if QSCINTILLA_VERSION < 0x020d03
+  installEventFilter( this );
+#endif
 }
 
 // Workaround a bug in QScintilla 2.8.X
@@ -310,6 +314,21 @@ void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )
       QsciScintilla::contextMenuEvent( event );
       break;
   }
+}
+
+bool QgsCodeEditor::eventFilter( QObject *watched, QEvent *event )
+{
+#if QSCINTILLA_VERSION < 0x020d03
+  if ( watched == this && event->type() == QEvent::InputMethod )
+  {
+    // swallow input method events, which cause loss of selected text.
+    // See https://sourceforge.net/p/scintilla/bugs/1913/ , which was ported to QScintilla
+    // in version 2.13.3
+    return true;
+  }
+#endif
+
+  return QsciScintilla::eventFilter( watched, event );
 }
 
 void QgsCodeEditor::initializeLexer()

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -502,6 +502,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     void focusOutEvent( QFocusEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
     void contextMenuEvent( QContextMenuEvent *event ) override;
+    bool eventFilter( QObject *watched, QEvent *event ) override;
 
     /**
      * Called when the dialect specific code lexer needs to be initialized (or reinitialized).


### PR DESCRIPTION
These are triggered when a InputMethod event is sent to the widget. There's some upstream discussion at https://sourceforge.net/p/scintilla/bugs/1913/ which suggests this was fixed upstream years ago, but it's still reproducible on recent qscintilla versions.

As the loss of text is an extreme risk, just disable input method handling in these widgets on linux entirely.

Fixes #52459
