### PR TITLE
Advanced digitizing: respect project settings units for distance

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2426,6 +2426,17 @@ Qgis.LineExtensionSide.__doc__ = 'Designates whether the line extension constrai
 # --
 Qgis.LineExtensionSide.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.CadConstraintType.Generic.__doc__ = "Generic value"
+Qgis.CadConstraintType.Angle.__doc__ = "Angle value"
+Qgis.CadConstraintType.Distance.__doc__ = "Distance value"
+Qgis.CadConstraintType.XCoordinate.__doc__ = "X Coordinate value"
+Qgis.CadConstraintType.YCoordinate.__doc__ = "Y Coordinate value"
+Qgis.CadConstraintType.ZValue.__doc__ = "Z value"
+Qgis.CadConstraintType.MValue.__doc__ = "M value"
+Qgis.CadConstraintType.__doc__ = 'Advanced digitizing constraint type.\n\n.. versionadded:: 3.32\n\n' + '* ``Generic``: ' + Qgis.CadConstraintType.Generic.__doc__ + '\n' + '* ``Angle``: ' + Qgis.CadConstraintType.Angle.__doc__ + '\n' + '* ``Distance``: ' + Qgis.CadConstraintType.Distance.__doc__ + '\n' + '* ``XCoordinate``: ' + Qgis.CadConstraintType.XCoordinate.__doc__ + '\n' + '* ``YCoordinate``: ' + Qgis.CadConstraintType.YCoordinate.__doc__ + '\n' + '* ``ZValue``: ' + Qgis.CadConstraintType.ZValue.__doc__ + '\n' + '* ``MValue``: ' + Qgis.CadConstraintType.MValue.__doc__
+# --
+Qgis.CadConstraintType.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ = "If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed."
 Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__ = "If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider."
 Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions.__doc__ = "If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored"

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1460,6 +1460,19 @@ The development version
       NoVertex,
     };
 
+
+    enum class CadConstraintType
+    {
+      Generic,
+      Angle,
+      Distance,
+      XCoordinate,
+      YCoordinate,
+      ZValue,
+      MValue,
+    };
+
+
     enum class ProjectFlag
     {
       EvaluateDefaultValuesOnProviderSide,

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -65,17 +65,6 @@ It contains all values (locked, value, relative) and pointers to corresponding w
           HardLock
         };
 
-        enum ConstraintType
-        {
-          Generic,
-          Angle,
-          Distance,
-          XCoordinate,
-          YCoordinate,
-          ZValue,
-          MValue,
-        };
-
         CadConstraint( QLineEdit *lineEdit, QToolButton *lockerButton, QToolButton *relativeButton = 0, QToolButton *repeatingLockButton = 0 );
 %Docstring
 Constructor for CadConstraint.
@@ -188,14 +177,14 @@ Sets the numeric precision (decimal places) to show in the associated widget.
 .. versionadded:: 3.22
 %End
 
-        ConstraintType constraintType() const;
+        Qgis::CadConstraintType cadConstraintType() const;
 %Docstring
 Returns the constraint type
 
 .. versionadded:: 3.32
 %End
 
-        void setConstraintType( ConstraintType constraintType );
+        void setCadConstraintType( Qgis::CadConstraintType constraintType );
 %Docstring
 Sets the constraint type to ``constraintType``
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -45,7 +45,7 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
     class CadConstraint
 {
 %Docstring(signature="appended")
-The CadConstraint is an abstract class for all basic constraints (angle/distance/x/y).
+The CadConstraint is a class for all basic constraints (angle/distance/x/y).
 It contains all values (locked, value, relative) and pointers to corresponding widgets.
 
 .. note::
@@ -63,6 +63,17 @@ It contains all values (locked, value, relative) and pointers to corresponding w
           NoLock,
           SoftLock,
           HardLock
+        };
+
+        enum ConstraintType
+        {
+          Generic,
+          Angle,
+          Distance,
+          XCoordinate,
+          YCoordinate,
+          ZValue,
+          MValue,
         };
 
         CadConstraint( QLineEdit *lineEdit, QToolButton *lockerButton, QToolButton *relativeButton = 0, QToolButton *repeatingLockButton = 0 );
@@ -142,6 +153,13 @@ Set the value of the constraint
 :param updateWidget: set to ``False`` to prevent automatically updating the associated widget's value
 %End
 
+        QString displayValue() const;
+%Docstring
+Returns a localized formatted string representation of the value.
+
+.. versionadded:: 3.32
+%End
+
         void toggleLocked();
 %Docstring
 Toggle lock mode
@@ -168,6 +186,27 @@ Sets the numeric precision (decimal places) to show in the associated widget.
 .. seealso:: :py:func:`precision`
 
 .. versionadded:: 3.22
+%End
+
+        ConstraintType constraintType() const;
+%Docstring
+Returns the constraint type
+
+.. versionadded:: 3.32
+%End
+
+        void setConstraintType( ConstraintType constraintType );
+%Docstring
+Sets the constraint type to ``constraintType``
+
+.. versionadded:: 3.32
+%End
+
+        void setMapCanvas( QgsMapCanvas *mapCanvas );
+%Docstring
+Sets the map canvas to ``mapCanvas``
+
+.. versionadded:: 3.32
 %End
 
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2486,6 +2486,24 @@ class CORE_EXPORT Qgis
     };
     Q_ENUM( LineExtensionSide )
 
+
+    /**
+     * Advanced digitizing constraint type.
+     * \since QGIS 3.32
+     */
+    enum class CadConstraintType : int
+    {
+      Generic,      //!< Generic value
+      Angle,        //!< Angle value
+      Distance,     //!< Distance value
+      XCoordinate,  //!< X Coordinate value
+      YCoordinate,  //!< Y Coordinate value
+      ZValue,       //!< Z value
+      MValue,       //!< M value
+    };
+    Q_ENUM( CadConstraintType )
+
+
     /**
      * Flags which control the behavior of QgsProjects.
      *

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -30,7 +30,6 @@
 #include "qgspointxy.h"
 #include "qgspointlocator.h"
 #include "qgssnapindicator.h"
-#include "qgscadutils.h"
 
 
 class QgsAdvancedDigitizingCanvasItem;
@@ -81,7 +80,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * \ingroup gui
-     * \brief The CadConstraint is an abstract class for all basic constraints (angle/distance/x/y).
+     * \brief The CadConstraint is a class for all basic constraints (angle/distance/x/y).
      * It contains all values (locked, value, relative) and pointers to corresponding widgets.
      * \note Relative is not mandatory since it is not used for distance.
      */
@@ -97,6 +96,21 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
           NoLock,
           SoftLock,
           HardLock
+        };
+
+        /**
+         * Constraint type
+         * \since QGIS 3.32
+         */
+        enum ConstraintType
+        {
+          Generic,      //!< Generic value
+          Angle,        //!< Angle value
+          Distance,     //!< Distance value
+          XCoordinate,  //!< X Coordinate value
+          YCoordinate,  //!< Y Coordinate value
+          ZValue,       //!< Z value
+          MValue,       //!< M value
         };
 
         /**
@@ -178,6 +192,12 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
         void setValue( double value, bool updateWidget = true );
 
         /**
+         * Returns a localized formatted string representation of the value.
+         * \since QGIS 3.32
+         */
+        QString displayValue() const;
+
+        /**
          * Toggle lock mode
          */
         void toggleLocked();
@@ -203,6 +223,24 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
          */
         void setPrecision( int precision );
 
+        /**
+         * Returns the constraint type
+         * \since QGIS 3.32
+         */
+        ConstraintType constraintType() const;
+
+        /**
+         * Sets the constraint type to \a constraintType
+         * \since QGIS 3.32
+         */
+        void setConstraintType( ConstraintType constraintType );
+
+        /**
+         * Sets the map canvas to \a mapCanvas
+         * \since QGIS 3.32
+         */
+        void setMapCanvas( QgsMapCanvas *mapCanvas );
+
       private:
         QLineEdit *mLineEdit = nullptr;
         QToolButton *mLockerButton = nullptr;
@@ -213,6 +251,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
         bool mRelative;
         double mValue;
         int mPrecision = 6;
+        ConstraintType mConstraintType = ConstraintType::Generic;
+        QgsMapCanvas *mMapCanvas = nullptr;
     };
 
     /**
@@ -969,7 +1009,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     CadConstraint *objectToConstraint( const QObject *obj ) const;
 
     //! Attempts to convert a user input value to double, either directly or via expression
-    double parseUserInput( const QString &inputValue, bool &ok ) const;
+    double parseUserInput( const QString &inputValue, const CadConstraint::ConstraintType type, bool &ok ) const;
 
     /**
      * Updates a constraint value based on a text input.

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -99,21 +99,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
         };
 
         /**
-         * Constraint type
-         * \since QGIS 3.32
-         */
-        enum ConstraintType
-        {
-          Generic,      //!< Generic value
-          Angle,        //!< Angle value
-          Distance,     //!< Distance value
-          XCoordinate,  //!< X Coordinate value
-          YCoordinate,  //!< Y Coordinate value
-          ZValue,       //!< Z value
-          MValue,       //!< M value
-        };
-
-        /**
          * Constructor for CadConstraint.
          * \param lineEdit associated line edit for constraint value
          * \param lockerButton associated button for locking constraint
@@ -227,13 +212,13 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
          * Returns the constraint type
          * \since QGIS 3.32
          */
-        ConstraintType constraintType() const;
+        Qgis::CadConstraintType cadConstraintType() const;
 
         /**
          * Sets the constraint type to \a constraintType
          * \since QGIS 3.32
          */
-        void setConstraintType( ConstraintType constraintType );
+        void setCadConstraintType( Qgis::CadConstraintType constraintType );
 
         /**
          * Sets the map canvas to \a mapCanvas
@@ -251,7 +236,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
         bool mRelative;
         double mValue;
         int mPrecision = 6;
-        ConstraintType mConstraintType = ConstraintType::Generic;
+        Qgis::CadConstraintType mCadConstraintType = Qgis::CadConstraintType::Generic;
         QgsMapCanvas *mMapCanvas = nullptr;
     };
 
@@ -1009,7 +994,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     CadConstraint *objectToConstraint( const QObject *obj ) const;
 
     //! Attempts to convert a user input value to double, either directly or via expression
-    double parseUserInput( const QString &inputValue, const CadConstraint::ConstraintType type, bool &ok ) const;
+    double parseUserInput( const QString &inputValue, const Qgis::CadConstraintType type, bool &ok ) const;
 
     /**
      * Updates a constraint value based on a text input.

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -198,7 +198,7 @@ void QgsAdvancedDigitizingFloater::changeM( const QString &text )
 
 void QgsAdvancedDigitizingFloater::changeCommonAngleSnapping( double angle )
 {
-  mCommonAngleSnappingLineEdit->setText( qgsDoubleNear( angle, 0.0 ) ? tr( "disabled" ) : QLocale().toString( angle ).append( QStringLiteral( "°" ) ) );
+  mCommonAngleSnappingLineEdit->setText( qgsDoubleNear( angle, 0.0 ) ? tr( "disabled" ) : QLocale().toString( angle ).append( tr( " °" ) ) );
 }
 
 void QgsAdvancedDigitizingFloater::changeDistance( const QString &text )

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>252</width>
-    <height>262</height>
+    <height>344</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -108,33 +108,6 @@
             <property name="spacing">
              <number>3</number>
             </property>
-            <item row="3" column="0">
-             <widget class="QToolButton" name="mRelativeYButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>d</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="0">
              <widget class="QToolButton" name="mRelativeAngleButton">
               <property name="toolTip">
@@ -158,8 +131,21 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
-             <widget class="QToolButton" name="mRelativeMButton">
+            <item row="6" column="0">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="5" column="4">
+             <widget class="QToolButton" name="mRepeatingLockMButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -168,7 +154,7 @@
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -192,66 +178,6 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="4">
-             <widget class="QToolButton" name="mRepeatingLockMButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="4">
-             <widget class="QToolButton" name="mRepeatingLockXButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="4">
-             <widget class="QToolButton" name="mRepeatingLockDistanceButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
             <item row="4" column="1">
              <widget class="QLabel" name="mZLabel">
               <property name="text">
@@ -259,15 +185,42 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="2">
-             <widget class="QLineEdit" name="mAngleLineEdit">
+            <item row="5" column="0">
+             <widget class="QToolButton" name="mRelativeMButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QLineEdit" name="mZLineEdit">
               <property name="toolTip">
                <string/>
               </property>
              </widget>
             </item>
-            <item row="2" column="3">
-             <widget class="QToolButton" name="mLockXButton">
+            <item row="0" column="1">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>d</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QToolButton" name="mLockDistanceButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -306,10 +259,10 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>a</string>
+            <item row="2" column="2">
+             <widget class="QLineEdit" name="mXLineEdit">
+              <property name="toolTip">
+               <string/>
               </property>
              </widget>
             </item>
@@ -333,116 +286,8 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="2">
-             <widget class="QLineEdit" name="mXLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="mLabelX">
-              <property name="text">
-               <string>x</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="3">
-             <widget class="QToolButton" name="mLockMButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="3">
-             <widget class="QToolButton" name="mLockZButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="QLineEdit" name="mYLineEdit">
-              <property name="toolTip">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="mLabelY">
-              <property name="text">
-               <string>y</string>
-              </property>
-             </widget>
-            </item>
             <item row="4" column="4">
              <widget class="QToolButton" name="mRepeatingLockZButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QToolButton" name="mLockDistanceButton">
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="4">
-             <widget class="QToolButton" name="mRepeatingLockAngleButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -481,8 +326,42 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="2">
-             <widget class="QLineEdit" name="mZLineEdit">
+            <item row="3" column="4">
+             <widget class="QToolButton" name="mRepeatingLockYButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="mLabelY">
+              <property name="text">
+               <string>y</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>a</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="QLineEdit" name="mYLineEdit">
               <property name="toolTip">
                <string/>
               </property>
@@ -508,8 +387,15 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="4">
-             <widget class="QToolButton" name="mRepeatingLockYButton">
+            <item row="1" column="2">
+             <widget class="QLineEdit" name="mAngleLineEdit">
+              <property name="toolTip">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="4">
+             <widget class="QToolButton" name="mRepeatingLockAngleButton">
               <property name="toolTip">
                <string/>
               </property>
@@ -528,6 +414,46 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="4">
+             <widget class="QToolButton" name="mRepeatingLockXButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QToolButton" name="mRelativeYButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/delta.svg</normaloff>:/images/themes/default/cadtools/delta.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="5" column="1">
              <widget class="QLabel" name="mMLabel">
               <property name="text">
@@ -535,18 +461,92 @@
               </property>
              </widget>
             </item>
-            <item row="6" column="0">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
+            <item row="0" column="4">
+             <widget class="QToolButton" name="mRepeatingLockDistanceButton">
+              <property name="toolTip">
+               <string/>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
+              <property name="text">
+               <string>…</string>
               </property>
-             </spacer>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QToolButton" name="mLockXButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="3">
+             <widget class="QToolButton" name="mLockZButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="3">
+             <widget class="QToolButton" name="mLockMButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>…</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="mLabelX">
+              <property name="text">
+               <string>x</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>

--- a/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
+++ b/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
@@ -67,66 +67,66 @@ void TestQgsAdvancedDigitizingDockWidget::parseUserInput()
 
   QLocale::setDefault( QLocale::English );
 
-  result = widget.parseUserInput( QStringLiteral( "1.2345" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1.2345" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 1.2345 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1,234.5" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1,234.5" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 1234.5 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1,200.6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1,200.6/2" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1200.6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1200.6/2" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
   // Italian locale (comma as decimal separator)
   QLocale::setDefault( QLocale::Italian );
 
-  result = widget.parseUserInput( QStringLiteral( "1,2345" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1,2345" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 1.2345 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1.234,5" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1.234,5" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 1234.5 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1.200,6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1.200,6/2" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1200,6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
+  result = widget.parseUserInput( QStringLiteral( "1200,6/2" ), Qgis::CadConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
   // Test UOMs for angles and distance
   QLocale::setDefault( QLocale::English );
-  result = widget.parseUserInput( QStringLiteral( "120.123" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123" ), Qgis::CadConstraintType::Angle, ok );
   QCOMPARE( result, 120.123 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "120.123°" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123°" ), Qgis::CadConstraintType::Angle, ok );
   QCOMPARE( result, 120.123 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "120.123 °" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123 °" ), Qgis::CadConstraintType::Angle, ok );
   QCOMPARE( result, 120.123 );
   QVERIFY( ok );
 
   QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::NauticalMiles );
 
-  result = widget.parseUserInput( QStringLiteral( "120.123" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123" ), Qgis::CadConstraintType::Distance, ok );
   QCOMPARE( result, 222467.796 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "120.123 NM" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123 NM" ), Qgis::CadConstraintType::Distance, ok );
   QCOMPARE( result, 222467.796 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "120.123NM" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  result = widget.parseUserInput( QStringLiteral( "120.123NM" ), Qgis::CadConstraintType::Distance, ok );
   QCOMPARE( result, 222467.796 );
   QVERIFY( ok );
 

--- a/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
+++ b/tests/src/gui/testqgsadvanceddigitizingdockwidget.cpp
@@ -67,38 +67,67 @@ void TestQgsAdvancedDigitizingDockWidget::parseUserInput()
 
   QLocale::setDefault( QLocale::English );
 
-  result = widget.parseUserInput( QStringLiteral( "1.2345" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1.2345" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 1.2345 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1,234.5" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1,234.5" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 1234.5 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1,200.6/2" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1,200.6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1200.6/2" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1200.6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
+  // Italian locale (comma as decimal separator)
   QLocale::setDefault( QLocale::Italian );
 
-  result = widget.parseUserInput( QStringLiteral( "1,2345" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1,2345" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 1.2345 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1.234,5" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1.234,5" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 1234.5 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1.200,6/2" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1.200,6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
   QVERIFY( ok );
 
-  result = widget.parseUserInput( QStringLiteral( "1200,6/2" ), ok );
+  result = widget.parseUserInput( QStringLiteral( "1200,6/2" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Generic, ok );
   QCOMPARE( result, 600.3 );
+  QVERIFY( ok );
+
+  // Test UOMs for angles and distance
+  QLocale::setDefault( QLocale::English );
+  result = widget.parseUserInput( QStringLiteral( "120.123" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  QCOMPARE( result, 120.123 );
+  QVERIFY( ok );
+
+  result = widget.parseUserInput( QStringLiteral( "120.123°" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  QCOMPARE( result, 120.123 );
+  QVERIFY( ok );
+
+  result = widget.parseUserInput( QStringLiteral( "120.123 °" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Angle, ok );
+  QCOMPARE( result, 120.123 );
+  QVERIFY( ok );
+
+  QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::NauticalMiles );
+
+  result = widget.parseUserInput( QStringLiteral( "120.123" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  QCOMPARE( result, 222467.796 );
+  QVERIFY( ok );
+
+  result = widget.parseUserInput( QStringLiteral( "120.123 NM" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  QCOMPARE( result, 222467.796 );
+  QVERIFY( ok );
+
+  result = widget.parseUserInput( QStringLiteral( "120.123NM" ), QgsAdvancedDigitizingDockWidget::CadConstraint::ConstraintType::Distance, ok );
+  QCOMPARE( result, 222467.796 );
   QVERIFY( ok );
 
 }


### PR DESCRIPTION
- respect project settings for distance units
- format angle
- format geographic coordintates

Whether this is a bug or a feature is debatable, IMO it is a bug: the units for distance measurements should be taken from the project settings.


![advanced-digitizing-distance-uom](https://user-images.githubusercontent.com/142164/236775675-fab2d7f8-28e3-47ac-a566-955bd748a9d5.gif)
