### PR TITLE
Cleanup 'comment' handling in new field dialog, add support for alias storage

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -341,6 +341,14 @@ QgsVectorDataProvider.UnknownCount.__doc__ = "Provider returned an unknown featu
 Qgis.FeatureCountState.__doc__ = 'Enumeration of feature count states\n\n.. versionadded:: 3.20\n\n' + '* ``Uncounted``: ' + Qgis.FeatureCountState.Uncounted.__doc__ + '\n' + '* ``UnknownCount``: ' + Qgis.FeatureCountState.UnknownCount.__doc__
 # --
 Qgis.FeatureCountState.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.VectorDataProviderAttributeEditCapability.EditAlias.__doc__ = "Allows editing aliases"
+Qgis.VectorDataProviderAttributeEditCapability.EditComment.__doc__ = "Allows editing comments"
+Qgis.VectorDataProviderAttributeEditCapability.__doc__ = 'Attribute editing capabilities which may be supported by vector data providers.\n\n.. versionadded:: 3.32\n\n' + '* ``EditAlias``: ' + Qgis.VectorDataProviderAttributeEditCapability.EditAlias.__doc__ + '\n' + '* ``EditComment``: ' + Qgis.VectorDataProviderAttributeEditCapability.EditComment.__doc__
+# --
+Qgis.VectorDataProviderAttributeEditCapability.baseClass = Qgis
+Qgis.VectorDataProviderAttributeEditCapabilities.baseClass = Qgis
+VectorDataProviderAttributeEditCapabilities = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsSymbol.SymbolType = Qgis.SymbolType
 # monkey patching scoped based enum
 QgsSymbol.Marker = Qgis.SymbolType.Marker

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -208,6 +208,16 @@ The development version
       UnknownCount,
     };
 
+    enum class VectorDataProviderAttributeEditCapability
+    {
+      EditAlias,
+      EditComment,
+    };
+
+
+    typedef QFlags<Qgis::VectorDataProviderAttributeEditCapability> VectorDataProviderAttributeEditCapabilities;
+
+
     enum class SymbolType
       {
       Marker,
@@ -2052,6 +2062,8 @@ QFlags<Qgis::HistoryProviderBackend> operator|(Qgis::HistoryProviderBackend f1, 
 QFlags<Qgis::MapLayerProperty> operator|(Qgis::MapLayerProperty f1, QFlags<Qgis::MapLayerProperty> f2);
 
 QFlags<Qgis::DataProviderFlag> operator|(Qgis::DataProviderFlag f1, QFlags<Qgis::DataProviderFlag> f2);
+
+QFlags<Qgis::VectorDataProviderAttributeEditCapability> operator|(Qgis::VectorDataProviderAttributeEditCapability f1, QFlags<Qgis::VectorDataProviderAttributeEditCapability> f2);
 
 QFlags<Qgis::SnappingType> operator|(Qgis::SnappingType f1, QFlags<Qgis::SnappingType> f2);
 

--- a/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -424,11 +424,22 @@ Returns flags containing the supported capabilities
 \note, some capabilities may change depending on whether
 a spatial filter is active on this provider, so it may
 be prudent to check this value per intended operation.
+
+.. seealso:: :py:func:`attributeEditCapabilities`
 %End
 
     QString capabilitiesString() const;
 %Docstring
 Returns the above in friendly format.
+%End
+
+    virtual Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities() const;
+%Docstring
+Returns the provider's supported attribute editing capabilities.
+
+.. seealso:: :py:func:`capabilities`
+
+.. versionadded:: 3.32
 %End
 
     virtual void setEncoding( const QString &e );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1845,6 +1845,10 @@ bool QgsOgrProvider::addAttributeOGRLevel( const QgsField &field, bool &ignoreEr
       break;
   }
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+  OGR_Fld_SetAlternativeName( fielddefn.get(), textEncoding()->fromUnicode( field.alias() ).constData() );
+#endif
+
   if ( mOgrLayer->CreateField( fielddefn.get(), true ) != OGRERR_NONE )
   {
     pushError( tr( "OGR error creating field %1: %2" ).arg( field.name(), CPLGetLastErrorMsg() ) );
@@ -2754,6 +2758,11 @@ QgsVectorDataProvider::Capabilities QgsOgrProvider::capabilities() const
   return mCapabilities;
 }
 
+Qgis::VectorDataProviderAttributeEditCapabilities QgsOgrProvider::attributeEditCapabilities() const
+{
+  return mAttributeEditCapabilities;
+}
+
 void QgsOgrProvider::computeCapabilities()
 {
   QgsVectorDataProvider::Capabilities ability = QgsVectorDataProvider::Capabilities();
@@ -2905,6 +2914,18 @@ void QgsOgrProvider::computeCapabilities()
       ability |= FeatureSymbology;
       ability |= CreateRenderer;
     }
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+    if ( const char *pszAlterFieldDefnFlags = GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DMD_ALTER_FIELD_DEFN_FLAGS, nullptr ) )
+    {
+      char **papszTokens = CSLTokenizeString2( pszAlterFieldDefnFlags, " ", 0 );
+      if ( CSLFindString( papszTokens, "AlternativeName" ) >= 0 )
+      {
+        mAttributeEditCapabilities |= Qgis::VectorDataProviderAttributeEditCapability::EditAlias;
+      }
+      CSLDestroy( papszTokens );
+    }
+#endif
   }
 
   ability |= ReadLayerMetadata;

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -110,6 +110,7 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     bool createSpatialIndex() override;
     bool createAttributeIndex( int field ) override;
     QgsVectorDataProvider::Capabilities capabilities() const override;
+    Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     void setEncoding( const QString &e ) override;
     bool enterUpdateMode() override { return _enterUpdateMode(); }
@@ -326,6 +327,7 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     void computeCapabilities();
 
     QgsVectorDataProvider::Capabilities mCapabilities = QgsVectorDataProvider::Capabilities();
+    Qgis::VectorDataProviderAttributeEditCapabilities mAttributeEditCapabilities = Qgis::VectorDataProviderAttributeEditCapabilities();
 
     bool doInitialActionsForEdition();
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -313,6 +313,27 @@ class CORE_EXPORT Qgis
     Q_ENUM( FeatureCountState )
 
     /**
+     * Attribute editing capabilities which may be supported by vector data providers.
+     *
+     * \since QGIS 3.32
+     */
+    enum class VectorDataProviderAttributeEditCapability
+    {
+      EditAlias = 1 << 0, //!< Allows editing aliases
+      EditComment = 1 << 1, //!< Allows editing comments
+    };
+
+    Q_ENUM( VectorDataProviderAttributeEditCapability )
+
+    /**
+     * Attribute editing capabilities which may be supported by vector data providers.
+     *
+     * \since QGIS 3.32
+     */
+    Q_DECLARE_FLAGS( VectorDataProviderAttributeEditCapabilities, VectorDataProviderAttributeEditCapability )
+    Q_FLAG( VectorDataProviderAttributeEditCapabilities )
+
+    /**
      * \brief Symbol types
      * \since QGIS 3.20
      */
@@ -3498,6 +3519,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::TextRendererFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::HistoryProviderBackends )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerProperties )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::DataProviderFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorDataProviderAttributeEditCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SnappingTypes )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::PlotToolFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProfileGeneratorFlags )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -824,6 +824,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         if ( ogrSubType != OFSTNone )
           OGR_Fld_SetSubType( fld.get(), ogrSubType );
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
+        OGR_Fld_SetAlternativeName( fld.get(), mCodec->fromUnicode( attrField.alias() ).constData() );
+#endif
+
         // create the field
         QgsDebugMsgLevel( "creating field " + attrField.name() +
                           " type " + QString( QVariant::typeToName( attrField.type() ) ) +

--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -395,6 +395,11 @@ QString QgsVectorDataProvider::capabilitiesString() const
   return abilitiesList.join( QLatin1String( ", " ) );
 }
 
+Qgis::VectorDataProviderAttributeEditCapabilities QgsVectorDataProvider::attributeEditCapabilities() const
+{
+  return Qgis::VectorDataProviderAttributeEditCapabilities();
+}
+
 int QgsVectorDataProvider::fieldNameIndex( const QString &fieldName ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/vector/qgsvectordataprovider.h
+++ b/src/core/vector/qgsvectordataprovider.h
@@ -409,6 +409,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * \note, some capabilities may change depending on whether
      * a spatial filter is active on this provider, so it may
      * be prudent to check this value per intended operation.
+     *
+     * \see attributeEditCapabilities()
      */
     Q_INVOKABLE virtual QgsVectorDataProvider::Capabilities capabilities() const;
 
@@ -416,6 +418,14 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      *  Returns the above in friendly format.
      */
     QString capabilitiesString() const;
+
+    /**
+     * Returns the provider's supported attribute editing capabilities.
+     *
+     * \see capabilities()
+     * \since QGIS 3.32
+     */
+    virtual Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities() const;
 
     /**
      * Set encoding used for accessing data from layer.

--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -31,8 +31,10 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
   connect( mTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAddAttrDialog::mTypeBox_currentIndexChanged );
   connect( mLength, &QSpinBox::editingFinished, this, &QgsAddAttrDialog::mLength_editingFinished );
 
-  if ( !vlayer )
+  if ( !vlayer || !vlayer->dataProvider() )
     return;
+
+  const Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities = vlayer->dataProvider()->attributeEditCapabilities();
 
   //fill data types into the combo box
   const QList< QgsVectorDataProvider::NativeType > &typelist = vlayer->dataProvider()->nativeTypes();
@@ -66,6 +68,12 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
     mNameEdit->setMaxLength( 10 );
 
   mNameEdit->setFocus();
+
+  if ( !( attributeEditCapabilities & Qgis::VectorDataProviderAttributeEditCapability::EditComment ) )
+  {
+    mLabelComment->hide();
+    mCommentEdit->hide();
+  }
 }
 
 void QgsAddAttrDialog::setIllegalFieldNames( const QSet<QString> &names )

--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -69,6 +69,11 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
 
   mNameEdit->setFocus();
 
+  if ( !( attributeEditCapabilities & Qgis::VectorDataProviderAttributeEditCapability::EditAlias ) )
+  {
+    mLabelAlias->hide();
+    mAliasEdit->hide();
+  }
   if ( !( attributeEditCapabilities & Qgis::VectorDataProviderAttributeEditCapability::EditComment ) )
   {
     mLabelComment->hide();
@@ -164,13 +169,18 @@ QgsField QgsAddAttrDialog::field() const
                     .arg( mPrec->value() )
                     .arg( mCommentEdit->text() ), 2 );
 
-  return QgsField(
-           mNameEdit->text(),
-           ( QVariant::Type ) mTypeBox->currentData( Qt::UserRole ).toInt(),
-           mTypeBox->currentData( Qt::UserRole + 1 ).toString(),
-           mLength->value(),
-           mPrec->isEnabled() ? mPrec->value() : 0,
-           mCommentEdit->text(),
-           static_cast<QVariant::Type>( mTypeBox->currentData( Qt::UserRole ).toInt() ) == QVariant::Map ? QVariant::String : QVariant::Invalid
-         );
+  QgsField res = QgsField(
+                   mNameEdit->text(),
+                   ( QVariant::Type ) mTypeBox->currentData( Qt::UserRole ).toInt(),
+                   mTypeBox->currentData( Qt::UserRole + 1 ).toString(),
+                   mLength->value(),
+                   mPrec->isEnabled() ? mPrec->value() : 0,
+                   mCommentEdit->text(),
+                   static_cast<QVariant::Type>( mTypeBox->currentData( Qt::UserRole ).toInt() ) == QVariant::Map ? QVariant::String : QVariant::Invalid
+                 );
+
+  if ( !mAliasEdit->text().isEmpty() )
+    res.setAlias( mAliasEdit->text() );
+
+  return res;
 }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3696,6 +3696,11 @@ QgsVectorDataProvider::Capabilities QgsPostgresProvider::capabilities() const
   return mEnabledCapabilities;
 }
 
+Qgis::VectorDataProviderAttributeEditCapabilities QgsPostgresProvider::attributeEditCapabilities() const
+{
+  return Qgis::VectorDataProviderAttributeEditCapability::EditComment;
+}
+
 QgsFeatureSource::SpatialIndexPresence QgsPostgresProvider::hasSpatialIndex() const
 {
   QgsPostgresProviderConnection conn( mUri.uri(), QVariantMap() );

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -181,6 +181,7 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     bool setSubsetString( const QString &theSQL, bool updateFeatureCount = true ) override;
     bool supportsSubsetString() const override { return true; }
     QgsVectorDataProvider::Capabilities capabilities() const override;
+    Qgis::VectorDataProviderAttributeEditCapabilities attributeEditCapabilities() const override;
     SpatialIndexPresence hasSpatialIndex() const override;
 
     /**

--- a/src/ui/qgsaddattrdialogbase.ui
+++ b/src/ui/qgsaddattrdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>236</height>
+    <height>268</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -73,12 +73,15 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="mCommentEdit"/>
    </item>
    <item row="3" column="1">
     <widget class="QLabel" name="mTypeName">
@@ -97,6 +100,16 @@
      </property>
     </widget>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="mLabelComment">
+     <property name="text">
+      <string>Comment</string>
+     </property>
+     <property name="buddy">
+      <cstring>mCommentEdit</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="mTypeBox"/>
    </item>
@@ -107,7 +120,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -121,9 +134,9 @@
     </spacer>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="mLabelComment">
+    <widget class="QLabel" name="mLabelAlias">
      <property name="text">
-      <string>Comment</string>
+      <string>Alias</string>
      </property>
      <property name="buddy">
       <cstring>mCommentEdit</cstring>
@@ -131,7 +144,7 @@
     </widget>
    </item>
    <item row="6" column="1">
-    <widget class="QLineEdit" name="mCommentEdit"/>
+    <widget class="QLineEdit" name="mAliasEdit"/>
    </item>
   </layout>
  </widget>
@@ -148,6 +161,8 @@
   <tabstop>mTypeBox</tabstop>
   <tabstop>mLength</tabstop>
   <tabstop>mPrec</tabstop>
+  <tabstop>mAliasEdit</tabstop>
+  <tabstop>mCommentEdit</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsaddattrdialogbase.ui
+++ b/src/ui/qgsaddattrdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>245</width>
-    <height>201</height>
+    <width>279</width>
+    <height>236</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,45 +17,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="textLabel1">
-     <property name="text">
-      <string>N&amp;ame</string>
-     </property>
-     <property name="buddy">
-      <cstring>mNameEdit</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="mNameEdit"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="textLabel1_2">
-     <property name="text">
-      <string>Comment</string>
-     </property>
-     <property name="buddy">
-      <cstring>mCommentEdit</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="mCommentEdit"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="textLabel2">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="buddy">
-      <cstring>mTypeBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="mTypeBox"/>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -63,33 +24,16 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="mTypeName">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mNameEdit"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="textLabel1">
      <property name="text">
-      <string>Type</string>
+      <string>N&amp;ame</string>
      </property>
      <property name="buddy">
-      <cstring>mTypeBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="mLengthLabel">
-     <property name="toolTip">
-      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
-     </property>
-     <property name="text">
-      <string>Length</string>
-     </property>
-     <property name="buddy">
-      <cstring>mLength</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QgsSpinBox" name="mLength">
-     <property name="toolTip">
-      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
+      <cstring>mNameEdit</cstring>
      </property>
     </widget>
    </item>
@@ -106,6 +50,46 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mLengthLabel">
+     <property name="toolTip">
+      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
+     </property>
+     <property name="text">
+      <string>Length</string>
+     </property>
+     <property name="buddy">
+      <cstring>mLength</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="textLabel2">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="buddy">
+      <cstring>mTypeBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="mTypeName">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="buddy">
+      <cstring>mTypeBox</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="1">
     <widget class="QgsSpinBox" name="mPrec">
      <property name="toolTip">
@@ -113,7 +97,17 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="2" column="1">
+    <widget class="QComboBox" name="mTypeBox"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsSpinBox" name="mLength">
+     <property name="toolTip">
+      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -126,15 +120,22 @@
      </property>
     </spacer>
    </item>
-   <item row="7" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="6" column="0">
+    <widget class="QLabel" name="mLabelComment">
+     <property name="text">
+      <string>Comment</string>
+     </property>
+     <property name="buddy">
+      <cstring>mCommentEdit</cstring>
      </property>
     </widget>
    </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="mCommentEdit"/>
+   </item>
   </layout>
  </widget>
+ <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>QgsSpinBox</class>
@@ -142,10 +143,8 @@
    <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
- <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>mNameEdit</tabstop>
-  <tabstop>mCommentEdit</tabstop>
   <tabstop>mTypeBox</tabstop>
   <tabstop>mLength</tabstop>
   <tabstop>mPrec</tabstop>


### PR DESCRIPTION
[When creating new fields, only expose the 'Comment' option for datasources which support editing comments.  This support is currently limited to the postgres provider, so exposing the comment field for all other vector layer types
is just misleading to users. The comment will be completed discarded without any warning!

Also add support for setting field aliases in the dialog, and expose for supported OGR formats (currently limited to ESRI file geodatabases, GPKG support pending upstream)
