### PR TITLE
Fix coords widget locale issues (plus other unreported)

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -78,7 +78,6 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     //! Widget that will live on the statusbar to display "Coordinate / Extent"
     QLabel *mLabel = nullptr;
 
-    QValidator *mCoordsEditValidator = nullptr;
     QTimer *mDizzyTimer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     int mTwoCharSize = 0;


### PR DESCRIPTION
1. fix #52446
2. fix unreported coords not swapped when needed before centering the canvas
3. fix unreported coords not transformed when needed before centering the canvas
