### PR TITLE
Add network request initiators to remote COPC/EPT code

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
@@ -20,7 +20,7 @@
 #include "qgstiledownloadmanager.h"
 #include "qgslazdecoder.h"
 #include "qgsapplication.h"
-#include "qgsremotecopcpointcloudindex.h"
+#include "qgsnetworkaccessmanager.h"
 
 //
 // QgsCopcPointCloudBlockRequest
@@ -36,6 +36,8 @@ QgsCopcPointCloudBlockRequest::QgsCopcPointCloudBlockRequest( const IndexedPoint
     mBlockOffset( blockOffset ), mBlockSize( blockSize ), mPointCount( pointCount ), mLazInfo( lazInfo )
 {
   QNetworkRequest nr( mUri );
+  QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsCopcPointCloudBlockRequest" ) );
+  QgsSetRequestInitiatorId( nr, node.toString() );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 

--- a/src/core/pointcloud/qgseptpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgseptpointcloudblockrequest.cpp
@@ -21,7 +21,7 @@
 #include "qgseptdecoder.h"
 #include "qgslazdecoder.h"
 #include "qgsapplication.h"
-#include "qgsremoteeptpointcloudindex.h"
+#include "qgsnetworkaccessmanager.h"
 
 //
 // QgsEptPointCloudBlockRequest
@@ -36,6 +36,8 @@ QgsEptPointCloudBlockRequest::QgsEptPointCloudBlockRequest( const IndexedPointCl
     mDataType( dataType )
 {
   QNetworkRequest nr( mUri );
+  QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsEptPointCloudBlockRequest" ) );
+  QgsSetRequestInitiatorId( nr, node.toString() );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
   mTileDownloadManagerReply.reset( QgsApplication::tileDownloadManager()->get( nr ) );

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -325,6 +325,7 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
   // Fetch VLR data
   {
     QNetworkRequest nr( url );
+    QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsLazInfo" ) );
     nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
     nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
     uint32_t firstVlrOffset = lazInfo.firstVariableLengthRecord();
@@ -351,6 +352,7 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
 bool QgsLazInfo::supportsRangeQueries( QUrl &url )
 {
   QNetworkRequest nr( url );
+  QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsLazInfo" ) );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
   nr.setRawHeader( "Range", "bytes=0-0" );

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -19,6 +19,7 @@
 
 #include "qgslogger.h"
 #include "qgsblockingnetworkrequest.h"
+#include "qgsnetworkaccessmanager.h"
 
 #include "lazperf/readers.hpp"
 
@@ -302,6 +303,7 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
   // Fetch header data
   {
     QNetworkRequest nr( url );
+    QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsLazInfo" ) );
     nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
     nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
     nr.setRawHeader( "Range", "bytes=0-374" );

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -28,21 +28,14 @@
 #include <QQueue>
 #include <QTimer>
 
-#include "qgseptdecoder.h"
-#include "qgscoordinatereferencesystem.h"
 #include "qgspointcloudrequest.h"
 #include "qgspointcloudattribute.h"
 #include "qgslogger.h"
-#include "qgsfeedback.h"
-#include "qgsmessagelog.h"
-
 #include "qgstiledownloadmanager.h"
-#include "qgsblockingnetworkrequest.h"
-#include "qgslazdecoder.h"
-#include "qgsfileutils.h"
 #include "qgsapplication.h"
 #include "qgscopcpointcloudblockrequest.h"
 #include "qgspointcloudexpression.h"
+#include "qgsnetworkaccessmanager.h"
 
 ///@cond PRIVATE
 
@@ -180,6 +173,7 @@ bool QgsRemoteCopcPointCloudIndex::isValid() const
 void QgsRemoteCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t byteSize ) const
 {
   QNetworkRequest nr( mUrl );
+  QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsRemoteCopcPointCloudIndex" ) );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
   QByteArray queryRange = QStringLiteral( "bytes=%1-%2" ).arg( offset ).arg( offset + byteSize - 1 ).toLocal8Bit();

--- a/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
@@ -28,21 +28,16 @@
 #include <QQueue>
 #include <QTimer>
 
-#include "qgseptdecoder.h"
-#include "qgscoordinatereferencesystem.h"
+#include "qgsapplication.h"
 #include "qgspointcloudrequest.h"
 #include "qgspointcloudattribute.h"
 #include "qgslogger.h"
 #include "qgsfeedback.h"
-#include "qgsmessagelog.h"
-
 #include "qgstiledownloadmanager.h"
 #include "qgsblockingnetworkrequest.h"
-
-#include "qgsfileutils.h"
-#include "qgsapplication.h"
 #include "qgseptpointcloudblockrequest.h"
 #include "qgspointcloudexpression.h"
+#include "qgsnetworkaccessmanager.h"
 
 ///@cond PRIVATE
 
@@ -198,21 +193,23 @@ bool QgsRemoteEptPointCloudIndex::loadNodeHierarchy( const IndexedPointCloudNode
 
     const QString fileUrl = QStringLiteral( "%1/ept-hierarchy/%2.json" ).arg( mUrlDirectoryPart, node.toString() );
     QNetworkRequest nr( fileUrl );
-
+    QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsRemoteEptPointCloudIndex" ) );
     nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
     nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
-    QgsBlockingNetworkRequest req;
-    const QgsBlockingNetworkRequest::ErrorCode errCode = req.get( nr );
-    if ( errCode != QgsBlockingNetworkRequest::NoError )
+    std::unique_ptr<QgsTileDownloadManagerReply> reply( QgsApplication::tileDownloadManager()->get( nr ) );
+
+    QEventLoop loop;
+    connect( reply.get(), &QgsTileDownloadManagerReply::finished, &loop, &QEventLoop::quit );
+    loop.exec();
+
+    if ( reply->error() != QNetworkReply::NoError )
     {
-      QgsDebugMsgLevel( QStringLiteral( "unable to read hierarchy from file %1" ).arg( fileUrl ), 2 );
+      QgsDebugMsg( QStringLiteral( "Request failed: " ) + mUrl.toString() );
       return false;
     }
 
-    const QgsNetworkReplyContent reply = req.reply();
-
-    const QByteArray dataJsonH = reply.content();
+    const QByteArray dataJsonH = reply->data();
     QJsonParseError errH;
     const QJsonDocument docH = QJsonDocument::fromJson( dataJsonH, &errH );
     if ( errH.error != QJsonParseError::NoError )


### PR DESCRIPTION
This will make it easier to identify where the individual requests are coming from (which is harder especially with COPC where byte ranges are fetched from the same file)

Also switch hierarchy fetching in EPT to use QgsTileDownloadManager like used for COPC. This will ensure that in case of multiple requests in parallel there will be just one going out.