### PR TITLE
Remove arbitrary minimum pixel size for "create raster" algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -66,7 +66,7 @@ void QgsConstantRasterAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "EXTENT" ), QObject::tr( "Desired extent" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "ProjectCrs" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "PIXEL_SIZE" ), QObject::tr( "Pixel size" ),
-                QgsProcessingParameterNumber::Double, 0.00001, false, 0 ) );
+                QgsProcessingParameterNumber::Double, 1, false, 0 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "NUMBER" ), QObject::tr( "Constant value" ),
                 QgsProcessingParameterNumber::Double, 1, false ) );
 

--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -95,8 +95,9 @@ QVariantMap QgsConstantRasterAlgorithm::processAlgorithm( const QVariantMap &par
   const double value = parameterAsDouble( parameters, QStringLiteral( "NUMBER" ), context );
   const int typeId = parameterAsInt( parameters, QStringLiteral( "OUTPUT_TYPE" ), context );
 
-  if ( pixelSize <= 0 ) {
-	  throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
+  if ( pixelSize <= 0 )
+  {
+    throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
   }
 
   //implement warning if input float has decimal places but is written to integer raster

--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -66,7 +66,7 @@ void QgsConstantRasterAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "EXTENT" ), QObject::tr( "Desired extent" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "ProjectCrs" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "PIXEL_SIZE" ), QObject::tr( "Pixel size" ),
-                QgsProcessingParameterNumber::Double, 0.00001, false, 0.01 ) );
+                QgsProcessingParameterNumber::Double, 0.00001, false, 0 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "NUMBER" ), QObject::tr( "Constant value" ),
                 QgsProcessingParameterNumber::Double, 1, false ) );
 
@@ -94,6 +94,10 @@ QVariantMap QgsConstantRasterAlgorithm::processAlgorithm( const QVariantMap &par
   const double pixelSize = parameterAsDouble( parameters, QStringLiteral( "PIXEL_SIZE" ), context );
   const double value = parameterAsDouble( parameters, QStringLiteral( "NUMBER" ), context );
   const int typeId = parameterAsInt( parameters, QStringLiteral( "OUTPUT_TYPE" ), context );
+
+  if ( pixelSize <= 0 ) {
+	  throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
+  }
 
   //implement warning if input float has decimal places but is written to integer raster
   double fractpart;

--- a/src/analysis/processing/qgsalgorithmrandomraster.cpp
+++ b/src/analysis/processing/qgsalgorithmrandomraster.cpp
@@ -41,7 +41,7 @@ void QgsRandomRasterAlgorithmBase::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "EXTENT" ), QObject::tr( "Desired extent" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "ProjectCrs" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "PIXEL_SIZE" ), QObject::tr( "Pixel size" ),
-                QgsProcessingParameterNumber::Double, 1, false, 0.01 ) );
+                QgsProcessingParameterNumber::Double, 1, false, 0 ) );
 
   //add specific parameters
   addAlgorithmParams();
@@ -55,6 +55,10 @@ bool QgsRandomRasterAlgorithmBase::prepareAlgorithm( const QVariantMap &paramete
   mCrs = parameterAsCrs( parameters, QStringLiteral( "TARGET_CRS" ), context );
   mExtent = parameterAsExtent( parameters, QStringLiteral( "EXTENT" ), context, mCrs );
   mPixelSize = parameterAsDouble( parameters, QStringLiteral( "PIXEL_SIZE" ), context );
+
+  if ( mPixelSize <= 0 ) {
+	  throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
+  }
 
   return true;
 }

--- a/src/analysis/processing/qgsalgorithmrandomraster.cpp
+++ b/src/analysis/processing/qgsalgorithmrandomraster.cpp
@@ -56,8 +56,9 @@ bool QgsRandomRasterAlgorithmBase::prepareAlgorithm( const QVariantMap &paramete
   mExtent = parameterAsExtent( parameters, QStringLiteral( "EXTENT" ), context, mCrs );
   mPixelSize = parameterAsDouble( parameters, QStringLiteral( "PIXEL_SIZE" ), context );
 
-  if ( mPixelSize <= 0 ) {
-	  throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
+  if ( mPixelSize <= 0 )
+  {
+    throw QgsProcessingException( QObject::tr( "Pixel size must be greater than 0." ) );
   }
 
   return true;


### PR DESCRIPTION
## Description

Removes the arbitrary minimum pixel size for "create raster" algorithms. Fixes #39732

They accept anything now and will raise an exception if the pixel size is not greater than 0. This gives maximum freedom to the users. Previously it was not possible to great detailed rasters in a CRS like WGS84 where 0.01 is a huge area.

I also changed the default pixel size for "Create Constant Raster" to 1 (it was a tiny 0.00001 before) which is the same as the Create Random Raster algorithms use. @alexbruy had once suggested to use 0.01 in https://github.com/qgis/QGIS/pull/39734 but that seems just as arbitrary to me. Rasterize uses 100 even.