### PR TITLE
Add a simple cache for read tile data from vtpk data sources

### DIFF
--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -19,6 +19,10 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsdataprovider.h"
+#include "qgstiles.h"
+
+#include <QCache>
+#include <QReadWriteLock>
 
 class QgsTileMatrixSet;
 class QgsTileXYZ;
@@ -26,6 +30,20 @@ class QgsVectorTileRawData;
 class QgsVectorTileMatrixSet;
 
 #define SIP_NO_FILE
+
+class QgsVectorTileDataProviderSharedData
+{
+  public:
+    QgsVectorTileDataProviderSharedData();
+
+    bool getCachedTileData( QgsVectorTileRawData &data, QgsTileXYZ );
+    void storeCachedTileData( const QgsVectorTileRawData &data );
+
+    QCache< QgsTileXYZ, QgsVectorTileRawData > mTileCache;
+
+    QReadWriteLock mMutex; //!< Access to all data members is guarded by the mutex
+
+};
 
 /**
  * Base class for vector tile layer data providers.
@@ -148,6 +166,11 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
      * into a subset of the GUI properties "Metadata" tab.
      */
     virtual QString htmlMetadata() const;
+
+  protected:
+
+    std::shared_ptr<QgsVectorTileDataProviderSharedData> mShared;  //!< Mutable data shared between provider instances
+
 };
 
 

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -31,12 +31,29 @@ class QgsVectorTileMatrixSet;
 
 #define SIP_NO_FILE
 
+/**
+ * Shared data class for vector tile layer data providers.
+ *
+ * \note Not available in Python bindings
+ *
+ * \ingroup core
+ * \since QGIS 3.32
+ */
 class QgsVectorTileDataProviderSharedData
 {
   public:
     QgsVectorTileDataProviderSharedData();
 
-    bool getCachedTileData( QgsVectorTileRawData &data, QgsTileXYZ );
+    /**
+     * Retrieves previously cached raw tile data for a tile with matching \a id.
+     *
+     * Returns TRUE if tile data was already cached and could be retrieved.
+     */
+    bool getCachedTileData( QgsVectorTileRawData &data, QgsTileXYZ id );
+
+    /**
+     * Stores raw tile data in the shared cache.
+     */
     void storeCachedTileData( const QgsVectorTileRawData &data );
 
     QCache< QgsTileXYZ, QgsVectorTileRawData > mTileCache;


### PR DESCRIPTION
The process of reading raw tile data from a vtpk comes with some cost due to the necessary unzipping of files from the vtpk archive. We can cut out this cost for previously retrieved tiles through a simple tile -> raw data cache.

The guts of the caching sits in the generic vector tile data provider class so it could be potentially used by other vector tile sources, but profiling reveals that there's not a significant cost associated with retrieving raw tile data for our other existing VT providers.
