### PR TITLE
Fix formula for exponential interpolation in scale_exp

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -547,7 +547,8 @@ static QVariant fcnExpScale( const QVariantList &values, const QgsExpressionCont
   }
 
   // Return exponentially scaled value
-  return QVariant( ( ( rangeMax - rangeMin ) / std::pow( domainMax - domainMin, exponent ) ) * std::pow( val - domainMin, exponent ) + rangeMin );
+  double ratio = ( std::pow( exponent, val - domainMin ) - 1 ) / ( std::pow( exponent, domainMax - domainMin ) - 1 );
+  return QVariant( ( rangeMax - rangeMin ) * ratio + rangeMin );
 }
 
 static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )


### PR DESCRIPTION
It looks like the formula for exponential interpolation in `scale_exp` function has been actually polynomial all the time.

`scale_exp` was added 10 years ago in 10acbe017e5d84a1264beb5cbad0c66fe80636e4 (and formula has not changed since)

We'll use the following notation for the math:
- $x$ - input value for interpolation
- $y$ - output value from interpolation
- $x_0$, $x_1$ - range of the domain (input)
- $y_0$, $y_1$ - range of values (output)
- $b$ - is exponential base

The interpolation formula is this:  $$y = y_0 + (y_1 - y_0) * t$$ where $t$ is the interpolation ratio (this works for both any interpolation method)

Now the ratio used in QGIS is: $$t = \frac{(x-x_0)^b}{(x_1-x_0)^b}$$

I would like to argue that the correct ratio should be $$t = \frac{b^{x-x_0}-1}{b^{x_1-x_0}-1}$$

The formula currently used in QGIS is simply polynomial interpolation - the $x$ is the only variable, everything else is a fixed constant, so we are calculating a polynomial $x^b$ and doing some offset and scaling. The proposed formula instead boils down to having exponential function ($b^x$) as the only variable part.

It is surprisingly hard to find good authoritative formula for exponential interpolation online.

I have found this issue by seeing incorrectly scale line widths of some mapbox gl styles - the docs in mapbox-gl-js source offer also derivation of the formula for the ratio: https://github.com/mapbox/mapbox-gl-js/blob/0e6d49ec79da6e777181ddb416c2ae2718928867/src/style-spec/expression/definitions/interpolate.js#LL221C4-L221C11

For the illustration how big is the difference: these are ratios for $b=2$, $x_0=0$, $x_1=10$. One can see that the "new" ratio is behaving much more "exponentially" :slightly_smiling_face:  - it grows slowly but then starts to increase fast.

![image](https://github.com/qgis/QGIS/assets/193367/86ca549d-0411-490c-8f5f-5743722f1a95)


If we agree about the formula change, the real question is what to do - shall we just replace the formula with the new one? Or introduce another expression function (e.g. `scale_exp_2` for the sake of compatibility of existing code?