### PR TITLE
[Feature] [OAPIF] Implements server-side filtering using Part 1 or Part 3

### DIFF
--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -28,12 +28,14 @@ set(WFS_SRCS
   oapif/qgsoapifcollection.cpp
   oapif/qgsoapifconformancerequest.cpp
   oapif/qgsoapifcreatefeaturerequest.cpp
+  oapif/qgsoapifcql2textexpressioncompiler.cpp
   oapif/qgsoapifdeletefeaturerequest.cpp
   oapif/qgsoapifpatchfeaturerequest.cpp
   oapif/qgsoapifputfeaturerequest.cpp
   oapif/qgsoapifitemsrequest.cpp
   oapif/qgsoapifoptionsrequest.cpp
   oapif/qgsoapifprovider.cpp
+  oapif/qgsoapifqueryablesrequest.cpp
   oapif/qgsoapifutils.cpp
 )
 

--- a/src/providers/wfs/oapif/qgsoapifapirequest.h
+++ b/src/providers/wfs/oapif/qgsoapifapirequest.h
@@ -52,6 +52,23 @@ class QgsOapifApiRequest : public QgsBaseNetworkRequest
     //! Return metadata (mostly contact info)
     const QgsAbstractMetadataBase &metadata() const { return mMetadata; }
 
+    //! Describes a simple queryable parameter.
+    struct SimpleQueryable
+    {
+      // type as in a JSON schema: "string", "integer", "number", etc.
+      QString mType;
+    };
+
+    //! Describes the properties of a collection.
+    struct CollectionProperties
+    {
+      // Map of simple queryables items (that is as query parameters). The key of the map is a queryable name.
+      QMap<QString, SimpleQueryable> mSimpleQueryables;
+    };
+
+    //! Get collection properties. The key of the map is a collection name.
+    const QMap<QString, CollectionProperties> &collectionProperties() const { return mCollectionProperties; }
+
   signals:
     //! emitted when the capabilities have been fully parsed, or an error occurred */
     void gotResponse();
@@ -70,6 +87,8 @@ class QgsOapifApiRequest : public QgsBaseNetworkRequest
     int mDefaultLimit = -1;
 
     QgsLayerMetadata mMetadata;
+
+    QMap<QString, CollectionProperties> mCollectionProperties;
 
     ApplicationLevelError mAppLevelError = ApplicationLevelError::NoError;
 

--- a/src/providers/wfs/oapif/qgsoapifcql2textexpressioncompiler.cpp
+++ b/src/providers/wfs/oapif/qgsoapifcql2textexpressioncompiler.cpp
@@ -1,0 +1,578 @@
+/***************************************************************************
+    qgsoapifcql2textexpressioncompiler.cpp
+    --------------------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsoapifcql2textexpressioncompiler.h"
+
+#include "qgsexpressionnodeimpl.h"
+#include "qgsexpressionfunction.h"
+#include "qgsexpression.h"
+#include "qgsgeometry.h"
+#include "qgslogger.h"
+#include "qgsvariantutils.h"
+
+QgsOapifCql2TextExpressionCompiler::QgsOapifCql2TextExpressionCompiler(
+  const QMap<QString, QgsOapifQueryablesRequest::Queryable> &queryables,
+  bool supportsLikeBetweenIn,
+  bool supportsCaseI,
+  bool supportsBasicSpatialOperators,
+  bool invertAxisOrientation ):
+  mQueryables( queryables ),
+  mSupportsLikeBetweenIn( supportsLikeBetweenIn ),
+  mSupportsCaseI( supportsCaseI ),
+  mSupportsBasicSpatialOperators( supportsBasicSpatialOperators ),
+  mInvertAxisOrientation( invertAxisOrientation )
+{
+}
+
+QgsOapifCql2TextExpressionCompiler::Result QgsOapifCql2TextExpressionCompiler::compile( const QgsExpression *exp )
+{
+  if ( exp->rootNode() )
+    return compileNode( exp->rootNode(), mResult );
+  else
+    return Fail;
+}
+
+QString QgsOapifCql2TextExpressionCompiler::literalValue( const QVariant &value ) const
+{
+  if ( QgsVariantUtils::isNull( value ) )
+    return QStringLiteral( "NULL" );
+
+  switch ( value.type() )
+  {
+    case QVariant::Int:
+    case QVariant::LongLong:
+    case QVariant::Double:
+      return value.toString();
+
+    case QVariant::Bool:
+      return value.toBool() ? QStringLiteral( "TRUE" ) : QStringLiteral( "FALSE" );
+
+    case QVariant::DateTime:
+      return value.toDateTime().toOffsetFromUtc( 0 ).toString( Qt::ISODateWithMs ).prepend( "TIMESTAMP('" ).append( "')" );
+
+    case QVariant::Date:
+      return value.toDate().toString( Qt::ISODate ).prepend( "DATE('" ).append( "')" );
+
+    case QVariant::String:
+    default:
+      QString v = value.toString();
+      v.replace( '\'', QLatin1String( "''" ) );
+      return v.replace( '\\', QLatin1String( "\\\\" ) ).prepend( '\'' ).append( '\'' );
+  }
+}
+
+QString QgsOapifCql2TextExpressionCompiler::quotedIdentifier( const QString &identifier ) const
+{
+  bool isAlphaNumOnly = true;
+  for ( QChar ch : identifier )
+  {
+    if ( !ch.isDigit() && !ch.isLetter() )
+    {
+      isAlphaNumOnly = false;
+      break;
+    }
+  }
+  if ( isAlphaNumOnly )
+  {
+    return identifier;
+  }
+  QString quoted = identifier;
+  quoted.replace( '"', QLatin1String( "\"\"" ) );
+  quoted = quoted.prepend( '\"' ).append( '\"' );
+  return quoted;
+}
+
+static bool isGeometryColumn( const QgsExpressionNode *node )
+{
+  if ( node->nodeType() != QgsExpressionNode::ntFunction )
+    return false;
+
+  const QgsExpressionNodeFunction *fn = static_cast<const QgsExpressionNodeFunction *>( node );
+  QgsExpressionFunction *fd = QgsExpression::Functions()[fn->fnIndex()];
+  return fd->name() == QLatin1String( "$geometry" );
+}
+
+static QgsGeometry geometryFromConstExpr( const QgsExpressionNode *node )
+{
+  // Right now we support only geomFromWKT(' ..... ')
+  // Ideally we should support any constant sub-expression (not dependent on feature's geometry or attributes)
+
+  if ( node->nodeType() == QgsExpressionNode::ntFunction )
+  {
+    const QgsExpressionNodeFunction *fnNode = static_cast<const QgsExpressionNodeFunction *>( node );
+    QgsExpressionFunction *fnDef = QgsExpression::Functions()[fnNode->fnIndex()];
+    if ( fnDef->name() == QLatin1String( "geom_from_wkt" ) )
+    {
+      const QList<QgsExpressionNode *> &args = fnNode->args()->list();
+      if ( args[0]->nodeType() == QgsExpressionNode::ntLiteral )
+      {
+        const QString wkt = static_cast<const QgsExpressionNodeLiteral *>( args[0] )->value().toString();
+        return QgsGeometry::fromWkt( wkt );
+      }
+    }
+  }
+  return QgsGeometry();
+}
+
+QgsOapifCql2TextExpressionCompiler::Result QgsOapifCql2TextExpressionCompiler::compileNodeFunction( const QgsExpressionNodeFunction *node, QString &result )
+{
+  QgsExpressionFunction *fd = QgsExpression::Functions()[node->fnIndex()];
+
+  if ( fd->name() == QLatin1String( "intersects_bbox" ) && mSupportsBasicSpatialOperators )
+  {
+    QList<QgsExpressionNode *> argNodes = node->args()->list();
+    Q_ASSERT( argNodes.count() == 2 ); // binary spatial ops must have two args
+
+    const QgsGeometry geom = geometryFromConstExpr( argNodes[1] );
+    if ( !geom.isNull() && isGeometryColumn( argNodes[0] ) )
+    {
+      QString geometryColumn;
+      for ( const auto &kv : mQueryables.toStdMap() )
+      {
+        if ( kv.second.mIsGeometry )
+        {
+          geometryColumn = kv.first;
+          break;
+        }
+      }
+      if ( geometryColumn.isEmpty() )
+      {
+        return Fail;
+      }
+
+      QgsRectangle rect = geom.boundingBox();
+      if ( mInvertAxisOrientation )
+        rect.invert();
+      QString coordString;
+      coordString += qgsDoubleToString( rect.xMinimum() );
+      coordString += ',';
+      coordString += qgsDoubleToString( rect.yMinimum() );
+      coordString += ',';
+      coordString += qgsDoubleToString( rect.xMaximum() );
+      coordString += ',';
+      coordString += qgsDoubleToString( rect.yMaximum() );
+      result = QStringLiteral( "S_INTERSECTS(" );
+      result += quotedIdentifier( geometryColumn );
+      result += QStringLiteral( ",BBOX(" );
+      result += coordString;
+      result += QStringLiteral( "))" );
+      mGeometryLiteralUsed = true;
+      return Complete;
+    }
+  }
+
+  if ( fd->name() == QLatin1String( "intersects" ) && mSupportsBasicSpatialOperators )
+  {
+    QList<QgsExpressionNode *> argNodes = node->args()->list();
+    Q_ASSERT( argNodes.count() == 2 ); // binary spatial ops must have two args
+
+    const QgsGeometry geom = geometryFromConstExpr( argNodes[1] );
+    if ( !geom.isNull() && geom.wkbType() == Qgis::WkbType::Point && isGeometryColumn( argNodes[0] ) )
+    {
+      QString geometryColumn;
+      for ( const auto &kv : mQueryables.toStdMap() )
+      {
+        if ( kv.second.mIsGeometry )
+        {
+          geometryColumn = kv.first;
+          break;
+        }
+      }
+      if ( geometryColumn.isEmpty() )
+      {
+        return Fail;
+      }
+
+      const QgsPoint *point = static_cast<const QgsPoint *>( geom.constGet() );
+      QString coordString;
+      coordString += qgsDoubleToString( mInvertAxisOrientation ? point->y() : point->x() );
+      coordString += ' ';
+      coordString += qgsDoubleToString( mInvertAxisOrientation ? point->x() : point->y() );
+      result = QStringLiteral( "S_INTERSECTS(" );
+      result += quotedIdentifier( geometryColumn );
+      result += QStringLiteral( ",POINT(" );
+      result += coordString;
+      result += QStringLiteral( "))" );
+      mGeometryLiteralUsed = true;
+      return Complete;
+    }
+  }
+
+  if ( fd->name() == QLatin1String( "make_datetime" ) )
+  {
+    QList<QgsExpressionNode *> argNodes = node->args()->list();
+    if ( argNodes.count() == 6 )
+    {
+      std::vector<int> values;
+      for ( int i = 0; i < 6; ++i )
+      {
+        if ( argNodes[i]->nodeType() != QgsExpressionNode::ntLiteral )
+          return Fail;
+        const QgsExpressionNodeLiteral *n = static_cast<const QgsExpressionNodeLiteral *>( argNodes[i] );
+        if ( n->value().type() != QVariant::Int )
+          return Fail;
+        values.push_back( n->value().toInt() );
+      }
+      result = QDateTime( QDate( values[0], values[1], values[2] ),
+                          QTime( values[3], values[4], values[5] ),
+                          Qt::UTC ).toString( Qt::ISODateWithMs ).prepend( "TIMESTAMP('" ).append( "')" );
+      return Complete;
+    }
+  }
+
+  if ( fd->name() == QLatin1String( "make_date" ) )
+  {
+    QList<QgsExpressionNode *> argNodes = node->args()->list();
+    if ( argNodes.count() == 3 )
+    {
+      std::vector<int> values;
+      for ( int i = 0; i < 3; ++i )
+      {
+        if ( argNodes[i]->nodeType() != QgsExpressionNode::ntLiteral )
+          return Fail;
+        const QgsExpressionNodeLiteral *n = static_cast<const QgsExpressionNodeLiteral *>( argNodes[i] );
+        if ( n->value().type() != QVariant::Int )
+          return Fail;
+        values.push_back( n->value().toInt() );
+      }
+      result = QDate( values[0], values[1], values[2] ).toString( Qt::ISODate ).prepend( "DATE('" ).append( "')" );
+      return Complete;
+    }
+  }
+  return Fail;
+}
+
+QgsOapifCql2TextExpressionCompiler::Result QgsOapifCql2TextExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
+{
+  if ( node->hasCachedStaticValue() )
+  {
+    result = literalValue( node->cachedStaticValue() );
+    return Complete;
+  }
+
+  switch ( node->nodeType() )
+  {
+    case QgsExpressionNode::ntUnaryOperator:
+    {
+      const QgsExpressionNodeUnaryOperator *n = static_cast<const QgsExpressionNodeUnaryOperator *>( node );
+      switch ( n->op() )
+      {
+        case QgsExpressionNodeUnaryOperator::uoNot:
+        {
+          QString right;
+          if ( compileNode( n->operand(), right ) == Complete )
+          {
+            result = "(NOT (" + right + "))";
+            return Complete;
+          }
+
+          return Fail;
+        }
+
+        case QgsExpressionNodeUnaryOperator::uoMinus:
+        {
+          QString right;
+          if ( compileNode( n->operand(), right ) == Complete )
+          {
+            result = "( - (" + right + "))";
+            return Complete;
+          }
+
+          return Fail;
+        }
+      }
+
+      break;
+    }
+
+    case QgsExpressionNodeBinaryOperator::ntBinaryOperator:
+    {
+      const QgsExpressionNodeBinaryOperator *n = static_cast<const QgsExpressionNodeBinaryOperator *>( node );
+
+      QString op;
+      bool isCaseI = false;
+      switch ( n->op() )
+      {
+        case QgsExpressionNodeBinaryOperator::boEQ:
+          op = QStringLiteral( "=" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boGE:
+          op = QStringLiteral( ">=" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boGT:
+          op = QStringLiteral( ">" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boLE:
+          op = QStringLiteral( "<=" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boLT:
+          op = QStringLiteral( "<" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boIs:
+          op = QStringLiteral( "IS" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boIsNot:
+          op = QStringLiteral( "IS NOT" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boLike:
+          if ( !mSupportsLikeBetweenIn )
+            return Fail;
+          op = QStringLiteral( "LIKE" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boILike:
+          if ( !mSupportsLikeBetweenIn )
+            return Fail;
+          if ( !mSupportsCaseI )
+            return Fail;
+          isCaseI = true;
+          op = QStringLiteral( "LIKE" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boNotLike:
+          if ( !mSupportsLikeBetweenIn )
+            return Fail;
+          op = QStringLiteral( "NOT LIKE" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boNotILike:
+          if ( !mSupportsLikeBetweenIn )
+            return Fail;
+          if ( !mSupportsCaseI )
+            return Fail;
+          isCaseI = true;
+          op = QStringLiteral( "NOT LIKE" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boOr:
+          op = QStringLiteral( "OR" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boAnd:
+          op = QStringLiteral( "AND" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boNE:
+          op = QStringLiteral( "<>" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boMul:
+          op = QStringLiteral( "*" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boPlus:
+          op = QStringLiteral( "+" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boMinus:
+          op = QStringLiteral( "-" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boDiv:
+          op = QStringLiteral( "/" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boMod:
+          op = QStringLiteral( "%" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boConcat:
+          return Fail;
+
+        case QgsExpressionNodeBinaryOperator::boIntDiv:
+          op = QStringLiteral( "/" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boPow:
+          op = QStringLiteral( "^" );
+          break;
+
+        case QgsExpressionNodeBinaryOperator::boRegexp:
+          return Fail;
+      }
+
+      QString left;
+      const Result lr( compileNode( n->opLeft(), left ) );
+
+      QString right;
+      // Special case to handle "datetimefield OP 'YYYY-MM-DDTHH:MM:SS'"
+      // or "datefield OP 'YYYY-MM-DD'"
+      // that can be suggested by the query builder
+      if ( n->opLeft()->nodeType() == QgsExpressionNode::ntColumnRef &&
+           n->opRight()->nodeType() == QgsExpressionNode::ntLiteral )
+      {
+        const QgsExpressionNodeColumnRef *nLeft = static_cast<const QgsExpressionNodeColumnRef *>( n->opLeft() );
+        const QgsExpressionNodeLiteral *nRight = static_cast<const QgsExpressionNodeLiteral *>( n->opRight() );
+        if ( nRight->value().type() == QVariant::String )
+        {
+          QString columnFormat;
+          for ( const auto &kv : mQueryables.toStdMap() )
+          {
+            if ( kv.first.compare( nLeft->name(), Qt::CaseInsensitive ) == 0 )
+            {
+              columnFormat = kv.second.mFormat;
+              break;
+            }
+          }
+          if ( columnFormat == "date-time" )
+          {
+            QDateTime dt = QDateTime::fromString( nRight->value().toString(), Qt::ISODateWithMs );
+            if ( dt.isValid() )
+            {
+              right = literalValue( QVariant( dt ) );
+            }
+          }
+          else if ( columnFormat == "date" )
+          {
+            QDate date = QDate::fromString( nRight->value().toString(), Qt::ISODate );
+            if ( date.isValid() )
+            {
+              right = literalValue( QVariant( date ) );
+            }
+          }
+        }
+      }
+
+      const Result rr( right.isEmpty() ? compileNode( n->opRight(), right ) : Complete );
+
+      if ( lr != Complete )
+      {
+        if ( n->op() == QgsExpressionNodeBinaryOperator::boAnd )
+        {
+          result = right;
+          return rr != Fail ? Partial : Fail;
+        }
+        return Fail;
+      }
+
+      if ( rr != Complete )
+      {
+        if ( n->op() == QgsExpressionNodeBinaryOperator::boAnd )
+        {
+          result = left;
+          return lr != Fail ? Partial : Fail;
+        }
+        return Fail;
+      }
+
+      if ( isCaseI )
+        result = "(CASEI(" + left + ") " + op + " CASEI(" + right + "))";
+      else
+        result = '(' + left + ' ' + op + ' ' + right + ')';
+      return Complete;
+    }
+
+    case QgsExpressionNode::ntBetweenOperator:
+    {
+      if ( !mSupportsLikeBetweenIn )
+        return Fail;
+      const QgsExpressionNodeBetweenOperator *n = static_cast<const QgsExpressionNodeBetweenOperator *>( node );
+      QString res;
+
+      if ( compileNode( n->node(), res ) != Complete )
+        return Fail;
+
+      QString s;
+      if ( compileNode( n->lowerBound(), s ) != Complete )
+        return Fail;
+
+      res.append( n->negate() ? QStringLiteral( " NOT BETWEEN %1" ).arg( s ) : QStringLiteral( " BETWEEN %1" ).arg( s ) );
+
+      if ( compileNode( n->higherBound(), s ) != Complete )
+        return Fail;
+
+      res.append( QStringLiteral( " AND %1" ).arg( s ) );
+      result = res;
+      return Complete;
+    }
+
+    case QgsExpressionNode::ntLiteral:
+    {
+      const QgsExpressionNodeLiteral *n = static_cast<const QgsExpressionNodeLiteral *>( node );
+      result = literalValue( n->value() );
+      return Complete;
+    }
+
+    case QgsExpressionNode::ntColumnRef:
+    {
+      const QgsExpressionNodeColumnRef *n = static_cast<const QgsExpressionNodeColumnRef *>( node );
+
+      // QGIS expressions don't care about case sensitive field naming, so we match case insensitively here to the
+      // layer's fields and then retrieve the actual case of the field name for use in the compilation
+      QString columnName;
+      for ( const auto &kv : mQueryables.toStdMap() )
+      {
+        if ( kv.first.compare( n->name(), Qt::CaseInsensitive ) == 0 )
+        {
+          columnName = kv.first;
+          break;
+        }
+      }
+      if ( columnName.isEmpty() )
+      {
+        QgsDebugMsgLevel( QStringLiteral( "%1 is not a queryable" ).arg( n->name() ), 4 );
+        return Fail;
+      }
+
+      result = quotedIdentifier( columnName );
+
+      return Complete;
+    }
+
+    case QgsExpressionNode::ntInOperator:
+    {
+      if ( !mSupportsLikeBetweenIn )
+        return Fail;
+      const QgsExpressionNodeInOperator *n = static_cast<const QgsExpressionNodeInOperator *>( node );
+      QStringList list;
+
+      const auto constList = n->list()->list();
+      for ( const QgsExpressionNode *ln : constList )
+      {
+        QString s;
+        if ( compileNode( ln, s ) != Complete )
+          return Fail;
+        list << s;
+      }
+
+      QString nd;
+      if ( compileNode( n->node(), nd ) != Complete )
+        return Fail;
+
+      result = QStringLiteral( "%1 %2IN (%3)" ).arg( nd, n->isNotIn() ? QStringLiteral( "NOT " ) : QString(), list.join( ',' ) );
+      return Complete;
+    }
+
+    case QgsExpressionNode::ntFunction:
+    {
+      const QgsExpressionNodeFunction *n = static_cast<const QgsExpressionNodeFunction *>( node );
+      return compileNodeFunction( n, result );
+    }
+
+    case QgsExpressionNode::ntCondition:
+    case QgsExpressionNode::ntIndexOperator:
+      break;
+  }
+
+  return Fail;
+}
+

--- a/src/providers/wfs/oapif/qgsoapifcql2textexpressioncompiler.h
+++ b/src/providers/wfs/oapif/qgsoapifcql2textexpressioncompiler.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+    qgsoapifcql2textexpressioncompiler.h
+    ------------------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFCQL2TEXTEXPRESSIONCOMPILER_H
+#define QGSOAPIFCQL2TEXTEXPRESSIONCOMPILER_H
+
+#include "qgis_core.h"
+#include "qgsfields.h"
+#include "qgsexpressionnodeimpl.h"
+
+#include "qgsoapifqueryablesrequest.h"
+
+class QgsExpression;
+class QgsExpressionNode;
+
+/**
+ * Compiles a QgsExpression to a CQL2-Text expression:
+ * cf https://docs.ogc.org/DRAFTS/21-065.html
+ */
+class QgsOapifCql2TextExpressionCompiler
+{
+  public:
+    QgsOapifCql2TextExpressionCompiler(
+      const QMap<QString, QgsOapifQueryablesRequest::Queryable> &queryables,
+      bool supportsLikeBetweenIn,
+      bool supportsCaseI,
+      bool supportsBasicSpatialOperators,
+      bool invertAxisOrientation );
+
+    //! Possible results from expression compilation
+    enum Result
+    {
+      Complete, //!< Expression was successfully compiled and can be completely delegated to provider
+      Partial, //!< Expression was partially compiled, but provider will return extra records and results must be double-checked using QGIS' expression engine
+      Fail //!< Provider cannot handle expression
+    };
+
+    /**
+     * Compiles an expression and returns the result of the compilation.
+     */
+    Result compile( const QgsExpression *exp );
+
+    /**
+     * Returns the compiled expression string for use by the provider.
+     */
+    QString result() const { return mResult; }
+
+    /**
+     * Returns whether a geometry literal has been used (which might require filter-crs to be emitted)
+     */
+    bool geometryLiteralUsed() const { return mGeometryLiteralUsed; }
+
+  private:
+
+    Result compileNode( const QgsExpressionNode *node, QString &result );
+
+    Result compileNodeFunction( const QgsExpressionNodeFunction *n, QString &result );
+
+    QString literalValue( const QVariant &value ) const;
+
+    QString quotedIdentifier( const QString &identifier ) const;
+
+    // Input
+    const QMap<QString, QgsOapifQueryablesRequest::Queryable> &mQueryables;
+    const bool mSupportsLikeBetweenIn;
+    const bool mSupportsCaseI;
+    const bool mSupportsBasicSpatialOperators;
+    const bool mInvertAxisOrientation;
+
+    // Output
+    QString mResult;
+    bool mGeometryLiteralUsed = false;
+};
+
+#endif // QGSOAPIFCQL2TEXTEXPRESSIONCOMPILER_H

--- a/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
@@ -38,7 +38,7 @@ QgsOapifItemsRequest::QgsOapifItemsRequest( const QgsDataSourceUri &baseUri, con
 
 bool QgsOapifItemsRequest::request( bool synchronous, bool forceRefresh )
 {
-  if ( !sendGET( QUrl( mUrl ), QString( "application/geo+json, application/json" ), synchronous, forceRefresh ) )
+  if ( !sendGET( QUrl::fromEncoded( mUrl.toLatin1() ), QString( "application/geo+json, application/json" ), synchronous, forceRefresh ) )
   {
     emit gotResponse();
     return false;

--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -1101,11 +1101,11 @@ bool QgsOapifSharedData::computeServerFilter( QString &errorMsg )
   {
     if ( mFilterTranslationState == QgsOapifProvider::FilterTranslationState::PARTIAL )
     {
-      QgsDebugMsg( QStringLiteral( "Part of the filter will be evaluated on client-side: %1" ).arg( mClientSideFilterExpression ) );
+      QgsDebugMsgLevel( QStringLiteral( "Part of the filter will be evaluated on client-side: %1" ).arg( mClientSideFilterExpression ), 2 );
     }
     else if ( mFilterTranslationState == QgsOapifProvider::FilterTranslationState::FULLY_CLIENT )
     {
-      QgsDebugMsg( "Whole filter will be evaluated on client-side" );
+      QgsDebugMsgLevel( QStringLiteral( "Whole filter will be evaluated on client-side" ), 2 );
     }
   }
   return ret;

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -240,10 +240,16 @@ class QgsOapifSharedData final: public QObject, public QgsBackgroundCachedShared
 
   private:
 
-    // Translate part of an expression to a server-side filter
-    QString translateNodeToServer( const QgsExpressionNode *node,
-                                   QgsOapifProvider::FilterTranslationState &translationState,
-                                   QString &untranslatedPart );
+    // Translate part of an expression to a server-side filter using Part1 features only
+    QString compileExpressionNodeUsingPart1( const QgsExpressionNode *node,
+        QgsOapifProvider::FilterTranslationState &translationState,
+        QString &untranslatedPart ) const;
+
+    // Translate part of an expression to a server-side filter using Part1 or Part3
+    bool computeFilter( const QgsExpression &expr,
+                        QgsOapifProvider::FilterTranslationState &translationState,
+                        QString &serverSideParameters,
+                        QString &clientSideFilterExpression ) const;
 
     //! Log error to QgsMessageLog and raise it to the provider
     void pushError( const QString &errorMsg ) const override;

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -25,6 +25,7 @@
 #include "qgswfsdatasourceuri.h"
 #include "qgsoapifapirequest.h"
 #include "qgsoapifitemsrequest.h"
+#include "qgsoapifqueryablesrequest.h"
 
 #include "qgsprovidermetadata.h"
 
@@ -218,6 +219,21 @@ class QgsOapifSharedData final: public QObject, public QgsBackgroundCachedShared
 
     // Map of simple queryables items (that is as query parameters). The key of the map is a queryable name.
     QMap<QString, QgsOapifApiRequest::SimpleQueryable> mSimpleQueryables;
+
+    //! Whether server supports OGC API Features Part3 with CQL2-Text
+    bool mServerSupportsFilterCql2Text = false;
+
+    //! Whether server supports CQL2 advanced-comparison-operators conformance class (LIKE, BETWEEN, IN)
+    bool mServerSupportsLikeBetweenIn = false;
+
+    //! Whether server supports CQL2 case-insensitive-comparison conformance class (CASEI function)
+    bool mServerSupportsCaseI = false;
+
+    //! Whether server supports CQL2 basic-spatial-operators conformance class (S_INTERSECTS(,BBOX() or POINT()))
+    bool mServerSupportsBasicSpatialOperators = false;
+
+    // Map of queryables items for CQL2 request. The key of the map is a queryable name.
+    QMap<QString, QgsOapifQueryablesRequest::Queryable> mQueryables;
 
     //! Append extra query parameters if needed
     QString appendExtraQueryParameters( const QString &url ) const;

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -23,6 +23,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsbackgroundcachedshareddata.h"
 #include "qgswfsdatasourceuri.h"
+#include "qgsoapifapirequest.h"
 #include "qgsoapifitemsrequest.h"
 
 #include "qgsprovidermetadata.h"
@@ -214,6 +215,9 @@ class QgsOapifSharedData final: public QObject, public QgsBackgroundCachedShared
 
     //! Set if an "id" is present in the "properties" object of features
     bool mFoundIdInProperties = false;
+
+    // Map of simple queryables items (that is as query parameters). The key of the map is a queryable name.
+    QMap<QString, QgsOapifApiRequest::SimpleQueryable> mSimpleQueryables;
 
     //! Append extra query parameters if needed
     QString appendExtraQueryParameters( const QString &url ) const;

--- a/src/providers/wfs/oapif/qgsoapifqueryablesrequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifqueryablesrequest.cpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+    qgsoapifqueryablesrequest.cpp
+    -----------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <nlohmann/json.hpp>
+using namespace nlohmann;
+
+#include "qgslogger.h"
+#include "qgsoapifqueryablesrequest.h"
+#include "qgsoapifutils.h"
+#include "qgswfsconstants.h"
+
+#include <QTextCodec>
+
+QgsOapifQueryablesRequest::QgsOapifQueryablesRequest( const QgsDataSourceUri &uri ):
+  QgsBaseNetworkRequest( QgsAuthorizationSettings( uri.username(), uri.password(), uri.authConfigId() ), "OAPIF" )
+{
+  // Using Qt::DirectConnection since the download might be running on a different thread.
+  // In this case, the request was sent from the main thread and is executed with the main
+  // thread being blocked in future.waitForFinished() so we can run code on this object which
+  // lives in the main thread without risking havoc.
+  connect( this, &QgsBaseNetworkRequest::downloadFinished, this, &QgsOapifQueryablesRequest::processReply, Qt::DirectConnection );
+}
+
+const QMap<QString, QgsOapifQueryablesRequest::Queryable> &QgsOapifQueryablesRequest::queryables( const QUrl &queryablesUrl )
+{
+  sendGET( queryablesUrl, QString( "application/schema+json" ), /*synchronous=*/true, /*forceRefresh=*/false );
+  return mQueryables;
+}
+
+QString QgsOapifQueryablesRequest::errorMessageWithReason( const QString &reason )
+{
+  return tr( "Download of queryables failed: %1" ).arg( reason );
+}
+
+void QgsOapifQueryablesRequest::processReply()
+{
+  if ( mErrorCode != QgsBaseNetworkRequest::NoError )
+  {
+    return;
+  }
+  const QByteArray &buffer = mResponse;
+  if ( buffer.isEmpty() )
+  {
+    mErrorMessage = tr( "empty response" );
+    mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
+    return;
+  }
+
+  QgsDebugMsgLevel( QStringLiteral( "parsing Queryables response: " ) + buffer, 4 );
+
+  QTextCodec::ConverterState state;
+  QTextCodec *codec = QTextCodec::codecForName( "UTF-8" );
+  Q_ASSERT( codec );
+
+  const QString utf8Text = codec->toUnicode( buffer.constData(), buffer.size(), &state );
+  if ( state.invalidChars != 0 )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Invalid UTF-8 content" ) );
+    return;
+  }
+
+  try
+  {
+    const json j = json::parse( utf8Text.toStdString() );
+
+    if ( j.is_object() && j.contains( "properties" ) )
+    {
+      const json jProperties = j["properties"];
+      if ( jProperties.is_object() )
+      {
+        for ( const auto& [key, val] : jProperties.items() )
+        {
+          if ( val.is_object() &&
+               val.contains( "type" ) )
+          {
+            const json jType = val["type"];
+            if ( jType.is_string() )
+            {
+              Queryable queryable;
+              queryable.mType = QString::fromStdString( jType.get<std::string>() );
+              if ( val.contains( "format" ) )
+              {
+                const json jFormat = val["format"];
+                if ( jFormat.is_string() )
+                {
+                  queryable.mFormat = QString::fromStdString( jFormat.get<std::string>() );
+                }
+              }
+              mQueryables[ QString::fromStdString( key ) ] = queryable;
+            }
+          }
+          else if ( val.is_object() &&
+                    val.contains( "$ref" ) )
+          {
+            const json jRef = val["$ref"];
+            if ( jRef.is_string() )
+            {
+              const auto ref = jRef.get<std::string>();
+              const char *prefix = "https://geojson.org/schema/";
+              if ( ref.size() > strlen( prefix ) &&
+                   ref.compare( 0, strlen( prefix ), prefix ) == 0 )
+              {
+                Queryable queryable;
+                queryable.mIsGeometry = true;
+                mQueryables[ QString::fromStdString( key ) ] = queryable;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  catch ( const json::parse_error &ex )
+  {
+    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+    mErrorMessage = errorMessageWithReason( tr( "Cannot decode JSON document: %1" ).arg( QString::fromStdString( ex.what() ) ) );
+    return;
+  }
+}

--- a/src/providers/wfs/oapif/qgsoapifqueryablesrequest.h
+++ b/src/providers/wfs/oapif/qgsoapifqueryablesrequest.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+    qgsoapifqueryablesrequest.h
+    ---------------------------
+    begin                : April 2023
+    copyright            : (C) 2023 by Even Rouault
+    email                : even.rouault at spatialys.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOAPIFQUERYABLESREQUEST_H
+#define QGSOAPIFQUERYABLESREQUEST_H
+
+#include <QObject>
+#include <QMap>
+
+#include "qgsdatasourceuri.h"
+#include "qgsbasenetworkrequest.h"
+
+//! Manages the conformance request
+class QgsOapifQueryablesRequest : public QgsBaseNetworkRequest
+{
+    Q_OBJECT
+  public:
+    explicit QgsOapifQueryablesRequest( const QgsDataSourceUri &uri );
+
+    //! Describes a queryable parameter.
+    struct Queryable
+    {
+      //! whether the parameter is a geometry
+      bool mIsGeometry = false;
+
+      //! type as in a JSON schema: "string", "integer", "number", etc.
+      QString mType;
+
+      //! format as in JSON schema. e.g "date-time" if mType="string"
+      QString mFormat;
+    };
+
+    //! Issue the request synchronously and return queryables
+    const QMap<QString, Queryable> &queryables( const QUrl &queryablesUrl );
+
+  private slots:
+    void processReply();
+
+  private:
+    QMap<QString, Queryable> mQueryables;
+
+  protected:
+    QString errorMessageWithReason( const QString &reason ) override;
+};
+
+#endif // QGSOAPIFQUERYABLESREQUEST_H

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -108,9 +108,18 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
   if ( modifiedUrl.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
   {
     // Just for testing with local files instead of http:// resources
-    QString modifiedUrlString = modifiedUrl.toString();
-    // Qt5 does URL encoding from some reason (of the FILTER parameter for example)
-    modifiedUrlString = QUrl::fromPercentEncoding( modifiedUrlString.toUtf8() );
+    QString modifiedUrlString;
+
+    if ( modifiedUrl.toString().contains( QLatin1String( "fake_qgis_http_endpoint_encoded_query" ) ) )
+    {
+      // Get encoded representation (used by test_provider_oapif.py testSimpleQueryableFiltering())
+      modifiedUrlString = modifiedUrl.toEncoded();
+    }
+    else
+    {
+      // Get representation with percent decoding (easier for WFS filtering)
+      modifiedUrlString = QUrl::fromPercentEncoding( modifiedUrl.toString().toUtf8() );
+    }
 
     if ( !acceptHeader.isEmpty() )
     {

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -595,8 +595,16 @@ void QgsWFSSourceSelect::buildQuery( const QModelIndex &index )
       }
       else if ( provider->filterTranslatedState() == QgsOapifProvider::FilterTranslationState::PARTIAL )
       {
-        QMessageBox::information( nullptr, tr( "Filter" ),
-                                  tr( "The following part of the filter will be evaluated on client side : %1" ).arg( provider->clientSideFilterExpression() ) );
+        if ( provider->clientSideFilterExpression().isEmpty() )
+        {
+          QMessageBox::information( nullptr, tr( "Filter" ),
+                                    tr( "The filter will partially evaluated on client side." ) );
+        }
+        else
+        {
+          QMessageBox::information( nullptr, tr( "Filter" ),
+                                    tr( "The following part of the filter will be evaluated on client side : %1" ).arg( provider->clientSideFilterExpression() ) );
+        }
       }
       mModelProxy->setData( filterIndex, QVariant( gb.sql() ) );
     }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -565,6 +565,11 @@ void QgsWFSSourceSelect::buildQuery( const QModelIndex &index )
   QgsWfsConnection connection( cmbConnections->currentText() );
   QgsWFSDataSourceURI uri( connection.uri().uri( false ) );
   uri.setTypeName( typeName );
+  if ( gbCRS->isEnabled() )
+  {
+    QString crsString = labelCoordRefSys->text();
+    uri.setSRSName( crsString );
+  }
 
   QModelIndex filterIndex = index.sibling( index.row(), MODEL_IDX_SQL );
   QString sql( filterIndex.data().toString() );

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -69,6 +69,7 @@ ACCEPT_API = 'Accept=application/vnd.oai.openapi+json;version=3.0, application/o
 ACCEPT_COLLECTION = 'Accept=application/json'
 ACCEPT_CONFORMANCE = 'Accept=application/json'
 ACCEPT_ITEMS = 'Accept=application/geo+json, application/json'
+ACCEPT_QUERYABLES = 'Accept=application/schema+json'
 
 
 def mergeDict(d1, d2):
@@ -86,7 +87,8 @@ def create_landing_page_api_collection(endpoint,
                                        storageCrs=None,
                                        crsList=None,
                                        bbox=[-71.123, 66.33, -65.32, 78.3],
-                                       additionalApiResponse={}):
+                                       additionalApiResponse={},
+                                       additionalConformance=[]):
 
     questionmark_extraparam = '?' + extraparam if extraparam else ''
 
@@ -122,7 +124,7 @@ def create_landing_page_api_collection(endpoint,
     # conformance
     with open(sanitize(endpoint, '/conformance?' + add_params(extraparam, ACCEPT_CONFORMANCE)), 'wb') as f:
         f.write(json.dumps({
-            "conformsTo": ["http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"]
+            "conformsTo": ["http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"] + additionalConformance
         }).encode('UTF-8'))
 
     # collection
@@ -838,6 +840,203 @@ class TestPyQgsOapifProvider(unittest.TestCase, ProviderTestCase):
         values = [f['id'] for f in vl.getFeatures()]
         os.unlink(filename)
         self.assertEqual(values, [])
+
+    def testCQL2TextFiltering(self):
+        """Test Part 3 CQL2-Text filtering"""
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_encoded_query_testCQL2TextFiltering'
+        additionalConformance = [
+            "http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-operators",
+            "http://www.opengis.net/spec/cql2/1.0/conf/case-insensitive-comparison",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+        ]
+
+        create_landing_page_api_collection(endpoint, additionalConformance=additionalConformance)
+
+        filename = sanitize(endpoint, '/collections/mycollection/queryables?' + ACCEPT_QUERYABLES)
+        queryables = {
+            "properties": {
+                "strfield": {
+                    "type": "string"
+                },
+                "strfield2": {
+                    "type": "string"
+                },
+                "intfield": {
+                    "type": "integer"
+                },
+                "doublefield": {
+                    "type": "number"
+                },
+                "boolfield": {
+                    "type": "boolean"
+                },
+                "boolfield2": {
+                    "type": "boolean"
+                },
+                "datetimefield": {
+                    "type": "string",
+                    "format": "date-time",
+                },
+                "datefield": {
+                    "type": "string",
+                    "format": "date",
+                },
+                "geometry": {
+                    "$ref": "https://geojson.org/schema/Point.json"
+                },
+            }
+        }
+        with open(filename, 'wb') as f:
+            f.write(json.dumps(queryables).encode('UTF-8'))
+
+        items = {
+            "type": "FeatureCollection",
+            "features": [
+                {"type": "Feature", "id": "feat.1", "properties":
+                 {"strfield": "foo=bar",
+                  "strfield2": None,
+                  "intfield": 1,
+                  "doublefield": 1.5,
+                  "not_a_queryable": 3,
+                  "datetimefield": "2023-04-19T12:34:56Z",
+                  "datefield": "2023-04-19",
+                  "boolfield": True,
+                  "boolfield2": False},
+                 "geometry": {"type": "Point", "coordinates": [-70.5, 66.5]}}
+            ]
+        }
+
+        filename = sanitize(endpoint, '/collections/mycollection/items?limit=10&' + ACCEPT_ITEMS)
+        with open(filename, 'wb') as f:
+            f.write(json.dumps(items).encode('UTF-8'))
+
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' typename='mycollection'", 'test', 'OAPIF')
+        self.assertTrue(vl.isValid())
+        os.unlink(filename)
+
+        tests = [
+            (""""strfield" = 'foo=bar' and intfield = 1""",
+             """filter=((strfield%20%3D%20'foo%3Dbar')%20AND%20(intfield%20%3D%201))&filter-lang=cql2-text"""),
+            ("""doublefield = 1.5 or boolfield = true""",
+             """filter=((doublefield%20%3D%201.5)%20OR%20(boolfield%20%3D%20TRUE))&filter-lang=cql2-text"""),
+            ("boolfield2 = false", "filter=(boolfield2%20%3D%20FALSE)&filter-lang=cql2-text"""),
+            ("NOT(intfield = 0)", """filter=(NOT%20((intfield%20%3D%200)))&filter-lang=cql2-text"""),
+            ("intfield <> 0", """filter=(intfield%20%3C%3E%200)&filter-lang=cql2-text"""),
+            ("intfield > 0", """filter=(intfield%20%3E%200)&filter-lang=cql2-text"""),
+            ("intfield >= 1", """filter=(intfield%20%3E%3D%201)&filter-lang=cql2-text"""),
+            ("intfield < 2", """filter=(intfield%20%3C%202)&filter-lang=cql2-text"""),
+            ("intfield <= 1", """filter=(intfield%20%3C%3D%201)&filter-lang=cql2-text"""),
+            ("intfield IN (1, 2)", """filter=intfield%20IN%20(1,2)&filter-lang=cql2-text"""),
+            ("intfield NOT IN (3, 4)", """filter=intfield%20NOT%20IN%20(3,4)&filter-lang=cql2-text"""),
+            ("intfield BETWEEN 0 AND 2", "filter=intfield%20BETWEEN%200%20AND%202&filter-lang=cql2-text"),
+            ("intfield NOT BETWEEN 3 AND 4", "filter=intfield%20NOT%20BETWEEN%203%20AND%204&filter-lang=cql2-text"),
+            ("strfield2 IS NULL", """filter=(strfield2%20IS%20NULL)&filter-lang=cql2-text"""),
+            ("intfield IS NOT NULL", """filter=(intfield%20IS%20NOT%20NULL)&filter-lang=cql2-text"""),
+            ("datetimefield = make_datetime(2023, 4, 19, 12, 34, 56)",
+             "filter=(datetimefield%20%3D%20TIMESTAMP('2023-04-19T12:34:56.000Z'))&filter-lang=cql2-text"),
+            ("datetimefield = '2023-04-19T12:34:56.000Z'",
+             "filter=(datetimefield%20%3D%20TIMESTAMP('2023-04-19T12:34:56.000Z'))&filter-lang=cql2-text"),
+            ("datefield = make_date(2023, 4, 19)",
+             "filter=(datefield%20%3D%20DATE('2023-04-19'))&filter-lang=cql2-text"),
+            ("datefield = '2023-04-19'",
+             "filter=(datefield%20%3D%20DATE('2023-04-19'))&filter-lang=cql2-text"),
+            (""""strfield" LIKE 'foo%'""",
+             """filter=(strfield%20LIKE%20'foo%25')&filter-lang=cql2-text"""),
+            (""""strfield" NOT LIKE 'bar'""",
+             """filter=(strfield%20NOT%20LIKE%20'bar')&filter-lang=cql2-text"""),
+            (""""strfield" ILIKE 'fo%'""",
+             """filter=(CASEI(strfield)%20LIKE%20CASEI('fo%25'))&filter-lang=cql2-text"""),
+            (""""strfield" NOT ILIKE 'bar'""",
+             """filter=(CASEI(strfield)%20NOT%20LIKE%20CASEI('bar'))&filter-lang=cql2-text"""),
+            ("""intersects_bbox($geometry, geomFromWkt('POLYGON((-180 -90,-180 90,180 90,180 -90,-180 -90))'))""",
+             """filter=S_INTERSECTS(geometry,BBOX(-180,-90,180,90))&filter-lang=cql2-text"""),
+            ("""intersects($geometry, geomFromWkt('POINT(-70.5 66.5))'))""",
+             """filter=S_INTERSECTS(geometry,POINT(-70.5%2066.5))&filter-lang=cql2-text"""),
+            # Partially evaluated on server
+            ("intfield >= 1 AND not_a_queryable = 3", """filter=(intfield%20%3E%3D%201)&filter-lang=cql2-text"""),
+            ("not_a_queryable = 3 AND intfield >= 1", """filter=(intfield%20%3E%3D%201)&filter-lang=cql2-text"""),
+            # Only evaluated on client
+            ("intfield >= 1 OR not_a_queryable = 3", ""),
+            ("not_a_queryable = 3 AND not_a_queryable = 3", ""),
+        ]
+        for (expr, cql_filter) in tests:
+            assert vl.setSubsetString(expr)
+
+            filename = sanitize(endpoint,
+                                "/collections/mycollection/items?limit=1000&" + cql_filter + ("&" if cql_filter else "") + ACCEPT_ITEMS)
+            with open(filename, 'wb') as f:
+                f.write(json.dumps(items).encode('UTF-8'))
+            values = [f['id'] for f in vl.getFeatures()]
+            os.unlink(filename)
+            self.assertEqual(values, ['feat.1'], expr)
+
+    def testCQL2TextFilteringAndPart2(self):
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_encoded_query_testCQL2TextFilteringAndPart2'
+        additionalConformance = [
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-operators",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+        ]
+
+        create_landing_page_api_collection(endpoint,
+                                           storageCrs="http://www.opengis.net/def/crs/EPSG/0/4258",
+                                           crsList=["http://www.opengis.net/def/crs/OGC/0/CRS84",
+                                                    "http://www.opengis.net/def/crs/EPSG/0/4258"],
+                                           additionalConformance=additionalConformance)
+
+        filename = sanitize(endpoint, '/collections/mycollection/queryables?' + ACCEPT_QUERYABLES)
+        queryables = {
+            "properties": {
+                "geometry": {
+                    "$ref": "https://geojson.org/schema/Point.json"
+                },
+            }
+        }
+        with open(filename, 'wb') as f:
+            f.write(json.dumps(queryables).encode('UTF-8'))
+
+        items = {
+            "type": "FeatureCollection",
+            "features": [
+                {"type": "Feature", "id": "feat.1", "properties":
+                 {},
+                 # lat, long order
+                 "geometry": {"type": "Point", "coordinates": [49, 2]}}
+            ]
+        }
+
+        filename = sanitize(endpoint, '/collections/mycollection/items?limit=10&' + ACCEPT_ITEMS)
+        with open(filename, 'wb') as f:
+            f.write(json.dumps(items).encode('UTF-8'))
+
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' typename='mycollection'", 'test', 'OAPIF')
+        self.assertTrue(vl.isValid())
+        os.unlink(filename)
+
+        tests = [
+            ("""intersects($geometry, geomFromWkt('POINT(2 49))'))""",
+             """filter=S_INTERSECTS(geometry,POINT(49%202))&filter-lang=cql2-text&filter-crs=http://www.opengis.net/def/crs/EPSG/0/4258"""),
+        ]
+        for (expr, cql_filter) in tests:
+            assert vl.setSubsetString(expr)
+
+            filename = sanitize(endpoint,
+                                "/collections/mycollection/items?limit=1000&" + cql_filter + ("&" if cql_filter else "") + "crs=http://www.opengis.net/def/crs/EPSG/0/4258&" + ACCEPT_ITEMS)
+            with open(filename, 'wb') as f:
+                f.write(json.dumps(items).encode('UTF-8'))
+            values = [f['id'] for f in vl.getFeatures()]
+            os.unlink(filename)
+            self.assertEqual(values, ['feat.1'], expr)
 
     def testStringList(self):
 


### PR DESCRIPTION
-   [OAPIF provider] Add support for filtering on feature properties (OGC API Features Part 1 - /rec/core/fc-filters)
    
    This uses the /api endpoint to get the list of queryable items.

-   [OAPIF provider] Add support for filtering based on OGC API Features Part 3 - CQL2-text
    
    This requires server /conformance to declare at least:
    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter
    - http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter
    - http://www.opengis.net/spec/cql2/1.0/conf/cql2-text
    - http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2
    
    The /collections/{collid}/queryables endpoint is requested to get the
    queryable properties.
    
    And it can use the following extra conformance classes:
    - http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators:
      for IN, BETWEEN, LIKE
    - http://www.opengis.net/spec/cql2/1.0/conf/case-insensitive-comparison:
      for ILIKE
    - http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-operators:
      for intersects(geomcolumn, geomFromWkt('POINT(x y)')) and
      bbox_intersects(geomcolumn, geomFromWkt('WKT LITERAL'))

-  [WFS / OAPIF] GUI: pass selected CRS to query builder UI

-  [OAPIF provider] Implements getFeature() expression translation

CC @3nids