### PR TITLE
[Plugin installer] Don't show wait cursor when fetching repositories

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -120,22 +120,21 @@ class QgsPluginInstaller(QObject):
         """ Fetch plugins from all enabled repositories."""
         """  reloadMode = true:  Fully refresh data from QgsSettings to mRepositories  """
         """  reloadMode = false: Fetch unready repositories only """
-        with OverrideCursor(Qt.WaitCursor):
-            if reloadMode:
-                repositories.load()
-                plugins.clearRepoCache()
-                plugins.getAllInstalled()
+        if reloadMode:
+            repositories.load()
+            plugins.clearRepoCache()
+            plugins.getAllInstalled()
 
-            for key in repositories.allEnabled():
-                if reloadMode or repositories.all()[key]["state"] == 3:  # if state = 3 (error or not fetched yet), try to fetch once again
-                    repositories.requestFetching(key, force_reload=reloadMode)
+        for key in repositories.allEnabled():
+            if reloadMode or repositories.all()[key]["state"] == 3:  # if state = 3 (error or not fetched yet), try to fetch once again
+                repositories.requestFetching(key, force_reload=reloadMode)
 
-            if repositories.fetchingInProgress():
-                fetchDlg = QgsPluginInstallerFetchingDialog(iface.mainWindow())
-                fetchDlg.exec_()
-                del fetchDlg
-                for key in repositories.all():
-                    repositories.killConnection(key)
+        if repositories.fetchingInProgress():
+            fetchDlg = QgsPluginInstallerFetchingDialog(iface.mainWindow())
+            fetchDlg.exec_()
+            del fetchDlg
+            for key in repositories.all():
+                repositories.killConnection(key)
 
         # display error messages for every unavailable repository, unless Shift pressed nor all repositories are unavailable
         keepQuiet = QgsApplication.keyboardModifiers() == Qt.KeyboardModifiers(Qt.ShiftModifier)

--- a/python/pyplugin_installer/qgsplugininstallerfetchingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerfetchingdialog.py
@@ -24,7 +24,7 @@
  ***************************************************************************/
 """
 
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import Qt, QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog, QTreeWidgetItem
 
 from .ui_qgsplugininstallerfetchingbase import Ui_QgsPluginInstallerFetchingDialogBase
@@ -54,6 +54,7 @@ class QgsPluginInstallerFetchingDialog(QDialog, Ui_QgsPluginInstallerFetchingDia
                 self.itemProgress[key] = 0
                 self.displayState(key, 2)
         self.treeWidget.resizeColumnToContents(0)
+        self.treeWidget.setCursor(Qt.WaitCursor)
         repositories.repositoryFetched.connect(self.repositoryFetched)
         repositories.anythingChanged.connect(self.displayState)
 


### PR DESCRIPTION
When fetching repositories, the wait cursor displayed over the progress window is redundant. In case of SSL errors, it's even worse with the certificate config dialog, when the user is supposed to make some clicks:

![Screenshot_20230422_174927](https://user-images.githubusercontent.com/1000043/233794182-850253bf-d1c9-49a7-b97b-4ce193e29ba6.png)

With this PR, the cursor is not changed anymore. Instead, the wait cursor is only set locally for the QTreeWidget with state of downloading:

![Screenshot_20230422_181431](https://user-images.githubusercontent.com/1000043/233795495-5d4e490f-eedb-445c-916f-de6e75c6ea99.png)

