### PR TITLE
Fix a crash using the "Points along geometry" processing alg with an empty geometry (Fix #52698)

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2625,7 +2625,7 @@ double QgsGeometry::lineLocatePoint( const QgsGeometry &point ) const
 
 double QgsGeometry::interpolateAngle( double distance ) const
 {
-  if ( !d->geometry )
+  if ( !d->geometry || d->geometry->isEmpty() )
     return 0.0;
 
   const QgsAbstractGeometry *geom = d->geometry->simplifiedTypeRef();

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -898,7 +898,18 @@ int QgsGeometryCollection::partCount() const
 
 QgsPoint QgsGeometryCollection::vertexAt( QgsVertexId id ) const
 {
-  return mGeometries[id.part]->vertexAt( id );
+  if ( id.part < 0 || id.part >= mGeometries.size() )
+  {
+    return QgsPoint();
+  }
+
+  const QgsAbstractGeometry *geom = mGeometries[id.part];
+  if ( !geom )
+  {
+    return QgsPoint();
+  }
+
+  return geom->vertexAt( id );
 }
 
 bool QgsGeometryCollection::isValid( QString &error, Qgis::GeometryValidityFlags flags ) const

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -155,6 +155,11 @@ bool QgsGeometryUtils::verticesAtDistance( const QgsAbstractGeometry &geometry, 
   previousVertex = QgsVertexId();
   nextVertex = QgsVertexId();
 
+  if ( geometry.isEmpty() )
+  {
+    return false;
+  }
+
   QgsPoint point;
   QgsPoint previousPoint;
 

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -58,6 +58,8 @@ void TestQgsGeometryCollection::geometryCollection()
   QCOMPARE( c1.vertexCount( 0, 0 ), 0 );
   QCOMPARE( c1.vertexCount( 0, 1 ), 0 );
   QCOMPARE( c1.vertexCount( 1, 0 ), 0 );
+  // no crash!
+  QCOMPARE( c1.vertexAt( QgsVertexId( -1, -1, -1 ) ), QgsPoint() );
 
   //addGeometry
 


### PR DESCRIPTION
## Description

Fixes a crash (occurring in the QgsGeometryCollection::vertexAt function) using the "Points along geometry" (native:pointsalonglines) processing algorithm with a feature containing an empty geometry.

Fixes #52698.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
