### PR TITLE
Fix conversion of max zoom level from mapbox styles

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilebasiclabeling.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasiclabeling.sip.in
@@ -80,21 +80,64 @@ Returns whether this style is enabled (used for rendering)
 
     void setMinZoomLevel( int minZoom );
 %Docstring
-Sets minimum zoom level index (negative number means no limit)
+Sets minimum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is greater than or equal
+to ``minZoom``.
+
+.. seealso:: :py:func:`minZoomLevel`
+
+.. seealso:: :py:func:`setMaxZoomLevel`
 %End
+
     int minZoomLevel() const;
 %Docstring
-Returns minimum zoom level index (negative number means no limit)
+Returns the minimum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is greater than or equal
+to the this level.
+
+.. seealso:: :py:func:`setMinZoomLevel`
+
+.. seealso:: :py:func:`maxZoomLevel`
 %End
 
     void setMaxZoomLevel( int maxZoom );
 %Docstring
-Sets maximum zoom level index (negative number means no limit)
+Sets maximum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is less than or equal
+to ``maxZoom``.
+
+.. warning::
+
+   This differs from the handling of the max zoom as defined
+   in the MapBox Style Specifications, where the style is rendered
+   only if the zoom level is less than the maximum zoom.
+
+.. seealso:: :py:func:`maxZoomLevel`
+
+.. seealso:: :py:func:`setMinZoomLevel`
 %End
+
     int maxZoomLevel() const;
 %Docstring
-Returns maxnimum zoom level index (negative number means no limit)
+Returns the maximum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is less than or equal
+to the maximum zoom.
+
+.. warning::
+
+   This differs from the handling of the max zoom as defined
+   in the MapBox Style Specifications, where the style is rendered
+   only if the zoom level is less than the maximum zoom.
+
+.. seealso:: :py:func:`setMaxZoomLevel`
+
+.. seealso:: :py:func:`minZoomLevel`
 %End
+
 
     bool isActive( int zoomLevel ) const;
 %Docstring

--- a/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -100,20 +100,62 @@ Returns whether this style is enabled (used for rendering)
 
     void setMinZoomLevel( int minZoom );
 %Docstring
-Sets minimum zoom level index (negative number means no limit)
+Sets minimum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is greater than or equal
+to ``minZoom``.
+
+.. seealso:: :py:func:`minZoomLevel`
+
+.. seealso:: :py:func:`setMaxZoomLevel`
 %End
+
     int minZoomLevel() const;
 %Docstring
-Returns minimum zoom level index (negative number means no limit)
+Returns the minimum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is greater than or equal
+to the this level.
+
+.. seealso:: :py:func:`setMinZoomLevel`
+
+.. seealso:: :py:func:`maxZoomLevel`
 %End
 
     void setMaxZoomLevel( int maxZoom );
 %Docstring
-Sets maximum zoom level index (negative number means no limit)
+Sets maximum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is less than or equal
+to ``maxZoom``.
+
+.. warning::
+
+   This differs from the handling of the max zoom as defined
+   in the MapBox Style Specifications, where the style is rendered
+   only if the zoom level is less than the maximum zoom.
+
+.. seealso:: :py:func:`maxZoomLevel`
+
+.. seealso:: :py:func:`setMinZoomLevel`
 %End
+
     int maxZoomLevel() const;
 %Docstring
-Returns maxnimum zoom level index (negative number means no limit)
+Returns the maximum zoom level index (negative number means no limit).
+
+The style will be rendered if the zoom level is less than or equal
+to the maximum zoom.
+
+.. warning::
+
+   This differs from the handling of the max zoom as defined
+   in the MapBox Style Specifications, where the style is rendered
+   only if the zoom level is less than the maximum zoom.
+
+.. seealso:: :py:func:`setMaxZoomLevel`
+
+.. seealso:: :py:func:`minZoomLevel`
 %End
 
     bool isActive( int zoomLevel ) const;

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -136,7 +136,17 @@ void QgsMapBoxGlStyleConverter::parseLayers( const QVariantList &layers, QgsMapB
     const QString layerName = jsonLayer.value( QStringLiteral( "source-layer" ) ).toString();
 
     const int minZoom = jsonLayer.value( QStringLiteral( "minzoom" ), QStringLiteral( "-1" ) ).toInt();
-    const int maxZoom = jsonLayer.value( QStringLiteral( "maxzoom" ), QStringLiteral( "-1" ) ).toInt();
+
+    // WARNING -- the QGIS renderers for vector tiles treat maxzoom different to the MapBox Style Specifications.
+    // from the MapBox Specifications:
+    //
+    // "The maximum zoom level for the layer. At zoom levels equal to or greater than the maxzoom, the layer will be hidden."
+    //
+    // However the QGIS styles will be hidden if the zoom level is GREATER THAN (not equal to) maxzoom.
+    // Accordingly we need to subtract 1 from the maxzoom value in the JSON:
+    int maxZoom = jsonLayer.value( QStringLiteral( "maxzoom" ), QStringLiteral( "-1" ) ).toInt();
+    if ( maxZoom != -1 )
+      maxZoom--;
 
     const bool enabled = jsonLayer.value( QStringLiteral( "visibility" ) ).toString() != QLatin1String( "none" );
 

--- a/src/core/vectortile/qgsvectortilebasiclabeling.h
+++ b/src/core/vectortile/qgsvectortilebasiclabeling.h
@@ -62,15 +62,58 @@ class CORE_EXPORT QgsVectorTileBasicLabelingStyle
     //! Returns whether this style is enabled (used for rendering)
     bool isEnabled() const { return mEnabled; }
 
-    //! Sets minimum zoom level index (negative number means no limit)
+    /**
+     * Sets minimum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is greater than or equal
+     * to \a minZoom.
+     *
+     * \see minZoomLevel()
+     * \see setMaxZoomLevel()
+     */
     void setMinZoomLevel( int minZoom ) { mMinZoomLevel = minZoom; }
-    //! Returns minimum zoom level index (negative number means no limit)
+
+    /**
+     * Returns the minimum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is greater than or equal
+     * to the this level.
+     *
+     * \see setMinZoomLevel()
+     * \see maxZoomLevel()
+     */
     int minZoomLevel() const { return mMinZoomLevel; }
 
-    //! Sets maximum zoom level index (negative number means no limit)
+    /**
+     * Sets maximum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is less than or equal
+     * to \a maxZoom.
+     *
+     * \warning This differs from the handling of the max zoom as defined
+     * in the MapBox Style Specifications, where the style is rendered
+     * only if the zoom level is less than the maximum zoom.
+     *
+     * \see maxZoomLevel()
+     * \see setMinZoomLevel()
+     */
     void setMaxZoomLevel( int maxZoom ) { mMaxZoomLevel = maxZoom; }
-    //! Returns maxnimum zoom level index (negative number means no limit)
+
+    /**
+     * Returns the maximum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is less than or equal
+     * to the maximum zoom.
+     *
+     * \warning This differs from the handling of the max zoom as defined
+     * in the MapBox Style Specifications, where the style is rendered
+     * only if the zoom level is less than the maximum zoom.
+     *
+     * \see setMaxZoomLevel()
+     * \see minZoomLevel()
+     */
     int maxZoomLevel() const { return mMaxZoomLevel; }
+
 
     //! Returns whether the style is active at given zoom level (also checks "enabled" flag)
     bool isActive( int zoomLevel ) const

--- a/src/core/vectortile/qgsvectortilebasicrenderer.h
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.h
@@ -84,14 +84,56 @@ class CORE_EXPORT QgsVectorTileBasicRendererStyle
     //! Returns whether this style is enabled (used for rendering)
     bool isEnabled() const { return mEnabled; }
 
-    //! Sets minimum zoom level index (negative number means no limit)
+    /**
+     * Sets minimum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is greater than or equal
+     * to \a minZoom.
+     *
+     * \see minZoomLevel()
+     * \see setMaxZoomLevel()
+     */
     void setMinZoomLevel( int minZoom ) { mMinZoomLevel = minZoom; }
-    //! Returns minimum zoom level index (negative number means no limit)
+
+    /**
+     * Returns the minimum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is greater than or equal
+     * to the this level.
+     *
+     * \see setMinZoomLevel()
+     * \see maxZoomLevel()
+     */
     int minZoomLevel() const { return mMinZoomLevel; }
 
-    //! Sets maximum zoom level index (negative number means no limit)
+    /**
+     * Sets maximum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is less than or equal
+     * to \a maxZoom.
+     *
+     * \warning This differs from the handling of the max zoom as defined
+     * in the MapBox Style Specifications, where the style is rendered
+     * only if the zoom level is less than the maximum zoom.
+     *
+     * \see maxZoomLevel()
+     * \see setMinZoomLevel()
+     */
     void setMaxZoomLevel( int maxZoom ) { mMaxZoomLevel = maxZoom; }
-    //! Returns maxnimum zoom level index (negative number means no limit)
+
+    /**
+     * Returns the maximum zoom level index (negative number means no limit).
+     *
+     * The style will be rendered if the zoom level is less than or equal
+     * to the maximum zoom.
+     *
+     * \warning This differs from the handling of the max zoom as defined
+     * in the MapBox Style Specifications, where the style is rendered
+     * only if the zoom level is less than the maximum zoom.
+     *
+     * \see setMaxZoomLevel()
+     * \see minZoomLevel()
+     */
     int maxZoomLevel() const { return mMaxZoomLevel; }
 
     //! Returns whether the style is active at given zoom level (also checks "enabled" flag)

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -941,6 +941,72 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertFalse(labeling_style.labelSettings().isExpression)
         self.assertEqual(labeling_style.labelSettings().fieldName, 'substance')
 
+    def test_parse_zoom_levels(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "sources": {
+                "Basemaps": {
+                    "type": "vector",
+                    "url": "https://xxxxxx"
+                }
+            },
+            "layers": [
+                {
+                    "id": "water",
+                    "source": "streets",
+                    "source-layer": "water",
+                    "minzoom": 3,
+                    "maxzoom": 11,
+                    "type": "fill",
+                    "paint": {
+                        "fill-color": "#00ffff"
+                    }
+                },
+                {
+                    "layout": {
+                        "text-field": "{name_en}",
+                        "text-font": [
+                            "Open Sans Semibold",
+                            "Arial Unicode MS Bold"
+                        ],
+                        "text-max-width": 8,
+                        "text-anchor": "top",
+                        "text-size": 11,
+                        "icon-size": 1
+                    },
+                    "type": "symbol",
+                    "id": "poi_label",
+                    "minzoom": 3,
+                    "maxzoom": 11,
+                    "paint": {
+                        "text-color": "#666",
+                        "text-halo-width": 1.5,
+                        "text-halo-color": "rgba(255,255,255,0.95)",
+                        "text-halo-blur": 1
+                    },
+                    "source-layer": "poi_label"
+                }
+            ]
+        }
+
+        converter = QgsMapBoxGlStyleConverter()
+        converter.convert(style, context)
+
+        renderer = converter.renderer()
+        style = renderer.style(0)
+        self.assertEqual(style.minZoomLevel(), 3)
+        # This differs from the handling of the max zoom as defined
+        # in the MapBox Style, since in MapBox styles the style is rendered
+        # only if the zoom level is less than the maximum zoom but in QGIS
+        # styles the style is rendered if the zoom level is less than OR EQUAL TO
+        # the maximum zoom
+        self.assertEqual(style.maxZoomLevel(), 10)
+
+        labeling = converter.labeling()
+        style = labeling.style(0)
+        self.assertEqual(style.minZoomLevel(), 3)
+        self.assertEqual(style.maxZoomLevel(), 10)
+
     def test_parse_raster_source(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
The QGIS renderers for vector tiles treat maxzoom different to the MapBox Style Specifications.
    
From the MapBox Specifications:
    
"The maximum zoom level for the layer. At zoom levels equal to or greater than the maxzoom, the layer will be hidden."
    
However the QGIS styles will be hidden if the zoom level is GREATER THAN (not equal to) maxzoom.
    
Accordingly we need to subtract 1 from the maxzoom value when converting mapbox styles.