### PR TITLE
[Backport release-3_28] Fix enabling field length parameter in New Temporary Scratch Layer dialog (Fix #52543)

### DIFF
--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -96,7 +96,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ), "doublelist" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), "integer64list" );
   mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Map ), QgsVariantUtils::typeToDisplayString( QVariant::Map ), "map" );
-  mTypeBox_currentIndexChanged( 1 );
+  mTypeBox_currentIndexChanged( 0 );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 30, this ) );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -160,6 +160,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int index )
       mPrecision->clear();
       mPrecision->setEnabled( false );
       mWidth->setValidator( new QIntValidator( 1, 255, this ) );
+      mWidth->setEnabled( true );
       break;
     case 1: // Whole number
       if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 10 )
@@ -167,6 +168,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int index )
       mPrecision->clear();
       mPrecision->setEnabled( false );
       mWidth->setValidator( new QIntValidator( 1, 10, this ) );
+      mWidth->setEnabled( true );
       break;
     case 2: // Decimal number
       if ( mWidth->text().toInt() < 1 || mWidth->text().toInt() > 30 )
@@ -175,6 +177,7 @@ void QgsNewMemoryLayerDialog::mTypeBox_currentIndexChanged( int index )
         mPrecision->setText( QStringLiteral( "6" ) );
       mPrecision->setEnabled( true );
       mWidth->setValidator( new QIntValidator( 1, 20, this ) );
+      mWidth->setEnabled( true );
       break;
     case 3: // Boolean
       mWidth->clear();


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/52557.