### PR TITLE
Add support for point cloud expressions to Processing expression parameter

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -3577,3 +3577,9 @@ QgsEditFormConfig.CodeSourceEnvironment.__doc__ = "Use the Python code available
 Qgis.AttributeFormPythonInitCodeSource.__doc__ = 'The Python init code source for attribute forms.\n\n.. note::\n\n   Prior to QGIS 3.32 this was available as :py:class:`QgsEditFormConfig`.PythonInitCodeSource.\n\n.. versionadded:: 3.32\n\n' + '* ``CodeSourceNone``: ' + Qgis.AttributeFormPythonInitCodeSource.NoSource.__doc__ + '\n' + '* ``CodeSourceFile``: ' + Qgis.AttributeFormPythonInitCodeSource.File.__doc__ + '\n' + '* ``CodeSourceDialog``: ' + Qgis.AttributeFormPythonInitCodeSource.Dialog.__doc__ + '\n' + '* ``CodeSourceEnvironment``: ' + Qgis.AttributeFormPythonInitCodeSource.Environment.__doc__
 # --
 Qgis.AttributeFormPythonInitCodeSource.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.ExpressionType.Qgis.__doc__ = "Native QGIS expression"
+Qgis.ExpressionType.PointCloud.__doc__ = "Point cloud expression"
+Qgis.ExpressionType.__doc__ = 'Expression types\n\n.. versionadded:: 3.32\n\n' + '* ``Qgis``: ' + Qgis.ExpressionType.Qgis.__doc__ + '\n' + '* ``PointCloud``: ' + Qgis.ExpressionType.PointCloud.__doc__
+# --
+Qgis.ExpressionType.baseClass = Qgis

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2887,16 +2887,9 @@ An expression parameter for processing algorithms.
 %End
   public:
 
-    enum Type
-    {
-      Qgis,
-      PointCloud,
-    };
-
-
     QgsProcessingParameterExpression( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                       const QString &parentLayerParameterName = QString(),
-                                      bool optional = false, Type type = Qgis );
+                                      bool optional = false, Qgis::ExpressionType type = Qgis::ExpressionType::Qgis );
 %Docstring
 Constructor for QgsProcessingParameterExpression.
 %End
@@ -2929,7 +2922,7 @@ Sets the name of the parent layer parameter. Use an empty string if this is not 
 .. seealso:: :py:func:`parentLayerParameterName`
 %End
 
-    Type expressionType() const;
+    Qgis::ExpressionType expressionType() const;
 %Docstring
 Returns the parameter's expression type.
 
@@ -2938,7 +2931,7 @@ Returns the parameter's expression type.
 .. versionadded:: 3.32
 %End
 
-    void setExpressionType( Type type );
+    void setExpressionType( Qgis::ExpressionType type );
 %Docstring
 Sets the parameter's expression ``type``.
 

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2887,9 +2887,16 @@ An expression parameter for processing algorithms.
 %End
   public:
 
+    enum Type
+    {
+      Qgis,
+      PointCloud,
+    };
+
+
     QgsProcessingParameterExpression( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                       const QString &parentLayerParameterName = QString(),
-                                      bool optional = false );
+                                      bool optional = false, Type type = Qgis );
 %Docstring
 Constructor for QgsProcessingParameterExpression.
 %End
@@ -2920,6 +2927,24 @@ Returns the name of the parent layer parameter, or an empty string if this is no
 Sets the name of the parent layer parameter. Use an empty string if this is not required.
 
 .. seealso:: :py:func:`parentLayerParameterName`
+%End
+
+    Type expressionType() const;
+%Docstring
+Returns the parameter's expression type.
+
+.. seealso:: :py:func:`setExpressionType`
+
+.. versionadded:: 3.32
+%End
+
+    void setExpressionType( Type type );
+%Docstring
+Sets the parameter's expression ``type``.
+
+.. seealso:: :py:func:`expressionType`
+
+.. versionadded:: 3.32
 %End
 
     virtual QVariantMap toVariantMap() const;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2020,6 +2020,12 @@ The development version
       Environment
     };
 
+    enum class ExpressionType
+    {
+      Qgis,
+      PointCloud,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsrunprocess.h"
 #include "qgspointcloudlayer.h"
+#include "qgspointcloudexpression.h"
 
 ///@cond PRIVATE
 
@@ -60,7 +61,7 @@ QgsPdalFilterAlgorithm *QgsPdalFilterAlgorithm::createInstance() const
 void QgsPdalFilterAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterString( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), false, true ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), false, QgsProcessingParameterExpression::PointCloud ) );
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "FILTER_EXTENT" ), QObject::tr( "Cropping extent" ), QVariant(), true ) );
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output" ) ) );
 }
@@ -86,7 +87,8 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
   const QString filterExpression = parameterAsString( parameters, QStringLiteral( "FILTER_EXPRESSION" ), context ).trimmed();
   if ( !filterExpression.isEmpty() )
   {
-    args << QStringLiteral( "--filter=%1" ).arg( filterExpression );
+    QgsPointCloudExpression exp( filterExpression );
+    args << QStringLiteral( "--filter=%1" ).arg( exp.asPdalExpression() );
   }
 
   if ( parameters.value( QStringLiteral( "FILTER_EXTENT" ) ).isValid() )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -61,7 +61,7 @@ QgsPdalFilterAlgorithm *QgsPdalFilterAlgorithm::createInstance() const
 void QgsPdalFilterAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), false, QgsProcessingParameterExpression::PointCloud ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), false, Qgis::ExpressionType::PointCloud ) );
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "FILTER_EXTENT" ), QObject::tr( "Cropping extent" ), QVariant(), true ) );
   addParameter( new QgsProcessingParameterPointCloudDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output" ) ) );
 }

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsapplication.h"
 #include "qgsrunprocess.h"
+#include "qgspointcloudexpression.h"
 
 ///@cond PRIVATE
 
@@ -47,7 +48,7 @@ QString QgsPdalAlgorithmBase::wrenchExecutableBinary() const
 
 void QgsPdalAlgorithmBase::createCommonParameters()
 {
-  std::unique_ptr< QgsProcessingParameterString > filterParam = std::make_unique< QgsProcessingParameterString >( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), false, true );
+  std::unique_ptr< QgsProcessingParameterExpression > filterParam = std::make_unique< QgsProcessingParameterExpression >( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), true, QgsProcessingParameterExpression::PointCloud );
   filterParam->setFlags( filterParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( filterParam.release() );
 
@@ -61,7 +62,8 @@ void QgsPdalAlgorithmBase::applyCommonParameters( QStringList &arguments, QgsCoo
   const QString filterExpression = parameterAsString( parameters, QStringLiteral( "FILTER_EXPRESSION" ), context ).trimmed();
   if ( !filterExpression.isEmpty() )
   {
-    arguments << QStringLiteral( "--filter=%1" ).arg( filterExpression );
+    QgsPointCloudExpression exp( filterExpression );
+    arguments << QStringLiteral( "--filter=%1" ).arg( exp.asPdalExpression() );
   }
 
   if ( parameters.value( QStringLiteral( "FILTER_EXTENT" ) ).isValid() )

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -48,7 +48,7 @@ QString QgsPdalAlgorithmBase::wrenchExecutableBinary() const
 
 void QgsPdalAlgorithmBase::createCommonParameters()
 {
-  std::unique_ptr< QgsProcessingParameterExpression > filterParam = std::make_unique< QgsProcessingParameterExpression >( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), true, QgsProcessingParameterExpression::PointCloud );
+  std::unique_ptr< QgsProcessingParameterExpression > filterParam = std::make_unique< QgsProcessingParameterExpression >( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QVariant(), QStringLiteral( "INPUT" ), true, Qgis::ExpressionType::PointCloud );
   filterParam->setFlags( filterParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( filterParam.release() );
 

--- a/src/core/pointcloud/expression/qgspointcloudexpression.cpp
+++ b/src/core/pointcloud/expression/qgspointcloudexpression.cpp
@@ -207,3 +207,11 @@ bool QgsPointCloudExpression::checkExpression( const QgsExpression &expression, 
   errorMessage = exp.parserErrorString();
   return !exp.hasParserError();
 }
+
+QString QgsPointCloudExpression::asPdalExpression() const
+{
+  if ( !d->mRootNode )
+    return QString();
+
+  return d->mRootNode->toPdal();
+}

--- a/src/core/pointcloud/expression/qgspointcloudexpression.h
+++ b/src/core/pointcloud/expression/qgspointcloudexpression.h
@@ -205,6 +205,13 @@ class CORE_EXPORT QgsPointCloudExpression
      */
     static bool checkExpression( const QgsExpression &expression, const QgsPointCloudBlock *block, QString &errorMessage );
 
+    /**
+     * Returns an expression string converted to PDAL expression format.
+     *
+     * \since QGIS 3.32
+     */
+    QString asPdalExpression() const;
+
   private:
 
     /**

--- a/src/core/pointcloud/expression/qgspointcloudexpressionnode.h
+++ b/src/core/pointcloud/expression/qgspointcloudexpressionnode.h
@@ -166,6 +166,13 @@ class CORE_EXPORT QgsPointCloudExpressionNode
     bool prepare( QgsPointCloudExpression *parent, const QgsPointCloudBlock *block );
 
     /**
+     * Converts this node into a PDAL expression format.
+     *
+     * \since QGIS 3.32
+     */
+    virtual QString toPdal() const = 0;
+
+    /**
      * First line in the parser this node was found.
      * \note This might not be complete for all nodes. Currently
      * only \see QgsPointCloudExpressionNode has this complete

--- a/src/core/pointcloud/expression/qgspointcloudexpressionnodeimpl.h
+++ b/src/core/pointcloud/expression/qgspointcloudexpressionnodeimpl.h
@@ -68,6 +68,13 @@ class CORE_EXPORT QgsPointCloudExpressionNodeUnaryOperator : public QgsPointClou
     double evalNode( QgsPointCloudExpression *parent, int pointIndex ) override;
     QString dump() const override;
 
+    /**
+     * Returns PDAL expression representing the node
+     *
+     * \since QGIS 3.32
+     */
+    QString toPdal() const override;
+
     QSet<QString> referencedAttributes() const override;
     QList<const QgsPointCloudExpressionNode *> nodes() const override;
     QgsPointCloudExpressionNode *clone() const override;
@@ -159,6 +166,13 @@ class CORE_EXPORT QgsPointCloudExpressionNodeBinaryOperator : public QgsPointClo
     double evalNode( QgsPointCloudExpression *parent, int pointIndex ) override;
     QString dump() const override;
 
+    /**
+     * Returns PDAL expression representing the node
+     *
+     * \since QGIS 3.32
+     */
+    QString toPdal() const override;
+
     QSet<QString> referencedAttributes() const override;
     QList<const QgsPointCloudExpressionNode *> nodes( ) const override;
 
@@ -233,6 +247,13 @@ class CORE_EXPORT QgsPointCloudExpressionNodeInOperator : public QgsPointCloudEx
     double evalNode( QgsPointCloudExpression *parent, int pointIndex ) override;
     QString dump() const override;
 
+    /**
+     * Returns PDAL expression representing the node
+     *
+     * \since QGIS 3.32
+     */
+    QString toPdal() const override;
+
     QSet<QString> referencedAttributes() const override;
     QList<const QgsPointCloudExpressionNode *> nodes() const override;
     QgsPointCloudExpressionNode *clone() const override;
@@ -268,6 +289,13 @@ class CORE_EXPORT QgsPointCloudExpressionNodeLiteral : public QgsPointCloudExpre
     bool prepareNode( QgsPointCloudExpression *parent, const QgsPointCloudBlock *block ) override;
     double evalNode( QgsPointCloudExpression *parent, int pointIndex ) override;
     QString dump() const override;
+
+    /**
+     * Returns PDAL expression representing the node
+     *
+     * \since QGIS 3.32
+     */
+    QString toPdal() const override;
 
     QSet<QString> referencedAttributes() const override;
 
@@ -309,6 +337,13 @@ class CORE_EXPORT QgsPointCloudExpressionNodeAttributeRef : public QgsPointCloud
     bool prepareNode( QgsPointCloudExpression *parent, const QgsPointCloudBlock *block ) override;
     double evalNode( QgsPointCloudExpression *parent, int pointIndex ) override;
     QString dump() const override;
+
+    /**
+     * Returns PDAL expression representing the node
+     *
+     * \since QGIS 3.32
+     */
+    QString toPdal() const override;
 
     QSet<QString> referencedAttributes() const override;
     QList<const QgsPointCloudExpressionNode *> nodes( ) const override;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -5318,7 +5318,7 @@ QgsProcessingParameterAuthConfig *QgsProcessingParameterAuthConfig::fromScriptCo
 // QgsProcessingParameterExpression
 //
 
-QgsProcessingParameterExpression::QgsProcessingParameterExpression( const QString &name, const QString &description, const QVariant &defaultValue, const QString &parentLayerParameterName, bool optional, Type type )
+QgsProcessingParameterExpression::QgsProcessingParameterExpression( const QString &name, const QString &description, const QVariant &defaultValue, const QString &parentLayerParameterName, bool optional, Qgis::ExpressionType type )
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
   , mParentLayerParameterName( parentLayerParameterName )
   , mExpressionType( type )
@@ -5367,14 +5367,9 @@ QString QgsProcessingParameterExpression::asPythonString( const QgsProcessing::P
       QgsProcessingContext c;
       code += QStringLiteral( ", defaultValue=%1" ).arg( valueAsPythonString( mDefault, c ) );
 
-      switch ( mExpressionType )
+      if ( mExpressionType == Qgis::ExpressionType::PointCloud )
       {
-        case Qgis:
-          code += QStringLiteral( ", type=QgsProcessingParameterExpression.Qgis)" );
-          break;
-        case PointCloud:
-          code += QStringLiteral( ", type=QgsProcessingParameterExpression.PointCloud)" );
-          break;
+        code += QStringLiteral( ", type=Qgis.ExpressionType.PointCloud)" );
       }
       return code;
     }
@@ -5392,12 +5387,12 @@ void QgsProcessingParameterExpression::setParentLayerParameterName( const QStrin
   mParentLayerParameterName = parentLayerParameterName;
 }
 
-QgsProcessingParameterExpression::Type QgsProcessingParameterExpression::expressionType() const
+Qgis::ExpressionType QgsProcessingParameterExpression::expressionType() const
 {
   return mExpressionType;
 }
 
-void QgsProcessingParameterExpression::setExpressionType( Type expressionType )
+void QgsProcessingParameterExpression::setExpressionType( Qgis::ExpressionType expressionType )
 {
   mExpressionType = expressionType;
 }
@@ -5406,7 +5401,7 @@ QVariantMap QgsProcessingParameterExpression::toVariantMap() const
 {
   QVariantMap map = QgsProcessingParameterDefinition::toVariantMap();
   map.insert( QStringLiteral( "parent_layer" ), mParentLayerParameterName );
-  map.insert( QStringLiteral( "expression_type" ), mExpressionType );
+  map.insert( QStringLiteral( "expression_type" ), static_cast< int >( mExpressionType ) );
   return map;
 }
 
@@ -5414,13 +5409,13 @@ bool QgsProcessingParameterExpression::fromVariantMap( const QVariantMap &map )
 {
   QgsProcessingParameterDefinition::fromVariantMap( map );
   mParentLayerParameterName = map.value( QStringLiteral( "parent_layer" ) ).toString();
-  mExpressionType = static_cast< Type >( map.value( QStringLiteral( "expression_type" ) ).toInt() );
+  mExpressionType = static_cast< Qgis::ExpressionType >( map.value( QStringLiteral( "expression_type" ) ).toInt() );
   return true;
 }
 
 QgsProcessingParameterExpression *QgsProcessingParameterExpression::fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition )
 {
-  return new QgsProcessingParameterExpression( name, description, definition, QString(), isOptional, Qgis );
+  return new QgsProcessingParameterExpression( name, description, definition, QString(), isOptional, Qgis::ExpressionType::Qgis );
 }
 
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -5371,6 +5371,10 @@ QString QgsProcessingParameterExpression::asPythonString( const QgsProcessing::P
       {
         code += QStringLiteral( ", type=Qgis.ExpressionType.PointCloud)" );
       }
+      else
+      {
+        code += QStringLiteral( ")" );
+      }
       return code;
     }
   }

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2826,20 +2826,12 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
 {
   public:
 
-    //! Expression type
-    enum Type
-    {
-      Qgis, //!< Native QGIS expression
-      PointCloud, //!< Point cloud expression
-    };
-
-
     /**
      * Constructor for QgsProcessingParameterExpression.
      */
     QgsProcessingParameterExpression( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                       const QString &parentLayerParameterName = QString(),
-                                      bool optional = false, Type type = Qgis );
+                                      bool optional = false, Qgis::ExpressionType type = Qgis::ExpressionType::Qgis );
 
     /**
      * Returns the type name for the parameter class.
@@ -2869,7 +2861,7 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
      *
      * \since QGIS 3.32
      */
-    Type expressionType() const;
+    Qgis::ExpressionType expressionType() const;
 
     /**
      * Sets the parameter's expression \a type.
@@ -2877,7 +2869,7 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
      *
      * \since QGIS 3.32
      */
-    void setExpressionType( Type type );
+    void setExpressionType( Qgis::ExpressionType type );
 
     QVariantMap toVariantMap() const override;
     bool fromVariantMap( const QVariantMap &map ) override;
@@ -2890,7 +2882,7 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
   private:
 
     QString mParentLayerParameterName;
-    Type mExpressionType = Qgis;
+    Qgis::ExpressionType mExpressionType = Qgis::ExpressionType::Qgis;
 };
 
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2826,12 +2826,20 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
 {
   public:
 
+    //! Expression type
+    enum Type
+    {
+      Qgis, //!< Native QGIS expression
+      PointCloud, //!< Point cloud expression
+    };
+
+
     /**
      * Constructor for QgsProcessingParameterExpression.
      */
     QgsProcessingParameterExpression( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                       const QString &parentLayerParameterName = QString(),
-                                      bool optional = false );
+                                      bool optional = false, Type type = Qgis );
 
     /**
      * Returns the type name for the parameter class.
@@ -2855,6 +2863,22 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
      */
     void setParentLayerParameterName( const QString &parentLayerParameterName );
 
+    /**
+     * Returns the parameter's expression type.
+     * \see setExpressionType()
+     *
+     * \since QGIS 3.32
+     */
+    Type expressionType() const;
+
+    /**
+     * Sets the parameter's expression \a type.
+     * \see expressionType()
+     *
+     * \since QGIS 3.32
+     */
+    void setExpressionType( Type type );
+
     QVariantMap toVariantMap() const override;
     bool fromVariantMap( const QVariantMap &map ) override;
 
@@ -2866,7 +2890,7 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
   private:
 
     QString mParentLayerParameterName;
-
+    Type mExpressionType = Qgis;
 };
 
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3508,6 +3508,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( AttributeFormPythonInitCodeSource )
 
     /**
+     * Expression types
+     *
+     * \since QGIS 3.32
+     */
+    enum class ExpressionType
+    {
+      Qgis, //!< Native QGIS expression
+      PointCloud, //!< Point cloud expression
+    };
+    Q_ENUM( ExpressionType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -384,6 +384,7 @@ set(QGIS_GUI_SRCS
   processing/qgsprocessingoutputdestinationwidget.cpp
   processing/qgsprocessingparameterdefinitionwidget.cpp
   processing/qgsprocessingparameterswidget.cpp
+  processing/qgsprocessingpointcloudexpressionlineedit.cpp
   processing/qgsprocessingrecentalgorithmlog.cpp
   processing/qgsprocessingtininputlayerswidget.cpp
   processing/qgsprocessingtoolboxmodel.cpp
@@ -1301,6 +1302,7 @@ set(QGIS_GUI_HDRS
   processing/qgsprocessingoutputdestinationwidget.h
   processing/qgsprocessingparameterdefinitionwidget.h
   processing/qgsprocessingparameterswidget.h
+  processing/qgsprocessingpointcloudexpressionlineedit.h
   processing/qgsprocessingrecentalgorithmlog.h
   processing/qgsprocessingtininputlayerswidget.h
   processing/qgsprocessingtoolboxmodel.h

--- a/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
+++ b/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
@@ -1,0 +1,328 @@
+/***************************************************************************
+                         qgsprocessingpointcloudexpressionlineedit.cpp
+                         ---------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Alexander Bruy
+    email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingpointcloudexpressionlineedit.h"
+#include "qgsgui.h"
+#include "qgsapplication.h"
+#include "qgsfilterlineedit.h"
+#include "qgspointcloudlayer.h"
+#include "qgspointcloudexpression.h"
+
+#include <QHBoxLayout>
+#include <QToolButton>
+#include <QListView>
+#include <QPushButton>
+#include <QMessageBox>
+
+QgsProcessingPointCloudExpressionLineEdit::QgsProcessingPointCloudExpressionLineEdit( QWidget *parent )
+  : QWidget( parent )
+{
+  mLineEdit = new QgsFilterLineEdit();
+  mLineEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
+
+  mButton = new QToolButton();
+  mButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
+  mButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIconExpression.svg" ) ) );
+  connect( mButton, &QAbstractButton::clicked, this, &QgsProcessingPointCloudExpressionLineEdit::editExpression );
+
+  QHBoxLayout *layout = new QHBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->addWidget( mLineEdit );
+  layout->addWidget( mButton );
+  setLayout( layout );
+
+  setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
+  setFocusProxy( mLineEdit );
+  connect( mLineEdit, &QLineEdit::textChanged, this, static_cast < void ( QgsProcessingPointCloudExpressionLineEdit::* )( const QString & ) > ( &QgsProcessingPointCloudExpressionLineEdit::expressionEdited ) );
+
+  setExpression( expression() );
+}
+
+QgsProcessingPointCloudExpressionLineEdit::~QgsProcessingPointCloudExpressionLineEdit() = default;
+
+void QgsProcessingPointCloudExpressionLineEdit::setLayer( QgsPointCloudLayer *layer )
+{
+  mLayer = layer;
+}
+
+QgsPointCloudLayer *QgsProcessingPointCloudExpressionLineEdit::layer() const
+{
+  return mLayer;
+}
+
+QString QgsProcessingPointCloudExpressionLineEdit::expression() const
+{
+  if ( mLineEdit )
+    return mLineEdit->text();
+
+  return QString();
+}
+
+void QgsProcessingPointCloudExpressionLineEdit::setExpression( const QString &newExpression )
+{
+  if ( mLineEdit )
+    mLineEdit->setText( newExpression );
+}
+
+void QgsProcessingPointCloudExpressionLineEdit::editExpression()
+{
+  const QString currentExpression = expression();
+  QgsProcessingPointCloudExpressionDialog dlg( mLayer );
+  dlg.setExpression( currentExpression );
+
+  if ( dlg.exec() )
+  {
+    const QString newExpression = dlg.expression();
+    setExpression( newExpression );
+  }
+}
+
+void QgsProcessingPointCloudExpressionLineEdit::expressionEdited()
+{
+  emit expressionChanged( expression() );
+}
+
+void QgsProcessingPointCloudExpressionLineEdit::expressionEdited( const QString &expression )
+{
+  emit expressionChanged( expression );
+}
+
+
+QgsProcessingPointCloudExpressionDialog::QgsProcessingPointCloudExpressionDialog( QgsPointCloudLayer *layer, const QString &startExpression, QWidget *parent )
+  : QDialog( parent )
+  , mLayer( layer )
+  , mInitialText( startExpression )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mModelAttributes = new QStandardItemModel();
+  mModelValues = new QStandardItemModel();
+  lstAttributes->setModel( mModelAttributes );
+  lstValues->setModel( mModelValues );
+
+  populateAttributes();
+
+  connect( lstAttributes->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsProcessingPointCloudExpressionDialog::lstAttributes_currentChanged );
+  connect( lstAttributes, &QListView::doubleClicked, this, &QgsProcessingPointCloudExpressionDialog::lstAttributes_doubleClicked );
+  connect( lstValues, &QListView::doubleClicked, this, &QgsProcessingPointCloudExpressionDialog::lstValues_doubleClicked );
+  connect( btnEqual, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnEqual_clicked );
+  connect( btnLessThan, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnLessThan_clicked );
+  connect( btnGreaterThan, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnGreaterThan_clicked );
+  connect( btnIn, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnIn_clicked );
+  connect( btnNotIn, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnNotIn_clicked );
+  connect( btnLessEqual, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnLessEqual_clicked );
+  connect( btnGreaterEqual, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnGreaterEqual_clicked );
+  connect( btnNotEqual, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnNotEqual_clicked );
+  connect( btnAnd, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnAnd_clicked );
+  connect( btnOr, &QPushButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::btnOr_clicked );
+
+  QPushButton *pbn = new QPushButton( tr( "&Test" ) );
+  buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
+  connect( pbn, &QAbstractButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::test );
+
+  pbn = new QPushButton( tr( "&Clear" ) );
+  buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
+  connect( pbn, &QAbstractButton::clicked, this, &QgsProcessingPointCloudExpressionDialog::clear );
+
+  mTxtSql->setText( mInitialText );
+}
+
+void QgsProcessingPointCloudExpressionDialog::setExpression( const QString &text )
+{
+  mTxtSql->setText( text );
+}
+
+QString QgsProcessingPointCloudExpressionDialog::expression()
+{
+  return mTxtSql->text();
+}
+
+void QgsProcessingPointCloudExpressionDialog::populateAttributes()
+{
+  if ( !mLayer )
+  {
+    return;
+  }
+
+  const QgsFields &fields = mLayer->dataProvider()->attributes().toFields();
+  mTxtSql->setFields( fields );
+  for ( int idx = 0; idx < fields.count(); ++idx )
+  {
+    QStandardItem *myItem = new QStandardItem( fields.at( idx ).displayNameWithAlias() );
+    mModelAttributes->insertRow( mModelAttributes->rowCount(), myItem );
+  }
+}
+
+void QgsProcessingPointCloudExpressionDialog::lstAttributes_currentChanged( const QModelIndex &current, const QModelIndex &previous )
+{
+  Q_UNUSED( previous )
+
+  mModelValues->clear();
+  const QString attribute = current.data().toString();
+  if ( attribute.compare( QLatin1String( "Classification" ), Qt::CaseInsensitive ) == 0 )
+  {
+    const QMap<int, QString> codes = QgsPointCloudDataProvider::translatedLasClassificationCodes();
+    for ( int i = 0; i <= 18; ++i )
+    {
+      QStandardItem *item = new QStandardItem( QString( "%1: %2" ).arg( i ).arg( codes.value( i ) ) );
+      item->setData( i, Qt::UserRole );
+      mModelValues->insertRow( mModelValues->rowCount(), item );
+    }
+  }
+  else
+  {
+    const QgsPointCloudStatistics stats = mLayer->statistics();
+    double value = stats.minimum( attribute );
+    QString valueString = std::isnan( value ) ? tr( "n/a" ) : QString::number( value );
+    QStandardItem *item = new QStandardItem( tr( "Minimum: %1" ).arg( valueString ) );
+    item->setData( value, Qt::UserRole );
+    mModelValues->insertRow( mModelValues->rowCount(), item );
+
+    value = stats.maximum( attribute );
+    valueString = std::isnan( value ) ? tr( "n/a" ) : QString::number( value );
+    item = new QStandardItem( tr( "Maximum: %1" ).arg( valueString ) );
+    item->setData( value, Qt::UserRole );
+    mModelValues->insertRow( mModelValues->rowCount(), item );
+
+    value = stats.mean( attribute );
+    valueString = std::isnan( value ) ? tr( "n/a" ) : QString::number( value );
+    item = new QStandardItem( tr( "Mean: %1" ).arg( valueString ) );
+    item->setData( value, Qt::UserRole );
+    mModelValues->insertRow( mModelValues->rowCount(), item );
+
+    value = stats.stDev( attribute );
+    valueString = std::isnan( value ) ? tr( "n/a" ) : QString::number( value );
+    item = new QStandardItem( tr( "StdDev: %1" ).arg( valueString ) );
+    item->setData( value, Qt::UserRole );
+    mModelValues->insertRow( mModelValues->rowCount(), item );
+  }
+}
+
+void QgsProcessingPointCloudExpressionDialog::lstAttributes_doubleClicked( const QModelIndex &index )
+{
+  mTxtSql->insertText( QStringLiteral( "%1 " ).arg( mModelAttributes->data( index ).toString() ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::lstValues_doubleClicked( const QModelIndex &index )
+{
+  mTxtSql->insertText( QStringLiteral( "%1 " ).arg( mModelValues->data( index, Qt::UserRole ).toString() ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnEqual_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "= " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnLessThan_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "< " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnGreaterThan_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "> " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnIn_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "IN () " ) );
+  int i, j;
+  mTxtSql->getCursorPosition( &i, &j );
+  mTxtSql->setCursorPosition( i, j - 2 );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnNotIn_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "NOT IN () " ) );
+  int i, j;
+  mTxtSql->getCursorPosition( &i, &j );
+  mTxtSql->setCursorPosition( i, j - 2 );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnLessEqual_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "<= " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnGreaterEqual_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( ">= " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnNotEqual_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "!= " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnAnd_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "AND " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::btnOr_clicked()
+{
+  mTxtSql->insertText( QStringLiteral( "OR " ) );
+  mTxtSql->setFocus();
+}
+
+void QgsProcessingPointCloudExpressionDialog::test()
+{
+  QgsPointCloudExpression expression( mTxtSql->text() );
+
+  if ( !expression.isValid() && !mTxtSql->text().isEmpty() )
+  {
+    QMessageBox::warning( this,
+                          tr( "Query Result" ),
+                          tr( "An error occurred while parsing the expression:\n%1" ).arg( expression.parserErrorString() ) );
+  }
+  else
+  {
+    const QSet<QString> attributes = expression.referencedAttributes();
+    int offset;
+    for ( const auto &attribute : attributes )
+    {
+      if ( mLayer->dataProvider() &&
+           !mLayer->dataProvider()->attributes().find( attribute, offset ) )
+      {
+        QMessageBox::warning( this,
+                              tr( "Query Result" ),
+                              tr( "\"%1\" not recognized as an available attribute." ).arg( attribute ) );
+        return;
+      }
+    }
+    QMessageBox::information( this,
+                              tr( "Query Result" ),
+                              tr( "The expression was successfully parsed." ) );
+  }
+}
+
+void QgsProcessingPointCloudExpressionDialog::clear()
+{
+  mTxtSql->clear();
+}

--- a/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
+++ b/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
@@ -28,6 +28,8 @@
 #include <QPushButton>
 #include <QMessageBox>
 
+/// @cond PRIVATE
+
 QgsProcessingPointCloudExpressionLineEdit::QgsProcessingPointCloudExpressionLineEdit( QWidget *parent )
   : QWidget( parent )
 {
@@ -326,3 +328,5 @@ void QgsProcessingPointCloudExpressionDialog::clear()
 {
   mTxtSql->clear();
 }
+
+///@endcond

--- a/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.h
+++ b/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.h
@@ -40,6 +40,7 @@ class QgsPointCloudLayer;
 /**
  * Processing point cloud expression line edit.
  * \ingroup gui
+ * \class QgsProcessingPointCloudExpressionLineEdit
  * \warning Not part of stable API and may change in future QGIS releases.
  * \since QGIS 3.32
  */

--- a/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.h
+++ b/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.h
@@ -1,0 +1,179 @@
+/***************************************************************************
+                         qgsprocessingpointcloudexpressionlineedit.h
+                         ---------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Alexander Bruy
+    email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGPOINTCLOUDEXPRESSIONLINEEDIT_H
+#define QGSPROCESSINGPOINTCLOUDEXPRESSIONLINEEDIT_H
+
+#define SIP_NO_FILE
+
+#include <QWidget>
+#include <QDialog>
+#include <QStandardItemModel>
+#include <QStandardItem>
+#include <QModelIndex>
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "ui_qgsprocessingpointcloudexpressiondialogbase.h"
+
+
+class QgsFilterLineEdit;
+class QToolButton;
+class QgsPointCloudLayer;
+
+/// @cond PRIVATE
+
+/**
+ * Processing point cloud expression line edit.
+ * \ingroup gui
+ * \warning Not part of stable API and may change in future QGIS releases.
+ * \since QGIS 3.32
+ */
+class GUI_EXPORT QgsProcessingPointCloudExpressionLineEdit : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingPointCloudExpressionLineEdit.
+     * \param parent parent widget
+     */
+    explicit QgsProcessingPointCloudExpressionLineEdit( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    ~QgsProcessingPointCloudExpressionLineEdit() override;
+
+    /**
+     * Sets a layer associated with the widget. Required in order to get the attributes
+     * from the layer.
+     */
+    void setLayer( QgsPointCloudLayer *layer );
+
+    /**
+     * Returns the layer currently associated with the widget.
+     * \see setLayer()
+     */
+    QgsPointCloudLayer *layer() const;
+
+    /**
+     * Returns the current expression shown in the widget.
+     * \see setExpression()
+     */
+    QString expression() const;
+
+  signals:
+
+    /**
+     * Emitted when the expression is changed.
+     * \param expression new expression
+     */
+    void expressionChanged( const QString &expression );
+
+  public slots:
+
+    /**
+     * Sets the current expression to show in the widget.
+     * \param expression expression string
+     * \see expression()
+     */
+    void setExpression( const QString &expression );
+
+  private slots:
+
+    void expressionEdited( const QString &expression );
+    void expressionEdited();
+
+    //! Opens the expression editor dialog to edit the current expression
+    void editExpression();
+
+  private:
+    QgsFilterLineEdit *mLineEdit = nullptr;
+    QToolButton *mButton = nullptr;
+    QgsPointCloudLayer *mLayer = nullptr;
+};
+
+/**
+ * A dialog for editing point cloud expressions.
+ * \ingroup gui
+ * \warning Not part of stable API and may change in future QGIS releases.
+ * \since QGIS 3.32
+ */
+class GUI_EXPORT QgsProcessingPointCloudExpressionDialog : public QDialog, private Ui::QgsProcessingPointCloudExpressionDialogBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingPointCloudExpressionDialog.
+     */
+    QgsProcessingPointCloudExpressionDialog( QgsPointCloudLayer *layer, const QString &startExpression = QString(), QWidget *parent = nullptr );
+
+    /**
+     * Sets the current expression to show in the widget.
+     * \param text expression string
+     * \see expression()
+     */
+    void setExpression( const QString &text );
+
+    /**
+     * Returns the current expression shown in the widget.
+     * \see setExpression()
+     */
+    QString expression();
+
+  private slots:
+
+    /**
+     * Test if the typed expression is valid and can be used as a \a QgsPointCloudExpression
+     */
+    void test();
+
+    /**
+     * Clears the typed expression
+     */
+    void clear();
+
+    void lstAttributes_currentChanged( const QModelIndex &current, const QModelIndex &previous );
+    void lstAttributes_doubleClicked( const QModelIndex &index );
+    void lstValues_doubleClicked( const QModelIndex &index );
+    void btnEqual_clicked();
+    void btnLessThan_clicked();
+    void btnGreaterThan_clicked();
+    void btnIn_clicked();
+    void btnNotIn_clicked();
+    void btnLessEqual_clicked();
+    void btnGreaterEqual_clicked();
+    void btnNotEqual_clicked();
+    void btnAnd_clicked();
+    void btnOr_clicked();
+
+  private:
+    //! Populate the attribute list for the selected layer
+    void populateAttributes();
+
+    //! Model for attributes ListView
+    QStandardItemModel *mModelAttributes = nullptr;
+
+    //! Model for values ListView
+    QStandardItemModel *mModelValues = nullptr;
+
+    QgsPointCloudLayer *mLayer = nullptr;
+    const QString mInitialText;
+};
+
+///@endcond
+#endif // QGSPROCESSINGPOINTCLOUDEXPRESSIONLINEEDIT_H

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2125,8 +2125,8 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
 
   vlayout->addWidget( new QLabel( tr( "Expression type" ) ) );
   mExpressionTypeComboBox = new QComboBox();
-  mExpressionTypeComboBox->addItem( tr( "Qgis" ), QgsProcessingParameterExpression::Qgis );
-  mExpressionTypeComboBox->addItem( tr( "Point cloud" ), QgsProcessingParameterExpression::PointCloud );
+  mExpressionTypeComboBox->addItem( tr( "QGIS" ), static_cast< int >( Qgis::ExpressionType::Qgis ) );
+  mExpressionTypeComboBox->addItem( tr( "Point Cloud" ), static_cast< int >( Qgis::ExpressionType::PointCloud ) );
 
   connect( mExpressionTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
   {
@@ -2137,7 +2137,7 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
     if ( const QgsProcessingParameterExpression *expParam = dynamic_cast<const QgsProcessingParameterExpression *>( definition ) )
       initialParent = expParam->parentLayerParameterName();
 
-    QgsProcessingParameterExpression::Type exprType = static_cast< QgsProcessingParameterExpression::Type >( mExpressionTypeComboBox->currentData().toInt() );
+    Qgis::ExpressionType exprType = static_cast< Qgis::ExpressionType >( mExpressionTypeComboBox->currentData().toInt() );
 
     if ( QgsProcessingModelAlgorithm *model = widgetContext.model() )
     {
@@ -2145,7 +2145,7 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
       const QMap<QString, QgsProcessingModelParameter> components = model->parameterComponents();
       for ( auto it = components.constBegin(); it != components.constEnd(); ++it )
       {
-        if ( exprType == QgsProcessingParameterExpression::Qgis )
+        if ( exprType == Qgis::ExpressionType::Qgis )
         {
           if ( const QgsProcessingParameterFeatureSource *definition = dynamic_cast< const QgsProcessingParameterFeatureSource * >( model->parameterDefinition( it.value().parameterName() ) ) )
           {
@@ -2189,7 +2189,7 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
 
   mExpressionTypeComboBox->setCurrentIndex( -1 );
   if ( const QgsProcessingParameterExpression *expParam = dynamic_cast<const QgsProcessingParameterExpression *>( definition ) )
-    mExpressionTypeComboBox->setCurrentIndex( mExpressionTypeComboBox->findData( expParam->expressionType() ) );
+    mExpressionTypeComboBox->setCurrentIndex( mExpressionTypeComboBox->findData( static_cast< int >( expParam->expressionType() ) ) );
   else
     mExpressionTypeComboBox->setCurrentIndex( 0 );
 
@@ -2200,7 +2200,7 @@ QgsProcessingExpressionParameterDefinitionWidget::QgsProcessingExpressionParamet
 
 QgsProcessingParameterDefinition *QgsProcessingExpressionParameterDefinitionWidget::createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const
 {
-  QgsProcessingParameterExpression::Type expressionType = static_cast< QgsProcessingParameterExpression::Type >( mExpressionTypeComboBox->currentData().toInt() );
+  Qgis::ExpressionType expressionType = static_cast< Qgis::ExpressionType >( mExpressionTypeComboBox->currentData().toInt() );
   auto param = std::make_unique< QgsProcessingParameterExpression >( name, description, mDefaultLineEdit->text(), mParentLayerComboBox->currentData().toString(), false, expressionType );
   param->setFlags( flags );
   return param.release();
@@ -2235,7 +2235,7 @@ QWidget *QgsProcessingExpressionWidgetWrapper::createWidget()
       }
       else
       {
-        if ( expParam->expressionType() == QgsProcessingParameterExpression::PointCloud )
+        if ( expParam->expressionType() == Qgis::ExpressionType::PointCloud )
         {
           mPointCloudExpLineEdit = new QgsProcessingPointCloudExpressionLineEdit();
           mPointCloudExpLineEdit->setToolTip( parameterDefinition()->toolTip() );
@@ -2337,7 +2337,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
   const QgsProcessingParameterExpression *expParam = dynamic_cast< const QgsProcessingParameterExpression *>( parameterDefinition() );
   switch ( expParam->expressionType() )
   {
-    case QgsProcessingParameterExpression::Qgis:
+    case Qgis::ExpressionType::Qgis:
     {
       if ( val.userType() == QMetaType::type( "QgsProcessingFeatureSourceDefinition" ) )
       {
@@ -2380,7 +2380,7 @@ void QgsProcessingExpressionWidgetWrapper::setParentLayerWrapperValue( const Qgs
 
       break;
     }
-    case QgsProcessingParameterExpression::PointCloud:
+    case Qgis::ExpressionType::PointCloud:
     {
       QgsPointCloudLayer *layer = QgsProcessingParameters::parameterAsPointCloudLayer( parentWrapper->parameterDefinition(), val, *context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
       if ( !layer )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -698,8 +698,8 @@ class GUI_EXPORT QgsProcessingExpressionParameterDefinitionWidget : public QgsPr
   private:
 
     QComboBox *mParentLayerComboBox = nullptr;
-    //QgsExpressionLineEdit *mDefaultLineEdit = nullptr;
-    QLineEdit *mDefaultLineEdit = nullptr;
+    QgsExpressionLineEdit *mDefaultQgisLineEdit = nullptr;
+    QgsProcessingPointCloudExpressionLineEdit *mDefaultPointCloudLineEdit = nullptr;
     QComboBox *mExpressionTypeComboBox = nullptr;
 
 };

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -70,6 +70,7 @@ class QgsPointCloudAttributeComboBox;
 class QgsProcessingLayerOutputDestinationWidget;
 class QgsCheckableComboBox;
 class QgsMapLayerComboBox;
+class QgsProcessingPointCloudExpressionLineEdit;
 
 ///@cond PRIVATE
 
@@ -697,7 +698,9 @@ class GUI_EXPORT QgsProcessingExpressionParameterDefinitionWidget : public QgsPr
   private:
 
     QComboBox *mParentLayerComboBox = nullptr;
-    QgsExpressionLineEdit *mDefaultLineEdit = nullptr;
+    //QgsExpressionLineEdit *mDefaultLineEdit = nullptr;
+    QLineEdit *mDefaultLineEdit = nullptr;
+    QComboBox *mExpressionTypeComboBox = nullptr;
 
 };
 
@@ -742,7 +745,8 @@ class GUI_EXPORT QgsProcessingExpressionWidgetWrapper : public QgsAbstractProces
     QgsFieldExpressionWidget *mFieldExpWidget = nullptr;
     QgsExpressionBuilderWidget *mExpBuilderWidget = nullptr;
     QgsExpressionLineEdit *mExpLineEdit = nullptr;
-    std::unique_ptr< QgsVectorLayer > mParentLayer;
+    QgsProcessingPointCloudExpressionLineEdit *mPointCloudExpLineEdit = nullptr;
+    std::unique_ptr< QgsMapLayer > mParentLayer;
 
     friend class TestProcessingGui;
 };

--- a/src/ui/processing/qgsprocessingpointcloudexpressiondialogbase.ui
+++ b/src/ui/processing/qgsprocessingpointcloudexpressiondialogbase.ui
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsProcessingPointCloudExpressionDialogBase</class>
+ <widget class="QDialog" name="QgsProcessingPointCloudExpressionDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>560</width>
+    <height>481</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Point Cloud Expression</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0" colspan="2">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Attributes</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Values</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QListView" name="lstAttributes">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="uniformItemSizes">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QListView" name="lstValues">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="uniformItemSizes">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="title">
+      <string>Operators</string>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>11</number>
+      </property>
+      <property name="topMargin">
+       <number>11</number>
+      </property>
+      <property name="rightMargin">
+       <number>11</number>
+      </property>
+      <property name="bottomMargin">
+       <number>11</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="btnEqual">
+        <property name="text">
+         <string>=</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="btnLessThan">
+        <property name="text">
+         <string>&lt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="btnLessEqual">
+        <property name="text">
+         <string>&lt;=</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="btnGreaterThan">
+        <property name="text">
+         <string>&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QPushButton" name="btnAnd">
+        <property name="text">
+         <string>AND</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="btnOr">
+        <property name="text">
+         <string>OR</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="btnGreaterEqual">
+        <property name="text">
+         <string>&gt;=</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QPushButton" name="btnIn">
+        <property name="text">
+         <string>IN</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="btnNotEqual">
+        <property name="text">
+         <string>!=</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="btnNotIn">
+        <property name="text">
+         <string>NOT IN</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5" rowspan="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Filter Expression</string>
+     </property>
+     <layout class="QGridLayout" name="_2">
+      <property name="leftMargin">
+       <number>11</number>
+      </property>
+      <property name="topMargin">
+       <number>11</number>
+      </property>
+      <property name="rightMargin">
+       <number>11</number>
+      </property>
+      <property name="bottomMargin">
+       <number>11</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QgsCodeEditorSQL" name="mTxtSql" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCodeEditorSQL</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorsql.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsProcessingPointCloudExpressionDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsProcessingPointCloudExpressionDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6482,7 +6482,7 @@ void TestQgsProcessing::parameterExpression()
   QVERIFY( ok );
 
   QString pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='1+1', type=QgsProcessingParameterExpression.Qgis)" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='1+1')" ) );
 
   QString code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##non_optional=expression 1+1" ) );
@@ -6525,7 +6525,7 @@ void TestQgsProcessing::parameterExpression()
   QCOMPARE( QgsProcessingParameters::parameterAsExpression( def.get(), params, context ), QString( "default" ) );
 
   pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('optional', '', optional=True, parentLayerParameterName='', defaultValue='default', type=QgsProcessingParameterExpression.Qgis)" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('optional', '', optional=True, parentLayerParameterName='', defaultValue='default')" ) );
 
   code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##optional=optional expression default" ) );
@@ -6544,9 +6544,9 @@ void TestQgsProcessing::parameterExpression()
   QVERIFY( !def->checkValueIsAcceptable( QVariant() ) ); // should NOT be acceptable, because it will fallback to invalid default value
 
   // set point cloud expression type
-  def.reset( new QgsProcessingParameterExpression( "non_optional", QString(), QString( "default" ), QString(), false, QgsProcessingParameterExpression::PointCloud ) );
+  def.reset( new QgsProcessingParameterExpression( "non_optional", QString(), QString( "default" ), QString(), false, Qgis::ExpressionType::PointCloud ) );
   pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='default', type=QgsProcessingParameterExpression.PointCloud)" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='default', type=Qgis.ExpressionType.PointCloud)" ) );
 }
 
 void TestQgsProcessing::parameterField()

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6482,7 +6482,7 @@ void TestQgsProcessing::parameterExpression()
   QVERIFY( ok );
 
   QString pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='1+1')" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='1+1', type=QgsProcessingParameterExpression.Qgis)" ) );
 
   QString code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##non_optional=expression 1+1" ) );
@@ -6525,7 +6525,7 @@ void TestQgsProcessing::parameterExpression()
   QCOMPARE( QgsProcessingParameters::parameterAsExpression( def.get(), params, context ), QString( "default" ) );
 
   pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('optional', '', optional=True, parentLayerParameterName='', defaultValue='default')" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('optional', '', optional=True, parentLayerParameterName='', defaultValue='default', type=QgsProcessingParameterExpression.Qgis)" ) );
 
   code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##optional=optional expression default" ) );
@@ -6543,6 +6543,10 @@ void TestQgsProcessing::parameterExpression()
   QVERIFY( !def->checkValueIsAcceptable( "" ) );
   QVERIFY( !def->checkValueIsAcceptable( QVariant() ) ); // should NOT be acceptable, because it will fallback to invalid default value
 
+  // set point cloud expression type
+  def.reset( new QgsProcessingParameterExpression( "non_optional", QString(), QString( "default" ), QString(), false, QgsProcessingParameterExpression::PointCloud ) );
+  pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterExpression('non_optional', '', parentLayerParameterName='', defaultValue='default', type=QgsProcessingParameterExpression.PointCloud)" ) );
 }
 
 void TestQgsProcessing::parameterField()

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -1073,7 +1073,7 @@ void TestQgsProcessingPdalAlgs::filter()
             << QStringLiteral( "--output=%1" ).arg( outputPointCloud )
           );
 
-  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Classification == 7 || Classification == 8" ) );
+  parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Classification = 7 OR Classification = 8" ) );
   args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "translate" )
             << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath )

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -2956,7 +2956,7 @@ void TestProcessingGui::testExpressionWrapper()
     //
     // point cloud expression
     //
-    param.setExpressionType( QgsProcessingParameterExpression::PointCloud );
+    param.setExpressionType( Qgis::ExpressionType::PointCloud );
     param.setParentLayerParameterName( QStringLiteral( "pointcloud" ) );
     QgsProcessingExpressionWidgetWrapper wrapper3( &param, type );
     w = wrapper3.createWrappedWidget( context );
@@ -3052,7 +3052,7 @@ void TestProcessingGui::testExpressionWrapper()
   QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
   QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) ); // should default to mandatory
   QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
-  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), QgsProcessingParameterExpression::Qgis );
+  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), Qgis::ExpressionType::Qgis );
 
   // using a parameter definition as initial values
   QgsProcessingParameterExpression exprParam( QStringLiteral( "n" ), QStringLiteral( "test desc" ), QVariant(), QStringLiteral( "parent" ) );
@@ -3063,9 +3063,9 @@ void TestProcessingGui::testExpressionWrapper()
   QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
   QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
   QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->parentLayerParameterName(), QStringLiteral( "parent" ) );
-  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), QgsProcessingParameterExpression::Qgis );
+  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), Qgis::ExpressionType::Qgis );
   exprParam.setFlags( QgsProcessingParameterDefinition::FlagAdvanced | QgsProcessingParameterDefinition::FlagOptional );
-  exprParam.setExpressionType( QgsProcessingParameterExpression::PointCloud );
+  exprParam.setExpressionType( Qgis::ExpressionType::PointCloud );
   exprParam.setParentLayerParameterName( QString() );
   widget = std::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "expression" ), context, widgetContext, &exprParam );
   def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
@@ -3074,7 +3074,7 @@ void TestProcessingGui::testExpressionWrapper()
   QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
   QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
   QVERIFY( static_cast< QgsProcessingParameterExpression * >( def.get() )->parentLayerParameterName().isEmpty() );
-  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), QgsProcessingParameterExpression::PointCloud );
+  QCOMPARE( static_cast< QgsProcessingParameterExpression * >( def.get() )->expressionType(), Qgis::ExpressionType::PointCloud );
 }
 
 void TestProcessingGui::testFieldSelectionPanel()


### PR DESCRIPTION
## Description

With addition of filtering capabilities to point cloud algorithms, we need a userfriedly way to build point cloud expressions similarly to the QGIS native expressions.

To make it possible this pull-request adds a `Type` enum to `QgsProcessingParameterExpression` parameter with two options `Qgis` and `PointCloud`. If parameter has a `PointCloud` type, it will use new widget wrapper with GUI point cloud expression builder.
![2023-04-17-091207_1366x768_scrot](https://user-images.githubusercontent.com/776954/232438577-9d957691-6c89-4557-820f-d36e7408239e.png)
To maintain backward compatibility, by default expression parameter uses `Qgis` expression type.

The `QgsPointCloudExpression` class was extented with the new method to convert QGIS point cloud expressions to [PDAL expressions](https://pdal.io/en/latest/stages/expression.html).

All PDAL algorithms using expression filter were updated to use expression parameter instead of strings.