### PR TITLE
[ui] Remove browser widget title bar within the data source manager dialog

### DIFF
--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -58,6 +58,7 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserGuiModel *brow
   // BROWSER Add the browser widget to the first stacked widget page
   mBrowserWidget = new QgsBrowserDockWidget( QStringLiteral( "Browser" ), mBrowserModel, this );
   mBrowserWidget->setFeatures( QDockWidget::NoDockWidgetFeatures );
+  mBrowserWidget->setTitleBarWidget( new QWidget( mBrowserWidget ) );
   ui->mOptionsStackedWidget->addWidget( mBrowserWidget );
   mPageProviderKeys.append( QStringLiteral( "browser" ) );
   mPageProviderNames.append( QStringLiteral( "browser" ) );


### PR DESCRIPTION
## Description

This PR hides this unnecessary 'Browser' title bar:
![image](https://user-images.githubusercontent.com/1728657/233901624-fa466921-396e-4455-b868-b1221af76fae.png)
