### PR TITLE
Fix QgsDoubleValidator for positive sign and for negative and exponential signs in some locales (Fix #52341)

### DIFF
--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -25,7 +25,7 @@
 
 #include "qgsdoublevalidator.h"
 
-const QString PERMISSIVE_DOUBLE = R"([-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+\-%3]?[\d]{0,%2})?)";
+const QString PERMISSIVE_DOUBLE = R"([+\-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+\-%3]?[\d]{0,%2})?)";
 
 QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   : QRegularExpressionValidator( parent )

--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -25,7 +25,7 @@
 
 #include "qgsdoublevalidator.h"
 
-const QString PERMISSIVE_DOUBLE = R"(-?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+-]?[\d]{0,%2})?)";
+const QString PERMISSIVE_DOUBLE = R"([-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+\-%3]?[\d]{0,%2})?)";
 
 QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   : QRegularExpressionValidator( parent )
@@ -33,7 +33,7 @@ QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ).arg( locale().negativeSign() ) );
   setRegularExpression( reg );
 }
 
@@ -51,7 +51,7 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, QObject *pare
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ).arg( locale().negativeSign() ) );
   setRegularExpression( reg );
 }
 
@@ -61,7 +61,7 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, 
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ).arg( locale().negativeSign() ) );
   setRegularExpression( reg );
 }
 
@@ -71,13 +71,13 @@ QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ).arg( locale().negativeSign() ) );
   setRegularExpression( reg );
 }
 
 void QgsDoubleValidator::setMaxDecimals( int maxDecimals )
 {
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( maxDecimals ) ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( maxDecimals ) ).arg( locale().negativeSign() ) );
   setRegularExpression( reg );
 }
 

--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -25,7 +25,7 @@
 
 #include "qgsdoublevalidator.h"
 
-const QString PERMISSIVE_DOUBLE = R"([+\-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+\-%3]?[\d]{0,%2})?)";
+const QString PERMISSIVE_DOUBLE = R"([+\-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?([eE%4][+\-%3]?[\d]{0,%2})?)";
 
 QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   : QRegularExpressionValidator( parent )
@@ -33,7 +33,10 @@ QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ).arg( locale().negativeSign() ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() )
+                                .arg( 1000 )
+                                .arg( QLocale().negativeSign() )
+                                .arg( QLocale().exponential() ) );
   setRegularExpression( reg );
 }
 
@@ -51,7 +54,10 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, QObject *pare
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( 1000 ).arg( locale().negativeSign() ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() )
+                                .arg( 1000 )
+                                .arg( QLocale().negativeSign() )
+                                .arg( QLocale().exponential() ) );
   setRegularExpression( reg );
 }
 
@@ -61,7 +67,10 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, 
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ).arg( locale().negativeSign() ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() )
+                                .arg( QString::number( decimal ) )
+                                .arg( QLocale().negativeSign() )
+                                .arg( QLocale().exponential() ) );
   setRegularExpression( reg );
 }
 
@@ -71,13 +80,19 @@ QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ).arg( locale().negativeSign() ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() )
+                                .arg( QString::number( decimal ) )
+                                .arg( QLocale().negativeSign() )
+                                .arg( QLocale().exponential() ) );
   setRegularExpression( reg );
 }
 
 void QgsDoubleValidator::setMaxDecimals( int maxDecimals )
 {
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( maxDecimals ) ).arg( locale().negativeSign() ) );
+  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() )
+                                .arg( QString::number( maxDecimals ) )
+                                .arg( QLocale().negativeSign() )
+                                .arg( QLocale().exponential() ) );
   setRegularExpression( reg );
 }
 
@@ -142,7 +157,7 @@ double QgsDoubleValidator::toDouble( const QString &input, bool *ok )
   // Still non ok? Try without locale's group separator
   if ( ! *ok && !( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator ) )
   {
-    value = QLocale( ).toDouble( QString( input ).replace( QLocale().groupSeparator(), QString() ), ok );
+    value = QLocale().toDouble( QString( input ).replace( QLocale().groupSeparator(), QString() ), ok );
   }
   return value ;
 }

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -70,6 +70,13 @@ void TestQgsDoubleValidator::validate_data()
 
   QTest::newRow( "positive sign C decimal" ) << QString( "+4cd6" ) << int( QValidator::Acceptable ) << false;
 
+  QTest::newRow( "exponent <e> C negative" ) << QString( "44446ecn1" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "exponent <e> locale negative" ) << QString( "44446eln1" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "locale decimal exponent <E> positive" ) << QString( "444ld46E1" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "locale decimal exponent <E> positive sign" ) << QString( "444ld46E+1" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "locale exponent locale negative" ) << QString( "4446leln1" ) << int( QValidator::Acceptable ) << false;
+
+
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
   QTest::newRow( "locale group separator + locale decimal" ) << QString( "4lg444ld6" ) << int( QValidator::Intermediate ) << false;
@@ -99,6 +106,12 @@ void TestQgsDoubleValidator::toDouble_data()
 
   QTest::newRow( "positive sign C decimal" ) << QString( "+4cd6" ) << 4.6;
 
+  QTest::newRow( "exponent <e> C negative" ) << QString( "44446ecn1" ) << 4444.6;
+  QTest::newRow( "exponent <e> locale negative" ) << QString( "44446eln1" ) << 4444.6;
+  QTest::newRow( "locale decimal exponent <E> positive" ) << QString( "444ld46E1" ) << 4444.6;
+  QTest::newRow( "locale decimal exponent <E> positive sign" ) << QString( "444ld46E+1" ) << 4444.6;
+  QTest::newRow( "locale exponent locale negative" ) << QString( "44446leln1" ) << 4444.6;
+
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
   QTest::newRow( "locale group separator + locale decimal" ) << QString( "4lg444ld6" ) << 4444.6;
@@ -116,7 +129,6 @@ void TestQgsDoubleValidator::toDouble_data()
 void TestQgsDoubleValidator::validate()
 {
   QLineEdit *lineEdit = new QLineEdit();
-  QgsDoubleValidator *validator = new QgsDoubleValidator( lineEdit );
 
   QFETCH( QString, actualState );
   QFETCH( int, expState );
@@ -124,27 +136,29 @@ void TestQgsDoubleValidator::validate()
   QString value;
   int expectedValue;
 
-  if ( negative )
-    validator->setRange( -10000, -4 );
-  else
-    validator->setRange( 4, 10000 );
-
-  lineEdit->setValidator( validator );
-
-  const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian, QLocale::NorwegianBokmal} );
+  const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian, QLocale::NorwegianBokmal, QLocale::Ukrainian} );
   QLocale loc;
   for ( int i = 0; i < listLocale.count(); ++i )
   {
     loc = listLocale.at( i );
     QLocale::setDefault( loc );
+
+    QgsDoubleValidator *validator = new QgsDoubleValidator( lineEdit );
+    if ( negative )
+      validator->setRange( -10000, -4 );
+    else
+      validator->setRange( 4, 10000 );
     validator->setLocale( loc );
+    lineEdit->setValidator( validator );
+
     value = actualState;
     value = value.replace( "ld", QLocale().decimalPoint() )
             .replace( "cd", QLocale( QLocale::C ).decimalPoint() )
             .replace( "lg", QLocale().groupSeparator() )
             .replace( "cg", QLocale( QLocale::C ).groupSeparator() )
             .replace( "ln", QLocale().negativeSign() )
-            .replace( "cn", QLocale( QLocale::C ).negativeSign() );
+            .replace( "cn", QLocale( QLocale::C ).negativeSign() )
+            .replace( "le", QLocale().exponential() );
     expectedValue = expState;
     // if the local group separator / decimal point is equal to the C one,
     // expected result will be different for double with test with mixed
@@ -165,8 +179,8 @@ void TestQgsDoubleValidator::validate()
     // to the C decimal point and there is no decimal point,
     // in that case the value is valid, because the fall
     // back check is to test after removing all group separators
-    if ( QLocale( ).groupSeparator() == QLocale( QLocale::C ).decimalPoint()
-         && ! value.contains( QLocale( ).decimalPoint() )
+    if ( QLocale().groupSeparator() == QLocale( QLocale::C ).decimalPoint()
+         && ! value.contains( QLocale().decimalPoint() )
          && value != "string" && expectedValue == 0 )
     {
       expectedValue = 1;
@@ -183,7 +197,7 @@ void TestQgsDoubleValidator::toDouble()
   QString value;
   double expectedValue;
 
-  const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian, QLocale::NorwegianBokmal} );
+  const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian, QLocale::NorwegianBokmal, QLocale::Ukrainian} );
   QLocale loc;
   for ( int i = 0; i < listLocale.count(); ++i )
   {
@@ -195,7 +209,8 @@ void TestQgsDoubleValidator::toDouble()
             .replace( "lg", QLocale().groupSeparator() )
             .replace( "cg", QLocale( QLocale::C ).groupSeparator() )
             .replace( "ln", QLocale().negativeSign() )
-            .replace( "cn", QLocale( QLocale::C ).negativeSign() );
+            .replace( "cn", QLocale( QLocale::C ).negativeSign() )
+            .replace( "le", QLocale().exponential() );
     expectedValue = expValue;
     // if the local group separator / decimal point is equal to the C one,
     // expected result will be different for double with test with mixed
@@ -216,8 +231,8 @@ void TestQgsDoubleValidator::toDouble()
     // to the C decimal point and there is no decimal point,
     // in that case the value is valid, because the fall
     // back check is to test after removing all group separators
-    if ( QLocale( ).groupSeparator() == QLocale( QLocale::C ).decimalPoint()
-         && ! value.contains( QLocale( ).decimalPoint() )
+    if ( QLocale().groupSeparator() == QLocale( QLocale::C ).decimalPoint()
+         && ! value.contains( QLocale().decimalPoint() )
          && value != "string" && expectedValue == 0 )
     {
       expectedValue = 44446;

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -68,6 +68,8 @@ void TestQgsDoubleValidator::validate_data()
   QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << int( QValidator::Acceptable ) << true;
   QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << int( QValidator::Acceptable ) << true;
 
+  QTest::newRow( "positive sign C decimal" ) << QString( "+4cd6" ) << int( QValidator::Acceptable ) << false;
+
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
   QTest::newRow( "locale group separator + locale decimal" ) << QString( "4lg444ld6" ) << int( QValidator::Intermediate ) << false;
@@ -94,6 +96,8 @@ void TestQgsDoubleValidator::toDouble_data()
   QTest::newRow( "C negative C decimal" ) << QString( "cn4cd6" ) << -4.6;
   QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << -4.6;
   QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << -4444.6;
+
+  QTest::newRow( "positive sign C decimal" ) << QString( "+4cd6" ) << 4.6;
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable


### PR DESCRIPTION
## Description

Some locales (see https://github.com/qgis/QGIS/issues/52341#issuecomment-1523360839 for the list) use the `−` character `Unicode Character “−” (U+2212)` as negative sign, instead of the `-` character `Unicode Character “-” (U+002D)`.

This PR makes the QgsDoubleValidator accept also the `Unicode Character “−” (U+2212)` as negative sign in the locales in which it is used.

Fixes #52341.

It also makes QgsDoubleValidator accept the plus sign in front of positive numbers and accept the `E` character as exponential sign and the `Unicode Character “е” (U+0435)` as exponential sign in the locales in which it is used (uk_UA Ukranian).


**NOTE**: looking at the original "parametrized" regex `PERMISSIVE_DOUBLE = R"(-?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+-]?[\d]{0,%2})?)";` it seems to me it has other various issues:
1. ~~it does not allow the plus sign in front of the value: should I also fix it?~~ [**ADDRESSED IN THIS PR**]
2. the `%2` parameter should be the number of allowed decimal digits but it seems to me it is in the wrong place: it should be in the second {0,1000} (which is the decimals part) and not after the `e` (which is the exponent part). @SebastienPeillet could you please confirm that it is due to a typo in your PR https://github.com/qgis/QGIS/pull/37136 and that I should also fix it? [I WILL FIX IT IN A DIFFERENT PR]
3. ~~it is only allowed the `e` exponent character, but it should be allowed also the `E` character and the character returned by `QLocale().exponential()` (actually it seems only uk_UA Ukranian laguage uses the character `Unicode Character “е” (U+0435)` instead of `Unicode Character “e” (U+0065)` for the exponent): should I also fix it in the same way?~~ [**ADDRESSED IN THIS PR**]
4. it does not accept values with the group separator, so there are issues editing a value when the "Show group (thousand) separator" option is checked in the setting [I WILL OPEN AN ISSUE REPORT]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
