### PR TITLE
Font size/family overridding cleanup and hidpi fixes

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -138,6 +138,13 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   mOptionsTreeView->setModel( mTreeModel );
 
+  // stylesheet setup
+  mStyleSheetBuilder = QgisApp::instance()->styleSheetBuilder();
+  mStyleSheetNewOpts = mStyleSheetBuilder->defaultOptions();
+  mStyleSheetOldOpts = QMap<QString, QVariant>( mStyleSheetNewOpts );
+
+  spinFontSize->setClearValue( mStyleSheetBuilder->defaultFont().pointSizeF() );
+
   connect( cbxProjectDefaultNew, &QCheckBox::toggled, this, &QgsOptions::cbxProjectDefaultNew_toggled );
   connect( leLayerGlobalCrs, &QgsProjectionSelectionWidget::crsChanged, this, &QgsOptions::leLayerGlobalCrs_crsChanged );
   connect( lstRasterDrivers, &QTreeWidget::itemDoubleClicked, this, &QgsOptions::lstRasterDrivers_itemDoubleClicked );
@@ -172,11 +179,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     }
     accept();
   } );
-
-  // stylesheet setup
-  mStyleSheetBuilder = QgisApp::instance()->styleSheetBuilder();
-  mStyleSheetNewOpts = mStyleSheetBuilder->defaultOptions();
-  mStyleSheetOldOpts = QMap<QString, QVariant>( mStyleSheetNewOpts );
 
   connect( mFontFamilyRadioCustom, &QAbstractButton::toggled, mFontFamilyComboBox, &QWidget::setEnabled );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -142,7 +142,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( leLayerGlobalCrs, &QgsProjectionSelectionWidget::crsChanged, this, &QgsOptions::leLayerGlobalCrs_crsChanged );
   connect( lstRasterDrivers, &QTreeWidget::itemDoubleClicked, this, &QgsOptions::lstRasterDrivers_itemDoubleClicked );
   connect( mProjectOnLaunchCmbBx, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::mProjectOnLaunchCmbBx_currentIndexChanged );
-  connect( spinFontSize, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsOptions::spinFontSize_valueChanged );
+  connect( spinFontSize, qOverload< double>( &QDoubleSpinBox::valueChanged ), this, &QgsOptions::spinFontSize_valueChanged );
   connect( mFontFamilyRadioQt, &QRadioButton::released, this, &QgsOptions::mFontFamilyRadioQt_released );
   connect( mFontFamilyRadioCustom, &QRadioButton::released, this, &QgsOptions::mFontFamilyRadioCustom_released );
   connect( mFontFamilyComboBox, &QFontComboBox::currentFontChanged, this, &QgsOptions::mFontFamilyComboBox_currentFontChanged );
@@ -679,7 +679,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mFontFamilyRadioCustom->blockSignals( true );
   mFontFamilyComboBox->blockSignals( true );
 
-  spinFontSize->setValue( mStyleSheetOldOpts.value( QStringLiteral( "fontPointSize" ) ).toInt() );
+  spinFontSize->setValue( mStyleSheetOldOpts.value( QStringLiteral( "fontPointSize" ) ).toDouble() );
   QString fontFamily = mStyleSheetOldOpts.value( QStringLiteral( "fontFamily" ) ).toString();
   bool isQtDefault = ( fontFamily == mStyleSheetBuilder->defaultFont().family() );
   mFontFamilyRadioQt->setChecked( isQtDefault );
@@ -1885,7 +1885,7 @@ void QgsOptions::rejectOptions()
   }
 }
 
-void QgsOptions::spinFontSize_valueChanged( int fontSize )
+void QgsOptions::spinFontSize_valueChanged( double fontSize )
 {
   mStyleSheetNewOpts.insert( QStringLiteral( "fontPointSize" ), QVariant( fontSize ) );
   mStyleSheetBuilder->buildStyleSheet( mStyleSheetNewOpts );

--- a/src/app/options/qgsoptions.h
+++ b/src/app/options/qgsoptions.h
@@ -113,7 +113,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void selectProjectOnLaunch();
 
     //! Slot to select the default font point size for app
-    void spinFontSize_valueChanged( int fontSize );
+    void spinFontSize_valueChanged(double fontSize );
 
     //! Slot to set font family for app to Qt default
     void mFontFamilyRadioQt_released();

--- a/src/app/options/qgsoptions.h
+++ b/src/app/options/qgsoptions.h
@@ -112,18 +112,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     //! Slot to choose path to project to open after launch
     void selectProjectOnLaunch();
 
-    //! Slot to select the default font point size for app
-    void spinFontSize_valueChanged(double fontSize );
-
-    //! Slot to set font family for app to Qt default
-    void mFontFamilyRadioQt_released();
-
-    //! Slot to set font family for app to custom choice
-    void mFontFamilyRadioCustom_released();
-
-    //! Slot to select custom font family choice for app
-    void mFontFamilyComboBox_currentFontChanged( const QFont &font );
-
     void mProxyTypeComboBox_currentIndexChanged( int idx );
 
     //! Add a new URL to no proxy URL list
@@ -292,8 +280,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
 
   protected:
     QgisAppStyleSheet *mStyleSheetBuilder = nullptr;
-    QMap<QString, QVariant> mStyleSheetNewOpts;
-    QMap<QString, QVariant> mStyleSheetOldOpts;
 
     static const int PALETTE_COLOR_ROLE = Qt::UserRole + 1;
     static const int PALETTE_LABEL_ROLE = Qt::UserRole + 2;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4129,7 +4129,7 @@ void QgisApp::setTheme( const QString &themeName )
 
   QString theme = themeName;
 
-  mStyleSheetBuilder->applyStyleSheet( mStyleSheetBuilder->defaultOptions() );
+  mStyleSheetBuilder->updateStyleSheet();
   QgsApplication::setUITheme( theme );
 
   mActionNewProject->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFileNew.svg" ) ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4129,7 +4129,7 @@ void QgisApp::setTheme( const QString &themeName )
 
   QString theme = themeName;
 
-  mStyleSheetBuilder->buildStyleSheet( mStyleSheetBuilder->defaultOptions() );
+  mStyleSheetBuilder->applyStyleSheet( mStyleSheetBuilder->defaultOptions() );
   QgsApplication::setUITheme( theme );
 
   mActionNewProject->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFileNew.svg" ) ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3290,12 +3290,6 @@ void QgisApp::createActionGroups()
 
 void QgisApp::setAppStyleSheet( const QString &stylesheet )
 {
-  // avoid crash on stylesheet change -- see https://bugreports.qt.io/browse/QTBUG-69204
-  static bool sOnce = false;
-  if ( sOnce )
-    return;
-  sOnce = true;
-
   setStyleSheet( stylesheet );
 
   // cascade styles to any current layout designers

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -491,7 +491,7 @@ void QgisAppInterface::buildStyleSheet( const QMap<QString, QVariant> &opts )
     newOpts.remove( QStringLiteral( "fontFamily" ) );
   }
 
-  qgis->styleSheetBuilder()->buildStyleSheet( newOpts );
+  qgis->styleSheetBuilder()->applyStyleSheet( newOpts );
 }
 
 void QgisAppInterface::saveStyleSheetOptions( const QMap<QString, QVariant> &opts )

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -465,16 +465,51 @@ void QgisAppInterface::showProjectPropertiesDialog( const QString &currentPage )
 
 QMap<QString, QVariant> QgisAppInterface::defaultStyleSheetOptions()
 {
-  return qgis->styleSheetBuilder()->defaultOptions();
+  QMap<QString, QVariant> res = qgis->styleSheetBuilder()->defaultOptions();
+
+  // for compatibility with older code, re-add the fontPointSize and fontFamily values which are
+  // no longer handled by the styleSheetBuilder method.
+  res.insert( QStringLiteral( "fontPointSize" ), qgis->styleSheetBuilder()->fontSize() );
+  res.insert( QStringLiteral( "fontFamily" ), qgis->styleSheetBuilder()->fontFamily() );
+
+  return res;
 }
 
 void QgisAppInterface::buildStyleSheet( const QMap<QString, QVariant> &opts )
 {
-  qgis->styleSheetBuilder()->buildStyleSheet( opts );
+  // remove unwanted fontPointSize / fontFamily keys, which may be present from older code
+  QMap< QString, QVariant> newOpts = opts;
+  if ( newOpts.contains( QStringLiteral( "fontPointSize" ) ) && (
+         newOpts.value( QStringLiteral( "fontPointSize" ) ).toDouble() == qgis->styleSheetBuilder()->defaultFont().pointSizeF()
+         || newOpts.value( QStringLiteral( "fontPointSize" ) ).toString() == QString::number( qgis->styleSheetBuilder()->defaultFont().pointSizeF() ) ) )
+  {
+    newOpts.remove( QStringLiteral( "fontPointSize" ) );
+  }
+  if ( newOpts.contains( QStringLiteral( "fontFamily" ) ) &&
+       newOpts.value( QStringLiteral( "fontFamily" ) ).toString() == qgis->styleSheetBuilder()->defaultFont().family() )
+  {
+    newOpts.remove( QStringLiteral( "fontFamily" ) );
+  }
+
+  qgis->styleSheetBuilder()->buildStyleSheet( newOpts );
 }
 
 void QgisAppInterface::saveStyleSheetOptions( const QMap<QString, QVariant> &opts )
 {
+  // remove unwanted fontPointSize / fontFamily keys, which may be present from older code
+  QMap< QString, QVariant> newOpts = opts;
+  if ( newOpts.contains( QStringLiteral( "fontPointSize" ) ) && (
+         newOpts.value( QStringLiteral( "fontPointSize" ) ).toDouble() == qgis->styleSheetBuilder()->defaultFont().pointSizeF()
+         || newOpts.value( QStringLiteral( "fontPointSize" ) ).toString() == QString::number( qgis->styleSheetBuilder()->defaultFont().pointSizeF() ) ) )
+  {
+    newOpts.remove( QStringLiteral( "fontPointSize" ) );
+  }
+  if ( newOpts.contains( QStringLiteral( "fontFamily" ) ) &&
+       newOpts.value( QStringLiteral( "fontFamily" ) ).toString() == qgis->styleSheetBuilder()->defaultFont().family() )
+  {
+    newOpts.remove( QStringLiteral( "fontFamily" ) );
+  }
+
   qgis->styleSheetBuilder()->saveToSettings( opts );
 }
 

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -185,13 +185,13 @@ void QgisAppStyleSheet::setUserFontSize( double size )
   QgsSettings settings;
   if ( size == mDefaultFont.pointSizeF() || size < 0 )
   {
-    settings.remove( QStringLiteral( "/qgis/stylesheet/fontPointSize" ) );
+    settings.remove( QStringLiteral( "/app/fontPointSize" ) );
     mUserFontSize = -1;
   }
   else
   {
     mUserFontSize = size;
-    settings.setValue( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), mUserFontSize );
+    settings.setValue( QStringLiteral( "/app/fontPointSize" ), mUserFontSize );
   }
 }
 
@@ -200,13 +200,13 @@ void QgisAppStyleSheet::setUserFontFamily( const QString &family )
   QgsSettings settings;
   if ( family == mDefaultFont.family() || family.isEmpty() )
   {
-    settings.remove( QStringLiteral( "/qgis/stylesheet/fontFamily" ) );
+    settings.remove( QStringLiteral( "/app/fontFamily" ) );
     mUserFontFamily.clear();
   }
   else
   {
     mUserFontFamily = family;
-    settings.setValue( QStringLiteral( "/qgis/stylesheet/fontFamily" ), mUserFontFamily );
+    settings.setValue( QStringLiteral( "/app/fontFamily" ), mUserFontFamily );
   }
 }
 
@@ -244,7 +244,7 @@ void QgisAppStyleSheet::setActiveValues()
   }
   else
   {
-    const double fontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), mDefaultFont.pointSizeF() ).toDouble();
+    const double fontSize = settings.value( QStringLiteral( "/app/fontPointSize" ), mDefaultFont.pointSizeF() ).toDouble();
     if ( fontSize != mDefaultFont.pointSizeF() )
     {
       mUserFontSize = fontSize;
@@ -255,7 +255,7 @@ void QgisAppStyleSheet::setActiveValues()
     }
   }
 
-  QString fontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), mDefaultFont.family() ).toString();
+  QString fontFamily = settings.value( QStringLiteral( "/app/fontFamily" ), mDefaultFont.family() ).toString();
   // make sure family exists on system
   if ( fontFamily != mDefaultFont.family() )
   {

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -42,26 +42,6 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
   // constructor to set reasonable non-Qt defaults for the app stylesheet
   QgsSettings settings;
 
-  // TODO: find a better default fontsize maybe using DPI detection or so (from Marco Bernasocchi commit)
-  const double defaultFontSize = mAndroidOS ? 8 : mDefaultFont.pointSizeF();
-  const double fontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), defaultFontSize ).toDouble();
-  QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( fontSize ), 2 );
-  opts.insert( QStringLiteral( "fontPointSize" ), fontSize );
-
-  QString fontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), mDefaultFont.family() ).toString();
-  // make sure family exists on system
-  if ( fontFamily != mDefaultFont.family() )
-  {
-    const QFont tempFont( fontFamily );
-    if ( tempFont.family() != fontFamily )
-    {
-      // missing from system, drop back to default
-      fontFamily = mDefaultFont.family();
-    }
-  }
-  QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ), 2 );
-  opts.insert( QStringLiteral( "fontFamily" ), QVariant( fontFamily ) );
-
   opts.insert( QStringLiteral( "toolbarSpacing" ), settings.value( QStringLiteral( "/qgis/stylesheet/toolbarSpacing" ), QString() ) );
 
   opts.insert( QStringLiteral( "iconSize" ), settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ) );
@@ -76,25 +56,37 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
 
   // QgisApp-wide font
   {
-    bool fontSizeOk = false;
-    const double fontSize = opts.value( QStringLiteral( "fontPointSize" ) ).toDouble( &fontSizeOk );
-    QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( fontSize ), 2 );
-    if ( !fontSizeOk )
+    bool overriddenFontSize = false;
+    double currentFontSize = fontSize();
+    if ( opts.contains( QStringLiteral( "fontPointSize" ) ) )
     {
-      return;
+      const double fontSizeFromOpts = opts.value( QStringLiteral( "fontPointSize" ) ).toDouble();
+      currentFontSize = fontSizeFromOpts;
+    }
+    QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( currentFontSize ), 2 );
+    if ( currentFontSize != defaultFont().pointSizeF() )
+    {
+      overriddenFontSize = true;
     }
 
-    const QString fontFamily = opts.value( QStringLiteral( "fontFamily" ) ).toString();
-    QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ), 2 );
-    if ( fontFamily.isEmpty() )
+    bool overriddenFontFamily = false;
+    QString currentFontFamily = fontFamily();
+    if ( opts.contains( QStringLiteral( "fontFamily" ) ) )
     {
-      return;
+      currentFontFamily = opts.value( QStringLiteral( "fontFamily" ) ).toString();
+    }
+    QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( currentFontFamily ), 2 );
+    if ( !currentFontFamily.isEmpty() && currentFontFamily != defaultFont().family() )
+    {
+      overriddenFontFamily = true;
     }
 
-    const double defaultSize = mDefaultFont.pointSizeF();
-    const QString defaultFamily = mDefaultFont.family();
-    if ( fontSize != defaultSize || fontFamily != defaultFamily )
-      ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( fontSize ).arg( fontFamily );
+    if ( overriddenFontFamily && overriddenFontSize )
+      ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( currentFontSize ).arg( currentFontFamily );
+    else if ( overriddenFontFamily )
+      ss += QStringLiteral( "* { font-family: \"%1\"} " ).arg( currentFontFamily );
+    else if ( overriddenFontSize )
+      ss += QStringLiteral( "* { font-size: %1pt } " ).arg( overriddenFontSize );
   }
 
   if ( mMacStyle )
@@ -203,6 +195,38 @@ void QgisAppStyleSheet::setActiveValues()
   mOxyStyle = mStyle.contains( QLatin1String( "oxygen" ) ); // oxygen
 
   mDefaultFont = qApp->font(); // save before it is changed in any way
+
+  QgsSettings settings;
+
+  if ( mAndroidOS )
+  {
+    // TODO: find a better default fontsize maybe using DPI detection or so (from Marco Bernasocchi commit)
+    mUserFontSize = 8;
+  }
+  else
+  {
+    const double fontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), mDefaultFont.pointSizeF() ).toDouble();
+    if ( fontSize != mDefaultFont.pointSizeF() )
+    {
+      mUserFontSize = fontSize;
+    }
+    else
+    {
+      mUserFontSize = -1;
+    }
+  }
+
+  QString fontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), mDefaultFont.family() ).toString();
+  // make sure family exists on system
+  if ( fontFamily != mDefaultFont.family() )
+  {
+    const QFont tempFont( fontFamily );
+    if ( tempFont.family() == fontFamily )
+    {
+      // font exists on system
+      mUserFontFamily = fontFamily;
+    }
+  }
 
   // platforms, specific
 #ifdef Q_OS_WIN

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -58,13 +58,14 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
   {
     bool overriddenFontSize = false;
     double currentFontSize = fontSize();
+    const QFont appFont = QApplication::font();
     if ( opts.contains( QStringLiteral( "fontPointSize" ) ) )
     {
       const double fontSizeFromOpts = opts.value( QStringLiteral( "fontPointSize" ) ).toDouble();
       currentFontSize = fontSizeFromOpts;
     }
     QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( currentFontSize ), 2 );
-    if ( currentFontSize != defaultFont().pointSizeF() )
+    if ( currentFontSize != appFont.pointSizeF() )
     {
       overriddenFontSize = true;
     }
@@ -76,17 +77,20 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
       currentFontFamily = opts.value( QStringLiteral( "fontFamily" ) ).toString();
     }
     QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( currentFontFamily ), 2 );
-    if ( !currentFontFamily.isEmpty() && currentFontFamily != defaultFont().family() )
+    if ( !currentFontFamily.isEmpty() && currentFontFamily != appFont.family() )
     {
       overriddenFontFamily = true;
     }
 
-    if ( overriddenFontFamily && overriddenFontSize )
-      ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( currentFontSize ).arg( currentFontFamily );
-    else if ( overriddenFontFamily )
-      ss += QStringLiteral( "* { font-family: \"%1\"} " ).arg( currentFontFamily );
-    else if ( overriddenFontSize )
-      ss += QStringLiteral( "* { font-size: %1pt } " ).arg( currentFontSize );
+    if ( overriddenFontFamily || overriddenFontSize )
+    {
+      QFont font = QApplication::font();
+      if ( overriddenFontFamily )
+        font.setFamily( currentFontFamily );
+      if ( overriddenFontSize )
+        font.setPointSizeF( currentFontSize );
+      QApplication::setFont( font );
+    }
   }
 
   if ( mMacStyle )

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -86,7 +86,7 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
     else if ( overriddenFontFamily )
       ss += QStringLiteral( "* { font-family: \"%1\"} " ).arg( currentFontFamily );
     else if ( overriddenFontSize )
-      ss += QStringLiteral( "* { font-size: %1pt } " ).arg( overriddenFontSize );
+      ss += QStringLiteral( "* { font-size: %1pt } " ).arg( currentFontSize );
   }
 
   if ( mMacStyle )
@@ -169,6 +169,41 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
   QgsDebugMsgLevel( QStringLiteral( "Stylesheet built: %1" ).arg( ss ), 2 );
 
   emit appStyleSheetChanged( ss );
+}
+
+void QgisAppStyleSheet::updateStyleSheet()
+{
+  applyStyleSheet( defaultOptions() );
+}
+
+void QgisAppStyleSheet::setUserFontSize( double size )
+{
+  QgsSettings settings;
+  if ( size == mDefaultFont.pointSizeF() || size < 0 )
+  {
+    settings.remove( QStringLiteral( "/qgis/stylesheet/fontPointSize" ) );
+    mUserFontSize = -1;
+  }
+  else
+  {
+    mUserFontSize = size;
+    settings.setValue( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), mUserFontSize );
+  }
+}
+
+void QgisAppStyleSheet::setUserFontFamily( const QString &family )
+{
+  QgsSettings settings;
+  if ( family == mDefaultFont.family() || family.isEmpty() )
+  {
+    settings.remove( QStringLiteral( "/qgis/stylesheet/fontFamily" ) );
+    mUserFontFamily.clear();
+  }
+  else
+  {
+    mUserFontFamily = family;
+    settings.setValue( QStringLiteral( "/qgis/stylesheet/fontFamily" ), mUserFontFamily );
+  }
 }
 
 void QgisAppStyleSheet::saveToSettings( const QMap<QString, QVariant> &opts )

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -49,7 +49,7 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
   return opts;
 }
 
-void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
+void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
 {
   const QgsSettings settings;
   QString ss;

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -50,6 +50,28 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
     //! Gets reference font for initial qApp
     QFont defaultFont() { return mDefaultFont; }
 
+    /**
+     * Returns the user set font size override value, or -1 if not set and the Qt default font size should be used.
+     */
+    double userFontSize() const { return mUserFontSize; }
+
+    /**
+     * Returns the user set font family override value, or an empty if not set and the Qt default font family should be used.
+     */
+    QString userFontFamily() const { return mUserFontFamily; }
+
+    /**
+     * Returns the application font size to use. This will match userFontSize() if the user
+     * has set a custom font size, or the defaultFont() font size otherwise.
+     */
+    double fontSize() const { return mUserFontSize > 0 ? mUserFontSize : mDefaultFont.pointSizeF(); }
+
+    /**
+     * Returns the application font family. This will match userFontFamily() if the user
+     * has set a custom font, or the defaultFont() family otherwise.
+     */
+    QString fontFamily() const { return !mUserFontFamily.isEmpty() ? mUserFontFamily : mDefaultFont.family(); }
+
   signals:
 
     /**
@@ -69,6 +91,9 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
 
     // default font saved for reference
     QFont mDefaultFont;
+
+    double mUserFontSize = -1;
+    QString mUserFontFamily;
 
     // platforms, specific
     bool mWinOS = false;

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -38,11 +38,12 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
     QMap<QString, QVariant> defaultOptions();
 
     /**
-     * Generate stylesheet
+     * Build and apply a stylesheet.
+     *
      * \param opts generated default option values, or a changed copy of them
      * \note on success emits appStyleSheetChanged
      */
-    void buildStyleSheet( const QMap<QString, QVariant> &opts );
+    void applyStyleSheet( const QMap<QString, QVariant> &opts );
 
     //! Save changed default option keys/values to user settings
     void saveToSettings( const QMap<QString, QVariant> &opts );

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -45,6 +45,21 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
      */
     void applyStyleSheet( const QMap<QString, QVariant> &opts );
 
+    /**
+     * Applies an updated stylesheet using current user settings.
+     */
+    void updateStyleSheet();
+
+    /**
+     * Sets a new user font \a size. Set to -1 to force the default Qt font size to be used.
+     */
+    void setUserFontSize( double size );
+
+    /**
+     * Sets a new user font \a family. Set to an empty string to force the default Qt font family to be used.
+     */
+    void setUserFontFamily( const QString &family );
+
     //! Save changed default option keys/values to user settings
     void saveToSettings( const QMap<QString, QVariant> &opts );
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -423,8 +423,8 @@ QString QgsMapTip::htmlText( const QString &text, int maxWidth )
 
   const QgsSettings settings;
   const QFont defaultFont = qApp->font();
-  const int fontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), defaultFont.pointSize() ).toInt();
-  const QString fontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), defaultFont.family() ).toString();
+  const int fontSize = defaultFont.pointSize();
+  const QString fontFamily = defaultFont.family();
   const QString backgroundColor = QgsApplication::palette().base().color().name();
   const QString strokeColor = QgsApplication::palette().shadow().color().name();
   const QString textColor = QgsApplication::palette().toolTipText().color().name();

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -147,10 +147,6 @@ void QgsAmsLegendFetcher::handleFinished()
 
     QgsSettings settings;
     QFont font = qApp->font();
-    int fontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), font.pointSize() ).toInt();
-    font.setPointSize( fontSize );
-    QString fontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), font.family() ).toString();
-    font.setFamily( fontFamily );
     QFontMetrics fm( font );
     int textWidth = 0;
     int textHeight = fm.ascent();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -122,7 +122,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>7</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -370,7 +370,7 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_27">
+                   <layout class="QHBoxLayout" name="horizontalLayout_27" stretch="0,0,0,4,0,1">
                     <item>
                      <widget class="QLabel" name="label_43">
                       <property name="text">
@@ -424,15 +424,12 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QgsSpinBox" name="spinFontSize">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
+                     <widget class="QgsDoubleSpinBox" name="spinFontSize">
+                      <property name="decimals">
+                       <number>1</number>
                       </property>
                       <property name="minimum">
-                       <number>4</number>
+                       <double>2.000000000000000</double>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
Cleans up the API around user overrides of font family and size, and uses the correct Qt approach to setting application font to help fix sizing issues on hi-dpi displays