### PR TITLE
Fix equals test for QgsFieldItem

### DIFF
--- a/src/core/browser/qgsfieldsitem.cpp
+++ b/src/core/browser/qgsfieldsitem.cpp
@@ -224,6 +224,6 @@ bool QgsFieldItem::equal( const QgsDataItem *other )
   if ( !o )
     return false;
 
-  return ( mPath == o->mPath && mName == o->mName && mField == o->mField );
+  return ( mPath == o->mPath && mName == o->mName && mField == o->mField && mField.comment() == o->mField.comment() );
 }
 


### PR DESCRIPTION
We need to manually consider the comment here, as it's NOT considered as part of the QgsField equality operator
