### PR TITLE
Zoom pan behavior

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2668,13 +2668,13 @@ void QgsMapCanvas::setWheelFactor( double factor )
 
 void QgsMapCanvas::zoomIn()
 {
-  // magnification is alreday handled in zoomByFactor
+  // magnification is already handled in zoomByFactor
   zoomByFactor( zoomInFactor() );
 }
 
 void QgsMapCanvas::zoomOut()
 {
-  // magnification is alreday handled in zoomByFactor
+  // magnification is already handled in zoomByFactor
   zoomByFactor( zoomOutFactor() );
 }
 
@@ -2689,16 +2689,8 @@ void QgsMapCanvas::zoomWithCenter( int x, int y, bool zoomIn )
 
   // transform the mouse pos to map coordinates
   QgsPointXY center  = getCoordinateTransform()->toMapCoordinates( x, y );
+  zoomByFactor( scaleFactor, &center, !mScaleLocked );
 
-  if ( mScaleLocked )
-  {
-    ScaleRestorer restorer( this );
-    setMagnificationFactor( mapSettings().magnificationFactor() / scaleFactor, &center );
-  }
-  else
-  {
-    zoomByFactor( scaleFactor, &center );
-  }
 }
 
 void QgsMapCanvas::setScaleLocked( bool isLocked )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -268,8 +268,6 @@ QgsMapCanvas::~QgsMapCanvas()
     tool->mCanvas = nullptr;
   }
 
-  mLastNonZoomMapTool = nullptr;
-
   cancelJobs();
 
   // delete canvas items prior to deleting the canvas
@@ -2529,25 +2527,6 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
     // call handler of current map tool
     if ( mMapTool )
     {
-      // right button was pressed in zoom tool? return to previous non zoom tool
-      if ( e->button() == Qt::RightButton && mMapTool->flags() & QgsMapTool::Transient )
-      {
-        QgsDebugMsgLevel( QStringLiteral( "Right click in map tool zoom or pan, last tool is %1." ).arg(
-                            mLastNonZoomMapTool ? QStringLiteral( "not null" ) : QStringLiteral( "null" ) ), 2 );
-
-        QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCurrentLayer );
-
-        // change to older non-zoom tool
-        if ( mLastNonZoomMapTool
-             && ( !( mLastNonZoomMapTool->flags() & QgsMapTool::EditTool )
-                  || ( vlayer && vlayer->isEditable() ) ) )
-        {
-          QgsMapTool *t = mLastNonZoomMapTool;
-          mLastNonZoomMapTool = nullptr;
-          setMapTool( t );
-        }
-        return;
-      }
       std::unique_ptr<QgsMapMouseEvent> me( new QgsMapMouseEvent( this, e ) );
       mMapTool->canvasReleaseEvent( me.get() );
     }
@@ -2754,19 +2733,6 @@ void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
     mMapTool->deactivate();
   }
 
-  if ( ( tool->flags() & QgsMapTool::Transient )
-       && mMapTool && !( mMapTool->flags() & QgsMapTool::Transient ) )
-  {
-    // if zoom or pan tool will be active, save old tool
-    // to bring it back on right click
-    // (but only if it wasn't also zoom or pan tool)
-    mLastNonZoomMapTool = mMapTool;
-  }
-  else
-  {
-    mLastNonZoomMapTool = nullptr;
-  }
-
   QgsMapTool *oldTool = mMapTool;
 
   // set new map tool and activate it
@@ -2790,11 +2756,6 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
     oldTool->deactivate();
     emit mapToolSet( nullptr, oldTool );
     setCursor( Qt::ArrowCursor );
-  }
-
-  if ( mLastNonZoomMapTool && mLastNonZoomMapTool == tool )
-  {
-    mLastNonZoomMapTool = nullptr;
   }
 }
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1365,9 +1365,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     //! pointer to current map tool
     QgsMapTool *mMapTool = nullptr;
 
-    //! previous tool if current is for zooming/panning
-    QgsMapTool *mLastNonZoomMapTool = nullptr;
-
     //! Pointer to project linked to this canvas
     QgsProject *mProject = nullptr;
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -109,9 +109,7 @@ class GUI_EXPORT QgsMapTool : public QObject
      */
     enum Flag
     {
-      Transient = 1 << 1, /*!< Indicates that this map tool performs a transient (one-off) operation.
-                               If it does, the tool can be operated once and then a previous map
-                               tool automatically restored. */
+      Transient = 1 << 1, //!< Deprecated since QGIS 3.32 -- no longer used by QGIS and will be removed in QGIS 4.0
       EditTool = 1 << 2, //!< Map tool is an edit tool, which can only be used when layer is editable
       AllowZoomRect = 1 << 3, //!< Allow zooming by rectangle (by holding shift and dragging) while the tool is active
       ShowContextMenu = 1 << 4, //!< Show a context menu when right-clicking with the tool (since QGIS 3.14). See populateContextMenu().

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -118,9 +118,17 @@ void QgsMapToolPan::canvasReleaseEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolPan::canvasDoubleClickEvent( QgsMapMouseEvent *e )
 {
-  if ( !mPinching )
+  const bool panSingle = ( e->modifiers() & Qt::ControlModifier ) &&
+                         mCanvas->allowInteraction( QgsMapCanvasInteractionBlocker::Interaction::MapPanOnSingleClick ) ;
+  if ( !mPinching && !panSingle )
   {
-    mCanvas->zoomWithCenter( e->x(), e->y(), true );
+    // Calculate the new center point
+    const QgsPointXY mousePos = e->mapPoint();
+    const QgsPointXY oldCenter = mCanvas->center();
+    const double factor = mCanvas->zoomInFactor();
+    const QgsPointXY center = QgsPointXY( mousePos.x() + ( ( oldCenter.x() - mousePos.x() ) * factor ),
+                                          mousePos.y() + ( ( oldCenter.y() - mousePos.y() ) * factor ) );
+    mCanvas->zoomByFactor( factor, &center );
   }
 }
 

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -90,7 +90,9 @@ void QgsMapToolPan::canvasReleaseEvent( QgsMapMouseEvent *e )
       }
       else // add pan to mouse cursor
       {
-        if ( mCanvas->allowInteraction( QgsMapCanvasInteractionBlocker::Interaction::MapPanOnSingleClick ) )
+        const bool panSingle = ( e->modifiers() & Qt::ControlModifier ) &&
+                               mCanvas->allowInteraction( QgsMapCanvasInteractionBlocker::Interaction::MapPanOnSingleClick ) ;
+        if ( panSingle )
         {
           // transform the mouse pos to map coordinates
           const QgsPointXY prevCenter = mCanvas->center();

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -51,7 +51,7 @@ void QgsMapToolPan::deactivate()
 
 QgsMapTool::Flags QgsMapToolPan::flags() const
 {
-  return QgsMapTool::Transient | QgsMapTool::AllowZoomRect | QgsMapTool::ShowContextMenu;
+  return QgsMapTool::AllowZoomRect | QgsMapTool::ShowContextMenu;
 }
 
 void QgsMapToolPan::canvasPressEvent( QgsMapMouseEvent *e )

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -113,8 +113,8 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
     delete mRubberBand;
     mRubberBand = nullptr;
 
-    QgsPointXY mousePos = e->mapPoint();
-    bool centerOnPoint = e->modifiers().testFlag( Qt::ControlModifier );
+    const QgsPointXY mousePos = e->mapPoint();
+    const bool centerOnPoint = e->modifiers().testFlag( Qt::ControlModifier );
     const double factor =  zoomFactor();
 
     QgsPointXY center;
@@ -127,7 +127,7 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
     else
     {
       // Calculate the new center point
-      QgsPointXY oldCenter = mCanvas->center();
+      const QgsPointXY oldCenter = mCanvas->center();
       center = QgsPointXY( mousePos.x() + ( ( oldCenter.x() - mousePos.x() ) * factor ),
                            mousePos.y() + ( ( oldCenter.y() - mousePos.y() ) * factor ) );
     }

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -49,7 +49,7 @@ QgsMapToolZoom::~QgsMapToolZoom()
 
 QgsMapTool::Flags QgsMapToolZoom::flags() const
 {
-  return QgsMapTool::Transient | QgsMapTool::ShowContextMenu;
+  return QgsMapTool::ShowContextMenu;
 }
 
 void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -68,6 +68,7 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
 
   private:
     void setZoomMode( bool zoomOut, bool force = false );
+    double zoomFactor();
 };
 
 #endif


### PR DESCRIPTION
- Fixes #52461

## Description

This PR aims to make the zoom and pan tools more intuitive.

### ZoomIn/Out tools improvements
- Zoom In/Out keep the clicked point under mouse by default (like the wheel zoom). To zoom and center on the clicked point (previous default behavior), press Ctrl

### PanTool improvements
- When single clicking, pan to the clicked point only if Ctrl is pressed.
- Double clicking the canvas while the pan tool is active zooms in while keeping the clicked point under the cursor
- From any other tool, Ctrl+Middle click pans to the clicked point.