### PR TITLE
Show raster row/column of clicked point in identify results

### DIFF
--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1072,11 +1072,11 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
       const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-      derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-      derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+      derivedAttributes.unite( tr( "(clicked raster column)" ), QLocale().toString( rasterCol ) );
+      derivedAttributes.unite( tr( "(clicked raster row)" ), QLocale().toString( rasterRow ) );
 #else
-      derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-      derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+      derivedAttributes.insert( tr( "(clicked raster column)" ), QLocale().toString( rasterCol ) );
+      derivedAttributes.insert( tr( "(clicked raster row)" ), QLocale().toString( rasterRow ) );
 #endif
     }
   }

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1054,11 +1054,12 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   derivedAttributes.insert( derivedAttributesForPoint( QgsPoint( pointInCanvasCrs ) ) );
 #endif
 
-  // Get raster row and column of clicked point
-  // Thanks to the Value Tool plugin developers for the math
+  // Try to determine the clicked column/row (0-based) in the raster
   const QgsRectangle extent = dprovider->extent();
-  const int rasterRow = std::floor( ( extent.yMaximum() - point.y() ) / layer->rasterUnitsPerPixelY() );
-  const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelX() );
+  const double xres = layer->rasterUnitsPerPixelY();
+  const double yres = layer->rasterUnitsPerPixelX();
+  const int rasterCol = static_cast< int >( std::floor( ( point.x() - extent.xMinimum() ) / xres ) );
+  const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1054,6 +1054,18 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   derivedAttributes.insert( derivedAttributesForPoint( QgsPoint( pointInCanvasCrs ) ) );
 #endif
 
+	// Get raster row and column of clicked point
+	// Thanks to the Value Tool plugin developers for the math
+	const QgsRectangle extent = dprovider->extent();
+	const double xres = extent.width() / dprovider->xSize();
+	const double yres = extent.height() / dprovider->ySize();
+
+	const int raster_row = std::floor((extent.yMaximum() - point.y()) / yres);
+	const int raster_col = std::floor((point.x() - extent.xMinimum()) / xres);
+
+	derivedAttributes.insert( "Clicked raster row", QLocale().toString( raster_row ));
+	derivedAttributes.insert( "Clicked raster column", QLocale().toString( raster_col ));
+
   if ( identifyResult.isValid() )
   {
     QMap<int, QVariant> values = identifyResult.results();

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1054,26 +1054,32 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   derivedAttributes.insert( derivedAttributesForPoint( QgsPoint( pointInCanvasCrs ) ) );
 #endif
 
-  // Try to determine the clicked column/row (0-based) in the raster
-  const QgsRectangle extent = dprovider->extent();
-  const double xres = layer->rasterUnitsPerPixelY();
-  const double yres = layer->rasterUnitsPerPixelX();
-
-  // rasterUnitsPerPixel might be 0 (eg for XYZ or other rasters where the concept doesn't make sense)
-  if ( xres > 0 && yres > 0 )
+  // Don't derive clicked column/row for providers that serve dynamically rendered map images
+  if (
+    dprovider->name() != QStringLiteral( "wms" ) &&
+    dprovider->name() != QStringLiteral( "arcgismapserver" )
+  )
   {
-    const int rasterCol = static_cast< int >( std::floor( ( point.x() - extent.xMinimum() ) / xres ) );
-    const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
+    // Try to determine the clicked column/row (0-based) in the raster
+    const QgsRectangle extent = dprovider->extent();
+    const double xres = layer->rasterUnitsPerPixelX();
+    const double yres = layer->rasterUnitsPerPixelY();
+
+    // rasterUnitsPerPixel might be 0 (eg for XYZ or other rasters where the concept doesn't make sense)
+    if ( xres > 0 && yres > 0 )
+    {
+      const int rasterCol = static_cast< int >( std::floor( ( point.x() - extent.xMinimum() ) / xres ) );
+      const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-    derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+      derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+      derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #else
-    derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-    derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+      derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+      derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #endif
+    }
   }
-
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1058,7 +1058,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   // Thanks to the Value Tool plugin developers for the math
   const QgsRectangle extent = dprovider->extent();
   const int rasterRow = std::floor( ( extent.yMaximum() - point.y() ) / layer->rasterUnitsPerPixelY() );
-  const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelY() );
+  const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelX() );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1057,14 +1057,11 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   // Get raster row and column of clicked point
   // Thanks to the Value Tool plugin developers for the math
   const QgsRectangle extent = dprovider->extent();
-  const double xres = extent.width() / dprovider->xSize();
-  const double yres = extent.height() / dprovider->ySize();
+  const int rasterRow = std::floor( ( extent.yMaximum() - point.y() ) / layer->rasterUnitsPerPixelY() );
+  const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelY() );
 
-  const int raster_row = std::floor( ( extent.yMaximum() - point.y() ) / yres );
-  const int raster_col = std::floor( ( point.x() - extent.xMinimum() ) / xres );
-
-  derivedAttributes.insert( "Clicked raster row", QLocale().toString( raster_row ) );
-  derivedAttributes.insert( "Clicked raster column", QLocale().toString( raster_col ) );
+  derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+  derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1060,8 +1060,13 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   const int rasterRow = std::floor( ( extent.yMaximum() - point.y() ) / layer->rasterUnitsPerPixelY() );
   const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelY() );
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+  derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+  derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+#else
   derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
   derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+#endif
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1058,16 +1058,22 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   const QgsRectangle extent = dprovider->extent();
   const double xres = layer->rasterUnitsPerPixelY();
   const double yres = layer->rasterUnitsPerPixelX();
-  const int rasterCol = static_cast< int >( std::floor( ( point.x() - extent.xMinimum() ) / xres ) );
-  const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
+
+  // rasterUnitsPerPixel might be 0 (eg for XYZ or other rasters where the concept doesn't make sense)
+  if ( xres > 0 && yres > 0 )
+  {
+    const int rasterCol = static_cast< int >( std::floor( ( point.x() - extent.xMinimum() ) / xres ) );
+    const int rasterRow = static_cast< int >( std::floor( ( extent.yMaximum() - point.y() ) / yres ) );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-  derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-  derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+    derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+    derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #else
-  derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
-  derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
+    derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+    derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #endif
+  }
+
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1054,17 +1054,17 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   derivedAttributes.insert( derivedAttributesForPoint( QgsPoint( pointInCanvasCrs ) ) );
 #endif
 
-	// Get raster row and column of clicked point
-	// Thanks to the Value Tool plugin developers for the math
-	const QgsRectangle extent = dprovider->extent();
-	const double xres = extent.width() / dprovider->xSize();
-	const double yres = extent.height() / dprovider->ySize();
+  // Get raster row and column of clicked point
+  // Thanks to the Value Tool plugin developers for the math
+  const QgsRectangle extent = dprovider->extent();
+  const double xres = extent.width() / dprovider->xSize();
+  const double yres = extent.height() / dprovider->ySize();
 
-	const int raster_row = std::floor((extent.yMaximum() - point.y()) / yres);
-	const int raster_col = std::floor((point.x() - extent.xMinimum()) / xres);
+  const int raster_row = std::floor( ( extent.yMaximum() - point.y() ) / yres );
+  const int raster_col = std::floor( ( point.x() - extent.xMinimum() ) / xres );
 
-	derivedAttributes.insert( "Clicked raster row", QLocale().toString( raster_row ));
-	derivedAttributes.insert( "Clicked raster column", QLocale().toString( raster_col ));
+  derivedAttributes.insert( "Clicked raster row", QLocale().toString( raster_row ) );
+  derivedAttributes.insert( "Clicked raster column", QLocale().toString( raster_col ) );
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1061,11 +1061,11 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   const int rasterCol = std::floor( ( point.x() - extent.xMinimum() ) / layer->rasterUnitsPerPixelX() );
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-  derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
   derivedAttributes.unite( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+  derivedAttributes.unite( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #else
-  derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
   derivedAttributes.insert( tr( "Clicked raster column" ), QLocale().toString( rasterCol ) );
+  derivedAttributes.insert( tr( "Clicked raster row" ), QLocale().toString( rasterRow ) );
 #endif
 
   if ( identifyResult.isValid() )

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -723,30 +723,30 @@ void TestQgsMapToolIdentifyAction::identifyRasterDerivedAttributes()
 
   results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMaximum() - layerYSize/2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster column" )], QString( "0" ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster row" )], QString( "0" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "0" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString( "0" ) );
 
   results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize/2, layerExtent.yMaximum() - layerYSize/2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster column" )], QString::number( tempLayer->width()-1 ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster row" )], QString( "0" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString( "0" ) );
 
-  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize , layerExtent.yMinimum() + layerYSize/2 );
+  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMinimum() + layerYSize/2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster column" )], QString( "0" ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster row" )], QString::number( tempLayer->height()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "0" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height()-1 ) );
 
   results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize/2, layerExtent.yMinimum() + layerYSize/2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster column" )], QString::number( tempLayer->width()-1 ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster row" )], QString::number( tempLayer->height()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height()-1 ) );
 
   const double xSomewhereCenter = layerExtent.xMinimum() + layerXSize*200 + layerXSize;
   const double ySomewhereCenter = layerExtent.yMaximum() - layerYSize*140 - layerYSize;
   results = testIdentifyRaster( tempLayer.get(), xSomewhereCenter, ySomewhereCenter );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster column" )], QString( "200" ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "Clicked raster row" )], QString( "140" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "200" ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString( "140" ) );
 }
 
 void TestQgsMapToolIdentifyAction::identifyMesh()

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -721,28 +721,28 @@ void TestQgsMapToolIdentifyAction::identifyRasterDerivedAttributes()
   // checking the four corners of the raster plus one somewhere in the center
   QList<QgsMapToolIdentify::IdentifyResult> results;
 
-  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMaximum() - layerYSize/2 );
+  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMaximum() - layerYSize / 2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
   QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "0" ) );
   QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString( "0" ) );
 
-  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize/2, layerExtent.yMaximum() - layerYSize/2 );
+  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize / 2, layerExtent.yMaximum() - layerYSize / 2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width() - 1 ) );
   QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString( "0" ) );
 
-  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMinimum() + layerYSize/2 );
+  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMinimum() + layerXSize, layerExtent.yMinimum() + layerYSize / 2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
   QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "0" ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height() - 1 ) );
 
-  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize/2, layerExtent.yMinimum() + layerYSize/2 );
+  results = testIdentifyRaster( tempLayer.get(), layerExtent.xMaximum() - layerXSize / 2, layerExtent.yMinimum() + layerYSize / 2 );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width()-1 ) );
-  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height()-1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString::number( tempLayer->width() - 1 ) );
+  QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster row)" )], QString::number( tempLayer->height() - 1 ) );
 
-  const double xSomewhereCenter = layerExtent.xMinimum() + layerXSize*200 + layerXSize;
-  const double ySomewhereCenter = layerExtent.yMaximum() - layerYSize*140 - layerYSize;
+  const double xSomewhereCenter = layerExtent.xMinimum() + layerXSize * 200 + layerXSize;
+  const double ySomewhereCenter = layerExtent.yMaximum() - layerYSize * 140 - layerYSize;
   results = testIdentifyRaster( tempLayer.get(), xSomewhereCenter, ySomewhereCenter );
   QCOMPARE( results.length(), 1 );  // just to ensure that we did get a result back
   QCOMPARE( results[0].mDerivedAttributes[QStringLiteral( "(clicked raster column)" )], QString( "200" ) );


### PR DESCRIPTION
## Description
This makes identify results on raster layers include the clicked raster row/column as derived.

![grafik](https://user-images.githubusercontent.com/7661092/233475317-22837b9b-94a7-4882-8109-3ad2f8b22a80.png)

Thanks to the Value Tool plugin developers for the math <3

Implements #50421

Tested with:

- local raster TIF, GPKG and SQLite/Rasterlite = OK
- remote COG = OK
- WCS = OK
- WMS = 0, 0 <- **bad!**
- XYZ tiles are not considered by the identify tool by QGIS
- WMTS tiles are not considered by the identify tool by QGIS


# TODO
I'll try to ask around at the contributor meeting but if you read this, comments at the issue are super welcome and if you are in Den Bosch, come find me :)
- [x] Disable it for WMS layers as the results make no sense there.
- [x] ~~Any other raster layer types I should test this with?~~
- [x] Does it work with rasters that have flipped/negative axes?
- [ ] I have no idea why the "(clicked coordinate x)" and "(clicked coordinate y)" texts are written in lower case and surrounded by parenthesis. This matches vector layer identify results but even there, all other derived attributes are without parenthesis and in proper case. I much prefer that so I wrote these in that way. OK?
- [ ] I have no clue about C++ and if I used `const` and `std::floor` correctly.
- [x] Just above my additions there is a macro deciding between `derivedAttributes.unite` and `derivedAttributes.insert` depending on the Qt version, I guess I should use that too?
- [x] This should very probably be unittested I guess?