### PR TITLE
Move cppcheck workflow to ubuntu latest

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -187,8 +187,8 @@ jobs:
       - name: Sip Files Up To Date
         run: ./tests/code_layout/sipify/test_sipfiles.sh
 
-  cppcheck_18_04:
-    runs-on: ubuntu-18.04
+  cppcheck:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -19,6 +19,8 @@ LOG_FILE=/tmp/cppcheck_qgis.txt
 rm -f ${LOG_FILE}
 echo "Checking ${SCRIPT_DIR}/../src ..."
 
+# qgsgcptransformer.cpp causes an effective hang on newer cppcheck!
+
 cppcheck --library=qt.cfg --inline-suppr \
          --template='{file}:{line},{severity},{id},{message}' \
          --enable=all --inconclusive --std=c++11 \
@@ -34,6 +36,7 @@ cppcheck --library=qt.cfg --inline-suppr \
          -DQ_NOWARN_DEPRECATED_PUSH= \
          -DQ_NOWARN_DEPRECATED_POP= \
          -DQ_DECLARE_OPAQUE_POINTER= \
+         -i src/analysis/georeferencing/qgsgcptransformer.cpp \
          -j $(nproc) \
          ${SCRIPT_DIR}/../src \
          >>${LOG_FILE} 2>&1 &

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -36,6 +36,9 @@ cppcheck --library=qt.cfg --inline-suppr \
          -DQ_NOWARN_DEPRECATED_PUSH= \
          -DQ_NOWARN_DEPRECATED_POP= \
          -DQ_DECLARE_OPAQUE_POINTER= \
+         -DQGIS_PROTECT_QOBJECT_THREAD_ACCESS = \
+         -DQ_DECLARE_SQLDRIVER_PRIVATE = \
+         -DSIP_MONKEYPATCH_SCOPEENUM_UNNEST = \
          -i src/analysis/georeferencing/qgsgcptransformer.cpp \
          -j $(nproc) \
          ${SCRIPT_DIR}/../src \


### PR DESCRIPTION
Spinoff of https://github.com/qgis/QGIS/pull/52542 . There's valid issues flagged by the newer cppcheck, so I suggest we address each in turn and backport as required.

In the meantime, let's trade the old broken failing workflow for a new, non-broken, still failing, workflow... :upside_down_face: 