### PR TITLE
Python - Use some format function for translations

### DIFF
--- a/python/plugins/processing/algs/gdal/ogr2ogr.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogr.py
@@ -87,7 +87,7 @@ class ogr2ogr(GdalAlgorithm):
         output, outputFormat = GdalUtils.ogrConnectionStringAndFormat(outFile, context)
 
         if outputFormat in ('SQLite', 'GPKG') and os.path.isfile(output):
-            raise QgsProcessingException(self.tr(f'Output file "{output}" already exists.'))
+            raise QgsProcessingException(self.tr('Output file "{}" already exists.').format(output))
 
         arguments = []
         if outputFormat:

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -136,7 +136,8 @@ class IdwInterpolation(QgisAlgorithm):
             data.valueSource = int(v[1])
             data.interpolationAttribute = int(v[2])
             if data.valueSource == QgsInterpolator.ValueAttribute and data.interpolationAttribute == -1:
-                raise QgsProcessingException(self.tr(f'Layer {i + 1} is set to use a value attribute, but no attribute was set'))
+                raise QgsProcessingException(self.tr(
+                    'Layer {} is set to use a value attribute, but no attribute was set').format(i + 1))
 
             if v[3] == '0':
                 data.sourceType = QgsInterpolator.SourcePoints

--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -122,7 +122,8 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
             selValue = value if method != 1 else int(round(value * len(subset), 0))
             if selValue > len(subset):
                 selValue = len(subset)
-                feedback.reportError(self.tr(f'Subset "{k}" is smaller than requested number of features.'))
+                feedback.reportError(self.tr(
+                    'Subset "{}" is smaller than requested number of features.').format(k))
             selran.extend(random.sample(subset, selValue))
 
         total = 100.0 / featureCount if featureCount else 1

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -193,7 +193,7 @@ class RandomPointsPolygons(QgisAlgorithm):
                 pointCount = int(round(this_value * da.measureArea(fGeom)))
 
             if pointCount == 0:
-                feedback.pushInfo(f"Skip feature {f.id()} as number of points for it is 0.")
+                feedback.pushInfo(self.tr("Skip feature {} as number of points for it is 0.").format(f.id()))
                 continue
 
             index = None

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -133,7 +133,7 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
                 selValue = value if method != 1 else int(round(value * len(subset), 0))
                 if selValue > len(subset):
                     selValue = len(subset)
-                    feedback.reportError(self.tr(f'Subset "{k}" is smaller than requested number of features.'))
+                    feedback.reportError(self.tr('Subset "{}" is smaller than requested number of features.').format(k))
                 selran.extend(random.sample(subset, selValue))
 
             layer.selectByIds(selran)

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -155,7 +155,8 @@ class TinInterpolation(QgisAlgorithm):
             data.valueSource = int(v[1])
             data.interpolationAttribute = int(v[2])
             if data.valueSource == QgsInterpolator.ValueAttribute and data.interpolationAttribute == -1:
-                raise QgsProcessingException(self.tr(f'Layer {i + 1} is set to use a value attribute, but no attribute was set'))
+                raise QgsProcessingException(self.tr(
+                    'Layer {} is set to use a value attribute, but no attribute was set').format(i + 1))
 
             if v[3] == '0':
                 data.sourceType = QgsInterpolator.SourcePoints

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -238,7 +238,7 @@ class ModelerParameterDefinitionDialog(QDialog):
 
             paramTypeDef = QgsApplication.instance().processingRegistry().parameterType(typeId)
             if not paramTypeDef:
-                msg = self.tr(f'The parameter `{typeId}` is not registered, are you missing a required plugin?')
+                msg = self.tr('The parameter `{}` is not registered, are you missing a required plugin?').format(typeId)
                 raise UndefinedParameterException(msg)
             self.param = paramTypeDef.create(name)
             self.param.setDescription(description)


### PR DESCRIPTION
I have checked my two PR #52873 and #52760

I think fstring shouldn't be used when there is a translated string, see https://stackoverflow.com/questions/49797658/how-to-use-gettext-with-python-3-6-f-strings

Strings mustn't be evaluated before the translation are gathered. 

CC @m-kuhn @nyalldawson 