### PR TITLE
Fix "Qt : QString::arg: 1 argument(s) missing in getting %1 with %2" opening Settings->Options dialog window

### DIFF
--- a/src/gui/settings/qgssettingstreemodel.cpp
+++ b/src/gui/settings/qgssettingstreemodel.cpp
@@ -134,17 +134,17 @@ void QgsSettingsTreeModelNodeData::addChildForSetting( const QgsSettingsEntryBas
   switch ( mNamedParentNodes.count() )
   {
     case 1:
-      QgsDebugMsg( QString( "getting %1 with %2" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ) ) );
+      QgsDebugMsgLevel( QString( "getting %1 with %2" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ) ), 3 );
       break;
     case 2:
-      QgsDebugMsg( QString( "getting %1 with %2 and %3" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ), mNamedParentNodes.at( 1 ) ) );
+      QgsDebugMsgLevel( QString( "getting %1 with %2 and %3" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ), mNamedParentNodes.at( 1 ) ), 3 );
       break;
     case 0:
-      QgsDebugMsg( QString( "getting %1" ).arg( setting->definitionKey() ) );
+      QgsDebugMsgLevel( QString( "getting %1" ).arg( setting->definitionKey() ), 3 );
       break;
     default:
       Q_ASSERT( false );
-      QgsDebugMsg( QString( "Not handling that many named parent nodes for %1" ).arg( setting->definitionKey() ) );
+      QgsDebugMsgLevel( QString( "Not handling that many named parent nodes for %1" ).arg( setting->definitionKey() ), 3 );
       break;
   }
 

--- a/src/gui/settings/qgssettingstreemodel.cpp
+++ b/src/gui/settings/qgssettingstreemodel.cpp
@@ -137,7 +137,7 @@ void QgsSettingsTreeModelNodeData::addChildForSetting( const QgsSettingsEntryBas
       QgsDebugMsg( QString( "getting %1 with %2" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ) ) );
       break;
     case 2:
-      QgsDebugMsg( QString( "getting %1 with %2" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ), mNamedParentNodes.at( 1 ) ) );
+      QgsDebugMsg( QString( "getting %1 with %2 and %3" ).arg( setting->definitionKey(), mNamedParentNodes.at( 0 ), mNamedParentNodes.at( 1 ) ) );
       break;
     case 0:
       QgsDebugMsg( QString( "getting %1" ).arg( setting->definitionKey() ) );


### PR DESCRIPTION
## Description

There is a missing numbered place marker in https://github.com/qgis/QGIS/blob/e2fa27e4a6be3f2f106738b00bea78ad9079facf/src/gui/settings/qgssettingstreemodel.cpp#L140
(probably an oversight in https://github.com/qgis/QGIS/pull/52847).

@3nids, could you please have a look?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
