### PR TITLE
qgsfunction decorator improvements

### DIFF
--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -19,98 +19,121 @@
 import inspect
 import string
 import traceback
-from builtins import str
+
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis._core import QgsExpressionFunction, QgsExpression, QgsMessageLog, QgsFeatureRequest, Qgis
 
 
+class QgsPyExpressionFunction(QgsExpressionFunction):
+    """Python expression function"""
+
+    def __init__(
+        self,
+        function,
+        name,
+        group,
+        helptext="",
+        usesgeometry=False,
+        referenced_columns=QgsFeatureRequest.ALL_ATTRIBUTES,
+        handlesnull=False,
+        params_as_list=False,
+    ):
+        # Call the parent constructor
+        # -1 means that function can take any number of arguments
+        QgsExpressionFunction.__init__(self, name, -1, group, helptext)
+        self.function = function
+        self.params_as_list = params_as_list
+        self.usesgeometry = usesgeometry
+        self.referenced_columns = referenced_columns
+        self.handlesnull = handlesnull
+
+    def func(self, values, context, parent, node):
+        feature = None
+        if context:
+            feature = context.feature()
+        try:
+            # Inspect the inner function signature to get the list of parameters
+            parameters = inspect.signature(self.function).parameters
+            kwvalues = {}
+
+            # Handle special parameters
+            # those will not be inserted in the arguments list
+            # if they are present in the function signature
+            if "context" in parameters:
+                kwvalues["context"] = context
+            if "feature" in parameters:
+                kwvalues["feature"] = feature
+            if "parent" in parameters:
+                kwvalues["parent"] = parent
+
+            # In this context, values is a list of the parameters passed to the expression.
+            # If self.params_as_list is True, values is passed as is to the inner function.
+            if self.params_as_list:
+                return self.function(values, **kwvalues)
+            # Otherwise (default), the parameters are expanded
+            return self.function(*values, **kwvalues)
+
+        except Exception as ex:
+            tb = traceback.format_exception(None, ex, ex.__traceback__)
+            formatted_traceback = "".join(tb)
+            formatted_exception = f"{ex}:<pre>{formatted_traceback}</pre>"
+            parent.setEvalErrorString(formatted_exception)
+            return None
+
+    def usesGeometry(self, node):
+        return self.usesgeometry
+
+    def referencedColumns(self, node):
+        return self.referenced_columns
+
+    def handlesNull(self):
+        return self.handlesnull
+
+
 def register_function(
     function,
-    group,
+    args="auto",
+    group="custom",
     usesgeometry=False,
     referenced_columns=[QgsFeatureRequest.ALL_ATTRIBUTES],
     handlesnull=False,
+    params_as_list=None,
     **kwargs,
 ):
     """
     Register a Python function to be used as a expression function.
 
-    The function signature may contains special parameters:
-    - context: the QgsExpressionContext-related to the current evaluation
-    - feature: the QgsFeature-related to the current evaluation
+    The function signature may contain special parameters (in any order at the end of the signature):
+    - feature: the QgsFeature related to the current evaluation
     - parent: the QgsExpressionFunction parent
+    - context: the QgsExpressionContext related to the current evaluation
 
     If those parameters are present in the function signature, they will be automatically passed to the function,
     without the need to specify them in the expression.
 
-    If the only other parameter in the signature is called "values", parameters will be passed as a list.
-    Otherwise, parameters will be expanded in the parameter list.
-
     Functions should return a value compatible with QVariant
     Eval errors can be raised using parent.setEvalErrorString("Error message")
-    :param function:
-    :param group:
-    :param usesgeometry:
-    :param handlesnull: Needs to be set to True if this function does not always return NULL if any parameter is NULL. Default False.
+
+    :param function: the Python function to be used as an expression function
+    :param args: DEPRECATED since QGIS 3.32.  Use ``params_as_list`` if you want to pass parameters as a list.
+    :param group: the expression group in which the function should be added
+    :param usesgeometry: Defines if this expression requires the geometry. By default False.
+    :param referenced_columns: An array of field names on which this expression works. By default ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. Can be set to None for slightly faster evaluation.
+    :param handlesnull: Defines if this expression has custom handling for NULL values. If False, the result will always be NULL as soon as any parameter is NULL. False by default.
+    :param params_as_list: If True, the function will receive the expression parameters as a list. If False, the function will receive the parameters as individual arguments. False by default.
+
+    :Keyword Arguments:
+    * *register* (``bool``) --
+        Set to False to create the QgsPyExpressionFunction without registering it. Useful for testing puposes. By default True.
+    * *name* (``str``) --
+        If provided, replace the function name
+    * *helpText* (``str``) --
+        If provided, used in the help tooltip instead of the function docstring
+
     :return:
     """
 
-    class QgsPyExpressionFunction(QgsExpressionFunction):
-        def __init__(
-            self,
-            func,
-            name,
-            group,
-            helptext="",
-            usesGeometry=True,
-            referencedColumns=QgsFeatureRequest.ALL_ATTRIBUTES,
-            handlesNull=False,
-            paramsAsList=False,
-        ):
-            QgsExpressionFunction.__init__(self, name, -1, group, helptext)
-            self.function = func
-            self.params_as_list = paramsAsList
-            self.uses_geometry = usesGeometry
-            self.referenced_columns = referencedColumns
-            self.handles_null = handlesNull
-
-        def func(self, values, context, parent, node):
-            feature = None
-            if context:
-                feature = context.feature()
-            try:
-                parameters = inspect.signature(self.function).parameters
-                kwvalues = {}
-
-                # Handle special parameters
-                # those will not be inserted in the parameter list
-                # if they are present in the function signature
-                if "context" in parameters:
-                    kwvalues["context"] = context
-                if "feature" in parameters:
-                    kwvalues["feature"] = feature
-                if "parent" in parameters:
-                    kwvalues["parent"] = parent
-
-                if self.params_as_list:
-                    return self.function(values, **kwvalues)
-                return self.function(*values, **kwvalues)
-            except Exception as ex:
-                tb = traceback.format_exception(None, ex, ex.__traceback__)
-                formatted_traceback = "".join(tb)
-                formatted_exception = f"{ex}:<pre>{formatted_traceback}</pre>"
-                parent.setEvalErrorString(formatted_exception)
-                return None
-
-        def usesGeometry(self, node):
-            return self.uses_geometry
-
-        def referencedColumns(self, node):
-            return self.referenced_columns
-
-        def handlesNull(self):
-            return self.handles_null
-
+    # Format the help text
     helptemplate = string.Template("<h3>$name function</h3><br>$doc")
     name = kwargs.get("name", function.__name__)
     helptext = kwargs.get("helpText") or function.__doc__ or ""
@@ -130,7 +153,7 @@ def register_function(
     helptext = helptemplate.safe_substitute(name=name, doc=helptext)
 
     # Legacy: if args was not 'auto', parameters were passed as a list
-    params_as_list = kwargs.get("params_as_list", kwargs.get("args", "auto") != "auto")
+    params_as_list = params_as_list or args != "auto"
     f = QgsPyExpressionFunction(
         function, name, group, helptext, usesgeometry, referenced_columns, handlesnull, params_as_list
     )
@@ -143,47 +166,123 @@ def register_function(
 def qgsfunction(args="auto", group="custom", **kwargs):
     r"""
     Decorator function used to define a user expression function.
-    :param args: DEPRECATED since QGIS 3.32. Use the "params_as_list" keyword argument instead if you want to pass parameters as a list.
+
+    The decorated function signature may contain special parameters (in any order at the end of the signature):
+    - feature: the QgsFeature related to the current evaluation
+    - parent: the QgsExpressionFunction parent
+    - context: the QgsExpressionContext related to the current evaluation
+    If those parameters are present in the function signature, they will be automatically passed to the function,
+    without the need to specify them in the expression.
+
+    Functions should return a value compatible with QVariant
+    Eval errors can be raised using parent.setEvalErrorString("Error message")
+
+    :param args: DEPRECATED since QGIS 3.32. Use the "params_as_list" keyword argument if you want to pass parameters as a list.
     :param group: The expression group to which this expression should be added.
     :param \**kwargs:
         See below
     :Keyword Arguments:
-        * *referenced_columns* (``list``) --
-          An array of field names on which this expression works. Can be set to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. By default empty.
         * *usesgeometry* (``bool``) --
           Defines if this expression requires the geometry. By default False.
+        * *referenced_columns* (``list``) --
+          An array of field names on which this expression works. By default ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. Can be set to None for slightly faster evaluation.
         * *handlesnull* (``bool``) --
           Defines if this expression has custom handling for NULL values. If False, the result will always be NULL as soon as any parameter is NULL. False by default.
         * *params_as_list* (``bool``) \since QGIS 3.32 --
-          Defines if the parameters are passed to the function as a list, or if they are expanded. Default to False.
+          Defines if the parameters are passed to the function as a list. If set the False, they will be expanded. By default False.
+        * *register* (``bool``) --
+            Set to False to create the QgsPyExpressionFunction without registering it. Useful for testing puposes. By default True.
+        * *name* (``str``) --
+            If provided, replace the function name
+        * *helpText* (``str``) --
+            If provided, used in the help tooltip instead of the function docstring
 
-    Examples:
 
+    **Example 1 (Basic function, with default parameters) **:
+
+    ```
+    @qgsfunction(group="python")
+    def center(text, width, fillchar=" "):
+        return text.center(width, fillchar)
+
+    ```
+
+    This registers a function called "center" in the "python" group.
+    This expression requires two parameters: text and width.
+    An optional third parameter can be provided: fillchar.
+
+    ```
+    >>> center('Hello', 10)
+    '  Hello   '
+    >>> center('Hello', 15, '*')
+    '*****Hello*****'
+    ```
+
+
+    **Example 2 (variable number of parameters) **:
+    ```
     @qgsfunction(group="custom")
-    def myfunc(values, feature, parent):
-        return values + [feature.id()]
+    def fibonnaci_numbers(*args):
+        def fibonnaci(n):
+            if n <= 1:
+                return n
+            else:
+                return fibonnaci(n - 1) + fibonnaci(n - 2)
+        return [fibonnaci(arg) for arg in args]
 
-    This register a function called "myfunc" in the "custom" group. It can then be called with any number of parameters
-    which will be passed as a list to the function. From the function, it is possible to access the feature and the parent
+    ```
 
-    >>> myfunc("a", "b", "c")
-    ["a", "b", "c", 1]
+    This registers a function called "fibonnaci_numbers" in the "custom" group.
+    This expression can be called with any number of parameters, and will return a list of the fibonnaci numbers
+    corresponding to the parameters.
 
+    ```
+    >>> fibonnaci_numbers()
+    []
+    >>> fibonnaci_numbers(1)
+    [1]
+    >>> fibonnaci_numbers(3)
+    [2]
+    >>> fibonnaci_numbers(1, 2, 3, 4, 5, 6, 7)
+    [ 1, 1, 2, 3, 5, 8, 13 ]
+    ```
 
+    **Example 3 (feature and parent) **:
+
+    ```
     @qgsfunction(group="custom")
-    def myfunc2(val1, val2, context):
-        return val1 + val2
+    def display_field(fieldname, feature, parent):
+        try:
+            return f"<b>{fieldname}</b>: {feature[fieldname]}"
+        except KeyError:
+            parent.setEvalErrorString(f"Field {fieldname} not found")
+    ```
 
-    This register a function called "myfunc2" in the "custom" group. It expects exactly two parameters, val1 and val2
-    From the function, it is possible to access the feature and the parent
+    This registers a function called "display_field" in the "custom" group.
+    This expression requires an unique parameter: fieldname. Feature is automatically passed to the function.
+    parent is the QgsExpressionFunction parent, and can be used to raise an error.
 
-    >>> myfunc2(40, 2)
-    42
+    ```
+    >>> display_field("altitude")
+    <b>altitude</b>: 164
+    >>> display_field("lat")
+    <b>lat</b>: 45.4
+    ```
+
+    **Example 4 (context)**:
+    ```
+    @qgsfunction(group="custom")
+    def title_layer_name(context):
+        return context.variable("layer_name").title()
+    ```
+
+    This registers a function called "title_layer_name" in the "custom" group. It takes no parameters,
+    but extracts the layer name from the expression context and returns it as a title case string.
+
+
     """
 
-    kwargs["args"] = args
-
     def wrapper(func):
-        return register_function(func, group, **kwargs)
+        return register_function(func, args, group, **kwargs)
 
     return wrapper

--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     qgsfunction.py
@@ -26,30 +24,31 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis._core import QgsExpressionFunction, QgsExpression, QgsMessageLog, QgsFeatureRequest, Qgis
 
 
-def register_function(function, arg_count, group, usesgeometry=False,
-                      referenced_columns=[QgsFeatureRequest.ALL_ATTRIBUTES], handlesnull=False, **kwargs):
+def register_function(
+    function,
+    group,
+    usesgeometry=False,
+    referenced_columns=[QgsFeatureRequest.ALL_ATTRIBUTES],
+    handlesnull=False,
+    **kwargs,
+):
     """
     Register a Python function to be used as a expression function.
 
-    Functions should take (values, feature, parent) as args:
+    The function signature may contains special parameters:
+    - context: the QgsExpressionContext-related to the current evaluation
+    - feature: the QgsFeature-related to the current evaluation
+    - parent: the QgsExpressionFunction parent
 
-    Example:
-        def myfunc(values, feature, parent):
-            pass
+    If those parameters are present in the function signature, they will be automatically passed to the function,
+    without the need to specify them in the expression.
 
-    They can also shortcut naming feature and parent args by using *args
-    if they are not needed in the function.
-
-    Example:
-        def myfunc(values, *args):
-            pass
+    If the only other parameter in the signature is called "values", parameters will be passed as a list.
+    Otherwise, parameters will be expanded in the parameter list.
 
     Functions should return a value compatible with QVariant
-
     Eval errors can be raised using parent.setEvalErrorString("Error message")
-
     :param function:
-    :param arg_count:
     :param group:
     :param usesgeometry:
     :param handlesnull: Needs to be set to True if this function does not always return NULL if any parameter is NULL. Default False.
@@ -57,12 +56,20 @@ def register_function(function, arg_count, group, usesgeometry=False,
     """
 
     class QgsPyExpressionFunction(QgsExpressionFunction):
-
-        def __init__(self, func, name, args, group, helptext='', usesGeometry=True,
-                     referencedColumns=QgsFeatureRequest.ALL_ATTRIBUTES, expandargs=False, handlesNull=False):
-            QgsExpressionFunction.__init__(self, name, args, group, helptext)
+        def __init__(
+            self,
+            func,
+            name,
+            group,
+            helptext="",
+            usesGeometry=True,
+            referencedColumns=QgsFeatureRequest.ALL_ATTRIBUTES,
+            handlesNull=False,
+            paramsAsList=False,
+        ):
+            QgsExpressionFunction.__init__(self, name, -1, group, helptext)
             self.function = func
-            self.expandargs = expandargs
+            self.params_as_list = paramsAsList
             self.uses_geometry = usesGeometry
             self.referenced_columns = referencedColumns
             self.handles_null = handlesNull
@@ -71,21 +78,26 @@ def register_function(function, arg_count, group, usesgeometry=False,
             feature = None
             if context:
                 feature = context.feature()
-
             try:
-                if self.expandargs:
-                    values.append(feature)
-                    values.append(parent)
-                    if inspect.getfullargspec(self.function).args[-1] == 'context':
-                        values.append(context)
-                    return self.function(*values)
-                else:
-                    if inspect.getfullargspec(self.function).args[-1] == 'context':
-                        self.function(values, feature, parent, context)
-                    return self.function(values, feature, parent)
+                parameters = inspect.signature(self.function).parameters
+                kwvalues = {}
+
+                # Handle special parameters
+                # those will not be inserted in the parameter list
+                # if they are present in the function signature
+                if "context" in parameters:
+                    kwvalues["context"] = context
+                if "feature" in parameters:
+                    kwvalues["feature"] = feature
+                if "parent" in parameters:
+                    kwvalues["parent"] = parent
+
+                if self.params_as_list:
+                    return self.function(values, **kwvalues)
+                return self.function(*values, **kwvalues)
             except Exception as ex:
                 tb = traceback.format_exception(None, ex, ex.__traceback__)
-                formatted_traceback = ''.join(tb)
+                formatted_traceback = "".join(tb)
                 formatted_exception = f"{ex}:<pre>{formatted_traceback}</pre>"
                 parent.setEvalErrorString(formatted_exception)
                 return None
@@ -99,53 +111,42 @@ def register_function(function, arg_count, group, usesgeometry=False,
         def handlesNull(self):
             return self.handles_null
 
-    helptemplate = string.Template("""<h3>$name function</h3><br>$doc""")
-    name = kwargs.get('name', function.__name__)
-    helptext = kwargs.get('helpText') or function.__doc__ or ''
+    helptemplate = string.Template("<h3>$name function</h3><br>$doc")
+    name = kwargs.get("name", function.__name__)
+    helptext = kwargs.get("helpText") or function.__doc__ or ""
     helptext = helptext.strip()
-    expandargs = False
 
-    if arg_count == "auto":
-        # Work out the number of args we need.
-        # Number of function args - 2.  The last two args are always feature, parent.
-        args = inspect.getfullargspec(function).args
-        number = len(args)
-        arg_count = number - 2
-        if args[-1] == 'context':
-            arg_count -= 1
-        expandargs = True
-
-    register = kwargs.get('register', True)
+    register = kwargs.get("register", True)
     if register and QgsExpression.isFunctionName(name):
         if not QgsExpression.unregisterFunction(name):
             msgtitle = QCoreApplication.translate("UserExpressions", "User expressions")
-            msg = QCoreApplication.translate("UserExpressions",
-                                             "The user expression {0} already exists and could not be unregistered.").format(
-                name)
+            msg = QCoreApplication.translate(
+                "UserExpressions", "The user expression {0} already exists and could not be unregistered."
+            ).format(name)
             QgsMessageLog.logMessage(msg + "\n", msgtitle, Qgis.Warning)
             return None
 
     function.__name__ = name
     helptext = helptemplate.safe_substitute(name=name, doc=helptext)
-    f = QgsPyExpressionFunction(function, name, arg_count, group, helptext, usesgeometry, referenced_columns,
-                                expandargs, handlesnull)
 
-    # This doesn't really make any sense here but does when used from a decorator context
-    # so it can stay.
+    # Legacy: if args was not 'auto', parameters were passed as a list
+    params_as_list = kwargs.get("params_as_list", kwargs.get("args", "auto") != "auto")
+    f = QgsPyExpressionFunction(
+        function, name, group, helptext, usesgeometry, referenced_columns, handlesnull, params_as_list
+    )
+
     if register:
         QgsExpression.registerFunction(f)
     return f
 
 
-def qgsfunction(args='auto', group='custom', **kwargs):
+def qgsfunction(args="auto", group="custom", **kwargs):
     r"""
     Decorator function used to define a user expression function.
-
-    :param args: Number of parameters, set to 'auto' to accept a variable length of parameters.
+    :param args: DEPRECATED since QGIS 3.32. Use the "params_as_list" keyword argument instead if you want to pass parameters as a list.
     :param group: The expression group to which this expression should be added.
     :param \**kwargs:
         See below
-
     :Keyword Arguments:
         * *referenced_columns* (``list``) --
           An array of field names on which this expression works. Can be set to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. By default empty.
@@ -153,24 +154,36 @@ def qgsfunction(args='auto', group='custom', **kwargs):
           Defines if this expression requires the geometry. By default False.
         * *handlesnull* (``bool``) --
           Defines if this expression has custom handling for NULL values. If False, the result will always be NULL as soon as any parameter is NULL. False by default.
+        * *params_as_list* (``bool``) \since QGIS 3.32 --
+          Defines if the parameters are passed to the function as a list, or if they are expanded. Default to False.
 
-    Example:
-      @qgsfunction(2, 'test'):
-      def add(values, feature, parent):
-        pass
+    Examples:
 
-    Will create and register a function in QgsExpression called 'add' in the
-    'test' group that takes two arguments.
+    @qgsfunction(group="custom")
+    def myfunc(values, feature, parent):
+        return values + [feature.id()]
 
-    or not using feature and parent:
+    This register a function called "myfunc" in the "custom" group. It can then be called with any number of parameters
+    which will be passed as a list to the function. From the function, it is possible to access the feature and the parent
 
-    Example:
-      @qgsfunction(2, 'test'):
-      def add(values, *args):
-        pass
+    >>> myfunc("a", "b", "c")
+    ["a", "b", "c", 1]
+
+
+    @qgsfunction(group="custom")
+    def myfunc2(val1, val2, context):
+        return val1 + val2
+
+    This register a function called "myfunc2" in the "custom" group. It expects exactly two parameters, val1 and val2
+    From the function, it is possible to access the feature and the parent
+
+    >>> myfunc2(40, 2)
+    42
     """
 
+    kwargs["args"] = args
+
     def wrapper(func):
-        return register_function(func, args, group, **kwargs)
+        return register_function(func, group, **kwargs)
 
     return wrapper

--- a/python/user.py
+++ b/python/user.py
@@ -66,8 +66,8 @@ if not os.path.exists(initfile):
 template = """from qgis.core import *
 from qgis.gui import *
 
-@qgsfunction(args='auto', group='Custom', referenced_columns=[])
-def my_sum(value1, value2, feature, parent):
+@qgsfunction(group='Custom', referenced_columns=[])
+def my_sum(value1, value2):
     \"\"\"
     Calculates the sum of the two parameters value1 and value2.
     <h2>Example usage:</h2>

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -209,16 +209,13 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   mFunctionBuilderHelp->setReadOnly( true );
   mFunctionBuilderHelp->setText( tr( "\"\"\"Define a new function using the @qgsfunction decorator.\n\
 \n\
- The function accepts the following parameters\n\
+ Besides its normal arguments, the function may specify the following arguments in its signature\n\
+ Those will not need to be specified when calling the function, but will be automatically injected \n\
 \n\
- : param [any]: Define any parameters you want to pass to your function before\n\
- the following arguments.\n\
  : param feature: The current feature\n\
  : param parent: The QgsExpression object\n\
- : param context: If there is an argument called ``context`` found at the last\n\
-                   position, this variable will contain a ``QgsExpressionContext``\n\
-                   object, that gives access to various additional information like\n\
-                   expression variables. E.g. ``context.variable( 'layer_id' )``\n\
+ : param context: ``QgsExpressionContext`` object, that gives access to various additional information like\n\
+                  expression variables. E.g. ``context.variable( 'layer_id' )``\n\
  : returns: The result of the expression.\n\
 \n\
 \n\
@@ -226,9 +223,6 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
  The @qgsfunction decorator accepts the following arguments:\n\
 \n\
 \n\
- : param args: Defines the number of arguments. With ``args = 'auto'`` the number of\n\
-               arguments will automatically be extracted from the signature.\n\
-               With ``args = -1``, any number of arguments are accepted.\n\
  : param group: The name of the group under which this expression function will\n\
                 be listed.\n\
  : param handlesnull: Set this to True if your function has custom handling for NULL values.\n\
@@ -238,7 +232,9 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
                         feature.geometry(). Defaults to False.\n\
  : param referenced_columns: An array of attribute names that are required to run\n\
                              this function. Defaults to [QgsFeatureRequest.ALL_ATTRIBUTES].\n\
-     \"\"\"" ) );
+ : param params_as_list : Set this to True to pass the function parameters as a list. Can be used to mimic \n\
+                        behavior before 3.32, when args was not \"auto\". Defaults to False.\n\
+\"\"\"" ) );
 }
 
 

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -17,6 +17,8 @@ from qgis.core import (
     QgsExpressionContext,
     QgsFeatureRequest,
     QgsFields,
+    QgsFeature,
+    QgsField,
 )
 from qgis.testing import unittest
 from qgis.utils import qgsfunction
@@ -28,10 +30,6 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     def testfun(values, feature, parent):
         """ Function help """
         return f"Testing_{values[0]}"
-
-    @qgsfunction(args="auto", group='testing', register=False)
-    def autocount(value1, value2, value3, feature, parent):
-        pass
 
     @qgsfunction(args="auto", group='testing', register=False)
     def expandargs(value1, value2, value3, feature, parent):
@@ -79,6 +77,30 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         # an undefined variable
         foo  # noqa: F821
 
+    @qgsfunction(group='testing', register=False)
+    def simple_sum(val1, val2):
+        return val1 + val2
+
+    @qgsfunction(group='testing', register=False)
+    def sum_vargs(val1, *args):
+        return val1 + sum(args)
+
+    @qgsfunction(group='testing', args=-1, register=False)
+    def func_params_as_list_legacy(values, feature, parent):
+        return values
+
+    @qgsfunction(group='testing', params_as_list=True, register=False)
+    def func_params_as_list(values):
+        return values
+
+    @qgsfunction(group='testing', register=False)
+    def func_params_no_list(values):
+        return values
+
+    @qgsfunction(group='testing', register=False)
+    def func_feature(*args, feature):
+        return (feature["a"] + sum(args)) * feature["b"]
+
     def tearDown(self):
         QgsExpression.unregisterFunction('testfun')
 
@@ -86,11 +108,6 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         QgsExpression.registerFunction(self.testfun)
         index = QgsExpression.functionIndex('testfun')
         self.assertNotEqual(index, -1)
-
-    def testAutoCountsCorrectArgs(self):
-        function = self.autocount
-        args = function.params()
-        self.assertEqual(args, 3)
 
     def testHelpPythonFunction(self):
         """Test help about python function."""
@@ -112,8 +129,6 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
 
     def testAutoArgsAreExpanded(self):
         function = self.expandargs
-        args = function.params()
-        self.assertEqual(args, 3)
         values = [1, 2, 3]
         exp = QgsExpression("")
         result = function.func(values, None, exp, None)
@@ -148,7 +163,6 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         func = self.testfun
         self.assertEqual(func.name(), 'testfun')
         self.assertEqual(func.group(), 'testing')
-        self.assertEqual(func.params(), 1)
 
     def testCantReregister(self):
         QgsExpression.registerFunction(self.testfun)
@@ -312,7 +326,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         regex = (
             "name 'foo' is not defined:<pre>Traceback \\(most recent call last\\):\n"
             "  File \".*qgsfunction.py\", line [0-9]+, in func\n"
-            "    return self.function\\(\\*values\\)\n"
+            "    return self.function\\(\\*values, \\*\\*kwvalues\\)\n"
             "  File \".*test_qgsexpression.py\", line [0-9]+, in raise_exception\n"
             "    foo  # noqa: F821\n"
             "NameError: name \'foo\' is not defined"
@@ -327,6 +341,88 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         self.assertTrue(e.isValid(), e.parserErrorString())
         e.setExpression("'b' between 'a' AND 'c'")
         self.assertTrue(e.isValid(), e.parserErrorString())
+
+    def testSimpleSum(self):
+
+        QgsExpression.registerFunction(self.simple_sum)
+
+        e = QgsExpression()
+        e.setExpression("simple_sum(4, 5)")
+        self.assertEqual(e.evaluate(), 9)
+
+        # Not enough parameters
+        e.setExpression("simple_sum(4)")
+        self.assertEqual(e.evaluate(), None)
+
+        # Too many parameters
+        e.setExpression("simple_sum(4, 7, 8)")
+        self.assertEqual(e.evaluate(), None)
+
+    def testSumVargs(self):
+
+        QgsExpression.registerFunction(self.sum_vargs)
+
+        e = QgsExpression()
+
+        # Not enough parameters
+        e.setExpression("sum_vargs()")
+        self.assertEqual(e.evaluate(), None)
+
+        e.setExpression("sum_vargs(4)")
+        self.assertEqual(e.evaluate(), 4)
+
+        e.setExpression("sum_vargs(4, 5)")
+        self.assertEqual(e.evaluate(), 9)
+
+        e.setExpression("sum_vargs(4, 5, 6, 7)")
+        self.assertEqual(e.evaluate(), 22)
+
+    def testListNoList(self):
+        QgsExpression.registerFunction(self.func_params_as_list_legacy)
+        QgsExpression.registerFunction(self.func_params_as_list)
+        QgsExpression.registerFunction(self.func_params_no_list)
+
+        e = QgsExpression()
+        e.setExpression("func_params_as_list_legacy('a', 'b', 'c')")
+        self.assertEqual(e.evaluate(), ["a", "b", "c"])
+
+        e.setExpression("func_params_as_list('a', 'b', 'c')")
+        self.assertEqual(e.evaluate(), ["a", "b", "c"])
+
+        e.setExpression("func_params_as_list('a')")
+        self.assertEqual(e.evaluate(), ["a"])
+
+        e.setExpression("func_params_no_list('a')")
+        self.assertEqual(e.evaluate(), "a")
+
+    def testFeature(self):
+        QgsExpression.registerFunction(self.func_feature)
+        context = QgsExpressionContext()
+        feature = QgsFeature(id=10)
+        fields = QgsFields()
+        fields.append(QgsField("a", QVariant.Int))
+        fields.append(QgsField("b", QVariant.String))
+
+        feature.setFields(fields)
+        feature["a"] = 4
+        feature["b"] = "world"
+
+        context.setFeature(feature)
+
+        e = QgsExpression()
+        e.setExpression("func_feature()")
+        self.assertEqual(e.evaluate(context), "worldworldworldworld")
+        e.setExpression("func_feature(-1, -1)")
+        self.assertEqual(e.evaluate(context), "worldworld")
+
+        feature["a"] = 2
+        feature["b"] = "_"
+
+        context.setFeature(feature)
+        e.setExpression("func_feature()")
+        self.assertEqual(e.evaluate(context), "__")
+        e.setExpression("func_feature(3)")
+        self.assertEqual(e.evaluate(context), "_____")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fixes #52796

## Description

Change the `@qgisfunction` expression decorator

- the args parameter becomes deprecated
- If the decorated function signature contains `feature`, `parent` or `context`, they are injected in the function parameters.

```Python
# Simple case
# -------------------------------
@qgisfunction(group="test")
def myfunction(a, b, c):
 return a + b + c

# usage:
# myfunction(4,5,6) => 15

# Function with vargs
# -------------------------------
@qgisfunction(group="test")
def myfunction_with_vargs(a, b, *args):
 return a + b + sum(args)

# usage:
# myfunction_with_vargs(4,5) => 9
# myfunction_with_vargs(4,5,1,2) => 12
# myfunction_with_vargs(4,5,1,2,10) => 22

# Function with feature
# -------------------------------
@qgisfunction(group="test")
def double_id(feature):
 return feature.id() * 2

# usage:
# double_id()
```

If one wants to keep the function parameters as a list (as was the case when args was specified and not equal to "auto" in the qgsfunction decorator), a new keyword `params_as_list` is added. 

```Python
@qgisfunction(group="test", params_as_list=True)
def myfunction(values):
 return values

myfunction(4,5) => [4, 5]
myfunction(4) => [4]
```

Compare to the default behavior (params_as_list=False)

```Python
@qgisfunction(group="test")
def myfunction(values):
 return values

myfunction(4,5) => None (Error, too many parameters)
myfunction(4) => 4
```