### PR TITLE
Deselect annotation item when modify tool is deactivated

### DIFF
--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -118,6 +118,7 @@ void QgsMapToolModifyAnnotation::deactivate()
   mSnapIndicator->setMatch( QgsPointLocator::Match() );
 
   clearHoveredItem();
+  clearSelectedItem();
   QgsMapToolAdvancedDigitizing::deactivate();
 }
 


### PR DESCRIPTION
## Description

Fix the following bug:

- Set "Modify Annotations" as active map tool
- Select a polygon annotation; it appears selected, with a rectangle rubberband
- Change the active map tool to Pan
- The selection rectangle is still there.