### PR TITLE
Fix vector iterator number of attributes returned with virtual fields and subset of attributes

### DIFF
--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -551,6 +551,8 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature &f )
 
     if ( mHasVirtualAttributes )
       addVirtualAttributes( f );
+    else
+      f.padAttributes( mSource->mFields.count() - f.attributeCount() );
 
     if ( mRequest.filterType() == QgsFeatureRequest::FilterExpression && mProviderRequest.filterType() != QgsFeatureRequest::FilterExpression )
     {
@@ -664,6 +666,8 @@ void QgsVectorLayerFeatureIterator::useAddedFeature( const QgsFeature &src, QgsF
 
   if ( mHasVirtualAttributes )
     addVirtualAttributes( f );
+  else
+    f.padAttributes( mSource->mFields.count() - f.attributeCount() );
 }
 
 
@@ -918,6 +922,7 @@ void QgsVectorLayerFeatureIterator::prepareFields()
   {
     createOrderedJoinList();
   }
+
 }
 
 void QgsVectorLayerFeatureIterator::createOrderedJoinList()
@@ -1292,6 +1297,8 @@ bool QgsVectorLayerFeatureIterator::nextFeatureFid( QgsFeature &f )
 
     if ( mHasVirtualAttributes )
       addVirtualAttributes( f );
+    else
+      f.padAttributes( mSource->mFields.count() - f.attributeCount() );
 
     return true;
   }


### PR DESCRIPTION
Fix the issue of wrong number of attributes returned when the feature request has setSubsetOfAttributes set, in that case the virtual fields were not returned causing an inconsistency in the API response.

With this patch the virtual fields are always returned (possibly Null).
