### PR TITLE
Added more customisation options for Layout Table Frame Grids

### DIFF
--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -407,9 +407,54 @@ Sets the ``width`` in mm for grid lines in the table.
 .. seealso:: :py:func:`setGridColor`
 %End
 
+    void setGridRowStrokeWidth( double width );
+%Docstring
+Sets the ``width`` in mm for grid row lines in the table.
+
+.. seealso:: :py:func:`gridStrokeWidth`
+
+.. seealso:: :py:func:`setShowGrid`
+
+.. seealso:: :py:func:`setGridColor`
+%End
+
+    void setGridColumnStrokeWidth( double width );
+%Docstring
+Sets the ``width`` in mm for grid column lines in the table.
+
+.. seealso:: :py:func:`gridStrokeWidth`
+
+.. seealso:: :py:func:`setShowGrid`
+
+.. seealso:: :py:func:`setGridColor`
+%End
+
+
     double gridStrokeWidth() const;
 %Docstring
 Returns the width of grid lines in the table in mm.
+
+.. seealso:: :py:func:`setGridStrokeWidth`
+
+.. seealso:: :py:func:`showGrid`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+    double gridRowStrokeWidth() const;
+%Docstring
+Returns the width of grid row lines in the table in mm.
+
+.. seealso:: :py:func:`setGridStrokeWidth`
+
+.. seealso:: :py:func:`showGrid`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+    double gridColumnStrokeWidth() const;
+%Docstring
+Returns the width of grid column lines in the table in mm.
 
 .. seealso:: :py:func:`setGridStrokeWidth`
 
@@ -429,9 +474,55 @@ Sets the ``color`` used for grid lines in the table.
 .. seealso:: :py:func:`setGridStrokeWidth`
 %End
 
+
+    void setGridRowColor( const QColor &color );
+%Docstring
+Sets the ``color`` used for grid row lines in the table.
+
+.. seealso:: :py:func:`gridColor`
+
+.. seealso:: :py:func:`setShowGrid`
+
+.. seealso:: :py:func:`setGridStrokeWidth`
+%End
+
+
+    void setGridColumnColor( const QColor &color );
+%Docstring
+Sets the ``color`` used for grid column lines in the table.
+
+.. seealso:: :py:func:`gridColor`
+
+.. seealso:: :py:func:`setShowGrid`
+
+.. seealso:: :py:func:`setGridStrokeWidth`
+%End
+
     QColor gridColor() const;
 %Docstring
 Returns the color used for grid lines in the table.
+
+.. seealso:: :py:func:`setGridColor`
+
+.. seealso:: :py:func:`showGrid`
+
+.. seealso:: :py:func:`gridStrokeWidth`
+%End
+
+    QColor gridRowColor() const;
+%Docstring
+Returns the color used for grid row lines in the table.
+
+.. seealso:: :py:func:`setGridColor`
+
+.. seealso:: :py:func:`showGrid`
+
+.. seealso:: :py:func:`gridStrokeWidth`
+%End
+
+    QColor gridColumnColor() const;
+%Docstring
+Returns the color used for grid column lines in the table.
 
 .. seealso:: :py:func:`setGridColor`
 
@@ -688,6 +779,10 @@ new data.
 
 
   protected:
+
+
+
+
 
 
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -514,6 +514,45 @@ Returns the color used for the background of the table.
 .. seealso:: :py:func:`gridColor`
 %End
 
+    void setNumberAlternatingRows( int rows );
+%Docstring
+Sets the number of rows before alternating to other color.
+
+.. seealso:: :py:func:`setBackgroundColor`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+
+    int numberAlternatingRows() const;
+%Docstring
+Returns the number of rows before alternating to other color.
+
+.. seealso:: :py:func:`setBackgroundColor`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+    void setNumberAlternatingColumns( int columns );
+%Docstring
+Sets the number of columns before alternating to other color.
+
+.. seealso:: :py:func:`setBackgroundColor`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+
+    int numberAlternatingColumns() const;
+%Docstring
+Returns the number of columns before alternating to other color.
+
+.. seealso:: :py:func:`setBackgroundColor`
+
+.. seealso:: :py:func:`gridColor`
+%End
+
+
     void setWrapBehavior( WrapBehavior behavior );
 %Docstring
 Sets the wrap ``behavior`` for the table, which controls how text within cells is
@@ -649,6 +688,8 @@ new data.
 
 
   protected:
+
+
 
 
 

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -1440,9 +1440,9 @@ void QgsLayoutTable::drawHorizontalGridLines( QgsLayoutItemRenderContext &contex
   double currentY = 0;
   currentY = halfGridStrokeWidth;
   QPen pen;
-  pen.setWidth(mGridRowStrokeWidth);
-  pen.setColor(mGridRowColor);
-  painter->setPen(pen);
+  pen.setWidth( mGridRowStrokeWidth );
+  pen.setColor( mGridRowColor );
+  painter->setPen( pen );
   if ( drawHeaderLines )
   {
     painter->drawLine( QPointF( halfGridStrokeWidth, currentY ), QPointF( mTableSize.width() - halfGridStrokeWidth, currentY ) );
@@ -1551,9 +1551,9 @@ void QgsLayoutTable::drawVerticalGridLines( QgsLayoutItemRenderContext &context,
   double halfGridStrokeWidth = ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 ) / 2.0;
   double currentX = halfGridStrokeWidth;
   QPen pen;
-  pen.setWidth(mGridColumnStrokeWidth);
-  pen.setColor(mGridColumnColor);
-  painter->setPen(pen);
+  pen.setWidth( mGridColumnStrokeWidth );
+  pen.setColor( mGridColumnColor );
+  painter->setPen( pen );
   painter->drawLine( QPointF( currentX, halfGridStrokeWidth ), QPointF( currentX, tableHeight - halfGridStrokeWidth ) );
   currentX += ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 );
   QMap<int, double>::const_iterator maxColWidthIt = maxWidthMap.constBegin();

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -85,7 +85,11 @@ bool QgsLayoutTable::writePropertiesToElement( QDomElement &elem, QDomDocument &
   contentElem.appendChild( contentTextElem );
   elem.appendChild( contentElem );
   elem.setAttribute( QStringLiteral( "gridStrokeWidth" ), QString::number( mGridStrokeWidth ) );
+  elem.setAttribute( QStringLiteral( "gridRowStrokeWidth" ), QString::number( mGridRowStrokeWidth ) );
+  elem.setAttribute( QStringLiteral( "gridColumnStrokeWidth" ), QString::number( mGridColumnStrokeWidth ) );
   elem.setAttribute( QStringLiteral( "gridColor" ), QgsSymbolLayerUtils::encodeColor( mGridColor ) );
+  elem.setAttribute( QStringLiteral( "gridRowColor" ), QgsSymbolLayerUtils::encodeColor( mGridRowColor ) );
+  elem.setAttribute( QStringLiteral( "gridColumnColor" ), QgsSymbolLayerUtils::encodeColor( mGridColumnColor ) );
   elem.setAttribute( QStringLiteral( "horizontalGrid" ), mHorizontalGrid );
   elem.setAttribute( QStringLiteral( "verticalGrid" ), mVerticalGrid );
   elem.setAttribute( QStringLiteral( "showGrid" ), mShowGrid );
@@ -201,10 +205,14 @@ bool QgsLayoutTable::readPropertiesFromElement( const QDomElement &itemElem, con
 
   mCellMargin = itemElem.attribute( QStringLiteral( "cellMargin" ), QStringLiteral( "1.0" ) ).toDouble();
   mGridStrokeWidth = itemElem.attribute( QStringLiteral( "gridStrokeWidth" ), QStringLiteral( "0.5" ) ).toDouble();
+  mGridRowStrokeWidth = itemElem.attribute( QStringLiteral( "gridRowStrokeWidth" ), QStringLiteral( "0.5" ) ).toDouble();
+  mGridColumnStrokeWidth = itemElem.attribute( QStringLiteral( "gridColumnStrokeWidth" ), QStringLiteral( "0.5" ) ).toDouble();
   mHorizontalGrid = itemElem.attribute( QStringLiteral( "horizontalGrid" ), QStringLiteral( "1" ) ).toInt();
   mVerticalGrid = itemElem.attribute( QStringLiteral( "verticalGrid" ), QStringLiteral( "1" ) ).toInt();
   mShowGrid = itemElem.attribute( QStringLiteral( "showGrid" ), QStringLiteral( "1" ) ).toInt();
   mGridColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "gridColor" ), QStringLiteral( "0,0,0,255" ) ) );
+  mGridRowColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "gridRowColor" ), QStringLiteral( "0,0,0,255" ) ) );
+  mGridColumnColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "gridColumnColor" ), QStringLiteral( "0,0,0,255" ) ) );
   mBackgroundColor = QgsSymbolLayerUtils::decodeColor( itemElem.attribute( QStringLiteral( "backgroundColor" ), QStringLiteral( "255,255,255,0" ) ) );
   mWrapBehavior = QgsLayoutTable::WrapBehavior( itemElem.attribute( QStringLiteral( "wrapBehavior" ), QStringLiteral( "0" ) ).toInt() );
   mRowAlternate = itemElem.attribute( QStringLiteral( "numberAlternatingRows" ), QStringLiteral( "2" ) ).toInt();
@@ -292,18 +300,18 @@ int QgsLayoutTable::rowsVisible( QgsRenderContext &context, double frameHeight, 
   double headerHeight = 0;
   if ( includeHeader )
   {
-    headerHeight = mMaxRowHeightMap.value( 0 ) + 2 * ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + 2 * mCellMargin;
+    headerHeight = mMaxRowHeightMap.value( 0 ) + 2 * ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 ) + 2 * mCellMargin;
   }
   else
   {
     //frame has no header text, just the stroke
-    headerHeight = ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 );
+    headerHeight = ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 );
   }
 
   //remaining height available for content rows
   double contentHeight = frameHeight - headerHeight;
 
-  double gridHeight = ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 );
+  double gridHeight = ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 );
 
   int currentRow = firstRow;
   while ( contentHeight > 0 && currentRow <= mTableContents.count() )
@@ -316,7 +324,7 @@ int QgsLayoutTable::rowsVisible( QgsRenderContext &context, double frameHeight, 
   if ( includeEmptyRows && contentHeight > 0 )
   {
     const QFontMetricsF emptyRowContentFontMetrics = QgsTextRenderer::fontMetrics( context, mContentTextFormat, QgsTextRenderer::FONT_WORKAROUND_SCALE );
-    double rowHeight = ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + 2 * mCellMargin + emptyRowContentFontMetrics.ascent() / context.convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters ) / QgsTextRenderer::FONT_WORKAROUND_SCALE;
+    double rowHeight = ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 ) + 2 * mCellMargin + emptyRowContentFontMetrics.ascent() / context.convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters ) / QgsTextRenderer::FONT_WORKAROUND_SCALE;
     currentRow += std::max( std::floor( contentHeight / rowHeight ), 0.0 );
   }
 
@@ -388,8 +396,8 @@ void QgsLayoutTable::render( QgsLayoutItemRenderContext &context, const QRectF &
   //calculate which rows to show in this frame
   QPair< int, int > rowsToShow = rowRange( context.renderContext(), frameIndex );
 
-  double gridSizeX = mShowGrid && mVerticalGrid ? mGridStrokeWidth : 0;
-  double gridSizeY = mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0;
+  double gridSizeX = mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0;
+  double gridSizeY = mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0;
   double cellHeaderHeight = mMaxRowHeightMap[0] + 2 * mCellMargin;
   double cellBodyHeightForEmptyRows = QgsTextRenderer::fontMetrics( context.renderContext(), mContentTextFormat, QgsTextRenderer::FONT_WORKAROUND_SCALE ).ascent() / context.renderContext().convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters ) / QgsTextRenderer::FONT_WORKAROUND_SCALE + 2 * mCellMargin;
   QRectF cell;
@@ -861,6 +869,36 @@ void QgsLayoutTable::setGridStrokeWidth( const double width )
   }
 
   mGridStrokeWidth = width;
+  mGridRowStrokeWidth = width;
+  mGridColumnStrokeWidth = width;
+  //since grid spacing has changed, we need to recalculate the table size
+  recalculateTableSize();
+
+  emit changed();
+}
+
+void QgsLayoutTable::setGridRowStrokeWidth( const double width )
+{
+  if ( qgsDoubleNear( width, mGridRowStrokeWidth ) )
+  {
+    return;
+  }
+
+  mGridRowStrokeWidth = width;
+  //since grid spacing has changed, we need to recalculate the table size
+  recalculateTableSize();
+
+  emit changed();
+}
+
+void QgsLayoutTable::setGridColumnStrokeWidth( const double width )
+{
+  if ( qgsDoubleNear( width, mGridColumnStrokeWidth ) )
+  {
+    return;
+  }
+
+  mGridColumnStrokeWidth = width;
   //since grid spacing has changed, we need to recalculate the table size
   recalculateTableSize();
 
@@ -875,6 +913,34 @@ void QgsLayoutTable::setGridColor( const QColor &color )
   }
 
   mGridColor = color;
+  mGridRowColor = color;
+  mGridColumnColor = color;
+  update();
+
+  emit changed();
+}
+
+void QgsLayoutTable::setGridRowColor( const QColor &color )
+{
+  if ( color == mGridRowColor )
+  {
+    return;
+  }
+
+  mGridRowColor = color;
+  update();
+
+  emit changed();
+}
+
+void QgsLayoutTable::setGridColumnColor( const QColor &color )
+{
+  if ( color == mGridColumnColor )
+  {
+    return;
+  }
+
+  mGridColumnColor = color;
   update();
 
   emit changed();
@@ -1278,7 +1344,7 @@ double QgsLayoutTable::totalWidth()
     totalWidth += maxColWidthIt.value();
   }
   totalWidth += ( 2 * mMaxColumnWidthMap.size() * mCellMargin );
-  totalWidth += ( mMaxColumnWidthMap.size() + 1 ) * ( mShowGrid && mVerticalGrid ? mGridStrokeWidth : 0 );
+  totalWidth += ( mMaxColumnWidthMap.size() + 1 ) * ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 );
 
   return totalWidth;
 }
@@ -1370,19 +1436,23 @@ void QgsLayoutTable::drawHorizontalGridLines( QgsLayoutItemRenderContext &contex
   QPainter *painter = context.renderContext().painter();
 
   double cellBodyHeightForEmptyRows = QgsTextRenderer::fontMetrics( context.renderContext(), mContentTextFormat, QgsTextRenderer::FONT_WORKAROUND_SCALE ).ascent() / QgsTextRenderer::FONT_WORKAROUND_SCALE / context.renderContext().convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters );
-  double halfGridStrokeWidth = ( mShowGrid ? mGridStrokeWidth : 0 ) / 2.0;
+  double halfGridStrokeWidth = ( mShowGrid ? mGridRowStrokeWidth : 0 ) / 2.0;
   double currentY = 0;
   currentY = halfGridStrokeWidth;
+  QPen pen;
+  pen.setWidth(mGridRowStrokeWidth);
+  pen.setColor(mGridRowColor);
+  painter->setPen(pen);
   if ( drawHeaderLines )
   {
     painter->drawLine( QPointF( halfGridStrokeWidth, currentY ), QPointF( mTableSize.width() - halfGridStrokeWidth, currentY ) );
-    currentY += ( mShowGrid ? mGridStrokeWidth : 0 );
+    currentY += ( mShowGrid ? mGridRowStrokeWidth : 0 );
     currentY += mMaxRowHeightMap[0] + 2 * mCellMargin;
   }
   for ( int row = firstRow; row < lastRow; ++row )
   {
     painter->drawLine( QPointF( halfGridStrokeWidth, currentY ), QPointF( mTableSize.width() - halfGridStrokeWidth, currentY ) );
-    currentY += ( mShowGrid ? mGridStrokeWidth : 0 );
+    currentY += ( mShowGrid ? mGridRowStrokeWidth : 0 );
     double rowHeight = row < mTableContents.count() ? mMaxRowHeightMap[row + 1] : cellBodyHeightForEmptyRows;
     currentY += ( rowHeight + 2 * mCellMargin );
   }
@@ -1466,22 +1536,26 @@ void QgsLayoutTable::drawVerticalGridLines( QgsLayoutItemRenderContext &context,
   double tableHeight = 0;
   if ( hasHeader )
   {
-    tableHeight += ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + mCellMargin * 2 + mMaxRowHeightMap[0];
+    tableHeight += ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 ) + mCellMargin * 2 + mMaxRowHeightMap[0];
   }
-  tableHeight += ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 );
+  tableHeight += ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 );
   double headerHeight = tableHeight;
 
   double cellBodyHeightForEmptyRows = QgsTextRenderer::fontMetrics( context.renderContext(), mContentTextFormat, QgsTextRenderer::FONT_WORKAROUND_SCALE ).ascent() / QgsTextRenderer::FONT_WORKAROUND_SCALE / context.renderContext().convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters );
   for ( int row = firstRow; row < lastRow; ++row )
   {
     double rowHeight = row < mTableContents.count() ? mMaxRowHeightMap[row + 1] : cellBodyHeightForEmptyRows;
-    tableHeight += rowHeight + ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + mCellMargin * 2;
+    tableHeight += rowHeight + ( mShowGrid && mHorizontalGrid ? mGridRowStrokeWidth : 0 ) + mCellMargin * 2;
   }
 
-  double halfGridStrokeWidth = ( mShowGrid && mVerticalGrid ? mGridStrokeWidth : 0 ) / 2.0;
+  double halfGridStrokeWidth = ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 ) / 2.0;
   double currentX = halfGridStrokeWidth;
+  QPen pen;
+  pen.setWidth(mGridColumnStrokeWidth);
+  pen.setColor(mGridColumnColor);
+  painter->setPen(pen);
   painter->drawLine( QPointF( currentX, halfGridStrokeWidth ), QPointF( currentX, tableHeight - halfGridStrokeWidth ) );
-  currentX += ( mShowGrid && mVerticalGrid ? mGridStrokeWidth : 0 );
+  currentX += ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 );
   QMap<int, double>::const_iterator maxColWidthIt = maxWidthMap.constBegin();
   int col = 1;
   for ( ; maxColWidthIt != maxWidthMap.constEnd(); ++maxColWidthIt )
@@ -1496,7 +1570,7 @@ void QgsLayoutTable::drawVerticalGridLines( QgsLayoutItemRenderContext &context,
       painter->drawLine( QPointF( currentX, halfGridStrokeWidth ), QPointF( currentX, headerHeight - halfGridStrokeWidth ) );
     }
 
-    currentX += ( mShowGrid && mVerticalGrid ? mGridStrokeWidth : 0 );
+    currentX += ( mShowGrid && mVerticalGrid ? mGridColumnStrokeWidth : 0 );
     col++;
   }
 }

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -386,12 +386,45 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
     void setGridStrokeWidth( double width );
 
     /**
+     * Sets the \a width in mm for grid row lines in the table.
+     * \see gridStrokeWidth()
+     * \see setShowGrid()
+     * \see setGridColor()
+     */
+    void setGridRowStrokeWidth( double width );
+
+    /**
+     * Sets the \a width in mm for grid column lines in the table.
+     * \see gridStrokeWidth()
+     * \see setShowGrid()
+     * \see setGridColor()
+     */
+    void setGridColumnStrokeWidth( double width );
+
+
+    /**
      * Returns the width of grid lines in the table in mm.
      * \see setGridStrokeWidth()
      * \see showGrid()
      * \see gridColor()
      */
     double gridStrokeWidth() const { return mGridStrokeWidth; }
+
+    /**
+     * Returns the width of grid row lines in the table in mm.
+     * \see setGridStrokeWidth()
+     * \see showGrid()
+     * \see gridColor()
+     */
+    double gridRowStrokeWidth() const { return mGridRowStrokeWidth; }
+
+    /**
+     * Returns the width of grid column lines in the table in mm.
+     * \see setGridStrokeWidth()
+     * \see showGrid()
+     * \see gridColor()
+     */
+    double gridColumnStrokeWidth() const { return mGridColumnStrokeWidth; }
 
     /**
      * Sets the \a color used for grid lines in the table.
@@ -401,6 +434,24 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      */
     void setGridColor( const QColor &color );
 
+
+    /**
+     * Sets the \a color used for grid row lines in the table.
+     * \see gridColor()
+     * \see setShowGrid()
+     * \see setGridStrokeWidth()
+     */
+    void setGridRowColor( const QColor &color );
+
+
+    /**
+     * Sets the \a color used for grid column lines in the table.
+     * \see gridColor()
+     * \see setShowGrid()
+     * \see setGridStrokeWidth()
+     */
+    void setGridColumnColor( const QColor &color );
+
     /**
      * Returns the color used for grid lines in the table.
      * \see setGridColor()
@@ -408,6 +459,22 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see gridStrokeWidth()
      */
     QColor gridColor() const { return mGridColor; }
+
+    /**
+     * Returns the color used for grid row lines in the table.
+     * \see setGridColor()
+     * \see showGrid()
+     * \see gridStrokeWidth()
+     */
+    QColor gridRowColor() const { return mGridRowColor; }
+
+    /**
+     * Returns the color used for grid column lines in the table.
+     * \see setGridColor()
+     * \see showGrid()
+     * \see gridStrokeWidth()
+     */
+    QColor gridColumnColor() const { return mGridColumnColor; }
 
     /**
      * Sets whether the grid's horizontal lines should be drawn in the table
@@ -639,8 +706,20 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
     //! Width of grid lines
     double mGridStrokeWidth = 0.5;
 
+    //! Width of grid row lines
+    double mGridRowStrokeWidth = 0.5;
+
+    //! Width of grid lines
+    double mGridColumnStrokeWidth = 0.5;
+
     //! Color for grid lines
     QColor mGridColor = Qt::black;
+
+    //! Color for grid row lines
+    QColor mGridRowColor = Qt::black;
+
+    //! Color for grid column lines
+    QColor mGridColumnColor = Qt::black;
 
     //! True if grid should be shown
     bool mHorizontalGrid = true;

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -387,17 +387,19 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
 
     /**
      * Sets the \a width in mm for grid row lines in the table.
-     * \see gridStrokeWidth()
+     * \see gridRowStrokeWidth()
      * \see setShowGrid()
-     * \see setGridColor()
+     * \see setGridRowColor()
+     * \since QGIS 3.32
      */
     void setGridRowStrokeWidth( double width );
 
     /**
      * Sets the \a width in mm for grid column lines in the table.
-     * \see gridStrokeWidth()
+     * \see gridColumnStrokeWidth()
      * \see setShowGrid()
-     * \see setGridColor()
+     * \see setGridColumnColor()
+     * \since QGIS 3.32
      */
     void setGridColumnStrokeWidth( double width );
 
@@ -412,17 +414,19 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
 
     /**
      * Returns the width of grid row lines in the table in mm.
-     * \see setGridStrokeWidth()
+     * \see setGridRowStrokeWidth()
      * \see showGrid()
-     * \see gridColor()
+     * \see gridRowColor()
+     * \since QGIS 3.32
      */
     double gridRowStrokeWidth() const { return mGridRowStrokeWidth; }
 
     /**
      * Returns the width of grid column lines in the table in mm.
-     * \see setGridStrokeWidth()
+     * \see setGridColumnStrokeWidth()
      * \see showGrid()
-     * \see gridColor()
+     * \see gridColumnColor()
+     * \since QGIS 3.32
      */
     double gridColumnStrokeWidth() const { return mGridColumnStrokeWidth; }
 
@@ -431,24 +435,27 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see gridColor()
      * \see setShowGrid()
      * \see setGridStrokeWidth()
+     * \since QGIS 3.32
      */
     void setGridColor( const QColor &color );
 
 
     /**
      * Sets the \a color used for grid row lines in the table.
-     * \see gridColor()
+     * \see gridRowColor()
      * \see setShowGrid()
      * \see setGridStrokeWidth()
+     * \since QGIS 3.32
      */
     void setGridRowColor( const QColor &color );
 
 
     /**
      * Sets the \a color used for grid column lines in the table.
-     * \see gridColor()
+     * \see gridColumnColor()
      * \see setShowGrid()
-     * \see setGridStrokeWidth()
+     * \see setGridColumnStrokeWidth()
+     * \since QGIS 3.32
      */
     void setGridColumnColor( const QColor &color );
 
@@ -464,7 +471,8 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * Returns the color used for grid row lines in the table.
      * \see setGridColor()
      * \see showGrid()
-     * \see gridStrokeWidth()
+     * \see gridRowStrokeWidth()
+     * \since QGIS 3.32
      */
     QColor gridRowColor() const { return mGridRowColor; }
 
@@ -472,7 +480,8 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * Returns the color used for grid column lines in the table.
      * \see setGridColor()
      * \see showGrid()
-     * \see gridStrokeWidth()
+     * \see gridColumnStrokeWidth()
+     * \since QGIS 3.32
      */
     QColor gridColumnColor() const { return mGridColumnColor; }
 

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -462,6 +462,37 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
     QColor backgroundColor() const { return mBackgroundColor; }
 
     /**
+     * Sets the number of rows before alternating to other color.
+     * \see setBackgroundColor()
+     * \see gridColor()
+     */
+    void setNumberAlternatingRows( int rows );
+
+
+    /**
+     * Returns the number of rows before alternating to other color.
+     * \see setBackgroundColor()
+     * \see gridColor()
+     */
+    int numberAlternatingRows() const {return mRowAlternate; }
+
+    /**
+     * Sets the number of columns before alternating to other color.
+     * \see setBackgroundColor()
+     * \see gridColor()
+     */
+    void setNumberAlternatingColumns( int columns );
+
+
+    /**
+     * Returns the number of columns before alternating to other color.
+     * \see setBackgroundColor()
+     * \see gridColor()
+     */
+    int numberAlternatingColumns() const {return mColAlternate; }
+
+
+    /**
      * Sets the wrap \a behavior for the table, which controls how text within cells is
      * automatically wrapped.
      * \see wrapBehavior()
@@ -634,6 +665,12 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
 
     //! Map of maximum height for each row
     QMap<int, double> mMaxRowHeightMap;
+
+    //! Number of rows before alternating between colors
+    int mRowAlternate = 1;
+
+    //! Number of columns before alternating between colors
+    int mColAlternate = 1;
 
     QSizeF mTableSize;
 

--- a/src/gui/layout/qgslayoutattributetablewidget.cpp
+++ b/src/gui/layout/qgslayoutattributetablewidget.cpp
@@ -41,8 +41,10 @@ QgsLayoutAttributeTableWidget::QgsLayoutAttributeTableWidget( QgsLayoutFrame *fr
   connect( mAttributesPushButton, &QPushButton::clicked, this, &QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked );
   connect( mMaximumRowsSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsLayoutAttributeTableWidget::mMaximumRowsSpinBox_valueChanged );
   connect( mMarginSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutAttributeTableWidget::mMarginSpinBox_valueChanged );
-  connect( mGridStrokeWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutAttributeTableWidget::mGridStrokeWidthSpinBox_valueChanged );
-  connect( mGridColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutAttributeTableWidget::mGridColorButton_colorChanged );
+  connect( mGridRowStrokeWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutAttributeTableWidget::mGridRowStrokeWidthSpinBox_valueChanged );
+  connect( mGridColumnStrokeWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutAttributeTableWidget::mGridColumnStrokeWidthSpinBox_valueChanged );
+  connect( mGridRowColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutAttributeTableWidget::mGridRowColorButton_colorChanged );
+  connect( mGridColumnColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutAttributeTableWidget::mGridColumnColorButton_colorChanged );
   connect( mBackgroundColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutAttributeTableWidget::mBackgroundColorButton_colorChanged );
   connect( mDrawHorizontalGrid, &QCheckBox::toggled, this, &QgsLayoutAttributeTableWidget::mDrawHorizontalGrid_toggled );
   connect( mDrawVerticalGrid, &QCheckBox::toggled, this, &QgsLayoutAttributeTableWidget::mDrawVerticalGrid_toggled );
@@ -113,10 +115,16 @@ QgsLayoutAttributeTableWidget::QgsLayoutAttributeTableWidget( QgsLayoutFrame *fr
   mComposerMapComboBox->setItemType( QgsLayoutItemRegistry::LayoutMap );
   connect( mComposerMapComboBox, &QgsLayoutItemComboBox::itemChanged, this, &QgsLayoutAttributeTableWidget::composerMapChanged );
 
-  mGridColorButton->setColorDialogTitle( tr( "Select Grid Color" ) );
-  mGridColorButton->setAllowOpacity( true );
-  mGridColorButton->setContext( QStringLiteral( "composer" ) );
-  mGridColorButton->setDefaultColor( Qt::black );
+  mGridRowColorButton->setColorDialogTitle( tr( "Select Grid Row Color" ) );
+  mGridRowColorButton->setAllowOpacity( true );
+  mGridRowColorButton->setContext( QStringLiteral( "composer" ) );
+  mGridRowColorButton->setDefaultColor( Qt::black );
+
+  mGridColumnColorButton->setColorDialogTitle( tr( "Select Grid Column Color" ) );
+  mGridColumnColorButton->setAllowOpacity( true );
+  mGridColumnColorButton->setContext( QStringLiteral( "composer" ) );
+  mGridColumnColorButton->setDefaultColor( Qt::black );
+
   mBackgroundColorButton->setColorDialogTitle( tr( "Select Background Color" ) );
   mBackgroundColorButton->setAllowOpacity( true );
   mBackgroundColorButton->setContext( QStringLiteral( "composer" ) );
@@ -335,19 +343,31 @@ void QgsLayoutAttributeTableWidget::contentFontChanged()
   mTable->endCommand();
 }
 
-void QgsLayoutAttributeTableWidget::mGridStrokeWidthSpinBox_valueChanged( double d )
+void QgsLayoutAttributeTableWidget::mGridRowStrokeWidthSpinBox_valueChanged( double d )
 {
   if ( !mTable )
   {
     return;
   }
 
-  mTable->beginCommand( tr( "Change Table Line Width" ), QgsLayoutMultiFrame::UndoTableGridStrokeWidth );
-  mTable->setGridStrokeWidth( d );
+  mTable->beginCommand( tr( "Change Table Row Line Width" ), QgsLayoutMultiFrame::UndoTableGridStrokeWidth );
+  mTable->setGridRowStrokeWidth( d );
   mTable->endCommand();
 }
 
-void QgsLayoutAttributeTableWidget::mGridColorButton_colorChanged( const QColor &newColor )
+void QgsLayoutAttributeTableWidget::mGridColumnStrokeWidthSpinBox_valueChanged( double d )
+{
+  if ( !mTable )
+  {
+    return;
+  }
+
+  mTable->beginCommand( tr( "Change Table Column Line Width" ), QgsLayoutMultiFrame::UndoTableGridStrokeWidth );
+  mTable->setGridColumnStrokeWidth( d );
+  mTable->endCommand();
+}
+
+void QgsLayoutAttributeTableWidget::mGridRowColorButton_colorChanged( const QColor &newColor )
 {
   if ( !mTable )
   {
@@ -355,7 +375,19 @@ void QgsLayoutAttributeTableWidget::mGridColorButton_colorChanged( const QColor 
   }
 
   mTable->beginCommand( tr( "Change Table Grid Color" ), QgsLayoutMultiFrame::UndoTableGridColor );
-  mTable->setGridColor( newColor );
+  mTable->setGridRowColor( newColor );
+  mTable->endCommand();
+}
+
+void QgsLayoutAttributeTableWidget::mGridColumnColorButton_colorChanged( const QColor &newColor )
+{
+  if ( !mTable )
+  {
+    return;
+  }
+
+  mTable->beginCommand( tr( "Change Table Grid Color" ), QgsLayoutMultiFrame::UndoTableGridColor );
+  mTable->setGridColumnColor( newColor );
   mTable->endCommand();
 }
 
@@ -444,8 +476,10 @@ void QgsLayoutAttributeTableWidget::updateGuiElements()
   mComposerMapComboBox->setItem( mTable->map() );
   mMaximumRowsSpinBox->setValue( mTable->maximumNumberOfFeatures() );
   mMarginSpinBox->setValue( mTable->cellMargin() );
-  mGridStrokeWidthSpinBox->setValue( mTable->gridStrokeWidth() );
-  mGridColorButton->setColor( mTable->gridColor() );
+  mGridRowStrokeWidthSpinBox->setValue( mTable->gridRowStrokeWidth() );
+  mGridColumnStrokeWidthSpinBox->setValue( mTable->gridColumnStrokeWidth() );
+  mGridRowColorButton->setColor( mTable->gridRowColor() );
+  mGridColumnColorButton->setColor( mTable->gridColumnColor() );
   mDrawHorizontalGrid->setChecked( mTable->horizontalGrid() );
   mDrawVerticalGrid->setChecked( mTable->verticalGrid() );
   if ( mTable->showGrid() )
@@ -591,8 +625,10 @@ void QgsLayoutAttributeTableWidget::blockAllSignals( bool b )
   mComposerMapComboBox->blockSignals( b );
   mMaximumRowsSpinBox->blockSignals( b );
   mMarginSpinBox->blockSignals( b );
-  mGridColorButton->blockSignals( b );
-  mGridStrokeWidthSpinBox->blockSignals( b );
+  mGridRowColorButton->blockSignals( b );
+  mGridColumnColorButton->blockSignals( b );
+  mGridRowStrokeWidthSpinBox->blockSignals( b );
+  mGridColumnStrokeWidthSpinBox->blockSignals( b );
   mBackgroundColorButton->blockSignals( b );
   mDrawHorizontalGrid->blockSignals( b );
   mDrawVerticalGrid->blockSignals( b );

--- a/src/gui/layout/qgslayoutattributetablewidget.h
+++ b/src/gui/layout/qgslayoutattributetablewidget.h
@@ -68,8 +68,10 @@ class GUI_EXPORT QgsLayoutAttributeTableWidget: public QgsLayoutItemBaseWidget, 
     void composerMapChanged( QgsLayoutItem *item );
     void mMaximumRowsSpinBox_valueChanged( int i );
     void mMarginSpinBox_valueChanged( double d );
-    void mGridStrokeWidthSpinBox_valueChanged( double d );
-    void mGridColorButton_colorChanged( const QColor &newColor );
+    void mGridRowStrokeWidthSpinBox_valueChanged( double d );
+    void mGridColumnStrokeWidthSpinBox_valueChanged( double d );
+    void mGridRowColorButton_colorChanged( const QColor &newColor );
+    void mGridColumnColorButton_colorChanged( const QColor &newColor );
     void mBackgroundColorButton_colorChanged( const QColor &newColor );
     void headerFontChanged();
     void contentFontChanged();

--- a/src/gui/layout/qgslayouttablebackgroundcolorsdialog.cpp
+++ b/src/gui/layout/qgslayouttablebackgroundcolorsdialog.cpp
@@ -78,6 +78,8 @@ void QgsLayoutTableBackgroundColorsDialog::apply()
   }
 
   mTable->setBackgroundColor( mDefaultColorButton->color() );
+  mTable->setNumberAlternatingRows( mSpinRowAlternate->value() );
+  mTable->setNumberAlternatingColumns( mSpinColumnAlternate->value() );
   mTable->endCommand();
   mTable->update();
 }
@@ -116,6 +118,8 @@ void QgsLayoutTableBackgroundColorsDialog::setGuiElementValues()
   }
 
   mDefaultColorButton->setColor( mTable->backgroundColor() );
+  mSpinRowAlternate->setValue( mTable->numberAlternatingRows() );
+  mSpinColumnAlternate->setValue( mTable->numberAlternatingColumns() );
   mDefaultColorButton->setAllowOpacity( true );
   mDefaultColorButton->setColorDialogTitle( tr( "Select Background Color" ) );
   mDefaultColorButton->setShowNoColor( true );

--- a/src/ui/layout/qgslayoutattributetablewidgetbase.ui
+++ b/src/ui/layout/qgslayoutattributetablewidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-551</y>
-        <width>394</width>
-        <height>1343</height>
+        <y>-866</y>
+        <width>392</width>
+        <height>1674</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -269,36 +269,13 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
-          <item row="6" column="1">
-           <widget class="QLineEdit" name="mEmptyMessageLineEdit"/>
-          </item>
           <item row="5" column="1">
            <widget class="QComboBox" name="mEmptyModeComboBox"/>
           </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="mHeaderModeComboBox"/>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="label_11">
+          <item row="11" column="0">
+           <widget class="QLabel" name="label_12">
             <property name="text">
-             <string>Wrap text on</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QPushButton" name="mAdvancedCustomizationButton">
-            <property name="text">
-             <string>Advanced Customization…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Background color</string>
+             <string>Oversized text</string>
             </property>
            </widget>
           </item>
@@ -309,6 +286,27 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Background color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="mEmptyMessageLabel">
+            <property name="text">
+             <string>Message to display</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Display header</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="mDrawEmptyCheckBox">
             <property name="text">
@@ -316,10 +314,13 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="label_12">
+          <item row="10" column="0">
+           <widget class="QLabel" name="label_11">
             <property name="text">
-             <string>Oversized text</string>
+             <string>Wrap text on</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -359,19 +360,22 @@
             </item>
            </layout>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Display header</string>
-            </property>
-           </widget>
-          </item>
           <item row="10" column="1">
            <widget class="QLineEdit" name="mWrapStringLineEdit">
             <property name="frame">
              <bool>true</bool>
             </property>
            </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QPushButton" name="mAdvancedCustomizationButton">
+            <property name="text">
+             <string>Advanced Customization…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="mEmptyMessageLineEdit"/>
           </item>
           <item row="2" column="1">
            <widget class="QgsDoubleSpinBox" name="mMarginSpinBox">
@@ -389,12 +393,8 @@
           <item row="11" column="1">
            <widget class="QComboBox" name="mWrapBehaviorComboBox"/>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="mEmptyMessageLabel">
-            <property name="text">
-             <string>Message to display</string>
-            </property>
-           </widget>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="mHeaderModeComboBox"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="mMarginLabel">
@@ -437,43 +437,27 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
-          <item row="0" column="0">
-           <widget class="QLabel" name="mGridStrokeWidthLabel">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="mDrawHorizontalGrid">
+            <property name="text">
+             <string>Draw horizontal lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Line width</string>
             </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mGridStrokeWidthSpinBox</cstring>
-            </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QgsDoubleSpinBox" name="mGridStrokeWidthSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="showClearButton" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="mGridRowStrokeWidthSpinBox"/>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Color</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QgsColorButton" name="mGridColorButton">
+             <widget class="QgsColorButton" name="mGridRowColorButton">
               <property name="minimumSize">
                <size>
                 <width>120</width>
@@ -492,7 +476,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer">
+             <spacer name="horizontalSpacer_2">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -506,19 +490,72 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="mDrawHorizontalGrid">
+          <item row="10" column="0">
+           <widget class="QLabel" name="label_24">
             <property name="text">
-             <string>Draw horizontal lines</string>
+             <string>Color</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>Line width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QDoubleSpinBox" name="mGridColumnStrokeWidthSpinBox"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="2">
            <widget class="QCheckBox" name="mDrawVerticalGrid">
             <property name="text">
              <string>Draw vertical lines</string>
             </property>
            </widget>
+          </item>
+          <item row="10" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_13">
+            <item>
+             <widget class="QgsColorButton" name="mGridColumnColorButton">
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>120</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_11">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -551,13 +588,6 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Font</string>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="1">
               <widget class="QgsFontButton" name="mHeaderFontToolButton">
                <property name="sizePolicy">
@@ -578,6 +608,13 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Font</string>
                </property>
               </widget>
              </item>
@@ -634,23 +671,10 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0">
-           <widget class="QLabel" name="mResizeModeLabel">
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="mHideEmptyBgCheckBox">
             <property name="text">
-             <string>Resize mode</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="mResizeModeComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+             <string>Don't draw background if frame is empty</string>
             </property>
            </widget>
           </item>
@@ -661,6 +685,16 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="mResizeModeLabel">
+            <property name="text">
+             <string>Resize mode</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="mEmptyFrameCheckBox">
             <property name="text">
@@ -668,10 +702,13 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QCheckBox" name="mHideEmptyBgCheckBox">
-            <property name="text">
-             <string>Don't draw background if frame is empty</string>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="mResizeModeComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
            </widget>
           </item>
@@ -686,31 +723,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFontButton</class>
@@ -718,9 +738,15 @@
    <header>qgsfontbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
@@ -732,6 +758,18 @@
    <class>QgsLayoutItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgslayoutitemcombobox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -764,8 +802,6 @@
   <tabstop>mWrapStringLineEdit</tabstop>
   <tabstop>mWrapBehaviorComboBox</tabstop>
   <tabstop>mShowGridGroupCheckBox</tabstop>
-  <tabstop>mGridStrokeWidthSpinBox</tabstop>
-  <tabstop>mGridColorButton</tabstop>
   <tabstop>mDrawHorizontalGrid</tabstop>
   <tabstop>mDrawVerticalGrid</tabstop>
   <tabstop>groupBox_3</tabstop>
@@ -779,6 +815,7 @@
   <tabstop>mHideEmptyBgCheckBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/layout/qgslayouttablebackgroundstyles.ui
+++ b/src/ui/layout/qgslayouttablebackgroundstyles.ui
@@ -20,187 +20,6 @@
    <string>Table Background Colors</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="14" column="0" colspan="2">
-    <widget class="QCheckBox" name="mFirstRowCheckBox">
-     <property name="text">
-      <string>First row</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="2">
-    <widget class="QCheckBox" name="mHeaderRowCheckBox">
-     <property name="text">
-      <string>Header row</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="2">
-    <widget class="QgsColorButton" name="mLastRowColorButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>120</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QgsColorButton" name="mEvenColumnsColorButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>120</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mEvenColumnsCheckBox">
-     <property name="text">
-      <string>Even columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QCheckBox" name="mFirstColumnCheckBox">
-     <property name="text">
-      <string>First column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QCheckBox" name="mEvenRowsCheckBox">
-     <property name="text">
-      <string>Even rows</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QgsColorButton" name="mOddColumnsColorButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>120</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="2">
-    <widget class="QgsColorButton" name="mHeaderRowColorButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>120</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="mOddColumnsCheckBox">
-     <property name="text">
-      <string>Odd columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0" colspan="2">
-    <widget class="QCheckBox" name="mLastRowCheckBox">
-     <property name="text">
-      <string>Last row</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <widget class="QgsColorButton" name="mFirstColumnColorButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>120</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QCheckBox" name="mLastColumnCheckBox">
-     <property name="text">
-      <string>Last column</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
@@ -208,8 +27,8 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QgsColorButton" name="mDefaultColorButton">
+   <item row="15" column="2">
+    <widget class="QgsColorButton" name="mLastRowColorButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -243,8 +62,61 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="2">
-    <widget class="QgsColorButton" name="mFirstRowColorButton">
+   <item row="13" column="0" colspan="2">
+    <widget class="QCheckBox" name="mHeaderRowCheckBox">
+     <property name="text">
+      <string>Header row</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QCheckBox" name="mOddRowsCheckBox">
+     <property name="text">
+      <string>Odd rows</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="2">
+    <widget class="QCheckBox" name="mFirstRowCheckBox">
+     <property name="text">
+      <string>First row</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QgsColorButton" name="mDefaultColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="mEvenColumnsCheckBox">
+     <property name="text">
+      <string>Even columns</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QgsColorButton" name="mEvenColumnsColorButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -293,10 +165,19 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
-    <widget class="QCheckBox" name="mOddRowsCheckBox">
+   <item row="2" column="0" colspan="3">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>Odd rows</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check options to enable shading for matching cells. Options lower in this list will take precedence over higher options. For example, if both &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;First row&lt;/span&gt;&amp;quot; and &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;Odd rows&lt;/span&gt;&amp;quot; are checked, the cells in the first row will be shaded using the color specified for &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;First row&lt;/span&gt;&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -325,6 +206,127 @@
      </property>
     </widget>
    </item>
+   <item row="14" column="2">
+    <widget class="QgsColorButton" name="mFirstRowColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="2">
+    <widget class="QgsColorButton" name="mHeaderRowColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QCheckBox" name="mEvenRowsCheckBox">
+     <property name="text">
+      <string>Even rows</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QCheckBox" name="mFirstColumnCheckBox">
+     <property name="text">
+      <string>First column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QgsColorButton" name="mFirstColumnColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QgsColorButton" name="mOddColumnsColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="mOddColumnsCheckBox">
+     <property name="text">
+      <string>Odd columns</string>
+     </property>
+    </widget>
+   </item>
    <item row="12" column="2">
     <widget class="QgsColorButton" name="mLastColumnColorButton">
      <property name="sizePolicy">
@@ -350,19 +352,45 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check options to enable shading for matching cells. Options lower in this list will take precedence over higher options. For example, if both &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;First row&lt;/span&gt;&amp;quot; and &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;Odd rows&lt;/span&gt;&amp;quot; are checked, the cells in the first row will be shaded using the color specified for &amp;quot;&lt;span style=&quot; font-style:italic;&quot;&gt;First row&lt;/span&gt;&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>Number of columns before alternating color</string>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QCheckBox" name="mLastColumnCheckBox">
+     <property name="text">
+      <string>Last column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QSpinBox" name="mSpinColumnAlternate">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="2">
+    <widget class="QCheckBox" name="mLastRowCheckBox">
+     <property name="text">
+      <string>Last row</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2">
+    <widget class="QSpinBox" name="mSpinRowAlternate">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Number of rows before alternating color</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

Layout Table Frames now have individual color and width settings for horizontal and vertical lines. 
These properties can be modified through the API and GUI, where the properties are located under Item Properties>Show Grid.

![image](https://user-images.githubusercontent.com/26354156/231025443-b4e90420-d6f2-4063-a2bb-9a15fb34c6bf.png)

![image](https://user-images.githubusercontent.com/26354156/231025461-0ed94478-1fc6-4d40-8e86-b14fca389e0d.png)

The GUI for the Layout Table Frame's Grid Color and Width has been deprecated following these changes but can still be accessed by API calls. Using the API will set the properties on both horizontal and vertical lines.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
