### PR TITLE
Avoid installing QgsCPLHTTPFetchOverrider for every ogr feature fetched if we can avoid it

### DIFF
--- a/src/core/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.h
@@ -27,12 +27,15 @@
 #include <set>
 #include "qgis_sip.h"
 
+
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
 class QgsOgrFeatureIterator;
 class QgsOgrProvider;
 class QgsOgrDataset;
+class QgsCPLHTTPFetchOverrider;
+
 using QgsOgrDatasetSharedPtr = std::shared_ptr< QgsOgrDataset>;
 
 class QgsOgrFeatureSource final: public QgsAbstractFeatureSource
@@ -120,6 +123,8 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
 
     QgsGeometry mDistanceWithinGeom;
     std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+
+    std::unique_ptr< QgsCPLHTTPFetchOverrider > mCplHttpFetchOverrider;
 
     QVector< int > mRequestAttributes;
 

--- a/src/core/qgscplhttpfetchoverrider.cpp
+++ b/src/core/qgscplhttpfetchoverrider.cpp
@@ -20,9 +20,10 @@
 #include "cpl_http.h"
 #include "gdal.h"
 
-QgsCPLHTTPFetchOverrider::QgsCPLHTTPFetchOverrider( const QString &authCfg, QgsFeedback *feedback ):
-  mAuthCfg( authCfg ),
-  mFeedback( feedback )
+QgsCPLHTTPFetchOverrider::QgsCPLHTTPFetchOverrider( const QString &authCfg, QgsFeedback *feedback )
+  : mAuthCfg( authCfg )
+  , mFeedback( feedback )
+  , mThread( QThread::currentThread() )
 {
   CPLHTTPPushFetchCallback( QgsCPLHTTPFetchOverrider::callback, this );
 }
@@ -187,4 +188,14 @@ CPLHTTPResult *QgsCPLHTTPFetchOverrider::callback( const char *pszURL,
 void QgsCPLHTTPFetchOverrider::setAttribute( QNetworkRequest::Attribute code, const QVariant &value )
 {
   mAttributes[code] = value;
+}
+
+void QgsCPLHTTPFetchOverrider::setFeedback( QgsFeedback *feedback )
+{
+  mFeedback = feedback;
+}
+
+QThread *QgsCPLHTTPFetchOverrider::thread() const
+{
+  return mThread;
 }

--- a/src/core/qgscplhttpfetchoverrider.h
+++ b/src/core/qgscplhttpfetchoverrider.h
@@ -20,6 +20,7 @@
 
 #include <QNetworkRequest>
 #include <QString>
+#include <QPointer>
 #include "qgsnetworkaccessmanager.h" // for QgsSetRequestInitiatorClass
 
 #include "cpl_http.h"
@@ -28,7 +29,7 @@
 class QgsFeedback;
 
 #ifndef SIP_RUN
-#define QgsSetCPLHTTPFetchOverriderInitiatorClass(overrider, _class) QgsSetRequestInitiatorClass(overrider, _class)
+#define QgsSetCPLHTTPFetchOverriderInitiatorClass(overrider, _class) QgsSetRequestInitiatorClass((overrider), _class)
 #endif
 
 /**
@@ -53,6 +54,20 @@ class QgsCPLHTTPFetchOverrider
     //! Define attribute that must be forwarded to the actual QNetworkRequest
     void setAttribute( QNetworkRequest::Attribute code, const QVariant &value );
 
+    /**
+     * Sets the \a feedback cancellation object for the redirection.
+     *
+     * \since QGIS 3.32
+     */
+    void setFeedback( QgsFeedback *feedback );
+
+    /**
+     * Returns the thread associated with the overrider.
+     *
+     * \since QGIS 3.32
+     */
+    QThread *thread() const;
+
   private:
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,2,0)
@@ -68,6 +83,8 @@ class QgsCPLHTTPFetchOverrider
     QString mAuthCfg;
 
     QgsFeedback *mFeedback = nullptr;
+
+    QPointer< QThread > mThread;
 
     std::map<QNetworkRequest::Attribute, QVariant> mAttributes;
 };


### PR DESCRIPTION
This is a relatively expensive operation to do (specifically the calls to QgsCPLHTTPFetchOverrider::setAttribute) compared with the actual costs of fetching features from GDAL

Avoid creating a new override for every feature, if we detect that its safe to use an override created in the OGR feature iterator constructor.
