### PR TITLE
Try to workaround https://bugreports.qt.io/browse/QTBUG-113227 on qt6 ci builds

### DIFF
--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -70,7 +70,7 @@ RUN dnf -y --refresh install \
     dos2unix
 
 # Workaround https://bugreports.qt.io/browse/QTBUG-113227 for now, roll back to qt 6.4
-dnf downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
+RUN dnf downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
 
 # Oracle : client side
 RUN curl https://download.oracle.com/otn_software/linux/instantclient/199000/instantclient-basic-linux.x64-19.9.0.0.0dbru.zip > instantclient-basic-linux.x64-19.9.0.0.0dbru.zip

--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -69,6 +69,9 @@ RUN dnf -y --refresh install \
     patch \
     dos2unix
 
+# Workaround https://bugreports.qt.io/browse/QTBUG-113227 for now, roll back to qt 6.4
+dnf downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
+
 # Oracle : client side
 RUN curl https://download.oracle.com/otn_software/linux/instantclient/199000/instantclient-basic-linux.x64-19.9.0.0.0dbru.zip > instantclient-basic-linux.x64-19.9.0.0.0dbru.zip
 RUN curl https://download.oracle.com/otn_software/linux/instantclient/199000/instantclient-sdk-linux.x64-19.9.0.0.0dbru.zip > instantclient-sdk-linux.x64-19.9.0.0.0dbru.zip

--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -70,7 +70,7 @@ RUN dnf -y --refresh install \
     dos2unix
 
 # Workaround https://bugreports.qt.io/browse/QTBUG-113227 for now, roll back to qt 6.4
-RUN dnf downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
+RUN dnf -y downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
 
 # Oracle : client side
 RUN curl https://download.oracle.com/otn_software/linux/instantclient/199000/instantclient-basic-linux.x64-19.9.0.0.0dbru.zip > instantclient-basic-linux.x64-19.9.0.0.0dbru.zip

--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -70,7 +70,7 @@ RUN dnf -y --refresh install \
     dos2unix
 
 # Workaround https://bugreports.qt.io/browse/QTBUG-113227 for now, roll back to qt 6.4
-RUN dnf -y downgrade qt6-qtbase-6.4.3-1.fc38 --allowerasing
+RUN dnf -y downgrade qt6-qtbase-6.4.3-1.fc38 qt6-qt3d-6.4.3-1.fc38 qt6-qtdeclarative.6.4.3-1.fc38 qt6-qtserialport.6.4.3-1.fc38 qt6-qtsvg.6.4.3-1.fc38 qt6-qtpositioning.6.4.3-1.fc38  qt6-qtdeclarative.6.4.3-1.fc38 qt6-qt5compat-6.4.3-1.fc38  qt6-qtmultimedia.6.4.3-1.fc38 --allowerasing
 
 # Oracle : client side
 RUN curl https://download.oracle.com/otn_software/linux/instantclient/199000/instantclient-basic-linux.x64-19.9.0.0.0dbru.zip > instantclient-basic-linux.x64-19.9.0.0.0dbru.zip

--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -81,6 +81,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python \
             -DWITH_3D=ON \
+            -DWITH_PDAL=OFF \
             -DWITH_CUSTOM_WIDGETS=ON \
             -DWITH_QWTPOLAR=ON \
             -DQWTPOLAR_LIBRARY=${MINGW_PREFIX}/lib/libqwt-qt5.dll.a \


### PR DESCRIPTION
This bug has completely broken qt6 applications which use QVariants :upside_down_face: 