### PR TITLE
Improve project parallel loading with credentials requested

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1387,13 +1387,13 @@ void QgsProject::preloadProviders( const QVector<QDomNode> &parallelLayerNodes,
           layersToLoad.remove( layId );
           i++;
           QgsRunnableProviderCreator *finishedRun = runnables.value( layId, nullptr );
-          if ( finishedRun )
-          {
-            std::unique_ptr<QgsDataProvider> provider( finishedRun->dataProvider() );
-            if ( provider && provider->isValid() )
-              loadedProviders.insert( layId, provider.release() );
-            emit layerLoaded( i, totalProviderCount );
-          }
+          Q_ASSERT( finishedRun );
+
+          std::unique_ptr<QgsDataProvider> provider( finishedRun->dataProvider() );
+          Q_ASSERT( provider && provider->isValid() );
+
+          loadedProviders.insert( layId, provider.release() );
+          emit layerLoaded( i, totalProviderCount );
         }
         else
         {

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2272,6 +2272,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Returns the property definition used for a data defined server property
     static QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions();
 
+    //! Attempts to preload providers in parallel
     void preloadProviders( const QVector<QDomNode> &asynchronusLayerNodes,
                            const QgsReadWriteContext &context,
                            QMap<QString, QgsDataProvider *> &loadedProviders,

--- a/src/core/providers/qgsrunnableprovidercreator.cpp
+++ b/src/core/providers/qgsrunnableprovidercreator.cpp
@@ -44,8 +44,3 @@ QgsDataProvider *QgsRunnableProviderCreator::dataProvider()
 {
   return mDataProvider.release();
 }
-
-QString QgsRunnableProviderCreator::layerId() const
-{
-  return mLayerId;
-}

--- a/src/core/providers/qgsrunnableprovidercreator.cpp
+++ b/src/core/providers/qgsrunnableprovidercreator.cpp
@@ -37,7 +37,7 @@ void QgsRunnableProviderCreator::run()
   QgsScopedRuntimeProfile profile( "Create data providers/" + mLayerId, QStringLiteral( "projectload" ) );
   mDataProvider.reset( QgsProviderRegistry::instance()->createProvider( mProviderKey, mDataSource, mOptions, mFlags ) );
   mDataProvider->moveToThread( QObject::thread() );
-  emit providerCreated( mDataProvider->isValid() );
+  emit providerCreated( mDataProvider->isValid(), mLayerId );
 }
 
 QgsDataProvider *QgsRunnableProviderCreator::dataProvider()

--- a/src/core/providers/qgsrunnableprovidercreator.h
+++ b/src/core/providers/qgsrunnableprovidercreator.h
@@ -56,7 +56,7 @@ class QgsRunnableProviderCreator : public QObject, public QRunnable
 
   signals:
     //! Emitted when a provider is created with \a isValid set to True when the provider is valid
-    void providerCreated( bool isValid );
+    void providerCreated( bool isValid, const QString &layerId );
 
   private:
     std::unique_ptr<QgsDataProvider> mDataProvider;

--- a/src/core/providers/qgsrunnableprovidercreator.h
+++ b/src/core/providers/qgsrunnableprovidercreator.h
@@ -51,9 +51,6 @@ class QgsRunnableProviderCreator : public QObject, public QRunnable
      */
     QgsDataProvider *dataProvider();
 
-    //! Returns the layer id \a layerId corresponding to the layer associated to the created provider.
-    QString layerId() const;
-
   signals:
     //! Emitted when a provider is created with \a isValid set to True when the provider is valid
     void providerCreated( bool isValid, const QString &layerId );


### PR DESCRIPTION
This PR improves parallel loading (see #53069 ) when there are some credentials requested. 
Before this PR, the parallel loading skip all layers that require credentials.

With this PR, when a attempt returns a invalid layer, as it could be a layer that request credentials to be entered by user, the parallel loading stop, try to open the layer in the main thread, so credentials are eventually requested and are stored  in the cache, then restart parallel loading. If there are some layers that request the same credential, there are in the cache and the layers are loaded in parallel.
