### PR TITLE
Vector tile layer labeling fixes

### DIFF
--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -809,3 +809,8 @@ const QgsPalLayerSettings &QgsVectorLayerLabelProvider::settings() const
 {
   return mSettings;
 }
+
+void QgsVectorLayerLabelProvider::setFields( const QgsFields &fields )
+{
+  mFields = fields;
+}

--- a/src/core/labeling/qgsvectorlayerlabelprovider.h
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * a call to prepare() which uses the list of fields.
      * \since QGIS 3.14
      */
-    void setFields( const QgsFields &fields ) { mFields = fields; }
+    void setFields( const QgsFields &fields );
 
   protected:
     //! initialization method - called from constructors
@@ -147,6 +147,8 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
   private:
 
     friend class TestQgsLabelingEngine;
+    friend class QgsVectorTileBasicLabelProvider;
+
     void drawCallout( QgsRenderContext &context, pal::LabelPosition *label ) const;
 };
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1375,7 +1375,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
   }
 
   // buffer color
-  QColor bufferColor;
+  QColor bufferColor( 0, 0, 0, 0 );
   if ( jsonPaint.contains( QStringLiteral( "text-halo-color" ) ) )
   {
     const QVariant jsonBufferColor = jsonPaint.value( QStringLiteral( "text-halo-color" ) );
@@ -1474,10 +1474,15 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
 
   if ( bufferSize > 0 )
   {
+    // Color and opacity are separate components in QGIS
+    const double opacity = bufferColor.alphaF();
+    bufferColor.setAlphaF( 1.0 );
+
     format.buffer().setEnabled( true );
     format.buffer().setSize( bufferSize );
     format.buffer().setSizeUnit( context.targetUnit() );
     format.buffer().setColor( bufferColor );
+    format.buffer().setOpacity( opacity );
 
     if ( haloBlurSize > 0 )
     {

--- a/src/core/vectortile/qgsvectortilebasiclabeling.cpp
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.cpp
@@ -186,6 +186,8 @@ bool QgsVectorTileBasicLabelProvider::prepare( QgsRenderContext &context, QSet<Q
     QgsExpressionContextScopePopper popper( context.expressionContext(), scope );
 
     mSubProviders[i]->setFields( fields );
+    // check is required as fields are not available through the GUI, which can lead to isExpression wrongly set to true
+    mSubProviders[i]->mSettings.isExpression = !fields.names().contains( mSubProviders[i]->mSettings.fieldName );
     if ( !mSubProviders[i]->prepare( context, attributeNames ) )
     {
       QgsDebugMsg( QStringLiteral( "Failed to prepare labeling for style index" ) + QString::number( i ) );


### PR DESCRIPTION
## Description

This PR fixes a serious issue with vector tiles whereas editing a label style (from an imported style) would lead to the whole label going missing. The long story short here is that when editing the style, the label settings widget has no fields context, and when passing on the edited label settings, it'll wrongly flag vector tile layer fields as expression here (https://github.com/qgis/QGIS/blob/master/src/gui/labeling/qgslabelinggui.cpp#L527).

The fix is to run a check when calling  QgsVectorLayerLabelProvider::setFields to see if the label settings' fieldName string is contained in the list of fields we just attached.

And that just gives us proper editing of imported mapboxgl label styles et cie. Woupidou.

To save some CI CPU cycles, I've also attached an important mapboxgl style converter fix to its handling of buffer. The converter didn't follow the spec on the default buffer color value (https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#paint-symbol-text-halo-color). We were using an invalid default color instead of the spec default value of RGBA 0,0,0,0. That resulted in really bad buffer renderings when the text-halo-color wasn't specified:
![Screenshot from 2023-04-08 12-52-05](https://user-images.githubusercontent.com/1728657/230707787-4e0b82a3-ae81-4850-aaef-c00b505881b5.png)

With the fix in, we look much better out of the box:
![Screenshot from 2023-04-08 12-52-37](https://user-images.githubusercontent.com/1728657/230707797-ae4ed67d-0a4f-4547-8894-5599e85e420b.png)
