### PR TITLE
Fix enabling field length parameter in New Temporary Scratch Layer dialog (Fix #52543)

### DIFF
--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -161,6 +161,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int )
     mPrecision->clear();
     mPrecision->setEnabled( false );
     mWidth->setValidator( new QIntValidator( 1, 255, this ) );
+    mWidth->setEnabled( true );
   }
   else if ( fieldType == QLatin1String( "integer" ) )
   {
@@ -169,6 +170,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int )
     mPrecision->clear();
     mPrecision->setEnabled( false );
     mWidth->setValidator( new QIntValidator( 1, 10, this ) );
+    mWidth->setEnabled( true );
   }
   else if ( fieldType == QLatin1String( "double" ) )
   {
@@ -178,6 +180,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int )
       mPrecision->setText( QStringLiteral( "6" ) );
     mPrecision->setEnabled( true );
     mWidth->setValidator( new QIntValidator( 1, 20, this ) );
+    mWidth->setEnabled( true );
   }
   else if ( fieldType == QLatin1String( "bool" ) )
   {

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -94,7 +94,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), "integer64list" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Map ), QgsVariantUtils::typeToDisplayString( QVariant::Map ), "map" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::UserType, QVariant::Invalid, QStringLiteral( "geometry" ) ), tr( "Geometry" ), "geometry" );
-  mTypeBox_currentIndexChanged( 1 );
+  mTypeBox_currentIndexChanged( 0 );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 30, this ) );


### PR DESCRIPTION
## Description

Commit 7ed0b4c1e889ed4ecaec2a6302c17528bc77ad5b fixes the enabling of the field length parameter when switching from a field type to another.
Fixes https://github.com/qgis/QGIS/issues/52543.

Commit 606554c92f26509e61dff7493ba1116acfcb3713 also fixes an unreported issue with the field length parameter predefined value: opening a "New Temporary Scratch Layer" dialog, the field type comobo box value is "Text (string)" but the field length predefined value is set to the "Integer (32 bit)" field length predefined value. The issue only affects QGIS 3.28, but the fix is also suitable for master and 3.30, while it is not strictly needed.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
