### PR TITLE
3d/terrain: Improve debugging tile info visibility

### DIFF
--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -109,7 +109,11 @@ void QgsTerrainTextureGenerator::waitForFinished()
     {
       // extra tile information for debugging
       QPainter p( &img );
-      p.setPen( Qt::white );
+      p.setPen( Qt::red );
+      p.setBackgroundMode( Qt::OpaqueMode );
+      QFont font = p.font();
+      font.setPixelSize( std::max( 30, mMap.mapTileResolution() / 6 ) );
+      p.setFont( font );
       p.drawRect( 0, 0, img.width() - 1, img.height() - 1 );
       p.drawText( img.rect(), jobData.debugText, QTextOption( Qt::AlignCenter ) );
       p.end();
@@ -139,7 +143,11 @@ void QgsTerrainTextureGenerator::onRenderingFinished()
   {
     // extra tile information for debugging
     QPainter p( &img );
-    p.setPen( Qt::white );
+    p.setPen( Qt::red );
+    p.setBackgroundMode( Qt::OpaqueMode );
+    QFont font = p.font();
+    font.setPixelSize( std::max( 30, mMap.mapTileResolution() / 6 ) );
+    p.setFont( font );
     p.drawRect( 0, 0, img.width() - 1, img.height() - 1 );
     p.drawText( img.rect(), jobData.debugText, QTextOption( Qt::AlignCenter ) );
     p.end();


### PR DESCRIPTION
The `show map tile info` option allows to display the tile information of the terrain. However this info is not really visible because the info is in the same color as the scene background (white) and the text is too small.

This issue is fixed with the following changes:
- change the color to black
- make the text background opaque
- increase the text size

### Current behavior

![Capture d’écran du 2023-04-26 19-37-20](https://user-images.githubusercontent.com/497207/234657889-e44e93de-58a5-4936-8c50-afbdb12a9557.png)


### New behavior


![Capture d’écran du 2023-04-27 18-54-28](https://user-images.githubusercontent.com/497207/234934859-33a07f0c-ee33-4628-8f5b-7e8e9c43c196.png)


cc @uclaros @benoitdm-oslandia @wonder-sk 