### PR TITLE
Set map tool

### DIFF
--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -299,6 +299,12 @@ signal emitted once the map tool is activated
 signal emitted once the map tool is deactivated
 %End
 
+    void reactivated();
+%Docstring
+
+.. versionadded:: 3.32
+%End
+
   protected:
 
     QgsMapTool( QgsMapCanvas *canvas /TransferThis/ );

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -180,6 +180,15 @@ called when set as currently active map tool
 called when map tool is being deactivated
 %End
 
+    virtual void reactivate();
+%Docstring
+Called when the map tool is being activated while it is already active.
+
+The default implementation does nothing.
+
+.. versionadded:: 3.32
+%End
+
     virtual void clean();
 %Docstring
 convenient method to clean members

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -184,7 +184,7 @@ called when map tool is being deactivated
 %Docstring
 Called when the map tool is being activated while it is already active.
 
-The default implementation does nothing.
+The default implementation emits the reactivated () signal.
 
 .. versionadded:: 3.32
 %End

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -103,6 +103,7 @@ void QgsMeasureTool::reactivate()
   // User clicked on the measure action while it was already active
   // Only ensure that the dialog is visible
   mDialog->show();
+  QgsMapTool::reactivate();
 }
 
 void QgsMeasureTool::restart()

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -98,6 +98,13 @@ void QgsMeasureTool::deactivate()
   QgsMapTool::deactivate();
 }
 
+void QgsMeasureTool::reactivate()
+{
+  // User clicked on the measure action while it was already active
+  // Only ensure that the dialog is visible
+  mDialog->show();
+}
+
 void QgsMeasureTool::restart()
 {
   mPoints.clear();

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -62,6 +62,7 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void activate() override;
     void deactivate() override;
+    void reactivate() override;
     void keyPressEvent( QKeyEvent *e ) override;
 
   public slots:

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2713,6 +2713,12 @@ void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
   if ( !tool )
     return;
 
+  if ( tool == mMapTool )
+  {
+    mMapTool->reactivate();
+    return;
+  }
+
   if ( mMapTool )
   {
     if ( clean )

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -120,7 +120,7 @@ void QgsMapTool::deactivate()
 
 void QgsMapTool::reactivate()
 {
-
+  emit reactivated();
 }
 
 void QgsMapTool::clean()

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -117,6 +117,12 @@ void QgsMapTool::deactivate()
   emit deactivated();
 }
 
+
+void QgsMapTool::reactivate()
+{
+
+}
+
 void QgsMapTool::clean()
 {
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -287,6 +287,9 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! signal emitted once the map tool is deactivated
     void deactivated();
 
+    //! \since QGIS 3.32 signal emitted when the map tool is activated while it is already active
+    void reactivated();
+
   private slots:
     //! clear pointer when action is destroyed
     void actionDestroyed();

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -195,7 +195,7 @@ class GUI_EXPORT QgsMapTool : public QObject
     /**
      * Called when the map tool is being activated while it is already active.
      *
-     * The default implementation does nothing.
+     * The default implementation emits the reactivated () signal.
      * \since QGIS 3.32
      */
     virtual void reactivate();

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -192,6 +192,14 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! called when map tool is being deactivated
     virtual void deactivate();
 
+    /**
+     * Called when the map tool is being activated while it is already active.
+     *
+     * The default implementation does nothing.
+     * \since QGIS 3.32
+     */
+    virtual void reactivate();
+
     //! convenient method to clean members
     virtual void clean();
 


### PR DESCRIPTION
## Description

When setting a map tool, QGIS does not check if it is already the active tool, and will always deactivate then reactivate the tool. This may cause issues (e.g glitchy MeasureDialog on Ubuntu when user clicks on the measure tool button while it is already active)

This PR modify the `QgsMapCanvas::setMapTool` method, to check whether the new tool is actually the old one. It it is, rather than deactivating and activating the tool, we call `QgsMapTool::reactivate()` and return. `QgsMapTool::reactivate()` default implementation does nothing. The glitchy MeasureDialog on Ubuntu is also adressed in this PR.