### PR TITLE
add filtering by rectangle and expression to PDAL algortihms

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
@@ -60,9 +60,10 @@ QgsPdalBoundaryAlgorithm *QgsPdalBoundaryAlgorithm::createInstance() const
 void QgsPdalBoundaryAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterVectorDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Boundary" ), QgsProcessing::TypeVectorPolygon ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of cells used to calculate boundary" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 1 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "THRESHOLD" ), QObject::tr( "Minimal number of points in a cell to consider cell occupied" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 1 ) );
+  createCommonParameters();
+  addParameter( new QgsProcessingParameterVectorDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Boundary" ), QgsProcessing::TypeVectorPolygon ) );
 }
 
 QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
@@ -99,6 +100,7 @@ QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &pa
     args << QStringLiteral( "--threshold=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "THRESHOLD" ), context ) );
   }
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
@@ -99,7 +99,7 @@ QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &pa
     args << QStringLiteral( "--threshold=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "THRESHOLD" ), context ) );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
@@ -100,7 +100,7 @@ QStringList QgsPdalBuildVpcAlgorithm::createArgumentLists( const QVariantMap &pa
     args << "--overview";
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
 
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -87,7 +87,7 @@ QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parame
                         QStringLiteral( "--polygon=%1" ).arg( overlayPath )
                       };
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -62,6 +62,7 @@ void QgsPdalClipAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "OVERLAY" ), QObject::tr( "Clipping polygons" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
+  createCommonParameters();
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Clipped point cloud" ) ) );
 }
 
@@ -87,6 +88,7 @@ QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parame
                         QStringLiteral( "--polygon=%1" ).arg( overlayPath )
                       };
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
@@ -79,7 +79,7 @@ QStringList QgsPdalConvertFormatAlgorithm::createArgumentLists( const QVariantMa
                        QStringLiteral( "--output=%1" ).arg( outputFile )
                      };
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
@@ -108,7 +108,7 @@ QStringList QgsPdalDensityAlgorithm::createArgumentLists( const QVariantMap &par
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
@@ -70,6 +70,8 @@ void QgsPdalDensityAlgorithm::initAlgorithm( const QVariantMap & )
   paramOriginY->setFlags( paramOriginY->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginY.release() );
 
+  createCommonParameters();
+
   addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Density raster" ) ) );
 }
 
@@ -108,6 +110,7 @@ QStringList QgsPdalDensityAlgorithm::createArgumentLists( const QVariantMap &par
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -111,7 +111,7 @@ QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -71,6 +71,8 @@ void QgsPdalExportRasterAlgorithm::initAlgorithm( const QVariantMap & )
   paramOriginY->setFlags( paramOriginY->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginY.release() );
 
+  createCommonParameters();
+
   addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output raster" ) ) );
 }
 
@@ -111,6 +113,7 @@ QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -108,7 +108,7 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -70,6 +70,8 @@ void QgsPdalExportRasterTinAlgorithm::initAlgorithm( const QVariantMap & )
   paramOriginY->setFlags( paramOriginY->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginY.release() );
 
+  createCommonParameters();
+
   addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output raster" ) ) );
 }
 
@@ -108,6 +110,7 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
@@ -61,6 +61,7 @@ void QgsPdalExportVectorAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterPointCloudAttribute( QStringLiteral( "ATTRIBUTE" ), QObject::tr( "Attribute" ), QVariant(), QStringLiteral( "INPUT" ), true, true ) );
+  createCommonParameters();
   addParameter( new QgsProcessingParameterVectorDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output vector" ), QgsProcessing::TypeVectorPoint ) );
 }
 
@@ -89,6 +90,7 @@ QStringList QgsPdalExportVectorAlgorithm::createArgumentLists( const QVariantMap
     }
   }
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
@@ -89,7 +89,7 @@ QStringList QgsPdalExportVectorAlgorithm::createArgumentLists( const QVariantMap
     }
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -44,12 +44,12 @@ QString QgsPdalFilterAlgorithm::groupId() const
 
 QStringList QgsPdalFilterAlgorithm::tags() const
 {
-  return QObject::tr( "filter,subset,extract,dimension,attribute" ).split( ',' );
+  return QObject::tr( "filter,subset,extract,dimension,attribute,extent,bounds,rectangle" ).split( ',' );
 }
 
 QString QgsPdalFilterAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm extracts point from the input point cloud which match PDAL expression." );
+  return QObject::tr( "This algorithm extracts point from the input point cloud which match PDAL expression and/or are inside of a cropping rectangle." );
 }
 
 QgsPdalFilterAlgorithm *QgsPdalFilterAlgorithm::createInstance() const
@@ -60,7 +60,8 @@ QgsPdalFilterAlgorithm *QgsPdalFilterAlgorithm::createInstance() const
 void QgsPdalFilterAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterString( QStringLiteral( "FILTER" ), QObject::tr( "Filter expression" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterExtent( QStringLiteral( "FILTER_EXTENT" ), QObject::tr( "Cropping extent" ), QVariant(), true ) );
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output" ) ) );
 }
 
@@ -77,9 +78,38 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
 
   QStringList args = { QStringLiteral( "translate" ),
                        QStringLiteral( "--input=%1" ).arg( layer->source() ),
-                       QStringLiteral( "--filter=%1" ).arg( parameterAsString( parameters, QStringLiteral( "FILTER" ), context ) ),
                        QStringLiteral( "--output=%1" ).arg( outputFile )
                      };
+
+
+  const QString filterExpression = parameterAsString( parameters, QStringLiteral( "FILTER_EXPRESSION" ), context ).trimmed();
+  if ( !filterExpression.isEmpty() )
+  {
+    args << QStringLiteral( "--filter=%1" ).arg( filterExpression );
+  }
+
+  if ( parameters.value( QStringLiteral( "FILTER_EXTENT" ) ).isValid() )
+  {
+    if ( layer->crs().isValid() )
+    {
+      const QgsRectangle extent = parameterAsExtent( parameters, QStringLiteral( "FILTER_EXTENT" ), context, layer->crs() );
+      args << QStringLiteral( "--bounds=([%1, %2], [%3, %4])" )
+           .arg( extent.xMinimum() )
+           .arg( extent.xMaximum() )
+           .arg( extent.yMinimum() )
+           .arg( extent.yMaximum() );
+
+    }
+    else
+    {
+      const QgsRectangle extent = parameterAsExtent( parameters, QStringLiteral( "FILTER_EXTENT" ), context );
+      args << QStringLiteral( "--bounds=([%1, %2], [%3, %4])" )
+           .arg( extent.xMinimum() )
+           .arg( extent.xMaximum() )
+           .arg( extent.yMinimum() )
+           .arg( extent.yMaximum() );
+    }
+  }
 
   applyThreadsParameter( args );
   return args;

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -81,7 +81,7 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
                        QStringLiteral( "--output=%1" ).arg( outputFile )
                      };
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfixprojection.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfixprojection.cpp
@@ -83,7 +83,7 @@ QStringList QgsPdalFixProjectionAlgorithm::createArgumentLists( const QVariantMa
                        QStringLiteral( "--assign-crs=%1" ).arg( crs.authid() )
                      };
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -60,6 +60,7 @@ QgsPdalMergeAlgorithm *QgsPdalMergeAlgorithm::createInstance() const
 void QgsPdalMergeAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterMultipleLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ), QgsProcessing::TypePointCloud ) );
+  createCommonParameters();
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Destination file" ) ) );
 }
 
@@ -82,6 +83,7 @@ QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &param
   args << QStringLiteral( "merge" )
        << QStringLiteral( "--output=%1" ).arg( outputFile );
 
+  applyCommonParameters( args, layers.at( 0 )->crs(), parameters, context );
   applyThreadsParameter( args );
 
   for ( const QgsMapLayer *layer : std::as_const( layers ) )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -82,7 +82,7 @@ QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &param
   args << QStringLiteral( "merge" )
        << QStringLiteral( "--output=%1" ).arg( outputFile );
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
 
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {

--- a/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
@@ -95,7 +95,7 @@ QStringList QgsPdalReprojectAlgorithm::createArgumentLists( const QVariantMap &p
     args << QStringLiteral( "--transform-coord-op=%1" ).arg( coordOp );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
@@ -86,7 +86,7 @@ QStringList QgsPdalThinAlgorithm::createArgumentLists( const QVariantMap &parame
                        QStringLiteral( "--%1=%2" ).arg( mode == 0 ? QStringLiteral( "step-every-nth" ) : QStringLiteral( "step-sample" ) ).arg( step )
                      };
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
   return args;
 }
 

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
@@ -62,6 +62,7 @@ void QgsPdalThinAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "MODE" ), QObject::tr( "Mode" ), QStringList() << QObject::tr( "Every N-th" ) << QObject::tr( "Sample" ), false, 0 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "STEP" ), QObject::tr( "Step" ), QgsProcessingParameterNumber::Integer, 20, false, 1 ) );
+  createCommonParameters();
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output layer" ) ) );
 }
 
@@ -86,6 +87,7 @@ QStringList QgsPdalThinAlgorithm::createArgumentLists( const QVariantMap &parame
                        QStringLiteral( "--%1=%2" ).arg( mode == 0 ? QStringLiteral( "step-every-nth" ) : QStringLiteral( "step-sample" ) ).arg( step )
                      };
 
+  applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args );
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
@@ -101,7 +101,7 @@ QStringList QgsPdalTileAlgorithm::createArgumentLists( const QVariantMap &parame
     args << QStringLiteral( "--a_srs=%1" ).arg( crs.authid() );
   }
 
-  addThreadsParameter( args );
+  applyThreadsParameter( args );
 
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -45,6 +45,49 @@ QString QgsPdalAlgorithmBase::wrenchExecutableBinary() const
   return QString( wrenchExecutable );
 }
 
+void QgsPdalAlgorithmBase::createCommonParameters()
+{
+  std::unique_ptr< QgsProcessingParameterString > filterParam = std::make_unique< QgsProcessingParameterString >( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), false, true );
+  filterParam->setFlags( filterParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( filterParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterExtent > extentParam = std::make_unique< QgsProcessingParameterExtent >( QStringLiteral( "FILTER_EXTENT" ), QObject::tr( "Cropping extent" ), QVariant(), true );
+  extentParam->setFlags( extentParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( extentParam.release() );
+}
+
+void QgsPdalAlgorithmBase::applyCommonParameters( QStringList &arguments, QgsCoordinateReferenceSystem crs, const QVariantMap &parameters, QgsProcessingContext &context )
+{
+  const QString filterExpression = parameterAsString( parameters, QStringLiteral( "FILTER_EXPRESSION" ), context ).trimmed();
+  if ( !filterExpression.isEmpty() )
+  {
+    arguments << QStringLiteral( "--filter=%1" ).arg( filterExpression );
+  }
+
+  if ( parameters.value( QStringLiteral( "FILTER_EXTENT" ) ).isValid() )
+  {
+    if ( crs.isValid() )
+    {
+      const QgsRectangle extent = parameterAsExtent( parameters, QStringLiteral( "FILTER_EXTENT" ), context, crs );
+      arguments << QStringLiteral( "--bounds=([%1, %2], [%3, %4])" )
+                .arg( extent.xMinimum() )
+                .arg( extent.xMaximum() )
+                .arg( extent.yMinimum() )
+                .arg( extent.yMaximum() );
+
+    }
+    else
+    {
+      const QgsRectangle extent = parameterAsExtent( parameters, QStringLiteral( "FILTER_EXTENT" ), context );
+      arguments << QStringLiteral( "--bounds=([%1, %2], [%3, %4])" )
+                .arg( extent.xMinimum() )
+                .arg( extent.xMaximum() )
+                .arg( extent.yMinimum() )
+                .arg( extent.yMaximum() );
+    }
+  }
+}
+
 void QgsPdalAlgorithmBase::applyThreadsParameter( QStringList &arguments )
 {
   QgsSettings settings;

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -45,7 +45,7 @@ QString QgsPdalAlgorithmBase::wrenchExecutableBinary() const
   return QString( wrenchExecutable );
 }
 
-void QgsPdalAlgorithmBase::addThreadsParameter( QStringList &arguments )
+void QgsPdalAlgorithmBase::applyThreadsParameter( QStringList &arguments )
 {
   QgsSettings settings;
   int threads = settings.value( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 0 ).toInt();

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -42,10 +42,10 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
     void setOutputValue( const QString &name, const QVariant &value );
 
     /**
-     * Adds max number of concurrent threads for parallel runs parameter
+     * Applies max number of concurrent threads for parallel runs parameter
      * if user has MAX_THREADS option set in Processing options.
      */
-    void addThreadsParameter( QStringList &arguments );
+    void applyThreadsParameter( QStringList &arguments );
 
     /**
      * Returns path to the pdal_wrench executable binary.

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -42,8 +42,18 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
     void setOutputValue( const QString &name, const QVariant &value );
 
     /**
-     * Applies max number of concurrent threads for parallel runs parameter
-     * if user has MAX_THREADS option set in Processing options.
+     * Creates common advanced parameters, such as expression and rectangle filters
+     */
+    void createCommonParameters();
+
+    /**
+     * Evaluates common advanced parameters and adds them to the pdal_wrench
+     * command line.
+     */
+    void applyCommonParameters( QStringList &arguments, QgsCoordinateReferenceSystem crs, const QVariantMap &parameters, QgsProcessingContext &context );
+
+    /**
+     * Adds "--threads"parameter to the pdal_wrench command line.
      */
     void applyThreadsParameter( QStringList &arguments );
 

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -246,6 +246,29 @@ void TestQgsProcessingPdalAlgs::thin()
             << QStringLiteral( "--step-sample=200" )
           );
 
+  // filter exression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "thin" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+            << QStringLiteral( "--mode=sample" )
+            << QStringLiteral( "--step-sample=200" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "thin" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+            << QStringLiteral( "--mode=sample" )
+            << QStringLiteral( "--step-sample=200" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -254,6 +277,8 @@ void TestQgsProcessingPdalAlgs::thin()
             << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
             << QStringLiteral( "--mode=sample" )
             << QStringLiteral( "--step-sample=200" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -292,6 +317,30 @@ void TestQgsProcessingPdalAlgs::boundary()
             << QStringLiteral( "--threshold=%1" ).arg( 10 )
           );
 
+  // with filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "boundary" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputGpkg )
+            << QStringLiteral( "--resolution=%1" ).arg( 3000 )
+            << QStringLiteral( "--threshold=%1" ).arg( 10 )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // with filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "boundary" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputGpkg )
+            << QStringLiteral( "--resolution=%1" ).arg( 3000 )
+            << QStringLiteral( "--threshold=%1" ).arg( 10 )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -300,6 +349,8 @@ void TestQgsProcessingPdalAlgs::boundary()
             << QStringLiteral( "--output=%1" ).arg( outputGpkg )
             << QStringLiteral( "--resolution=%1" ).arg( 3000 )
             << QStringLiteral( "--threshold=%1" ).arg( 10 )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -370,6 +421,33 @@ void TestQgsProcessingPdalAlgs::density()
             << QStringLiteral( "--tile-origin-y=10" )
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "density" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "density" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -380,6 +458,8 @@ void TestQgsProcessingPdalAlgs::density()
             << QStringLiteral( "--tile-size=100" )
             << QStringLiteral( "--tile-origin-x=1" )
             << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -450,6 +530,33 @@ void TestQgsProcessingPdalAlgs::exportRasterTin()
             << QStringLiteral( "--tile-origin-y=10" )
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_raster_tin" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_raster_tin" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -460,6 +567,8 @@ void TestQgsProcessingPdalAlgs::exportRasterTin()
             << QStringLiteral( "--tile-size=100" )
             << QStringLiteral( "--tile-origin-x=1" )
             << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -615,6 +724,35 @@ void TestQgsProcessingPdalAlgs::exportRaster()
             << QStringLiteral( "--tile-origin-y=10" )
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_raster" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--attribute=ReturnNumber" )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_raster" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--attribute=ReturnNumber" )
+            << QStringLiteral( "--resolution=100" )
+            << QStringLiteral( "--tile-size=100" )
+            << QStringLiteral( "--tile-origin-x=1" )
+            << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -626,6 +764,8 @@ void TestQgsProcessingPdalAlgs::exportRaster()
             << QStringLiteral( "--tile-size=100" )
             << QStringLiteral( "--tile-origin-x=1" )
             << QStringLiteral( "--tile-origin-y=10" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -661,6 +801,27 @@ void TestQgsProcessingPdalAlgs::exportVector()
             << QStringLiteral( "--attribute=Z" )
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_vector" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--attribute=Z" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_vector" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--attribute=Z" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -668,6 +829,8 @@ void TestQgsProcessingPdalAlgs::exportVector()
             << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--attribute=Z" )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }
@@ -705,11 +868,34 @@ void TestQgsProcessingPdalAlgs::merge()
             << pointCloud2
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << pointCloud1
+            << pointCloud2
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+            << pointCloud1
+            << pointCloud2
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
             << pointCloud1
             << pointCloud2
@@ -820,6 +1006,27 @@ void TestQgsProcessingPdalAlgs::clip()
             << QStringLiteral( "--polygon=%1" ).arg( polygonsFile )
           );
 
+  // filter expression
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "clip" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--polygon=%1" ).arg( polygonsFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+          );
+
+  // filter extent
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "clip" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputFile )
+            << QStringLiteral( "--polygon=%1" ).arg( polygonsFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
+          );
+
   // set max threads to 2, a --threads argument should be added
   QgsSettings().setValue( QStringLiteral( "/Processing/Configuration/MAX_THREADS" ), 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
@@ -827,6 +1034,8 @@ void TestQgsProcessingPdalAlgs::clip()
             << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--polygon=%1" ).arg( polygonsFile )
+            << QStringLiteral( "--filter=Intensity > 50" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -844,14 +844,29 @@ void TestQgsProcessingPdalAlgs::filter()
 
   QVariantMap parameters;
   parameters.insert( QStringLiteral( "INPUT" ), mPointCloudLayerPath );
-  parameters.insert( QStringLiteral( "FILTER" ), QStringLiteral( "Classification == 7 || Classification == 8" ) );
   parameters.insert( QStringLiteral( "OUTPUT" ), outputPointCloud );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "translate" )
             << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
-            << QStringLiteral( "--filter=Classification == 7 || Classification == 8" )
             << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+          );
+
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Classification == 7 || Classification == 8" ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "translate" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+            << QStringLiteral( "--filter=Classification == 7 || Classification == 8" )
+          );
+
+  parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "translate" )
+            << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
+            << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+            << QStringLiteral( "--filter=Classification == 7 || Classification == 8" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
           );
 
   // set max threads to 2, a --threads argument should be added
@@ -859,8 +874,9 @@ void TestQgsProcessingPdalAlgs::filter()
   args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "translate" )
             << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )
-            << QStringLiteral( "--filter=Classification == 7 || Classification == 8" )
             << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
+            << QStringLiteral( "--filter=Classification == 7 || Classification == 8" )
+            << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
           );
 }


### PR DESCRIPTION
## Description

Add option to filter input point cloud by rectangle (extent) and expression in the following PDAL algorithms:
 - boundary
 - clip
 - density
 - export to raster (normal and TIN variants)
 - export to vector
 - merge
 - thin

This allows to process only subset of points from the input file(s) without the need to performing an intermediate filtering step and creating an intemediate temporary file.

For these who need only filtering there is also a separate Filter algorithm capable of filtering either by extent, by expression or by their combination.
