### PR TITLE
Fix slow loading of PostgreSQL layers

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6499,13 +6499,17 @@ bool QgisApp::addProject( const QString &projectFile )
     }
 #endif
 
-    // Check for missing layer widget dependencies
-    const auto constVLayers { QgsProject::instance()->layers<QgsVectorLayer *>( ) };
-    for ( QgsVectorLayer *vl : constVLayers )
     {
-      if ( vl->isValid() )
+      QgsScopedRuntimeProfile profile( tr( "Resolve vector layer dependencies" ), QStringLiteral( "projectload" ) );
+
+      // Check for missing layer widget dependencies
+      const auto constVLayers { QgsProject::instance()->layers<QgsVectorLayer *>( ) };
+      for ( QgsVectorLayer *vl : constVLayers )
       {
-        QgsAppLayerHandling::resolveVectorLayerDependencies( vl );
+        if ( vl->isValid() )
+        {
+          QgsAppLayerHandling::resolveVectorLayerDependencies( vl );
+        }
       }
     }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1387,6 +1387,11 @@ bool QgsPostgresProvider::loadFields()
 
     mIdentityFields.insert( mAttributeFields.size(), identityMap[tableoid][attnum][0].toLatin1() );
     mAttributeFields.append( newField );
+
+    // if we know for sure that this field is not enumerated type or a domain type, let's
+    // mark it here, so that enumValues() does not need to check it again (for types like int, text, ...)
+    if ( fieldTType != QLatin1String( "e" ) && !isDomain )
+      mShared->setFieldSupportsEnumValues( fields.count() - 1, false );
   }
 
   setEditorWidgets();


### PR DESCRIPTION
This fixes a big performance issue when loading projects with PostgreSQL layers. In the last stage of project loading, code in QgisApp would run code to resolve broken layer dependencies, which in turn tried to find out best edit widget for all columns of all layers, and the enumeration widget tried to figure out all enum values, doing two SQL calls for each column for each layer.

We know what are types of columns when loading a layer, so enumValues() can leave early without doing the excessive queries when it's not necessary.

Testing on a real world QGIS project with 300+ layers (but not all PostgreSQL):
- before: ~35 minutes to load / ~8K PostgreSQL queries
- after: ~10 minutes to load / ~2K PostgreSQL queries

Also adds the time of resolution of broken layers / assignment of edit widgets to the project load timing, so that it shows up in timing.