### PR TITLE
Expose method for setting field comments in browser

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1373,6 +1373,7 @@ void QgsFieldItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
       const QString fieldName = fieldItem->field().name();
       const QString domainName = fieldItem->field().constraints().domainName();
       const QString alias = fieldItem->field().alias();
+      const QString comment = fieldItem->field().comment();
 
       // Check if it is supported
       QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( providerKey ) };
@@ -1505,6 +1506,34 @@ void QgsFieldItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
           } );
 
           menu->addAction( setAliasAction );
+        }
+
+        if ( conn && conn->capabilities2().testFlag( Qgis::DatabaseProviderConnectionCapability2::SetFieldComment ) )
+        {
+          QAction *setCommentAction = new QAction( tr( "Set Comment…" ), menu );
+          const QString itemName { item->name() };
+
+          connect( setCommentAction, &QAction::triggered, fieldsItem, [ md, fieldsItem, itemName, comment, context ]
+          {
+            bool ok = false;
+
+            const QString newComment = QInputDialog::getText( QgisApp::instance(), tr( "Set Comment For %1" ).arg( itemName ), tr( "Comment" ), QLineEdit::Normal, comment, &ok );
+            if ( ok && comment != newComment )
+            {
+              std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2 { static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( fieldsItem->connectionUri(), {} ) ) };
+              try
+              {
+                conn2->setFieldComment( itemName, fieldsItem->schema(), fieldsItem->tableName(), newComment );
+                fieldsItem->refresh();
+              }
+              catch ( const QgsProviderConnectionException &ex )
+              {
+                notify( tr( "Set Field Comment" ), tr( "Failed to set comment for field '%1': %2" ).arg( itemName, ex.what() ), context, Qgis::MessageLevel::Critical );
+              }
+            }
+          } );
+
+          menu->addAction( setCommentAction );
         }
 
         if ( conn && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::DeleteField ) )

--- a/src/core/browser/qgsfieldsitem.cpp
+++ b/src/core/browser/qgsfieldsitem.cpp
@@ -22,6 +22,7 @@
 #include "qgslogger.h"
 #include "qgsapplication.h"
 #include "qgsvectorlayer.h"
+#include "qgsfieldmodel.h"
 
 QgsFieldsItem::QgsFieldsItem( QgsDataItem *parent,
                               const QString &path,
@@ -157,20 +158,8 @@ QgsFieldItem::QgsFieldItem( QgsDataItem *parent, const QgsField &field )
     mCapabilities |= Qgis::BrowserItemCapability::Rename;
 
   setState( Qgis::BrowserItemState::Populated );
-  const auto constraints { field.constraints().constraints() };
-  QStringList constraintsText;
-  if ( constraints.testFlag( QgsFieldConstraints::Constraint::ConstraintNotNull ) )
-  {
-    constraintsText.push_back( tr( "NOT NULL" ) );
-  }
-  if ( constraints.testFlag( QgsFieldConstraints::Constraint::ConstraintUnique ) )
-  {
-    constraintsText.push_back( tr( "UNIQUE" ) );
-  }
-  if ( ! constraintsText.isEmpty() )
-  {
-    setToolTip( QStringLiteral( "<ul><li>%1</li></ul>" ).arg( constraintsText.join( QLatin1String( "</li><li>" ) ) ) );
-  }
+
+  setToolTip( QgsFieldModel::fieldToolTip( field ) );
 }
 
 QgsFieldItem::~QgsFieldItem()

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -453,6 +453,10 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
     {
       mCapabilities2 |= Qgis::DatabaseProviderConnectionCapability2::SetFieldAlias;
     }
+    if ( CSLFindString( papszTokens, "Comment" ) >= 0 )
+    {
+      mCapabilities2 |= Qgis::DatabaseProviderConnectionCapability2::SetFieldComment;
+    }
 #endif
 
     CSLDestroy( papszTokens );
@@ -1058,6 +1062,46 @@ void QgsOgrProviderConnection::setFieldAlias( const QString &fieldName, const QS
   ( void )tableName;
   ( void )alias;
   throw QgsProviderConnectionException( QObject::tr( "Setting field aliases for datasets requires GDAL 3.7 or later" ) );
+#endif
+}
+
+void QgsOgrProviderConnection::setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const
+{
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+  if ( ! schema.isEmpty() )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Schema is not supported by OGR, ignoring" ), QStringLiteral( "OGR" ), Qgis::MessageLevel::Info );
+  }
+
+  QString errCause;
+  QgsOgrLayerUniquePtr layer = QgsOgrProviderUtils::getLayer( uri(),
+                               true,
+                               QStringList(),
+                               tableName, errCause, true );
+  if ( !layer )
+  {
+    throw QgsProviderConnectionException( QObject::tr( "There was an error opening the dataset: %1" ).arg( errCause ) );
+  }
+
+  //type does not matter, it will not be used
+  gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( fieldName.toUtf8().constData(), OFTReal ) );
+  OGR_Fld_SetComment( fld.get(), comment.toUtf8().constData() );
+
+  const int fieldIndex = layer->GetLayerDefn().GetFieldIndex( fieldName.toUtf8().constData() );
+  if ( fieldIndex < 0 )
+  {
+    throw QgsProviderConnectionException( QObject::tr( "Could not set comment for %1 - field does not exist" ).arg( fieldName ) );
+  }
+  if ( layer->AlterFieldDefn( fieldIndex, fld.get(), ALTER_COMMENT_FLAG ) != OGRERR_NONE )
+  {
+    throw QgsProviderConnectionException( QObject::tr( "Could not set comment: %1" ).arg( CPLGetLastErrorMsg() ) );
+  }
+#else
+  ( void )fieldName;
+  ( void )schema;
+  ( void )tableName;
+  ( void )comment;
+  throw QgsProviderConnectionException( QObject::tr( "Setting field comments for datasets requires GDAL 3.7 or later" ) );
 #endif
 }
 

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -90,6 +90,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void addFieldDomain( const QgsFieldDomain &domain, const QString &schema ) const override;
     void renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const override;
     void setFieldAlias( const QString &fieldName, const QString &schema, const QString &tableName, const QString &alias ) const override;
+    void setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const override;
     SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
     QList< Qgis::RelationshipCardinality > supportedRelationshipCardinalities() const override;
     QList< Qgis::RelationshipStrength > supportedRelationshipStrengths() const override;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -827,6 +827,9 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
         OGR_Fld_SetAlternativeName( fld.get(), mCodec->fromUnicode( attrField.alias() ).constData() );
 #endif
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+        OGR_Fld_SetComment( fld.get(), mCodec->fromUnicode( attrField.comment() ).constData() );
+#endif
 
         // create the field
         QgsDebugMsgLevel( "creating field " + attrField.name() +

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -3309,6 +3309,50 @@ class PyQgsOGRProvider(unittest.TestCase):
             self.assertEqual(fields['my_field'].alias(), 'my alias')
             self.assertEqual(fields['my_field2'].alias(), 'my alias2')
 
+    @unittest.skipIf(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(3, 7, 0), "GDAL 3.7 required")
+    def test_provider_set_field_comment(self):
+        """
+        Test setting field comments via the vector data provider api
+        """
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tmpfile = os.path.join(temp_dir, 'test_gpkg.gpkg')
+
+            ok, err = metadata.createDatabase(tmpfile)
+            self.assertTrue(ok)
+            self.assertFalse(err)
+
+            conn = metadata.createConnection(tmpfile, {})
+            self.assertTrue(conn)
+
+            fields = QgsFields()
+            field = QgsField('my_field', QVariant.String)
+            field.setComment('my comment')
+            fields.append(field)
+            conn.createVectorTable('', 'test', fields, QgsWkbTypes.Point, QgsCoordinateReferenceSystem('EPSG:4326'), False, {})
+            layer = QgsVectorLayer(tmpfile + '|layername=test')
+            self.assertTrue(layer.isValid())
+
+            fields = layer.fields()
+            self.assertEqual(fields['my_field'].comment(), 'my comment')
+
+            self.assertTrue(
+                layer.dataProvider().attributeEditCapabilities() & Qgis.VectorDataProviderAttributeEditCapability.EditComment)
+
+            field2 = QgsField('my_field2', QVariant.String)
+            field2.setComment('my comment2')
+
+            self.assertTrue(layer.dataProvider().addAttributes([field2]))
+
+            del layer
+
+            layer = QgsVectorLayer(tmpfile + '|layername=test')
+            self.assertTrue(layer.isValid())
+
+            fields = layer.fields()
+            self.assertEqual(fields['my_field'].comment(), 'my comment')
+            self.assertEqual(fields['my_field2'].comment(), 'my comment2')
+
     @unittest.skipIf(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(3, 7, 0), "GDAL 3.7.0 required")
     def testFieldComment(self):
         """Test reading field comments"""


### PR DESCRIPTION
A companion to https://github.com/qgis/QGIS/pull/52644, allowing users to set field comments for compatible database fields via the QGIS browser.

Currently supported for OGR formats with field comment capabilites (eg GPKG, NetCDF, Geoparquet, ...)
