### PR TITLE
have CI stop accepting gitstatus checks failures from non-provider tests

### DIFF
--- a/.docker/docker-compose-testing.yml
+++ b/.docker/docker-compose-testing.yml
@@ -44,4 +44,3 @@ services:
       - LANG=C.UTF-8
       - LC_ALL=en_US.UTF-8
       - QGIS_HTTPBIN_HOST=httpbin
-      - QGIS_TEST_ACCEPT_GITSTATUS_CHECK_FAILURE=1


### PR DESCRIPTION
See also GH-48904

Continues from #49124 locked-closed by some new github policy ( according to https://github.com/qgis/QGIS/issues/52478#issuecomment-1492880979 )