### PR TITLE
Add control over horizontal / vertical stretch for attribute form widgets

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
@@ -130,6 +130,50 @@ Controls if this element should be labeled with a title (field, relation or grou
 .. versionadded:: 2.18
 %End
 
+    int horizontalStretch() const;
+%Docstring
+Returns the horizontal stretch factor for the element.
+
+.. seealso:: :py:func:`setHorizontalStretch`
+
+.. seealso:: :py:func:`verticalStretch`
+
+.. versionadded:: 3.32
+%End
+
+    void setHorizontalStretch( int stretch );
+%Docstring
+Sets the horizontal ``stretch`` factor for the element.
+
+.. seealso:: :py:func:`horizontalStretch`
+
+.. seealso:: :py:func:`setVerticalStretch`
+
+.. versionadded:: 3.32
+%End
+
+    int verticalStretch() const;
+%Docstring
+Returns the vertical stretch factor for the element.
+
+.. seealso:: :py:func:`setVerticalStretch`
+
+.. seealso:: :py:func:`horizontalStretch`
+
+.. versionadded:: 3.32
+%End
+
+    void setVerticalStretch( int stretch );
+%Docstring
+Sets the vertical ``stretch`` factor for the element.
+
+.. seealso:: :py:func:`verticalStretch`
+
+.. seealso:: :py:func:`setHorizontalStretch`
+
+.. versionadded:: 3.32
+%End
+
     LabelStyle labelStyle() const;
 %Docstring
 Returns the label style.

--- a/src/core/editform/qgsattributeeditorelement.cpp
+++ b/src/core/editform/qgsattributeeditorelement.cpp
@@ -32,6 +32,8 @@ QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
   QDomElement elem = doc.createElement( typeIdentifier() );
   elem.setAttribute( QStringLiteral( "name" ), mName );
   elem.setAttribute( QStringLiteral( "showLabel" ), mShowLabel );
+  elem.setAttribute( QStringLiteral( "horizontalStretch" ), mHorizontalStretch );
+  elem.setAttribute( QStringLiteral( "verticalStretch" ), mVerticalStretch );
   elem.appendChild( mLabelStyle.writeXml( doc ) );
   saveConfiguration( elem, doc );
   return elem;
@@ -106,6 +108,9 @@ QgsAttributeEditorElement *QgsAttributeEditorElement::create( const QDomElement 
       newElement->setShowLabel( element.attribute( QStringLiteral( "showLabel" ) ).toInt() );
     else
       newElement->setShowLabel( true );
+
+    newElement->setHorizontalStretch( element.attribute( QStringLiteral( "horizontalStretch" ), QStringLiteral( "0" ) ).toInt() );
+    newElement->setVerticalStretch( element.attribute( QStringLiteral( "verticalStretch" ), QStringLiteral( "0" ) ).toInt() );
 
     // Label font and color
     LabelStyle style;

--- a/src/core/editform/qgsattributeeditorelement.h
+++ b/src/core/editform/qgsattributeeditorelement.h
@@ -115,7 +115,6 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
       : mType( type )
       , mName( name )
       , mParent( parent )
-      , mShowLabel( true )
     {}
 
     virtual ~QgsAttributeEditorElement() = default;
@@ -178,6 +177,46 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
     void setShowLabel( bool showLabel );
 
     /**
+     * Returns the horizontal stretch factor for the element.
+     *
+     * \see setHorizontalStretch()
+     * \see verticalStretch()
+     *
+     * \since QGIS 3.32
+     */
+    int horizontalStretch() const { return mHorizontalStretch; }
+
+    /**
+     * Sets the horizontal \a stretch factor for the element.
+     *
+     * \see horizontalStretch()
+     * \see setVerticalStretch()
+     *
+     * \since QGIS 3.32
+     */
+    void setHorizontalStretch( int stretch ) { mHorizontalStretch = stretch; }
+
+    /**
+     * Returns the vertical stretch factor for the element.
+     *
+     * \see setVerticalStretch()
+     * \see horizontalStretch()
+     *
+     * \since QGIS 3.32
+     */
+    int verticalStretch() const { return mVerticalStretch; }
+
+    /**
+     * Sets the vertical \a stretch factor for the element.
+     *
+     * \see verticalStretch()
+     * \see setHorizontalStretch()
+     *
+     * \since QGIS 3.32
+     */
+    void setVerticalStretch( int stretch ) { mVerticalStretch = stretch; }
+
+    /**
      * Returns the label style.
      * \see setLabelStyle()
      * \since QGIS 3.26
@@ -194,10 +233,12 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
 
   protected:
 #ifndef SIP_RUN
-    Qgis::AttributeEditorType mType;
+    Qgis::AttributeEditorType mType = Qgis::AttributeEditorType::Invalid;
     QString mName;
     QgsAttributeEditorElement *mParent = nullptr;
-    bool mShowLabel;
+    bool mShowLabel = true;
+    int mHorizontalStretch = 0;
+    int mVerticalStretch = 0;
     LabelStyle mLabelStyle;
 #endif
 

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -35,6 +35,9 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mTypeCombo->addItem( tr( "Group Box" ), QVariant::fromValue( Qgis::AttributeEditorContainerType::GroupBox ) );
   mTypeCombo->addItem( tr( "Row" ), QVariant::fromValue( Qgis::AttributeEditorContainerType::Row ) );
 
+  mHozStretchSpin->setClearValue( 0, tr( "Default" ) );
+  mVertStretchSpin->setClearValue( 0, tr( "Default" ) );
+
   mTitleLineEdit->setText( itemData.name() );
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
   mTypeCombo->setCurrentIndex( mTypeCombo->findData( QVariant::fromValue( itemData.containerType() ) ) );
@@ -50,6 +53,9 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mCollapsedCheckBox->setChecked( itemData.collapsed() );
   mControlCollapsedGroupBox->setChecked( itemData.collapsedExpression().enabled() );
   mCollapsedExpressionWidget->setExpression( itemData.collapsedExpression()->expression() );
+
+  mHozStretchSpin->setValue( itemData.horizontalStretch() );
+  mVertStretchSpin->setValue( itemData.verticalStretch() );
 
   mFormLabelFormatWidget->setLabelStyle( itemData.labelStyle() );
 
@@ -73,6 +79,8 @@ void QgsAttributeFormContainerEdit::updateItemData()
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setBackgroundColor( mBackgroundColorButton->color() );
   itemData.setLabelStyle( mFormLabelFormatWidget->labelStyle() );
+  itemData.setHorizontalStretch( mHozStretchSpin->value() );
+  itemData.setVerticalStretch( mVertStretchSpin->value() );
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -24,6 +24,8 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
 
 {
   setupUi( this );
+  mHozStretchSpin->setClearValue( 0, tr( "Default" ) );
+  mVertStretchSpin->setClearValue( 0, tr( "Default" ) );
 
   const QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
 
@@ -31,6 +33,8 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
 
   mFormLabelFormatWidget->setLabelStyle( itemData.labelStyle() );
+  mHozStretchSpin->setValue( itemData.horizontalStretch() );
+  mVertStretchSpin->setValue( itemData.verticalStretch() );
 
   switch ( itemData.type() )
   {
@@ -68,6 +72,8 @@ void QgsAttributeWidgetEdit::updateItemData()
   // common configs
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setLabelStyle( mFormLabelFormatWidget->labelStyle() );
+  itemData.setHorizontalStretch( mHozStretchSpin->value() );
+  itemData.setVerticalStretch( mVertStretchSpin->value() );
 
   // specific configs
   switch ( itemData.type() )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1724,7 +1724,18 @@ void QgsAttributeForm::init()
             {
               widgetInfo.widget->setFont( widgetInfo.labelStyle.font );
             }
+
             layout->addWidget( widgetInfo.widget, row, column, 1, 2 );
+            if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
+            {
+              layout->setColumnStretch( column + 1, widgDef->horizontalStretch() );
+            }
+            if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+            {
+              layout->setRowStretch( row, widgDef->verticalStretch() );
+              addSpacer = false;
+            }
+
             if ( containerDef->visibilityExpression().enabled() || containerDef->collapsedExpression().enabled() )
             {
               registerContainerInformation( new ContainerInformation( widgetInfo.widget, containerDef->visibilityExpression().enabled() ? containerDef->visibilityExpression().data() : QgsExpression(), containerDef->collapsed(), containerDef->collapsedExpression().enabled() ? containerDef->collapsedExpression().data() : QgsExpression() ) );
@@ -1738,6 +1749,16 @@ void QgsAttributeForm::init()
             tabWidget = nullptr;
             WidgetInfo widgetInfo = createWidgetFromDef( widgDef, formWidget, mLayer, mContext );
             layout->addWidget( widgetInfo.widget, row, column, 1, 2 );
+            if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+            {
+              layout->setRowStretch( row, widgDef->verticalStretch() );
+              addSpacer = false;
+            }
+            if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
+            {
+              layout->setColumnStretch( column + 1, widgDef->horizontalStretch() );
+            }
+
             if ( containerDef->visibilityExpression().enabled() || containerDef->collapsedExpression().enabled() )
             {
               registerContainerInformation( new ContainerInformation( widgetInfo.widget, containerDef->visibilityExpression().enabled() ? containerDef->visibilityExpression().data() : QgsExpression(), containerDef->collapsed(), containerDef->collapsedExpression().enabled() ? containerDef->collapsedExpression().data() : QgsExpression() ) );
@@ -1802,6 +1823,12 @@ void QgsAttributeForm::init()
         QVBoxLayout *c = new QVBoxLayout();
         c->addWidget( collapsibleGroupBox );
         layout->addLayout( c, row, column, 1, 2 );
+
+        if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+          layout->setRowStretch( row, widgDef->verticalStretch() );
+        if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
+          layout->setColumnStretch( column + 1, widgDef->horizontalStretch() );
+
         column += 2;
 
         // we consider all relation editors should be expanding
@@ -1848,6 +1875,17 @@ void QgsAttributeForm::init()
           label->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
           c->addWidget( widgetInfo.widget );
           layout->addLayout( c, row, column, 1, 2 );
+
+          if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+          {
+            layout->setRowStretch( row, widgDef->verticalStretch() );
+            addSpacer = false;
+          }
+          if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
+          {
+            layout->setColumnStretch( column + 1, widgDef->horizontalStretch() );
+          }
+
           column += 2;
         }
         else if ( widgetInfo.labelOnTop )
@@ -1857,12 +1895,34 @@ void QgsAttributeForm::init()
           c->addWidget( label );
           c->addWidget( widgetInfo.widget );
           layout->addLayout( c, row, column, 1, 2 );
+
+          if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+          {
+            layout->setRowStretch( row, widgDef->verticalStretch() );
+            addSpacer = false;
+          }
+          if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
+          {
+            layout->setColumnStretch( column + 1, widgDef->horizontalStretch() );
+          }
+
           column += 2;
         }
         else
         {
+          const int widgetColumn = column + 1;
           layout->addWidget( label, row, column++ );
           layout->addWidget( widgetInfo.widget, row, column++ );
+
+          if ( widgDef->verticalStretch() > 0 && widgDef->verticalStretch() > layout->rowStretch( row ) )
+          {
+            layout->setRowStretch( row, widgDef->verticalStretch() );
+            addSpacer = false;
+          }
+          if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( widgetColumn ) )
+          {
+            layout->setColumnStretch( widgetColumn, widgDef->horizontalStretch() );
+          }
         }
 
         // Alias DD overrides
@@ -2492,9 +2552,13 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
           }
         }
 
+        // column containing the actual widget, not the label
+        int widgetColumn = column;
+
         if ( widgetInfo.labelText.isNull() || ! widgetInfo.showLabel )
         {
           gbLayout->addWidget( widgetInfo.widget, row, column, 1, 2 );
+          widgetColumn = column + 1;
           column += 2;
         }
         else
@@ -2552,6 +2616,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
           if ( widgetInfo.labelOnTop )
           {
+            widgetColumn = column + 1;
             QVBoxLayout *c = new QVBoxLayout();
             mypLabel->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
             c->layout()->addWidget( mypLabel );
@@ -2561,9 +2626,22 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
           }
           else
           {
+            widgetColumn = column + 1;
             gbLayout->addWidget( mypLabel, row, column++ );
             gbLayout->addWidget( widgetInfo.widget, row, column++ );
           }
+        }
+
+        const int childHorizontalStretch = childDef->horizontalStretch();
+        const int existingColumnStretch = gbLayout->columnStretch( widgetColumn );
+        if ( childHorizontalStretch > 0 && childHorizontalStretch > existingColumnStretch )
+        {
+          gbLayout->setColumnStretch( widgetColumn, childHorizontalStretch );
+        }
+
+        if ( childDef->verticalStretch() > 0  && childDef->verticalStretch() > gbLayout->rowStretch( row ) )
+        {
+          gbLayout->setRowStretch( row, childDef->verticalStretch() );
         }
 
         if ( column >= columnCount * 2 )

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -437,14 +437,21 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
 
 QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAttributeEditorElement *const widgetDef, QTreeWidgetItem *parent, QgsAttributesDnDTree *tree )
 {
+  auto setCommonProperties = [widgetDef]( DnDTreeItemData & itemData )
+  {
+    itemData.setShowLabel( widgetDef->showLabel() );
+    itemData.setLabelStyle( widgetDef->labelStyle() );
+    itemData.setHorizontalStretch( widgetDef->horizontalStretch() );
+    itemData.setVerticalStretch( widgetDef->verticalStretch() );
+  };
+
   QTreeWidgetItem *newWidget = nullptr;
   switch ( widgetDef->type() )
   {
     case Qgis::AttributeEditorType::Field:
     {
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -456,8 +463,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       if ( action.isValid() )
       {
         DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Action, action.id().toString(), action.shortTitle().isEmpty() ? action.name() : action.shortTitle() );
-        itemData.setShowLabel( widgetDef->showLabel() );
-        itemData.setLabelStyle( widgetDef->labelStyle() );
+        setCommonProperties( itemData );
         newWidget = tree->addItem( parent, itemData );
       }
       else
@@ -471,8 +477,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
 
       RelationEditorConfiguration relEdConfig;
 //      relEdConfig.buttons = relationEditor->visibleButtons();
@@ -489,7 +494,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     case Qgis::AttributeEditorType::Container:
     {
       DnDTreeItemData itemData( DnDTreeItemData::Container, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
 
       const QgsAttributeEditorContainer *container = static_cast<const QgsAttributeEditorContainer *>( widgetDef );
       if ( !container )
@@ -501,7 +505,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       itemData.setVisibilityExpression( container->visibilityExpression() );
       itemData.setCollapsedExpression( container->collapsedExpression() );
       itemData.setCollapsed( container->collapsed() );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+
+      setCommonProperties( itemData );
+
       newWidget = tree->addItem( parent, itemData );
 
       const QList<QgsAttributeEditorElement *> children = container->children();
@@ -516,11 +522,10 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       const QgsAttributeEditorQmlElement *qmlElementEditor = static_cast<const QgsAttributeEditorQmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::QmlWidget, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
       QmlElementEditorConfiguration qmlEdConfig;
       qmlEdConfig.qmlCode = qmlElementEditor->qmlCode();
       itemData.setQmlElementEditorConfiguration( qmlEdConfig );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -529,11 +534,10 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       const QgsAttributeEditorHtmlElement *htmlElementEditor = static_cast<const QgsAttributeEditorHtmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::HtmlWidget, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
       HtmlElementEditorConfiguration htmlEdConfig;
       htmlEdConfig.htmlCode = htmlElementEditor->htmlCode();
       itemData.setHtmlElementEditorConfiguration( htmlEdConfig );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -542,11 +546,10 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       const QgsAttributeEditorTextElement *textElementEditor = static_cast<const QgsAttributeEditorTextElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::TextWidget, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
       TextElementEditorConfiguration textEdConfig;
       textEdConfig.text = textElementEditor->text();
       itemData.setTextElementEditorConfiguration( textEdConfig );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -555,11 +558,10 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       const QgsAttributeEditorSpacerElement *spacerElementEditor = static_cast<const QgsAttributeEditorSpacerElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::SpacerWidget, widgetDef->name(), widgetDef->name() );
-      itemData.setShowLabel( widgetDef->showLabel() );
       SpacerElementEditorConfiguration spacerEdConfig;
       spacerEdConfig.drawLine = spacerElementEditor->drawLine();
       itemData.setSpacerElementEditorConfiguration( spacerEdConfig );
-      itemData.setLabelStyle( widgetDef->labelStyle() );
+      setCommonProperties( itemData );
       itemData.setShowLabel( false );
       newWidget = tree->addItem( parent, itemData );
       break;
@@ -859,6 +861,8 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
   {
     widgetDef->setShowLabel( itemData.showLabel() );
     widgetDef->setLabelStyle( itemData.labelStyle() );
+    widgetDef->setHorizontalStretch( itemData.horizontalStretch() );
+    widgetDef->setVerticalStretch( itemData.verticalStretch() );
   }
 
   return widgetDef;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -190,6 +190,46 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         bool showLabel() const;
         void setShowLabel( bool showLabel );
 
+        /**
+         * Returns the horizontal stretch factor for the element.
+         *
+         * \see setHorizontalStretch()
+         * \see verticalStretch()
+         *
+         * \since QGIS 3.32
+         */
+        int horizontalStretch() const { return mHorizontalStretch; }
+
+        /**
+         * Sets the horizontal \a stretch factor for the element.
+         *
+         * \see horizontalStretch()
+         * \see setVerticalStretch()
+         *
+         * \since QGIS 3.32
+         */
+        void setHorizontalStretch( int stretch ) { mHorizontalStretch = stretch; }
+
+        /**
+         * Returns the vertical stretch factor for the element.
+         *
+         * \see setVerticalStretch()
+         * \see horizontalStretch()
+         *
+         * \since QGIS 3.32
+         */
+        int verticalStretch() const { return mVerticalStretch; }
+
+        /**
+         * Sets the vertical \a stretch factor for the element.
+         *
+         * \see verticalStretch()
+         * \see setHorizontalStretch()
+         *
+         * \since QGIS 3.32
+         */
+        void setVerticalStretch( int stretch ) { mVerticalStretch = stretch; }
+
         QgsOptionalExpression visibilityExpression() const;
 
         /**
@@ -263,6 +303,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         int mColumnCount = 1;
         Qgis::AttributeEditorContainerType mContainerType = Qgis::AttributeEditorContainerType::Tab;
         bool mShowLabel = true;
+        int mHorizontalStretch = 0;
+        int mVerticalStretch = 0;
         QgsOptionalExpression mVisibilityExpression;
         RelationEditorConfiguration mRelationEditorConfiguration;
         QmlElementEditorConfiguration mQmlElementEditorConfiguration;

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -7,36 +7,63 @@
     <x>0</x>
     <y>0</y>
     <width>401</width>
-    <height>387</height>
+    <height>552</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="8" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="mControlCollapsedGroupBox">
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="mSizeGroupBox">
      <property name="title">
-      <string>Control Collapsed by Expression</string>
+      <string>Size</string>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
+     <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mCollapsedExpressionWidget" native="true"/>
+       <widget class="QLabel" name="mColumnsLabel_2">
+        <property name="text">
+         <string>Horizontal stretch</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsSpinBox" name="mHozStretchSpin">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mColumnsLabel_3">
+        <property name="text">
+         <string>Vertical stretch</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="mVertStretchSpin">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="mShowLabelCheckBox">
-     <property name="text">
-      <string>Show label</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
      <property name="title">
       <string>Control Visibility by Expression</string>
@@ -51,7 +78,41 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCollapsedCheckBox">
+     <property name="text">
+      <string>Collapsed</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Title</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QCheckBox" name="mShowLabelCheckBox">
+     <property name="text">
+      <string>Show label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="12" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Style</string>
@@ -80,33 +141,31 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mCollapsedCheckBox">
-     <property name="text">
-      <string>Collapsed</string>
+   <item row="10" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mControlCollapsedGroupBox">
+     <property name="title">
+      <string>Control Collapsed by Expression</string>
      </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QgsFieldExpressionWidget" name="mCollapsedExpressionWidget" native="true"/>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="11" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="mTypeCombo"/>
    </item>
    <item row="2" column="1">
     <widget class="QLineEdit" name="mTitleLineEdit"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Title</string>
+      <string>Type</string>
      </property>
     </widget>
    </item>
@@ -126,16 +185,6 @@
       <number>10</number>
      </property>
     </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="mTypeCombo"/>
    </item>
   </layout>
  </widget>
@@ -175,6 +224,8 @@
   <tabstop>mTitleLineEdit</tabstop>
   <tabstop>mTypeCombo</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
+  <tabstop>mHozStretchSpin</tabstop>
+  <tabstop>mVertStretchSpin</tabstop>
   <tabstop>mControlVisibilityGroupBox</tabstop>
   <tabstop>mCollapsedCheckBox</tabstop>
   <tabstop>mControlCollapsedGroupBox</tabstop>

--- a/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>283</width>
-    <height>242</height>
+    <height>298</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,6 +35,55 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="mSizeGroupBox">
+     <property name="title">
+      <string>Size</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QLabel" name="mColumnsLabel_2">
+        <property name="text">
+         <string>Horizontal stretch</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsSpinBox" name="mHozStretchSpin">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mColumnsLabel_3">
+        <property name="text">
+         <string>Vertical stretch</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="mVertStretchSpin">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QgsCollapsibleGroupBox" name="mWidgetSpecificConfigGroupBox">
      <property name="title">
       <string>GroupBox</string>
@@ -55,6 +104,11 @@
    <extends>QWidget</extends>
    <header>qgsformlabelformatwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This exposes two new "size" options for edit form widgets, allowing control over the horizontal and vertical stretch factors for the widget. By setting a horizontal or vertical stretch, users can control how edit widgets will relatively resize when resizing an attribute form.

Eg a user can set a higher horizontal stretch value for widgets which should "grab" more of the available horizontal space, eg for those widgets which are expected to have longer values and accordingly will benefit from the extra space.

Similarly, the vertical stretch setting controls how widgets will relatively grow vertically when resizing forms vertically. (Note that only some widgets can vertically grow -- eg. spin boxes can't be stretched vertically!)

Together these options give more control to users over the exact layout and sizing of their attribute forms.

By default, the stretch values are set to "Default" which is the same as previous behavior.
