### PR TITLE
[ogr] Read field comments automatically on GDAL >= 3.7

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -814,6 +814,16 @@ void QgsOgrProvider::loadFields()
       newField.setAlias( alias );
     }
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+    {
+      const QString comment = textEncoding()->toUnicode( OGR_Fld_GetComment( fldDef ) );
+      if ( !comment.isEmpty() )
+      {
+        newField.setComment( comment );
+      }
+    }
+#endif
+
     // check if field is nullable
     bool nullable = OGR_Fld_IsNullable( fldDef );
     if ( !nullable )


### PR DESCRIPTION
Specifically, this permits QGIS to automatically load comments for fields which are stored in the GeoPackage "gpkg_data_columns" metadata table.

The comment reading is abstracted through GDAL though, so there's potentially other OGR formats which allow comments which will be supported in future automatically.
