### PR TITLE
Fixes #52375. Removes duplicate encoding aliases returned by QgsVectorrDataProvider::availableEncodings()

### DIFF
--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -745,7 +745,7 @@ static bool _compareEncodings( const QString &s1, const QString &s2 )
 
 static bool _removeDuplicateEncodings( const QString &s1, const QString &s2 )
 {
-  return ( s1.toLower() == s2.toLower() );
+  return ( s1.compare( s2, Qt::CaseInsensitive ) == 0 );
 }
 
 QStringList QgsVectorDataProvider::availableEncodings()

--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -745,7 +745,7 @@ static bool _compareEncodings( const QString &s1, const QString &s2 )
 
 static bool _removeDuplicateEncodings( const QString &s1, const QString &s2 )
 {
-  return ( s1.compare( s2, Qt::CaseInsensitive ) == 0 );
+  return s1.compare( s2, Qt::CaseInsensitive ) == 0;
 }
 
 QStringList QgsVectorDataProvider::availableEncodings()

--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -743,6 +743,11 @@ static bool _compareEncodings( const QString &s1, const QString &s2 )
   return s1.toLower() < s2.toLower();
 }
 
+static bool _removeDuplicateEncodings( const QString &s1, const QString &s2 )
+{
+  return ( s1.toLower() == s2.toLower() );
+}
+
 QStringList QgsVectorDataProvider::availableEncodings()
 {
   static std::once_flag initialized;
@@ -801,8 +806,10 @@ QStringList QgsVectorDataProvider::availableEncodings()
     smEncodings << "System";
 #endif
 
-    // Do case-insensitive sorting of encodings
+    // Do case-insensitive sorting of encodings then remove duplicates
     std::sort( sEncodings.begin(), sEncodings.end(), _compareEncodings );
+    const auto last = std::unique( sEncodings.begin(), sEncodings.end(), _removeDuplicateEncodings );
+    sEncodings.erase( last, sEncodings.end() );
 
   } );
 


### PR DESCRIPTION
Fixes  #52375
------

Why:
------
QgsVectorDataProvider::availableEncodings() is used to populate the Data source encoding combo box in the layer properties dialog. This function uses QT's QTextCodec::availableCodecs() to get the possible encoding aliases, which returns several entries (aliases) for a single encoding.

While it is useful to get aliases for a single encoding, it may be confusing to have exactly the same alias twice or more. For the issue this PR solves, there was "UTF-8" and "UTF-8", which is exactly the same string. 

What:
-------
This PR simply adds to QgsVectorDataProvider::availableEncodings() the std::unique() function from the C++ standard library to remove the identical strings after sorting them.

