### PR TITLE
Fix missing last timestep in certain temporal controller scenario's

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -35,7 +35,7 @@ void QgsTemporalNavigationObject::timerTimeout()
   {
     case AnimationState::Forward:
       next();
-      if ( mCurrentFrameNumber >= totalFrameCount() - 1 )
+      if ( mCurrentFrameNumber >= totalFrameCount() )
       {
         if ( mLoopAnimation )
           mCurrentFrameNumber = -1; // we don't jump immediately to frame 0, instead we delay that till the next timeout
@@ -197,7 +197,7 @@ void QgsTemporalNavigationObject::setCurrentFrameNumber( long long frameNumber )
 {
   if ( mCurrentFrameNumber != frameNumber )
   {
-    mCurrentFrameNumber = std::max( 0LL, std::min( frameNumber, totalFrameCount() - 1 ) );
+    mCurrentFrameNumber = std::max( 0LL, std::min( frameNumber, totalFrameCount() ) );
     const QgsDateTimeRange range = dateTimeRangeForFrameNumber( mCurrentFrameNumber );
 
     if ( !mBlockUpdateTemporalRangeSignal )
@@ -272,7 +272,7 @@ void QgsTemporalNavigationObject::pause()
 
 void QgsTemporalNavigationObject::playForward()
 {
-  if ( mPlayBackMode == Idle &&  mCurrentFrameNumber >= totalFrameCount() - 1 )
+  if ( mPlayBackMode == Idle &&  mCurrentFrameNumber >= totalFrameCount() )
   {
     // if we are paused at the end of the video, and the user hits play, we automatically rewind and play again
     rewindToStart();
@@ -311,7 +311,7 @@ void QgsTemporalNavigationObject::rewindToStart()
 
 void QgsTemporalNavigationObject::skipToEnd()
 {
-  const long long frame = totalFrameCount() - 1;
+  const long long frame = totalFrameCount();
   setCurrentFrameNumber( frame );
 }
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -293,7 +293,7 @@ void QgsTemporalControllerWidget::updateTemporalExtent()
   const QgsDateTimeRange temporalExtent = QgsDateTimeRange( start, end,
                                           true, !isTimeInstant && mNavigationObject->navigationMode() == QgsTemporalNavigationObject::FixedRange ? false : true );
   mNavigationObject->setTemporalExtents( temporalExtent );
-  mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
+  mSlider->setRange( 0, mNavigationObject->totalFrameCount() );
   mSlider->setValue( mNavigationObject->currentFrameNumber() );
 }
 
@@ -314,7 +314,7 @@ void QgsTemporalControllerWidget::updateFrameDuration()
                    QgsProject::instance()->timeSettings()->timeStepUnit() ) );
     mSlider->setValue( mNavigationObject->currentFrameNumber() );
   }
-  mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
+  mSlider->setRange( 0, mNavigationObject->totalFrameCount() );
   mSlider->setValue( mNavigationObject->currentFrameNumber() );
 
   if ( unit == Qgis::TemporalUnit::IrregularStep )

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -118,7 +118,7 @@ void TestQgsTemporalNavigationObject::animationState()
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
 
   navigationObject->skipToEnd();
-  QCOMPARE( navigationObject->currentFrameNumber(), 9 );
+  QCOMPARE( navigationObject->currentFrameNumber(), 10 );
 
   navigationObject->rewindToStart();
   QCOMPARE( navigationObject->currentFrameNumber(), 0 );
@@ -247,7 +247,7 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   // Test Overflow
   navigationObject->setCurrentFrameNumber( 100 );
-  QCOMPARE( navigationObject->currentFrameNumber(), navigationObject->totalFrameCount() - 1 );
+  QCOMPARE( navigationObject->currentFrameNumber(), navigationObject->totalFrameCount() );
   QCOMPARE( temporalRangeSignal.count(), 4 );
 
   // Test Underflow


### PR DESCRIPTION
Working with small dataset of say 3 timeframes it appeared to me that it was not possible to reach the last timeframe, see #48942. Loading a netcdf with 3 time(instances) in it, QGIS failed to show the last one. 
First thought to fix this in mdal provider: https://github.com/qgis/QGIS/pull/49283 but then it appeared vector data (with instantaneous events) was also having the issue.

The solution I propose here is to actually always add the extra frame in the controller.
This has as drawback that when working with events having a duration >0 or with events having a begin and end time, there will be one frame too much (so an empty frame with no data on the end, testable with testdata below).
But I think that is better then loosing a frame with data... 

To test, unzip the zip (data + python code) and run the python in the python console.
It will load a csv (with 3 temporal scenario's) and one tiny netcdf (with 3 timesteps, see ncinfo and ncdump), all in same position and time:
[temporal_tests.zip](https://github.com/qgis/QGIS/files/11304584/temporal_tests.zip)

In current master you will be able to just run 2 frames, with this PR you will have 3

![Screenshot from 2023-04-23 20-57-51](https://user-images.githubusercontent.com/731673/233859408-d020c7d6-fb26-4b56-8104-2e19cfe97a2b.png)

