### PR TITLE
Avoid unusable blank python console

### DIFF
--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -281,7 +281,7 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     // going from dock -> window
     // note -- we explicitly DO NOT set the parent for the dialog, as we want these treated as
     // proper top level windows and have their own taskbar entries. See https://github.com/qgis/QGIS/issues/49286
-    mDialog = new QDialog( nullptr, Qt::Window );
+    mDialog = new QgsNonRejectableDialog( nullptr, Qt::Window );
     mDialog->setStyleSheet( sAppStylesheetFunction() );
 
     mDialog->setWindowTitle( mWindowTitle );
@@ -466,4 +466,21 @@ bool QgsDockableWidgetHelper::eventFilter( QObject *watched, QEvent *event )
   return QObject::eventFilter( watched, event );
 }
 
+//
+// QgsNonRejectableDialog
+//
+
+QgsNonRejectableDialog::QgsNonRejectableDialog( QWidget *parent, Qt::WindowFlags f )
+  : QDialog( parent, f )
+{
+
+}
+
+void QgsNonRejectableDialog::reject()
+{
+  // swallow rejection -- we don't want this dialog to be closable via escape key
+}
+
+
 ///@endcond
+

--- a/src/gui/qgsdockablewidgethelper.h
+++ b/src/gui/qgsdockablewidgethelper.h
@@ -30,6 +30,15 @@ class QgsDockWidget;
 
 ///@cond PRIVATE
 
+class GUI_EXPORT QgsNonRejectableDialog : public QDialog
+{
+    Q_OBJECT
+  public:
+
+    explicit QgsNonRejectableDialog( QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+    void reject() override;
+};
+
 /**
  * This class is responible of displaying a QWidget inside a top level window or a dock widget (only one of the 2 is alive at most).
  * The widget is not owned by this class and its ownership is passed to the owner window before this class's object is deleted or


### PR DESCRIPTION
 if escape is pressed in console window when console is shown in the dialog mode
