### PR TITLE
Fallback to UTF-8 when no encoding is specified

### DIFF
--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -264,7 +264,15 @@ void QgsVectorDataProvider::setEncoding( const QString &e )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  mEncoding = QTextCodec::codecForName( e.toLocal8Bit().constData() );
+  // Use UTF-8 if no encoding is specified
+  if ( e.isEmpty() )
+  {
+    mEncoding = QTextCodec::codecForName( "UTF-8" );
+  }
+  else
+  {
+    mEncoding = QTextCodec::codecForName( e.toLocal8Bit().constData() );
+  }
   if ( !mEncoding && e != QLatin1String( "System" ) )
   {
     if ( !e.isEmpty() )


### PR DESCRIPTION
- Fixes #52692
- Fixes #51261
## Description

Tweak QgsVectorDataProvider to consistently falls back to UTF-8 when no encoding is specified when loading a vector data file. #52692 did not occur on Ubuntu since default encoding is UTF-8, but on Windows, QGIS used windows-1252.

⚠️ May have a bunch of side-effects.