### PR TITLE
[Backport 3.30] [WFS / OAPIF] Emit request headers of initial request when following a redirect

### DIFF
--- a/src/providers/wfs/qgsbasenetworkrequest.h
+++ b/src/providers/wfs/qgsbasenetworkrequest.h
@@ -122,6 +122,10 @@ class QgsBaseNetworkRequest : public QObject
     virtual int defaultExpirationInSec() { return 0; }
 
   private:
+
+    //! Request headers
+    QList<QNetworkReply::RawHeaderPair> mRequestHeaders;
+
     QString errorMessageFailedAuth();
 
     void logMessageIfEnabled();


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/53011