### PR TITLE
[gui][editor widgets] Fix height of video frame going to zero after one successful playback

### DIFF
--- a/src/gui/qgsmediawidget.cpp
+++ b/src/gui/qgsmediawidget.cpp
@@ -32,9 +32,9 @@ QgsMediaWidget::QgsMediaWidget( QWidget *parent )
   mLayout->setContentsMargins( 0, 0, 0, 0 );
 
   mVideoWidget = new QVideoWidget( this );
-  mVideoWidget->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
-  mVideoWidget->setMinimumHeight( 0 );
-  mVideoWidget->setMaximumHeight( 9999 );
+  const int vHeight = QFontMetrics( font() ).height() * 12;
+  mVideoWidget->setMinimumHeight( vHeight );
+  mVideoWidget->setMaximumHeight( vHeight );
   mLayout->addWidget( mVideoWidget );
 
   QHBoxLayout *controlsLayout = new QHBoxLayout();
@@ -126,8 +126,9 @@ int QgsMediaWidget::videoHeight() const
 
 void QgsMediaWidget::setVideoHeight( int height )
 {
-  mVideoWidget->setMinimumHeight( height );
-  mVideoWidget->setMaximumHeight( height > 0 ? height : 9999 );
+  const int vHeight = height > 0 ? height : QFontMetrics( font() ).height() * 12;
+  mVideoWidget->setMinimumHeight( vHeight );
+  mVideoWidget->setMaximumHeight( vHeight );
 }
 
 void QgsMediaWidget::adjustControls()


### PR DESCRIPTION
## Description

Upon successfully playing a video through, the QVideoWidget frame height goes to 0, and never expands upon playing a media content again. To work around this Qt shortcoming, let's hardcode a height of 250 (unless user specifies a non-zero height in the attachment configuration panel).