### PR TITLE
[fix] losing WFS DCP endpoints upon cloning WFS URI

### DIFF
--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -469,7 +469,17 @@ void QgsWFSDataSourceURI::setGetEndpoints( const QgsStringMap &map )
   mGetEndpoints = map;
 }
 
+QgsStringMap QgsWFSDataSourceURI::getGetEndpoints() const
+{
+  return mGetEndpoints;
+}
+
 void QgsWFSDataSourceURI::setPostEndpoints( const QgsStringMap &map )
 {
   mPostEndpoints = map;
+}
+
+QgsStringMap QgsWFSDataSourceURI::getPostEndpoints() const
+{
+  return mPostEndpoints;
 }

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -151,7 +151,7 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
   }
 }
 
-QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QgsWFSDataSourceURI& other )
+QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QgsWFSDataSourceURI &other )
   : mURI( other.mURI )
   , mAuth( other.mAuth )
   , mGetEndpoints( other.mGetEndpoints )
@@ -160,7 +160,7 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QgsWFSDataSourceURI& other )
 {
 }
 
-QgsWFSDataSourceURI& QgsWFSDataSourceURI::operator=( const QgsWFSDataSourceURI &other )
+QgsWFSDataSourceURI &QgsWFSDataSourceURI::operator=( const QgsWFSDataSourceURI &other )
 {
   mURI = other.mURI;
   mAuth = other.mAuth;

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -151,6 +151,25 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
   }
 }
 
+QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QgsWFSDataSourceURI& other )
+  : mURI( other.mURI )
+  , mAuth( other.mAuth )
+  , mGetEndpoints( other.mGetEndpoints )
+  , mPostEndpoints( other.mPostEndpoints )
+  , mDeprecatedURI( other.mDeprecatedURI )
+{
+}
+
+QgsWFSDataSourceURI& QgsWFSDataSourceURI::operator=( const QgsWFSDataSourceURI &other )
+{
+  mURI = other.mURI;
+  mAuth = other.mAuth;
+  mGetEndpoints = other.mGetEndpoints;
+  mPostEndpoints = other.mPostEndpoints;
+  mDeprecatedURI = other.mDeprecatedURI;
+  return *this;
+}
+
 bool QgsWFSDataSourceURI::isValid() const
 {
   return mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) &&
@@ -469,17 +488,7 @@ void QgsWFSDataSourceURI::setGetEndpoints( const QgsStringMap &map )
   mGetEndpoints = map;
 }
 
-QgsStringMap QgsWFSDataSourceURI::getGetEndpoints() const
-{
-  return mGetEndpoints;
-}
-
 void QgsWFSDataSourceURI::setPostEndpoints( const QgsStringMap &map )
 {
   mPostEndpoints = map;
-}
-
-QgsStringMap QgsWFSDataSourceURI::getPostEndpoints() const
-{
-  return mPostEndpoints;
 }

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -42,6 +42,9 @@ class QgsWFSDataSourceURI
 
     explicit QgsWFSDataSourceURI( const QString &uri );
 
+    //! Copy constructor
+    QgsWFSDataSourceURI( const QgsWFSDataSourceURI& other );
+
     //! Returns whether the URI is a valid one
     bool isValid() const;
 
@@ -140,20 +143,17 @@ class QgsWFSDataSourceURI
     //! Sets Get DCP endpoints
     void setGetEndpoints( const QgsStringMap &map );
 
-    //! Return Get DCP endpoints
-    QgsStringMap getGetEndpoints() const;
-
     //! Sets Post DCP endpoints
     void setPostEndpoints( const QgsStringMap &map );
-
-    //! Return Post DCP endpoints
-    QgsStringMap getPostEndpoints() const;
 
     //! Return set of unknown parameter keys in the URI.
     QSet<QString> unknownParamKeys() const;
 
     //! Whether the initial GetFeature request, used to determine if gml:description/name/identifiers are used, should be skipped
     bool skipInitialGetFeature() const;
+
+    //! Assigment operator
+    QgsWFSDataSourceURI& operator=( const QgsWFSDataSourceURI &other );
 
   private:
     QgsDataSourceUri    mURI;

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -140,8 +140,14 @@ class QgsWFSDataSourceURI
     //! Sets Get DCP endpoints
     void setGetEndpoints( const QgsStringMap &map );
 
+    //! Return Get DCP endpoints
+    QgsStringMap getGetEndpoints() const;
+
     //! Sets Post DCP endpoints
     void setPostEndpoints( const QgsStringMap &map );
+
+    //! Return Post DCP endpoints
+    QgsStringMap getPostEndpoints() const;
 
     //! Return set of unknown parameter keys in the URI.
     QSet<QString> unknownParamKeys() const;

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -43,7 +43,7 @@ class QgsWFSDataSourceURI
     explicit QgsWFSDataSourceURI( const QString &uri );
 
     //! Copy constructor
-    QgsWFSDataSourceURI( const QgsWFSDataSourceURI& other );
+    QgsWFSDataSourceURI( const QgsWFSDataSourceURI &other );
 
     //! Returns whether the URI is a valid one
     bool isValid() const;
@@ -152,8 +152,8 @@ class QgsWFSDataSourceURI
     //! Whether the initial GetFeature request, used to determine if gml:description/name/identifiers are used, should be skipped
     bool skipInitialGetFeature() const;
 
-    //! Assigment operator
-    QgsWFSDataSourceURI& operator=( const QgsWFSDataSourceURI &other );
+    //! Assignment operator
+    QgsWFSDataSourceURI &operator=( const QgsWFSDataSourceURI &other );
 
   private:
     QgsDataSourceUri    mURI;

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -49,6 +49,8 @@ bool QgsWFSSharedData::isRestrictedToRequestBBOX() const
 QgsWFSSharedData *QgsWFSSharedData::clone() const
 {
   QgsWFSSharedData *copy = new QgsWFSSharedData( mURI.uri( true ) );
+  copy->mURI.setGetEndpoints(mURI.getGetEndpoints());
+  copy->mURI.setPostEndpoints(mURI.getPostEndpoints());	
   copy->mWFSVersion = mWFSVersion;
   copy->mGeometryAttribute = mGeometryAttribute;
   copy->mLayerPropertiesList = mLayerPropertiesList;

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -49,8 +49,7 @@ bool QgsWFSSharedData::isRestrictedToRequestBBOX() const
 QgsWFSSharedData *QgsWFSSharedData::clone() const
 {
   QgsWFSSharedData *copy = new QgsWFSSharedData( mURI.uri( true ) );
-  copy->mURI.setGetEndpoints(mURI.getGetEndpoints());
-  copy->mURI.setPostEndpoints(mURI.getPostEndpoints());	
+  copy->mURI = mURI;
   copy->mWFSVersion = mWFSVersion;
   copy->mGeometryAttribute = mGeometryAttribute;
   copy->mLayerPropertiesList = mLayerPropertiesList;


### PR DESCRIPTION
When the WFS datasource URI is cloned (e. g. when applying an additional filter to a WFS layer) Get/Post DCP endpoints which have been originally parsed from the capabilities document are lost and all WFS operations fall back to using the capabilities URL. 

This commit introduces two new getters to the `QgsWFSDataSourceURI` class which are used to transfer the stored endpoint informationen to a new instance upon cloning.