### PR TITLE
Cppcheck ubuntu latest

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -188,7 +188,7 @@ jobs:
         run: ./tests/code_layout/sipify/test_sipfiles.sh
 
   cppcheck_18_04:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Sip Files Up To Date
         run: ./tests/code_layout/sipify/test_sipfiles.sh
 
-  cppcheck_18_04:
+  cppcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/python/core/auto_generated/qgsproxyprogresstask.sip.in
+++ b/python/core/auto_generated/qgsproxyprogresstask.sip.in
@@ -33,6 +33,7 @@ task manager.
 Constructor for QgsProxyProgressTask, with the specified ``description``.
 %End
 
+
     void finalize( bool result );
 %Docstring
 Finalizes the task, with the specified ``result``.

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -2481,7 +2481,6 @@ Sets the rotation ``angle`` of the pattern, in degrees clockwise.
   protected:
 
 
-
     virtual void applyDataDefinedSettings( QgsSymbolRenderContext &context );
 
 

--- a/python/gui/auto_generated/qgsproviderguiregistry.sip.in
+++ b/python/gui/auto_generated/qgsproviderguiregistry.sip.in
@@ -48,7 +48,7 @@ Returns list of available providers by their keys
 Returns metadata of the provider or ``None`` if not found
 %End
 
-    void registerGuis( QMainWindow *widget );
+    void registerGuis( QMainWindow *widget ) const;
 %Docstring
 Called during GUI initialization - allows providers to do its internal initialization
 of GUI components, possibly making use of the passed pointer to the QGIS main window.

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -19,6 +19,8 @@ LOG_FILE=/tmp/cppcheck_qgis.txt
 rm -f ${LOG_FILE}
 echo "Checking ${SCRIPT_DIR}/../src ..."
 
+# qgsgcptransformer.cpp causes an effective hang on newer cppcheck!
+
 cppcheck --library=qt.cfg --inline-suppr \
          --template='{file}:{line},{severity},{id},{message}' \
          --enable=all --inconclusive --std=c++11 \
@@ -34,6 +36,7 @@ cppcheck --library=qt.cfg --inline-suppr \
          -DQ_NOWARN_DEPRECATED_PUSH= \
          -DQ_NOWARN_DEPRECATED_POP= \
          -DQ_DECLARE_OPAQUE_POINTER= \
+         -i src/analysis/georeferencing/qgsgcptransformer.cpp \
          -j $(nproc) \
          ${SCRIPT_DIR}/../src \
          >>${LOG_FILE} 2>&1 &

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -36,6 +36,9 @@ cppcheck --library=qt.cfg --inline-suppr \
          -DQ_NOWARN_DEPRECATED_PUSH= \
          -DQ_NOWARN_DEPRECATED_POP= \
          -DQ_DECLARE_OPAQUE_POINTER= \
+         -DQGIS_PROTECT_QOBJECT_THREAD_ACCESS = \
+         -DQ_DECLARE_SQLDRIVER_PRIVATE = \
+         -DSIP_MONKEYPATCH_SCOPEENUM_UNNEST = \
          -i src/analysis/georeferencing/qgsgcptransformer.cpp \
          -j $(nproc) \
          ${SCRIPT_DIR}/../src \

--- a/src/3d/chunks/qgschunkloader_p.h
+++ b/src/3d/chunks/qgschunkloader_p.h
@@ -107,9 +107,9 @@ class _3D_EXPORT QgsQuadtreeChunkLoaderFactory : public QgsChunkLoaderFactory
   protected:
     QgsAABB mRootBbox;
     QgsAABB mClippingBbox;
-    float mRootError;
+    float mRootError = 0;
     //! maximum allowed depth of quad tree
-    int mMaxLevel;
+    int mMaxLevel = 0;
 
 };
 

--- a/src/3d/qgs3daxissettings.cpp
+++ b/src/3d/qgs3daxissettings.cpp
@@ -18,23 +18,7 @@
 #include <QDomDocument>
 
 #include "qgsreadwritecontext.h"
-#include "qgssymbollayerutils.h"
 
-Qgs3DAxisSettings::Qgs3DAxisSettings( const Qgs3DAxisSettings &other )
-  : mMode( other.mMode )
-  , mHorizontalPosition( other.mHorizontalPosition )
-  , mVerticalPosition( other.mVerticalPosition )
-{
-
-}
-
-Qgs3DAxisSettings &Qgs3DAxisSettings::operator=( Qgs3DAxisSettings const &rhs )
-{
-  this->mMode = rhs.mMode;
-  this->mHorizontalPosition = rhs.mHorizontalPosition;
-  this->mVerticalPosition = rhs.mVerticalPosition;
-  return *this;
-}
 
 bool Qgs3DAxisSettings::operator==( Qgs3DAxisSettings const &rhs ) const
 {

--- a/src/3d/qgs3daxissettings.h
+++ b/src/3d/qgs3daxissettings.h
@@ -48,10 +48,6 @@ class _3D_EXPORT Qgs3DAxisSettings
 
     //! default constructor
     Qgs3DAxisSettings() = default;
-    //! copy constructor
-    Qgs3DAxisSettings( const Qgs3DAxisSettings &other );
-    //! delete assignment operator
-    Qgs3DAxisSettings &operator=( Qgs3DAxisSettings const &rhs );
 
     //! Returns true if both objects are equal
     bool operator==( Qgs3DAxisSettings const &rhs ) const;

--- a/src/3d/qgsskyboxsettings.h
+++ b/src/3d/qgsskyboxsettings.h
@@ -71,7 +71,7 @@ class _3D_EXPORT QgsSkyboxSettings
     void setCubeMapFace( const QString &face, const QString &path ) { mCubeMapFacesPaths[face] = path; }
 
   private:
-    QgsSkyboxEntity::SkyboxType mSkyboxType;
+    QgsSkyboxEntity::SkyboxType mSkyboxType = QgsSkyboxEntity::PanoramicSkybox;
     //
     QString mPanoramicTexturePath;
     //

--- a/src/analysis/georeferencing/qgsgcptransformer.h
+++ b/src/analysis/georeferencing/qgsgcptransformer.h
@@ -211,8 +211,8 @@ class ANALYSIS_EXPORT QgsHelmertGeorefTransform : public QgsGcpTransformerInterf
     struct HelmertParameters
     {
       QgsPointXY origin;
-      double scale;
-      double angle;
+      double scale = 0;
+      double angle = 0;
       bool invertYAxis = false;
     };
     HelmertParameters mHelmertParameters;

--- a/src/analysis/processing/qgsalgorithmcellstatistics.h
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.h
@@ -45,16 +45,16 @@ class QgsCellStatisticsAlgorithmBase : public QgsProcessingAlgorithm
     virtual void processRasterStack( QgsProcessingFeedback *feedback ) = 0;
 
     std::vector< QgsRasterAnalysisUtils::RasterLogicInput > mInputs;
-    bool mIgnoreNoData;
-    Qgis::DataType mDataType;
+    bool mIgnoreNoData = false;
+    Qgis::DataType mDataType = Qgis::DataType::UnknownDataType;
     double mNoDataValue = -9999;
-    int mLayerWidth;
-    int mLayerHeight;
+    int mLayerWidth = 0;
+    int mLayerHeight = 0;
     QgsRectangle mExtent;
     QgsCoordinateReferenceSystem mCrs;
-    double mRasterUnitsPerPixelX;
-    double mRasterUnitsPerPixelY;
-    QgsRasterDataProvider *mOutputRasterDataProvider;
+    double mRasterUnitsPerPixelX = 0;
+    double mRasterUnitsPerPixelY = 0;
+    QgsRasterDataProvider *mOutputRasterDataProvider = nullptr;
 };
 
 class QgsCellStatisticsAlgorithm : public QgsCellStatisticsAlgorithmBase
@@ -75,7 +75,7 @@ class QgsCellStatisticsAlgorithm : public QgsCellStatisticsAlgorithmBase
     void processRasterStack( QgsProcessingFeedback *feedback ) override;
 
   private:
-    QgsRasterAnalysisUtils::CellValueStatisticMethods mMethod;
+    QgsRasterAnalysisUtils::CellValueStatisticMethods mMethod = QgsRasterAnalysisUtils::CellValueStatisticMethods::Sum;
 
 };
 
@@ -98,7 +98,7 @@ class QgsCellStatisticsPercentileAlgorithm : public QgsCellStatisticsAlgorithmBa
     void processRasterStack( QgsProcessingFeedback *feedback ) override;
 
   private:
-    QgsRasterAnalysisUtils::CellValuePercentileMethods mMethod;
+    QgsRasterAnalysisUtils::CellValuePercentileMethods mMethod = QgsRasterAnalysisUtils::CellValuePercentileMethods::NearestRankPercentile;
     double mPercentile = 0.0;
 };
 
@@ -121,7 +121,7 @@ class QgsCellStatisticsPercentRankFromValueAlgorithm : public QgsCellStatisticsA
     void processRasterStack( QgsProcessingFeedback *feedback ) override;
 
   private:
-    QgsRasterAnalysisUtils::CellValuePercentRankMethods mMethod;
+    QgsRasterAnalysisUtils::CellValuePercentRankMethods mMethod = QgsRasterAnalysisUtils::CellValuePercentRankMethods::InterpolatedPercentRankInc;
     double mValue = 0.0;
 
 };
@@ -145,9 +145,9 @@ class QgsCellStatisticsPercentRankFromRasterAlgorithm : public QgsCellStatistics
     void processRasterStack( QgsProcessingFeedback *feedback ) override;
 
   private:
-    QgsRasterAnalysisUtils::CellValuePercentRankMethods mMethod;
+    QgsRasterAnalysisUtils::CellValuePercentRankMethods mMethod = QgsRasterAnalysisUtils::CellValuePercentRankMethods::InterpolatedPercentRankInc;
     std::unique_ptr< QgsRasterInterface > mValueRasterInterface;
-    int mValueRasterBand;
+    int mValueRasterBand = 1;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.h
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.h
@@ -57,11 +57,11 @@ class QgsFieldCalculatorAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
   private:
     QgsFields mFields;
-    int mFieldIdx;
+    int mFieldIdx = -1;
     QgsExpression mExpression;
     QgsExpressionContext mExpressionContext;
     QgsDistanceArea mDa;
-    int mRowNumber;
+    int mRowNumber = 0;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmfillnodata.h
+++ b/src/analysis/processing/qgsalgorithmfillnodata.h
@@ -55,17 +55,17 @@ class QgsFillNoDataAlgorithm : public QgsProcessingAlgorithm
                                   QgsProcessingFeedback *feedback ) override;
 
   private:
-    QgsRasterLayer *mInputRaster;
+    QgsRasterLayer *mInputRaster = nullptr;
     double mFillValue = 0;
-    int mBand;
+    int mBand = 1;
     std::unique_ptr< QgsRasterInterface > mInterface;
     QgsRectangle mExtent;
     QgsCoordinateReferenceSystem mCrs;
-    int mLayerWidth;
-    int mLayerHeight;
+    int mLayerWidth = 0;
+    int mLayerHeight = 0;
     int mNbCellsXProvider = 0;
     int mNbCellsYProvider = 0;
-    double mInputNoDataValue;
+    double mInputNoDataValue = 0;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmgrid.h
+++ b/src/analysis/processing/qgsalgorithmgrid.h
@@ -56,13 +56,13 @@ class QgsGridAlgorithm : public QgsProcessingAlgorithm
 
 
   private:
-    int mIdx;
+    int mIdx = 0;
     QgsRectangle mGridExtent;
     QgsCoordinateReferenceSystem mCrs;
-    double mHSpacing;
-    double mVSpacing;
-    double mHOverlay;
-    double mVOverlay;
+    double mHSpacing = 1;
+    double mVSpacing = 1;
+    double mHOverlay = 0;
+    double mVOverlay = 0;
 
     //define grid creation methods
     void createPointGrid( std::unique_ptr< QgsFeatureSink > &sink, QgsProcessingFeedback *feedback );

--- a/src/analysis/processing/qgsalgorithmlinedensity.h
+++ b/src/analysis/processing/qgsalgorithmlinedensity.h
@@ -61,8 +61,8 @@ class QgsLineDensityAlgorithm : public QgsProcessingAlgorithm
   private:
     std::unique_ptr< QgsFeatureSource > mSource;
     QString mWeightField;
-    double mSearchRadius;
-    double mPixelSize;
+    double mSearchRadius = 0;
+    double mPixelSize = 0;
     QgsGeometry mSearchGeometry;
     QgsRectangle mExtent;
     QgsCoordinateReferenceSystem mCrs;

--- a/src/analysis/processing/qgsalgorithmrandompointsextent.h
+++ b/src/analysis/processing/qgsalgorithmrandompointsextent.h
@@ -57,9 +57,9 @@ class QgsRandomPointsExtentAlgorithm : public QgsProcessingAlgorithm
 
   private:
     QgsRectangle mExtent;
-    int mNumPoints;
-    double mDistance;
-    int mMaxAttempts;
+    int mNumPoints = 0;
+    double mDistance = 0;
+    int mMaxAttempts = 0;
     QgsCoordinateReferenceSystem mCrs;
 
 };

--- a/src/analysis/processing/qgsalgorithmrasterlayerproperties.h
+++ b/src/analysis/processing/qgsalgorithmrasterlayerproperties.h
@@ -55,12 +55,12 @@ class QgsRasterLayerPropertiesAlgorithm : public QgsProcessingAlgorithm
     int mBandCount = 0;
     bool mHasNoDataValue = false;
     QVariant mNoDataValue;
-    int mLayerWidth;
-    int mLayerHeight;
+    int mLayerWidth = 0;
+    int mLayerHeight = 0;
     QgsRectangle mExtent;
     QgsCoordinateReferenceSystem mCrs;
-    double mRasterUnitsPerPixelX;
-    double mRasterUnitsPerPixelY;
+    double mRasterUnitsPerPixelX = 0;
+    double mRasterUnitsPerPixelY = 0;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmrastersampling.h
+++ b/src/analysis/processing/qgsalgorithmrastersampling.h
@@ -53,7 +53,7 @@ class QgsRasterSamplingAlgorithm : public QgsProcessingAlgorithm
   private:
 
     std::unique_ptr< QgsRasterDataProvider > mDataProvider;
-    int mBandCount;
+    int mBandCount = 1;
     QgsCoordinateReferenceSystem mCrs;
 
 };

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -217,6 +217,8 @@ void QgsAuthMethodRegistry::clean()
     delete it->second;
     ++it;
   }
+
+  mAuthMethods.clear();
 }
 
 

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -359,17 +359,16 @@ QgsDefaultVectorLayerLegend::QgsDefaultVectorLayerLegend( QgsVectorLayer *vl )
 QList<QgsLayerTreeModelLegendNode *> QgsDefaultVectorLayerLegend::createLayerTreeModelLegendNodes( QgsLayerTreeLayer *nodeLayer )
 {
   QList<QgsLayerTreeModelLegendNode *> nodes;
+  if ( !mLayer )
+    return nodes;
 
-  if ( mLayer )
+  const QString placeholderImage = mLayer->legendPlaceholderImage();
+  if ( !placeholderImage.isEmpty() )
   {
-    const QString placeholderImage = mLayer->legendPlaceholderImage();
-    if ( !placeholderImage.isEmpty() )
-    {
-      bool fitsInCache;
-      const QImage img = QgsApplication::imageCache()->pathAsImage( placeholderImage, QSize(), false, 1.0, fitsInCache );
-      nodes << new QgsImageLegendNode( nodeLayer, img );
-      return nodes;
-    }
+    bool fitsInCache;
+    const QImage img = QgsApplication::imageCache()->pathAsImage( placeholderImage, QSize(), false, 1.0, fitsInCache );
+    nodes << new QgsImageLegendNode( nodeLayer, img );
+    return nodes;
   }
 
   QgsFeatureRenderer *r = mLayer->renderer();

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -45,6 +45,11 @@ class CORE_EXPORT QgsProxyProgressTask : public QgsTask
      */
     QgsProxyProgressTask( const QString &description, bool canCancel = false );
 
+    //! QgsProxyProgressTask cannot be copied
+    QgsProxyProgressTask( const QgsProxyProgressTask &other ) = delete;
+    //! QgsProxyProgressTask cannot be copied
+    QgsProxyProgressTask &operator=( const QgsProxyProgressTask &other ) = delete;
+
     /**
      * Finalizes the task, with the specified \a result.
      *

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -141,6 +141,7 @@ QgsSQLStatement::QgsSQLStatement( const QString &expr, bool allowFragments )
 }
 
 QgsSQLStatement::QgsSQLStatement( const QgsSQLStatement &other )
+  : mAllowFragments( other.mAllowFragments )
 {
   mRootNode = ::parse( other.mStatement, mParserErrorString, other.mAllowFragments );
   mStatement = other.mStatement;
@@ -154,6 +155,7 @@ QgsSQLStatement &QgsSQLStatement::operator=( const QgsSQLStatement &other )
     mParserErrorString.clear();
     mRootNode = ::parse( other.mStatement, mParserErrorString, other.mAllowFragments );
     mStatement = other.mStatement;
+    mAllowFragments = other.mAllowFragments;
   }
   return *this;
 }

--- a/src/core/qgsstoredexpressionmanager.h
+++ b/src/core/qgsstoredexpressionmanager.h
@@ -82,7 +82,7 @@ struct CORE_EXPORT QgsStoredExpression
   //! expression text
   QString expression;
   //! category of the expression use case
-  Category tag;
+  Category tag = Category::FilterExpression;
 };
 
 /**

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -54,9 +54,9 @@ class CORE_EXPORT QgsTileXYZ
     QString toString() const { return QStringLiteral( "X=%1 Y=%2 Z=%3" ).arg( mColumn ).arg( mRow ).arg( mZoomLevel ); }
 
   private:
-    int mColumn;
-    int mRow;
-    int mZoomLevel;
+    int mColumn = -1;
+    int mRow = -1;
+    int mZoomLevel = -1;
 };
 
 
@@ -87,10 +87,10 @@ class CORE_EXPORT QgsTileRange
     int endRow() const { return mEndRow; }
 
   private:
-    int mStartColumn;
-    int mEndColumn;
-    int mStartRow;
-    int mEndRow;
+    int mStartColumn = -1;
+    int mEndColumn = -1;
+    int mStartRow = -1;
+    int mEndRow = -1;
 };
 
 
@@ -198,17 +198,17 @@ class CORE_EXPORT QgsTileMatrix
     //! Zoom level index associated with the tile matrix
     int mZoomLevel = -1;
     //! Number of columns of the tile matrix
-    int mMatrixWidth;
+    int mMatrixWidth = 0;
     //! Number of rows of the tile matrix
-    int mMatrixHeight;
+    int mMatrixHeight = 0;
     //! Matrix extent in map units in the CRS of tile matrix set
     QgsRectangle mExtent;
     //! Scale denominator of the map scale associated with the tile matrix
-    double mScaleDenom;
+    double mScaleDenom = 0;
     //! Width of a single tile in map units (derived from extent and matrix size)
-    double mTileXSpan;
+    double mTileXSpan = 0;
     //! Height of a single tile in map units (derived from extent and matrix size)
-    double mTileYSpan;
+    double mTileYSpan = 0;
 
     friend class QgsTileMatrixSet;
 };

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -2222,8 +2222,6 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QgsMapUnitScale mRandomDeviationYMapUnitScale;
     unsigned long mSeed = 0;
 
-    double mAngle = 0;
-
     void applyDataDefinedSettings( QgsSymbolRenderContext &context ) override;
 
   private:

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -742,6 +742,7 @@ QgsSymbol *QgsSymbol::defaultSymbol( Qgis::GeometryType geomType )
   }
 
   // set opacity
+  // cppcheck-suppress nullPointerRedundantCheck
   s->setOpacity( QgsProject::instance()->styleSettings()->defaultSymbolOpacity() );
 
   // set random color, it project prefs allow

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -771,6 +771,7 @@ bool QgsVectorLayerEditBuffer::commitChangesChangeAttributes( bool &attributesCh
 
   if ( L->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeFeatures && !mChangedGeometries.isEmpty() && !mChangedAttributeValues.isEmpty() )
   {
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( ( L->dataProvider()->capabilities() & ( QgsVectorDataProvider::ChangeAttributeValues | QgsVectorDataProvider::ChangeGeometries ) ) == ( QgsVectorDataProvider::ChangeAttributeValues | QgsVectorDataProvider::ChangeGeometries ) );
 
     if ( L->dataProvider()->changeFeatures( mChangedAttributeValues, mChangedGeometries ) )

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -536,7 +536,7 @@ void QgsVectorLayerProfileResults::renderResultsAsIndividualFeatures( QgsProfile
 
     renderer->stopRender( context.renderContext() );
   }
-  else
+  else if ( mLayer )
   {
     QSet<QString> attributes;
     attributes.unite( mMarkerSymbol->usedAttributes( context.renderContext() ) );

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -150,7 +150,10 @@ void QgsRelationReferenceWidgetWrapper::showIndeterminateState()
 
 QVariantList QgsRelationReferenceWidgetWrapper::additionalFieldValues() const
 {
-  if ( !mWidget || !mWidget->relation().isValid() )
+  if ( !mWidget )
+    return {};
+
+  if ( !mWidget->relation().isValid() )
   {
     QVariantList values;
     for ( int i = 0; i < mWidget->relation().fieldPairs().count(); i++ )

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -216,8 +216,7 @@ void QgsMeshLayerProperties::syncToLayer()
   mLayerOrigNameLineEd->setText( mMeshLayer->name() );
   whileBlocking( mCrsSelector )->setCrs( mMeshLayer->crs() );
 
-  if ( mMeshLayer )
-    mDatasetGroupTreeWidget->syncToLayer( mMeshLayer );
+  mDatasetGroupTreeWidget->syncToLayer( mMeshLayer );
 
   QgsDebugMsgLevel( QStringLiteral( "populate config tab" ), 4 );
   for ( QgsMapLayerConfigWidget *w : std::as_const( mConfigWidgets ) )

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -226,7 +226,7 @@ QgsProviderGuiRegistry::~QgsProviderGuiRegistry()
   mProviders.clear();
 }
 
-void QgsProviderGuiRegistry::registerGuis( QMainWindow *parent )
+void QgsProviderGuiRegistry::registerGuis( QMainWindow *parent ) const
 {
   GuiProviders::const_iterator it = mProviders.begin();
   while ( it != mProviders.end() )

--- a/src/gui/qgsproviderguiregistry.h
+++ b/src/gui/qgsproviderguiregistry.h
@@ -70,7 +70,7 @@ class GUI_EXPORT QgsProviderGuiRegistry
      * Called during GUI initialization - allows providers to do its internal initialization
      * of GUI components, possibly making use of the passed pointer to the QGIS main window.
      */
-    void registerGuis( QMainWindow *widget );
+    void registerGuis( QMainWindow *widget ) const;
 
     /**
      * Returns all data item gui providers registered in provider with \a providerKey

--- a/src/gui/symbology/qgssymbolwidgetcontext.cpp
+++ b/src/gui/symbology/qgssymbolwidgetcontext.cpp
@@ -19,6 +19,8 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgstemporalcontroller.h"
 
+// should mSymbolType be copied?
+// cppcheck-suppress missingMemberCopy
 QgsSymbolWidgetContext::QgsSymbolWidgetContext( const QgsSymbolWidgetContext &other )
   : mMapCanvas( other.mMapCanvas )
   , mMessageBar( other.mMessageBar )
@@ -30,6 +32,8 @@ QgsSymbolWidgetContext::QgsSymbolWidgetContext( const QgsSymbolWidgetContext &ot
   }
 }
 
+// should mSymbolType be copied?
+// cppcheck-suppress operatorEqVarError
 QgsSymbolWidgetContext &QgsSymbolWidgetContext::operator=( const QgsSymbolWidgetContext &other )
 {
   mMapCanvas = other.mMapCanvas;
@@ -43,6 +47,7 @@ QgsSymbolWidgetContext &QgsSymbolWidgetContext::operator=( const QgsSymbolWidget
   {
     mExpressionContext.reset();
   }
+
   return *this;
 }
 

--- a/src/plugins/grass/qtermwidget/ColorScheme.cpp
+++ b/src/plugins/grass/qtermwidget/ColorScheme.cpp
@@ -216,7 +216,7 @@ void ColorScheme::getColorTable( ColorEntry *table, uint randomSeed ) const
 }
 bool ColorScheme::randomizedBackgroundColor() const
 {
-  return _randomTable ? false : !_randomTable[1].isNull();
+  return !_randomTable ? false : !_randomTable[1].isNull();
 }
 void ColorScheme::setRandomizedBackgroundColor( bool randomize )
 {

--- a/src/plugins/grass/qtermwidget/History.cpp
+++ b/src/plugins/grass/qtermwidget/History.cpp
@@ -575,13 +575,17 @@ void CompactHistoryBlockList::deallocate(void* ptr)
   Q_ASSERT( !list.isEmpty());
 
   int i=0;
+  // cppcheck-suppress containerOutOfBounds
   CompactHistoryBlock *block = list.at(i);
+  // cppcheck-suppress containerOutOfBounds
   while ( i<list.size() && !block->contains(ptr) )
   {
     i++;
+    // cppcheck-suppress containerOutOfBounds
     block=list.at(i);
   }
 
+  // cppcheck-suppress containerOutOfBounds
   Q_ASSERT( i<list.size() );
 
   block->deallocate();

--- a/src/plugins/grass/qtermwidget/kpty.h
+++ b/src/plugins/grass/qtermwidget/kpty.h
@@ -184,6 +184,7 @@ class KPty {
     KPtyPrivate * const d_ptr;
 
   private:
+    // cppcheck-suppress unusedPrivateFunction
     Q_DECLARE_PRIVATE(KPty)
 
     KPty( const KPty& ) = delete;

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -2518,23 +2518,16 @@ void QgsGrass::adjustCellHead( struct Cell_head *cellhd, int row_flag, int col_f
 
 QMap<int, QString> QgsGrass::vectorTypeMap()
 {
-  static QMap<int, QString> sVectorTypes;
-  static QMutex sMutex;
-  if ( sVectorTypes.isEmpty() )
+  const thread_local QMap<int, QString> sVectorTypes
   {
-    sMutex.lock();
-    if ( sVectorTypes.isEmpty() )
-    {
-      sVectorTypes.insert( GV_POINT, QStringLiteral( "point" ) );
-      sVectorTypes.insert( GV_CENTROID, QStringLiteral( "centroid" ) );
-      sVectorTypes.insert( GV_LINE, QStringLiteral( "line" ) );
-      sVectorTypes.insert( GV_BOUNDARY, QStringLiteral( "boundary" ) );
-      sVectorTypes.insert( GV_AREA, QStringLiteral( "area" ) );
-      sVectorTypes.insert( GV_FACE, QStringLiteral( "face" ) );
-      sVectorTypes.insert( GV_KERNEL, QStringLiteral( "kernel" ) );
-    }
-    sMutex.unlock();
-  }
+    { GV_POINT, QStringLiteral( "point" ) },
+    { GV_CENTROID, QStringLiteral( "centroid" ) },
+    { GV_LINE, QStringLiteral( "line" ) },
+    { GV_BOUNDARY, QStringLiteral( "boundary" ) },
+    { GV_AREA, QStringLiteral( "area" ) },
+    { GV_FACE, QStringLiteral( "face" ) },
+    { GV_KERNEL, QStringLiteral( "kernel" ) },
+  };
   return sVectorTypes;
 }
 

--- a/src/providers/hana/qgshanaconnectionstringbuilder.h
+++ b/src/providers/hana/qgshanaconnectionstringbuilder.h
@@ -89,7 +89,7 @@ class QgsHanaConnectionStringBuilder
     bool mProxyEnabled = false;
     bool mProxyHttp = false;
     QString mProxyHost;
-    uint mProxyPort;
+    uint mProxyPort = 0;
     QString mProxyUsername;
     QString mProxyPassword;
 };

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -47,6 +47,7 @@ QVariantList QgsHanaProviderResultIterator::nextRowPrivate()
     return ret;
 
   ret.reserve( mNumColumns );
+  // cppcheck-suppress unsignedLessThanZero
   for ( unsigned short i = 1; i <= mNumColumns; ++i )
     ret.push_back( mResultSet->getValue( i ) );
   mNextRow = mResultSet->next();

--- a/src/providers/spatialite/qgsspatialiteconnpool.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnpool.cpp
@@ -26,6 +26,7 @@ QgsSpatiaLiteConnPool *QgsSpatiaLiteConnPool::instance()
   {
     static QMutex sMutex;
     QMutexLocker locker( &sMutex );
+    // cppcheck-suppress identicalInnerCondition
     if ( ! sInstance )
     {
       sInstance = new QgsSpatiaLiteConnPool();

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
@@ -121,7 +121,7 @@ QgsVirtualRasterProvider::QgsVirtualRasterProvider( const QgsVirtualRasterProvid
   , mYBlockSize( other.mYBlockSize )
   , mFormulaString( other.mFormulaString )
   , mLastError( other.mLastError )
-
+  , mRasterLayers{}
 {
   for ( const auto &it : other.mRasterLayers )
   {

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -478,11 +478,11 @@ struct QgsWmtsTileMatrix
   QStringList keywords;
   double scaleDenom = 0;
   QgsPointXY topLeft;  //!< Top-left corner of the tile matrix in map units
-  int tileWidth;     //!< Width of a tile in pixels
-  int tileHeight;    //!< Height of a tile in pixels
-  int matrixWidth;   //!< Number of tiles horizontally
-  int matrixHeight;  //!< Number of tiles vertically
-  double tres;       //!< Pixel span in map units
+  int tileWidth = 0;     //!< Width of a tile in pixels
+  int tileHeight = 0;    //!< Height of a tile in pixels
+  int matrixWidth = 0;   //!< Number of tiles horizontally
+  int matrixHeight = 0;  //!< Number of tiles vertically
+  double tres = 0;       //!< Pixel span in map units
 
   /**
    * Returns extent of a tile in map coordinates.

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1801,6 +1801,9 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
   tl.tileMode = XYZ;
   tl.identifier = QStringLiteral( "xyz" );  // as set in parseUri
   tl.boundingBoxes << bbox;
+  // suppress cppcheck warnings
+  tl.dpi = -1;
+  tl.timeFormat = QgsWmtsTileLayer::WmtsTimeFormat::yyyyMMdd;
 
   double tilePixelRatio = sourceTilePixelRatio;  // by default 0 = unknown
   if ( parsedUri.hasParam( QStringLiteral( "tilePixelRatio" ) ) )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -648,8 +648,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
                                      QImage *image,
                                      const QgsRectangle &viewExtent,
                                      double sourceResolution,
-                                     bool resamplingEnabled,
                                      bool smoothPixmapTransform,
+                                     bool resamplingEnabled,
                                      QgsRasterBlockFeedback *feedback );
     ~QgsWmsTiledImageDownloadHandler() override;
 

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -738,7 +738,7 @@ namespace QgsWmts
     //defining TileMatrix idx
     const int tm_idx = params.tileMatrixAsInt();
     //read TileMatrix
-    if ( tm_idx < 0 || tms.tileMatrixList.count() < tm_idx )
+    if ( tm_idx < 0 || tm_idx >= tms.tileMatrixList.count() )
     {
       throw QgsRequestNotWellFormedException( QStringLiteral( "TileMatrix is unknown" ) );
     }


### PR DESCRIPTION
Exclude qgsgcptransformer.cpp from cppcheck scanning.  This file causes cppcheck to hang indefinitely on newer cppcheck versions. Suppressing warnings is not sufficient, we need to completely exclude this file from the scan.

There's a ... lot... of new errors to fix :scream: 