### PR TITLE
A few fixes for PDAL provider

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
@@ -60,7 +60,7 @@ QgsPdalBoundaryAlgorithm *QgsPdalBoundaryAlgorithm::createInstance() const
 void QgsPdalBoundaryAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterPointCloudLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of cells used to calculate boundary" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 1 ) );
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of cells used to calculate boundary" ), QgsProcessingParameterNumber::Double, QVariant(), true, 1 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "THRESHOLD" ), QObject::tr( "Minimal number of points in a cell to consider cell occupied" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 1 ) );
   createCommonParameters();
   addParameter( new QgsProcessingParameterVectorDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Boundary" ), QgsProcessing::TypeVectorPolygon ) );
@@ -92,7 +92,7 @@ QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &pa
 
   if ( hasResolution )
   {
-    args << QStringLiteral( "--resolution=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "RESOLUTION" ), context ) );
+    args << QStringLiteral( "--resolution=%1" ).arg( parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context ) );
   }
 
   if ( hasThreshold )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -79,7 +79,8 @@ QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parame
                         QgsVectorFileWriter::supportedFormatExtensions()[0],
                         feedback );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args =  { QStringLiteral( "clip" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
@@ -63,7 +63,7 @@ void QgsPdalDensityAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of the density raster" ), QgsProcessingParameterNumber::Integer, 1, false, 1 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TILE_SIZE" ), QObject::tr( "Tile size for parallel runs" ), QgsProcessingParameterNumber::Integer, 1000, false, 1 ) );
 
-  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
+  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
   paramOriginX->setFlags( paramOriginX->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginX.release() );
   std::unique_ptr< QgsProcessingParameterNumber > paramOriginY = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_Y" ), QObject::tr( "Y origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
@@ -94,7 +94,7 @@ QStringList QgsPdalDensityAlgorithm::createArgumentLists( const QVariantMap &par
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
-  int resolution = parameterAsInt( parameters, QStringLiteral( "RESOLUTION" ), context );
+  int resolution = parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context );
   int tileSize = parameterAsInt( parameters, QStringLiteral( "TILE_SIZE" ), context );
 
   QStringList args = { QStringLiteral( "density" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -64,7 +64,7 @@ void QgsPdalExportRasterAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of the density raster" ), QgsProcessingParameterNumber::Integer, 1, false, 1 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TILE_SIZE" ), QObject::tr( "Tile size for parallel runs" ), QgsProcessingParameterNumber::Integer, 1000, false, 1 ) );
 
-  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
+  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
   paramOriginX->setFlags( paramOriginX->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginX.release() );
   std::unique_ptr< QgsProcessingParameterNumber > paramOriginY = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_Y" ), QObject::tr( "Y origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
@@ -96,7 +96,7 @@ QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   const QString attribute = parameterAsString( parameters, QStringLiteral( "ATTRIBUTE" ), context );
-  const int resolution = parameterAsInt( parameters, QStringLiteral( "RESOLUTION" ), context );
+  const int resolution = parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context );
   const int tileSize = parameterAsInt( parameters, QStringLiteral( "TILE_SIZE" ), context );
 
   QStringList args = { QStringLiteral( "to_raster" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -63,7 +63,7 @@ void QgsPdalExportRasterTinAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of the density raster" ), QgsProcessingParameterNumber::Integer, 1, false, 1 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TILE_SIZE" ), QObject::tr( "Tile size for parallel runs" ), QgsProcessingParameterNumber::Integer, 1000, false, 1 ) );
 
-  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
+  std::unique_ptr< QgsProcessingParameterNumber > paramOriginX = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
   paramOriginX->setFlags( paramOriginX->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( paramOriginX.release() );
   std::unique_ptr< QgsProcessingParameterNumber > paramOriginY = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ORIGIN_Y" ), QObject::tr( "Y origin of a tile for parallel runs" ), QgsProcessingParameterNumber::Integer, QVariant(), true, 0 );
@@ -94,7 +94,7 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
-  int resolution = parameterAsInt( parameters, QStringLiteral( "RESOLUTION" ), context );
+  int resolution = parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context );
   int tileSize = parameterAsInt( parameters, QStringLiteral( "TILE_SIZE" ), context );
 
   QStringList args = { QStringLiteral( "to_raster_tin" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -73,7 +73,8 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = { QStringLiteral( "translate" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthin.cpp
@@ -74,7 +74,8 @@ QStringList QgsPdalThinAlgorithm::createArgumentLists( const QVariantMap &parame
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   int mode = parameterAsInt( parameters, QStringLiteral( "MODE" ), context );

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -99,6 +99,27 @@ void QgsPdalAlgorithmBase::applyThreadsParameter( QStringList &arguments )
   }
 }
 
+QString QgsPdalAlgorithmBase::fixOutputFileName( const QString &inputFileName, const QString &outputFileName, QgsProcessingContext &context )
+{
+  bool inputIsVpc = inputFileName.endsWith( QStringLiteral( ".vpc" ), Qt::CaseInsensitive );
+  bool isTempOutput = outputFileName.startsWith( QgsProcessingUtils::tempFolder(), Qt::CaseInsensitive );
+  if ( inputIsVpc && isTempOutput )
+  {
+    QFileInfo fi( outputFileName );
+    QString newFileName = fi.path() + '/' + fi.completeBaseName() + QStringLiteral( ".vpc" );
+
+    if ( context.willLoadLayerOnCompletion( outputFileName ) )
+    {
+      QMap< QString, QgsProcessingContext::LayerDetails > layersToLoad = context.layersToLoadOnCompletion();
+      QgsProcessingContext::LayerDetails details = layersToLoad.take( outputFileName );
+      layersToLoad[ newFileName ] = details;
+      context.setLayersToLoadOnCompletion( layersToLoad );
+    }
+    return newFileName;
+  }
+  return outputFileName;
+}
+
 QStringList QgsPdalAlgorithmBase::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   Q_UNUSED( parameters );

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -58,6 +58,17 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
     void applyThreadsParameter( QStringList &arguments );
 
     /**
+     * "Fixes" output file name by changing suffix to .vpc if input file
+     * is a VPC and output is a temporary output.
+     *
+     * This is necessary as pdal_wrench at the moment can create only VPC
+     * output if input file is a VPC. We automatically adjust output file
+     * extension for temporary outputs to provide better UX. For normal outputs
+     * user will see a error if output files is not a VPC.
+     */
+    QString fixOutputFileName( const QString &inputFileName, const QString &outputFileName, QgsProcessingContext &context );
+
+    /**
      * Returns path to the pdal_wrench executable binary.
      */
     QString wrenchExecutableBinary() const;

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -83,7 +83,7 @@ QStringList QgsPdalAlgorithms::supportedOutputRasterLayerExtensions() const
 
 QStringList QgsPdalAlgorithms::supportedOutputPointCloudLayerExtensions() const
 {
-  return QStringList() << QStringLiteral( "las" ) << QStringLiteral( "laz" ) << QStringLiteral( "copc.laz" );
+  return QStringList() << QStringLiteral( "las" ) << QStringLiteral( "laz" ) << QStringLiteral( "copc.laz" ) << QStringLiteral( "vpc" );
 }
 
 void QgsPdalAlgorithms::loadAlgorithms()


### PR DESCRIPTION
## Description

Some fixes for Processing PDAL provider:
 - resolution parameter in export raster, density and boundary algorithms accepts float values
 - added VPC as a supported output format and use point cloud output in the build VPC algorithm, so result can be added to canvas
 - added special handling of temporary output format in algorithms that output point cloud files when input is a VPC. This is needed because right now `pdal_wrench` can't create las/laz/copc files from vpc files. As a result if input is a VPC and a temporary output is used algorithm will fail. This workaround will be removed when `pdal_wrench` limitation will be addressed.