### PR TITLE
Enable build with PDAL by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ if(WITH_CORE)
     endif()
   endif(WITH_HANA)
 
-  set (WITH_PDAL FALSE CACHE BOOL "Determines whether PDAL support should be built")
+  set (WITH_PDAL TRUE CACHE BOOL "Determines whether PDAL support should be built")
 
   set (WITH_EPT TRUE CACHE BOOL "Determines whether Entwine Point Cloud (EPT) support should be built")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if(WITH_CORE)
       endif()
   endif()
 
-  set (WITH_3D FALSE CACHE BOOL "Determines whether QGIS 3D library should be built")
+  set (WITH_3D TRUE CACHE BOOL "Determines whether QGIS 3D library should be built")
 
   set (WITH_QUICK FALSE CACHE BOOL "Determines whether QGIS Quick library should be built")
 


### PR DESCRIPTION
Point cloud support has been there in a couple of QGIS releases already and it would make sense to have the PDAL support built by default. Without PDAL, point cloud layer implementation is very limited, not allowing indexing and display of regular files like LAS/LAZ, and the Processing algorithms are not available either...
