### PR TITLE
Fix categorized symbol renderer feature counts for null values

### DIFF
--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -1224,10 +1224,7 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
     }
     else
     {
-      // Numeric NULL cat value is stored as an empty string
-      if ( QgsVariantUtils::isNull( value ) && ( value.userType() == QMetaType::Type::Double || value.userType() == QMetaType::Type::Int ||
-           value.userType() == QMetaType::Type::UInt || value.userType() == QMetaType::Type::LongLong ||
-           value.userType() == QMetaType::Type::ULongLong || value.userType() == QMetaType::Type::Bool ) )
+      if ( QgsVariantUtils::isNull( value ) )
       {
         match = cat.value().toString().isEmpty();
       }

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -1478,6 +1478,38 @@ class TestQgsCategorizedSymbolRenderer(QgisTestCase):
 
         self.assertEqual(renderer.maximumExtentBuffer(QgsRenderContext()), 20)
 
+    def test_layer_counts(self):
+        layer = QgsVectorLayer("Point?field=test_field:string", "test_layer", "memory")
+        fields = QgsFields()
+        fields.append(QgsField('test_field', QVariant.String))
+
+        # add test values
+        for attr_value in ['a'] * 3 + ['b'] * 2 + [None]:
+            f = QgsFeature(fields)
+            f.setAttributes([attr_value])
+            layer.dataProvider().addFeature(f)
+
+        self.assertEqual(layer.featureCount(), 6)
+
+        renderer = QgsCategorizedSymbolRenderer()
+        renderer.setClassAttribute('test_field')
+
+        renderer.addCategory(QgsRendererCategory('a', createMarkerSymbol(), 'a'))
+        renderer.addCategory(QgsRendererCategory('b', createMarkerSymbol(), 'b'))
+        # add default category
+        renderer.addCategory(QgsRendererCategory(None, createMarkerSymbol(), 'nulls'))
+
+        self.assertEqual(renderer.legendKeys(), {'0', '1', '2'})
+
+        layer.setRenderer(renderer)
+
+        counter = layer.countSymbolFeatures()
+        counter.waitForFinished()
+
+        self.assertEqual(layer.featureCount('0'), 3)
+        self.assertEqual(layer.featureCount('1'), 2)
+        self.assertEqual(layer.featureCount('2'), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes issue #52690

## Description

Feature count for null values when using categorized styling was not working when field type was other than numeric. Removed condition for checking type when checking for null values seems to fix the issue. However, adding a unit test using a string field did not fail before the fix. Running the previous [python test](https://github.com/qgis/QGIS/pull/45361/files#diff-41dc46fc2cb73daee2223f381098ccd73e132212cc574727c82b24d3c040f0c7) in python console did fail though when using a string field. Layer feature count also showed 0 before the fix in the python console:
![image](https://user-images.githubusercontent.com/12234068/233778491-23540e6e-e535-4c53-9f1f-454615b4083a.png)

I have also tested the null value counts with timestamp, boolean and json fields and they seem to work.