### PR TITLE
[processing] Fix crash when loading a layer from a string pointing to an invalid/corrupt file

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -373,7 +373,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
         pointCloudLayer = std::make_unique< QgsPointCloudLayer >( uri, name, preferredProviders.at( 0 ).metadata()->key(), pointCloudOptions );
       }
     }
-    if ( pointCloudLayer->isValid() )
+    if ( pointCloudLayer && pointCloudLayer->isValid() )
     {
       return pointCloudLayer.release();
     }


### PR DESCRIPTION
## Description

Stumbled on this crash as part of a large model that downloads a remote zipped shapefile dataset and loads that as a layer. The remote zipped shapefile got corrupted, and QGIS would crash.