### PR TITLE
Make map id optional in map_credits layout function

### DIFF
--- a/resources/function_help/json/map_credits
+++ b/resources/function_help/json/map_credits
@@ -2,10 +2,11 @@
   "name": "map_credits",
   "type": "function",
   "groups": ["Layout"],
-  "description": "Returns a list of credit (usage rights) strings for the layers shown in a layout map item.",
+  "description": "Returns a list of credit (usage rights) strings for the layers shown in a layout, or specific layout map item.",
   "arguments": [{
     "arg": "id",
-    "description": "map item ID"
+    "optional": true,
+    "description": "Map item ID. If not specified, the layers from all maps in the layout will be used."
   }, {
     "arg": "include_layer_names",
     "description": "Set to true to include layer names before their credit strings",
@@ -18,6 +19,9 @@
     "default": "': '"
   }],
   "examples": [{
+    "expression": "array_to_string( map_credits() )",
+    "returns": "comma separated list of layer credits for all layers shown in all map items in the layout, e.g 'CC-BY-NC, CC-BY-SA'"
+  }, {
     "expression": "array_to_string( map_credits( 'Main Map' ) )",
     "returns": "comma separated list of layer credits for layers shown in the 'Main Map' layout item, e.g 'CC-BY-NC, CC-BY-SA'"
   }, {

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -211,7 +211,8 @@ void QgsLayoutLabelWidget::buildInsertDynamicTextMenu( QgsLayout *layout, QMenu 
         {
           std::make_pair( tr( "Layout Name" ), QStringLiteral( "@layout_name" ) ),
           std::make_pair( tr( "Layout Page Number" ), QStringLiteral( "@layout_page" ) ),
-          std::make_pair( tr( "Layout Page Count" ), QStringLiteral( "@layout_numpages" ) )
+          std::make_pair( tr( "Layout Page Count" ), QStringLiteral( "@layout_numpages" ) ),
+          std::make_pair( tr( "Layer Credits" ), QStringLiteral( "array_to_string(map_credits())" ) )
         } )
   {
     addExpression( menu, expression.first, expression.second );

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -1454,12 +1454,18 @@ void TestQgsLayoutItem::mapCreditsFunction()
   QVariant r = e.evaluate( &c );
   QVERIFY( !r.isValid() );
 
+  e = QgsExpression( QStringLiteral( "array_to_string( map_credits() )" ) );
+  r = e.evaluate( &c );
+  QVERIFY( !r.isValid() );
+
   QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
   map->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
   map->attemptSetSceneRect( QRectF( 30, 60, 200, 100 ) );
   map->setExtent( extent );
   l.addLayoutItem( map );
   map->setId( QStringLiteral( "Map_id" ) );
+
+  e = QgsExpression( QStringLiteral( "array_to_string( map_credits( 'Map_id' ) )" ) );
 
   c = l.createExpressionContext();
   e.prepare( &c );
@@ -1506,6 +1512,11 @@ void TestQgsLayoutItem::mapCreditsFunction()
   QgsExpression e4( QStringLiteral( "array_to_string( map_credits( 'Map_2', include_layer_names:=true ) )" ) );
   e4.prepare( &c );
   QCOMPARE( e4.evaluate( &c ).toString(), QStringLiteral( "A: CC BY SA" ) );
+
+  // credits from all maps
+  QgsExpression e5( QStringLiteral( "array_to_string( map_credits(include_layer_names:=true ) )" ) );
+  e5.prepare( &c );
+  QCOMPARE( e5.evaluate( &c ).toString(), QStringLiteral( "A: CC BY SA,B: CC NC,C: CC BY SA" ) );
 }
 
 void TestQgsLayoutItem::rotation()


### PR DESCRIPTION
If not specified, the credits for ALL layers from ALL maps will be collected