### PR TITLE
qgsquadrilateral: Fix memory leak in area and polygon calls

### DIFF
--- a/src/core/geometry/qgsquadrilateral.cpp
+++ b/src/core/geometry/qgsquadrilateral.cpp
@@ -435,10 +435,12 @@ QString QgsQuadrilateral::toString( int pointPrecision ) const
 
 double QgsQuadrilateral::area() const
 {
-  return toPolygon()->area();
+  std::unique_ptr<QgsPolygon> polygon( toPolygon() );
+  return polygon->area();
 }
 
 double QgsQuadrilateral::perimeter() const
 {
-  return toPolygon()->perimeter();
+  std::unique_ptr<QgsPolygon> polygon( toPolygon() );
+  return polygon->perimeter();
 }


### PR DESCRIPTION
The toPolygon() call releases the unique_ptr, the `QgsPolygon` object needs to be deleted.

