### PR TITLE
Drop cppcheck workflow from stable branches

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -188,15 +188,3 @@ jobs:
       - name: Sip Files Up To Date
         run: ./tests/code_layout/sipify/test_sipfiles.sh
 
-  cppcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Requirements
-        run: |
-          sudo apt install -y cppcheck
-
-      - name: Run cppcheck test
-        run: ./scripts/cppcheck.sh


### PR DESCRIPTION
The amount of fixes required to get this passing again will be far too intrusive for safe backporting

I suggest instead we selectively backport only the fixes which are valid issues and focus on getting the check to pass again on master only.