### PR TITLE
Fix QgsCoordinateFormatter rounding error when precision >= 8

### DIFF
--- a/src/core/qgscoordinateformatter.cpp
+++ b/src/core/qgscoordinateformatter.cpp
@@ -117,7 +117,7 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds( double val, int 
     wrappedX = wrappedX + 360.0;
   }
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   int degreesX = int( std::fabs( wrappedX ) );
   const double floatMinutesX = ( std::fabs( wrappedX ) - degreesX ) * 60.0;
@@ -199,7 +199,7 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutesSeconds( double val, int 
     wrappedY = wrappedY + 180.0;
   }
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   int degreesY = int( std::fabs( wrappedY ) );
   const double floatMinutesY = ( std::fabs( wrappedY ) - degreesY ) * 60.0;
@@ -278,7 +278,7 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutes( double val, int precisi
   int degreesX = int( std::fabs( wrappedX ) );
   double floatMinutesX = ( std::fabs( wrappedX ) - degreesX ) * 60.0;
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   //make sure rounding to specified precision doesn't create minutes >= 60
   if ( std::round( floatMinutesX * precisionMultiplier ) >= 60 * precisionMultiplier )
@@ -341,7 +341,7 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutes( double val, int precisi
   int degreesY = int( std::fabs( wrappedY ) );
   double floatMinutesY = ( std::fabs( wrappedY ) - degreesY ) * 60.0;
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   //make sure rounding to specified precision doesn't create minutes >= 60
   if ( std::round( floatMinutesY * precisionMultiplier ) >= 60 * precisionMultiplier )
@@ -398,7 +398,7 @@ QString QgsCoordinateFormatter::formatXAsDegrees( double val, int precision, For
 
   const double absX = std::fabs( wrappedX );
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   QString hemisphere;
   QString sign;
@@ -447,7 +447,7 @@ QString QgsCoordinateFormatter::formatYAsDegrees( double val, int precision, For
 
   const double absY = std::fabs( wrappedY );
 
-  const int precisionMultiplier = std::pow( 10.0, precision );
+  const double precisionMultiplier = std::pow( 10.0, precision );
 
   QString hemisphere;
   QString sign;

--- a/tests/src/python/test_qgscoordinateformatter.py
+++ b/tests/src/python/test_qgscoordinateformatter.py
@@ -71,8 +71,8 @@ class TestQgsCoordinateFormatter(unittest.TestCase):
 
         # check precision
         self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "80°0′0.0000″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "80°7′24.4444″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), "80°7′24″E")
+        for precision in range(1, 20):
+            self.assertEqual(QgsCoordinateFormatter.formatX(80.123456789123456789, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, precision), "80°7′{{:.0{}f}}″E".format(precision).format(24.444440844426935655064880848))
 
         # check if longitudes > 180 or <-180 wrap around
         self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″E")
@@ -130,8 +130,8 @@ class TestQgsCoordinateFormatter(unittest.TestCase):
 
         # check precision
         self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°0′0.0000″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°7′24.4444″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), "20°7′24″N")
+        for precision in range(1, 20):
+            self.assertEqual(QgsCoordinateFormatter.formatY(20.123456789123456789, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, precision), "20°7′{{:.0{}f}}″N".format(precision).format(24.4444408444397254243086))
 
         # check if latitudes > 90 or <-90 wrap around
         self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″N")


### PR DESCRIPTION
- Fix #52927

## Description

Fix an integer overflow in `QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds` and `QgsCoordinateFormatter::formatYAsDegreesMinutesSeconds` which caused rounding errors when precision was >= 8. 

This was already fixed for `QgsGeographicCoordinateNumericFormat` (see https://github.com/qgis/QGIS/commit/a70a1d90ad4e41f1a01d305a7ca952754df03f61)

Update the tests accordingly

