### PR TITLE
Fix pan tool cursor

### DIFF
--- a/src/gui/layout/qgslayoutviewtoolpan.cpp
+++ b/src/gui/layout/qgslayoutviewtoolpan.cpp
@@ -36,7 +36,7 @@ void QgsLayoutViewToolPan::layoutPressEvent( QgsLayoutViewMouseEvent *event )
 
   mIsPanning = true;
   mLastMousePos = event->pos();
-  view()->setCursor( Qt::ClosedHandCursor );
+  view()->viewport()->setCursor( Qt::ClosedHandCursor );
 }
 
 void QgsLayoutViewToolPan::layoutMoveEvent( QgsLayoutViewMouseEvent *event )
@@ -84,7 +84,7 @@ void QgsLayoutViewToolPan::layoutReleaseEvent( QgsLayoutViewMouseEvent *event )
   }
 
   mIsPanning = false;
-  view()->setCursor( Qt::OpenHandCursor );
+  view()->viewport()->setCursor( Qt::OpenHandCursor );
 }
 
 void QgsLayoutViewToolPan::deactivate()

--- a/src/gui/processing/models/qgsmodelviewtoolpan.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolpan.cpp
@@ -36,7 +36,7 @@ void QgsModelViewToolPan::modelPressEvent( QgsModelViewMouseEvent *event )
 
   mIsPanning = true;
   mLastMousePos = event->pos();
-  view()->setCursor( Qt::ClosedHandCursor );
+  view()->viewport()->setCursor( Qt::ClosedHandCursor );
 }
 
 void QgsModelViewToolPan::modelMoveEvent( QgsModelViewMouseEvent *event )
@@ -79,7 +79,7 @@ void QgsModelViewToolPan::modelReleaseEvent( QgsModelViewMouseEvent *event )
   }
 
   mIsPanning = false;
-  view()->setCursor( Qt::OpenHandCursor );
+  view()->viewport()->setCursor( Qt::OpenHandCursor );
 }
 
 void QgsModelViewToolPan::deactivate()


### PR DESCRIPTION
## Description

Fixes the open/closed hand cursor of the Layout and Model pan tools.
In the event handlers, the cursor was set to the view instead of the viewport so the hand was never displayed as closed.