### PR TITLE
Setup framework for data provider's to provide information about elevation related properties to their layers

### DIFF
--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -165,6 +165,16 @@ This may be ``None``, depending on the data provider.
 %End
 
 
+    virtual QgsDataProviderElevationProperties *elevationProperties();
+%Docstring
+Returns the provider's elevation properties.
+
+This may be ``None``, depending on the data provider.
+
+.. versionadded:: 3.32
+%End
+
+
     virtual QgsRectangle extent() const = 0;
 %Docstring
 Returns the extent of the layer

--- a/python/core/auto_generated/qgsdataproviderelevationproperties.sip.in
+++ b/python/core/auto_generated/qgsdataproviderelevationproperties.sip.in
@@ -1,0 +1,50 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsdataproviderelevationproperties.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsDataProviderElevationProperties
+{
+%Docstring(signature="appended")
+Base class for handling elevation related properties for a data provider.
+
+.. versionadded:: 3.32
+%End
+
+%TypeHeaderCode
+#include "qgsdataproviderelevationproperties.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsRasterDataProviderElevationProperties *>( sipCpp ) )
+    {
+      sipType = sipType_QgsRasterDataProviderElevationProperties;
+    }
+    else
+    {
+      sipType = 0;
+    }
+%End
+  public:
+
+    QgsDataProviderElevationProperties();
+%Docstring
+Constructor for QgsDataProviderElevationProperties.
+%End
+
+    virtual ~QgsDataProviderElevationProperties();
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsdataproviderelevationproperties.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -213,6 +213,8 @@ their own layers, such as WMS
 
     virtual QgsRasterDataProviderTemporalCapabilities *temporalCapabilities();
 
+    virtual QgsRasterDataProviderElevationProperties *elevationProperties();
+
 
     virtual bool supportsLegendGraphic() const;
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterdataproviderelevationproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataproviderelevationproperties.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/raster/qgsrasterdataproviderelevationproperties.h           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsRasterDataProviderElevationProperties : QgsDataProviderElevationProperties
+{
+%Docstring(signature="appended")
+Handles elevation related properties for a raster data provider.
+
+.. versionadded:: 3.32
+%End
+
+%TypeHeaderCode
+#include "qgsrasterdataproviderelevationproperties.h"
+%End
+  public:
+
+    QgsRasterDataProviderElevationProperties();
+%Docstring
+Constructor for QgsRasterDataProviderElevationProperties.
+%End
+
+    bool containsElevationData() const;
+%Docstring
+Returns ``True`` if the raster data provider definitely contains elevation related data.
+
+.. note::
+
+   Even if this method returns ``False``, the raster data may still relate to elevation values. ``True`` will only
+   be returned in situations where elevation data is definitively present.
+
+.. seealso:: :py:func:`setContainsElevationData`
+%End
+
+    void setContainsElevationData( bool contains );
+%Docstring
+Sets whether the raster data provider definitely contains elevation related data.
+
+.. seealso:: :py:func:`containsElevationData`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/raster/qgsrasterdataproviderelevationproperties.h           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayerelevationproperties.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsRasterLayerElevationProperties : QgsMapLayerElevationProperties
 {
 %Docstring(signature="appended")
@@ -118,6 +119,23 @@ Returns the symbology option used to render the raster profile in elevation prof
 Sets the ``symbology`` option used to render the raster profile in elevation profile plots.
 
 .. seealso:: :py:func:`setProfileSymbology`
+%End
+
+    static bool layerLooksLikeDem( QgsRasterLayer *layer );
+%Docstring
+Returns ``True`` if a raster ``layer`` looks like a DEM.
+
+This method applies some heuristics to ``layer`` to determine whether it looks like a candidate
+for a DEM layer.
+
+Specifically, it checks:
+
+- the layer's name for DEM-like wording hints
+- whether the layer contains a single band
+- whether the layer contains an attribute table (if so, it's unlikely to be a DEM)
+- the layer's data type
+
+.. versionadded:: 3.32
 %End
 
 };

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -31,6 +31,7 @@
 %Include auto_generated/qgsdatabaseschemamodel.sip
 %Include auto_generated/qgsdatabasetablemodel.sip
 %Include auto_generated/qgsdatadefinedsizelegend.sip
+%Include auto_generated/qgsdataproviderelevationproperties.sip
 %Include auto_generated/qgsdataprovidertemporalcapabilities.sip
 %Include auto_generated/qgsdatasourceuri.sip
 %Include auto_generated/qgsdatetimestatisticalsummary.sip
@@ -610,6 +611,7 @@
 %Include auto_generated/raster/qgsrasterchecker.sip
 %Include auto_generated/raster/qgsrastercontourrenderer.sip
 %Include auto_generated/raster/qgsrasterdataprovider.sip
+%Include auto_generated/raster/qgsrasterdataproviderelevationproperties.sip
 %Include auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip
 %Include auto_generated/raster/qgsrasterdrawer.sip
 %Include auto_generated/raster/qgsrasterfilewriter.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -377,6 +377,7 @@ set(QGIS_CORE_SRCS
   qgsdatabasetablemodel.cpp
   qgsdatadefinedsizelegend.cpp
   qgsdatasourceuri.cpp
+  qgsdataproviderelevationproperties.cpp
   qgsdataprovidertemporalcapabilities.cpp
   qgsdatetimestatisticalsummary.cpp
   qgsdbfilterproxymodel.cpp
@@ -704,6 +705,7 @@ set(QGIS_CORE_SRCS
   raster/qgsrasterchecker.cpp
   raster/qgsrastercontourrenderer.cpp
   raster/qgsrasterdataprovider.cpp
+  raster/qgsrasterdataproviderelevationproperties.cpp
   raster/qgsrasterdataprovidertemporalcapabilities.cpp
   raster/qgsrasterfilewritertask.cpp
   raster/qgsrasteridentifyresult.cpp
@@ -1047,6 +1049,7 @@ set(QGIS_CORE_HDRS
   qgsdatabaseschemamodel.h
   qgsdatabasetablemodel.h
   qgsdatadefinedsizelegend.h
+  qgsdataproviderelevationproperties.h
   qgsdataprovidertemporalcapabilities.h
   qgsdatasourceuri.h
   qgsdatetimestatisticalsummary.h
@@ -1775,6 +1778,7 @@ set(QGIS_CORE_HDRS
   raster/qgsrasterchecker.h
   raster/qgsrastercontourrenderer.h
   raster/qgsrasterdataprovider.h
+  raster/qgsrasterdataproviderelevationproperties.h
   raster/qgsrasterdataprovidertemporalcapabilities.h
   raster/qgsrasterdrawer.h
   raster/qgsrasterfilewriter.h

--- a/src/core/providers/qgsdataprovider.cpp
+++ b/src/core/providers/qgsdataprovider.cpp
@@ -49,6 +49,20 @@ const QgsDataProviderTemporalCapabilities *QgsDataProvider::temporalCapabilities
   return nullptr;
 }
 
+QgsDataProviderElevationProperties *QgsDataProvider::elevationProperties()
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return nullptr;
+}
+
+const QgsDataProviderElevationProperties *QgsDataProvider::elevationProperties() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return nullptr;
+}
+
 void QgsDataProvider::reloadData()
 {
   // Because QgsVirtualLayerTask is not thread safe:

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -31,6 +31,7 @@
 class QgsRectangle;
 class QgsCoordinateReferenceSystem;
 class QgsDataProviderTemporalCapabilities;
+class QgsDataProviderElevationProperties;
 
 
 /**
@@ -231,6 +232,24 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * \since QGIS 3.14
      */
     virtual const QgsDataProviderTemporalCapabilities *temporalCapabilities() const SIP_SKIP;
+
+    /**
+     * Returns the provider's elevation properties.
+     *
+     * This may be NULLPTR, depending on the data provider.
+     *
+     * \since QGIS 3.32
+     */
+    virtual QgsDataProviderElevationProperties *elevationProperties();
+
+    /**
+     * Returns the provider's elevation properties.
+     *
+     * This may be NULLPTR, depending on the data provider.
+     *
+     * \since QGIS 3.32
+     */
+    virtual const QgsDataProviderElevationProperties *elevationProperties() const SIP_SKIP;
 
     /**
      * Returns the extent of the layer

--- a/src/core/qgsdataproviderelevationproperties.cpp
+++ b/src/core/qgsdataproviderelevationproperties.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************
+                         qgsdataproviderelevationproperties.h
+                         ---------------
+    begin                : May 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdataproviderelevationproperties.h"
+
+QgsDataProviderElevationProperties::QgsDataProviderElevationProperties() = default;
+
+QgsDataProviderElevationProperties::~QgsDataProviderElevationProperties() = default;

--- a/src/core/qgsdataproviderelevationproperties.h
+++ b/src/core/qgsdataproviderelevationproperties.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+                         qgsdataproviderelevationproperties.h
+                         ---------------
+    begin                : May 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSDATAPROVIDERELEVATIONPROPERTIES_H
+#define QGSDATAPROVIDERELEVATIONPROPERTIES_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+
+/**
+ * \class QgsDataProviderElevationProperties
+ * \ingroup core
+ * \brief Base class for handling elevation related properties for a data provider.
+ *
+ * \since QGIS 3.32
+ */
+class CORE_EXPORT QgsDataProviderElevationProperties
+{
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsRasterDataProviderElevationProperties *>( sipCpp ) )
+    {
+      sipType = sipType_QgsRasterDataProviderElevationProperties;
+    }
+    else
+    {
+      sipType = 0;
+    }
+    SIP_END
+#endif
+
+  public:
+
+    /**
+     * Constructor for QgsDataProviderElevationProperties.
+     */
+    QgsDataProviderElevationProperties();
+
+    virtual ~QgsDataProviderElevationProperties();
+};
+
+#endif // QGSDATAPROVIDERELEVATIONPROPERTIES_H

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -236,6 +236,7 @@ QgsRasterDataProvider::QgsRasterDataProvider()
   : QgsDataProvider( QString(), QgsDataProvider::ProviderOptions(), QgsDataProvider::ReadFlags() )
   , QgsRasterInterface( nullptr )
   , mTemporalCapabilities( std::make_unique< QgsRasterDataProviderTemporalCapabilities >() )
+  , mElevationProperties( std::make_unique< QgsRasterDataProviderElevationProperties >() )
 {
 
 }
@@ -245,6 +246,7 @@ QgsRasterDataProvider::QgsRasterDataProvider( const QString &uri, const Provider
   : QgsDataProvider( uri, options, flags )
   , QgsRasterInterface( nullptr )
   , mTemporalCapabilities( std::make_unique< QgsRasterDataProviderTemporalCapabilities >() )
+  , mElevationProperties( std::make_unique< QgsRasterDataProviderElevationProperties >() )
 {
 }
 
@@ -434,6 +436,20 @@ const QgsRasterDataProviderTemporalCapabilities *QgsRasterDataProvider::temporal
   return mTemporalCapabilities.get();
 }
 
+QgsRasterDataProviderElevationProperties *QgsRasterDataProvider::elevationProperties()
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mElevationProperties.get();
+}
+
+const QgsRasterDataProviderElevationProperties *QgsRasterDataProvider::elevationProperties() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return mElevationProperties.get();
+}
+
 QgsRasterDataProvider *QgsRasterDataProvider::create( const QString &providerKey,
     const QString &uri,
     const QString &format, int nBands,
@@ -571,10 +587,13 @@ void QgsRasterDataProvider::copyBaseSettings( const QgsRasterDataProvider &other
   mZoomedOutResamplingMethod = other.mZoomedOutResamplingMethod;
   mMaxOversampling = other.mMaxOversampling;
 
-  // copy temporal properties
   if ( mTemporalCapabilities && other.mTemporalCapabilities )
   {
     *mTemporalCapabilities = *other.mTemporalCapabilities;
+  }
+  if ( mElevationProperties && other.mElevationProperties )
+  {
+    *mElevationProperties = *other.mElevationProperties;
   }
 }
 

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -41,6 +41,7 @@
 #include "qgsrectangle.h"
 #include "qgsrasteriterator.h"
 #include "qgsrasterdataprovidertemporalcapabilities.h"
+#include "qgsrasterdataproviderelevationproperties.h"
 
 class QImage;
 class QByteArray;
@@ -274,6 +275,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     QgsRasterDataProviderTemporalCapabilities *temporalCapabilities() override;
     const QgsRasterDataProviderTemporalCapabilities *temporalCapabilities() const override SIP_SKIP;
+    QgsRasterDataProviderElevationProperties *elevationProperties() override;
+    const QgsRasterDataProviderElevationProperties *elevationProperties() const override SIP_SKIP;
 
     //! \brief Returns whether the provider supplies a legend graphic
     virtual bool supportsLegendGraphic() const { return false; }
@@ -913,6 +916,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      * Data provider temporal properties
      */
     std::unique_ptr< QgsRasterDataProviderTemporalCapabilities > mTemporalCapabilities;
+
+    std::unique_ptr< QgsRasterDataProviderElevationProperties > mElevationProperties;
 
     std::map<int, std::unique_ptr<QgsRasterAttributeTable>> mAttributeTables;
 

--- a/src/core/raster/qgsrasterdataproviderelevationproperties.cpp
+++ b/src/core/raster/qgsrasterdataproviderelevationproperties.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+                         qgsrasterdataproviderelevationproperties.h
+                         ---------------
+    begin                : May 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrasterdataproviderelevationproperties.h"
+
+QgsRasterDataProviderElevationProperties::QgsRasterDataProviderElevationProperties() = default;
+
+bool QgsRasterDataProviderElevationProperties::containsElevationData() const
+{
+  return mContainsElevationData;
+}
+
+void QgsRasterDataProviderElevationProperties::setContainsElevationData( bool contains )
+{
+  mContainsElevationData = contains;
+}

--- a/src/core/raster/qgsrasterdataproviderelevationproperties.h
+++ b/src/core/raster/qgsrasterdataproviderelevationproperties.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+                         qgsrasterdataproviderelevationproperties.h
+                         ---------------
+    begin                : May 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSRASTERDATAPROVIDERELEVATIONPROPERTIES_H
+#define QGSRASTERDATAPROVIDERELEVATIONPROPERTIES_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsdataproviderelevationproperties.h"
+
+/**
+ * \class QgsRasterDataProviderElevationProperties
+ * \ingroup core
+ * \brief Handles elevation related properties for a raster data provider.
+ *
+ * \since QGIS 3.32
+ */
+class CORE_EXPORT QgsRasterDataProviderElevationProperties : public QgsDataProviderElevationProperties
+{
+
+  public:
+
+    /**
+     * Constructor for QgsRasterDataProviderElevationProperties.
+     */
+    QgsRasterDataProviderElevationProperties();
+
+    /**
+     * Returns TRUE if the raster data provider definitely contains elevation related data.
+     *
+     * \note Even if this method returns FALSE, the raster data may still relate to elevation values. TRUE will only
+     * be returned in situations where elevation data is definitively present.
+     *
+     * \see setContainsElevationData()
+     */
+    bool containsElevationData() const;
+
+    /**
+     * Sets whether the raster data provider definitely contains elevation related data.
+     *
+     * \see containsElevationData()
+     */
+    void setContainsElevationData( bool contains );
+
+  private:
+
+    bool mContainsElevationData = false;
+
+};
+
+#endif // QGSRASTERDATAPROVIDERELEVATIONPROPERTIES_H

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -997,6 +997,14 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   }
   setCustomProperty( QStringLiteral( "identify/format" ), QgsRasterDataProvider::identifyFormatName( identifyFormat ) );
 
+  if ( QgsRasterDataProviderElevationProperties *properties = mDataProvider->elevationProperties() )
+  {
+    if ( properties->containsElevationData() )
+    {
+      mElevationProperties->setEnabled( true );
+    }
+  }
+
   // Store timestamp
   // TODO move to provider
   mLastModified = lastModified( mDataSource );

--- a/src/core/raster/qgsrasterlayerelevationproperties.h
+++ b/src/core/raster/qgsrasterlayerelevationproperties.h
@@ -24,6 +24,8 @@
 #include "qgsmaplayerelevationproperties.h"
 #include "qgslinesymbol.h"
 
+class QgsRasterLayer;
+
 /**
  * \class QgsRasterLayerElevationProperties
  * \ingroup core
@@ -126,6 +128,23 @@ class CORE_EXPORT QgsRasterLayerElevationProperties : public QgsMapLayerElevatio
      * \see setProfileSymbology()
      */
     void setProfileSymbology( Qgis::ProfileSurfaceSymbology symbology );
+
+    /**
+     * Returns TRUE if a raster \a layer looks like a DEM.
+     *
+     * This method applies some heuristics to \a layer to determine whether it looks like a candidate
+     * for a DEM layer.
+     *
+     * Specifically, it checks:
+     *
+     * - the layer's name for DEM-like wording hints
+     * - whether the layer contains a single band
+     * - whether the layer contains an attribute table (if so, it's unlikely to be a DEM)
+     * - the layer's data type
+     *
+     * \since QGIS 3.32
+     */
+    static bool layerLooksLikeDem( QgsRasterLayer *layer );
 
   private:
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -258,6 +258,10 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
 
 
   mConverter = QgsWmsInterpretationConverter::createConverter( mSettings.mInterpretation );
+  if ( mConverter && mConverter->representsElevation() )
+  {
+    elevationProperties()->setContainsElevationData( true );
+  }
 
   mValid = true;
   QgsDebugMsgLevel( QStringLiteral( "exiting constructor." ), 4 );
@@ -5397,6 +5401,11 @@ Qgis::DataType QgsWmsInterpretationConverter::dataType() const
   return Qgis::DataType::Float32;
 }
 
+bool QgsWmsInterpretationConverter::representsElevation() const
+{
+  return false;
+}
+
 //
 // QgsWmsInterpretationConverterMapTilerTerrainRGB
 //
@@ -5431,6 +5440,11 @@ QgsRasterHistogram QgsWmsInterpretationConverterMapTilerTerrainRGB::histogram( i
   return QgsRasterHistogram();
 }
 
+bool QgsWmsInterpretationConverterMapTilerTerrainRGB::representsElevation() const
+{
+  return true;
+}
+
 //
 // QgsWmsInterpretationConverterTerrariumRGB
 //
@@ -5462,4 +5476,9 @@ QgsRasterBandStats QgsWmsInterpretationConverterTerrariumRGB::statistics( int, i
 QgsRasterHistogram QgsWmsInterpretationConverterTerrariumRGB::histogram( int, int, double, double, const QgsRectangle &, int, bool, QgsRasterBlockFeedback * ) const
 {
   return QgsRasterHistogram();
+}
+
+bool QgsWmsInterpretationConverterTerrariumRGB::representsElevation() const
+{
+  return true;
 }

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -112,6 +112,9 @@ class QgsWmsInterpretationConverter
     //! Returns the output datatype of this converter
     virtual Qgis::DataType dataType() const;
 
+    //! Returns TRUE if the interpretation represents elevation values
+    virtual bool representsElevation() const;
+
     //! Returns statistics related to converted values
     virtual QgsRasterBandStats statistics( int bandNo,
                                            int stats = QgsRasterBandStats::All,
@@ -153,6 +156,8 @@ class QgsWmsInterpretationConverterMapTilerTerrainRGB : public QgsWmsInterpretat
                                   bool includeOutOfRange = false,
                                   QgsRasterBlockFeedback *feedback = nullptr ) const override;
 
+    bool representsElevation() const override;
+
     static QString displayName() {return QObject::tr( "MapTiler Terrain RGB" );}
     static QString interpretationKey() {return QStringLiteral( "maptilerterrain" );}
 };
@@ -176,6 +181,8 @@ class QgsWmsInterpretationConverterTerrariumRGB : public QgsWmsInterpretationCon
                                   int sampleSize = 0,
                                   bool includeOutOfRange = false,
                                   QgsRasterBlockFeedback *feedback = nullptr ) const override;
+
+    bool representsElevation() const override;
 
     static QString displayName() {return QObject::tr( "Terrarium Terrain RGB" );}
     static QString interpretationKey() {return QStringLiteral( "terrariumterrain" );}

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -167,6 +167,9 @@ class TestQgsWmsProvider: public QgsTest
       mapSettings.setOutputSize( QSize( 400, 400 ) );
       mapSettings.setOutputDpi( 96 );
       QVERIFY( imageCheck( "mbtiles_1", mapSettings ) );
+
+      // since no terrain interpretation set, we don't know for sure that the layer contains elevation
+      QVERIFY( !layer.dataProvider()->elevationProperties()->containsElevationData() );
     }
 
     void testMBTilesSample()
@@ -184,6 +187,9 @@ class TestQgsWmsProvider: public QgsTest
       const double value = layer.dataProvider()->sample( QgsPointXY( -496419, 7213350 ), 1, &ok );
       QVERIFY( ok );
       QCOMPARE( value, 1167617.375 );
+
+      // ensure that terrain interpretation correctly indicates that the layer contains elevation
+      QVERIFY( layer.dataProvider()->elevationProperties()->containsElevationData() );
     }
 
     void testMbtilesProviderMetadata()


### PR DESCRIPTION
And use this to ensure that wms tiles with maptiler terrain or terrarium terrain interpretation are always included by default in elevation profile plots.

Most specifically, this ensures that projects containing the out-of-the-box "Mapzen Global Terrain" layer will be automatically included in elevation plots.

Also, use some heuristics to guess when a raster layer looks like a DEM and auto-set the "represents elevation" flag for these

We do this when:

- the layer contains only one band
- the data type is int or float (not complex, rgb or byte)
- the layer doesn't have an attribute table
- there's something "dem-like" in the layer's name (ie 'elevation',
  'dem', 'height', 'srtm')

This should help make the elevation profile tool more user-friendly, as these layers will be included in the profiles by default

