### PR TITLE
Allow a range of cells to be copied from SQL results window

### DIFF
--- a/python/gui/auto_generated/qgsqueryresultwidget.sip.in
+++ b/python/gui/auto_generated/qgsqueryresultwidget.sip.in
@@ -93,6 +93,20 @@ in the SQL error panel is ``isSqlError`` is set.
 Triggered when the threaded API fetcher has new ``tokens`` to add.
 %End
 
+    void copyResults();
+%Docstring
+Copies the query results to the clipboard, as a formatted table.
+
+.. versionadded:: 3.32
+%End
+
+    void copyResults( int fromRow, int toRow, int fromColumn, int toColumn );
+%Docstring
+Copies a range of the query results to the clipboard, as a formatted table.
+
+.. versionadded:: 3.32
+%End
+
   signals:
 
     void createSqlVectorLayer( const QString &providerKey, const QString &connectionUri, const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions &options );

--- a/src/gui/qgsqueryresultwidget.h
+++ b/src/gui/qgsqueryresultwidget.h
@@ -209,6 +209,8 @@ class GUI_EXPORT QgsQueryResultWidget: public QWidget, private Ui::QgsQueryResul
 
     void showCellContextMenu( QPoint point );
 
+    void copySelection();
+
   private:
 
     std::unique_ptr<QgsAbstractDatabaseProviderConnection> mConnection;

--- a/src/gui/qgsqueryresultwidget.h
+++ b/src/gui/qgsqueryresultwidget.h
@@ -170,6 +170,20 @@ class GUI_EXPORT QgsQueryResultWidget: public QWidget, private Ui::QgsQueryResul
      */
     void tokensReady( const QStringList &tokens );
 
+    /**
+     * Copies the query results to the clipboard, as a formatted table.
+     *
+     * \since QGIS 3.32
+     */
+    void copyResults();
+
+    /**
+     * Copies a range of the query results to the clipboard, as a formatted table.
+     *
+     * \since QGIS 3.32
+     */
+    void copyResults( int fromRow, int toRow, int fromColumn, int toColumn );
+
   signals:
 
     /**


### PR DESCRIPTION
Allows selection of a range of cells to copy to clipboard. Results are copied as both plain text and html, so can be pasted easily into spreadsheet apps/etc as tables