### PR TITLE
Add new attribute form container type "Row"

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -3519,7 +3519,8 @@ Qgis.AttributeEditorType.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.AttributeEditorContainerType.GroupBox.__doc__ = "A group box"
 Qgis.AttributeEditorContainerType.Tab.__doc__ = "A tab widget"
-Qgis.AttributeEditorContainerType.__doc__ = 'Attribute editor container types.\n\n.. versionadded:: 3.32\n\n' + '* ``GroupBox``: ' + Qgis.AttributeEditorContainerType.GroupBox.__doc__ + '\n' + '* ``Tab``: ' + Qgis.AttributeEditorContainerType.Tab.__doc__
+Qgis.AttributeEditorContainerType.Row.__doc__ = "A row of editors (horizontal layout)"
+Qgis.AttributeEditorContainerType.__doc__ = 'Attribute editor container types.\n\n.. versionadded:: 3.32\n\n' + '* ``GroupBox``: ' + Qgis.AttributeEditorContainerType.GroupBox.__doc__ + '\n' + '* ``Tab``: ' + Qgis.AttributeEditorContainerType.Tab.__doc__ + '\n' + '* ``Row``: ' + Qgis.AttributeEditorContainerType.Row.__doc__
 # --
 Qgis.AttributeEditorContainerType.baseClass = Qgis
 QgsEditFormConfig.EditorLayout = Qgis.AttributeFormLayout

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1996,6 +1996,7 @@ The development version
     {
       GroupBox,
       Tab,
+      Row,
     };
 
     enum class AttributeFormLayout

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3458,6 +3458,7 @@ class CORE_EXPORT Qgis
     {
       GroupBox, //!< A group box
       Tab, //!< A tab widget
+      Row, //!< A row of editors (horizontal layout)
     };
     Q_ENUM( AttributeEditorContainerType )
 

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
@@ -47,6 +47,10 @@ class GUI_EXPORT QgsAttributeFormContainerEdit: public QWidget, private Ui_QgsAt
 
     void updateItemData();
 
+  private slots:
+
+    void containerTypeChanged();
+
   private:
     QTreeWidgetItem *mTreeItem = nullptr;
 };

--- a/src/gui/qgsaddtaborgroup.cpp
+++ b/src/gui/qgsaddtaborgroup.cpp
@@ -25,100 +25,125 @@
 #include <QComboBox>
 #include <QRadioButton>
 
-QgsAddTabOrGroup::QgsAddTabOrGroup( QgsVectorLayer *lyr, const QList < TabPair > &tabList, QTreeWidgetItem *currentTab, QWidget *parent )
+QgsAddAttributeFormContainerDialog::QgsAddAttributeFormContainerDialog( QgsVectorLayer *lyr, const QList<ContainerPair> &existingContainerList, QTreeWidgetItem *currentTab, QWidget *parent )
   : QDialog( parent )
   , mLayer( lyr )
-  , mTabs( tabList )
+  , mExistingContainers( existingContainerList )
 {
   setupUi( this );
-  connect( mGroupButton, &QRadioButton::toggled, this, &QgsAddTabOrGroup::mGroupButton_toggled );
-  connect( mTabButton, &QRadioButton::toggled, this, &QgsAddTabOrGroup::mTabButton_toggled );
 
-  mTabButton->setChecked( true );
-  mTabList->setEnabled( false );
-  if ( !mTabs.isEmpty() )
+  mTypeCombo->addItem( tr( "Tab" ), QVariant::fromValue( Qgis::AttributeEditorContainerType::Tab ) );
+  mTypeCombo->addItem( tr( "Group Box" ), QVariant::fromValue( Qgis::AttributeEditorContainerType::GroupBox ) );
+  mTypeCombo->addItem( tr( "Row" ), QVariant::fromValue( Qgis::AttributeEditorContainerType::Row ) );
+
+  mTypeCombo->setCurrentIndex( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::Tab ) ) );
+
+  mParentCombo->setEnabled( false );
+  if ( !mExistingContainers.isEmpty() )
   {
     int i = 0;
-    const auto constMTabs = mTabs;
-    for ( const TabPair &tab : constMTabs )
+    for ( const ContainerPair &container : std::as_const( mExistingContainers ) )
     {
-      mTabList->addItem( tab.first, i );
-      if ( tab.second == currentTab )
+      mParentCombo->addItem( container.first, i );
+      if ( container.second == currentTab )
       {
-        mTabList->setCurrentIndex( i );
-        mGroupButton->setChecked( true );
+        mParentCombo->setCurrentIndex( i );
+        mTypeCombo->setCurrentIndex( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::GroupBox ) ) );
       }
       ++i;
     }
   }
   else
   {
-    mGroupButton->setEnabled( false );
+    // top level items must be tabs
+    mTypeCombo->removeItem( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::GroupBox ) ) );
+    mTypeCombo->removeItem( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::Row ) ) );
   }
 
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAddTabOrGroup::showHelp );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAddAttributeFormContainerDialog::showHelp );
 
   mColumnCountSpinBox->setValue( QgsSettings().value( QStringLiteral( "/qgis/attributeForm/defaultTabColumnCount" ), 1 ).toInt() );
 
   setWindowTitle( tr( "Add Container for %1" ).arg( mLayer->name() ) );
+
+  connect( mTypeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsAddAttributeFormContainerDialog::containerTypeChanged );
+  containerTypeChanged();
 }
 
-QString QgsAddTabOrGroup::name()
+QString QgsAddAttributeFormContainerDialog::name()
 {
   return mName->text();
 }
 
-QTreeWidgetItem *QgsAddTabOrGroup::tab()
+QTreeWidgetItem *QgsAddAttributeFormContainerDialog::parentContainerItem()
 {
-  const TabPair tab = mTabs.at( mTabList->currentData().toInt() );
+  if ( containerType() == Qgis::AttributeEditorContainerType::Tab )
+    return nullptr;
+
+  const ContainerPair tab = mExistingContainers.at( mParentCombo->currentData().toInt() );
   return tab.second;
 }
 
-int QgsAddTabOrGroup::columnCount() const
+int QgsAddAttributeFormContainerDialog::columnCount() const
 {
   return mColumnCountSpinBox->value();
 }
 
-Qgis::AttributeEditorContainerType QgsAddTabOrGroup::containerType() const
+Qgis::AttributeEditorContainerType QgsAddAttributeFormContainerDialog::containerType() const
 {
-  return mTabButton->isChecked() ? Qgis::AttributeEditorContainerType::Tab : Qgis::AttributeEditorContainerType::GroupBox;
+  return mTypeCombo->currentData().value< Qgis::AttributeEditorContainerType >();
 }
 
-void QgsAddTabOrGroup::accept()
+void QgsAddAttributeFormContainerDialog::accept()
 {
   if ( mColumnCountSpinBox->value() > 0 )
   {
-    if ( mGroupButton->isChecked() )
+    switch ( containerType() )
     {
-      QgsSettings().setValue( QStringLiteral( "/qgis/attributeForm/defaultGroupColumnCount" ), mColumnCountSpinBox->value() );
-    }
-    else
-    {
-      QgsSettings().setValue( QStringLiteral( "/qgis/attributeForm/defaultTabColumnCount" ), mColumnCountSpinBox->value() );
+
+      case Qgis::AttributeEditorContainerType::GroupBox:
+        QgsSettings().setValue( QStringLiteral( "/qgis/attributeForm/defaultGroupColumnCount" ), mColumnCountSpinBox->value() );
+        break;
+      case Qgis::AttributeEditorContainerType::Tab:
+        QgsSettings().setValue( QStringLiteral( "/qgis/attributeForm/defaultTabColumnCount" ), mColumnCountSpinBox->value() );
+        break;
+      case Qgis::AttributeEditorContainerType::Row:
+        break;
     }
   }
 
   QDialog::accept();
 }
 
-void QgsAddTabOrGroup::mGroupButton_toggled( bool checked )
-{
-  mTabList->setEnabled( checked );
-
-  if ( checked )
-  {
-    mColumnCountSpinBox->setValue( QgsSettings().value( QStringLiteral( "/qgis/attributeForm/defaultGroupColumnCount" ), 1 ).toInt() );
-  }
-}
-
-void QgsAddTabOrGroup::mTabButton_toggled( bool checked )
-{
-  mTabList->setEnabled( !checked );
-  if ( checked )
-    mColumnCountSpinBox->setValue( QgsSettings().value( QStringLiteral( "/qgis/attributeForm/defaultTabColumnCount" ), 1 ).toInt() );
-}
-
-void QgsAddTabOrGroup::showHelp()
+void QgsAddAttributeFormContainerDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "working_with_vector/vector_properties.html#the-drag-and-drop-designer" ) );
+}
+
+void QgsAddAttributeFormContainerDialog::containerTypeChanged()
+{
+  const Qgis::AttributeEditorContainerType type = mTypeCombo->currentData().value< Qgis::AttributeEditorContainerType >();
+  switch ( type )
+  {
+    case Qgis::AttributeEditorContainerType::GroupBox:
+      mParentCombo->show();
+      mLabelParent->show();
+      mColumnsLabel->show();
+      mColumnCountSpinBox->show();
+      mColumnCountSpinBox->setValue( QgsSettings().value( QStringLiteral( "/qgis/attributeForm/defaultGroupColumnCount" ), 1 ).toInt() );
+      break;
+    case Qgis::AttributeEditorContainerType::Tab:
+      mParentCombo->hide();
+      mLabelParent->hide();
+      mColumnsLabel->show();
+      mColumnCountSpinBox->show();
+      mColumnCountSpinBox->setValue( QgsSettings().value( QStringLiteral( "/qgis/attributeForm/defaultTabColumnCount" ), 1 ).toInt() );
+      break;
+    case Qgis::AttributeEditorContainerType::Row:
+      mParentCombo->show();
+      mLabelParent->show();
+      mColumnsLabel->hide();
+      mColumnCountSpinBox->hide();
+      break;
+  }
 }

--- a/src/gui/qgsaddtaborgroup.h
+++ b/src/gui/qgsaddtaborgroup.h
@@ -36,22 +36,26 @@ class QgsVectorLayer;
  * \note This class is not a part of public API
  * \since QGIS 3.14
  */
-class GUI_EXPORT QgsAddTabOrGroup : public QDialog, private Ui::QgsAddTabOrGroupBase
+class GUI_EXPORT QgsAddAttributeFormContainerDialog : public QDialog, private Ui::QgsAddTabOrGroupBase
 {
     Q_OBJECT
 
   public:
-    typedef QPair<QString, QTreeWidgetItem *> TabPair;
+    typedef QPair<QString, QTreeWidgetItem *> ContainerPair;
 
   public:
     //! constructor
-    QgsAddTabOrGroup( QgsVectorLayer *lyr, const QList<TabPair> &tabList, QTreeWidgetItem *currentTab = nullptr, QWidget *parent = nullptr );
+    QgsAddAttributeFormContainerDialog( QgsVectorLayer *lyr, const QList<ContainerPair> &existingContainerList, QTreeWidgetItem *currentTab = nullptr, QWidget *parent = nullptr );
 
     //! Returns the name of the tab or group
     QString name();
 
-    //! Returns tree item corresponding to the added tab
-    QTreeWidgetItem *tab();
+    /**
+     * Returns tree item corresponding to the selected parent container.
+     *
+     * Will be NULLPTR when a new tab is created.
+     */
+    QTreeWidgetItem *parentContainerItem();
 
     //! Returns the column count
     int columnCount() const;
@@ -67,13 +71,12 @@ class GUI_EXPORT QgsAddTabOrGroup : public QDialog, private Ui::QgsAddTabOrGroup
     void accept() override;
 
   private slots:
-    void mGroupButton_toggled( bool checked );
-    void mTabButton_toggled( bool checked );
     void showHelp();
+    void containerTypeChanged();
 
   protected:
     QgsVectorLayer *mLayer = nullptr;
-    QList< TabPair > mTabs;
+    QList< ContainerPair > mExistingContainers;
 };
 
 #endif

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1733,6 +1733,19 @@ void QgsAttributeForm::init()
             break;
           }
 
+          case Qgis::AttributeEditorContainerType::Row:
+          {
+            tabWidget = nullptr;
+            WidgetInfo widgetInfo = createWidgetFromDef( widgDef, formWidget, mLayer, mContext );
+            layout->addWidget( widgetInfo.widget, row, column, 1, 2 );
+            if ( containerDef->visibilityExpression().enabled() || containerDef->collapsedExpression().enabled() )
+            {
+              registerContainerInformation( new ContainerInformation( widgetInfo.widget, containerDef->visibilityExpression().enabled() ? containerDef->visibilityExpression().data() : QgsExpression(), containerDef->collapsed(), containerDef->collapsedExpression().enabled() ? containerDef->collapsedExpression().data() : QgsExpression() ) );
+            }
+            column += 2;
+            break;
+          }
+
           case Qgis::AttributeEditorContainerType::Tab:
           {
             if ( !tabWidget )
@@ -2394,6 +2407,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
       QString widgetName;
       QWidget *myContainer = nullptr;
+      bool removeLayoutMargin = false;
       switch ( container->type() )
       {
         case Qgis::AttributeEditorContainerType::GroupBox:
@@ -2420,6 +2434,18 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
           groupBox->setCollapsed( container->collapsed() );
           break;
         }
+
+        case Qgis::AttributeEditorContainerType::Row:
+        {
+          QWidget *rowWidget = new QWidget();
+          widgetName = QStringLiteral( "Row" );
+          myContainer = rowWidget;
+          newWidgetInfo.widget = myContainer;
+          removeLayoutMargin = true;
+          columnCount = container->children().size();
+          break;
+        }
+
         case Qgis::AttributeEditorContainerType::Tab:
         {
           myContainer = new QWidget();
@@ -2443,6 +2469,8 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       }
 
       QGridLayout *gbLayout = new QGridLayout();
+      if ( removeLayoutMargin )
+        gbLayout->setContentsMargins( 0, 0, 0, 0 );
       myContainer->setLayout( gbLayout );
 
       int row = 0;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -303,6 +303,9 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
   public:
     explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr );
 
+    /**
+     * Creates a new attribute editor element based on the definition stored in \a item.
+     */
     QgsAttributeEditorElement *createAttributeEditorWidget( QTreeWidgetItem *item, QgsAttributeEditorElement *parent, bool isTopLevel = false );
 
     void init();

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -303,7 +303,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
   public:
     explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr );
 
-    QgsAttributeEditorElement *createAttributeEditorWidget( QTreeWidgetItem *item, QgsAttributeEditorElement *parent, bool forceGroup = true );
+    QgsAttributeEditorElement *createAttributeEditorWidget( QTreeWidgetItem *item, QgsAttributeEditorElement *parent, bool isTopLevel = false );
 
     void init();
     void apply();
@@ -363,7 +363,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitCode;
 
   private slots:
-    void addTabOrGroupButton();
+    void addContainer();
     void removeTabOrGroupButton();
     void mEditorLayoutComboBox_currentIndexChanged( int index );
     void pbnSelectEditForm_clicked();

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>401</width>
-    <height>385</height>
+    <height>387</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mControlCollapsedGroupBox">
      <property name="title">
       <string>Control Collapsed by Expression</string>
@@ -29,17 +29,29 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10</number>
+   <item row="0" column="0" colspan="2">
+    <widget class="QCheckBox" name="mShowLabelCheckBox">
+     <property name="text">
+      <string>Show label</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
+     <property name="title">
+      <string>Control Visibility by Expression</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Style</string>
@@ -68,56 +80,14 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCollapsedCheckBox">
      <property name="text">
-      <string>Type</string>
+      <string>Collapsed</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="mShowLabelCheckBox">
-     <property name="text">
-      <string>Show label</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="mTitleLineEdit"/>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
-     <property name="title">
-      <string>Control Visibility by Expression</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="mTypeCombo"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Title</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -130,12 +100,42 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCollapsedCheckBox">
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="mTitleLineEdit"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Collapsed</string>
+      <string>Title</string>
      </property>
     </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mColumnsLabel">
+     <property name="text">
+      <string>Columns</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="mTypeCombo"/>
    </item>
   </layout>
  </widget>
@@ -173,9 +173,9 @@
  <tabstops>
   <tabstop>mShowLabelCheckBox</tabstop>
   <tabstop>mTitleLineEdit</tabstop>
+  <tabstop>mTypeCombo</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
   <tabstop>mControlVisibilityGroupBox</tabstop>
-  <tabstop>mTypeCombo</tabstop>
   <tabstop>mCollapsedCheckBox</tabstop>
   <tabstop>mControlCollapsedGroupBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>

--- a/src/ui/qgsaddtaborgroupbase.ui
+++ b/src/ui/qgsaddtaborgroupbase.ui
@@ -6,44 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>447</width>
-    <height>238</height>
+    <width>479</width>
+    <height>231</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Dialog</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_0">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Label</string>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout_0" columnstretch="1,2">
    <item row="0" column="1">
     <widget class="QLineEdit" name="mName"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Number of columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -56,55 +30,41 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Container Type</string>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mTypeCombo"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Container type</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="mTabButton">
-        <property name="text">
-         <string>Tab</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="mGroupButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Group box in container</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="mTabList">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="2" column="1">
+    <widget class="QComboBox" name="mParentCombo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mColumnsLabel">
+     <property name="text">
+      <string>Number of columns</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
     <widget class="QgsSpinBox" name="mColumnCountSpinBox">
      <property name="minimum">
       <number>1</number>
@@ -114,13 +74,17 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Label</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mLabelParent">
+     <property name="text">
+      <string>Within</string>
      </property>
     </widget>
    </item>
@@ -135,9 +99,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>mName</tabstop>
-  <tabstop>mTabButton</tabstop>
-  <tabstop>mGroupButton</tabstop>
-  <tabstop>mTabList</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This container always lays out child widgets in a horizontal row, where the number of columns is automatically determined by the number of child widgets.

It's useful for creation of compact forms, where no space will be wasted by assigning extraneous horizontal width to widgets where the expected values will always be short.

Eg: creating 3 rows with 3, 2, 1 child widgets respectively results in the layout:

    Attr 1: [...] Attr 2: [...] Attr 3: [...]
    Attr 4: [..........] Attr 5: [..........]
    Attr 6: [...............................]

Without the option of row containers then the all horizontal rows will have the same number of columns, eg:

    Attr 1: [...] Attr 2: [...] Attr 3: [...]
    Attr 4: [...] Attr 5: [...] Attr 6: [...]

(leaving insufficient horizontal length for attributes 4-6), or

    Attr 1: [..........] Attr 2: [..........]
    Attr 2: [..........] Attr 3: [..........]
    Attr 4: [..........] Attr 5: [..........]
    Attr 6: [..........]

(resulting in wasted horizontal space next to attribute 6, and an extra row taking up vertical space)

Sponsored by NIWA
