### PR TITLE
Fix setting min/max decimal values for single band gray renderer

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsdoublevalidator.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdoublevalidator.sip.in
@@ -98,6 +98,7 @@ Converts ``input`` string to double value. It uses locale interpretation
 first and C locale interpretation as fallback
 %End
 
+
     void setBottom( double bottom );
 %Docstring
 Set top range limit

--- a/python/gui/auto_generated/qgsdoublevalidator.sip.in
+++ b/python/gui/auto_generated/qgsdoublevalidator.sip.in
@@ -98,11 +98,6 @@ Converts ``input`` string to double value. It uses locale interpretation
 first and C locale interpretation as fallback
 %End
 
-    static bool isDoubleConversionSafe( const QString &input );
-%Docstring
-Checks if ``input`` string can be safely converted to double
-and back to string without any changes.
-%End
 
     void setBottom( double bottom );
 %Docstring

--- a/python/gui/auto_generated/qgsdoublevalidator.sip.in
+++ b/python/gui/auto_generated/qgsdoublevalidator.sip.in
@@ -98,6 +98,12 @@ Converts ``input`` string to double value. It uses locale interpretation
 first and C locale interpretation as fallback
 %End
 
+    static bool isDoubleConversionSafe( const QString &input );
+%Docstring
+Checks if ``input`` string can be safely converted to double
+and back to string without any changes.
+%End
+
     void setBottom( double bottom );
 %Docstring
 Set top range limit

--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -162,3 +162,17 @@ double QgsDoubleValidator::toDouble( const QString &input, bool *ok )
   }
   return value;
 }
+
+bool QgsDoubleValidator::isDoubleConversionSafe( const QString &input )
+{
+  double converted = QgsDoubleValidator::toDouble( input );
+  if ( input == QLocale().toString( converted ) )
+  {
+    return true;
+  }
+  if ( QString( input ).replace( QLocale( QLocale::C ).decimalPoint(), QLocale().decimalPoint() ) == QLocale().toString( converted ) )
+  {
+    return true;
+  }
+  return false;
+}

--- a/src/gui/qgsdoublevalidator.h
+++ b/src/gui/qgsdoublevalidator.h
@@ -121,7 +121,7 @@ class GUI_EXPORT QgsDoubleValidator : public QRegularExpressionValidator
      * Checks if \a input string can be safely converted to double
      * and back to string without any changes.
     */
-    static bool isDoubleConversionSafe( const QString &input );
+    static bool isDoubleConversionSafe( const QString &input ) SIP_SKIP;
 
     /**
      * Set top range limit

--- a/src/gui/qgsdoublevalidator.h
+++ b/src/gui/qgsdoublevalidator.h
@@ -118,6 +118,12 @@ class GUI_EXPORT QgsDoubleValidator : public QRegularExpressionValidator
     static double toDouble( const QString &input );
 
     /**
+     * Checks if \a input string can be safely converted to double
+     * and back to string without any changes.
+    */
+    static bool isDoubleConversionSafe( const QString &input );
+
+    /**
      * Set top range limit
      * \see setTop
      * \see setRange

--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -200,34 +200,52 @@ void QgsMultiBandColorRendererWidget::onBandChanged( int index )
   emit widgetChanged();
 }
 
-void QgsMultiBandColorRendererWidget::mRedMinLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mRedMinLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsMultiBandColorRendererWidget::mRedMaxLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mRedMaxLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsMultiBandColorRendererWidget::mGreenMinLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mGreenMinLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsMultiBandColorRendererWidget::mGreenMaxLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mGreenMaxLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsMultiBandColorRendererWidget::mBlueMinLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mBlueMinLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsMultiBandColorRendererWidget::mBlueMaxLineEdit_textChanged( const QString & )
+void QgsMultiBandColorRendererWidget::mBlueMaxLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
+  {
+    minMaxModified();
+  }
 }
 
 void QgsMultiBandColorRendererWidget::minMaxModified()

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -121,8 +121,7 @@ void QgsSingleBandGrayRendererWidget::setMapCanvas( QgsMapCanvas *canvas )
 
 void QgsSingleBandGrayRendererWidget::mMinLineEdit_textChanged( const QString &value )
 {
-  double converted = QgsDoubleValidator::toDouble( value );
-  if ( value == QLocale().toString( converted ) )
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
   {
     minMaxModified();
   }
@@ -130,8 +129,7 @@ void QgsSingleBandGrayRendererWidget::mMinLineEdit_textChanged( const QString &v
 
 void QgsSingleBandGrayRendererWidget::mMaxLineEdit_textChanged( const QString &value )
 {
-  double converted = QgsDoubleValidator::toDouble( value );
-  if ( value == QLocale().toString( converted ) )
+  if ( QgsDoubleValidator::isDoubleConversionSafe( value ) )
   {
     minMaxModified();
   }

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -119,14 +119,22 @@ void QgsSingleBandGrayRendererWidget::setMapCanvas( QgsMapCanvas *canvas )
   mMinMaxWidget->setMapCanvas( canvas );
 }
 
-void QgsSingleBandGrayRendererWidget::mMinLineEdit_textChanged( const QString & )
+void QgsSingleBandGrayRendererWidget::mMinLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  double converted = QgsDoubleValidator::toDouble( value );
+  if ( value == QLocale().toString( converted ) )
+  {
+    minMaxModified();
+  }
 }
 
-void QgsSingleBandGrayRendererWidget::mMaxLineEdit_textChanged( const QString & )
+void QgsSingleBandGrayRendererWidget::mMaxLineEdit_textChanged( const QString &value )
 {
-  minMaxModified();
+  double converted = QgsDoubleValidator::toDouble( value );
+  if ( value == QLocale().toString( converted ) )
+  {
+    minMaxModified();
+  }
 }
 
 void QgsSingleBandGrayRendererWidget::minMaxModified()

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -261,7 +261,6 @@ void TestQgsDoubleValidator::isDoubleConversionSafe_data()
   QTest::newRow( "string" ) << QString( "abc" ) << false;
   QTest::newRow( "ends to locale decimal point" ) << QString( "3ld" ) << false;
   QTest::newRow( "ends to default locale decimal point" ) << QString( "3cd" ) << false;
-
 }
 
 void TestQgsDoubleValidator::isDoubleConversionSafe()
@@ -271,7 +270,7 @@ void TestQgsDoubleValidator::isDoubleConversionSafe()
   QString value;
   bool expectedValue;
 
-  const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian} );
+  const QVector<QLocale> listLocale( { QLocale::English, QLocale::French, QLocale::German, QLocale::Italian } );
   QLocale loc;
   for ( int i = 0; i < listLocale.count(); ++i )
   {
@@ -279,12 +278,11 @@ void TestQgsDoubleValidator::isDoubleConversionSafe()
     QLocale::setDefault( loc );
     value = inputValue;
     value = value.replace( "ld", QLocale().decimalPoint() )
-            .replace( "cd", QLocale( QLocale::C ).decimalPoint() );
+              .replace( "cd", QLocale( QLocale::C ).decimalPoint() );
     expectedValue = expValue;
 
     QCOMPARE( QgsDoubleValidator::isDoubleConversionSafe( value ), expectedValue );
   }
-
 }
 
 QGSTEST_MAIN( TestQgsDoubleValidator )


### PR DESCRIPTION
Fixes issue #50861

## Description

The issue was with layer styling dock updating QLineEdit's contents too fast because raster renderer is called at some point when raster min/max values are changed. Min/max decimal values are being converted from string to text in a way that truncates decimal point before decimal digits have been entered, thus making it difficult for the user to enter decimal values. Starting to type "2." will change the value automatically to "2" unless user is typing very fast.

The same issue is found at least in QgsMultiBandColorRendererWidget min/max values (tested with QGIS) and possibly in QgsPointCloudRgbRendererWidget (didn't test this but code looks similar). If the solution is ok, I could fix them (or at least QgsMultiBandColorRendererWidget) in this PR also.

The issue happens when QLineEdit's text change triggers rendering and the values are at some point set back to QLineEdit text (input converted from string -> to double -> back to string).


Renderer converts the string input to double:
```c++
// src/gui/raster/qgssinglebandgrayrendererwidget.cpp
QgsRasterRenderer *QgsSingleBandGrayRendererWidget::renderer()
    //...

    // Here "2." gets converted to 2 (QgsDoubleValidator handles it)
    QgsContrastEnhancement *e = new QgsContrastEnhancement( ( Qgis::DataType )(
        provider->dataType( band ) ) );
    e->setMinimumValue( QgsDoubleValidator::toDouble( mMinLineEdit->text() ) );
    e->setMaximumValue( QgsDoubleValidator::toDouble( mMaxLineEdit->text() ) );
    
    ///...
```

refreshAfterStyleChanged is triggered at some point during editing values in layer styling dock:
```c++
// src/gui/raster/qgssinglebandgrayrendererwidget.cpp
void QgsRendererRasterPropertiesWidget::refreshAfterStyleChanged()
{
  if ( mRendererWidget )
  {
    // Here renderer is called -> input of "2." sets QgsContrastEnhancement.minimumValue to 2
    QgsRasterRenderer *renderer = mRasterLayer->renderer();
    
    // ..
    
    else if ( QgsSingleBandGrayRenderer *sbgr = dynamic_cast<QgsSingleBandGrayRenderer *>( renderer ) )
    {
      const QgsContrastEnhancement *ce = sbgr->contrastEnhancement();
      if ( ce )
      {
        // Here values are set back to QLineEdit (see snippet below)
        mRendererWidget->setMin( QLocale().toString( ce->minimumValue() ) );
        mRendererWidget->setMax( QLocale().toString( ce->maximumValue() ) );
      }
    }
  }
}
```

```c++
// src/gui/raster/qgssinglebandgrayrendererwidget.cpp
void QgsSingleBandGrayRendererWidget::setMin( const QString &value, int )
{
  mDisableMinMaxWidgetRefresh = true;
  // Here value is set back to QLineEdit widget: 2 becomes "2" (which is 
  // seen in layer styling dock as decimal point disappearing while typing)
  mMinLineEdit->setText( value );
  mDisableMinMaxWidgetRefresh = false;
}
```

I was looking into this issue with @jgrocha  who came up the solution to check if `QgsDoubleValidator::toDouble` changes the input during conversion and only trigger rendering if conversion does not change the input. This allows user to type decimal point without re-rendering the raster (re-rendering happens when first digit is typed).

I was trying to find tests related to the raster renderer widgets but did not find one for QgsSingleBandGrayRendererWidget. I am unsure whether this needs an unit test as it is GUI related. If it does need a test, where should the test be added?