### PR TITLE
Fix group layer rendering

### DIFF
--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -105,6 +105,7 @@ void QgsLayerTreeGroupPropertiesWidget::apply()
     groupLayer->setPaintEffect( mPaintEffect->clone() );
 
     groupLayer->triggerRepaint();
+    QgsProject::instance()->setDirty( true );
   }
   else if ( mMapLayerConfigWidgetContext.mapCanvas() )
   {

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -155,9 +155,9 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers( QgsLayerTreeNode *node, QList
   const QList<QgsLayerTreeNode *> children = node->children();
   for ( QgsLayerTreeNode *child : children )
   {
-    if ( QgsLayerTreeGroup *group = QgsLayerTree::toGroup( node ) )
+    if ( QgsLayerTree::isGroup( child ) )
     {
-      if ( QgsGroupLayer *groupLayer = group->groupLayer() )
+      if ( QgsGroupLayer *groupLayer = QgsLayerTree::toGroup( child )->groupLayer() )
       {
         canvasLayers << groupLayer;
         continue;


### PR DESCRIPTION
- Fixes #52769

## Description

In `QgsLayerTreeMapCanvasBridge::setCanvasLayers`, if a node was a `QgsGroupLayer` (group with "render as a group" enabled), it was added to the canvas layers for every child layer. So if the group contained 5 layers, the whole group was actually rendered 5 times. 

This PR ensure the QgsGroupLayer is only added once.

Besides, it makes the project dirty when the group styling properties (opacity, blending mode and draw effects) are changed
