### PR TITLE
apply pixel size conversion factor to line width if style does not define "line-width" property

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -572,6 +572,10 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         break;
     }
   }
+  else
+  {
+    lineWidth *= context.pixelSizeConversionFactor();
+  }
 
   double lineOffset = 0.0;
   if ( jsonPaint.contains( QStringLiteral( "line-offset" ) ) )

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -542,7 +542,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
   }
 
 
-  double lineWidth = 1.0;
+  double lineWidth = 1.0 * context.pixelSizeConversionFactor();
   QgsProperty lineWidthProperty;
   if ( jsonPaint.contains( QStringLiteral( "line-width" ) ) )
   {
@@ -571,10 +571,6 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
         context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-width type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonLineWidth.type() ) ) );
         break;
     }
-  }
-  else
-  {
-    lineWidth *= context.pixelSizeConversionFactor();
   }
 
   double lineOffset = 0.0;

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -849,6 +849,33 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
                          'CASE WHEN @vector_tile_zoom >= 10 AND @vector_tile_zoom <= 11 THEN scale_exp(@vector_tile_zoom,10,11,1.5,2,1.2) WHEN @vector_tile_zoom > 11 AND @vector_tile_zoom <= 12 THEN scale_exp(@vector_tile_zoom,11,12,2,3,1.2) WHEN @vector_tile_zoom > 12 AND @vector_tile_zoom <= 13 THEN scale_exp(@vector_tile_zoom,12,13,3,5,1.2) WHEN @vector_tile_zoom > 13 AND @vector_tile_zoom <= 14 THEN scale_exp(@vector_tile_zoom,13,14,5,6,1.2) WHEN @vector_tile_zoom > 14 AND @vector_tile_zoom <= 16 THEN scale_exp(@vector_tile_zoom,14,16,6,10,1.2) WHEN @vector_tile_zoom > 16 AND @vector_tile_zoom <= 17 THEN scale_exp(@vector_tile_zoom,16,17,10,12,1.2) WHEN @vector_tile_zoom > 17 THEN 12 END')
         self.assertFalse(dd_properties.property(QgsSymbolLayer.PropertyCustomDash).isActive())
 
+    def testParseLineDashArrayNoWidth(self):
+        conversion_context = QgsMapBoxGlStyleConversionContext()
+        conversion_context.setPixelSizeConversionFactor(0.5)
+        style = {
+            "id": "water line (intermittent)/river",
+            "type": "line",
+            "source": "esri",
+            "source-layer": "water line (intermittent)",
+            "filter": ["==", "_symbol", 3],
+            "minzoom": 10,
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#aad3df",
+                "line-dasharray": [2, 1],
+            }
+        }
+        has_renderer, rendererStyle = QgsMapBoxGlStyleConverter.parseLineLayer(style, conversion_context)
+        self.assertTrue(has_renderer)
+        self.assertEqual(rendererStyle.geometryType(), QgsWkbTypes.LineGeometry)
+        self.assertTrue(rendererStyle.symbol()[0].useCustomDashPattern())
+        self.assertEqual(rendererStyle.symbol()[0].customDashVector(), [1.0, 0.5])
+        dd_properties = rendererStyle.symbol().symbolLayers()[0].dataDefinedProperties()
+        self.assertEqual(dd_properties.property(QgsSymbolLayer.PropertyStrokeWidth).asExpression(), '')
+        self.assertEqual(dd_properties.property(QgsSymbolLayer.PropertyCustomDash).asExpression(), '')
+
     def testLinePattern(self):
         """ Test line-pattern property """
         context = QgsMapBoxGlStyleConversionContext()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -849,32 +849,27 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
                          'CASE WHEN @vector_tile_zoom >= 10 AND @vector_tile_zoom <= 11 THEN scale_exp(@vector_tile_zoom,10,11,1.5,2,1.2) WHEN @vector_tile_zoom > 11 AND @vector_tile_zoom <= 12 THEN scale_exp(@vector_tile_zoom,11,12,2,3,1.2) WHEN @vector_tile_zoom > 12 AND @vector_tile_zoom <= 13 THEN scale_exp(@vector_tile_zoom,12,13,3,5,1.2) WHEN @vector_tile_zoom > 13 AND @vector_tile_zoom <= 14 THEN scale_exp(@vector_tile_zoom,13,14,5,6,1.2) WHEN @vector_tile_zoom > 14 AND @vector_tile_zoom <= 16 THEN scale_exp(@vector_tile_zoom,14,16,6,10,1.2) WHEN @vector_tile_zoom > 16 AND @vector_tile_zoom <= 17 THEN scale_exp(@vector_tile_zoom,16,17,10,12,1.2) WHEN @vector_tile_zoom > 17 THEN 12 END')
         self.assertFalse(dd_properties.property(QgsSymbolLayer.PropertyCustomDash).isActive())
 
-    def testParseLineDashArrayNoWidth(self):
+    def testParseLineNoWidth(self):
         conversion_context = QgsMapBoxGlStyleConversionContext()
-        conversion_context.setPixelSizeConversionFactor(0.5)
         style = {
             "id": "water line (intermittent)/river",
             "type": "line",
             "source": "esri",
             "source-layer": "water line (intermittent)",
-            "filter": ["==", "_symbol", 3],
-            "minzoom": 10,
-            "layout": {
-                "line-join": "round"
-            },
             "paint": {
                 "line-color": "#aad3df",
-                "line-dasharray": [2, 1],
             }
         }
         has_renderer, rendererStyle = QgsMapBoxGlStyleConverter.parseLineLayer(style, conversion_context)
         self.assertTrue(has_renderer)
         self.assertEqual(rendererStyle.geometryType(), QgsWkbTypes.LineGeometry)
-        self.assertTrue(rendererStyle.symbol()[0].useCustomDashPattern())
-        self.assertEqual(rendererStyle.symbol()[0].customDashVector(), [1.0, 0.5])
-        dd_properties = rendererStyle.symbol().symbolLayers()[0].dataDefinedProperties()
-        self.assertEqual(dd_properties.property(QgsSymbolLayer.PropertyStrokeWidth).asExpression(), '')
-        self.assertEqual(dd_properties.property(QgsSymbolLayer.PropertyCustomDash).asExpression(), '')
+        self.assertEqual(rendererStyle.symbol()[0].width(), 1.0)
+
+        conversion_context.setPixelSizeConversionFactor(0.5)
+        has_renderer, rendererStyle = QgsMapBoxGlStyleConverter.parseLineLayer(style, conversion_context)
+        self.assertTrue(has_renderer)
+        self.assertEqual(rendererStyle.geometryType(), QgsWkbTypes.LineGeometry)
+        self.assertEqual(rendererStyle.symbol()[0].width(), 0.5)
 
     def testLinePattern(self):
         """ Test line-pattern property """


### PR DESCRIPTION
## Description

Sometimes vector tile style does not define the "line-width" property for lines, for example like in this excerpt from the OpenMapTiles Basic style.

```
{
  "id": "admin_sub",
  "type": "line",
  "source": "openmaptiles",
  "source-layer": "boundary",
  "filter": ["in", "admin_level", 4, 6, 8],
  "layout": {"visibility": "visible"},
  "paint": {"line-color": "hsla(0, 0%, 60%, 0.5)", "line-dasharray": [2, 1]}
}
```
In this case a default line width of 1 pixel is used, however in that case we do not apply a pixel size conversion factor to it. As a result, some lines look too thick
![image](https://github.com/qgis/QGIS/assets/776954/2caf38e4-233a-4a9d-83e5-4f369d21f1dc)
![image](https://github.com/qgis/QGIS/assets/776954/9e34fe17-39de-483e-aac0-fb5cce10d3d4)

The solution is to apply the pixel size conversion factor to the default line width when "line-width" property is not present in the style definition. This gives exepected result
![image](https://github.com/qgis/QGIS/assets/776954/abfdc97f-4369-48e5-bb0b-7215235bcbd2)
![image](https://github.com/qgis/QGIS/assets/776954/96ab2f19-6d70-4f01-8168-74fa1a432049)



