### PR TITLE
Improve long feature fetch map draw

### DIFF
--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -587,7 +587,7 @@ class CORE_EXPORT QgsMapRendererJob : public QObject SIP_ABSTRACT
                                 const QgsMapRendererCache *cache = nullptr ) SIP_SKIP;
 
     //! \note not available in Python bindings
-    static QImage layerImageToBeComposed( const QgsMapSettings &settings, const LayerRenderJob &job, const QgsMapRendererCache *cache ) SIP_SKIP;
+    static QImage drawComposedLayerImage( const QgsMapSettings &settings, const LayerRenderJob &job, const QgsMapRendererCache *cache, QPainter &painter ) SIP_SKIP;
 
     //! \note not available in Python bindings
     static QgsElevationMap layerElevationToBeComposed( const QgsMapSettings &settings, const LayerRenderJob &job, const QgsMapRendererCache *cache ) SIP_SKIP;

--- a/src/core/vector/qgsvectorlayerrenderer.h
+++ b/src/core/vector/qgsvectorlayerrenderer.h
@@ -32,7 +32,6 @@ class QgsMapClippingRegion;
 
 #include <QList>
 #include <QPainter>
-#include <QElapsedTimer>
 
 typedef QList<int> QgsAttributeList;
 
@@ -71,8 +70,6 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     QgsFeatureRenderer *featureRenderer() SIP_SKIP { return mRenderer; }
 
     bool render() override;
-
-    void setLayerRenderingTimeHint( int time ) override;
 
   private:
 
@@ -153,9 +150,6 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
     bool mApplyLabelClipGeometries = false;
     bool mForceRasterRender = false;
 
-    int mRenderTimeHint = 0;
-    bool mBlockRenderUpdates = false;
-    QElapsedTimer mElapsedTimer;
 
     bool mNoSetLayerExpressionContext = false;
 


### PR DESCRIPTION
## Background
I'm working on an [AWS Redshift](https://aws.amazon.com/redshift/) driver for QGIS. Redshift is a data warehouse solution which supports querying [petabyte-scale data sets](https://docs.aws.amazon.com/whitepapers/latest/big-data-analytics-options/amazon-redshift.html). While testing [the driver](https://github.com/qgis/QGIS/compare/master...reflectored:QGIS:redshift_driver) (WIP) with large tables, that contain millions of geometry (Linestring) rows, I noticed a bad user experience in the QGIS map rendering, when working with large scale maps (> 1:400000).

## Description
The following commit 0edd4f94e8d314db93737b0982f98354168a0695, has introduced a hard coded 3 seconds flag that defers the vector layer composition render. During these 3 seconds the cached map (raster) image is displayed, at the 3 second mark, the raster image is discarded and then the already loaded and newly loaded features start to appear. In case that we load a large amount of features and/or the latency to the cluster is high, after 3 seconds the cached image will be discarded just to show an (almost) empty canvas.

## Solution

Discard the 3 seconds flag, keep the raster image until all features are loaded and draw new features outside of the raster image, using a mask based on the raster image.


## Demonstration
- QGIS Redshift driver build without the patch:
![before](https://user-images.githubusercontent.com/21270264/229489635-7de021e3-fddd-40de-b138-0b99cc3b461d.gif)
- QGIS Redshift driver build after the patch:
![After](https://user-images.githubusercontent.com/21270264/229489821-bd0fc555-44d7-40da-b988-c3064d413ab0.gif)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
