### PR TITLE
[3.28] Fix some invalid help example expressions

### DIFF
--- a/resources/function_help/json/eval
+++ b/resources/function_help/json/eval
@@ -8,7 +8,7 @@
     "description": "an expression string"
   }],
   "examples": [{
-    "expression": "eval('\\'nice\\'')",
+    "expression": "eval('\\\\'nice\\\\'')",
     "returns": "'nice'"
   }, {
     "expression": "eval(@expression_var)",

--- a/resources/function_help/json/flip_coordinates
+++ b/resources/function_help/json/flip_coordinates
@@ -11,7 +11,7 @@
     "expression": "geom_to_wkt(flip_coordinates(make_point(1, 2)))",
     "returns": "'Point (2 1)'"
   },{
-    "expression": "geom_to_wkt(flip_coordinates(geom_from_wkt('LineString(0 2, 1 0, 1 6)')))))",
+    "expression": "geom_to_wkt(flip_coordinates(geom_from_wkt('LineString(0 2, 1 0, 1 6)')))",
     "returns": "'LineString (2 0, 0 1, 6 1)'"
   }],
   "tags": ["latitude", "longitude", "reversed", "swapped", "coordinates", "repairing", "copy"]

--- a/resources/function_help/json/pole_of_inaccessibility
+++ b/resources/function_help/json/pole_of_inaccessibility
@@ -11,7 +11,7 @@
     "description": "maximum distance between the returned point and the true pole location"
   }],
   "examples": [{
-    "expression": "geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1, 0 9, 3 10, 3 3, 10 3, 10 1, 0 1))'), 0.1))'",
+    "expression": "geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1, 0 9, 3 10, 3 3, 10 3, 10 1, 0 1))'), 0.1))",
     "returns": "'Point(1.546875 2.546875)'"
   }],
   "tags": ["inaccessibility", "precise", "tolerances", "calculates", "guaranteed", "boundary", "require", "point", "true", "iterations", "internal", "uses", "approximate", "approach", "polylabel", "find", "distant", "calculate", "pole", "take", "surface", "specified", "tolerance", "iterative"]

--- a/resources/function_help/json/to_decimal
+++ b/resources/function_help/json/to_decimal
@@ -8,7 +8,7 @@
     "description": "A degree, minute, second string."
   }],
   "examples": [{
-    "expression": "to_decimal('6\u00b021\\'16.445')",
+    "expression": "to_decimal('6\u00b021\\\\'16.445')",
     "returns": "6.3545680555"
   }],
   "tags": ["converts", "minute", "degree", "equivalent", "second", "coordinate", "decimal"]


### PR DESCRIPTION
(cherry picked from commit fe158c2faa352b2d4ac2f21bc9c6ff079138a80e)

Partial backport of #52629