### PR TITLE
Fix typo in install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -602,7 +602,7 @@ On the command prompt clone the QGIS source from
 git to the source directory `QGIS`:
 
 ```cmd
-git clone git://github.com/qgis/QGIS.git
+git clone git@github.com:qgis/QGIS.git
 ```
 
 This requires Git. If you have Git for Windows on your PATH already,


### PR DESCRIPTION
The instruction here is a mixup between the http address and the git way. If I follow the instruction as it was written here, I just get a timeout. The correct way is described elsewhere in this same document, but it doesn't hurt to fix this typo.
The correct fix could also be the http address (`https://github.com/qgis/QGIS.git`), I have no preference.