### PR TITLE
Move loading MVT sprites to utils class and use it from QgsVectorTile…

### DIFF
--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -30,7 +30,10 @@
 #include "qgsvectortilemvtdecoder.h"
 #include "qgsvectortilelayer.h"
 #include "qgsvectortilerenderer.h"
-
+#include "qgsmapboxglstyleconverter.h"
+#include "qgsnetworkaccessmanager.h"
+#include "qgsblockingnetworkrequest.h"
+#include "qgsjsonutils.h"
 
 
 QPolygon QgsVectorTileUtils::tilePolygon( QgsTileXYZ id, const QgsCoordinateTransform &ct, const QgsTileMatrix &tm, const QgsMapToPixel &mtp )
@@ -179,3 +182,70 @@ void QgsVectorTileUtils::sortTilesByDistanceFromCenter( QVector<QgsTileXYZ> &til
   cmp.center = center;
   std::sort( tiles.begin(), tiles.end(), cmp );
 }
+
+void QgsVectorTileUtils::loadSprites( const QVariantMap &styleDefinition, QgsMapBoxGlStyleConversionContext &context, const QString &styleUrl )
+{
+  if ( styleDefinition.contains( QStringLiteral( "sprite" ) ) && ( context.spriteDefinitions().empty() || context.spriteImage().isNull() ) )
+  {
+    // retrieve sprite definition
+    QString spriteUriBase;
+    if ( styleDefinition.value( QStringLiteral( "sprite" ) ).toString().startsWith( QLatin1String( "http" ) ) )
+    {
+      spriteUriBase = styleDefinition.value( QStringLiteral( "sprite" ) ).toString();
+    }
+    else
+    {
+      spriteUriBase = styleUrl + '/' + styleDefinition.value( QStringLiteral( "sprite" ) ).toString();
+    }
+
+    for ( int resolution = 2; resolution > 0; resolution-- )
+    {
+      QUrl spriteUrl = QUrl( spriteUriBase );
+      spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.json" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
+      QNetworkRequest request = QNetworkRequest( spriteUrl );
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
+      QgsBlockingNetworkRequest networkRequest;
+      switch ( networkRequest.get( request ) )
+      {
+        case QgsBlockingNetworkRequest::NoError:
+        {
+          const QgsNetworkReplyContent content = networkRequest.reply();
+          const QVariantMap spriteDefinition = QgsJsonUtils::parseJson( content.content() ).toMap();
+
+          // retrieve sprite images
+          QUrl spriteUrl = QUrl( spriteUriBase );
+          spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.png" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
+          QNetworkRequest request = QNetworkRequest( spriteUrl );
+          QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
+          QgsBlockingNetworkRequest networkRequest;
+          switch ( networkRequest.get( request ) )
+          {
+            case QgsBlockingNetworkRequest::NoError:
+            {
+              const QgsNetworkReplyContent imageContent = networkRequest.reply();
+              const QImage spriteImage( QImage::fromData( imageContent.content() ) );
+              context.setSprites( spriteImage, spriteDefinition );
+              break;
+            }
+
+            case QgsBlockingNetworkRequest::NetworkError:
+            case QgsBlockingNetworkRequest::TimeoutError:
+            case QgsBlockingNetworkRequest::ServerExceptionError:
+              break;
+          }
+
+          break;
+        }
+
+        case QgsBlockingNetworkRequest::NetworkError:
+        case QgsBlockingNetworkRequest::TimeoutError:
+        case QgsBlockingNetworkRequest::ServerExceptionError:
+          break;
+      }
+
+      if ( !context.spriteDefinitions().isEmpty() )
+        break;
+    }
+  }
+}
+

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -21,6 +21,7 @@
 #define SIP_NO_FILE
 
 #include <QSet>
+#include <QVariantMap>
 
 class QPointF;
 class QPolygon;
@@ -35,6 +36,7 @@ class QgsTileMatrix;
 class QgsTileRange;
 class QgsTileXYZ;
 class QgsVectorTileLayer;
+class QgsMapBoxGlStyleConversionContext;
 
 /**
  * \ingroup core
@@ -84,6 +86,14 @@ class CORE_EXPORT QgsVectorTileUtils
     static QString formatXYZUrlTemplate( const QString &url, QgsTileXYZ tile, const QgsTileMatrix &tileMatrix );
     //! Checks whether the URL template string is correct (contains {x}, {y} / {-y}, {z} placeholders)
     static bool checkXYZUrlTemplate( const QString &url );
+
+    /**
+     * Downloads the sprite image and sets it to the conversion context
+     * \param styleDefinition the style definition map
+     * \param context the style conversion context
+     * \param optional the style url
+     */
+    static void loadSprites( const QVariantMap &styleDefinition, QgsMapBoxGlStyleConversionContext &context, const QString &styleUrl = QString() );
 };
 
 #endif // QGSVECTORTILEUTILS_H

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -91,7 +91,7 @@ class CORE_EXPORT QgsVectorTileUtils
      * Downloads the sprite image and sets it to the conversion context
      * \param styleDefinition the style definition map
      * \param context the style conversion context
-     * \param optional the style url
+     * \param styleUrl optional the style url
      */
     static void loadSprites( const QVariantMap &styleDefinition, QgsMapBoxGlStyleConversionContext &context, const QString &styleUrl = QString() );
 };

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -23,9 +23,11 @@
 #include "qgsvectortilebasicrendererwidget.h"
 #include "qgsvectortilebasiclabelingwidget.h"
 #include "qgsvectortilelayer.h"
+#include "qgsvectortileutils.h"
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsapplication.h"
+#include "qgsjsonutils.h"
 #include "qgsmetadatawidget.h"
 #include "qgsmaplayerloadstyledialog.h"
 #include "qgsmapboxglstyleconverter.h"
@@ -323,6 +325,10 @@ void QgsVectorTileLayerProperties::loadStyle()
         context.setTargetUnit( Qgis::RenderUnit::Millimeters );
         //assume source uses 96 dpi
         context.setPixelSizeConversionFactor( 25.4 / 96.0 );
+
+        //load sprites
+        QVariantMap styleDefinition = QgsJsonUtils::parseJson( content ).toMap();
+        QgsVectorTileUtils::loadSprites( styleDefinition, context );
 
         QgsMapBoxGlStyleConverter converter;
 


### PR DESCRIPTION
If a vector tile style is loaded from a file and the file contains a sprite-url, those sprites are currently not loaded. This PR moves the code for loading the sprites to QgsVectorTileUtils (or is there a better place for it?) and uses the function from QgsVectorTileLayerProperties and QgsVectorTileLayer. Like this, loading sprites works also from local file.