### PR TITLE
Fix OGC Filter on IN operator with only one list item

### DIFF
--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2216,7 +2216,14 @@ QDomElement QgsOgcUtilsExprToFilter::expressionColumnRefToOgcFilter( const QgsEx
 QDomElement QgsOgcUtilsExprToFilter::expressionInOperatorToOgcFilter( const QgsExpressionNodeInOperator *node, QgsExpression *expression, const QgsExpressionContext *context )
 {
   if ( node->list()->list().size() == 1 )
-    return expressionNodeToOgcFilter( node->list()->list()[0], expression, context );
+  {
+    const QDomElement leftNode = expressionNodeToOgcFilter( node->node(), expression, context );
+    const QDomElement firstListNode = expressionNodeToOgcFilter( node->list()->list().first(), expression, context );
+    QDomElement eqElem = mDoc.createElement( mFilterPrefix + ":PropertyIsEqualTo" );
+    eqElem.appendChild( leftNode );
+    eqElem.appendChild( firstListNode );
+    return eqElem;
+  }
 
   QDomElement orElem = mDoc.createElement( mFilterPrefix + ":Or" );
   const QDomElement leftNode = expressionNodeToOgcFilter( node->node(), expression, context );

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2716,7 +2716,20 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
 QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement::NodeInOperator *node )
 {
   if ( node->list()->list().size() == 1 )
-    return toOgcFilter( node->list()->list()[0] );
+  {
+    const QDomElement leftNode = toOgcFilter( node->node() );
+    const QDomElement firstListNode = toOgcFilter( node->list()->list().first() );
+    QDomElement eqElem = mDoc.createElement( mFilterPrefix + ":PropertyIsEqualTo" );
+    eqElem.appendChild( leftNode );
+    eqElem.appendChild( firstListNode );
+    if ( node->isNotIn() )
+    {
+      QDomElement notElem = mDoc.createElement( mFilterPrefix + ":Not" );
+      notElem.appendChild( eqElem );
+      return notElem;
+    }
+    return eqElem;
+  }
 
   QDomElement orElem = mDoc.createElement( mFilterPrefix + ":Or" );
   const QDomElement leftNode = toOgcFilter( node->node() );

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2222,6 +2222,12 @@ QDomElement QgsOgcUtilsExprToFilter::expressionInOperatorToOgcFilter( const QgsE
     QDomElement eqElem = mDoc.createElement( mFilterPrefix + ":PropertyIsEqualTo" );
     eqElem.appendChild( leftNode );
     eqElem.appendChild( firstListNode );
+    if ( node->isNotIn() )
+    {
+      QDomElement notElem = mDoc.createElement( mFilterPrefix + ":Not" );
+      notElem.appendChild( eqElem );
+      return notElem;
+    }
     return eqElem;
   }
 

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -1079,6 +1079,26 @@ void TestQgsOgcUtils::testSQLStatementToOgcFilter_data()
                               "</ogc:Not>"
                               "</ogc:Filter>" );
 
+  QTest::newRow( "in" ) << QStringLiteral( "SELECT * FROM t WHERE A IN (10)" ) <<
+                        QgsOgcUtils::GML_2_1_2 << QgsOgcUtils::FILTER_OGC_1_0 << layerProperties << QString(
+                          "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                          "<ogc:PropertyIsEqualTo>"
+                          "<ogc:PropertyName>A</ogc:PropertyName>"
+                          "<ogc:Literal>10</ogc:Literal>"
+                          "</ogc:PropertyIsEqualTo>"
+                          "</ogc:Filter>" );
+
+  QTest::newRow( "not in" ) << QStringLiteral( "SELECT * FROM t WHERE A NOT IN (10)" ) <<
+                            QgsOgcUtils::GML_2_1_2 << QgsOgcUtils::FILTER_OGC_1_0 << layerProperties << QString(
+                              "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                              "<ogc:Not>"
+                              "<ogc:PropertyIsEqualTo>"
+                              "<ogc:PropertyName>A</ogc:PropertyName>"
+                              "<ogc:Literal>10</ogc:Literal>"
+                              "</ogc:PropertyIsEqualTo>"
+                              "</ogc:Not>"
+                              "</ogc:Filter>" );
+
   QTest::newRow( "between" ) << QStringLiteral( "SELECT * FROM t WHERE A BETWEEN 1 AND 2" ) <<
                              QgsOgcUtils::GML_2_1_2 << QgsOgcUtils::FILTER_OGC_1_0 << layerProperties << QString(
                                "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -700,6 +700,24 @@ void TestQgsOgcUtils::testExpressionToOgcFilter_data()
                               "</ogc:Not>"
                               "</ogc:Filter>" );
 
+  QTest::newRow( "in" ) << QStringLiteral( "A IN (10)" ) << QString(
+                          "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                          "<ogc:PropertyIsEqualTo>"
+                          "<ogc:PropertyName>A</ogc:PropertyName>"
+                          "<ogc:Literal>10</ogc:Literal>"
+                          "</ogc:PropertyIsEqualTo>"
+                          "</ogc:Filter>" );
+
+  QTest::newRow( "not in" ) << QStringLiteral( "A NOT IN (10)" ) << QString(
+                              "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                              "<ogc:Not>"
+                              "<ogc:PropertyIsEqualTo>"
+                              "<ogc:PropertyName>A</ogc:PropertyName>"
+                              "<ogc:Literal>10</ogc:Literal>"
+                              "</ogc:PropertyIsEqualTo>"
+                              "</ogc:Not>"
+                              "</ogc:Filter>" );
+
   QTest::newRow( "intersects_bbox" ) << QStringLiteral( "intersects_bbox($geometry, geomFromWKT('POINT (5 6)'))" ) << QString(
                                        "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\">"
                                        "<ogc:BBOX>"


### PR DESCRIPTION
On having only one entry in the comparison list `"zonentyp_kanton_code" IN ('111.0')` it created an element like this:
```
<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">
 <ogc:Literal>111.0</ogc:Literal>
</ogc:Filter>
```
So `PropertyIsEqualTo` has been missing. This is fixed here:
```
<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">
 <ogc:PropertyIsEqualTo>
  <ogc:PropertyName>zonentyp_kanton_code</ogc:PropertyName>
  <ogc:Literal>111.0</ogc:Literal>
 </ogc:PropertyIsEqualTo>
</ogc:Filter>
```

As well on NOT IN of a single item list the `NOT` has not been considered. This is fixed here as well.