### PR TITLE
GDAL/OGR source select UX: add OGCAPI radio

### DIFF
--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -32,6 +32,8 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   setupUi( this );
   setupButtons( buttonBox );
 
+  mOpenOptionsGroupBox->setCollapsed( false );
+
   connect( radioSrcFile, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcFile_toggled );
   connect( radioSrcOgcApi, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcOgcApi_toggled );
   connect( radioSrcProtocol, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcProtocol_toggled );
@@ -145,6 +147,10 @@ void QgsGdalSourceSelect::radioSrcOgcApi_toggled( bool checked )
   {
     const QString vectorPath = mFileWidget->filePath();
     emit enableButtons( ! vectorPath.isEmpty() );
+    if ( mRasterPath.isEmpty() )
+    {
+      mRasterPath = QStringLiteral( "OGCAPI:" );
+    }
     fillOpenOptions();
   }
 }
@@ -436,6 +442,7 @@ void QgsGdalSourceSelect::fillOpenOptions()
   }
 
   mOpenOptionsGroupBox->setVisible( !mOpenOptionsWidgets.empty() );
+
 }
 
 ///@endcond

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -145,6 +145,7 @@ void QgsGdalSourceSelect::radioSrcOgcApi_toggled( bool checked )
   radioSrcFile_toggled( checked );
   if ( checked )
   {
+    rasterDatasetLabel->setText( tr( "OGC API Endpoint" ) );
     const QString vectorPath = mFileWidget->filePath();
     emit enableButtons( ! vectorPath.isEmpty() );
     if ( mRasterPath.isEmpty() )
@@ -152,6 +153,10 @@ void QgsGdalSourceSelect::radioSrcOgcApi_toggled( bool checked )
       mRasterPath = QStringLiteral( "OGCAPI:" );
     }
     fillOpenOptions();
+  }
+  else
+  {
+    rasterDatasetLabel->setText( tr( "Raster dataset(s)" ) );
   }
 }
 

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -47,6 +47,7 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
     void setProtocolWidgetsVisibility();
 
     void radioSrcFile_toggled( bool checked );
+    void radioSrcOgcApi_toggled( bool checked );
     void radioSrcProtocol_toggled( bool checked );
     void cmbProtocolTypes_currentIndexChanged( const QString &text );
 
@@ -59,7 +60,7 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
 
     QString mRasterPath;
     QStringList mDataSources;
-
+    bool mIsOgcApi = false;
 };
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -42,6 +42,8 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
+  mOpenOptionsGroupBox->setCollapsed( false );
+
   connect( radioSrcFile, &QRadioButton::toggled, this, &QgsOgrSourceSelect::radioSrcFile_toggled );
   connect( radioSrcOgcApi, &QRadioButton::toggled, this, &QgsOgrSourceSelect::radioSrcOgcApi_toggled );
   connect( radioSrcDirectory, &QRadioButton::toggled, this, &QgsOgrSourceSelect::radioSrcDirectory_toggled );

--- a/src/gui/providers/ogr/qgsogrsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrsourceselect.h
@@ -100,6 +100,7 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void setProtocolWidgetsVisibility();
 
     void radioSrcFile_toggled( bool checked );
+    void radioSrcOgcApi_toggled( bool checked );
     void radioSrcDirectory_toggled( bool checked );
     void radioSrcDatabase_toggled( bool checked );
     void radioSrcProtocol_toggled( bool checked );
@@ -117,7 +118,7 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void clearOpenOptions();
     void fillOpenOptions();
     std::vector<QWidget *> mOpenOptionsWidgets;
-
+    bool mIsOgcApi = false;
     QString mVectorPath;
 
 };

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>355</width>
-    <height>229</height>
+    <height>501</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,6 +49,13 @@
          <widget class="QRadioButton" name="radioSrcProtocol">
           <property name="text">
            <string>Protoco&amp;l: HTTP(S), cloud, etc.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioSrcOgcApi">
+          <property name="text">
+           <string>OGC API</string>
           </property>
          </widget>
         </item>
@@ -208,25 +215,25 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox">
-       <property name="title">
+      <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox" native="true">
+       <property name="title" stdset="0">
         <string>Options</string>
        </property>
        <layout class="QVBoxLayout" name="openOptionsVBoxLayout">
-         <item>
-           <widget class="QLabel" name="mOpenOptionsLabel">
-            <property name="text">
-             <string></string>
-            </property>
-           </widget>
-         </item>
-         <item>
-            <layout class="QFormLayout" name="mOpenOptionsLayout">
-                <property name="fieldGrowthPolicy">
-                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                </property>
-            </layout>
-         </item>
+        <item>
+         <widget class="QLabel" name="mOpenOptionsLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="mOpenOptionsLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>
@@ -260,11 +267,18 @@
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QWidget</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -88,7 +88,7 @@
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="rasterDatasetLabel">
           <property name="text">
            <string>Raster dataset(s)</string>
           </property>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -51,9 +51,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-282</y>
-        <width>508</width>
-        <height>745</height>
+        <y>0</y>
+        <width>537</width>
+        <height>757</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -98,6 +98,13 @@
                <widget class="QRadioButton" name="radioSrcProtocol">
                 <property name="text">
                  <string>Protoco&amp;l: HTTP(S), cloud, etc.</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="radioSrcOgcApi">
+                <property name="text">
+                 <string>OGC API</string>
                 </property>
                </widget>
               </item>
@@ -383,8 +390,8 @@
           </widget>
          </item>
          <item>
-          <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox">
-           <property name="title">
+          <widget class="QgsCollapsibleGroupBox" name="mOpenOptionsGroupBox" native="true">
+           <property name="title" stdset="0">
             <string>Options</string>
            </property>
            <layout class="QVBoxLayout" name="openOptionsVBoxLayout">
@@ -436,12 +443,6 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -451,6 +452,12 @@
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QWidget</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
Adds an entry for OGCAPI, in order to add
the endpoint without the need of OGCAPI: prefix.

![image](https://user-images.githubusercontent.com/142164/233688559-a4c264dd-ffa9-4516-8f1e-f30ab7973517.png)


![image](https://user-images.githubusercontent.com/142164/233687310-a8611df2-440a-47e3-a7e5-469cd055bff2.png)
