### PR TITLE
Fix QgsDatabaseTableComboBox::setTable when table empty

### DIFF
--- a/src/gui/qgsdatabasetablecombobox.cpp
+++ b/src/gui/qgsdatabasetablecombobox.cpp
@@ -154,6 +154,7 @@ void QgsDatabaseTableComboBox::setSchema( const QString &schema )
     const QString oldTable = currentTable();
     QgsDatabaseTableModel *oldModel = mModel;
     mModel = new QgsDatabaseTableModel( mProvider, mConnection, mSchema, this );
+    mModel->setAllowEmptyTable( mAllowEmpty );
     mSortModel->setSourceModel( mModel );
     oldModel->deleteLater();
     setTable( oldTable );


### PR DESCRIPTION
- Partially addresses #52745


## Description

Fix QgsDatabaseTableComboBox::setSchema that dropped the allowEmpty flag