### PR TITLE
Optimise QgsThreadStackOverflowGuard

### DIFF
--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -28,8 +28,12 @@
 #include "qgsexception.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsgeometryengine.h"
+#include "qgsconfig.h"
 
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
 #include <QThreadStorage>
+#endif
+
 #include <QStack>
 
 QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *layer )
@@ -380,26 +384,42 @@ class QgsThreadStackOverflowGuard
 {
   public:
 
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
     QgsThreadStackOverflowGuard( QThreadStorage<QStack<QString>> &storage, const QString &stackFrameInformation, int maxDepth )
+#else
+    QgsThreadStackOverflowGuard( QStack<QString> &storage, const QString &stackFrameInformation, int maxDepth )
+#endif
       : mStorage( storage )
       , mMaxDepth( maxDepth )
     {
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
       if ( !storage.hasLocalData() )
       {
         storage.setLocalData( QStack<QString>() );
       }
 
       storage.localData().push( stackFrameInformation );
+#else
+      storage.push( stackFrameInformation );
+#endif
     }
 
     ~QgsThreadStackOverflowGuard()
     {
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
       mStorage.localData().pop();
+#else
+      mStorage.pop();
+#endif
     }
 
     bool hasStackOverflow() const
     {
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
       if ( mStorage.localData().size() > mMaxDepth )
+#else
+      if ( mStorage.size() > mMaxDepth )
+#endif
         return true;
       else
         return false;
@@ -408,7 +428,11 @@ class QgsThreadStackOverflowGuard
     QString topFrames() const
     {
       QStringList dumpStack;
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
       const QStack<QString> &stack = mStorage.localData();
+#else
+      const QStack<QString> &stack = mStorage;
+#endif
 
       const int dumpSize = std::min( static_cast<int>( stack.size() ), 10 );
       for ( int i = 0; i < dumpSize; ++i )
@@ -421,11 +445,19 @@ class QgsThreadStackOverflowGuard
 
     int depth() const
     {
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
       return mStorage.localData().size();
+#else
+      return mStorage.size();
+#endif
     }
 
   private:
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
     QThreadStorage<QStack<QString>> &mStorage;
+#else
+    QStack<QString> &mStorage;
+#endif
     int mMaxDepth;
 };
 
@@ -438,7 +470,11 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature &f )
   if ( mClosed )
     return false;
 
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
   static QThreadStorage<QStack<QString>> sStack;
+#else
+  static thread_local QStack<QString> sStack;
+#endif
 
   const QgsThreadStackOverflowGuard guard( sStack, mSource->id(), 4 );
 
@@ -795,7 +831,11 @@ void QgsVectorLayerFeatureIterator::prepareJoin( int fieldIdx )
 
 void QgsVectorLayerFeatureIterator::prepareExpression( int fieldIdx )
 {
+#if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
   static QThreadStorage<QStack<QString>> sStack;
+#else
+  static thread_local QStack<QString> sStack;
+#endif
 
   const QgsThreadStackOverflowGuard guard( sStack, mSource->id(), 4 );
 


### PR DESCRIPTION
This is created for every vector layer feature fetched. By moving away from the Qt classes (where available!) we considerably cut down on the expense of this guard.