### PR TITLE
[qgsquick] Avoid all-black map canvas when first loading a QML scene with nothing to render

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -360,6 +360,11 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
     mDirty = false;
   }
 
+  if ( mImage.isNull() )
+  {
+    return nullptr;
+  }
+
   QSGSimpleTextureNode *node = static_cast<QSGSimpleTextureNode *>( oldNode );
   if ( !node )
   {


### PR DESCRIPTION
## Description

Doubles a tiny, micro optimization on scene loading.