### PR TITLE
qgs3dmapconfigwidget: Fix zoom level update on init

### DIFF
--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -172,8 +172,6 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   groupMeshTerrainShading->layout()->addWidget( mMeshSymbolWidget );
 
-  onTerrainTypeChanged();
-
   // ==================
   // Page: Skybox
   mSkyboxSettingsWidget = new QgsSkyboxRenderingSettingsWidget( this );
@@ -257,6 +255,8 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   mShowExtentIn2DViewCheckbox = new QCheckBox( tr( "Show in 2D map view" ) );
   mShowExtentIn2DViewCheckbox->setChecked( map->showExtentIn2DView() );
   groupExtent->layout()->addWidget( mShowExtentIn2DViewCheckbox );
+
+  onTerrainTypeChanged();
 }
 
 Qgs3DMapConfigWidget::~Qgs3DMapConfigWidget()


### PR DESCRIPTION
When the configuration widget is displayed, the zoom level is computed by calling `onTerrainLayerChanged` in the constructor. This function calls `updateMaxZoomLevel` which takes care of updating the max zoom level. This function relies on `groupExtent` to get the tile resolution. However, on startup, this resolution is always zero because `groupExtent` has not been initialized yet.

This issue is fixed by calling `onTerrainLayerChanged` after `groupExtent` initialization.

cc @uclaros @benoitdm-oslandia @wonder-sk 