### PR TITLE
Fix new profile map scales

### DIFF
--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -151,7 +151,7 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ), true );
 
   // migrate only one way for map scales
-  if ( !settingsMapScales->exists() )
+  if ( !settingsMapScales->exists() && QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
     settingsMapScales->setValue( QgsSettings().value( QStringLiteral( "Map/scales" ) ).toString().split( ',' ) );
 
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -151,6 +151,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueFromKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ), true );
 
   // handle bad migration - Fix profiles for old QGIS versions (restore the Map/scales key on windows)
+  // TODO: Remove this from QGIS 3.36
+  // PR Link: https://github.com/qgis/QGIS/pull/52580
   if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
   {
     const QStringList oldScales = QgsSettings().value( QStringLiteral( "Map/scales" ) ).toStringList();
@@ -164,6 +166,7 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   if ( !settingsMapScales->exists() )
   {
     // Handle bad migration. Prefer map/scales over Map/scales
+    // TODO: Discard this part starting from QGIS 3.36
     const QStringList oldScales = QgsSettings().value( QStringLiteral( "map/scales" ) ).toStringList();
     if ( ! oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
     {
@@ -176,6 +179,7 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       }
       settingsMapScales->setValue( actualScales );
     }
+    // TODO: keep only this part of the migration starting from QGIS 3.36
     else if ( QgsSettings().contains( QStringLiteral( "Map/scales" ) ) )
     {
       settingsMapScales->setValue( QgsSettings().value( QStringLiteral( "Map/scales" ) ).toString().split( ',' ) );


### PR DESCRIPTION
- Fixes #52383
## Description

This completes #52511 to fix issues regarding the map scale in QGIS 3.30.1

The map scale setting format has changed (QString -> QStringList). When QGIS launches, if the new setting do not exist, it is initailized from the old key. For new profiles however, the old key does not exist either, causing the default scales to be overwritten with an empty string (which also caused crashes, solved by #52511).

This PR checks if the old key actually exists before attempting to migrate it.