### PR TITLE
Prevent attribute form editor widgets from inherting too large horizontal minimum size

### DIFF
--- a/python/gui/auto_generated/qgsattributeformwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformwidget.sip.in
@@ -37,6 +37,8 @@ Consists of the widget which is visible in edit mode as well as the widget visib
 A new form widget for the wrapper ``widget`` on ``form``.
 %End
 
+    ~QgsAttributeFormWidget();
+
     virtual void createSearchWidgetWrappers() = 0;
 %Docstring
 Creates the search widget wrappers for the widget used when the form is in
@@ -138,6 +140,13 @@ this search widgte or defines the comparison operator to use.
 
 
 
+
+    void setVisiblePageForMode( QgsAttributeFormWidget::Mode mode );
+%Docstring
+Sets the visible page in the widget to the page matching the specified ``mode``.
+
+.. versionadded:: 3.32
+%End
 
 };
 

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -16,14 +16,12 @@
 #include "qgsattributeformeditorwidget.h"
 #include "qgsattributeform.h"
 #include "qgsmultiedittoolbutton.h"
-#include "qgssearchwidgettoolbutton.h"
 #include "qgseditorwidgetwrapper.h"
 #include "qgssearchwidgetwrapper.h"
 #include "qgsattributeeditorcontext.h"
 #include "qgseditorwidgetregistry.h"
 #include "qgsaggregatetoolbutton.h"
 #include "qgsgui.h"
-#include "qgsvectorlayerjoinbuffer.h"
 #include "qgsvectorlayerutils.h"
 
 #include <QLayout>
@@ -286,12 +284,13 @@ void QgsAttributeFormEditorWidget::updateWidgets()
     editPage()->layout()->addWidget( mMultiEditButton );
   }
 
+  setVisiblePageForMode( mode() );
+
   switch ( mode() )
   {
     case DefaultMode:
     case MultiEditMode:
     {
-      stack()->setCurrentWidget( editPage() );
       editPage()->layout()->addWidget( mConstraintResultLabel );
       break;
     }
@@ -299,14 +298,12 @@ void QgsAttributeFormEditorWidget::updateWidgets()
     case AggregateSearchMode:
     {
       mAggregateButton->setVisible( true );
-      stack()->setCurrentWidget( searchPage() );
       break;
     }
 
     case SearchMode:
     {
       mAggregateButton->setVisible( false );
-      stack()->setCurrentWidget( searchPage() );
       break;
     }
   }

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -151,7 +151,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     bool mIsMixed;
     bool mIsChanged;
 
-    void updateWidgets() override;
+    void updateWidgets() final;
 
     friend class TestQgsAttributeForm;
 };

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -55,6 +55,8 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
 
+    ~QgsAttributeFormWidget() override;
+
     /**
      * Creates the search widget wrappers for the widget used when the form is in
      * search mode.
@@ -171,6 +173,13 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      * \note not available in Python bindings
      */
     QWidget *searchPage() const SIP_SKIP;
+
+    /**
+     * Sets the visible page in the widget to the page matching the specified \a mode.
+     *
+     * \since QGIS 3.32
+     */
+    void setVisiblePageForMode( QgsAttributeFormWidget::Mode mode );
 
   private slots:
 

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -83,12 +83,12 @@
   }(void)(0)
 
 #define QGSVERIFYLESSTHAN(value,expected) { \
-    bool _xxxresult = value < expected; \
+    bool _xxxresult = ( value ) < ( expected ); \
     if ( !_xxxresult  ) \
     { \
       qDebug( "Expecting < %.10f got %.10f", static_cast< double >( expected ), static_cast< double >( value ) ); \
     } \
-    QVERIFY( value < expected ); \
+    QVERIFY( ( value ) < ( expected ) ); \
   }(void)(0)
 
 #define QGSCOMPARENEARPOINT(point1,point2,epsilon) { \

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -82,6 +82,15 @@
     QVERIFY( !qgsDoubleNear( value, not_expected, epsilon ) ); \
   }(void)(0)
 
+#define QGSVERIFYLESSTHAN(value,expected) { \
+    bool _xxxresult = value < expected; \
+    if ( !_xxxresult  ) \
+    { \
+      qDebug( "Expecting < %.10f got %.10f", static_cast< double >( expected ), static_cast< double >( value ) ); \
+    } \
+    QVERIFY( value < expected ); \
+  }(void)(0)
+
 #define QGSCOMPARENEARPOINT(point1,point2,epsilon) { \
     QGSCOMPARENEAR( point1.x(), point2.x(), epsilon ); \
     QGSCOMPARENEAR( point1.y(), point2.y(), epsilon ); \

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -59,6 +59,7 @@ class TestQgsAttributeForm : public QObject
     void testDefaultValueUpdateRecursion();
     void testSameFieldSync();
     void testZeroDoubles();
+    void testMinimumWidth();
 
   private:
     QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
@@ -1162,6 +1163,51 @@ void TestQgsAttributeForm::testZeroDoubles()
   const QList<QLineEdit *> les = form.findChildren<QLineEdit *>( "col0" );
   QCOMPARE( les.count(), 1 );
   QCOMPARE( les.at( 0 )->text(), QStringLiteral( "0" ) );
+}
+
+void TestQgsAttributeForm::testMinimumWidth()
+{
+  // ensure that the minimum width of editor widgets is as small as possible for the actual attribute form mode.
+  const QString def = QStringLiteral( "Point?field=col0:double" );
+  QgsVectorLayer layer { def, QStringLiteral( "test" ), QStringLiteral( "memory" ) };
+  layer.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() ) );
+  QgsFeature ft( layer.dataProvider()->fields(), 1 );
+  ft.setAttribute( QStringLiteral( "col0" ), 0.0 );
+  QgsAttributeEditorContext context;
+  context.setAttributeFormMode( QgsAttributeEditorContext::SingleEditMode );
+  std::unique_ptr< QgsAttributeForm > form = std::make_unique< QgsAttributeForm >( &layer, QgsFeature(), context );
+  form->setFeature( ft );
+  form->show();
+  // we don't want the larger width requirement of the search wrappers to be enforced when the attribute form
+  // is not in search modes
+  QLineEdit le;
+  const QFontMetrics leMetrics( le.fontMetrics() );
+  QGSVERIFYLESSTHAN( form->minimumWidth(), leMetrics.horizontalAdvance( 'x' ) * 20 );
+
+  form->setMode( QgsAttributeEditorContext::SearchMode );
+  QGSVERIFYLESSTHAN( form->minimumWidth(), leMetrics.horizontalAdvance( 'x' ) * 150 );
+
+  context.setAttributeFormMode( QgsAttributeEditorContext::AddFeatureMode );
+  form = std::make_unique< QgsAttributeForm >( &layer, QgsFeature(), context );
+  form->setFeature( ft );
+  form->show();
+  form->setMode( QgsAttributeEditorContext::AddFeatureMode );
+  QGSVERIFYLESSTHAN( form->minimumWidth(), leMetrics.horizontalAdvance( 'x' ) * 20 );
+
+  context.setAttributeFormMode( QgsAttributeEditorContext::AggregateSearchMode );
+  form = std::make_unique< QgsAttributeForm >( &layer, QgsFeature(), context );
+  form->setFeature( ft );
+  form->show();
+  form->setMode( QgsAttributeEditorContext::AggregateSearchMode );
+  QGSVERIFYLESSTHAN( form->minimumWidth(), leMetrics.horizontalAdvance( 'x' ) * 150 );
+
+  context.setAttributeFormMode( QgsAttributeEditorContext::MultiEditMode );
+  form = std::make_unique< QgsAttributeForm >( &layer, QgsFeature(), context );
+  form->setFeature( ft );
+  form->setMode( QgsAttributeEditorContext::MultiEditMode );
+  form->show();
+  QGSVERIFYLESSTHAN( form->minimumWidth(), leMetrics.horizontalAdvance( 'x' ) * 100 );
+
 }
 
 QGSTEST_MAIN( TestQgsAttributeForm )

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -19,6 +19,7 @@ from qgis.gui import (
     QgsDefaultSearchWidgetWrapper,
     QgsGui,
     QgsSearchWidgetWrapper,
+    QgsAttributeFormWidget,
 )
 from qgis.testing import start_app, unittest
 
@@ -38,6 +39,7 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, parent)
         af = QgsAttributeFormEditorWidget(wrapper, setup.type(), None)
         af.setSearchWidgetWrapper(w)
+        af.setMode(QgsAttributeFormWidget.SearchMode)
 
         # test that filter combines both current value in search widget wrapper and flags from search tool button
         w.lineEdit().setText('5.5')
@@ -57,6 +59,7 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, parent)
         af = QgsAttributeFormEditorWidget(wrapper, setup.type(), None)
         af.setSearchWidgetWrapper(w)
+        af.setMode(QgsAttributeFormWidget.SearchMode)
 
         sb = af.findChild(QWidget, "SearchWidgetToolButton")
         # start with inactive
@@ -83,6 +86,7 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, form)
         af = QgsAttributeFormEditorWidget(wrapper, 'DateTime', None)
         af.createSearchWidgetWrappers()
+        af.setMode(QgsAttributeFormWidget.SearchMode)
 
         d1 = af.findChildren(QDateTimeEdit)[0]
         d2 = af.findChildren(QDateTimeEdit)[1]


### PR DESCRIPTION
This bug causes editor widgets to inherit a very large minimum width from the search widget wrapper, regardless of what mode the attribute form is shown in. The outcome is that when adding/editing features all widgets have a large minimum width, causing very wide forms in multi-column setups with a lot of unnecessary edit widget width.

The root cause is that we were adding all edit widget mode pages to a QStackedWidget in the editor widget wrapperand QStackedWidgets will always inherit the minimum size of their largest page. Now, the pages are added and removed from the stack whenever the visible page is changed (in updateWidgets()). This ensures that the stack, and the editor widget too, only inherit the size requirements of the actual visible page.

Fix sponsored by NIWA
