### PR TITLE
Fix vtpk missing tiles

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvtpktiles.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvtpktiles.sip.in
@@ -94,6 +94,11 @@ Returns bounding box from metadata, given in the tiles :py:func:`~QgsVtpkTiles.c
     QByteArray tileData( int z, int x, int y );
 %Docstring
 Returns the raw tile data for the matching tile.
+
+Returns a null byte array if the requested tile does not exist.
+
+Will return an empty byte array (as opposed to a null byte array) if the tile
+exists but has a zero size.
 %End
 
   private:

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -150,7 +150,7 @@ const QgsVectorTileMatrixSet &QgsMbTilesVectorTileDataProvider::tileMatrixSet() 
   return mMatrixSet;
 }
 
-QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QgsVectorTileRawData QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -159,7 +159,7 @@ QByteArray QgsMbTilesVectorTileDataProvider::readTile( const QgsTileMatrixSet &,
 
   QgsMbTiles mbReader( dsUri.param( QStringLiteral( "url" ) ) );
   mbReader.open();
-  return loadFromMBTiles( mbReader, id, feedback );
+  return QgsVectorTileRawData( id, loadFromMBTiles( mbReader, id, feedback ) );
 }
 
 QList<QgsVectorTileRawData> QgsMbTilesVectorTileDataProvider::readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataPro
     QgsRectangle extent() const override;
     QgsCoordinateReferenceSystem crs() const override;
     const QgsVectorTileMatrixSet &tileMatrixSet() const override;
-    QByteArray readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QgsVectorTileRawData readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
 
     static QString MB_TILES_VECTOR_TILE_DATA_PROVIDER_KEY;

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -98,7 +98,7 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
     /**
      * Returns raw tile data for a single tile.
      */
-    virtual QByteArray readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const = 0;
+    virtual QgsVectorTileRawData readTile( const QgsTileMatrixSet &tileMatrixSet, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Returns raw tile data for a range of tiles.

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -20,6 +20,7 @@
 #include "qgsvectortilebasiclabeling.h"
 #include "qgsvectortilebasicrenderer.h"
 #include "qgsvectortilelabeling.h"
+#include "qgsvectortileloader.h"
 #include "qgsvectortileutils.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsdatasourceuri.h"
@@ -577,13 +578,13 @@ QString QgsVectorTileLayer::sourcePath() const
   return QString();
 }
 
-QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
+QgsVectorTileRawData QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   QgsVectorTileDataProvider *vtProvider = qobject_cast< QgsVectorTileDataProvider * >( mDataProvider.get() );
   if ( !vtProvider )
-    return QByteArray();
+    return QgsVectorTileRawData();
 
   return vtProvider->readTile( mMatrixSet, tileID );
 }
@@ -726,8 +727,8 @@ void QgsVectorTileLayer::selectByGeometry( const QgsGeometry &geometry, const Qg
 
       for ( const QgsTileXYZ &tileID : tiles )
       {
-        QByteArray data = getRawTile( tileID );
-        if ( data.isEmpty() )
+        const QgsVectorTileRawData data = getRawTile( tileID );
+        if ( data.data.isEmpty() )
           continue;  // failed to get data
 
         QgsVectorTileMVTDecoder decoder( tileMatrixSet() );

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -732,7 +732,7 @@ void QgsVectorTileLayer::selectByGeometry( const QgsGeometry &geometry, const Qg
           continue;  // failed to get data
 
         QgsVectorTileMVTDecoder decoder( tileMatrixSet() );
-        if ( !decoder.decode( tileID, data ) )
+        if ( !decoder.decode( data ) )
           continue;  // failed to decode
 
         QMap<QString, QgsFields> perLayerFields;

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -27,6 +27,7 @@ class QgsVectorTileLabeling;
 class QgsFeature;
 class QgsGeometry;
 class QgsSelectionContext;
+class QgsVectorTileRawData;
 
 /**
  * \ingroup core
@@ -197,7 +198,7 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
      * \note This call may issue a network request (depending on the source type) and will block
      * the caller until the request is finished.
      */
-    QByteArray getRawTile( QgsTileXYZ tileID ) SIP_SKIP;
+    QgsVectorTileRawData getRawTile( QgsTileXYZ tileID ) SIP_SKIP;
 
     /**
      * Sets renderer for the map layer.

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -218,7 +218,7 @@ void QgsVectorTileLayerRenderer::decodeAndDrawTile( const QgsVectorTileRawData &
 
   // currently only MVT encoding supported
   QgsVectorTileMVTDecoder decoder( mTileMatrixSet );
-  if ( !decoder.decode( rawTile.id, rawTile.data ) )
+  if ( !decoder.decode( rawTile ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "Failed to parse raw tile data! " ) + rawTile.id.toString(), 2 );
     return;

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -39,10 +39,21 @@ class QgsVectorTileRawData
   public:
     //! Constructs a raw tile object
     QgsVectorTileRawData( QgsTileXYZ tileID = QgsTileXYZ(), const QByteArray &raw = QByteArray() )
-      : id( tileID ), data( raw ) {}
+      : id( tileID ), tileGeometryId( tileID ), data( raw ) {}
 
     //! Tile position in tile matrix set
     QgsTileXYZ id;
+
+    /**
+     * Tile id associated with the raw tile data.
+     *
+     * This may differ from the tile id in the situation where lower zoom level tiles have been used to replace
+     * missing higher zoom level tiles. In this case, the tileGeometryId should be used when decoding tiles
+     * to features in order to obtain correct geometry scaling and placement, while the actual tile id
+     * should be used when determining the region of the tile for clipping purposes.
+     */
+    QgsTileXYZ tileGeometryId;
+
     //! Raw tile data
     QByteArray data;
 };

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -42,7 +42,7 @@ bool QgsVectorTileMVTDecoder::decode( const QgsVectorTileRawData &rawTileData )
   if ( !tile.ParseFromArray( rawTileData.data.constData(), rawTileData.data.count() ) )
     return false;
 
-  mTileID = rawTileData.id;
+  mTileID = rawTileData.tileGeometryId;
 
   mLayerNameToIndex.clear();
   for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -15,9 +15,9 @@
 
 #include <string>
 
+#include "qgsvectortileloader.h"
 #include "qgsvectortilemvtdecoder.h"
 
-#include "qgsvectortilelayerrenderer.h"
 #include "qgsvectortilemvtutils.h"
 #include "qgsvectortileutils.h"
 
@@ -37,12 +37,12 @@ QgsVectorTileMVTDecoder::QgsVectorTileMVTDecoder( const QgsVectorTileMatrixSet &
 
 QgsVectorTileMVTDecoder::~QgsVectorTileMVTDecoder() = default;
 
-bool QgsVectorTileMVTDecoder::decode( QgsTileXYZ tileID, const QByteArray &rawTileData )
+bool QgsVectorTileMVTDecoder::decode( const QgsVectorTileRawData &rawTileData )
 {
-  if ( !tile.ParseFromArray( rawTileData.constData(), rawTileData.count() ) )
+  if ( !tile.ParseFromArray( rawTileData.data.constData(), rawTileData.data.count() ) )
     return false;
 
-  mTileID = tileID;
+  mTileID = rawTileData.id;
 
   mLayerNameToIndex.clear();
   for ( int layerNum = 0; layerNum < tile.layers_size(); layerNum++ )

--- a/src/core/vectortile/qgsvectortilemvtdecoder.h
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.h
@@ -28,6 +28,7 @@ class QgsFeature;
 #include "qgsvectortilerenderer.h"
 #include "qgsvectortilematrixset.h"
 
+class QgsVectorTileRawData;
 
 /**
  * \ingroup core
@@ -46,7 +47,7 @@ class CORE_EXPORT QgsVectorTileMVTDecoder
     ~QgsVectorTileMVTDecoder();
 
     //! Tries to decode raw tile data, returns true on success
-    bool decode( QgsTileXYZ tileID, const QByteArray &rawTileData );
+    bool decode( const QgsVectorTileRawData &rawTileData );
 
     //! Returns a list of sub-layer names in a tile. It can only be called after a successful decode()
     QStringList layers() const;

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -27,6 +27,7 @@
 #include "qgsrectangle.h"
 #include "qgsvectorlayer.h"
 
+#include "qgsvectortileloader.h"
 #include "qgsvectortilemvtdecoder.h"
 #include "qgsvectortilelayer.h"
 #include "qgsvectortilerenderer.h"
@@ -86,7 +87,8 @@ int QgsVectorTileUtils::scaleToZoomLevel( double mapScale, int sourceMinZoom, in
 QgsVectorLayer *QgsVectorTileUtils::makeVectorLayerForTile( QgsVectorTileLayer *mvt, QgsTileXYZ tileID, const QString &layerName )
 {
   QgsVectorTileMVTDecoder decoder( mvt->tileMatrixSet() );
-  decoder.decode( tileID, mvt->getRawTile( tileID ) );
+  const QgsVectorTileRawData rawTile = mvt->getRawTile( tileID );
+  decoder.decode( tileID, rawTile.data );
   QSet<QString> fieldNames = qgis::listToSet( decoder.layerFieldNames( layerName ) );
   fieldNames << QStringLiteral( "_geom_type" );
   QMap<QString, QgsFields> perLayerFields;

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -88,7 +88,7 @@ QgsVectorLayer *QgsVectorTileUtils::makeVectorLayerForTile( QgsVectorTileLayer *
 {
   QgsVectorTileMVTDecoder decoder( mvt->tileMatrixSet() );
   const QgsVectorTileRawData rawTile = mvt->getRawTile( tileID );
-  decoder.decode( tileID, rawTile.data );
+  decoder.decode( rawTile );
   QSet<QString> fieldNames = qgis::listToSet( decoder.layerFieldNames( layerName ) );
   fieldNames << QStringLiteral( "_geom_type" );
   QMap<QString, QgsFields> perLayerFields;

--- a/src/core/vectortile/qgsvtpktiles.cpp
+++ b/src/core/vectortile/qgsvtpktiles.cpp
@@ -473,7 +473,12 @@ QByteArray QgsVtpkTiles::tileData( int z, int x, int y )
       const std::size_t tileOffset = indexValue % ( 2ULL << 39 );
       const std::size_t tileSize = static_cast< std::size_t>( std::floor( indexValue / ( 2ULL << 39 ) ) );
       // bundle is a gzip file;
-      if ( tileSize > 0 && !QgsZipUtils::decodeGzip( buf.get() + tileOffset, tileSize, res ) )
+      if ( tileSize == 0 )
+      {
+        // construct a non-null bytearray
+        res = QByteArray( "" );
+      }
+      else if ( !QgsZipUtils::decodeGzip( buf.get() + tileOffset, tileSize, res ) )
       {
         QgsMessageLog::logMessage( QObject::tr( "Error extracting bundle contents as gzip: %1" ).arg( fileName ) );
       }

--- a/src/core/vectortile/qgsvtpktiles.cpp
+++ b/src/core/vectortile/qgsvtpktiles.cpp
@@ -457,7 +457,8 @@ QByteArray QgsVtpkTiles::tileData( int z, int x, int y )
   const size_t len = stat.size;
   if ( len <= tileIndexOffset )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Cannot read gzip contents at offset %1: %2" ).arg( tileIndexOffset ).arg( fileName ) );
+    // seems this should be treated as "no content" here, rather then a broken VTPK
+    res = QByteArray( "" );
   }
   else
   {

--- a/src/core/vectortile/qgsvtpktiles.h
+++ b/src/core/vectortile/qgsvtpktiles.h
@@ -107,6 +107,11 @@ class CORE_EXPORT QgsVtpkTiles
 
     /**
      * Returns the raw tile data for the matching tile.
+     *
+     * Returns a null byte array if the requested tile does not exist.
+     *
+     * Will return an empty byte array (as opposed to a null byte array) if the tile
+     * exists but has a zero size.
      */
     QByteArray tileData( int z, int x, int y );
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -230,6 +230,11 @@ QString QgsVtpkVectorTileDataProvider::htmlMetadata() const
   else
     metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "VTPK storage" ) % QStringLiteral( "</td><td>" ) % tr( "Flat VTPK (no tilemap)" ) % QStringLiteral( "</td></tr>\n" );
 
+  if ( reader.metadata().contains( QStringLiteral( "minLOD" ) ) )
+  {
+    metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Tile detail levels" ) % QStringLiteral( "</td><td>" ) % QStringLiteral( "%1 - %2" ).arg( reader.metadata().value( QStringLiteral( "minLOD" ) ).toInt() ).arg( reader.metadata().value( QStringLiteral( "maxLOD" ) ).toInt() ) % QStringLiteral( "</td></tr>\n" );
+  }
+
   return metadata;
 }
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -176,7 +176,7 @@ QImage QgsVtpkVectorTileDataProvider::spriteImage() const
   return mSpriteImage;
 }
 
-QByteArray QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QgsVectorTileRawData QgsVtpkVectorTileDataProvider::readTile( const QgsTileMatrixSet &, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -204,10 +204,10 @@ QList<QgsVectorTileRawData> QgsVtpkVectorTileDataProvider::readTiles( const QgsT
     if ( feedback && feedback->isCanceled() )
       break;
 
-    const QByteArray rawData = loadFromVtpk( reader, id, feedback );
-    if ( !rawData.isEmpty() )
+    const QgsVectorTileRawData rawData = loadFromVtpk( reader, id, feedback );
+    if ( !rawData.data.isEmpty() )
     {
-      rawTiles.append( QgsVectorTileRawData( id, rawData ) );
+      rawTiles.append( rawData );
     }
   }
   return rawTiles;
@@ -230,7 +230,7 @@ QString QgsVtpkVectorTileDataProvider::htmlMetadata() const
   return metadata;
 }
 
-QByteArray QgsVtpkVectorTileDataProvider::loadFromVtpk( QgsVtpkTiles &vtpkTileReader, const QgsTileXYZ &id, QgsFeedback * )
+QgsVectorTileRawData QgsVtpkVectorTileDataProvider::loadFromVtpk( QgsVtpkTiles &vtpkTileReader, const QgsTileXYZ &id, QgsFeedback * )
 {
   const QByteArray tileData = vtpkTileReader.tileData( id.zoomLevel(), id.column(), id.row() );
   if ( tileData.isEmpty() )
@@ -241,7 +241,12 @@ QByteArray QgsVtpkVectorTileDataProvider::loadFromVtpk( QgsVtpkTiles &vtpkTileRe
 
     return QByteArray();
   }
-  return tileData;
+
+  if ( tileData.isEmpty() )
+    return QgsVectorTileRawData();
+
+  QgsVectorTileRawData res( id, tileData );
+  return res;
 }
 
 

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvid
     QVariantMap styleDefinition() const override;
     QVariantMap spriteDefinition() const override;
     QImage spriteImage() const override;
-    QByteArray readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QgsVectorTileRawData readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
     QString htmlMetadata() const override;
 
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvid
   private:
 
     //! Returns raw tile data for a single tile loaded from VTPK file
-    static QByteArray loadFromVtpk( QgsVtpkTiles &vtpkTileReader, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr );
+    static QgsVectorTileRawData loadFromVtpk( QgsVtpkTiles &vtpkTileReader, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr );
     bool mIsValid = false;
     QgsCoordinateReferenceSystem mCrs;
     QgsRectangle mExtent;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -57,9 +57,9 @@ bool QgsXyzVectorTileDataProviderBase::supportsAsync() const
   return true;
 }
 
-QByteArray QgsXyzVectorTileDataProviderBase::readTile( const QgsTileMatrixSet &set, const QgsTileXYZ &id, QgsFeedback *feedback ) const
+QgsVectorTileRawData QgsXyzVectorTileDataProviderBase::readTile( const QgsTileMatrixSet &set, const QgsTileXYZ &id, QgsFeedback *feedback ) const
 {
-  return loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), sourcePath(), mAuthCfg, mHeaders, feedback );
+  return QgsVectorTileRawData( id, loadFromNetwork( id, set.tileMatrix( id.zoomLevel() ), sourcePath(), mAuthCfg, mHeaders, feedback ) );
 }
 
 QList<QgsVectorTileRawData> QgsXyzVectorTileDataProviderBase::readTiles( const QgsTileMatrixSet &set, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback ) const

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.h
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsXyzVectorTileDataProviderBase : public QgsVectorTileDataPro
     QgsXyzVectorTileDataProviderBase &operator=( const QgsXyzVectorTileDataProviderBase &other ) = delete;
 
     bool supportsAsync() const override;
-    QByteArray readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
+    QgsVectorTileRawData readTile( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsVectorTileRawData> readTiles( const QgsTileMatrixSet &, const QVector<QgsTileXYZ> &tiles, QgsFeedback *feedback = nullptr ) const override;
     QNetworkRequest tileRequest( const QgsTileMatrixSet &tileMatrix, const QgsTileXYZ &id, Qgis::RendererUsage usage ) const override;
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -443,7 +443,14 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
       }
     }
 
-    const int tileZoom = layer->tileMatrixSet().scaleToZoomLevel( mCanvas->scale() );
+    const double tileScale = layer->tileMatrixSet().calculateTileScaleForMap(
+                               mCanvas->scale(),
+                               mCanvas->mapSettings().destinationCrs(),
+                               mCanvas->mapSettings().extent(),
+                               mCanvas->size(),
+                               mCanvas->logicalDpiX() );
+
+    const int tileZoom = layer->tileMatrixSet().scaleToZoomLevel( tileScale );
     const QgsTileMatrix tileMatrix = layer->tileMatrixSet().tileMatrix( tileZoom );
     const QgsTileRange tileRange = tileMatrix.tileRangeFromExtent( r );
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -35,6 +35,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayertemporalproperties.h"
 #include "qgsvectortilelayer.h"
+#include "qgsvectortileloader.h"
 #include "qgsvectortilemvtdecoder.h"
 #include "qgsvectortileutils.h"
 #include "qgsproject.h"
@@ -450,8 +451,8 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
 
     for ( const QgsTileXYZ &tileID : tiles )
     {
-      QByteArray data = layer->getRawTile( tileID );
-      if ( data.isEmpty() )
+      const QgsVectorTileRawData data = layer->getRawTile( tileID );
+      if ( data.data.isEmpty() )
         continue;  // failed to get data
 
       QgsVectorTileMVTDecoder decoder( layer->tileMatrixSet() );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -456,7 +456,7 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
         continue;  // failed to get data
 
       QgsVectorTileMVTDecoder decoder( layer->tileMatrixSet() );
-      if ( !decoder.decode( tileID, data ) )
+      if ( !decoder.decode( data ) )
         continue;  // failed to decode
 
       QMap<QString, QgsFields> perLayerFields;

--- a/tests/src/core/testqgsvectortilelayer.cpp
+++ b/tests/src/core/testqgsvectortilelayer.cpp
@@ -36,6 +36,7 @@
 #include "qgsproviderregistry.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsproviderutils.h"
+#include "qgsvectortileloader.h"
 
 /**
  * \ingroup UnitTests
@@ -129,11 +130,11 @@ void TestQgsVectorTileLayer::cleanupTestCase()
 void TestQgsVectorTileLayer::test_basic()
 {
   // tile fetch test
-  const QByteArray tile0rawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
-  QCOMPARE( tile0rawData.length(), 64822 );
+  const QgsVectorTileRawData tile0rawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  QCOMPARE( tile0rawData.data.length(), 64822 );
 
-  const QByteArray invalidTileRawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 99 ) );
-  QCOMPARE( invalidTileRawData.length(), 0 );
+  const QgsVectorTileRawData invalidTileRawData = mLayer->getRawTile( QgsTileXYZ( 0, 0, 99 ) );
+  QCOMPARE( invalidTileRawData.data.length(), 0 );
 
   // an xyz vector tile layer should be considered as a basemap layer
   QCOMPARE( mLayer->properties(), Qgis::MapLayerProperties( Qgis::MapLayerProperty::IsBasemapLayer ) );

--- a/tests/src/core/testqgsvectortilewriter.cpp
+++ b/tests/src/core/testqgsvectortilewriter.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgstiles.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectortileloader.h"
 #include "qgsvectortilemvtdecoder.h"
 #include "qgsvectortilelayer.h"
 #include "qgsvectortilewriter.h"
@@ -114,9 +115,9 @@ void TestQgsVectorTileWriter::test_basic()
 
   QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
 
-  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -183,9 +184,9 @@ void TestQgsVectorTileWriter::test_mbtiles()
 
   QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
 
-  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -299,9 +300,9 @@ void TestQgsVectorTileWriter::test_filtering()
 
   QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
 
-  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "b52" << "lines" );
@@ -362,9 +363,9 @@ void TestQgsVectorTileWriter::test_z0TileMatrix3857()
 
   QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
 
-  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -448,9 +449,9 @@ void TestQgsVectorTileWriter::test_z0TileMatrix2154()
 
   QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
 
-  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );

--- a/tests/src/core/testqgsvectortilewriter.cpp
+++ b/tests/src/core/testqgsvectortilewriter.cpp
@@ -117,7 +117,7 @@ void TestQgsVectorTileWriter::test_basic()
 
   const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
+  const bool resDecode0 = decoder.decode( tile0 );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -186,7 +186,7 @@ void TestQgsVectorTileWriter::test_mbtiles()
 
   const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
+  const bool resDecode0 = decoder.decode( tile0 );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -302,7 +302,7 @@ void TestQgsVectorTileWriter::test_filtering()
 
   const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
+  const bool resDecode0 = decoder.decode( tile0 );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "b52" << "lines" );
@@ -365,7 +365,7 @@ void TestQgsVectorTileWriter::test_z0TileMatrix3857()
 
   const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
+  const bool resDecode0 = decoder.decode( tile0 );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
@@ -451,7 +451,7 @@ void TestQgsVectorTileWriter::test_z0TileMatrix2154()
 
   const QgsVectorTileRawData tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
   QgsVectorTileMVTDecoder decoder( QgsVectorTileMatrixSet::fromWebMercator() );
-  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0.data );
+  const bool resDecode0 = decoder.decode( tile0 );
   QVERIFY( resDecode0 );
   const QStringList layerNames = decoder.layers();
   QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );


### PR DESCRIPTION
It seems that every VTPK behaves a bit like an indexed VTPK where higher zoom level tiles may be replaced with lower
zoom level tiles. This new special handling is required for non-indexed VTPKs where the high zoom level tile data
is empty, but there's not explicit tilemap present to advise of us this situation in advance.

Fixes https://github.com/qgis/QGIS/issues/52872