### PR TITLE
Fix deadlock when number of point cloud files loaded >= available threads

### DIFF
--- a/src/core/pointcloud/qgspointcloudstatscalculator.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculator.cpp
@@ -209,7 +209,9 @@ bool QgsPointCloudStatsCalculator::calculateStats( QgsFeedback *feedback, const 
 
   feedback->setProgress( 0 );
 
+  QThreadPool::globalInstance()->releaseThread();
   QVector<QgsPointCloudStatistics> list = QtConcurrent::blockingMapped( nodes, StatsProcessor( mIndex.get(), mRequest, feedback, 100.0 / ( double )nodes.size() ) );
+  QThreadPool::globalInstance()->reserveThread();
 
   for ( QgsPointCloudStatistics &s : list )
   {


### PR DESCRIPTION
This would cause multiple QgsTasks to be created, each of which uses one thread -- then if the number of tasks matches or exceeds the number of available threads, then the call to blockingMapped in QgsPointCloudStatsCalculator will hang forever waiting for a thread to be freed (which will never happen, since the running tasks CANNOT complete as they are blocked)

Avoid this by releasing and reserving the current thread from the QgsPointCloudStatsCalculationTask before performing the blockingMapped function.
