### PR TITLE
Fix for accessing the strength of field constraints

### DIFF
--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2011,6 +2011,118 @@ template<TYPE1, TYPE2>
 };
 
 
+%MappedType QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength>
+/TypeHint="Dict[QgsFieldConstraints.Constraint, QgsFieldConstraints.ConstraintStrength]", TypeHintValue="{}"/
+{
+%TypeHeaderCode
+#include <QMap>
+#include "qgsfieldconstraints.h"
+%End
+
+%ConvertFromTypeCode
+    // Create the dictionary.
+    PyObject *d = PyDict_New();
+
+    if (!d)
+        return NULL;
+
+    // Set the dictionary elements.
+    QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength>::const_iterator i = sipCpp->constBegin();
+
+    while (i != sipCpp->constEnd())
+    {
+        PyObject *kobj = sipConvertFromEnum(static_cast<int>(i.key()),
+                                            sipType_QgsFieldConstraints_Constraint);
+        PyObject *vobj = sipConvertFromEnum(static_cast<int>(i.value()),
+                                            sipType_QgsFieldConstraints_ConstraintStrength);
+
+        if (kobj == NULL || vobj == NULL || PyDict_SetItem(d, kobj, vobj) < 0)
+        {
+            Py_DECREF(d);
+
+            if (kobj)
+                Py_DECREF(kobj);
+
+            if (vobj)
+                Py_DECREF(vobj);
+
+            return NULL;
+        }
+
+        Py_DECREF(kobj);
+        Py_DECREF(vobj);
+
+        ++i;
+    }
+
+    return d;
+%End
+
+%ConvertToTypeCode
+    // Get the Python object as an iterator
+    PyObject *iter = PyObject_GetIter(sipPy);
+
+    if (!sipIsErr)
+    {
+        PyErr_Clear();
+        Py_XDECREF(iter);
+
+        return (iter && !PyBytes_Check(sipPy) && !PyUnicode_Check(sipPy));
+    }
+
+    if (!iter)
+    {
+        *sipIsErr = 1;
+
+        return 0;
+    }
+
+    // Create a new QMap to hold the values
+    QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> *map = new QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength>;
+
+    // Loop over the Python iterator
+    for (Py_ssize_t i = 0; ; ++i)
+    {
+        // Get the next Python item in the iterator
+        PyErr_Clear();
+        PyObject *item = PyIter_Next(iter);
+
+        if (!item)
+        {
+            if (PyErr_Occurred())
+            {
+                delete map;
+                Py_DECREF(iter);
+                *sipIsErr = 1;
+
+                return 0;
+            }
+
+            break;
+        }
+
+        // Get the key and value from the Python item
+        PyObject *key = PyTuple_GetItem(item, 0);
+        PyObject *value = PyTuple_GetItem(item, 1);
+
+        // Convert the key and value to C++ types
+        int keyVal = sipConvertToEnum(key, sipType_QgsFieldConstraints_Constraint);
+        int valueVal = sipConvertToEnum(value, sipType_QgsFieldConstraints_ConstraintStrength);
+
+        // Add the key and value to the map
+        map->insert(static_cast<QgsFieldConstraints::Constraint>(keyVal), static_cast<QgsFieldConstraints::ConstraintStrength>(valueVal));
+
+        Py_DECREF(item);
+    }
+
+    Py_DECREF(iter);
+
+    *sipCppPtr = map;
+
+    return sipGetState(sipTransferObj);
+%End
+};
+
 
 template<double, TYPE>
 %MappedType QMap<double, TYPE>

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2059,63 +2059,40 @@ template<TYPE1, TYPE2>
 %End
 
 %ConvertToTypeCode
-    // Get the Python object as an iterator
-    PyObject *iter = PyObject_GetIter(sipPy);
+    PyObject *key, *value;
+    Py_ssize_t i = 0;
 
-    if (!sipIsErr)
+    // Check the type if that is all that is required.
+    if (sipIsErr == NULL)
     {
-        PyErr_Clear();
-        Py_XDECREF(iter);
+        if (!PyDict_Check(sipPy))
+            return 0;
 
-        return (iter && !PyBytes_Check(sipPy) && !PyUnicode_Check(sipPy));
-    }
+        while (PyDict_Next(sipPy, &i, &key, &value))
+        {
+            if (!sipCanConvertToEnum(key, sipType_QgsFieldConstraints_Constraint))
+                return 0;
 
-    if (!iter)
-    {
-        *sipIsErr = 1;
+            if (!sipCanConvertToEnum(value, sipType_QgsFieldConstraints_ConstraintStrength))
+                return 0;
+        }
 
-        return 0;
+        return 1;
     }
 
     // Create a new QMap to hold the values
     QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> *map = new QMap<QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength>;
 
-    // Loop over the Python iterator
-    for (Py_ssize_t i = 0; ; ++i)
+    // Loop over the Python dictionary items
+    while (PyDict_Next(sipPy, &i, &key, &value))
     {
-        // Get the next Python item in the iterator
-        PyErr_Clear();
-        PyObject *item = PyIter_Next(iter);
-
-        if (!item)
-        {
-            if (PyErr_Occurred())
-            {
-                delete map;
-                Py_DECREF(iter);
-                *sipIsErr = 1;
-
-                return 0;
-            }
-
-            break;
-        }
-
-        // Get the key and value from the Python item
-        PyObject *key = PyTuple_GetItem(item, 0);
-        PyObject *value = PyTuple_GetItem(item, 1);
-
-        // Convert the key and value to C++ types
+        // Convert the key and value Python objects to C++ types
         int keyVal = sipConvertToEnum(key, sipType_QgsFieldConstraints_Constraint);
         int valueVal = sipConvertToEnum(value, sipType_QgsFieldConstraints_ConstraintStrength);
 
         // Add the key and value to the map
         map->insert(static_cast<QgsFieldConstraints::Constraint>(keyVal), static_cast<QgsFieldConstraints::ConstraintStrength>(valueVal));
-
-        Py_DECREF(item);
     }
-
-    Py_DECREF(iter);
 
     *sipCppPtr = map;
 

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2065,19 +2065,7 @@ template<TYPE1, TYPE2>
     // Check the type if that is all that is required.
     if (sipIsErr == NULL)
     {
-        if (!PyDict_Check(sipPy))
-            return 0;
-
-        while (PyDict_Next(sipPy, &i, &key, &value))
-        {
-            if (!sipCanConvertToEnum(key, sipType_QgsFieldConstraints_Constraint))
-                return 0;
-
-            if (!sipCanConvertToEnum(value, sipType_QgsFieldConstraints_ConstraintStrength))
-                return 0;
-        }
-
-        return 1;
+        return PyDict_Check(sipPy);
     }
 
     // Create a new QMap to hold the values
@@ -2088,7 +2076,32 @@ template<TYPE1, TYPE2>
     {
         // Convert the key and value Python objects to C++ types
         int keyVal = sipConvertToEnum(key, sipType_QgsFieldConstraints_Constraint);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Format(PyExc_TypeError,
+                         "a key has type '%s' but 'QgsFieldConstraints.Constraint' is expected",
+                         sipPyTypeName(Py_TYPE(key)));
+
+            delete map;
+            *sipIsErr = 1;
+
+            return 0;
+        }
+
         int valueVal = sipConvertToEnum(value, sipType_QgsFieldConstraints_ConstraintStrength);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Format(PyExc_TypeError,
+                         "a value has type '%s' but 'QgsFieldConstraints.ConstraintStrength' is expected",
+                         sipPyTypeName(Py_TYPE(value)));
+
+            delete map;
+            *sipIsErr = 1;
+
+            return 0;
+        }
 
         // Add the key and value to the map
         map->insert(static_cast<QgsFieldConstraints::Constraint>(keyVal), static_cast<QgsFieldConstraints::ConstraintStrength>(valueVal));

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3084,7 +3084,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertEqual(layer3.fields().at(0).constraints().constraints(), QgsFieldConstraints.ConstraintNotNull)
         self.assertEqual(layer3.fields().at(0).constraints().constraintOrigin(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintOriginLayer)
-        self.assertEqual(layer.fields().at(0).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
+        self.assertEqual(layer3.fields().at(0).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintStrengthHard)
         self.assertEqual(layer3.fields().at(1).constraints().constraints(),
                          QgsFieldConstraints.ConstraintNotNull | QgsFieldConstraints.ConstraintUnique)
@@ -3092,9 +3092,9 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
                          QgsFieldConstraints.ConstraintOriginLayer)
         self.assertEqual(layer3.fields().at(1).constraints().constraintOrigin(QgsFieldConstraints.ConstraintUnique),
                          QgsFieldConstraints.ConstraintOriginLayer)
-        self.assertEqual(layer.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
+        self.assertEqual(layer3.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintStrengthSoft)
-        self.assertEqual(layer.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintUnique),
+        self.assertEqual(layer3.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintUnique),
                          QgsFieldConstraints.ConstraintStrengthHard)
 
     def testGetSetConstraintExpressions(self):

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3014,6 +3014,10 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
                          QgsFieldConstraints.ConstraintOriginLayer)
         self.assertEqual(layer.fields().at(0).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintStrengthHard)
+        self.assertEqual(layer.fieldConstraintsAndStrength(0)[QgsFieldConstraints.ConstraintNotNull],
+                         QgsFieldConstraints.ConstraintStrengthHard)
+        self.assertEqual(len(layer.fieldConstraintsAndStrength(1)), 0)
+        self.assertEqual(len(layer.fieldConstraintsAndStrength(2)), 0)
 
         layer.setFieldConstraint(1, QgsFieldConstraints.ConstraintNotNull)
         layer.setFieldConstraint(1, QgsFieldConstraints.ConstraintUnique)
@@ -3066,6 +3070,8 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertTrue(layer2.readXml(elem, QgsReadWriteContext()))
         self.assertFalse(layer2.fieldConstraints(0))
         self.assertFalse(layer2.fieldConstraints(1))
+        self.assertFalse(layer2.fieldConstraintsAndStrength(0))
+        self.assertFalse(layer2.fieldConstraintsAndStrength(1))
 
         # set some constraints
         layer.setFieldConstraint(0, QgsFieldConstraints.ConstraintNotNull)
@@ -3086,6 +3092,8 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
                          QgsFieldConstraints.ConstraintOriginLayer)
         self.assertEqual(layer3.fields().at(0).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintStrengthHard)
+        self.assertEqual(layer3.fieldConstraintsAndStrength(0)[QgsFieldConstraints.ConstraintNotNull],
+                         QgsFieldConstraints.ConstraintStrengthHard)
         self.assertEqual(layer3.fields().at(1).constraints().constraints(),
                          QgsFieldConstraints.ConstraintNotNull | QgsFieldConstraints.ConstraintUnique)
         self.assertEqual(layer3.fields().at(1).constraints().constraintOrigin(QgsFieldConstraints.ConstraintNotNull),
@@ -3095,6 +3103,10 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertEqual(layer3.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintNotNull),
                          QgsFieldConstraints.ConstraintStrengthSoft)
         self.assertEqual(layer3.fields().at(1).constraints().constraintStrength(QgsFieldConstraints.ConstraintUnique),
+                         QgsFieldConstraints.ConstraintStrengthHard)
+        self.assertEqual(layer3.fieldConstraintsAndStrength(1)[QgsFieldConstraints.ConstraintNotNull],
+                         QgsFieldConstraints.ConstraintStrengthSoft)
+        self.assertEqual(layer3.fieldConstraintsAndStrength(1)[QgsFieldConstraints.ConstraintUnique],
                          QgsFieldConstraints.ConstraintStrengthHard)
 
     def testGetSetConstraintExpressions(self):


### PR DESCRIPTION
This PR adds a new SIP conversion to enable usage of `fieldConstraintsAndStrength` method when accessing through python bindings. Previously the method would always return `{0: 0}` regardless of which constraints were set.

Fixes #36462

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
