### PR TITLE
fix legend label position error by typo 

### DIFF
--- a/src/core/layertree/qgscolorramplegendnode.cpp
+++ b/src/core/layertree/qgscolorramplegendnode.cpp
@@ -352,7 +352,7 @@ QSizeF QgsColorRampLegendNode::drawSymbol( const QgsLegendSettings &settings, It
 
         case Qt::AlignRight:
           labelXMin = ctx->columnRight - rampWidth;
-          labelXMin = ctx->columnRight;
+          labelXMax = ctx->columnRight;
           break;
       }
 


### PR DESCRIPTION
fix the horizontal legend has an incorrect position when the label is on the right side
Fixes #52895