### PR TITLE
Copy print layout items by dragging + Alt

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -807,6 +807,7 @@
         <file>themes/default/cursors/mZoomIn.svg</file>
         <file>themes/default/cursors/mZoomOut.svg</file>
         <file>themes/default/cursors/mIdentify.svg</file>
+        <file>themes/default/cursors/mCopy.svg</file>
         <file>themes/default/mIconQgsProjectFile.svg</file>
         <file>themes/default/mIconPythonFile.svg</file>
         <file>themes/default/mIconQptFile.svg</file>

--- a/images/themes/default/cursors/mCopy.svg
+++ b/images/themes/default/cursors/mCopy.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24.000001 24.000001"
+   width="24"
+   version="1.1"
+   id="svg75"
+   sodipodi:docname="mCopy.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs79" />
+  <sodipodi:namedview
+     id="namedview77"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="17.4375"
+     inkscape:cx="-3.3548387"
+     inkscape:cy="17.204301"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg75" />
+  <path
+     id="path13963"
+     style="display:inline;color:#000000;fill:none;stroke-width:1.27481112;stroke-dasharray:none;stroke-dashoffset:0.4;paint-order:fill markers stroke;stroke:#ffffff;stroke-opacity:1"
+     d="M 12.983035 1028.3158 L 12.983035 1032.7137 L 8.0201921 1029.9785 C 7.9733869 1029.9528 7.9209466 1029.9397 7.8676991 1029.9397 C 7.6436226 1029.9397 7.490768 1030.1687 7.573871 1030.3785 L 11.946578 1041.3194 C 12.044551 1041.562 12.374264 1041.5898 12.510678 1041.3669 L 14.03065 1038.8867 L 17.189611 1042.3658 C 17.310376 1042.4997 17.517188 1042.5057 17.645851 1042.3795 L 18.948861 1041.0994 C 19.073105 1040.9776 19.077518 1040.7778 18.958779 1040.6506 L 15.750226 1037.2278 L 18.177717 1036.1665 C 18.420922 1036.0608 18.436396 1035.719 18.203752 1035.5914 L 17.774788 1035.3552 L 19.935726 1035.3552 L 19.935726 1028.3158 L 12.983035 1028.3158 z "
+     transform="matrix(1.5753792,0,0,1.5623675,-8.4512501,-1605.6072)"
+     inkscape:label="outline" />
+  <g
+     fill-rule="evenodd"
+     transform="translate(1.6470919,-1026.3921)"
+     id="g71"
+     style="display:inline">
+    <g
+       id="g5316"
+       transform="matrix(1.5753792,0,0,1.5623675,-10.098342,-579.21511)"
+       style="stroke-width:0.58564;stroke-dasharray:none">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.58564;stroke-dasharray:none;stroke-dashoffset:0.4;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect1626"
+         width="6.3685627"
+         height="6.4549575"
+         x="13.274615"
+         y="1028.6086" />
+      <path
+         id="rect2425"
+         style="opacity:1;stroke:none;stroke-width:0.58564;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.035937,1029.3113 v 2.0379 h -2.053609 v 0.9451 h 2.053609 v 2.0363 h 0.945161 v -2.0363 h 2.020638 v -0.9451 h -2.020638 v -2.0379 z" />
+    </g>
+    <path
+       d="m 2.2954952,1029.929 c -0.3530058,0 -0.5938095,0.3577 -0.4628906,0.6855 l 6.8886718,17.0938 c 0.1543448,0.379 0.6737665,0.4223 0.8886719,0.074 l 2.3945307,-3.875 4.976563,5.4355 c 0.19025,0.2093 0.516057,0.2192 0.71875,0.022 l 2.052734,-2 c 0.195733,-0.1903 0.20269,-0.5024 0.01563,-0.7012 l -5.054687,-5.3476 3.824219,-1.6582 c 0.383141,-0.1651 0.407522,-0.6992 0.04102,-0.8985 l -16.0429784,-8.7698 c -0.073736,-0.04 -0.1563493,-0.061 -0.2402344,-0.061 z"
+       overflow="visible"
+       id="path67" />
+    <path
+       d="m 4.8119613,1033.0805 9.9835337,5.4255"
+       fill="#cccccc"
+       stroke="#b3b3b3"
+       stroke-linecap="round"
+       id="path69" />
+  </g>
+</svg>

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -364,6 +364,7 @@ control the color of parameter based SVG icons.
       CapturePoint,
       Select,
       Sampler,
+      Copy,
     };
 
     static QCursor getThemeCursor( Cursor cursor );

--- a/python/gui/auto_generated/layout/qgslayoutview.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutview.sip.in
@@ -283,7 +283,7 @@ view.
 %Docstring
 Copies the selected items to the clipboard, and pastes them at the specified ``layoutPoint``
 
-.. versionadded:: 3.32
+.. versionadded:: 3.36
 %End
 
   public slots:

--- a/python/gui/auto_generated/layout/qgslayoutview.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutview.sip.in
@@ -279,6 +279,13 @@ Sets a section ``label``, to display above the first page shown in the
 view.
 %End
 
+    void copyPasteSelectedItems( const QPointF &layoutPoint );
+%Docstring
+Copies the selected items to the clipboard, and pastes them at the specified ``layoutPoint``
+
+.. versionadded:: 3.32
+%End
+
   public slots:
 
     void zoomFull();

--- a/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
@@ -38,6 +38,8 @@ Constructor for QgsLayoutViewToolSelect.
 
     virtual void keyPressEvent( QKeyEvent *event );
 
+    virtual void keyReleaseEvent( QKeyEvent *event );
+
     virtual void deactivate();
 
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -860,6 +860,11 @@ QCursor QgsApplication::getThemeCursor( Cursor cursor )
       activeY = 5;
       name = QStringLiteral( "mSampler.svg" );
       break;
+    case Copy:
+      activeX = 5;
+      activeY = 5;
+      name = QStringLiteral( "mCopy.svg" );
+      break;
       // No default
   }
   // It should never get here!

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -409,7 +409,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       CapturePoint, //!< Select and capture a point or a feature
       Select, //!< Select a rectangle
       Sampler, //!< Color/Value picker
-      Copy, //!< Copy cursor \since QGIS 3.32
+      Copy, //!< Copy cursor \since QGIS 3.36
     };
 
     /**

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -409,6 +409,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       CapturePoint, //!< Select and capture a point or a feature
       Select, //!< Select a rectangle
       Sampler, //!< Color/Value picker
+      Copy, //!< Copy cursor \since QGIS 3.32
     };
 
     /**

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -250,6 +250,30 @@ void QgsLayoutMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double
   qgis::down_cast< QgsLayoutItem * >( item )->attemptMoveBy( deltaX, deltaY );
 }
 
+bool QgsLayoutMouseHandles::copyDragEnabled() const
+{
+  return true;
+}
+
+void QgsLayoutMouseHandles::copyDrag()
+{
+  double minX = std::numeric_limits<double>::max();
+  double minY = std::numeric_limits<double>::max();
+  // Get the minimum reference point of the selected items
+  for ( const QGraphicsItem *item : selectedSceneItems( false ) )
+  {
+    if ( const QgsLayoutItem *layoutItem = dynamic_cast< const QgsLayoutItem * >( item ) )
+    {
+      QPointF itemPos = layoutItem->pagePos();
+      minX = std::min( minX, itemPos.x() );
+      minY = std::min( minY, itemPos.y() );
+    }
+  }
+
+  const QPointF refPos = QPointF( minX, minY ) + QPointF( transform().dx(), transform().dy() );
+  mView->copyPasteSelectedItems( refPos );
+}
+
 void QgsLayoutMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
   QgsLayoutItem *layoutItem = dynamic_cast< QgsLayoutItem * >( item );

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -77,6 +77,8 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     void expandItemList( const QList< QGraphicsItem * > &items, QList< QGraphicsItem * > &collected ) const override;
     void expandItemList( const QList< QgsLayoutItem * > &items, QList< QGraphicsItem * > &collected ) const;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
+    bool copyDragEnabled() const override;
+    void copyDrag() override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
     void showStatusMessage( const QString &message ) override;
     void hideAlignItems() override;

--- a/src/gui/layout/qgslayoutview.cpp
+++ b/src/gui/layout/qgslayoutview.cpp
@@ -1256,6 +1256,28 @@ QGraphicsLineItem *QgsLayoutView::createSnapLine() const
   return item.release();
 }
 
+void QgsLayoutView::copyPasteSelectedItems( const QPointF &layoutPoint )
+{
+  // Copy the selected items to the application clipboard
+  copySelectedItems( ClipboardCopy );
+
+  // Paste them at the new location
+  auto items = pasteItems( layoutPoint );
+
+  // Deselect previously selected items
+  whileBlocking( currentLayout() )->deselectAll();
+
+  // Select the pasted items
+  for ( QgsLayoutItem *item : items )
+  {
+    item->setSelected( true );
+  }
+
+  // Focus the first item. This will update the item properties dock
+  emit itemFocused( items.at( 0 ) );
+
+}
+
 //
 // QgsLayoutViewSnapMarker
 //

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -296,6 +296,13 @@ class GUI_EXPORT QgsLayoutView: public QGraphicsView
      */
     void setSectionLabel( const QString &label );
 
+    /**
+     * Copies the selected items to the clipboard, and pastes them at the specified \a layoutPoint
+     *
+     * \since QGIS 3.32
+    */
+    void copyPasteSelectedItems( const QPointF &layoutPoint );
+
   public slots:
 
     /**

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -299,7 +299,7 @@ class GUI_EXPORT QgsLayoutView: public QGraphicsView
     /**
      * Copies the selected items to the clipboard, and pastes them at the specified \a layoutPoint
      *
-     * \since QGIS 3.32
+     * \since QGIS 3.36
     */
     void copyPasteSelectedItems( const QPointF &layoutPoint );
 

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -175,9 +175,21 @@ void QgsLayoutViewToolSelect::layoutMoveEvent( QgsLayoutViewMouseEvent *event )
   }
   else
   {
-    if ( !mMouseHandles->isDragging() && !mMouseHandles->isResizing() )
+    if ( mMouseHandles->isDragging() )
     {
-      if ( layout()->layoutItemAt( event->layoutPoint(), true, searchToleranceInLayoutUnits() ) )
+      bool ctrlPressed = event->modifiers() & Qt::ControlModifier;
+      if ( ctrlPressed )
+      {
+        view()->viewport()->setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Copy ) );
+      }
+      else
+      {
+        view()->viewport()->setCursor( Qt::SizeAllCursor );
+      }
+    }
+    else
+    {
+      if ( layout()->layoutItemAt( event->layoutPoint(), true ) )
       {
         view()->viewport()->setCursor( Qt::SizeAllCursor );
       }
@@ -307,13 +319,33 @@ void QgsLayoutViewToolSelect::wheelEvent( QWheelEvent *event )
 
 void QgsLayoutViewToolSelect::keyPressEvent( QKeyEvent *event )
 {
-  if ( mMouseHandles->isDragging() || mMouseHandles->isResizing() )
+  if ( mMouseHandles->isDragging() )
+  {
+    if ( event->key() == Qt::Key_Control )
+    {
+      view()->viewport()->setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Copy ) );
+    }
+    return;
+  }
+  if ( mMouseHandles->isResizing() )
   {
     return;
   }
   else
   {
     event->ignore();
+  }
+}
+
+void QgsLayoutViewToolSelect::keyReleaseEvent( QKeyEvent *event )
+{
+  if ( mMouseHandles->isDragging() )
+  {
+    if ( event->key() == Qt::Key_Control )
+    {
+      view()->viewport()->setCursor( Qt::SizeAllCursor );
+    }
+    return;
   }
 }
 

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -177,8 +177,8 @@ void QgsLayoutViewToolSelect::layoutMoveEvent( QgsLayoutViewMouseEvent *event )
   {
     if ( mMouseHandles->isDragging() )
     {
-      bool ctrlPressed = event->modifiers() & Qt::ControlModifier;
-      if ( ctrlPressed )
+      bool altPressed = event->modifiers() & Qt::AltModifier;
+      if ( altPressed )
       {
         view()->viewport()->setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Copy ) );
       }
@@ -321,7 +321,7 @@ void QgsLayoutViewToolSelect::keyPressEvent( QKeyEvent *event )
 {
   if ( mMouseHandles->isDragging() )
   {
-    if ( event->key() == Qt::Key_Control )
+    if ( event->key() == Qt::Key_Alt )
     {
       view()->viewport()->setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Copy ) );
     }
@@ -341,7 +341,7 @@ void QgsLayoutViewToolSelect::keyReleaseEvent( QKeyEvent *event )
 {
   if ( mMouseHandles->isDragging() )
   {
-    if ( event->key() == Qt::Key_Control )
+    if ( event->key() == Qt::Key_Alt )
     {
       view()->viewport()->setCursor( Qt::SizeAllCursor );
     }

--- a/src/gui/layout/qgslayoutviewtoolselect.h
+++ b/src/gui/layout/qgslayoutviewtoolselect.h
@@ -47,6 +47,7 @@ class GUI_EXPORT QgsLayoutViewToolSelect : public QgsLayoutViewTool
     void layoutReleaseEvent( QgsLayoutViewMouseEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
+    void keyReleaseEvent( QKeyEvent *event ) override;
     void deactivate() override;
 
     ///@cond PRIVATE

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -574,29 +574,37 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
 
   if ( mCurrentMouseMoveAction == MoveItem )
   {
-    //move selected items
-    startMacroCommand( tr( "Move Items" ) );
-
-    QPointF mEndHandleMovePos = scenePos();
-
-    double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
-    double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
-
-    //move all selected items
-    const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
-    for ( QGraphicsItem *item : selectedItems )
+    //If Ctrl is pressed, copy the items instead of moving them
+    if ( copyDragEnabled() && event->modifiers() & Qt::ControlModifier )
     {
-      if ( itemIsLocked( item ) || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 || itemIsGroupMember( item ) )
-      {
-        //don't move locked items, or grouped items (group takes care of that)
-        continue;
-      }
-
-      createItemCommand( item );
-      moveItem( item, deltaX, deltaY );
-      endItemCommand( item );
+      copyDrag();
     }
-    endMacroCommand();
+    else
+    {
+      //move selected items
+      startMacroCommand( tr( "Move Items" ) );
+
+      QPointF mEndHandleMovePos = scenePos();
+
+      double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
+      double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
+
+      //move all selected items
+      const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+      for ( QGraphicsItem *item : selectedItems )
+      {
+        if ( itemIsLocked( item ) || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 || itemIsGroupMember( item ) )
+        {
+          //don't move locked items, or grouped items (group takes care of that)
+          continue;
+        }
+
+        createItemCommand( item );
+        moveItem( item, deltaX, deltaY );
+        endItemCommand( item );
+      }
+      endMacroCommand();
+    }
   }
   else if ( mCurrentMouseMoveAction != NoAction )
   {

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -574,8 +574,8 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
 
   if ( mCurrentMouseMoveAction == MoveItem )
   {
-    //If Ctrl is pressed, copy the items instead of moving them
-    if ( copyDragEnabled() && event->modifiers() & Qt::ControlModifier )
+    //If Alt is pressed, copy the items instead of moving them
+    if ( copyDragEnabled() && event->modifiers() & Qt::AltModifier )
     {
       copyDrag();
     }

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -179,6 +179,11 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     //! Returns the mouse handle bounds of current selection
     QRectF selectionBounds() const;
 
+    //! Returns whether items can be copied by Ctrl+dragging
+    virtual bool copyDragEnabled() const { return false; }
+
+    virtual void copyDrag() {}
+
     /**
      * Resizes a QRectF relative to a resized bounding rectangle.
      * \param rectToResize QRectF to resize, contained within boundsBefore. The

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -179,7 +179,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     //! Returns the mouse handle bounds of current selection
     QRectF selectionBounds() const;
 
-    //! Returns whether items can be copied by Ctrl+dragging
+    //! Returns whether items can be copied by Alt+dragging
     virtual bool copyDragEnabled() const { return false; }
 
     virtual void copyDrag() {}


### PR DESCRIPTION
- Fixes #47512

## Description

- Pressing Alt while draging one or several items copy them at the new location. 

![drag_copy](https://github.com/qgis/QGIS/assets/9693475/1025bbf4-1e37-4bdc-b472-b771c8d72dec)

Notes:
- Before merging #53245, the preview will not be shown while moving the items
- Ctrl+drag is used in some software to copy/drag, but it is already used for ignoring snapping.