### PR TITLE
Fix crash when removing drag and drop form elements

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -740,7 +740,17 @@ void QgsAttributesFormProperties::addContainer()
 
 void QgsAttributesFormProperties::removeTabOrGroupButton()
 {
-  qDeleteAll( mFormLayoutTree->selectedItems() );
+  // deleting an item may delete any number of nested child items -- so we delete
+  // them one at a time and then see if there's any selection left
+  while ( true )
+  {
+    const QList<QTreeWidgetItem *> items = mFormLayoutTree->selectedItems();
+    if ( items.empty() )
+      break;
+
+    delete items.at( 0 );
+  }
+
 }
 
 QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWidget( QTreeWidgetItem *item, QgsAttributeEditorElement *parent, bool isTopLevel )


### PR DESCRIPTION
If both a container and a item within that container are selected and then the "remove" button is pressed, QGIS will crash

Avoid the crash by removing items one-by-one, so that we don't try to delete a child item which was already deleted by its parent.
