### PR TITLE
Fix incorrect WCS request bbox when layer limited to an extent

### DIFF
--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -424,6 +424,7 @@ void QgsOWSSourceSelect::mChangeCRSButton_clicked()
     return;
 
   mSelectedCRS = mySelector->crs().authid();
+  mSpatialExtentBox->setOutputCrs( mySelector->crs() );
   delete mySelector;
 
   mSelectedCRSLabel->setText( descriptionForAuthId( mSelectedCRS ) );
@@ -480,6 +481,7 @@ void QgsOWSSourceSelect::populateCrs()
         mSelectedCRS = defaultCRS;
       }
     }
+    mSpatialExtentBox->setOutputCrs( QgsCoordinateReferenceSystem( mSelectedCRS ) );
     mSelectedCRSLabel->setText( descriptionForAuthId( mSelectedCRS ) );
     mChangeCRSButton->setEnabled( true );
   }

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -438,7 +438,7 @@ bool QgsWcsProvider::parseUri( const QString &uriString )
 
   mTime = uri.param( QStringLiteral( "time" ) );
 
-  QStringList bboxParts = uri.param( QStringLiteral( "bbox" ) ).split( "," );
+  const QStringList bboxParts = uri.param( QStringLiteral( "bbox" ) ).split( "," );
   if ( bboxParts.length() == 4 )
   {
     mBBOX = QgsRectangle( bboxParts[0].toDouble(), bboxParts[1].toDouble(), bboxParts[2].toDouble(), bboxParts[3].toDouble() );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -438,7 +438,11 @@ bool QgsWcsProvider::parseUri( const QString &uriString )
 
   mTime = uri.param( QStringLiteral( "time" ) );
 
-  mBBOX = uri.param( QStringLiteral( "bbox" ) );
+  QStringList bboxParts = uri.param( QStringLiteral( "bbox" ) ).split( "," );
+  if ( bboxParts.length() == 4 )
+  {
+    mBBOX = QgsRectangle( bboxParts[0].toDouble(), bboxParts[1].toDouble(), bboxParts[2].toDouble(), bboxParts[3].toDouble() );
+  }
 
   setFormat( uri.param( QStringLiteral( "format" ) ) );
 
@@ -699,8 +703,16 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const &viewExtent, int 
     extent = QgsRectangle( viewExtent.xMinimum() + xRes / 2., viewExtent.yMinimum() + yRes / 2., viewExtent.xMaximum() - xRes / 2., viewExtent.yMaximum() - yRes / 2. );
   }
 
+  if ( changeXY )
+  {
+    extent = QgsRectangle( extent.yMinimum(), extent.xMinimum(), extent.yMaximum(), extent.xMaximum() );
+  }
+  if ( !mBBOX.isEmpty() )
+  {
+    extent = extent.intersect( mBBOX );
+  }
   // Bounding box in WCS format (Warning: does not work with scientific notation)
-  QString bbox = QString( changeXY ? "%2,%1,%4,%3" : "%1,%2,%3,%4" )
+  QString bbox = QString( "%1,%2,%3,%4" )
                  .arg( qgsDoubleToString( extent.xMinimum() ),
                        qgsDoubleToString( extent.yMinimum() ),
                        qgsDoubleToString( extent.xMaximum() ),
@@ -729,7 +741,7 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const &viewExtent, int 
       setQueryItem( url, QStringLiteral( "TIME" ), mTime );
     }
 
-    setQueryItem( url, QStringLiteral( "BBOX" ), !mBBOX.isEmpty() ? mBBOX : bbox );
+    setQueryItem( url, QStringLiteral( "BBOX" ), bbox );
 
     setQueryItem( url, QStringLiteral( "CRS" ), crs ); // request BBOX CRS
     setQueryItem( url, QStringLiteral( "RESPONSE_CRS" ), crs ); // response CRS
@@ -749,7 +761,7 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const &viewExtent, int 
       setQueryItem( url, QStringLiteral( "TIMESEQUENCE" ), mTime );
     }
 
-    setQueryItem( url, QStringLiteral( "BOUNDINGBOX" ), !mBBOX.isEmpty() ? mBBOX : bbox );
+    setQueryItem( url, QStringLiteral( "BOUNDINGBOX" ), bbox );
 
 
     //  Example:

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -261,7 +261,7 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     //! Time (temporalDomain), optional
     QString mTime;
 
-    //! Specified bounding box
+    //! Specified bounding box. Note: X/Y may be inverted if WCS uri contains InvertAxisOrientation.
     QgsRectangle mBBOX;
 
     //! Format of coverage to be used in request

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -262,7 +262,7 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     QString mTime;
 
     //! Specified bounding box
-    QString mBBOX;
+    QgsRectangle mBBOX;
 
     //! Format of coverage to be used in request
     QString mFormat;

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -144,11 +144,11 @@ void QgsWCSSourceSelect::addButtonClicked()
   if ( mSpatialExtentBox->isChecked() )
   {
     QgsRectangle spatialExtent = mSpatialExtentBox->outputExtent();
-    spatialExtent = QgsCoordinateTransform(
-                      mSpatialExtentBox->outputCrs(),
+    QgsCoordinateTransform extentCrsToSSelectedCrs( mSpatialExtentBox->outputCrs(),
                       QgsCoordinateReferenceSystem( selectedCrs() ),
-                      QgsProject::instance()->transformContext()
-                    ).transformBoundingBox( spatialExtent );
+                      QgsProject::instance()->transformContext() );
+    extentCrsToSSelectedCrs.setBallparkTransformsAreAppropriate( true );
+    spatialExtent = extentCrsToSSelectedCrs.transformBoundingBox( spatialExtent );
     bool inverted = uri.hasParam( QStringLiteral( "InvertAxisOrientation" ) );
     QString bbox = QString( inverted ? "%2,%1,%4,%3" : "%1,%2,%3,%4" )
                    .arg( qgsDoubleToString( spatialExtent.xMinimum() ),

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -143,7 +143,12 @@ void QgsWCSSourceSelect::addButtonClicked()
 
   if ( mSpatialExtentBox->isChecked() )
   {
-    const QgsRectangle spatialExtent = mSpatialExtentBox->outputExtent();
+    QgsRectangle spatialExtent = mSpatialExtentBox->outputExtent();
+    spatialExtent = QgsCoordinateTransform(
+                      mSpatialExtentBox->outputCrs(),
+                      QgsCoordinateReferenceSystem( selectedCrs() ),
+                      QgsProject::instance()->transformContext()
+                    ).transformBoundingBox( spatialExtent );
     bool inverted = uri.hasParam( QStringLiteral( "InvertAxisOrientation" ) );
     QString bbox = QString( inverted ? "%2,%1,%4,%3" : "%1,%2,%3,%4" )
                    .arg( qgsDoubleToString( spatialExtent.xMinimum() ),

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -145,8 +145,8 @@ void QgsWCSSourceSelect::addButtonClicked()
   {
     QgsRectangle spatialExtent = mSpatialExtentBox->outputExtent();
     QgsCoordinateTransform extentCrsToSSelectedCrs( mSpatialExtentBox->outputCrs(),
-                      QgsCoordinateReferenceSystem( selectedCrs() ),
-                      QgsProject::instance()->transformContext() );
+        QgsCoordinateReferenceSystem( selectedCrs() ),
+        QgsProject::instance()->transformContext() );
     extentCrsToSSelectedCrs.setBallparkTransformsAreAppropriate( true );
     spatialExtent = extentCrsToSSelectedCrs.transformBoundingBox( spatialExtent );
     bool inverted = uri.hasParam( QStringLiteral( "InvertAxisOrientation" ) );


### PR DESCRIPTION
- The passed extent was in WGS84 and not necessarily in the selected CRS
- The delimiting extent was not intersected with the current view extent, resulting in an incorrect request bbox
