### PR TITLE
Leftpad default Atlas output filenames so they sort well (#31309)

### DIFF
--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -75,7 +75,7 @@ void QgsLayoutAtlasToImageAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExpression( QStringLiteral( "SORTBY_EXPRESSION" ), QObject::tr( "Sort expression" ), QString(), QStringLiteral( "COVERAGE_LAYER" ), true ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SORTBY_REVERSE" ), QObject::tr( "Reverse sort order (used when a sort expression is provided)" ), false, true ) );
 
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILENAME_EXPRESSION" ), QObject::tr( "Output filename expression" ), QStringLiteral( "'output_'||@atlas_featurenumber" ), QStringLiteral( "COVERAGE_LAYER" ) ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILENAME_EXPRESSION" ), QObject::tr( "Output filename expression" ), QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ), QStringLiteral( "COVERAGE_LAYER" ) ) );
   addParameter( new QgsProcessingParameterFile( QStringLiteral( "FOLDER" ), QObject::tr( "Output folder" ), QgsProcessingParameterFile::Folder ) );
 
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -348,7 +348,8 @@ QVariantMap QgsLayoutAtlasToMultiplePdfAlgorithm::exportAtlas( QgsLayoutAtlas *a
     QgsLayoutExporter::ExportResult result;
     if ( atlas->filenameExpression().isEmpty() && filename.isEmpty() )
     {
-      atlas->setFilenameExpression( QStringLiteral( "'output_'||@atlas_featurenumber" ), error );
+      atlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
+												    error );
     }
     else if ( !filename.isEmpty() )
     {

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -349,7 +349,7 @@ QVariantMap QgsLayoutAtlasToMultiplePdfAlgorithm::exportAtlas( QgsLayoutAtlas *a
     if ( atlas->filenameExpression().isEmpty() && filename.isEmpty() )
     {
       atlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
-												    error );
+                                    error );
     }
     else if ( !filename.isEmpty() )
     {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2863,7 +2863,7 @@ void QgsLayoutDesignerDialog::exportAtlasToRaster()
     }
     QString error;
     printAtlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
-									   error );
+                                       error );
   }
   else
   {
@@ -3271,7 +3271,7 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
       }
       QString error;
       printAtlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
-										 error );
+                                         error );
     }
 
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2862,7 +2862,8 @@ void QgsLayoutDesignerDialog::exportAtlasToRaster()
       return;
     }
     QString error;
-    printAtlas->setFilenameExpression( QStringLiteral( "'output_'||@atlas_featurenumber" ), error );
+    printAtlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
+									   error );
   }
   else
   {
@@ -3051,7 +3052,8 @@ void QgsLayoutDesignerDialog::exportAtlasToSvg()
       return;
     }
     QString error;
-    printAtlas->setFilenameExpression( QStringLiteral( "'output_'||@atlas_featurenumber" ), error );
+    printAtlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
+                                       error );
   }
 
   QString lastUsedDir = defaultExportPath();
@@ -3268,7 +3270,8 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
         return;
       }
       QString error;
-      printAtlas->setFilenameExpression( QStringLiteral( "'output_'||@atlas_featurenumber" ), error );
+      printAtlas->setFilenameExpression( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ),
+										 error );
     }
 
 

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -32,7 +32,7 @@
 QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
   : QObject( layout )
   , mLayout( layout )
-  , mFilenameExpressionString( QStringLiteral( "'output_'||@atlas_featurenumber" ) )
+  , mFilenameExpressionString( QStringLiteral( "'output_' || lpad(@atlas_featurenumber, length(to_string(@atlas_totalfeatures)), 0)" ) )
 {
 
   //listen out for layer removal

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -421,9 +421,10 @@ void TestQgsProcessingAlgsPt2::exportAtlasLayoutPdfMultiple()
   results = alg->run( parameters, *context, &feedback, &ok );
   QVERIFY( ok );
 
-  QVERIFY( QFile::exists( outputPdfDir + "/output_1.pdf" ) );
-  QVERIFY( QFile::exists( outputPdfDir + "/output_2.pdf" ) );
-  QVERIFY( QFile::exists( outputPdfDir + "/output_3.pdf" ) );
+  // we have 10 features in the layer so output numbering uses 2 letters
+  QVERIFY( QFile::exists( outputPdfDir + "/output_01.pdf" ) );
+  QVERIFY( QFile::exists( outputPdfDir + "/output_02.pdf" ) );
+  QVERIFY( QFile::exists( outputPdfDir + "/output_03.pdf" ) );
 }
 
 void TestQgsProcessingAlgsPt2::exportAtlasLayoutPng()


### PR DESCRIPTION
## Description

This will result in output filenames that are left-padded with leading zeros. They all have the same length as the required maximum length is determined by `length(to_string(@atlas_totalfeatures))`.

E. g. "output_1.png" -> "output_01.png" if there are <=99 features.

The motivation for this is safer and more deterministic ordering of the output files. Different OSs, file managers or video editing tools might order numbered files differently if there are no leading zeros.

The secondary benefit is a fixed length of the filenames.

For example when turning Atlas output into a video with ffmpeg, the common approach is to use a fixed size placeholder in the input string like `-i output_%03d.png`. This won't work if the filenames have different lengths. The alternative approach of using globbing `-pattern_type glob -i 'output_*.jpg'` depends on the shell's ordering.