### PR TITLE
Add flag for common angle/vertex snapping priority

### DIFF
--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -102,6 +102,8 @@ Defines constraints for the :py:func:`QgsCadUtils.alignMapPoint()` method.
         QgsCadUtils::AlignMapPointConstraint lineExtensionConstraint;
         QgsCadUtils::AlignMapPointConstraint xyVertexConstraint;
 
+        bool snappingToFeaturesOverridesCommonAngle;
+
 
         QList< QgsPoint > cadPoints() const;
 %Docstring

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -162,7 +162,10 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
   // *****************************
   // ---- Common Angle constraint
-  if ( numberOfHardLock < 2 && !ctx.angleConstraint.locked && ctx.cadPoints().count() >= 2 && ctx.commonAngleConstraint.locked && ctx.commonAngleConstraint.value != 0 )
+  if ( numberOfHardLock < 2 && !ctx.angleConstraint.locked && ctx.cadPoints().count() >= 2 && ctx.commonAngleConstraint.locked && ctx.commonAngleConstraint.value != 0
+       // Skip common angle constraint if the snapping to features has priority
+       && ( ! snapMatch.isValid() || ! ctx.snappingToFeaturesOverridesCommonAngle )
+     )
   {
     const double commonAngle = ctx.commonAngleConstraint.value * M_PI / 180;
     // see if soft common angle constraint should be performed

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -135,6 +135,12 @@ class CORE_EXPORT QgsCadUtils
         QgsCadUtils::AlignMapPointConstraint xyVertexConstraint;
 
         /**
+         * Flag to set snapping to features priority over common angle.
+         * \since QGIS 3.32
+         */
+        bool snappingToFeaturesOverridesCommonAngle = false;
+
+        /**
          * Dumps the context's properties, for debugging.
          * \note Not available in Python bindings.
          */

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -36,7 +36,6 @@
 #include "qgsmapmouseevent.h"
 #include "qgsmeshlayer.h"
 #include "qgsunittypes.h"
-#include "qgslocaldefaultsettings.h"
 
 #include <QActionGroup>
 
@@ -144,6 +143,21 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   {
     commonAngles << QPair<double, QString>( *it, formatCommonAngleSnapping( *it ) );
   }
+
+  {
+    QAction *action = new QAction( tr( "Snapping to features has priority over common angles" ), mCommonAngleActionsMenu );
+    action->setCheckable( true );
+    mCommonAngleActionsMenu->addAction( action );
+    connect( action, &QAction::changed, this, [ = ]
+    {
+      mSnappingToFeaturesOverridesCommonAngle = action->isChecked();
+      QgsSettings().setValue( QStringLiteral( "/Cad/SnappingToFeaturesOverridesCommonAngle" ), action->isChecked() );
+    } );
+    action->setChecked( QgsSettings().value( QStringLiteral( "/Cad/SnappingToFeaturesOverridesCommonAngle" ), false ).toBool() );
+  }
+
+  mCommonAngleActionsMenu->addSeparator();
+
   for ( QList< QPair<double, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
   {
     QAction *action = new QAction( it->second, mCommonAngleActionsMenu );
@@ -1181,6 +1195,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   context.mConstraint = _constraint( mMConstraint.get() );
   context.distanceConstraint = _constraint( mDistanceConstraint.get() );
   context.angleConstraint = _constraint( mAngleConstraint.get() );
+  context.snappingToFeaturesOverridesCommonAngle = mSnappingToFeaturesOverridesCommonAngle;
 
   context.lineExtensionConstraint = _constraint( mLineExtensionConstraint.get() );
   context.xyVertexConstraint = _constraint( mXyVertexConstraint.get() );

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -1051,6 +1051,9 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     Qgis::BetweenLineConstraint mBetweenLineConstraint;
     double mCommonAngleConstraint; // if 0: do not snap to common angles
 
+    //! Flag that controls whether snapping to features has priority over common angle
+    bool mSnappingToFeaturesOverridesCommonAngle = false;
+
     // point list and current snap point / segment
     QList<QgsPoint> mCadPointList;
     QList<QgsPointXY> mSnappedSegment;

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -1052,7 +1052,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     double mCommonAngleConstraint; // if 0: do not snap to common angles
 
     //! Flag that controls whether snapping to features has priority over common angle
-    bool mSnappingToFeaturesOverridesCommonAngle = false;
+    bool mSnappingPrioritizeFeatures = false;
 
     // point list and current snap point / segment
     QList<QgsPoint> mCadPointList;
@@ -1087,6 +1087,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     QMenu *mCommonAngleActionsMenu = nullptr;
     QMenu *mFloaterActionsMenu = nullptr;
+
+    static const QgsSettingsEntryBool *settingsCadSnappingPriorityPrioritizeFeature;
 
     friend class TestQgsAdvancedDigitizing;
     friend class TestQgsAdvancedDigitizingDockWidget;


### PR DESCRIPTION
Fixes #52333 

New option to control the behavior (but also see https://github.com/qgis/QGIS/issues/52333#issuecomment-1553050148).

![immagine](https://github.com/qgis/QGIS/assets/142164/efe48923-a70d-4ace-b110-b4dee727f17a)

Settings:

![immagine](https://github.com/qgis/QGIS/assets/142164/c043d7e0-db9b-4dc6-aee1-0ef506dccb53)
