### PR TITLE
Avoid loss of text in code editors when certain modifiers are pressed (3.28 backport)

### DIFF
--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -223,6 +223,8 @@ it is visible.
 
     virtual void keyPressEvent( QKeyEvent * event );
 
+    virtual bool eventFilter( QObject * watched, QEvent * event );
+
 
     virtual void initializeLexer();
 %Docstring

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -104,6 +104,10 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
     setSciWidget();
     initializeLexer();
   } );
+
+#if QSCINTILLA_VERSION < 0x020d03
+  installEventFilter( this );
+#endif
 }
 
 // Workaround a bug in QScintilla 2.8.X
@@ -148,6 +152,21 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
   {
     QsciScintilla::keyPressEvent( event );
   }
+}
+
+bool QgsCodeEditor::eventFilter( QObject *watched, QEvent *event )
+{
+#if QSCINTILLA_VERSION < 0x020d03
+  if ( watched == this && event->type() == QEvent::InputMethod )
+  {
+    // swallow input method events, which cause loss of selected text.
+    // See https://sourceforge.net/p/scintilla/bugs/1913/ , which was ported to QScintilla
+    // in version 2.13.3
+    return true;
+  }
+#endif
+
+  return QsciScintilla::eventFilter( watched, event );
 }
 
 void QgsCodeEditor::initializeLexer()

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -246,6 +246,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
 
     void focusOutEvent( QFocusEvent * event ) override;
     void keyPressEvent( QKeyEvent * event ) override;
+    bool eventFilter( QObject * watched, QEvent * event ) override;
 
     /**
      * Called when the dialect specific code lexer needs to be initialized (or reinitialized).


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/52493