### PR TITLE
Move determination of tiles in ranges to QgsTileMatrixSet, minor refactor to vector tile data provider api

### DIFF
--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -367,6 +367,13 @@ Sets the scale to tile zoom method.
 .. seealso:: :py:func:`scaleToTileZoomMethod`
 %End
 
+    QVector<QgsTileXYZ> tilesInRange( QgsTileRange range, int zoomLevel ) const;
+%Docstring
+Returns a list of tiles in the given tile range.
+
+.. versionadded:: 3.32
+%End
+
 };
 
 /************************************************************************

--- a/src/core/qgstiles.cpp
+++ b/src/core/qgstiles.cpp
@@ -398,3 +398,21 @@ QDomElement QgsTileMatrixSet::writeXml( QDomDocument &document, const QgsReadWri
 
   return setElement;
 }
+
+QVector<QgsTileXYZ> QgsTileMatrixSet::tilesInRange( QgsTileRange range, int zoomLevel ) const
+{
+  QVector<QgsTileXYZ> tiles;
+  tiles.reserve( static_cast< std::size_t>( range.endColumn() - range.startColumn() + 1 ) * ( range.endRow() - range.startRow() + 1 ) );
+
+  const QgsTileMatrix &matrix = mTileMatrices.value( zoomLevel );
+
+  for ( int tileRow = range.startRow(); tileRow <= range.endRow(); ++tileRow )
+  {
+    for ( int tileColumn = range.startColumn(); tileColumn <= range.endColumn(); ++tileColumn )
+    {
+      tiles.append( QgsTileXYZ( tileColumn, tileRow, zoomLevel ) );
+    }
+  }
+  return tiles;
+}
+

--- a/src/core/qgstiles.cpp
+++ b/src/core/qgstiles.cpp
@@ -402,7 +402,7 @@ QDomElement QgsTileMatrixSet::writeXml( QDomDocument &document, const QgsReadWri
 QVector<QgsTileXYZ> QgsTileMatrixSet::tilesInRange( QgsTileRange range, int zoomLevel ) const
 {
   QVector<QgsTileXYZ> tiles;
-  tiles.reserve( static_cast< std::size_t>( range.endColumn() - range.startColumn() + 1 ) * ( range.endRow() - range.startRow() + 1 ) );
+  tiles.reserve( ( range.endColumn() - range.startColumn() + 1 ) * ( range.endRow() - range.startRow() + 1 ) );
 
   for ( int tileRow = range.startRow(); tileRow <= range.endRow(); ++tileRow )
   {

--- a/src/core/qgstiles.cpp
+++ b/src/core/qgstiles.cpp
@@ -404,8 +404,6 @@ QVector<QgsTileXYZ> QgsTileMatrixSet::tilesInRange( QgsTileRange range, int zoom
   QVector<QgsTileXYZ> tiles;
   tiles.reserve( static_cast< std::size_t>( range.endColumn() - range.startColumn() + 1 ) * ( range.endRow() - range.startRow() + 1 ) );
 
-  const QgsTileMatrix &matrix = mTileMatrices.value( zoomLevel );
-
   for ( int tileRow = range.startRow(); tileRow <= range.endRow(); ++tileRow )
   {
     for ( int tileColumn = range.startColumn(); tileColumn <= range.endColumn(); ++tileColumn )

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -376,6 +376,13 @@ class CORE_EXPORT QgsTileMatrixSet
      */
     void setScaleToTileZoomMethod( Qgis::ScaleToTileZoomLevelMethod method ) { mScaleToTileZoomMethod = method; }
 
+    /**
+     * Returns a list of tiles in the given tile range.
+     *
+     * \since QGIS 3.32
+     */
+    QVector<QgsTileXYZ> tilesInRange( QgsTileRange range, int zoomLevel ) const;
+
   private:
 
     // Usually corresponds to zoom level 0, even if that zoom level is NOT present in the actual tile matrices for this set

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -150,7 +150,7 @@ const QgsVectorTileMatrixSet &QgsMbTilesVectorTileDataProvider::tileMatrixSet() 
   return mMatrixSet;
 }
 
-QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrix &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -162,7 +162,7 @@ QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrix &, co
   return loadFromMBTiles( mbReader, id, feedback );
 }
 
-QList<QgsVectorTileRawData> QgsMbTilesVectorTileDataProvider::readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
+QList<QgsVectorTileRawData> QgsMbTilesVectorTileDataProvider::readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -52,8 +52,8 @@ class CORE_EXPORT QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataPro
     QgsRectangle extent() const override;
     QgsCoordinateReferenceSystem crs() const override;
     const QgsVectorTileMatrixSet &tileMatrixSet() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
-    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+    QByteArray readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 
     static QString MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY;
     static QString MB_TILES_VECTOR_TILE_DATA_PROVIDER_DESCRIPTION;

--- a/src/core/vectortile/qgsvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvectortiledataprovider.cpp
@@ -61,7 +61,7 @@ bool QgsVectorTileDataProvider::supportsAsync() const
   return false;
 }
 
-QNetworkRequest QgsVectorTileDataProvider::tileRequest( const QgsTileMatrix &, const QgsTileXYZ &, Qgis::RendererUsage ) const
+QNetworkRequest QgsVectorTileDataProvider::tileRequest( const QgsTileMatrixSet &, const QgsTileXYZ &, Qgis::RendererUsage ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -20,7 +20,7 @@
 #include "qgis_sip.h"
 #include "qgsdataprovider.h"
 
-class QgsTileMatrix;
+class QgsTileMatrixSet;
 class QgsTileXYZ;
 class QgsVectorTileRawData;
 class QgsVectorTileMatrixSet;
@@ -105,19 +105,19 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
     /**
      * Returns raw tile data for a single tile.
      */
-    virtual QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const = 0;
+    virtual QByteArray readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Returns raw tile data for a range of tiles.
      */
-    virtual QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &tileMatrix, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const = 0;
+    virtual QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &tileMatrixSet, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Returns a network request for a tile.
      *
      * The default implementation returns an invalid request.
      */
-    virtual QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const;
+    virtual QNetworkRequest tileRequest( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const;
 
     /**
      * Returns the style definition for the provider, if available.

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -575,8 +575,7 @@ QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
   if ( !vtProvider )
     return QByteArray();
 
-  const QgsTileMatrix tileMatrix = mMatrixSet.tileMatrix( tileID.zoomLevel() );
-  return vtProvider->readTile( tileMatrix, tileID );
+  return vtProvider->readTile( mMatrixSet, tileID );
 }
 
 void QgsVectorTileLayer::setRenderer( QgsVectorTileRenderer *r )

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -110,13 +110,13 @@ bool QgsVectorTileLayerRenderer::render()
   {
     QElapsedTimer tFetch;
     tFetch.start();
-    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mDataProvider.get(), mTileMatrix, viewCenter, mTileRange, mFeedback.get() );
+    rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mDataProvider.get(), mTileMatrixSet, viewCenter, mTileRange, mTileZoom, mFeedback.get() );
     QgsDebugMsgLevel( QStringLiteral( "Tile fetching time: %1" ).arg( tFetch.elapsed() / 1000. ), 2 );
     QgsDebugMsgLevel( QStringLiteral( "Fetched tiles: %1" ).arg( rawTiles.count() ), 2 );
   }
   else
   {
-    asyncLoader.reset( new QgsVectorTileLoader( mDataProvider.get(), mTileMatrix, mTileRange, viewCenter, mFeedback.get(), renderContext()->rendererUsage() ) );
+    asyncLoader.reset( new QgsVectorTileLoader( mDataProvider.get(), mTileMatrixSet, mTileRange, mTileZoom, viewCenter, mFeedback.get(), renderContext()->rendererUsage() ) );
     QObject::connect( asyncLoader.get(), &QgsVectorTileLoader::tileRequestFinished, asyncLoader.get(), [this]( const QgsVectorTileRawData & rawTile )
     {
       QgsDebugMsgLevel( QStringLiteral( "Got tile asynchronously: " ) + rawTile.id.toString(), 2 );
@@ -234,7 +234,7 @@ void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &
 
   try
   {
-    tile.setTilePolygon( QgsVectorTileUtils::tilePolygon( rawTile.id, ct, mTileMatrix, ctx.mapToPixel() ) );
+    tile.setTilePolygon( QgsVectorTileUtils::tilePolygon( rawTile.id, ct, mTileMatrixSet.tileMatrix( rawTile.id.zoomLevel() ), ctx.mapToPixel() ) );
   }
   catch ( QgsCsException & )
   {

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -39,7 +39,7 @@ QgsVectorTileLoader::QgsVectorTileLoader( const QgsVectorTileDataProvider *provi
   }
 
   QgsDebugMsgLevel( QStringLiteral( "Starting network loader" ), 2 );
-  QVector<QgsTileXYZ> tiles = QgsVectorTileUtils::tilesInRange( range, zoomLevel );
+  QVector<QgsTileXYZ> tiles = tileMatrixSet.tilesInRange( range, zoomLevel );
   QgsVectorTileUtils::sortTilesByDistanceFromCenter( tiles, viewCenter );
   for ( QgsTileXYZ id : std::as_const( tiles ) )
   {
@@ -152,7 +152,7 @@ QList<QgsVectorTileRawData> QgsVectorTileLoader::blockingFetchTileRawData( const
   if ( feedback && feedback->isCanceled() )
     return {};
 
-  QVector<QgsTileXYZ> tiles = QgsVectorTileUtils::tilesInRange( range, zoomLevel );
+  QVector<QgsTileXYZ> tiles = tileMatrixSet.tilesInRange( range, zoomLevel );
 
   // if a tile matrix results in a HUGE number of tile requests, we skip the sort -- it can be expensive
   if ( tiles.size() < 10000 )

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -62,9 +62,10 @@ class QgsVectorTileLoader : public QObject
     //! Returns raw tile data for the specified range of tiles. Blocks the caller until all tiles are fetched.
     static QList<QgsVectorTileRawData> blockingFetchTileRawData(
       const QgsVectorTileDataProvider *provider,
-      const QgsTileMatrix &tileMatrix,
+      const QgsTileMatrixSet &tileMatrixSet,
       const QPointF &viewCenter,
       const QgsTileRange &range,
+      int zoomLevel,
       QgsFeedback *feedback = nullptr );
 
     //
@@ -72,7 +73,7 @@ class QgsVectorTileLoader : public QObject
     //
 
     //! Constructs tile loader for doing asynchronous requests and starts network requests
-    QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
+    QgsVectorTileLoader( const QgsVectorTileDataProvider *provider, const QgsTileMatrixSet &tileMatrixSet, const QgsTileRange &range, int zoomLevel, const QPointF &viewCenter,
                          QgsFeedback *feedback, Qgis::RendererUsage usage );
     ~QgsVectorTileLoader();
 
@@ -83,7 +84,7 @@ class QgsVectorTileLoader : public QObject
     QString error() const;
 
   private:
-    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QgsVectorTileDataProvider *provider, Qgis::RendererUsage usage );
+    void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrixSet &tileMatrixSet, const QgsVectorTileDataProvider *provider, Qgis::RendererUsage usage );
 
   private slots:
     void tileReplyFinished();

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -163,19 +163,6 @@ struct LessThanTileRequest
   }
 };
 
-QVector<QgsTileXYZ> QgsVectorTileUtils::tilesInRange( QgsTileRange range, int zoomLevel )
-{
-  QVector<QgsTileXYZ> tiles;
-  for ( int tileRow = range.startRow(); tileRow <= range.endRow(); ++tileRow )
-  {
-    for ( int tileColumn = range.startColumn(); tileColumn <= range.endColumn(); ++tileColumn )
-    {
-      tiles.append( QgsTileXYZ( tileColumn, tileRow, zoomLevel ) );
-    }
-  }
-  return tiles;
-}
-
 void QgsVectorTileUtils::sortTilesByDistanceFromCenter( QVector<QgsTileXYZ> &tiles, QPointF center )
 {
   LessThanTileRequest cmp;

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -48,8 +48,6 @@ class CORE_EXPORT QgsVectorTileUtils
 {
   public:
 
-    //! Returns a list of tiles in the given tile range
-    static QVector<QgsTileXYZ> tilesInRange( QgsTileRange range, int zoomLevel );
     //! Orders tile requests according to the distance from view center (given in tile matrix coords)
     static void sortTilesByDistanceFromCenter( QVector<QgsTileXYZ> &tiles, QPointF center );
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -171,7 +171,7 @@ QImage QgsVtpkVectorTileDataProvider::spriteImage() const
   return mSpriteImage;
 }
 
-QByteArray QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrix &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QByteArray QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -182,7 +182,7 @@ QByteArray QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrix &, const
   return loadFromVtpk( reader, id, feedback );
 }
 
-QList<QgsVectorTileRawData> QgsVtpkVectorTileDataProvider::readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
+QList<QgsVectorTileRawData> QgsVtpkVectorTileDataProvider::readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -58,8 +58,8 @@ class CORE_EXPORT QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvid
     QVariantMap styleDefinition() const override;
     QVariantMap spriteDefinition() const override;
     QImage spriteImage() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
-    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+    QByteArray readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 
     static QString DATA_PROVIDER_KEY;
     static QString DATA_PROVIDER_DESCRIPTION;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -57,12 +57,12 @@ bool QgsXyzVectorTileDataProviderBase::supportsAsync() const
   return true;
 }
 
-QByteArray QgsXyzVectorTileDataProviderBase::readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QByteArray QgsXyzVectorTileDataProviderBase::readTile( const QgsTileMatrixSet &set, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
-  return loadFromNetwork( id, tileMatrix, sourcePath(), mAuthCfg, mHeaders, feedback );
+  return loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), sourcePath(), mAuthCfg, mHeaders, feedback );
 }
 
-QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const QgsTileMatrix &tileMatrix, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
+QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const QgsTileMatrixSet &set, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const
 {
   QList<QgsVectorTileRawData> rawTiles;
   rawTiles.reserve( tiles.size() );
@@ -72,7 +72,7 @@ QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const Q
     if ( feedback && feedback->isCanceled() )
       break;
 
-    const QByteArray rawData = loadFromNetwork( id, tileMatrix, source, mAuthCfg, mHeaders, feedback );
+    const QByteArray rawData = loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), source, mAuthCfg, mHeaders, feedback );
     if ( !rawData.isEmpty() )
     {
       rawTiles.append( QgsVectorTileRawData( id, rawData ) );
@@ -81,7 +81,7 @@ QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const Q
   return rawTiles;
 }
 
-QNetworkRequest QgsXyzVectorTileDataProviderBase::tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const
+QNetworkRequest QgsXyzVectorTileDataProviderBase::tileRequest( const QgsTileMatrixSet &set, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const
 {
   QString urlTemplate = sourcePath();
 
@@ -101,7 +101,7 @@ QNetworkRequest QgsXyzVectorTileDataProviderBase::tileRequest( const QgsTileMatr
     }
   }
 
-  const QString url = QgsVectorTileUtils::formatXYZUrlTemplate( urlTemplate, id, tileMatrix );
+  const QString url = QgsVectorTileUtils::formatXYZUrlTemplate( urlTemplate, id, set.tileMatrix( id.zoomLevel() ) );
 
   QNetworkRequest request( url );
   QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsXyzVectorTileDataProvider" ) );

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.h
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.h
@@ -42,9 +42,9 @@ class CORE_EXPORT QgsXyzVectorTileDataProviderBase : public QgsVectorTileDataPro
     QgsXyzVectorTileDataProviderBase &operator=( const QgsXyzVectorTileDataProviderBase &other ) = delete;
 
     bool supportsAsync() const override;
-    QByteArray readTile( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
-    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrix &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
-    QNetworkRequest tileRequest( const QgsTileMatrix &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
+    QByteArray readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
+    QNetworkRequest tileRequest( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
 
   protected:
 

--- a/tests/src/python/test_qgstiles.py
+++ b/tests/src/python/test_qgstiles.py
@@ -94,6 +94,14 @@ class TestQgsTiles(unittest.TestCase):
         self.assertEqual(matrix_set.maximumZoom(), 1)
         self.assertEqual(matrix_set.crs().authid(), 'EPSG:4326')
 
+        range = QgsTileRange(1, 3, 4, 7)
+        tiles = matrix_set.tilesInRange(range, 1)
+        self.assertEqual(len(tiles), 12)
+        self.assertEqual(min(t.column() for t in tiles), 1)
+        self.assertEqual(max(t.column() for t in tiles), 3)
+        self.assertEqual(min(t.row() for t in tiles), 4)
+        self.assertEqual(max(t.row() for t in tiles), 7)
+
         # should not apply any special logic here, and return scales unchanged
         self.assertEqual(matrix_set.calculateTileScaleForMap(1000, QgsCoordinateReferenceSystem('EPSG:4326'),
                                                              QgsRectangle(0, 2, 20, 12), QSize(20, 10), 96), 1000)
@@ -122,6 +130,23 @@ class TestQgsTiles(unittest.TestCase):
         self.assertEqual(matrix_set.tileMatrix(1).zoomLevel(), 1)
         self.assertEqual(matrix_set.tileMatrix(2).zoomLevel(), 2)
         self.assertEqual(matrix_set.tileMatrix(99).zoomLevel(), -1)
+
+        tiles = matrix_set.tilesInRange(QgsTileRange(1, 3, 4, 7), 1)
+        self.assertEqual(len(tiles), 12)
+        self.assertEqual(min(t.column() for t in tiles), 1)
+        self.assertEqual(max(t.column() for t in tiles), 3)
+        self.assertEqual(min(t.row() for t in tiles), 4)
+        self.assertEqual(max(t.row() for t in tiles), 7)
+        self.assertEqual(min(t.zoomLevel() for t in tiles), 1)
+        self.assertEqual(max(t.zoomLevel() for t in tiles), 1)
+        tiles = matrix_set.tilesInRange(QgsTileRange(2, 4, 1, 3), 2)
+        self.assertEqual(len(tiles), 9)
+        self.assertEqual(min(t.column() for t in tiles), 2)
+        self.assertEqual(max(t.column() for t in tiles), 4)
+        self.assertEqual(min(t.row() for t in tiles), 1)
+        self.assertEqual(max(t.row() for t in tiles), 3)
+        self.assertEqual(min(t.zoomLevel() for t in tiles), 2)
+        self.assertEqual(max(t.zoomLevel() for t in tiles), 2)
 
         self.assertAlmostEqual(matrix_set.scaleToZoom(776503144), 1, 5)
         self.assertEqual(matrix_set.scaleToZoom(1776503144), 1)


### PR DESCRIPTION
Together these give more flexibility in future to handle known missing tiles or other special circumstances (eg falling back to lower zoom level tiles from the matrix set in certain circumstances)

Refs https://github.com/qgis/QGIS/issues/52874