### PR TITLE
[qgsquick] Add global map shading support to map canvas

### DIFF
--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -264,6 +264,7 @@ void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
 
   mMapSettings.setTransformContext( mProject->transformContext() );
   mMapSettings.setPathResolver( mProject->pathResolver() );
+  mMapSettings.setElevationShadingRenderer( mProject->elevationShadingRenderer() );
 
   emit extentChanged();
   emit destinationCrsChanged();


### PR DESCRIPTION
## Description

Without this commit, we end up with quick map canvases that don't render like their non-quick counterparts. With it, beauty:
![image](https://user-images.githubusercontent.com/1728657/236397440-6493d474-0f11-454c-a109-274b71cba3df.png)
