### PR TITLE
[FEATURE] [OAPIF provider] Add support for edition capabilities (OGC API Features Part 4)

### DIFF
--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -27,7 +27,12 @@ set(WFS_SRCS
   oapif/qgsoapifapirequest.cpp
   oapif/qgsoapifcollection.cpp
   oapif/qgsoapifconformancerequest.cpp
+  oapif/qgsoapifcreatefeaturerequest.cpp
+  oapif/qgsoapifdeletefeaturerequest.cpp
+  oapif/qgsoapifpatchfeaturerequest.cpp
+  oapif/qgsoapifputfeaturerequest.cpp
   oapif/qgsoapifitemsrequest.cpp
+  oapif/qgsoapifoptionsrequest.cpp
   oapif/qgsoapifprovider.cpp
   oapif/qgsoapifutils.cpp
 )

--- a/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+    qgsoapifcreatefeaturerequest.cpp
+    --------------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgslogger.h"
+#include "qgsjsonutils.h"
+#include "qgsoapifcreatefeaturerequest.h"
+#include "qgsoapifprovider.h"
+
+QgsOapifCreateFeatureRequest::QgsOapifCreateFeatureRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+}
+
+QString QgsOapifCreateFeatureRequest::createFeature( const QgsOapifSharedData *sharedData, const QgsFeature &f, const QString &contentCrs, bool hasAxisInverted )
+{
+  QgsJsonExporter exporter;
+
+  QgsFeature fModified( f );
+  if ( hasAxisInverted && f.hasGeometry() )
+  {
+    QgsGeometry g = f.geometry();
+    g.get()->swapXy();
+    fModified.setGeometry( g );
+  }
+
+  json j = exporter.exportFeatureToJsonObject( fModified );
+  auto iterId = j.find( "id" );
+  if ( iterId != j.end() )
+    j.erase( iterId );
+  auto iterBbox = j.find( "bbox" );
+  if ( iterBbox != j.end() )
+    j.erase( iterBbox );
+  if ( !sharedData->mFoundIdInProperties && j["properties"].contains( "id" ) )
+    j["properties"].erase( "id" );
+  const QString jsonFeature = QString::fromStdString( j.dump() );
+  QgsDebugMsgLevel( jsonFeature, 5 );
+  mEmptyResponseIsValid = true;
+  mFakeResponseHasHeaders = true;
+  QList<QNetworkReply::RawHeaderPair> extraHeaders;
+  if ( !contentCrs.isEmpty() )
+    extraHeaders.append( QNetworkReply::RawHeaderPair( QByteArray( "Content-Crs" ), contentCrs.toUtf8() ) );
+  if ( !sendPOST( sharedData->mItemsUrl, "application/geo+json", jsonFeature.toUtf8(), extraHeaders ) )
+    return QString();
+
+  QString location;
+  for ( const auto &headerKeyValue : mResponseHeaders )
+  {
+    if ( headerKeyValue.first == QByteArray( "Location" ) )
+    {
+      location = QString::fromUtf8( headerKeyValue.second );
+      break;
+    }
+  }
+
+  const int posItems = location.lastIndexOf( QLatin1String( "/items/" ) );
+  if ( posItems < 0 )
+    return QString();
+
+  const QString createdId = location.mid( posItems + static_cast<int>( strlen( "/items/" ) ) );
+  QgsDebugMsgLevel( "createdId = " + createdId, 5 );
+  return createdId;
+}
+
+QString QgsOapifCreateFeatureRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Create Feature request failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.h
+++ b/src/providers/wfs/oapif/qgsoapifcreatefeaturerequest.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+    qgsoapifcreatefeaturerequest.h
+    ------------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFCREATEFEATUREREQUEST_H
+#define QGSOAPIFCREATEFEATUREREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsfeature.h"
+#include "qgsbasenetworkrequest.h"
+
+class QgsOapifSharedData;
+
+//! Manages the Create Feature request
+class QgsOapifCreateFeatureRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifCreateFeatureRequest( const QgsDataSourceUri &uri );
+
+    //! Issue a POST request to create the feature and return its id
+    QString createFeature( const QgsOapifSharedData *sharedData, const QgsFeature &f, const QString &contentCrs, bool hasAxisInverted );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFCREATEFEATUREREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapifdeletefeaturerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifdeletefeaturerequest.cpp
@@ -1,0 +1,27 @@
+/***************************************************************************
+    qgsoapifdeletefeaturerequest.cpp
+    --------------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslogger.h"
+#include "qgsoapifdeletefeaturerequest.h"
+
+QgsOapifDeleteFeatureRequest::QgsOapifDeleteFeatureRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+}
+
+QString QgsOapifDeleteFeatureRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Delete Feature request failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/oapif/qgsoapifdeletefeaturerequest.h
+++ b/src/providers/wfs/oapif/qgsoapifdeletefeaturerequest.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+    qgsoapifdeletefeaturerequest.h
+    ------------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFDELETEFEATUREREQUEST_H
+#define QGSOAPIFDELETEFEATUREREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsbasenetworkrequest.h"
+
+//! Manages the Delete Feature request
+class QgsOapifDeleteFeatureRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifDeleteFeatureRequest( const QgsDataSourceUri &uri );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFDELETEFEATUREREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
@@ -133,6 +133,7 @@ void QgsOapifItemsRequest::processReply()
           if ( jFeature.is_object() && jFeature.contains( "id" ) )
           {
             const json id = jFeature["id"];
+            mFoundIdTopLevel = true;
             if ( id.is_string() )
             {
               mFeatures[i].second = QString::fromStdString( id.get<std::string>() );
@@ -140,6 +141,14 @@ void QgsOapifItemsRequest::processReply()
             else if ( id.is_number_integer() )
             {
               mFeatures[i].second = QString::number( id.get<qint64>() );
+            }
+          }
+          if ( jFeature.is_object() && jFeature.contains( "properties" ) )
+          {
+            const json properties = jFeature["properties"];
+            if ( properties.is_object() && properties.contains( "id" ) )
+            {
+              mFoundIdInProperties = true;
             }
           }
         }

--- a/src/providers/wfs/oapif/qgsoapifitemsrequest.h
+++ b/src/providers/wfs/oapif/qgsoapifitemsrequest.h
@@ -68,6 +68,12 @@ class QgsOapifItemsRequest : public QgsBaseNetworkRequest
     //! Return the url of the next page
     const QString &nextUrl() const { return mNextUrl; }
 
+    //! Return if an "id" is present at top level of features
+    bool foundIdTopLevel() const { return mFoundIdTopLevel; }
+
+    //! Return if an "id" is present in the "properties" object of features
+    bool foundIdInProperties() const { return mFoundIdInProperties; }
+
   signals:
     //! emitted when the capabilities have been fully parsed, or an error occurred
     void gotResponse();
@@ -97,6 +103,9 @@ class QgsOapifItemsRequest : public QgsBaseNetworkRequest
 
     ApplicationLevelError mAppLevelError = ApplicationLevelError::NoError;
 
+    bool mFoundIdTopLevel = false;
+
+    bool mFoundIdInProperties = false;
 };
 
 #endif // QGSOAPIFITEMSREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapifoptionsrequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifoptionsrequest.cpp
@@ -1,0 +1,26 @@
+/***************************************************************************
+    qgsoapifoptionsrequest.cpp
+    --------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsoapifoptionsrequest.h"
+
+QgsOapifOptionsRequest::QgsOapifOptionsRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+}
+
+QString QgsOapifOptionsRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Download of OPTIONS failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/oapif/qgsoapifoptionsrequest.h
+++ b/src/providers/wfs/oapif/qgsoapifoptionsrequest.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+    qgsoapifoptionsrequest.h
+    ------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFOPTIONSREQUEST_H
+#define QGSOAPIFOPTIONSREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsbasenetworkrequest.h"
+
+//! Manages the Options request
+class QgsOapifOptionsRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifOptionsRequest( const QgsDataSourceUri &uri );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFOPTIONSREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapifpatchfeaturerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifpatchfeaturerequest.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+    qgsoapifpatchfeaturerequest.cpp
+    -------------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgsjsonutils.h"
+
+#include "qgsoapifpatchfeaturerequest.h"
+#include "qgsoapifprovider.h"
+
+QgsOapifPatchFeatureRequest::QgsOapifPatchFeatureRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+}
+
+bool QgsOapifPatchFeatureRequest::patchFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsGeometry &geom, const QString &contentCrs, bool hasAxisInverted )
+{
+  QgsGeometry geomModified( geom );
+  if ( hasAxisInverted )
+  {
+    geomModified.get()->swapXy();
+  }
+
+  json j;
+  j["geometry"] = geomModified.asJsonObject();
+  QList<QNetworkReply::RawHeaderPair> extraHeaders;
+  if ( !contentCrs.isEmpty() )
+    extraHeaders.append( QNetworkReply::RawHeaderPair( QByteArray( "Content-Crs" ), contentCrs.toUtf8() ) );
+  mEmptyResponseIsValid = true;
+  mFakeURLIncludesContentType = true;
+  QUrl url( sharedData->mItemsUrl + QString( QStringLiteral( "/" ) + jsonId ) );
+  return sendPATCH( url, "application/merge-patch+json", QString::fromStdString( j.dump() ).toUtf8(), extraHeaders );
+}
+
+bool QgsOapifPatchFeatureRequest::patchFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsAttributeMap &attrMap )
+{
+  json properties;
+  QgsAttributeMap::const_iterator attMapIt = attrMap.constBegin();
+  for ( ; attMapIt != attrMap.constEnd(); ++attMapIt )
+  {
+    QString fieldName = sharedData->mFields.at( attMapIt.key() ).name();
+    properties[ fieldName.toStdString() ] = QgsJsonUtils::jsonFromVariant( attMapIt.value() );
+  }
+  json j;
+  j[ "properties" ] = properties;
+  mEmptyResponseIsValid = true;
+  mFakeURLIncludesContentType = true;
+  QUrl url( sharedData->mItemsUrl + QString( QStringLiteral( "/" ) + jsonId ) );
+  return sendPATCH( url, "application/merge-patch+json", QString::fromStdString( j.dump() ).toUtf8() );
+}
+
+QString QgsOapifPatchFeatureRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Patch Feature request failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/oapif/qgsoapifpatchfeaturerequest.h
+++ b/src/providers/wfs/oapif/qgsoapifpatchfeaturerequest.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+    qgsoapifpatchfeaturerequest.h
+    -----------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFPATCHFEATUREREQUEST_H
+#define QGSOAPIFPATCHFEATUREREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsfeature.h"
+#include "qgsbasenetworkrequest.h"
+
+class QgsOapifSharedData;
+
+//! Manages the Patch Feature request
+class QgsOapifPatchFeatureRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifPatchFeatureRequest( const QgsDataSourceUri &uri );
+
+    //! Issue a PATCH request to overwrite the feature by changing its geometry
+    bool patchFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsGeometry &geom, const QString &contentCrs, bool hasAxisInverted );
+
+    //! Issue a PATCH request to overwrite the feature by changing some attributes
+    bool patchFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsAttributeMap &attrMap );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFPATCHFEATUREREQUEST_H

--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -21,7 +21,12 @@
 #include "qgsoapifapirequest.h"
 #include "qgsoapifcollection.h"
 #include "qgsoapifconformancerequest.h"
+#include "qgsoapifcreatefeaturerequest.h"
+#include "qgsoapifdeletefeaturerequest.h"
+#include "qgsoapifpatchfeaturerequest.h"
+#include "qgsoapifputfeaturerequest.h"
 #include "qgsoapifitemsrequest.h"
+#include "qgsoapifoptionsrequest.h"
 #include "qgswfsconstants.h"
 #include "qgswfsutils.h" // for isCompatibleType()
 
@@ -228,6 +233,10 @@ bool QgsOapifProvider::init()
 
   mShared->mFields = itemsRequest.fields();
   mShared->mWKBType = itemsRequest.wkbType();
+  mShared->mFoundIdTopLevel = itemsRequest.foundIdTopLevel();
+  mShared->mFoundIdInProperties = itemsRequest.foundIdInProperties();
+
+  computeCapabilities( itemsRequest );
 
   return true;
 }
@@ -334,9 +343,59 @@ bool QgsOapifProvider::isValid() const
   return mValid;
 }
 
+void QgsOapifProvider::computeCapabilities( const QgsOapifItemsRequest &itemsRequest )
+{
+  mCapabilities = QgsVectorDataProvider::SelectAtId |
+                  QgsVectorDataProvider::ReadLayerMetadata |
+                  QgsVectorDataProvider::Capability::ReloadData;
+
+  // Determine edition capabilities: create (POST on /items),
+  // update (PUT on /items/some_id) and delete (DELETE on /items/some_id)
+  // by issuing a OPTIONS HTTP request.
+  QgsDataSourceUri uri( mShared->mURI.uri() );
+  QgsOapifOptionsRequest optionsItemsRequest( uri );
+  QStringList supportedOptions = optionsItemsRequest.sendOPTIONS( mShared->mItemsUrl );
+  if ( supportedOptions.contains( QLatin1String( "POST" ) ) )
+  {
+    mCapabilities |= QgsVectorDataProvider::AddFeatures;
+
+    const auto &features = itemsRequest.features();
+    QString testId;
+    if ( !features.empty() )
+    {
+      testId = features[0].second;
+    }
+    else
+    {
+      // If there is no existing feature, it is not obvious to know if the
+      // server supports PUT and DELETE on items. Attempt to request OPTIONS
+      // on a fake object...
+      testId = QStringLiteral( "unknown_id" );
+    }
+    QgsOapifOptionsRequest optionsOneItemRequest( uri );
+    QString url( mShared->mItemsUrl );
+    url += QStringLiteral( "/" );
+    url += testId;
+    supportedOptions = optionsOneItemRequest.sendOPTIONS( url );
+    if ( supportedOptions.contains( QLatin1String( "PUT" ) ) )
+    {
+      mCapabilities |= QgsVectorDataProvider::ChangeAttributeValues;
+      mCapabilities |= QgsVectorDataProvider::ChangeGeometries;
+    }
+    if ( supportedOptions.contains( QLatin1String( "DELETE" ) ) )
+    {
+      mCapabilities |= QgsVectorDataProvider::DeleteFeatures;
+    }
+    if ( supportedOptions.contains( QLatin1String( "PATCH" ) ) )
+    {
+      mSupportsPatch = true;
+    }
+  }
+}
+
 QgsVectorDataProvider::Capabilities QgsOapifProvider::capabilities() const
 {
-  return QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata | QgsVectorDataProvider::Capability::ReloadData;
+  return mCapabilities;
 }
 
 bool QgsOapifProvider::empty() const
@@ -427,6 +486,217 @@ void QgsOapifProvider::handlePostCloneOperations( QgsVectorDataProvider *source 
   mShared = qobject_cast<QgsOapifProvider *>( source )->mShared;
 }
 
+bool QgsOapifProvider::addFeatures( QgsFeatureList &flist, Flags flags )
+{
+  QgsDataSourceUri uri( mShared->mURI.uri() );
+  QStringList jsonIds;
+  QString contentCrs;
+  if ( mShared->mSourceCrs
+       != QgsCoordinateReferenceSystem::fromOgcWmsCrs( QgsOapifProvider::OAPIF_PROVIDER_DEFAULT_CRS ) )
+  {
+    contentCrs = mShared->mSourceCrs.toOgcUri();
+  }
+  const bool hasAxisInverted = mShared->mSourceCrs.hasAxisInverted();
+  for ( QgsFeature &f : flist )
+  {
+    QgsOapifCreateFeatureRequest req( uri );
+    const QString id = req.createFeature( mShared.get(), f, contentCrs, hasAxisInverted );
+    if ( id.isEmpty() )
+    {
+      pushError( tr( "Feature creation failed: %1" ).arg( req.errorMessage() ) );
+      return false;
+    }
+    jsonIds.append( id );
+  }
+
+  QStringList::const_iterator idIt = jsonIds.constBegin();
+  QgsFeatureList::iterator featureIt = flist.begin();
+
+  QVector<QgsFeatureUniqueIdPair> serializedFeatureList;
+  for ( ; idIt != jsonIds.constEnd() && featureIt != flist.end(); ++idIt, ++featureIt )
+  {
+    serializedFeatureList.push_back( QgsFeatureUniqueIdPair( *featureIt, *idIt ) );
+  }
+  mShared->serializeFeatures( serializedFeatureList );
+
+  if ( !( flags & QgsFeatureSink::FastInsert ) )
+  {
+    // And now set the feature id from the one got from the database
+    QMap< QString, QgsFeatureId > map;
+    for ( int idx = 0; idx < serializedFeatureList.size(); idx++ )
+      map[ serializedFeatureList[idx].second ] = serializedFeatureList[idx].first.id();
+
+    idIt = jsonIds.constBegin();
+    featureIt = flist.begin();
+    for ( ; idIt != jsonIds.constEnd() && featureIt != flist.end(); ++idIt, ++featureIt )
+    {
+      if ( map.find( *idIt ) != map.end() )
+        featureIt->setId( map[*idIt] );
+    }
+  }
+
+  return true;
+}
+
+bool QgsOapifProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
+{
+  QgsDataSourceUri uri( mShared->mURI.uri() );
+  QString contentCrs;
+  if ( mShared->mSourceCrs
+       != QgsCoordinateReferenceSystem::fromOgcWmsCrs( QgsOapifProvider::OAPIF_PROVIDER_DEFAULT_CRS ) )
+  {
+    contentCrs = mShared->mSourceCrs.toOgcUri();
+  }
+  const bool hasAxisInverted = mShared->mSourceCrs.hasAxisInverted();
+  QgsGeometryMap::const_iterator geomIt = geometry_map.constBegin();
+  for ( ; geomIt != geometry_map.constEnd(); ++geomIt )
+  {
+    const QgsFeatureId qgisFid = geomIt.key();
+    //find out feature id
+    QString jsonId = mShared->findUniqueId( qgisFid );
+    if ( jsonId.isEmpty() )
+    {
+      pushError( QStringLiteral( "Cannot identify feature of id %1" ).arg( qgisFid ) );
+      return false;
+    }
+
+    if ( mSupportsPatch )
+    {
+      // Push to server
+      QgsOapifPatchFeatureRequest req( uri );
+      if ( !req.patchFeature( mShared.get(), jsonId, geomIt.value(), contentCrs, hasAxisInverted ) )
+      {
+        pushError( QStringLiteral( "Cannot modify feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+    }
+    else
+    {
+      // Fetch existing feature
+      QgsFeatureRequest request;
+      request.setFilterFid( qgisFid );
+      QgsFeatureIterator featureIterator = getFeatures( request );
+      QgsFeature f;
+      if ( !featureIterator.nextFeature( f ) )
+      {
+        pushError( QStringLiteral( "Cannot retrieve feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+
+      // Patch it with new geometry
+      f.setGeometry( geomIt.value() );
+
+      // Push to server
+      QgsOapifPutFeatureRequest req( uri );
+      if ( !req.putFeature( mShared.get(), jsonId, f, contentCrs, hasAxisInverted ) )
+      {
+        pushError( QStringLiteral( "Cannot modify feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+    }
+  }
+
+  mShared->changeGeometryValues( geometry_map );
+  return true;
+}
+
+bool QgsOapifProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
+{
+  QgsDataSourceUri uri( mShared->mURI.uri() );
+  QString contentCrs;
+  if ( mShared->mSourceCrs
+       != QgsCoordinateReferenceSystem::fromOgcWmsCrs( QgsOapifProvider::OAPIF_PROVIDER_DEFAULT_CRS ) )
+  {
+    contentCrs = mShared->mSourceCrs.toOgcUri();
+  }
+  const bool hasAxisInverted = mShared->mSourceCrs.hasAxisInverted();
+  QgsChangedAttributesMap::const_iterator attIt = attr_map.constBegin();
+  for ( ; attIt != attr_map.constEnd(); ++attIt )
+  {
+    const QgsFeatureId qgisFid = attIt.key();
+    //find out feature id
+    QString jsonId = mShared->findUniqueId( qgisFid );
+    if ( jsonId.isEmpty() )
+    {
+      pushError( QStringLiteral( "Cannot identify feature of id %1" ).arg( qgisFid ) );
+      return false;
+    }
+
+    if ( mSupportsPatch )
+    {
+      // Push to server
+      QgsOapifPatchFeatureRequest req( uri );
+      if ( !req.patchFeature( mShared.get(), jsonId, attIt.value() ) )
+      {
+        pushError( QStringLiteral( "Cannot modify feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+    }
+    else
+    {
+      // Fetch existing feature
+      QgsFeatureRequest request;
+      request.setFilterFid( qgisFid );
+      QgsFeatureIterator featureIterator = getFeatures( request );
+      QgsFeature f;
+      if ( !featureIterator.nextFeature( f ) )
+      {
+        pushError( QStringLiteral( "Cannot retrieve feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+
+      // Patch it with new attribute values
+      QgsAttributeMap::const_iterator attMapIt = attIt.value().constBegin();
+      for ( ; attMapIt != attIt.value().constEnd(); ++attMapIt )
+      {
+        f.setAttribute( attMapIt.key(), attMapIt.value() );
+      }
+
+      // Push to server
+      QgsOapifPutFeatureRequest req( uri );
+      if ( !req.putFeature( mShared.get(), jsonId, f, contentCrs, hasAxisInverted ) )
+      {
+        pushError( QStringLiteral( "Cannot modify feature of id %1" ).arg( qgisFid ) );
+        return false;
+      }
+    }
+  }
+
+  mShared->changeAttributeValues( attr_map );
+  return true;
+}
+
+bool QgsOapifProvider::deleteFeatures( const QgsFeatureIds &ids )
+{
+  if ( ids.isEmpty() )
+  {
+    return true;
+  }
+
+  QgsDataSourceUri uri( mShared->mURI.uri() );
+  for ( const QgsFeatureId &id : ids )
+  {
+    //find out feature id
+    QString jsonId = mShared->findUniqueId( id );
+    if ( jsonId.isEmpty() )
+    {
+      pushError( QStringLiteral( "Cannot identify feature of id %1" ).arg( id ) );
+      return false;
+    }
+
+    QgsOapifDeleteFeatureRequest req( uri );
+    QUrl url( mShared->mItemsUrl + QString( QStringLiteral( "/" ) + jsonId ) );
+    if ( ! req.sendDELETE( url ) )
+    {
+      pushError( tr( "Feature deletion failed: %1" ).arg( req.errorMessage() ) );
+      return false;
+    }
+  }
+
+  mShared->deleteFeatures( ids );
+  return true;
+}
+
 QString QgsOapifProvider::name() const
 {
   return OAPIF_PROVIDER_KEY;
@@ -493,6 +763,8 @@ QgsOapifSharedData *QgsOapifSharedData::clone() const
   copy->mCollectionUrl = mCollectionUrl;
   copy->mItemsUrl = mItemsUrl;
   copy->mServerFilter = mServerFilter;
+  copy->mFoundIdTopLevel = mFoundIdTopLevel;
+  copy->mFoundIdInProperties = mFoundIdInProperties;
   QgsBackgroundCachedSharedData::copyStateToClone( copy );
 
   return copy;
@@ -882,7 +1154,7 @@ void QgsOapifFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFe
       {
         QgsGeometry g = f.geometry();
         if ( mShared->mSourceCrs.hasAxisInverted() )
-          g.transform( QTransform( 0, 1, 1, 0, 0, 0 ) );
+          g.get()->swapXy();
         dstFeat.setGeometry( g );
       }
       const auto srcAttrs = f.attributes();

--- a/src/providers/wfs/oapif/qgsoapifputfeaturerequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifputfeaturerequest.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+    qgsoapifputfeaturerequest.cpp
+    -----------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgslogger.h"
+#include "qgsjsonutils.h"
+#include "qgsoapifputfeaturerequest.h"
+#include "qgsoapifprovider.h"
+
+QgsOapifPutFeatureRequest::QgsOapifPutFeatureRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+}
+
+bool QgsOapifPutFeatureRequest::putFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsFeature &f, const QString &contentCrs, bool hasAxisInverted )
+{
+  QgsJsonExporter exporter;
+
+  QgsFeature fModified( f );
+  if ( hasAxisInverted && f.hasGeometry() )
+  {
+    QgsGeometry g = f.geometry();
+    g.get()->swapXy();
+    fModified.setGeometry( g );
+  }
+
+  json j = exporter.exportFeatureToJsonObject( fModified, QVariantMap(), jsonId );
+  auto iterBbox = j.find( "bbox" );
+  if ( iterBbox != j.end() )
+    j.erase( iterBbox );
+  if ( !sharedData->mFoundIdInProperties )
+  {
+    auto jPropertiesIter = j.find( "properties" );
+    if ( jPropertiesIter != j.end() )
+    {
+      auto &jProperties = *jPropertiesIter;
+      auto iterId = jProperties.find( "id" );
+      if ( iterId != jProperties.end() )
+        jProperties.erase( iterId );
+    }
+  }
+  const QString jsonFeature = QString::fromStdString( j.dump() );
+  QgsDebugMsgLevel( jsonFeature, 5 );
+  mEmptyResponseIsValid = true;
+  mFakeResponseHasHeaders = true;
+  QList<QNetworkReply::RawHeaderPair> extraHeaders;
+  if ( !contentCrs.isEmpty() )
+    extraHeaders.append( QNetworkReply::RawHeaderPair( QByteArray( "Content-Crs" ), contentCrs.toUtf8() ) );
+  QUrl url( sharedData->mItemsUrl + QString( QStringLiteral( "/" ) + jsonId ) );
+  return sendPUT( url, "application/geo+json", jsonFeature.toUtf8(), extraHeaders );
+}
+
+QString QgsOapifPutFeatureRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Put Feature request failed: %1" ).arg( reason );
+}

--- a/src/providers/wfs/oapif/qgsoapifputfeaturerequest.h
+++ b/src/providers/wfs/oapif/qgsoapifputfeaturerequest.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+    qgsoapifputfeaturerequest.h
+    ---------------------------
+    begin                : March 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFPUTFEATUREREQUEST_H
+#define QGSOAPIFPUTFEATUREREQUEST_H
+
+#include <QObject>
+
+#include "qgsdatasourceuri.h"
+#include "qgsfeature.h"
+#include "qgsbasenetworkrequest.h"
+
+class QgsOapifSharedData;
+
+//! Manages the Put Feature request
+class QgsOapifPutFeatureRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifPutFeatureRequest( const QgsDataSourceUri &uri );
+
+    //! Issue a PUT request to overwrite the feature
+    bool putFeature( const QgsOapifSharedData *sharedData, const QString &jsonId, const QgsFeature &f, const QString &contentCrs, bool hasAxisInverted );
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFPUTFEATUREREQUEST_H

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -79,7 +79,7 @@ void QgsBaseNetworkRequest::requestTimedOut( QNetworkReply *reply )
     mTimedout = true;
 }
 
-bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeader, bool synchronous, bool forceRefresh, bool cache )
+bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeader, bool synchronous, bool forceRefresh, bool cache, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
   abort(); // cancel previous
   mIsAborted = false;
@@ -111,16 +111,6 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     QString modifiedUrlString = modifiedUrl.toString();
     // Qt5 does URL encoding from some reason (of the FILTER parameter for example)
     modifiedUrlString = QUrl::fromPercentEncoding( modifiedUrlString.toUtf8() );
-    QgsDebugMsgLevel( QStringLiteral( "Get %1" ).arg( modifiedUrlString ), 4 );
-    modifiedUrlString = modifiedUrlString.mid( QStringLiteral( "http://" ).size() );
-#ifdef Q_OS_WIN
-    // Passing "urls" like "http://c:/path" to QUrl 'eats' the : after c,
-    // so we must restore it
-    if ( modifiedUrlString[1] == '/' )
-    {
-      modifiedUrlString = modifiedUrlString[0] + ":/" + modifiedUrlString.mid( 2 );
-    }
-#endif
 
     if ( !acceptHeader.isEmpty() )
     {
@@ -133,6 +123,29 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
         modifiedUrlString += QStringLiteral( "?Accept=" ) + acceptHeader;
       }
     }
+    for ( const QNetworkReply::RawHeaderPair &headerPair : extraHeaders )
+    {
+      if ( modifiedUrlString.indexOf( '?' ) > 0 )
+      {
+        modifiedUrlString += QStringLiteral( "&" );
+      }
+      else
+      {
+        modifiedUrlString += QStringLiteral( "?" );
+      }
+      modifiedUrlString += QString::fromUtf8( headerPair.first ) + QStringLiteral( "=" ) + QString::fromUtf8( headerPair.second ) ;
+    }
+
+    QgsDebugMsgLevel( QStringLiteral( "Get %1" ).arg( modifiedUrlString ), 4 );
+    modifiedUrlString = modifiedUrlString.mid( QStringLiteral( "http://" ).size() );
+#ifdef Q_OS_WIN
+    // Passing "urls" like "http://c:/path" to QUrl 'eats' the : after c,
+    // so we must restore it
+    if ( modifiedUrlString[1] == '/' )
+    {
+      modifiedUrlString = modifiedUrlString[0] + ":/" + modifiedUrlString.mid( 2 );
+    }
+#endif
 
     // For REST API using URL subpaths, normalize the subpaths
     const int afterEndpointStartPos = static_cast<int>( modifiedUrlString.indexOf( "fake_qgis_http_endpoint" ) + strlen( "fake_qgis_http_endpoint" ) );
@@ -183,6 +196,8 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
   {
     request.setRawHeader( "Accept", acceptHeader.toUtf8() );
   }
+  for ( const QNetworkReply::RawHeaderPair &headerPair : extraHeaders )
+    request.setRawHeader( headerPair.first, headerPair.second );
 
   QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsBaseNetworkRequest" ) );
   if ( !mAuth.setAuthorization( request ) )
@@ -199,19 +214,58 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
   }
 
+  const bool success = issueRequest( request, QByteArray( "GET" ), nullptr, synchronous );
+  if ( !success || !mErrorMessage.isEmpty() )
+  {
+    return false;
+  }
+
+  if ( synchronous )
+  {
+    // Insert response of requests GetCapabilities, DescribeFeatureType or GetFeature
+    // with a COUNT=1 into a short-lived memory cache, as they are emitted
+    // repeatedly in interactive scenarios when adding a WFS layer.
+    QString urlString = url.toString();
+    if ( urlString.contains( QStringLiteral( "REQUEST=GetCapabilities" ) ) ||
+         urlString.contains( QStringLiteral( "REQUEST=DescribeFeatureType" ) ) ||
+         ( urlString.contains( QStringLiteral( "REQUEST=GetFeature" ) ) && urlString.contains( QStringLiteral( "COUNT=1" ) ) ) )
+    {
+      QgsSettings s;
+      if ( s.value( QStringLiteral( "qgis/wfsMemoryCacheAllowed" ), true ).toBool() )
+      {
+        insertIntoMemoryCache( url, mResponse );
+      }
+    }
+  }
+
+  return true;
+}
+
+bool QgsBaseNetworkRequest::issueRequest( QNetworkRequest &request, const QByteArray &verb, const QByteArray *data, bool synchronous )
+{
+
   QWaitCondition waitCondition;
   QMutex waitConditionMutex;
 
   bool threadFinished = false;
   bool success = false;
 
-  const std::function<void()> downloaderFunction = [ this, request, synchronous, &waitConditionMutex, &waitCondition, &threadFinished, &success ]()
+  const std::function<void()> downloaderFunction = [ this, request, synchronous, data, &verb, &waitConditionMutex, &waitCondition, &threadFinished, &success ]()
   {
     if ( QThread::currentThread() != QApplication::instance()->thread() )
       QgsNetworkAccessManager::instance( Qt::DirectConnection );
 
     success = true;
-    mReply = QgsNetworkAccessManager::instance()->get( request );
+    if ( verb == QByteArray( "GET" ) )
+      mReply = QgsNetworkAccessManager::instance()->get( request );
+    else if ( verb == QByteArray( "POST" ) )
+      mReply = QgsNetworkAccessManager::instance()->post( request, *data );
+    else if ( verb == QByteArray( "PUT" ) )
+      mReply = QgsNetworkAccessManager::instance()->put( request, *data );
+    else if ( verb == QByteArray( "PATCH" ) )
+      mReply = QgsNetworkAccessManager::instance()->sendCustomRequest( request, verb, *data );
+    else
+      mReply = QgsNetworkAccessManager::instance()->sendCustomRequest( request, verb );
 
     if ( !mAuth.setAuthorizationReply( mReply ) )
     {
@@ -300,33 +354,10 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     downloaderFunction();
   }
 
-  if ( !success || !mErrorMessage.isEmpty() )
-  {
-    return false;
-  }
-
-  if ( synchronous )
-  {
-    // Insert response of requests GetCapabilities, DescribeFeatureType or GetFeature
-    // with a COUNT=1 into a short-lived memory cache, as they are emitted
-    // repeatedly in interactive scenarios when adding a WFS layer.
-    QString urlString = url.toString();
-    if ( urlString.contains( QStringLiteral( "REQUEST=GetCapabilities" ) ) ||
-         urlString.contains( QStringLiteral( "REQUEST=DescribeFeatureType" ) ) ||
-         ( urlString.contains( QStringLiteral( "REQUEST=GetFeature" ) ) && urlString.contains( QStringLiteral( "COUNT=1" ) ) ) )
-    {
-      QgsSettings s;
-      if ( s.value( QStringLiteral( "qgis/wfsMemoryCacheAllowed" ), true ).toBool() )
-      {
-        insertIntoMemoryCache( url, mResponse );
-      }
-    }
-  }
-
-  return true;
+  return success;
 }
 
-bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data )
+bool QgsBaseNetworkRequest::sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
 {
   abort(); // cancel previous
   mIsAborted = false;
@@ -343,7 +374,164 @@ bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTyp
     // Hack for testing purposes
     QUrl modifiedUrl( url );
     QUrlQuery query( modifiedUrl );
-    query.addQueryItem( QStringLiteral( "POSTDATA" ), QString::fromUtf8( data ) );
+    query.addQueryItem( QString( QString::fromUtf8( verb ) + QStringLiteral( "DATA" ) ), QString::fromUtf8( data ) );
+    modifiedUrl.setQuery( query );
+    QList<QNetworkReply::RawHeaderPair> extraHeadersModified( extraHeaders );
+    if ( mFakeURLIncludesContentType && !contentTypeHeader.isEmpty() )
+    {
+      extraHeadersModified.append( QNetworkReply::RawHeaderPair( QByteArray( "Content-Type" ), contentTypeHeader.toUtf8() ) );
+    }
+    bool ret = sendGET( modifiedUrl, QString(), true, true, false, extraHeadersModified );
+
+    if ( mFakeResponseHasHeaders )
+    {
+      // Expect the file content to be formatted like:
+      // header1: value1\r\n
+      // headerN: valueN\r\n
+      // \r\n
+      // content
+      int from = 0;
+      while ( true )
+      {
+        int pos = mResponse.indexOf( QByteArray( "\r\n" ), from );
+        if ( pos < 0 )
+        {
+          break;
+        }
+        QByteArray line = mResponse.mid( from, pos - from );
+        int posColon = line.indexOf( QByteArray( ":" ) );
+        if ( posColon > 0 )
+        {
+          mResponseHeaders.append( QNetworkReply::RawHeaderPair( line.mid( 0, posColon ), line.mid( posColon + 1 ).trimmed() ) );
+        }
+        from = pos + 2;
+        if ( from + 2 < mResponse.size() && mResponse[from] == '\r' && mResponse[from] == '\n' )
+        {
+          from += 2;
+          break;
+        }
+      }
+      mResponse = mResponse.mid( from );
+    }
+    return ret;
+  }
+
+  QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsBaseNetworkRequest" ) );
+  if ( !mAuth.setAuthorization( request ) )
+  {
+    mErrorCode = QgsBaseNetworkRequest::NetworkError;
+    mErrorMessage = errorMessageFailedAuth();
+    logMessageIfEnabled();
+    return false;
+  }
+  request.setHeader( QNetworkRequest::ContentTypeHeader, contentTypeHeader );
+  for ( const QNetworkReply::RawHeaderPair &headerPair : extraHeaders )
+    request.setRawHeader( headerPair.first, headerPair.second );
+
+  if ( !issueRequest( request, verb, &data, /*synchronous=*/true ) )
+  {
+    return false;
+  }
+
+  return mErrorMessage.isEmpty();
+}
+
+bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
+{
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "POST" ), contentTypeHeader, data, extraHeaders );
+}
+
+bool QgsBaseNetworkRequest::sendPUT( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
+{
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PUT" ), contentTypeHeader, data, extraHeaders );
+}
+
+bool QgsBaseNetworkRequest::sendPATCH( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders )
+{
+  return sendPOSTOrPUTOrPATCH( url, QByteArray( "PATCH" ), contentTypeHeader, data, extraHeaders );
+}
+
+QStringList QgsBaseNetworkRequest::sendOPTIONS( const QUrl &url )
+{
+  abort(); // cancel previous
+  mIsAborted = false;
+  mTimedout = false;
+  mGotNonEmptyResponse = false;
+  mEmptyResponseIsValid = true;
+
+  mErrorMessage.clear();
+  mErrorCode = QgsBaseNetworkRequest::NoError;
+  mForceRefresh = true;
+  mResponse.clear();
+
+  QByteArray allowValue;
+  if ( url.toEncoded().contains( "fake_qgis_http_endpoint" ) )
+  {
+    // Hack for testing purposes
+    QUrl modifiedUrl( url );
+    QUrlQuery query( modifiedUrl );
+    query.addQueryItem( QStringLiteral( "VERB" ), QStringLiteral( "OPTIONS" ) );
+    modifiedUrl.setQuery( query );
+    if ( !sendGET( modifiedUrl, QString(), true, true, false ) )
+      return QStringList();
+    allowValue = mResponse;
+  }
+  else
+  {
+    QNetworkRequest request( url );
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsBaseNetworkRequest" ) );
+    if ( !mAuth.setAuthorization( request ) )
+    {
+      mErrorCode = QgsBaseNetworkRequest::NetworkError;
+      mErrorMessage = errorMessageFailedAuth();
+      logMessageIfEnabled();
+      return QStringList();
+    }
+
+    if ( !issueRequest( request, QByteArray( "OPTIONS" ), /*data=*/nullptr, /*synchronous=*/true ) )
+    {
+      return QStringList();
+    }
+
+    for ( const auto &headerKeyValue : mResponseHeaders )
+    {
+      if ( headerKeyValue.first == QByteArray( "Allow" ) )
+      {
+        allowValue = headerKeyValue.second;
+        break;
+      }
+    }
+  }
+
+  QStringList res;
+  QStringList l = QString::fromLatin1( allowValue ).split( QLatin1Char( ',' ) );
+  for ( const QString &s : l )
+  {
+    res.append( s.trimmed() );
+  }
+  return res;
+}
+
+bool QgsBaseNetworkRequest::sendDELETE( const QUrl &url )
+{
+  abort(); // cancel previous
+  mIsAborted = false;
+  mTimedout = false;
+  mGotNonEmptyResponse = false;
+  mEmptyResponseIsValid = true;
+
+  mErrorMessage.clear();
+  mErrorCode = QgsBaseNetworkRequest::NoError;
+  mForceRefresh = true;
+  mResponse.clear();
+
+  if ( url.toEncoded().contains( "fake_qgis_http_endpoint" ) )
+  {
+    // Hack for testing purposes
+    QUrl modifiedUrl( url );
+    QUrlQuery query( modifiedUrl );
+    query.addQueryItem( QStringLiteral( "VERB" ), QString::fromUtf8( "DELETE" ) );
     modifiedUrl.setQuery( query );
     return sendGET( modifiedUrl, QString(), true, true, false );
   }
@@ -357,23 +545,11 @@ bool QgsBaseNetworkRequest::sendPOST( const QUrl &url, const QString &contentTyp
     logMessageIfEnabled();
     return false;
   }
-  request.setHeader( QNetworkRequest::ContentTypeHeader, contentTypeHeader );
 
-  mReply = QgsNetworkAccessManager::instance()->post( request, data );
-  if ( !mAuth.setAuthorizationReply( mReply ) )
+  if ( !issueRequest( request, QByteArray( "DELETE" ), nullptr, /*synchronous=*/true ) )
   {
-    mErrorCode = QgsBaseNetworkRequest::NetworkError;
-    mErrorMessage = errorMessageFailedAuth();
-    logMessageIfEnabled();
     return false;
   }
-  connect( mReply, &QNetworkReply::finished, this, &QgsBaseNetworkRequest::replyFinished );
-  connect( mReply, &QNetworkReply::downloadProgress, this, &QgsBaseNetworkRequest::replyProgress );
-  connect( mReply, &QNetworkReply::readyRead, this, &QgsBaseNetworkRequest::replyReadyRead );
-
-  QEventLoop loop;
-  connect( this, &QgsBaseNetworkRequest::downloadFinished, &loop, &QEventLoop::quit );
-  loop.exec( QEventLoop::ExcludeUserInputEvents );
 
   return mErrorMessage.isEmpty();
 }
@@ -507,7 +683,7 @@ void QgsBaseNetworkRequest::replyFinished()
 
         mResponse = mReply->readAll();
 
-        if ( mResponse.isEmpty() && !mGotNonEmptyResponse )
+        if ( mResponse.isEmpty() && !mGotNonEmptyResponse && !mEmptyResponseIsValid )
         {
           mErrorMessage = tr( "empty response: %1" ).arg( mReply->errorString() );
           mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
@@ -542,6 +718,8 @@ void QgsBaseNetworkRequest::replyFinished()
 
   if ( mReply )
   {
+    mResponseHeaders = mReply->rawHeaderPairs();
+
     mReply->deleteLater();
     mReply = nullptr;
   }

--- a/src/providers/wfs/qgsbasenetworkrequest.h
+++ b/src/providers/wfs/qgsbasenetworkrequest.h
@@ -35,10 +35,22 @@ class QgsBaseNetworkRequest : public QObject
     ~QgsBaseNetworkRequest() override;
 
     //! \brief proceed to sending a GET request
-    bool sendGET( const QUrl &url, const QString &acceptHeader, bool synchronous, bool forceRefresh = false, bool cache = true );
+    bool sendGET( const QUrl &url, const QString &acceptHeader, bool synchronous, bool forceRefresh = false, bool cache = true, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
 
     //! \brief proceed to sending a synchronous POST request
-    bool sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data );
+    bool sendPOST( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+
+    //! \brief proceed to sending a synchronous PUT request
+    bool sendPUT( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+
+    //! \brief proceed to sending a synchronous PATCH request
+    bool sendPATCH( const QUrl &url, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+
+    //! \brief proceed to sending a synchronous OPTIONS request and return the supported verbs
+    QStringList sendOPTIONS( const QUrl &url );
+
+    //! \brief proceed to sending a synchronous DELETE request
+    bool sendDELETE( const QUrl &url );
 
     //! Set whether to log error messages.
     void setLogErrors( bool enabled ) { mLogErrors = enabled; }
@@ -95,6 +107,9 @@ class QgsBaseNetworkRequest : public QObject
     //! Raw response
     QByteArray mResponse;
 
+    //! Response headers
+    QList<QNetworkReply::RawHeaderPair> mResponseHeaders;
+
     //! Whether the request is aborted.
     bool mIsAborted = false;
 
@@ -107,8 +122,17 @@ class QgsBaseNetworkRequest : public QObject
     //! Whether we already received bytes
     bool mGotNonEmptyResponse = false;
 
+    //! Whether an empty response is valid
+    bool mEmptyResponseIsValid = false;
+
     //! Whether to log error messages
     bool mLogErrors = true;
+
+    //! Whether in simulated HTTP mode, the response read in the file has HTTP headers
+    bool mFakeResponseHasHeaders = false;
+
+    //! Whether in simulated HTTP mode, the Content-Type request header should be included
+    bool mFakeURLIncludesContentType = false;
 
   protected:
 
@@ -125,6 +149,11 @@ class QgsBaseNetworkRequest : public QObject
     QString errorMessageFailedAuth();
 
     void logMessageIfEnabled();
+
+    //! \brief proceed to sending a synchronous POST, PUT or PATCH request
+    bool sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
+
+    bool issueRequest( QNetworkRequest &request, const QByteArray &verb, const QByteArray *data, bool synchronous );
 };
 
 


### PR DESCRIPTION
- Issues OPTIONS on /collections/{coll_id} and collections/{coll_id}/{feature_id} endpoints to check server capabilities
- Add support for addFeature() through POST /collections/{coll_id} endpoint
- Add support for changeGeometryValues()/changeAttributeValues() through PUT /collections/{coll_id}/{feature_id} endpoint. Or through PATCH /collections/{coll_id}/{feature_id} with just the updated subset, if available
- Add support for deleteFeatures() through DELETE /collections/{coll_id}/{feature_id} endpoint.
- For POST/PUT/PATCH, takes into account Part 2 (CRS support) when implemented by the server.

CC @3nids 