### PR TITLE
Allow creation of attribute form group boxes and rows which   aren't contained within tabs

### DIFF
--- a/src/gui/qgsaddtaborgroup.cpp
+++ b/src/gui/qgsaddtaborgroup.cpp
@@ -38,7 +38,7 @@ QgsAddAttributeFormContainerDialog::QgsAddAttributeFormContainerDialog( QgsVecto
 
   mTypeCombo->setCurrentIndex( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::Tab ) ) );
 
-  mParentCombo->setEnabled( false );
+  mParentCombo->addItem( QString() );
   if ( !mExistingContainers.isEmpty() )
   {
     int i = 0;
@@ -52,12 +52,6 @@ QgsAddAttributeFormContainerDialog::QgsAddAttributeFormContainerDialog( QgsVecto
       }
       ++i;
     }
-  }
-  else
-  {
-    // top level items must be tabs
-    mTypeCombo->removeItem( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::GroupBox ) ) );
-    mTypeCombo->removeItem( mTypeCombo->findData( QVariant::fromValue( Qgis::AttributeEditorContainerType::Row ) ) );
   }
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAddAttributeFormContainerDialog::showHelp );
@@ -78,6 +72,9 @@ QString QgsAddAttributeFormContainerDialog::name()
 QTreeWidgetItem *QgsAddAttributeFormContainerDialog::parentContainerItem()
 {
   if ( containerType() == Qgis::AttributeEditorContainerType::Tab )
+    return nullptr;
+
+  if ( !mParentCombo->currentData().isValid() )
     return nullptr;
 
   const ContainerPair tab = mExistingContainers.at( mParentCombo->currentData().toInt() );


### PR DESCRIPTION
(Temporarily includes https://github.com/qgis/QGIS/pull/52914)

This was always supported by the form, but blocked in the form editor. It stems from a subtle twist in the original logic of
"tab containers can ONLY be top level items" which was misinterpreted sometime as "top level items can ONLY be tabs".

Restore the original constraint that tabs can only be top level items and allow also top level group boxes and rows