### PR TITLE
Fill fill stroke conversion issues from MapBox styles

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -426,6 +426,8 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
 
   if ( fillOutlineColor.isValid() )
   {
+    // mapbox fill strokes are always 1 px wide
+    fillSymbol->setStrokeWidth( 0 );
     fillSymbol->setStrokeColor( fillOutlineColor );
   }
   else

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -424,7 +424,15 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
     symbol->setOpacity( fillOpacity );
   }
 
-  if ( fillOutlineColor.isValid() )
+  // some complex logic here!
+  // by default a MapBox fill style will share the same stroke color as the fill color.
+  // This is generally desirable and the 1px stroke can help to hide boundaries between features which
+  // would otherwise be visible due to antialiasing effects.
+  // BUT if the outline color is semi-transparent, then drawing the stroke will result in a double rendering
+  // of strokes for adjacent polygons, resulting in visible seams between tiles. Accordingly, we only
+  // set the stroke color if it's a completely different color to the fill (ie the style designer explicitly
+  // wants a visible stroke) OR the stroke color is opaque and the double-rendering artifacts aren't an issue
+  if ( fillOutlineColor.isValid() && ( fillOutlineColor.alpha() == 255 || fillOutlineColor != fillColor ) )
   {
     // mapbox fill strokes are always 1 px wide
     fillSymbol->setStrokeWidth( 0 );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -10,7 +10,11 @@ __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import qgis  # NOQA
-from qgis.PyQt.QtCore import QCoreApplication, QSize
+from qgis.PyQt.QtCore import (
+    Qt,
+    QCoreApplication,
+    QSize
+)
 from qgis.PyQt.QtGui import QColor, QImage
 from qgis.core import (
     Qgis,
@@ -1078,6 +1082,51 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
 
         # mapbox fill strokes are always 1 px wide
         self.assertEqual(renderer.symbol()[0].strokeWidth(), 0)
+
+        self.assertEqual(renderer.symbol()[0].strokeStyle(), Qt.SolidLine)
+        # if "fill-outline-color" is not specified, then MapBox specs state the
+        # stroke color matches the value of fill-color if unspecified.
+        self.assertEqual(renderer.symbol()[0].strokeColor().name(), '#47b312')
+        self.assertEqual(renderer.symbol()[0].strokeColor().alpha(), 255)
+
+        # explicit outline color
+        style = {
+            "id": "Land/Not ice",
+            "type": "fill",
+            "source": "esri",
+            "source-layer": "Land",
+            "layout": {},
+            "paint": {
+                "fill-color": "rgb(71,179,18)",
+                "fill-outline-color": "rgb(255,0,0)",
+            }
+        }
+        has_renderer, renderer = QgsMapBoxGlStyleConverter.parseFillLayer(style, context)
+        self.assertTrue(has_renderer)
+
+        self.assertEqual(renderer.symbol()[0].strokeStyle(), Qt.SolidLine)
+        self.assertEqual(renderer.symbol()[0].strokeColor().name(), '#ff0000')
+        self.assertEqual(renderer.symbol()[0].strokeColor().alpha(), 255)
+
+        # semi-transparent fill color
+        style = {
+            "id": "Land/Not ice",
+            "type": "fill",
+            "source": "esri",
+            "source-layer": "Land",
+            "layout": {},
+            "paint": {
+                "fill-color": "rgb(71,179,18,0.25)",
+            }
+        }
+        has_renderer, renderer = QgsMapBoxGlStyleConverter.parseFillLayer(style, context)
+        self.assertTrue(has_renderer)
+        # if the outline color is semi-transparent, then drawing the default 1px stroke
+        # will result in a double rendering of strokes for adjacent polygons,
+        # resulting in visible seams between tiles. Accordingly, we only
+        # set the stroke color if it's a completely different color to the
+        # fill if the stroke color is opaque and the double-rendering artifacts aren't an issue
+        self.assertEqual(renderer.symbol()[0].strokeStyle(), Qt.NoPen)
 
     def testFillOpacityWithStops(self):
         context = QgsMapBoxGlStyleConversionContext()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -1061,6 +1061,24 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertTrue(labeling_style.labelSettings().isExpression)
         self.assertEqual(labeling_style.labelSettings().fieldName, 'CASE WHEN @vector_tile_zoom > 6 AND @vector_tile_zoom < 15 THEN concat(\'my \',"class",\' and \',"stuff") WHEN @vector_tile_zoom >= 15 THEN concat(\'my \',"class",\' and \',"stuff") ELSE \'\' END')
 
+    def testFillStroke(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "id": "Land/Not ice",
+            "type": "fill",
+            "source": "esri",
+            "source-layer": "Land",
+            "layout": {},
+            "paint": {
+                "fill-color": "rgb(71,179,18)",
+            }
+        }
+        has_renderer, renderer = QgsMapBoxGlStyleConverter.parseFillLayer(style, context)
+        self.assertTrue(has_renderer)
+
+        # mapbox fill strokes are always 1 px wide
+        self.assertEqual(renderer.symbol()[0].strokeWidth(), 0)
+
     def testFillOpacityWithStops(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
Fixes two issues when converting vector tile fill symbols