### PR TITLE
Add invert selection tool on refactor fields processing fix #52816

### DIFF
--- a/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -146,9 +146,11 @@ Moves up currently selected field
 Moves down the currently selected field
 %End
 
-    bool invertSelection( );
+    void invertSelection( );
 %Docstring
-Invert the field selection state
+Invert the field selection state.
+
+.. versionadded:: 3.32
 %End
 
 };

--- a/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -146,6 +146,11 @@ Moves up currently selected field
 Moves down the currently selected field
 %End
 
+    bool invertSelection( );
+%Docstring
+Invert the field selection state
+%End
+
 };
 
 

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -53,7 +53,9 @@ QgsProcessingFieldMapPanelWidget::QgsProcessingFieldMapPanelWidget( QWidget *par
   connect( mDeleteButton, &QPushButton::clicked, mFieldsView, &QgsFieldMappingWidget::removeSelectedFields );
   connect( mUpButton, &QPushButton::clicked, mFieldsView, &QgsFieldMappingWidget::moveSelectedFieldsUp );
   connect( mDownButton, &QPushButton::clicked, mFieldsView, &QgsFieldMappingWidget::moveSelectedFieldsDown );
+  connect( mInvertSelectionButton, &QPushButton::clicked, mFieldsView, &QgsFieldMappingWidget::invertSelection );
   connect( mLoadLayerFieldsButton, &QPushButton::clicked, this, &QgsProcessingFieldMapPanelWidget::loadLayerFields );
+
 
   connect( mFieldsView, &QgsFieldMappingWidget::changed, this, [ = ]
   {

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsprocessingaggregatewidgets.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
+#include "QItemSelectionModel"
 
 #include <QTableView>
 #include <QVBoxLayout>
@@ -143,6 +144,21 @@ bool QgsFieldMappingWidget::removeSelectedFields()
     {
       return false;
     }
+  }
+  return true;
+}
+
+bool QgsFieldMappingWidget::invertSelection()
+{
+
+  for ( int i = 0; i < mTableView->model()->rowCount(); ++i )
+  {
+    for ( int j = 0; j < mTableView->model()->columnCount(); j++ )
+    {
+      QModelIndex index = mTableView->model()->index( i, j );
+      mTableView->selectionModel()->select( index, QItemSelectionModel::Toggle );
+    }
+
   }
   return true;
 }

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -150,7 +150,6 @@ bool QgsFieldMappingWidget::removeSelectedFields()
 
 bool QgsFieldMappingWidget::invertSelection()
 {
-
   for ( int i = 0; i < mTableView->model()->rowCount(); ++i )
   {
     for ( int j = 0; j < mTableView->model()->columnCount(); j++ )

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -157,7 +157,6 @@ bool QgsFieldMappingWidget::invertSelection()
       QModelIndex index = mTableView->model()->index( i, j );
       mTableView->selectionModel()->select( index, QItemSelectionModel::Toggle );
     }
-
   }
   return true;
 }

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -148,7 +148,7 @@ bool QgsFieldMappingWidget::removeSelectedFields()
   return true;
 }
 
-bool QgsFieldMappingWidget::invertSelection()
+void QgsFieldMappingWidget::invertSelection()
 {
   for ( int i = 0; i < mTableView->model()->rowCount(); ++i )
   {
@@ -158,7 +158,6 @@ bool QgsFieldMappingWidget::invertSelection()
       mTableView->selectionModel()->select( index, QItemSelectionModel::Toggle );
     }
   }
-  return true;
 }
 
 bool QgsFieldMappingWidget::moveSelectedFieldsUp()

--- a/src/gui/qgsfieldmappingwidget.h
+++ b/src/gui/qgsfieldmappingwidget.h
@@ -144,6 +144,9 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
     //! Moves down the currently selected field
     bool moveSelectedFieldsDown( );
 
+    //! Invert the field selection state
+    bool invertSelection( );
+
   private:
 
     QTableView *mTableView = nullptr;

--- a/src/gui/qgsfieldmappingwidget.h
+++ b/src/gui/qgsfieldmappingwidget.h
@@ -144,8 +144,12 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
     //! Moves down the currently selected field
     bool moveSelectedFieldsDown( );
 
-    //! Invert the field selection state
-    bool invertSelection( );
+    /**
+     * Invert the field selection state.
+     *
+     * \since QGIS 3.32
+     */
+    void invertSelection( );
 
   private:
 

--- a/src/ui/processing/qgsprocessingfieldsmappingpanelbase.ui
+++ b/src/ui/processing/qgsprocessingfieldsmappingpanelbase.ui
@@ -119,7 +119,7 @@
        <item>
         <widget class="QToolButton" name="mInvertSelectionButton">
          <property name="text">
-          <string>invert selection</string>
+          <string>Invert selection</string>
          </property>
          <property name="icon">
           <iconset resource="../../../images/images.qrc">

--- a/src/ui/processing/qgsprocessingfieldsmappingpanelbase.ui
+++ b/src/ui/processing/qgsprocessingfieldsmappingpanelbase.ui
@@ -117,6 +117,17 @@
         </widget>
        </item>
        <item>
+        <widget class="QToolButton" name="mInvertSelectionButton">
+         <property name="text">
+          <string>invert selection</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../images/images.qrc">
+           <normaloff>:/images/themes/default/mActionInvertSelection.svg</normaloff>:/images/themes/default/mActionInvertSelection.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -187,6 +198,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
## Description

Add a tool button to invert the selection. The use is when we have many attributes, and we want to delete most of them. We only need to select the attributes that we want to keep, invert the selection, and delete them (resolve #52816) 

![Peek 2023-04-23 11-09 - invert selection](https://user-images.githubusercontent.com/1421861/233830681-150b50c8-f478-4e8b-b316-43fec794bf93.gif)

Added on [QGIS Contributor Meeting 2023, s-hertogenbosch](https://github.com/qgis/QGIS/wiki/25th-Contributor-Meeting-in-'s-Hertogenbosch)

Funded by: [camptocamp.com](https://camptocamp.com/)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->


