### PR TITLE
Fix Map-based JSON handling in QgsField's convertCompatible()

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -600,16 +600,28 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
     }
   }
 
-  if ( d->type == QVariant::String && ( d->typeName.compare( QLatin1String( "json" ), Qt::CaseInsensitive ) == 0 || d->typeName == QLatin1String( "jsonb" ) ) )
+  if ( d->typeName.compare( QLatin1String( "json" ), Qt::CaseInsensitive ) == 0 || d->typeName.compare( QLatin1String( "jsonb" ), Qt::CaseInsensitive ) == 0 )
   {
-    const QJsonDocument doc = QJsonDocument::fromVariant( v );
-    if ( !doc.isNull() )
+    if ( d->type == QVariant::String )
     {
-      v = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).constData() );
-      return true;
+      const QJsonDocument doc = QJsonDocument::fromVariant( v );
+      if ( !doc.isNull() )
+      {
+        v = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).constData() );
+        return true;
+      }
+      v = QVariant( d->type );
+      return false;
     }
-    v = QVariant( d->type );
-    return false;
+    else if ( d->type == QVariant::Map )
+    {
+      if ( v.type() == QVariant::StringList || v.type() == QVariant::List || v.type() == QVariant::Map )
+      {
+        return true;
+      }
+      v = QVariant( d->type );
+      return false;
+    }
   }
 
   if ( ( d->type == QVariant::StringList || ( d->type == QVariant::List && d->subType == QVariant::String ) )

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -828,19 +828,37 @@ void TestQgsField::convertCompatible()
   QVariant vZero = 0;
   QVERIFY( intField.convertCompatible( vZero ) );
 
-  // Test json field conversion
-  const QgsField jsonField( QStringLiteral( "json" ), QVariant::String, QStringLiteral( "json" ) );
-  QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
-  QVERIFY( jsonField.convertCompatible( jsonValue ) );
-  QCOMPARE( jsonValue.type(), QVariant::String );
-  QCOMPARE( jsonValue, QString( "[1,5,8]" ) );
-  QVariantMap variantMap;
-  variantMap.insert( QStringLiteral( "a" ), 1 );
-  variantMap.insert( QStringLiteral( "c" ), 3 );
-  jsonValue = QVariant::fromValue( variantMap );
-  QVERIFY( jsonField.convertCompatible( jsonValue ) );
-  QCOMPARE( jsonValue.type(), QVariant::String );
-  QCOMPARE( jsonValue, QString( "{\"a\":1,\"c\":3}" ) );
+  // Test string-based json field conversion
+  {
+    const QgsField jsonField( QStringLiteral( "json" ), QVariant::String, QStringLiteral( "json" ) );
+    QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
+    QVERIFY( jsonField.convertCompatible( jsonValue ) );
+    QCOMPARE( jsonValue.type(), QVariant::String );
+    QCOMPARE( jsonValue, QString( "[1,5,8]" ) );
+    QVariantMap variantMap;
+    variantMap.insert( QStringLiteral( "a" ), 1 );
+    variantMap.insert( QStringLiteral( "c" ), 3 );
+    jsonValue = QVariant::fromValue( variantMap );
+    QVERIFY( jsonField.convertCompatible( jsonValue ) );
+    QCOMPARE( jsonValue.type(), QVariant::String );
+    QCOMPARE( jsonValue, QString( "{\"a\":1,\"c\":3}" ) );
+  }
+
+  // Test map-based json field (i.e. OGR geopackage JSON fields) conversion
+  {
+    const QgsField jsonField( QStringLiteral( "json" ), QVariant::Map, QStringLiteral( "json" ) );
+    QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
+    QVERIFY( jsonField.convertCompatible( jsonValue ) );
+    QCOMPARE( jsonValue.type(), QVariant::List );
+    QCOMPARE( jsonValue, QVariantList() << 1 << 5 << 8 );
+    QVariantMap variantMap;
+    variantMap.insert( QStringLiteral( "a" ), 1 );
+    variantMap.insert( QStringLiteral( "c" ), 3 );
+    jsonValue = QVariant::fromValue( variantMap );
+    QVERIFY( jsonField.convertCompatible( jsonValue ) );
+    QCOMPARE( jsonValue.type(), QVariant::Map );
+    QCOMPARE( jsonValue, variantMap );
+  }
 
   // geometry field conversion
   const QgsField geometryField( QStringLiteral( "geometry" ), QVariant::UserType, QStringLiteral( "geometry" ) );


### PR DESCRIPTION
## Description

Geopackage's JSON fields are declared with a QVariant::Map type. When using that JSON field's QgsField object, the convertCompatible fails when passing on valid list and map values (e.g. [1,2,3], {'my':'dict'}, etc.). This is problematic when relying on that function to prepare a value prior to calling a feature's setAttribute.

