### PR TITLE
[Bugfix] Processing plugin: bad check layer from QgsProcessingOutputMultipleLayers

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -200,7 +200,7 @@ class Processing(object):
                         if result:
                             layers_result = []
                             for l in result:
-                                if not isinstance(result, QgsMapLayer):
+                                if not isinstance(l, QgsMapLayer):
                                     layer = context.takeResultLayer(l)  # transfer layer ownership out of context
                                     if layer:
                                         layers_result.append(layer)


### PR DESCRIPTION
After running algorithm, the processing plugin take the layer from result to provide map layer instead of string. In the case of QgsProcessingOutputMultipleLayers, the instance check is not done on the layer but on an array.
