### PR TITLE
Hard-code toolbar icon size

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -310,7 +310,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
     initializeRegistry();
   }
   QgsSettings settings;
-  int size = settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ).toInt();
+  int size = settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toInt();
   setIconSize( QSize( size, size ) );
   setStyleSheet( QgisApp::instance()->styleSheet() );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -671,7 +671,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   }
 
   // set the default icon size
-  cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "qgis/iconSize" ), QGIS_ICON_SIZE ).toString() ) );
+  cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toString() ) );
 
   // set font size and family
   spinFontSize->blockSignals( true );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1628,7 +1628,7 @@ void QgsOptions::saveOptions()
 
   QgsApplication::setNullRepresentation( leNullValue->text() );
   mSettings->setValue( QStringLiteral( "/qgis/style" ), cmbStyle->currentText() );
-  mSettings->setValue( QStringLiteral( "/qgis/iconSize" ), cmbIconSize->currentText() );
+  mSettings->setValue( QStringLiteral( "/qgis/toolbarIconSize" ), cmbIconSize->currentText() );
 
   mSettings->setValue( QStringLiteral( "/qgis/messageTimeout" ), mMessageTimeoutSpnBx->value() );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1664,7 +1664,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   endProfile();
 
   // Set icon size of toolbars
-  int size = settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ).toInt();
+  int size = settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toInt();
   if ( size < 16 )
     size = QGIS_ICON_SIZE;
   setIconSizes( size );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1664,20 +1664,10 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   endProfile();
 
   // Set icon size of toolbars
-  if ( settings.contains( QStringLiteral( "/qgis/iconSize" ) ) )
-  {
-    int size = settings.value( QStringLiteral( "/qgis/iconSize" ) ).toInt();
-    if ( size < 16 )
-      size = QGIS_ICON_SIZE;
-    setIconSizes( size );
-  }
-  else
-  {
-    // first run, guess a good icon size
-    int size = chooseReasonableDefaultIconSize();
-    settings.setValue( QStringLiteral( "/qgis/iconSize" ), size );
-    setIconSizes( size );
-  }
+  int size = settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ).toInt();
+  if ( size < 16 )
+    size = QGIS_ICON_SIZE;
+  setIconSizes( size );
 
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutScaleBarValidityCheck() );
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutNorthArrowValidityCheck() );
@@ -2763,31 +2753,6 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
   canvas->setMapUpdateInterval( settings.value( QStringLiteral( "qgis/map_update_interval" ), 250 ).toInt() );
   canvas->setSegmentationTolerance( settings.value( QStringLiteral( "qgis/segmentationTolerance" ), "0.01745" ).toDouble() );
   canvas->setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType( settings.enumValue( QStringLiteral( "qgis/segmentationToleranceType" ), QgsAbstractGeometry::MaximumAngle ) ) );
-}
-
-int QgisApp::chooseReasonableDefaultIconSize() const
-{
-  QScreen *screen = QApplication::screens().at( 0 );
-  if ( screen->physicalDotsPerInch() < 115 )
-  {
-    // no hidpi screen, use default size
-    return QGIS_ICON_SIZE;
-  }
-  else
-  {
-    double size = fontMetrics().horizontalAdvance( 'X' ) * 3;
-    if ( size < 24 )
-      return 16;
-    else if ( size < 32 )
-      return 24;
-    else if ( size < 48 )
-      return 32;
-    else if ( size < 64 )
-      return 48;
-    else
-      return 64;
-  }
-
 }
 
 void QgisApp::readSettings()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1664,10 +1664,20 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   endProfile();
 
   // Set icon size of toolbars
-  int size = settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toInt();
-  if ( size < 16 )
-    size = QGIS_ICON_SIZE;
-  setIconSizes( size );
+  if ( settings.contains( QStringLiteral( "/qgis/toolbarIconSize" ) ) )
+  {
+    int size = settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toInt();
+    if ( size < 16 )
+      size = QGIS_ICON_SIZE;
+    setIconSizes( size );
+  }
+  else
+  {
+    // first run, set default value
+    int size = QGIS_ICON_SIZE;
+    settings.setValue( QStringLiteral( "/qgis/toolbarIconSize" ), size );
+    setIconSizes( size );
+  }
 
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutScaleBarValidityCheck() );
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutNorthArrowValidityCheck() );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2350,9 +2350,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsCoordinateReferenceSystem defaultCrsForNewLayers() const;
 
-    //! Attempts to choose a reasonable default icon size based on the window's screen DPI
-    int chooseReasonableDefaultIconSize() const;
-
     //! Populates project "load from" / "save to" menu based on project storages (when the menu is about to be shown)
     void populateProjectStorageMenu( QMenu *menu, bool saving );
 

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -84,7 +84,7 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
 
   settings.endGroup(); // "qgis/stylesheet"
 
-  opts.insert( QStringLiteral( "iconSize" ), settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ) );
+  opts.insert( QStringLiteral( "iconSize" ), settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ) );
 
   return opts;
 }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -172,7 +172,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   layout()->setContentsMargins( 0, 0, 0, 0 );
   static_cast< QGridLayout * >( layout() )->setVerticalSpacing( 0 );
 
-  int size = settings.value( QStringLiteral( "/qgis/iconSize" ), 16 ).toInt();
+  int size = settings.value( QStringLiteral( "/qgis/toolbarIconSize" ), 16 ).toInt();
   if ( size > 32 )
   {
     size -= 16;

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -363,7 +363,7 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   else
     QgisApp::instance()->panelMenu()->addAction( mDock->toggleViewAction() );
 
-  int size = mySettings.value( QStringLiteral( "/qgis/iconSize" ), 16 ).toInt();
+  int size = mySettings.value( QStringLiteral( "/qgis/toolbarIconSize" ), 16 ).toInt();
   if ( size > 32 )
   {
     size -= 16;

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -45,7 +45,8 @@ QgsStatusBarScaleWidget::QgsStatusBarScaleWidget( QgsMapCanvas *canvas, QWidget 
   mScale->setObjectName( QStringLiteral( "mScaleEdit" ) );
   // seems setFont() change font only for popup not for line edit,
   // so we need to set font for it separately
-  mScale->setMinimumWidth( 10 );
+  mScale->setMinimumContentsLength( 3 );
+  mScale->setSizeAdjustPolicy( QComboBox::AdjustToContents );
   mScale->setContentsMargins( 0, 0, 0, 0 );
   mScale->setToolTip( tr( "Current map scale" ) );
 
@@ -69,10 +70,7 @@ void QgsStatusBarScaleWidget::setScale( double scale )
   mScale->setScale( scale );
   mScale->blockSignals( false );
 
-  if ( mScale->width() > mScale->minimumWidth() )
-  {
-    mScale->setMinimumWidth( mScale->width() );
-  }
+  mScale->setMinimumContentsLength( mScale->scaleString().length() );
 }
 
 bool QgsStatusBarScaleWidget::isLocked() const

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -45,8 +45,7 @@ QgsStatusBarScaleWidget::QgsStatusBarScaleWidget( QgsMapCanvas *canvas, QWidget 
   mScale->setObjectName( QStringLiteral( "mScaleEdit" ) );
   // seems setFont() change font only for popup not for line edit,
   // so we need to set font for it separately
-  mScale->setMinimumContentsLength( 3 );
-  mScale->setSizeAdjustPolicy( QComboBox::AdjustToContents );
+  mScale->setMinimumWidth( 10 );
   mScale->setContentsMargins( 0, 0, 0, 0 );
   mScale->setToolTip( tr( "Current map scale" ) );
 
@@ -70,7 +69,10 @@ void QgsStatusBarScaleWidget::setScale( double scale )
   mScale->setScale( scale );
   mScale->blockSignals( false );
 
-  mScale->setMinimumContentsLength( mScale->scaleString().length() );
+  if ( mScale->width() > mScale->minimumWidth() )
+  {
+    mScale->setMinimumWidth( mScale->width() );
+  }
 }
 
 bool QgsStatusBarScaleWidget::isLocked() const

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -251,7 +251,7 @@ namespace QgsGuiUtils
   QSize iconSize( bool dockableToolbar )
   {
     const QgsSettings s;
-    const int w = s.value( QStringLiteral( "/qgis/iconSize" ), 32 ).toInt();
+    const int w = s.value( QStringLiteral( "/qgis/toolbarIconSize" ), 32 ).toInt();
     QSize size( w, w );
 
     if ( dockableToolbar )


### PR DESCRIPTION
Follow-up of :
https://github.com/qgis/QGIS/pull/52972

With automatic high DPI scaling enabled, the toolbar icon size can be hard-coded.