### PR TITLE
Fix merge features default value clause used as value

### DIFF
--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -233,7 +233,13 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
   {
     int idx = mTableWidget->horizontalHeaderItem( j )->data( FieldIndex ).toInt();
     bool setToManual = false;
-    if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
+
+    // For the Id use the target feature
+    if ( j == 0 )
+    {
+      mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, mTargetFeatureId );
+    }
+    else if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
     {
       mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, mVectorLayer->dataProvider()->defaultValueClause( idx ) );
       setToManual = true;

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -105,9 +105,6 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &featur
       break;
   }
 
-  if ( ! mFeatureList.isEmpty() )
-    mTargetFeatureId = mFeatureList.first().id();
-
   connect( mSkipAllButton, &QAbstractButton::clicked, this, &QgsMergeAttributesDialog::setAllToSkip );
   connect( mTableWidget, &QTableWidget::cellChanged, this, &QgsMergeAttributesDialog::tableWidgetCellChanged );
 
@@ -234,12 +231,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
     int idx = mTableWidget->horizontalHeaderItem( j )->data( FieldIndex ).toInt();
     bool setToManual = false;
 
-    // For the Id use the target feature
-    if ( j == 0 )
-    {
-      mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, mTargetFeatureId );
-    }
-    else if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
+    if ( !mVectorLayer->dataProvider()->defaultValueClause( idx ).isEmpty() )
     {
       mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, mVectorLayer->dataProvider()->defaultValueClause( idx ) );
       setToManual = true;

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -910,10 +910,18 @@ bool QgsVectorLayerEditUtils::mergeFeatures( const QgsFeatureId &targetFeatureId
       mLayer->deleteFeature( *feature_it );
   }
 
-  // Modify merge feature
+  // Modify target feature or create a new one if invalid
   QgsGeometry mergeGeometry = unionGeometry;
-  mLayer->changeGeometry( targetFeatureId, mergeGeometry );
-  mLayer->changeAttributeValues( targetFeatureId, newAttributes );
+  if ( targetFeatureId == FID_NULL )
+  {
+    QgsFeature mergeFeature = QgsVectorLayerUtils::createFeature( mLayer, mergeGeometry, newAttributes );
+    mLayer->addFeature( mergeFeature );
+  }
+  else
+  {
+    mLayer->changeGeometry( targetFeatureId, mergeGeometry );
+    mLayer->changeAttributeValues( targetFeatureId, newAttributes );
+  }
 
   mLayer->endEditCommand();
 

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -85,8 +85,8 @@ class TestQgsMergeattributesDialog : public QObject
       QgsMergeAttributesDialog dialog( QgsFeatureList() << f1 << f2, &layer, mQgisApp->mapCanvas() );
 
       // At beginnning the first feature of the list is the target
-      QCOMPARE( dialog.targetFeatureId(), f1.id() );
-      QCOMPARE( dialog.mergedAttributes().first(), f1.id() );
+      QCOMPARE( dialog.targetFeatureId(), FID_NULL );
+      QCOMPARE( dialog.mergedAttributes().first(), "Autogenerate" );
 
       // Check after taking feature with largest geometry
       QVERIFY( QMetaObject::invokeMethod( &dialog, "mFromLargestPushButton_clicked" ) );

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -86,10 +86,12 @@ class TestQgsMergeattributesDialog : public QObject
 
       // At beginnning the first feature of the list is the target
       QCOMPARE( dialog.targetFeatureId(), f1.id() );
+      QCOMPARE( dialog.mergedAttributes().first(), f1.id() );
 
       // Check after taking feature with largest geometry
       QVERIFY( QMetaObject::invokeMethod( &dialog, "mFromLargestPushButton_clicked" ) );
       QCOMPARE( dialog.targetFeatureId(), f2.id() );
+      QCOMPARE( dialog.mergedAttributes().first(), f2.id() );
     }
 };
 


### PR DESCRIPTION
During the move of merge logic to QgsVectorLayerEditUtils I changed the merge behavior so that the merge feature where always merged into an existing one.
This is causing problems for fields with default value clause, which is not calculated when the feature is already existing.
So would bring back the old behavior. When merging, create a new feature if no target feature was explicitly set with the buttons "Take attributes from selected feature" or "Take attributes from feature with the largest area/longest line".

Fix #52738
Fix #52726
Fix #50518