### PR TITLE
Annotations tools various improvements

### DIFF
--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -115,8 +115,9 @@ void QgsMapToolAnnotation::canvasPressEvent( QgsMapMouseEvent *e )
     const QgsPointXY mapPos = transformCanvasToAnnotation( toMapCoordinates( e->pos() ), annotation );
     annotation->setMapPosition( mapPos );
     annotation->setMapPositionCrs( mCanvas->mapSettings().destinationCrs() );
-    annotation->setRelativePosition( QPointF( e->pos().x() / mCanvas->width(),
-                                     e->pos().y() / mCanvas->height() ) );
+    annotation->setRelativePosition( QPointF(
+                                       static_cast<double>( e->pos().x() ) / mCanvas->width(),
+                                       static_cast<double>( e->pos().y() ) / mCanvas->height() ) );
     annotation->setFrameSizeMm( QSizeF( 50, 25 ) );
 
     QgsProject::instance()->annotationManager()->addAnnotation( annotation );
@@ -173,7 +174,7 @@ bool QgsMapToolAnnotation::populateContextMenuWithEvent( QMenu *menu, QgsMapMous
       dialog->exec();
     }
   } );
-  menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteSelected.svg" ) ), tr( "Delete" ), this, [this, existingItem]()
+  menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteSelected.svg" ) ), tr( "Delete" ), this, [existingItem]()
   {
     QgsProject::instance()->annotationManager()->removeAnnotation( existingItem->annotation() );
   } );

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -147,11 +147,6 @@ void QgsMapToolAnnotation::canvasPressEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolAnnotation::keyPressEvent( QKeyEvent *e )
 {
-  if ( e->key() == Qt::Key_T && e->modifiers() == Qt::ControlModifier )
-  {
-    toggleTextItemVisibilities();
-  }
-
   QgsMapCanvasAnnotationItem *item = selectedItem();
   if ( item )
   {
@@ -378,19 +373,6 @@ QList<QgsMapCanvasAnnotationItem *> QgsMapToolAnnotation::annotationItems() cons
   }
 }
 
-void QgsMapToolAnnotation::toggleTextItemVisibilities()
-{
-  const QList<QgsMapCanvasAnnotationItem *> itemList = annotationItems();
-  const auto constItemList = itemList;
-  for ( QgsMapCanvasAnnotationItem *item : constItemList )
-  {
-    QgsTextAnnotation *textItem = qobject_cast<QgsTextAnnotation *>( item->annotation() );
-    if ( textItem )
-    {
-      textItem->setVisible( !textItem->isVisible() );
-    }
-  }
-}
 
 QgsPointXY QgsMapToolAnnotation::transformCanvasToAnnotation( QgsPointXY p, QgsAnnotation *annotation ) const
 {

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -34,12 +34,13 @@
 #include "qgsexception.h"
 #include "qgsannotationmanager.h"
 #include "qgsmapmouseevent.h"
+#include "qgsapplication.h"
 
 
 QgsMapToolAnnotation::QgsMapToolAnnotation( QgsMapCanvas *canvas )
   : QgsMapTool( canvas )
 {
-  mCursor = QCursor( Qt::ArrowCursor );
+  mCursor = QgsApplication::getThemeCursor( QgsApplication::CapturePoint );
 }
 
 QgsMapTool::Flags QgsMapToolAnnotation::flags() const
@@ -81,7 +82,6 @@ void QgsMapToolAnnotation::canvasReleaseEvent( QgsMapMouseEvent *e )
   Q_UNUSED( e )
 
   mCurrentMoveAction = QgsMapCanvasAnnotationItem::NoAction;
-  mCanvas->setCursor( mCursor );
 }
 
 void QgsMapToolAnnotation::canvasPressEvent( QgsMapMouseEvent *e )
@@ -93,56 +93,50 @@ void QgsMapToolAnnotation::canvasPressEvent( QgsMapMouseEvent *e )
 
   mLastMousePosition = e->pos();
 
-  QgsMapCanvasAnnotationItem *item = selectedItem();
+  // Check if we clicked on an existing item
+  QgsMapCanvasAnnotationItem *item = itemAtPos( e->pos() );
   if ( item )
   {
     mCurrentMoveAction = item->moveActionForPosition( e->pos() );
-    if ( mCurrentMoveAction != QgsMapCanvasAnnotationItem::NoAction )
+    if ( !item->isSelected() )
     {
-      return;
+      mCanvas->scene()->clearSelection();
+      item->setSelected( true );
     }
+    return;
   }
 
-  if ( !item || mCurrentMoveAction == QgsMapCanvasAnnotationItem::NoAction )
+  // Otherwise create new one
+  mCanvas->scene()->clearSelection();
+
+  QgsAnnotation *annotation = createItem();
+  if ( annotation )
   {
-    //select a new item if there is one at this position
-    mCanvas->scene()->clearSelection();
-    QgsMapCanvasAnnotationItem *existingItem = itemAtPos( e->pos() );
-    if ( existingItem )
+    const QgsPointXY mapPos = transformCanvasToAnnotation( toMapCoordinates( e->pos() ), annotation );
+    annotation->setMapPosition( mapPos );
+    annotation->setMapPositionCrs( mCanvas->mapSettings().destinationCrs() );
+    annotation->setRelativePosition( QPointF( e->pos().x() / mCanvas->width(),
+                                     e->pos().y() / mCanvas->height() ) );
+    annotation->setFrameSizeMm( QSizeF( 50, 25 ) );
+
+    QgsProject::instance()->annotationManager()->addAnnotation( annotation );
+
+    // select newly added item
+    const auto constItems = mCanvas->items();
+    for ( QGraphicsItem *item : constItems )
     {
-      existingItem->setSelected( true );
-    }
-    else
-    {
-      //otherwise create new one
-      QgsAnnotation *annotation = createItem();
-      if ( annotation )
+      if ( QgsMapCanvasAnnotationItem *annotationItem = dynamic_cast< QgsMapCanvasAnnotationItem * >( item ) )
       {
-        const QgsPointXY mapPos = transformCanvasToAnnotation( toMapCoordinates( e->pos() ), annotation );
-        annotation->setMapPosition( mapPos );
-        annotation->setMapPositionCrs( mCanvas->mapSettings().destinationCrs() );
-        annotation->setRelativePosition( QPointF( e->pos().x() / mCanvas->width(),
-                                         e->pos().y() / mCanvas->height() ) );
-        annotation->setFrameSizeMm( QSizeF( 50, 25 ) );
-
-        QgsProject::instance()->annotationManager()->addAnnotation( annotation );
-
-        // select newly added item
-        const auto constItems = mCanvas->items();
-        for ( QGraphicsItem *item : constItems )
+        if ( annotationItem->annotation() == annotation )
         {
-          if ( QgsMapCanvasAnnotationItem *annotationItem = dynamic_cast< QgsMapCanvasAnnotationItem * >( item ) )
-          {
-            if ( annotationItem->annotation() == annotation )
-            {
-              annotationItem->setSelected( true );
-              break;
-            }
-          }
+          annotationItem->setSelected( true );
+          break;
         }
       }
     }
   }
+
+
 }
 
 void QgsMapToolAnnotation::keyPressEvent( QKeyEvent *e )
@@ -152,11 +146,10 @@ void QgsMapToolAnnotation::keyPressEvent( QKeyEvent *e )
   {
     if ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete )
     {
-      const QCursor neutralCursor( item->cursorShapeForAction( QgsMapCanvasAnnotationItem::NoAction ) );
       QgsProject::instance()->annotationManager()->removeAnnotation( item->annotation() );
       if ( mCanvas )
       {
-        mCanvas->setCursor( neutralCursor );
+        mCanvas->setCursor( mCursor );
         e->ignore();
       }
     }
@@ -191,14 +184,12 @@ bool QgsMapToolAnnotation::populateContextMenuWithEvent( QMenu *menu, QgsMapMous
 void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
 {
   QgsMapCanvasAnnotationItem *item = selectedItem();
-  if ( !item )
-    return;
 
-  QgsAnnotation *annotation = item->annotation();
-  if ( !annotation )
-    return;
+  QgsAnnotation *annotation = nullptr;
+  if ( item )
+    annotation = item->annotation();
 
-  if ( e->buttons() & Qt::LeftButton )
+  if ( annotation && ( e->buttons() & Qt::LeftButton ) )
   {
     if ( mCurrentMoveAction == QgsMapCanvasAnnotationItem::MoveMapPosition )
     {
@@ -295,12 +286,15 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
       QgsProject::instance()->setDirty( true );
     }
   }
-  else if ( item )
+  else if ( mCanvas )
   {
-    const QgsMapCanvasAnnotationItem::MouseMoveAction moveAction = item->moveActionForPosition( e->pos() );
-    if ( mCanvas )
+    if ( ( item = itemAtPos( e->pos() ) ) )
     {
-      mCanvas->setCursor( QCursor( item->cursorShapeForAction( moveAction ) ) );
+      mCanvas->setCursor( QCursor( item->cursorShapeForAction( item->moveActionForPosition( e->pos() ) ) ) );
+    }
+    else
+    {
+      mCanvas->setCursor( mCursor );
     }
   }
   mLastMousePosition = e->pos();
@@ -334,7 +328,9 @@ QgsMapCanvasAnnotationItem *QgsMapToolAnnotation::itemAtPos( QPointF pos ) const
   for ( ; gIt != graphicItems.end(); ++gIt )
   {
     QgsMapCanvasAnnotationItem *annotationItem = dynamic_cast<QgsMapCanvasAnnotationItem *>( *gIt );
-    if ( annotationItem )
+    // Consider only the topmost item that has a move action for the position
+    // (i.e. cursor is over the frame or over the anchor point)
+    if ( annotationItem && annotationItem->moveActionForPosition( pos ) != QgsMapCanvasAnnotationItem::NoAction )
     {
       return annotationItem;
     }

--- a/src/app/qgsmaptoolannotation.h
+++ b/src/app/qgsmaptoolannotation.h
@@ -56,8 +56,6 @@ class APP_EXPORT QgsMapToolAnnotation: public QgsMapTool
     QgsMapCanvasAnnotationItem *selectedItem() const;
     //! Returns a list of all annotationitems in the canvas
     QList<QgsMapCanvasAnnotationItem *> annotationItems() const;
-    //! Switches visibility states of text items
-    void toggleTextItemVisibilities();
 
     QgsPointXY transformCanvasToAnnotation( QgsPointXY p, QgsAnnotation *annotation ) const;
 

--- a/src/app/qgsmaptoolannotation.h
+++ b/src/app/qgsmaptoolannotation.h
@@ -31,11 +31,14 @@ class APP_EXPORT QgsMapToolAnnotation: public QgsMapTool
   public:
     QgsMapToolAnnotation( QgsMapCanvas *canvas );
 
+    Flags flags() const override;
+
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasDoubleClickEvent( QgsMapMouseEvent *e ) override;
     void keyPressEvent( QKeyEvent *e ) override;
+    bool populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEvent *event ) override;
 
   protected:
 

--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -229,37 +229,42 @@ QgsMapCanvasAnnotationItem::MouseMoveAction QgsMapCanvasAnnotationItem::moveActi
               itemPos.y() + cursorSensitivity >= offset.y() &&
               itemPos.y() - cursorSensitivity <= ( offset.y() + frameSize.height() ) );
 
-  if ( left && up )
+  // Resize actions are only available if the item is selected
+  // Otherwise, mouse handles are not visible
+  if ( isSelected() )
   {
-    return ResizeFrameLeftUp;
-  }
-  else if ( right && up )
-  {
-    return ResizeFrameRightUp;
-  }
-  else if ( left && down )
-  {
-    return ResizeFrameLeftDown;
-  }
-  else if ( right && down )
-  {
-    return ResizeFrameRightDown;
-  }
-  if ( left && inframe )
-  {
-    return ResizeFrameLeft;
-  }
-  if ( right && inframe )
-  {
-    return ResizeFrameRight;
-  }
-  if ( up && inframe )
-  {
-    return ResizeFrameUp;
-  }
-  if ( down && inframe )
-  {
-    return ResizeFrameDown;
+    if ( left && up )
+    {
+      return ResizeFrameLeftUp;
+    }
+    else if ( right && up )
+    {
+      return ResizeFrameRightUp;
+    }
+    else if ( left && down )
+    {
+      return ResizeFrameLeftDown;
+    }
+    else if ( right && down )
+    {
+      return ResizeFrameRightDown;
+    }
+    if ( left && inframe )
+    {
+      return ResizeFrameLeft;
+    }
+    if ( right && inframe )
+    {
+      return ResizeFrameRight;
+    }
+    if ( up && inframe )
+    {
+      return ResizeFrameUp;
+    }
+    if ( down && inframe )
+    {
+      return ResizeFrameDown;
+    }
   }
 
   //finally test if pos is in the frame area

--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -218,11 +218,16 @@ QgsMapCanvasAnnotationItem::MouseMoveAction QgsMapCanvasAnnotationItem::moveActi
   const QPointF offset = mAnnotation && mAnnotation->hasFixedMapPosition() ? mAnnotation->frameOffsetFromReferencePointMm() * mmToPixelScale : QPointF( 0, 0 );
   const QSizeF frameSize = mAnnotation ? mAnnotation->frameSizeMm() * mmToPixelScale : QSizeF( 0, 0 );
 
-  bool left, right, up, down;
+  bool left, right, up, down, inframe;
   left = std::fabs( itemPos.x() - offset.x() ) < cursorSensitivity;
   right = std::fabs( itemPos.x() - ( offset.x() + frameSize.width() ) ) < cursorSensitivity;
   up = std::fabs( itemPos.y() - offset.y() ) < cursorSensitivity;
   down = std::fabs( itemPos.y() - ( offset.y() + frameSize.height() ) ) < cursorSensitivity;
+  inframe = (
+              itemPos.x() + cursorSensitivity >= offset.x() &&
+              itemPos.x() - cursorSensitivity <= ( offset.x() + frameSize.width() ) &&
+              itemPos.y() + cursorSensitivity >= offset.y() &&
+              itemPos.y() - cursorSensitivity <= ( offset.y() + frameSize.height() ) );
 
   if ( left && up )
   {
@@ -240,26 +245,25 @@ QgsMapCanvasAnnotationItem::MouseMoveAction QgsMapCanvasAnnotationItem::moveActi
   {
     return ResizeFrameRightDown;
   }
-  if ( left )
+  if ( left && inframe )
   {
     return ResizeFrameLeft;
   }
-  if ( right )
+  if ( right && inframe )
   {
     return ResizeFrameRight;
   }
-  if ( up )
+  if ( up && inframe )
   {
     return ResizeFrameUp;
   }
-  if ( down )
+  if ( down && inframe )
   {
     return ResizeFrameDown;
   }
 
   //finally test if pos is in the frame area
-  if ( itemPos.x() >= offset.x() && itemPos.x() <= ( offset.x() + frameSize.width() )
-       && itemPos.y() >= offset.y() && itemPos.y() <= ( offset.y() + frameSize.height() ) )
+  if ( inframe )
   {
     return MoveFramePosition;
   }


### PR DESCRIPTION
## Description

This PR improve the behavior of annotation tools (Html, Text, Svg, Form and Move)

- Do not resize annotation when the cursor is not actually over the frame
![resize_outside](https://user-images.githubusercontent.com/9693475/236348999-2470437d-e8ab-43c2-87db-ce954d97626b.gif)
- Add a context menu (When an annotation tool is activated) on the annotation items
![annotation_context_menu](https://user-images.githubusercontent.com/9693475/236350546-1857cebd-7bbd-45a7-b744-9d82d22b6b47.gif)
- Drop the undocumented toggleTextItemVisibilities (when user presses Ctrl+T, toggle only the Text annotations visibility)
- Improve the selection and resizing behavior. Notably better handles overlapping annotations by not considering that an annotation is under the mouse if neither its frame nor anchor point are actually under the cursor. The behavior exhibited below was impossible before, as the large annotation would have prevented from selecting the small one.
![resize-move-annotation](https://user-images.githubusercontent.com/9693475/236351653-da2db815-d1ba-4b44-9c64-217b8bf17705.gif)



