### PR TITLE
Search sprite file relative to style file (if sprite url is not http)

### DIFF
--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -328,7 +328,9 @@ void QgsVectorTileLayerProperties::loadStyle()
 
         //load sprites
         QVariantMap styleDefinition = QgsJsonUtils::parseJson( content ).toMap();
-        QgsVectorTileUtils::loadSprites( styleDefinition, context );
+
+        QFileInfo fi( dlg.filePath() );
+        QgsVectorTileUtils::loadSprites( styleDefinition, context, QStringLiteral( "file://" ) + fi.absolutePath() );
 
         QgsMapBoxGlStyleConverter converter;
 


### PR DESCRIPTION
This is a small follow up to the last PR which allows to have the sprite files relative to the loaded style file (before it was only possible to load the sprite files over http)