### PR TITLE
Fix incorrect argument order in header

### DIFF
--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -648,8 +648,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
                                      QImage *image,
                                      const QgsRectangle &viewExtent,
                                      double sourceResolution,
-                                     bool resamplingEnabled,
                                      bool smoothPixmapTransform,
+                                     bool resamplingEnabled,
                                      QgsRasterBlockFeedback *feedback );
     ~QgsWmsTiledImageDownloadHandler() override;
 


### PR DESCRIPTION
No actual bug fixed by this -- both arguments are always true wherever this object is used
