### PR TITLE
Check type in QgsLayerTreeLayer::toLayer and QgsLayerTreeLayer::toGroup

### DIFF
--- a/src/core/layertree/qgslayertree.h
+++ b/src/core/layertree/qgslayertree.h
@@ -56,36 +56,36 @@ class CORE_EXPORT QgsLayerTree : public QgsLayerTreeGroup
     }
 
     /**
-     * Cast node to a group. No type checking is done - use isGroup() to find out whether this operation is legal.
+     * Cast node to a group.
      *
      * \note Not available in Python bindings, because cast is automatic.
      * \since QGIS 2.4
      */
     static inline QgsLayerTreeGroup *toGroup( QgsLayerTreeNode *node ) SIP_SKIP
     {
-      return static_cast<QgsLayerTreeGroup *>( node );
+      return qobject_cast<QgsLayerTreeGroup *>( node );
     }
 
     /**
-     * Cast node to a layer. No type checking is done - use isLayer() to find out whether this operation is legal.
+     * Cast node to a layer.
      *
      * \note Not available in Python bindings, because cast is automatic.
      * \since QGIS 2.4
      */
     static inline QgsLayerTreeLayer *toLayer( QgsLayerTreeNode *node ) SIP_SKIP
     {
-      return static_cast<QgsLayerTreeLayer *>( node );
+      return qobject_cast<QgsLayerTreeLayer *>( node );
     }
 
     /**
-     * Cast node to a layer. No type checking is done - use isLayer() to find out whether this operation is legal.
+     * Cast node to a layer.
      *
      * \note Not available in Python bindings, because cast is automatic.
      * \since QGIS 2.4
      */
     static inline const QgsLayerTreeLayer *toLayer( const QgsLayerTreeNode *node ) SIP_SKIP
     {
-      return static_cast< const QgsLayerTreeLayer *>( node );
+      return qobject_cast< const QgsLayerTreeLayer *>( node );
     }
 
     /**


### PR DESCRIPTION
## Description

`QgsLayerTree::toLayer` and `QgsLayerTree::toGroup` was using static_cast, which made accessing the resulting object unsafe, and not checkable against nullptr.

This PR uses `qobject_cast`, which makes snippets like this valid:

```C++

if ( QgsLayerTreeLayer *layer = QgsLayerTree::toLayer(node) )
{
    // do something with layer
}
```
