### PR TITLE
Annotation live preview

### DIFF
--- a/src/app/qgsannotationwidget.cpp
+++ b/src/app/qgsannotationwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgisapp.h"
 #include "qgsfillsymbol.h"
 #include "qgsmarkersymbol.h"
+#include "qgsdoublespinbox.h"
 
 #include <QColorDialog>
 
@@ -79,6 +80,17 @@ QgsAnnotationWidget::QgsAnnotationWidget( QgsMapCanvasAnnotationItem *item, QWid
   mFrameStyleButton->setMessageBar( QgisApp::instance()->messageBar() );
 
   connect( mFrameStyleButton, &QgsSymbolButton::changed, this, &QgsAnnotationWidget::frameStyleChanged );
+
+  // connect to the changed signal
+  connect( mFrameStyleButton, &QgsSymbolButton::changed, this, &QgsAnnotationWidget::changed );
+  connect( mMapMarkerButton, &QgsSymbolButton::changed, this, &QgsAnnotationWidget::changed );
+  connect( mLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsAnnotationWidget::changed );
+  connect( mSpinTopMargin,  static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsAnnotationWidget::changed );
+  connect( mSpinLeftMargin,  static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsAnnotationWidget::changed );
+  connect( mSpinRightMargin,  static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsAnnotationWidget::changed );
+  connect( mSpinBottomMargin,  static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsAnnotationWidget::changed );
+  connect( mMapPositionFixedCheckBox, &QCheckBox::stateChanged, this, &QgsAnnotationWidget::changed );
+
 }
 
 QColor QgsAnnotationWidget::backgroundColor()

--- a/src/app/qgsannotationwidget.cpp
+++ b/src/app/qgsannotationwidget.cpp
@@ -26,8 +26,13 @@
 #include "qgsfillsymbol.h"
 #include "qgsmarkersymbol.h"
 #include "qgsdoublespinbox.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingstree.h"
 
 #include <QColorDialog>
+
+
+const QgsSettingsEntryBool *QgsAnnotationWidget::settingLiveUpdate = new QgsSettingsEntryBool( QStringLiteral( "live-update" ), QgsSettingsTree::sTreeAnnotations, false, QObject::tr( "Whether the annotations are dynamically updated while they are edited" ) );
 
 
 QgsAnnotationWidget::QgsAnnotationWidget( QgsMapCanvasAnnotationItem *item, QWidget *parent, Qt::WindowFlags f )

--- a/src/app/qgsannotationwidget.h
+++ b/src/app/qgsannotationwidget.h
@@ -52,6 +52,9 @@ class APP_EXPORT QgsAnnotationWidget: public QWidget, private Ui::QgsAnnotationW
     //! Emitted when the background color of the annotation is changed
     void backgroundColorChanged( const QColor &color );
 
+    //! \since QGIS 3.32 Emitted when any property of the annotation is changed
+    void changed();
+
   private:
 
     QgsMapCanvasAnnotationItem *mItem = nullptr;

--- a/src/app/qgsannotationwidget.h
+++ b/src/app/qgsannotationwidget.h
@@ -25,6 +25,7 @@
 class QgsMapCanvasAnnotationItem;
 class QgsMarkerSymbol;
 class QgsFillSymbol;
+class QgsSettingsEntryBool;
 
 /**
  * A configuration widget to configure the annotation item properties.
@@ -35,6 +36,8 @@ class APP_EXPORT QgsAnnotationWidget: public QWidget, private Ui::QgsAnnotationW
 {
     Q_OBJECT
   public:
+
+    static const QgsSettingsEntryBool *settingLiveUpdate;
 
     QgsAnnotationWidget( QgsMapCanvasAnnotationItem *item, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 

--- a/src/app/qgsformannotationdialog.cpp
+++ b/src/app/qgsformannotationdialog.cpp
@@ -57,6 +57,11 @@ QgsFormAnnotationDialog::QgsFormAnnotationDialog( QgsMapCanvasAnnotationItem *it
   QObject::connect( deleteButton, &QPushButton::clicked, this, &QgsFormAnnotationDialog::deleteItem );
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsFormAnnotationDialog::onLiveUpdateToggled );
+  connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsFormAnnotationDialog::onSettingsChanged );
+  connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsFormAnnotationDialog::onSettingsChanged );
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsFormAnnotationDialog::onSettingsChanged );
+
   QgsGui::enableAutoGeometryRestore( this );
 }
 
@@ -113,4 +118,19 @@ void QgsFormAnnotationDialog::mButtonBox_clicked( QAbstractButton *button )
 void QgsFormAnnotationDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "map_views/map_view.html#sec-annotations" ) );
+}
+
+void QgsFormAnnotationDialog::onSettingsChanged()
+{
+  if ( mLiveCheckBox->isChecked() )
+  {
+    applySettingsToItem();
+  }
+}
+
+void QgsFormAnnotationDialog::onLiveUpdateToggled( bool checked )
+{
+  // Apply and Cancel buttons make no sense when live update is on
+  mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
+  mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
 }

--- a/src/app/qgsformannotationdialog.cpp
+++ b/src/app/qgsformannotationdialog.cpp
@@ -38,6 +38,13 @@ QgsFormAnnotationDialog::QgsFormAnnotationDialog( QgsMapCanvasAnnotationItem *it
   mStackedWidget->addWidget( mEmbeddedWidget );
   mStackedWidget->setCurrentWidget( mEmbeddedWidget );
 
+  // Form annotation can only be created from an ui file
+  // Mask the source radio button and the source text edit
+  mFileRadioButton->setChecked( true );
+  mFileRadioButton->hide();
+  mSourceRadioButton->hide();
+  mHtmlSourceTextEdit->hide();
+
   if ( item && item->annotation() )
   {
     QgsFormAnnotation *annotation = static_cast< QgsFormAnnotation * >( item->annotation() );

--- a/src/app/qgsformannotationdialog.cpp
+++ b/src/app/qgsformannotationdialog.cpp
@@ -70,9 +70,12 @@ void QgsFormAnnotationDialog::applySettingsToItem()
 
   if ( mItem && mItem->annotation() )
   {
-    QgsFormAnnotation *annotation = static_cast< QgsFormAnnotation * >( mItem->annotation() );
-    annotation->setDesignerForm( mFileLineEdit->text() );
-    mItem->update();
+    if ( !mFileLineEdit->text().isEmpty() )
+    {
+      QgsFormAnnotation *annotation = static_cast< QgsFormAnnotation * >( mItem->annotation() );
+      annotation->setDesignerForm( mFileLineEdit->text() );
+      mItem->update();
+    }
   }
 }
 
@@ -85,6 +88,10 @@ void QgsFormAnnotationDialog::mBrowseToolButton_clicked()
     directory = fi.absolutePath();
   }
   const QString filename = QFileDialog::getOpenFileName( nullptr, tr( "Qt designer file" ), directory, QStringLiteral( "*.ui" ) );
+  if ( filename.isEmpty() )
+  {
+    return;
+  }
   mFileLineEdit->setText( filename );
 }
 

--- a/src/app/qgsformannotationdialog.cpp
+++ b/src/app/qgsformannotationdialog.cpp
@@ -21,6 +21,8 @@
 #include "qgsannotationmanager.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
+#include "qgssettingsentryimpl.h"
+
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGraphicsScene>
@@ -58,6 +60,7 @@ QgsFormAnnotationDialog::QgsFormAnnotationDialog( QgsMapCanvasAnnotationItem *it
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsFormAnnotationDialog::onLiveUpdateToggled );
+  mLiveCheckBox->setChecked( QgsAnnotationWidget::settingLiveUpdate->value() );
   connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsFormAnnotationDialog::onSettingsChanged );
   connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsFormAnnotationDialog::onSettingsChanged );
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsFormAnnotationDialog::onSettingsChanged );
@@ -133,4 +136,5 @@ void QgsFormAnnotationDialog::onLiveUpdateToggled( bool checked )
   // Apply and Cancel buttons make no sense when live update is on
   mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
   mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
+  QgsAnnotationWidget::settingLiveUpdate->setValue( checked );
 }

--- a/src/app/qgsformannotationdialog.h
+++ b/src/app/qgsformannotationdialog.h
@@ -37,6 +37,8 @@ class APP_EXPORT QgsFormAnnotationDialog: public QDialog, private Ui::QgsFormAnn
     void deleteItem();
     void mButtonBox_clicked( QAbstractButton *button );
     void showHelp();
+    void onSettingsChanged();
+    void onLiveUpdateToggled( bool checked );
 };
 
 #endif // QGSFORMANNOTATIONDIALOG_H

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -65,6 +65,12 @@ QgsHtmlAnnotationDialog::QgsHtmlAnnotationDialog( QgsMapCanvasAnnotationItem *it
   QObject::connect( deleteButton, &QPushButton::clicked, this, &QgsHtmlAnnotationDialog::deleteItem );
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsHtmlAnnotationDialog::onLiveUpdateToggled );
+  connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
+  connect( mHtmlSourceTextEdit, &QgsCodeEditorHTML::textChanged, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
+  connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
+
   QgsGui::enableAutoGeometryRestore( this );
 }
 
@@ -114,11 +120,13 @@ void QgsHtmlAnnotationDialog::mBrowseToolButton_clicked()
 void QgsHtmlAnnotationDialog::fileRadioButtonToggled( bool checked )
 {
   mFileLineEdit->setEnabled( checked );
+  onSettingsChanged();
 }
 
 void QgsHtmlAnnotationDialog::sourceRadioButtonToggled( bool checked )
 {
   mHtmlSourceTextEdit->setEnabled( checked );
+  onSettingsChanged();
 }
 
 void QgsHtmlAnnotationDialog::deleteItem()
@@ -139,4 +147,19 @@ void QgsHtmlAnnotationDialog::mButtonBox_clicked( QAbstractButton *button )
 void QgsHtmlAnnotationDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "map_views/map_view.html#sec-annotations" ) );
+}
+
+void QgsHtmlAnnotationDialog::onSettingsChanged()
+{
+  if ( mLiveCheckBox->isChecked() )
+  {
+    applySettingsToItem();
+  }
+}
+
+void QgsHtmlAnnotationDialog::onLiveUpdateToggled( bool checked )
+{
+  // Apply and Cancel buttons make no sense when live update is on
+  mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
+  mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
 }

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -104,6 +104,10 @@ void QgsHtmlAnnotationDialog::mBrowseToolButton_clicked()
     directory = QDir::homePath();
   }
   const QString filename = QFileDialog::getOpenFileName( nullptr, tr( "html" ), directory, QStringLiteral( "HTML (*.html *.htm);;All files (*.*)" ) );
+  if ( filename.isEmpty() )
+  {
+    return;
+  }
   mFileLineEdit->setText( filename );
 }
 

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -21,6 +21,8 @@
 #include "qgsannotationmanager.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
+#include "qgssettingsentryimpl.h"
+
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGraphicsScene>
@@ -66,6 +68,7 @@ QgsHtmlAnnotationDialog::QgsHtmlAnnotationDialog( QgsMapCanvasAnnotationItem *it
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsHtmlAnnotationDialog::onLiveUpdateToggled );
+  mLiveCheckBox->setChecked( QgsAnnotationWidget::settingLiveUpdate->value() );
   connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
   connect( mHtmlSourceTextEdit, &QgsCodeEditorHTML::textChanged, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
   connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsHtmlAnnotationDialog::onSettingsChanged );
@@ -162,4 +165,5 @@ void QgsHtmlAnnotationDialog::onLiveUpdateToggled( bool checked )
   // Apply and Cancel buttons make no sense when live update is on
   mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
   mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
+  QgsAnnotationWidget::settingLiveUpdate->setValue( checked );
 }

--- a/src/app/qgshtmlannotationdialog.h
+++ b/src/app/qgshtmlannotationdialog.h
@@ -39,6 +39,8 @@ class APP_EXPORT QgsHtmlAnnotationDialog: public QDialog, private Ui::QgsFormAnn
     void fileRadioButtonToggled( bool checked );
     void sourceRadioButtonToggled( bool checked );
     void showHelp();
+    void onSettingsChanged();
+    void onLiveUpdateToggled( bool checked );
 };
 
 #endif // QgsHTMLAnnotationDialog_H

--- a/src/app/qgssvgannotationdialog.cpp
+++ b/src/app/qgssvgannotationdialog.cpp
@@ -23,6 +23,8 @@
 #include "qgsannotationmanager.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
+#include "qgssettingsentryimpl.h"
+
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGraphicsScene>
@@ -61,6 +63,7 @@ QgsSvgAnnotationDialog::QgsSvgAnnotationDialog( QgsMapCanvasAnnotationItem *item
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsSvgAnnotationDialog::onLiveUpdateToggled );
+  mLiveCheckBox->setChecked( QgsAnnotationWidget::settingLiveUpdate->value() );
   connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsSvgAnnotationDialog::onSettingsChanged );
   connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsSvgAnnotationDialog::onSettingsChanged );
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsSvgAnnotationDialog::onSettingsChanged );
@@ -136,4 +139,5 @@ void QgsSvgAnnotationDialog::onLiveUpdateToggled( bool checked )
   // Apply and Cancel buttons make no sense when live update is on
   mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
   mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
+  QgsAnnotationWidget::settingLiveUpdate->setValue( checked );
 }

--- a/src/app/qgssvgannotationdialog.cpp
+++ b/src/app/qgssvgannotationdialog.cpp
@@ -72,6 +72,10 @@ void QgsSvgAnnotationDialog::mBrowseToolButton_clicked()
     directory = fi.absolutePath();
   }
   const QString filename = QFileDialog::getOpenFileName( nullptr, tr( "Select SVG file" ), directory, tr( "SVG files" ) + " (*.svg)" );
+  if ( filename.isEmpty() )
+  {
+    return;
+  }
   mFileLineEdit->setText( filename );
 }
 
@@ -84,9 +88,12 @@ void QgsSvgAnnotationDialog::applySettingsToItem()
 
   if ( mItem && mItem->annotation() )
   {
-    QgsSvgAnnotation *annotation = static_cast< QgsSvgAnnotation * >( mItem->annotation() );
-    annotation->setFilePath( mFileLineEdit->text() );
-    mItem->update();
+    if ( !mFileLineEdit->text().isEmpty() )
+    {
+      QgsSvgAnnotation *annotation = static_cast< QgsSvgAnnotation * >( mItem->annotation() );
+      annotation->setFilePath( mFileLineEdit->text() );
+      mItem->update();
+    }
   }
 
 }

--- a/src/app/qgssvgannotationdialog.cpp
+++ b/src/app/qgssvgannotationdialog.cpp
@@ -41,6 +41,13 @@ QgsSvgAnnotationDialog::QgsSvgAnnotationDialog( QgsMapCanvasAnnotationItem *item
   mStackedWidget->addWidget( mEmbeddedWidget );
   mStackedWidget->setCurrentWidget( mEmbeddedWidget );
 
+  // SVG annotation can only be created from an svg file
+  // Mask the source radio button and the source text edit
+  mFileRadioButton->setChecked( true );
+  mFileRadioButton->hide();
+  mSourceRadioButton->hide();
+  mHtmlSourceTextEdit->hide();
+
   if ( mItem && mItem->annotation() )
   {
     QgsSvgAnnotation *annotation = static_cast< QgsSvgAnnotation * >( mItem->annotation() );

--- a/src/app/qgssvgannotationdialog.cpp
+++ b/src/app/qgssvgannotationdialog.cpp
@@ -60,6 +60,11 @@ QgsSvgAnnotationDialog::QgsSvgAnnotationDialog( QgsMapCanvasAnnotationItem *item
   QObject::connect( deleteButton, &QPushButton::clicked, this, &QgsSvgAnnotationDialog::deleteItem );
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
 
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsSvgAnnotationDialog::onLiveUpdateToggled );
+  connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsSvgAnnotationDialog::onSettingsChanged );
+  connect( mFileLineEdit, &QLineEdit::textChanged, this, &QgsSvgAnnotationDialog::onSettingsChanged );
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsSvgAnnotationDialog::onSettingsChanged );
+
   QgsGui::enableAutoGeometryRestore( this );
 }
 
@@ -116,4 +121,19 @@ void QgsSvgAnnotationDialog::mButtonBox_clicked( QAbstractButton *button )
 void QgsSvgAnnotationDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "map_views/map_view.html#sec-annotations" ) );
+}
+
+void QgsSvgAnnotationDialog::onSettingsChanged()
+{
+  if ( mLiveCheckBox->isChecked() )
+  {
+    applySettingsToItem();
+  }
+}
+
+void QgsSvgAnnotationDialog::onLiveUpdateToggled( bool checked )
+{
+  // Apply and Cancel buttons make no sense when live update is on
+  mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
+  mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
 }

--- a/src/app/qgssvgannotationdialog.h
+++ b/src/app/qgssvgannotationdialog.h
@@ -36,6 +36,8 @@ class APP_EXPORT QgsSvgAnnotationDialog: public QDialog, private Ui::QgsFormAnno
     void deleteItem();
     void mButtonBox_clicked( QAbstractButton *button );
     void showHelp();
+    void onSettingsChanged();
+    void onLiveUpdateToggled( bool checked );
 
   private:
     QgsSvgAnnotationDialog() = delete; //forbidden

--- a/src/app/qgstextannotationdialog.cpp
+++ b/src/app/qgstextannotationdialog.cpp
@@ -68,6 +68,13 @@ QgsTextAnnotationDialog::QgsTextAnnotationDialog( QgsMapCanvasAnnotationItem *it
   QPushButton *deleteButton = new QPushButton( tr( "Delete" ) );
   QObject::connect( deleteButton, &QPushButton::clicked, this, &QgsTextAnnotationDialog::deleteItem );
   mButtonBox->addButton( deleteButton, QDialogButtonBox::RejectRole );
+
+
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsTextAnnotationDialog::onLiveUpdateToggled );
+  connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsTextAnnotationDialog::onSettingsChanged );
+  connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsTextAnnotationDialog::onSettingsChanged );
+  connect( mTextEdit, &QTextEdit::textChanged, this, &QgsTextAnnotationDialog::onSettingsChanged );
+
 }
 
 void QgsTextAnnotationDialog::showEvent( QShowEvent * )
@@ -138,6 +145,7 @@ void QgsTextAnnotationDialog::changeCurrentFormat()
 
   //color
   mTextEdit->setTextColor( mFontColorButton->color() );
+  onSettingsChanged();
 }
 
 void QgsTextAnnotationDialog::mFontColorButton_colorChanged( const QColor &color )
@@ -177,4 +185,19 @@ void QgsTextAnnotationDialog::deleteItem()
 void QgsTextAnnotationDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "map_views/map_view.html#sec-annotations" ) );
+}
+
+void QgsTextAnnotationDialog::onSettingsChanged()
+{
+  if ( mLiveCheckBox->isChecked() )
+  {
+    applyTextToItem();
+  }
+}
+
+void QgsTextAnnotationDialog::onLiveUpdateToggled( bool checked )
+{
+  // Apply and Cancel buttons make no sense when live update is on
+  mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
+  mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
 }

--- a/src/app/qgstextannotationdialog.cpp
+++ b/src/app/qgstextannotationdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsgui.h"
 #include "qgshelp.h"
 #include "qgsfillsymbol.h"
+#include "qgssettingsentryimpl.h"
 
 #include <QColorDialog>
 #include <QGraphicsScene>
@@ -71,6 +72,7 @@ QgsTextAnnotationDialog::QgsTextAnnotationDialog( QgsMapCanvasAnnotationItem *it
 
 
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsTextAnnotationDialog::onLiveUpdateToggled );
+  mLiveCheckBox->setChecked( QgsAnnotationWidget::settingLiveUpdate->value() );
   connect( mLiveCheckBox, &QCheckBox::toggled, this, &QgsTextAnnotationDialog::onSettingsChanged );
   connect( mEmbeddedWidget, &QgsAnnotationWidget::changed, this, &QgsTextAnnotationDialog::onSettingsChanged );
   connect( mTextEdit, &QTextEdit::textChanged, this, &QgsTextAnnotationDialog::onSettingsChanged );
@@ -200,4 +202,5 @@ void QgsTextAnnotationDialog::onLiveUpdateToggled( bool checked )
   // Apply and Cancel buttons make no sense when live update is on
   mButtonBox->button( QDialogButtonBox::Apply )->setHidden( checked );
   mButtonBox->button( QDialogButtonBox::Cancel )->setHidden( checked );
+  QgsAnnotationWidget::settingLiveUpdate->setValue( checked );
 }

--- a/src/app/qgstextannotationdialog.h
+++ b/src/app/qgstextannotationdialog.h
@@ -52,6 +52,8 @@ class APP_EXPORT QgsTextAnnotationDialog: public QDialog, private Ui::QgsTextAnn
     void mButtonBox_clicked( QAbstractButton *button );
     void backgroundColorChanged( const QColor &color );
     void showHelp();
+    void onSettingsChanged();
+    void onLiveUpdateToggled( bool checked );
 };
 
 #endif // QGSTEXTANNOTATIONDIALOG_H

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -62,6 +62,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeSvg = treeRoot()->createChildNode( QStringLiteral( "svg" ) );
     static inline QgsSettingsTreeNode *sTreeWms = treeRoot()->createChildNode( QStringLiteral( "wms" ) );
     static inline QgsSettingsTreeNode *sTreeMeasure = treeRoot()->createChildNode( QStringLiteral( "measure" ) );
+    static inline QgsSettingsTreeNode *sTreeAnnotations = treeRoot()->createChildNode( QStringLiteral( "annotations" ) );
 
 #endif
 

--- a/src/ui/qgsformannotationdialogbase.ui
+++ b/src/ui/qgsformannotationdialogbase.ui
@@ -14,6 +14,19 @@
    <string>Form Annotation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="mSourceRadioButton">
+     <property name="text">
+      <string>Source</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -38,13 +51,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QStackedWidget" name="mStackedWidget">
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_2"/>
-    </widget>
-   </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -55,17 +62,24 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QgsCodeEditorHTML" name="mHtmlSourceTextEdit"/>
+    <widget class="QgsCodeEditorHTML" name="mHtmlSourceTextEdit" native="true"/>
    </item>
-   <item row="1" column="0">
-    <widget class="QRadioButton" name="mSourceRadioButton">
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="mLiveCheckBox">
      <property name="text">
-      <string>Source</string>
+      <string>Live update</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCodeEditorHTML</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorhtml.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -101,11 +115,4 @@
    </hints>
   </connection>
  </connections>
- <customwidgets>
-  <customwidget>
-   <class>QgsCodeEditorHTML</class>
-   <extends>QWidget</extends>
-   <header>qgscodeeditorhtml.h</header>
-  </customwidget>
-</customwidgets>
 </ui>

--- a/src/ui/qgstextannotationdialogbase.ui
+++ b/src/ui/qgstextannotationdialogbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>519</width>
+    <width>551</width>
     <height>364</height>
    </rect>
   </property>
@@ -14,6 +14,28 @@
    <string>Annotation Text</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QTextEdit" name="mTextEdit"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -92,25 +114,10 @@
     </layout>
    </item>
    <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QCheckBox" name="mLiveCheckBox">
+     <property name="text">
+      <string>Live update</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QTextEdit" name="mTextEdit"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QStackedWidget" name="mStackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_2"/>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Description

- Hide irrelevant Source field and radio buttons from the svg annotation and form annotation editor
- Add a "live update" checkbox in the annotation editors

![live_annotation_text](https://user-images.githubusercontent.com/9693475/233869801-fc28c3ad-c6d9-4abd-aba6-0ac1e071613b.gif)


![live_annotation_html](https://user-images.githubusercontent.com/9693475/233869809-07f5d435-2694-4671-bca1-16bb9a8785b1.gif)
