### PR TITLE
Attribute table optimization: do not load hidden fields until required

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -65,9 +65,26 @@ Returns ``True`` if the cache will fetch and cache feature geometries.
 
     void setCacheSubsetOfAttributes( const QgsAttributeList &attributes );
 %Docstring
-Set the subset of attributes to be cached
+Set the list (possibly a subset) of attributes to be cached.
+
+.. note::
+
+   By default the cache will store all layer's attributes.
 
 :param attributes: The attributes to be cached
+%End
+
+    QgsAttributeList cacheSubsetOfAttributes( ) const;
+%Docstring
+Returns the list (possibly a subset) of cached attributes.
+
+.. note::
+
+   By default the cache will store all layer's attributes.
+
+.. seealso:: :py:func:`setCacheSubsetOfAttributes`
+
+.. versionadded:: 3.32
 %End
 
     void setCacheAddedAttributes( bool cacheAddedAttributes );
@@ -179,6 +196,25 @@ Gets the feature at the given feature id. Considers the changed, added, deleted 
 :param skipCache: Will query the layer regardless if the feature is in the cache already
 
 :return: ``True`` in case of success
+%End
+
+    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+%Docstring
+Gets the feature at the given feature id with all attributes, if the cached feature
+already contains all attributes, calling this function has the same effect as calling
+:py:func:`~QgsVectorLayerCache.featureAtId`.
+
+Considers the changed, added, deleted and permanent features
+
+:param featureId: The id of the feature to query
+:param feature: The result of the operation will be written to this feature
+:param skipCache: Will query the layer regardless if the feature is in the cache already
+
+:return: ``True`` in case of success
+
+.. seealso:: :py:func:`featureAtId`
+
+.. versionadded:: 3.32
 %End
 
     bool removeCachedFeature( QgsFeatureId fid );

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -198,6 +198,14 @@ The config used for the attribute table.
 :return: The config used for the attribute table.
 %End
 
+    static QgsAttributeList requiredAttributes( const QgsVectorLayer *layer );
+%Docstring
+Returns the list of required attributes according to the attribute table configuration of the ``layer``,
+only visible attributes and virtual fields referenced fields are returned.
+
+.. versionadded:: 3.32
+%End
+
   public slots:
 
     void setCurrentEditSelection( const QgsFeatureIds &fids );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -198,39 +198,39 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   QgsAttributeEditorContext editorContext = QgisApp::instance()->createAttributeEditorContext();
   editorContext.setDistanceArea( da );
 
-  QgsFeatureRequest r;
+  QgsFeatureRequest request;
   bool needsGeom = false;
   if ( mLayer && mLayer->geometryType() != Qgis::GeometryType::Null &&
        initialMode == QgsAttributeTableFilterModel::ShowVisible )
   {
     QgsMapCanvas *mc = QgisApp::instance()->mapCanvas();
     QgsRectangle extent( mc->mapSettings().mapToLayerCoordinates( layer, mc->extent() ) );
-    r.setFilterRect( extent );
+    request.setFilterRect( extent );
     needsGeom = true;
   }
   else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
   {
-    r.setFilterFids( layer->selectedFeatureIds() );
+    request.setFilterFids( layer->selectedFeatureIds() );
   }
   else if ( initialMode == QgsAttributeTableFilterModel::ShowEdited )
   {
-    r.setFilterFids( layer->editBuffer() ? layer->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );
+    request.setFilterFids( layer->editBuffer() ? layer->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );
   }
   else if ( !filterExpression.isEmpty() )
   {
-    r.setFilterExpression( filterExpression );
+    request.setFilterExpression( filterExpression );
   }
   if ( !needsGeom )
-    r.setFlags( QgsFeatureRequest::NoGeometry );
+    request.setFlags( QgsFeatureRequest::NoGeometry );
+
 
   // Initialize dual view
   if ( mLayer )
   {
-    mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, editorContext, false );
-
+    request.setSubsetOfAttributes( mMainView->requiredAttributes( mLayer ) );
+    mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), request, editorContext, false );
     QgsAttributeTableConfig config = mLayer->attributeTableConfig();
     mMainView->setAttributeTableConfig( config );
-
     mFeatureFilterWidget->init( mLayer, editorContext, mMainView, QgisApp::instance()->messageBar(), QgsMessageBar::defaultMessageTimeout() );
   }
 

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -182,7 +182,7 @@ bool QgsCachedFeatureWriterIterator::fetchFeature( QgsFeature &f )
   if ( mFeatIt.nextFeature( f ) )
   {
     // As long as features can be fetched from the provider: Write them to cache
-    mVectorLayerCache->cacheFeature( f );
+    mVectorLayerCache->cacheFeature( f, ! mRequest.flags().testFlag( QgsFeatureRequest::Flag::SubsetOfAttributes ) );
     mFids.insert( f.id() );
     geometryToDestinationCrs( f, mTransform );
     return true;

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -83,7 +83,8 @@ void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
 
 void QgsVectorLayerCache::setCacheSubsetOfAttributes( const QgsAttributeList &attributes )
 {
-  if ( ! mCachedAttributes.toSet().contains( attributes.toSet() ) && ! mCache.isEmpty() )
+  if ( ! mCache.isEmpty() && ! QSet<int>( mCachedAttributes.cbegin(), mCachedAttributes.cend() )
+       .contains( QSet<int>( attributes.cbegin(), attributes.cend( ) ) ) )
     invalidate();
   mCachedAttributes = attributes;
 }

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -83,7 +83,14 @@ void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
 
 void QgsVectorLayerCache::setCacheSubsetOfAttributes( const QgsAttributeList &attributes )
 {
+  if ( ! mCachedAttributes.toSet().contains( attributes.toSet() ) && ! mCache.isEmpty() )
+    invalidate();
   mCachedAttributes = attributes;
+}
+
+QgsAttributeList QgsVectorLayerCache::cacheSubsetOfAttributes( ) const
+{
+  return mCachedAttributes;
 }
 
 void QgsVectorLayerCache::setFullCache( bool fullCache )
@@ -160,13 +167,51 @@ bool QgsVectorLayerCache::featureAtId( QgsFeatureId featureId, QgsFeature &featu
     feature = QgsFeature( *cachedFeature->feature() );
     featureFound = true;
   }
+  else
+  {
+    QgsFeatureRequest request { featureId };
+    const bool allAttrsFetched { mCachedAttributes.count( ) == mLayer->fields().count() };
+    if ( ! allAttrsFetched )
+    {
+      request.setSubsetOfAttributes( mCachedAttributes );
+    }
+    if ( !mCacheGeometry )
+    {
+      request.setFlags( request.flags().setFlag( QgsFeatureRequest::NoGeometry ) );
+    }
+    if ( mLayer->getFeatures( request ).nextFeature( feature ) )
+    {
+      cacheFeature( feature, allAttrsFetched );
+      featureFound = true;
+    }
+  }
+
+  return featureFound;
+}
+
+bool QgsVectorLayerCache::featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache )
+{
+
+  bool featureFound = false;
+
+  QgsCachedFeature *cachedFeature = nullptr;
+
+  if ( !skipCache )
+  {
+    cachedFeature = mCache[ featureId ];
+  }
+
+  if ( cachedFeature && cachedFeature->allAttributesFetched() )
+  {
+    feature = QgsFeature( *cachedFeature->feature() );
+    featureFound = true;
+  }
   else if ( mLayer->getFeatures( QgsFeatureRequest()
                                  .setFilterFid( featureId )
-                                 .setSubsetOfAttributes( mCachedAttributes )
                                  .setFlags( !mCacheGeometry ? QgsFeatureRequest::NoGeometry : QgsFeatureRequest::Flags() ) )
             .nextFeature( feature ) )
   {
-    cacheFeature( feature );
+    cacheFeature( feature, true );
     featureFound = true;
   }
 
@@ -342,11 +387,14 @@ void QgsVectorLayerCache::layerDeleted()
 
 void QgsVectorLayerCache::invalidate()
 {
-  mCache.clear();
-  mCacheOrderedKeys.clear();
-  mCacheUnorderedKeys.clear();
-  mFullCache = false;
-  emit invalidated();
+  if ( ! mCache.isEmpty() )
+  {
+    mCache.clear();
+    mCacheOrderedKeys.clear();
+    mCacheUnorderedKeys.clear();
+    mFullCache = false;
+    emit invalidated();
+  }
 }
 
 bool QgsVectorLayerCache::canUseCacheForRequest( const QgsFeatureRequest &featureRequest, QgsFeatureIterator &it )
@@ -433,12 +481,23 @@ QgsFeatureIterator QgsVectorLayerCache::getFeatures( const QgsFeatureRequest &fe
     if ( mCacheGeometry && mLayer->isSpatial() )
       myRequest.setFlags( featureRequest.flags() & ~QgsFeatureRequest::NoGeometry );
 
-    // Make sure, all the cached attributes are requested as well
-    const QgsAttributeList requestSubset = featureRequest.subsetOfAttributes();
-    QSet<int> attrs( requestSubset.begin(), requestSubset.end() );
-    for ( int attr : std::as_const( mCachedAttributes ) )
-      attrs.insert( attr );
-    myRequest.setSubsetOfAttributes( QgsAttributeList( attrs.begin(), attrs.end() ) );
+    // Make sure all the cached attributes are requested as well if requesting a subset
+    if ( myRequest.flags().testFlag( QgsFeatureRequest::SubsetOfAttributes ) )
+    {
+      if ( mCachedAttributes.count( ) != mLayer->fields().count() )
+      {
+        const QgsAttributeList requestSubset = featureRequest.subsetOfAttributes();
+        QSet<int> attrs( requestSubset.begin(), requestSubset.end() );
+        for ( int attr : std::as_const( mCachedAttributes ) )
+          attrs.insert( attr );
+        myRequest.setSubsetOfAttributes( attrs.values() );
+      }
+      else // we are already caching all attributes
+      {
+        myRequest.setSubsetOfAttributes( QgsAttributeList() );
+        myRequest.setFlags( myRequest.flags().setFlag( QgsFeatureRequest::Flag::SubsetOfAttributes, false ) );
+      }
+    }
 
     it = QgsFeatureIterator( new QgsCachedFeatureWriterIterator( this, myRequest ) );
   }
@@ -495,3 +554,9 @@ void QgsVectorLayerCache::connectJoinedLayers() const
       connect( vl, &QgsVectorLayer::attributeValueChanged, this, &QgsVectorLayerCache::onJoinAttributeValueChanged );
   }
 }
+
+bool QgsVectorLayerCache::QgsCachedFeature::allAttributesFetched() const
+{
+  return mAllAttributesFetched;
+}
+

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * will inform the cache, when it has been deleted, so indexes can be
      * updated that the wrapped feature needs to be fetched again if needed.
      */
-    class QgsCachedFeature
+    class CORE_EXPORT QgsCachedFeature
     {
       public:
 

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -63,9 +63,11 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
          *
          * \param feat     The feature to cache. A copy will be made.
          * \param vlCache  The cache to inform when the feature has been removed from the cache.
+         * \param allAttributesFetched TRUE if the feature was fetched with all attributes (and not a subset)
          */
-        QgsCachedFeature( const QgsFeature &feat, QgsVectorLayerCache *vlCache )
+        QgsCachedFeature( const QgsFeature &feat, QgsVectorLayerCache *vlCache, bool allAttributesFetched )
           : mCache( vlCache )
+          , mAllAttributesFetched( allAttributesFetched )
         {
           mFeature = new QgsFeature( feat );
         }
@@ -80,9 +82,12 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
 
         inline const QgsFeature *feature() { return mFeature; }
 
+        bool allAttributesFetched() const;
+
       private:
         QgsFeature *mFeature = nullptr;
         QgsVectorLayerCache *mCache = nullptr;
+        bool mAllAttributesFetched = true;
 
         friend class QgsVectorLayerCache;
         Q_DISABLE_COPY( QgsCachedFeature )
@@ -125,11 +130,21 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     bool cacheGeometry() const { return mCacheGeometry; }
 
     /**
-     * Set the subset of attributes to be cached
+     * Set the list (possibly a subset) of attributes to be cached.
      *
+     * \note By default the cache will store all layer's attributes.
      * \param attributes   The attributes to be cached
      */
     void setCacheSubsetOfAttributes( const QgsAttributeList &attributes );
+
+    /**
+     * Returns the list (possibly a subset) of cached attributes.
+     *
+     * \note By default the cache will store all layer's attributes.
+     * \see setCacheSubsetOfAttributes()
+     * \since QGIS 3.32
+     */
+    QgsAttributeList cacheSubsetOfAttributes( ) const;
 
     /**
      * If this is enabled, the subset of cached attributes will automatically be extended
@@ -242,6 +257,21 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \returns TRUE in case of success
      */
     bool featureAtId( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
+
+    /**
+     * Gets the feature at the given feature id with all attributes, if the cached feature
+     * already contains all attributes, calling this function has the same effect as calling
+     * featureAtId().
+     *
+     * Considers the changed, added, deleted and permanent features
+     * \param featureId The id of the feature to query
+     * \param feature   The result of the operation will be written to this feature
+     * \param skipCache Will query the layer regardless if the feature is in the cache already
+     * \returns TRUE in case of success
+     * \see featureAtId()
+     * \since QGIS 3.32
+     */
+    bool featureAtIdWithAllAttributes( QgsFeatureId featureId, QgsFeature &feature, bool skipCache = false );
 
     /**
      * Removes the feature identified by fid from the cache if present.
@@ -390,9 +420,9 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
 
     void connectJoinedLayers() const;
 
-    inline void cacheFeature( QgsFeature &feat )
+    inline void cacheFeature( QgsFeature &feat, bool allAttributesFetched )
     {
-      QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this );
+      QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this, allAttributesFetched );
       mCache.insert( feat.id(), cachedFeature );
       if ( mCacheUnorderedKeys.find( feat.id() ) == mCacheUnorderedKeys.end() )
       {

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -91,6 +91,22 @@ bool QgsAttributeTableModel::loadFeatureAtId( QgsFeatureId fid ) const
   return mLayerCache->featureAtId( fid, mFeat );
 }
 
+bool QgsAttributeTableModel::loadFeatureAtId( QgsFeatureId fid, int fieldIdx ) const
+{
+  QgsDebugMsgLevel( QStringLiteral( "loading feature %1 with field %2" ).arg( fid, fieldIdx ), 3 );
+
+  if ( mLayerCache->cacheSubsetOfAttributes().contains( fieldIdx ) )
+  {
+    return loadFeatureAtId( fid );
+  }
+
+  if ( fid == std::numeric_limits<int>::min() )
+  {
+    return false;
+  }
+  return mLayerCache->featureAtIdWithAllAttributes( fid, mFeat );
+}
+
 int QgsAttributeTableModel::extraColumns() const
 {
   return mExtraColumns;
@@ -702,9 +718,9 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
     return static_cast<Qt::Alignment::Int>( widgetData.fieldFormatter->alignmentFlag( mLayer, fieldId, widgetData.config ) | Qt::AlignVCenter );
   }
 
-  if ( mFeat.id() != rowId || !mFeat.isValid() )
+  if ( mFeat.id() != rowId || !mFeat.isValid() || ! mLayerCache->cacheSubsetOfAttributes().contains( fieldId ) )
   {
-    if ( !loadFeatureAtId( rowId ) )
+    if ( !loadFeatureAtId( rowId, fieldId ) )
       return QVariant( "ERROR" );
 
     if ( mFeat.id() != rowId )

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -387,6 +387,18 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
      */
     virtual bool loadFeatureAtId( QgsFeatureId fid ) const;
 
+    /**
+     * Load feature fid into local cache (mFeat) ensuring that the field with
+     * index \a fieldIdx is also fetched even if the cached attributes did not
+     * contain the field (e.g. because it was hidden in the attribute table).
+     *
+     * \param  fid      feature id
+     * \param  fieldIdx field index
+     *
+     * \returns feature exists
+     */
+    virtual bool loadFeatureAtId( QgsFeatureId fid, int fieldIdx ) const;
+
     QgsFeatureRequest mFeatureRequest;
 
     struct SortCache

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1149,13 +1149,12 @@ QgsAttributeList QgsDualView::requiredAttributes( const QgsVectorLayer *layer )
 
   const QgsAttributeTableConfig config { layer->attributeTableConfig() };
 
-  const QVector<QgsAttributeTableConfig::ColumnConfig> constCols { config.columns() };
-  for ( int colIdx = 0; colIdx < constCols.count(); ++colIdx )
+  const QVector<QgsAttributeTableConfig::ColumnConfig> constColumnconfigs { config.columns() };
+  for ( const QgsAttributeTableConfig::ColumnConfig &columnConfig : std::as_const( constColumnconfigs ) )
   {
-    const QgsAttributeTableConfig::ColumnConfig col { constCols.at( colIdx ) };
-    if ( col.type == QgsAttributeTableConfig::Type::Field && ! col.hidden )
+    if ( columnConfig.type == QgsAttributeTableConfig::Type::Field && ! columnConfig.hidden )
     {
-      attributes.insert( layer->fields().lookupField( col.name ) );
+      attributes.insert( layer->fields().lookupField( columnConfig.name ) );
     }
   }
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -332,20 +332,20 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
       break;
   }
 
-  QgsFeatureRequest r = mMasterModel->request();
+  QgsFeatureRequest request = mMasterModel->request();
   const bool needsGeometry = filterMode == QgsAttributeTableFilterModel::ShowVisible;
 
-  const bool requiresTableReload = ( r.filterType() != QgsFeatureRequest::FilterNone || r.spatialFilterType() != Qgis::SpatialFilterType::NoFilter ) // previous request was subset
-                                   || ( needsGeometry && r.flags() & QgsFeatureRequest::NoGeometry ) // no geometry for last request
+  const bool requiresTableReload = ( request.filterType() != QgsFeatureRequest::FilterNone || request.spatialFilterType() != Qgis::SpatialFilterType::NoFilter ) // previous request was subset
+                                   || ( needsGeometry && request.flags() & QgsFeatureRequest::NoGeometry ) // no geometry for last request
                                    || ( mMasterModel->rowCount() == 0 ); // no features
 
   if ( !needsGeometry )
-    r.setFlags( r.flags() | QgsFeatureRequest::NoGeometry );
+    request.setFlags( request.flags() | QgsFeatureRequest::NoGeometry );
   else
-    r.setFlags( r.flags() & ~( QgsFeatureRequest::NoGeometry ) );
-  r.setFilterFids( QgsFeatureIds() );
-  r.setFilterRect( QgsRectangle() );
-  r.disableFilter();
+    request.setFlags( request.flags() & ~( QgsFeatureRequest::NoGeometry ) );
+  request.setFilterFids( QgsFeatureIds() );
+  request.setFilterRect( QgsRectangle() );
+  request.disableFilter();
 
   // setup new connections and filter request parameters
   switch ( filterMode )
@@ -355,13 +355,13 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
       if ( mFilterModel->mapCanvas() )
       {
         const QgsRectangle rect = mFilterModel->mapCanvas()->mapSettings().mapToLayerCoordinates( mLayer, mFilterModel->mapCanvas()->extent() );
-        r.setFilterRect( rect );
+        request.setFilterRect( rect );
       }
       connect( mFilterModel, &QgsAttributeTableFilterModel::visibleReloaded, this, &QgsDualView::filterChanged );
       break;
 
     case QgsAttributeTableFilterModel::ShowEdited:
-      r.setFilterFids( masterModel()->layer()->editBuffer() ? masterModel()->layer()->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );
+      request.setFilterFids( masterModel()->layer()->editBuffer() ? masterModel()->layer()->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );
       connect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
       connect( mFilterModel, &QgsAttributeTableFilterModel::filterError, this, &QgsDualView::filterError );
       connect( masterModel()->layer(), &QgsVectorLayer::layerModified, this, &QgsDualView::updateEditedAddedFeatures );
@@ -382,7 +382,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     {
       const QString filterExpression = filterMode == QgsAttributeTableFilterModel::ShowFilteredList ? mFilterModel->filterExpression() : QString();
       if ( !filterExpression.isEmpty() )
-        r.setFilterExpression( mFilterModel->filterExpression() );
+        request.setFilterExpression( mFilterModel->filterExpression() );
       connect( mFilterModel, &QgsAttributeTableFilterModel::featuresFiltered, this, &QgsDualView::filterChanged );
       connect( mFilterModel, &QgsAttributeTableFilterModel::filterError, this, &QgsDualView::filterError );
       break;
@@ -390,7 +390,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
 
     case QgsAttributeTableFilterModel::ShowSelected:
       connect( masterModel()->layer(), &QgsVectorLayer::selectionChanged, this, &QgsDualView::updateSelectedFeatures );
-      r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
+      request.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
       break;
   }
 
@@ -415,7 +415,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     //disconnect the connections of the current (old) filtermode before reload
     mFilterModel->disconnectFilterModeConnections();
 
-    mMasterModel->setRequest( r );
+    mMasterModel->setRequest( request );
     whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
     mMasterModel->loadLayer();
   }
@@ -436,6 +436,7 @@ void QgsDualView::initLayerCache( bool cacheGeometry )
   const QgsSettings settings;
   const int cacheSize = settings.value( QStringLiteral( "qgis/attributeTableRowCache" ), "10000" ).toInt();
   mLayerCache = new QgsVectorLayerCache( mLayer, cacheSize, this );
+  mLayerCache->setCacheSubsetOfAttributes( requiredAttributes( mLayer ) );
   mLayerCache->setCacheGeometry( cacheGeometry );
   if ( 0 == cacheSize || 0 == ( QgsVectorDataProvider::SelectAtId & mLayer->dataProvider()->capabilities() ) )
   {
@@ -1142,6 +1143,36 @@ bool QgsDualView::modifySort()
 
 }
 
+QgsAttributeList QgsDualView::requiredAttributes( const QgsVectorLayer *layer )
+{
+  QSet<int> attributes;
+
+  const QgsAttributeTableConfig config { layer->attributeTableConfig() };
+
+  const QVector<QgsAttributeTableConfig::ColumnConfig> constCols { config.columns() };
+  for ( int colIdx = 0; colIdx < constCols.count(); ++colIdx )
+  {
+    const QgsAttributeTableConfig::ColumnConfig col { constCols.at( colIdx ) };
+    if ( col.type == QgsAttributeTableConfig::Type::Field && ! col.hidden )
+    {
+      attributes.insert( layer->fields().lookupField( col.name ) );
+    }
+  }
+
+  const QSet<int> colAttrs { attributes };
+  for ( const int attrIdx : std::as_const( colAttrs ) )
+  {
+    if ( layer->fields().fieldOrigin( attrIdx ) == QgsFields::FieldOrigin::OriginExpression )
+    {
+      attributes += QgsExpression( layer->expressionField( attrIdx ) ).referencedAttributeIndexes( layer->fields() );
+    }
+  }
+
+  QgsAttributeList attrs { attributes.values() };
+  std::sort( attrs.begin(), attrs.end() );
+  return attrs;
+}
+
 void QgsDualView::zoomToCurrentFeature()
 {
   const QModelIndex currentIndex = mTableView->currentIndex();
@@ -1301,6 +1332,11 @@ void QgsDualView::setAttributeTableConfig( const QgsAttributeTableConfig &config
   mLayer->setAttributeTableConfig( mConfig );
   mFilterModel->setAttributeTableConfig( mConfig );
   mTableView->setAttributeTableConfig( mConfig );
+  const QgsAttributeList attributes { requiredAttributes( mLayer ) };
+  QgsFeatureRequest request { mMasterModel->request() };
+  request.setSubsetOfAttributes( attributes );
+  mMasterModel->setRequest( request );
+  mLayerCache->setCacheSubsetOfAttributes( attributes );
 }
 
 void QgsDualView::setSortExpression( const QString &sortExpression, Qt::SortOrder sortOrder )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -228,6 +228,13 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     QgsAttributeTableConfig attributeTableConfig() const;
 
+    /**
+     * Returns the list of required attributes according to the attribute table configuration of the \a layer,
+     * only visible attributes and virtual fields referenced fields are returned.
+     * \since QGIS 3.32
+     */
+    static QgsAttributeList requiredAttributes( const QgsVectorLayer *layer );
+
   public slots:
 
     /**
@@ -425,7 +432,6 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     //! Returns TRUE if the expression dialog has been accepted
     bool modifySort();
-
 
     QgsFieldConditionalFormatWidget *mConditionalFormatWidget = nullptr;
     QgsAttributeEditorContext mEditorContext;

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -76,7 +76,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
   {
     QgsFeature feat;
 
-    mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
+    mFilterModel->layerCache()->featureAtIdWithAllAttributes( idxToFid( index ), feat );
 
     mExpressionContext.setFeature( feat );
     return mDisplayExpression.evaluate( &mExpressionContext );
@@ -88,7 +88,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
 
     QgsFeature feat;
 
-    mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
+    mFilterModel->layerCache()->featureAtIdWithAllAttributes( idxToFid( index ), feat );
 
     QgsVectorLayerEditBuffer *editBuffer = mFilterModel->layer()->editBuffer();
 
@@ -110,7 +110,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
   {
     QgsFeature feat;
 
-    mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
+    mFilterModel->layerCache()->featureAtIdWithAllAttributes( idxToFid( index ), feat );
 
     return QVariant::fromValue( feat );
   }
@@ -127,7 +127,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
     QgsVectorLayer *layer = mFilterModel->layer();
     QgsFeature feat;
     const QgsFeatureId fid = idxToFid( index );
-    mFilterModel->layerCache()->featureAtId( fid, feat );
+    mFilterModel->layerCache()->featureAtIdWithAllAttributes( fid, feat );
     mExpressionContext.setFeature( feat );
     QList<QgsConditionalStyle> styles;
 
@@ -242,7 +242,7 @@ QString QgsFeatureListModel::displayExpression() const
 
 bool QgsFeatureListModel::featureByIndex( const QModelIndex &index, QgsFeature &feat )
 {
-  return mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
+  return mFilterModel->layerCache()->featureAtIdWithAllAttributes( idxToFid( index ), feat );
 }
 
 void QgsFeatureListModel::onBeginRemoveRows( const QModelIndex &parent, int first, int last )

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -51,6 +51,9 @@ class TestQgsAttributeTable : public QObject
     void init();
     // will be called before each testfunction is executed.
     void cleanup() {} // will be called after every testfunction.
+
+  public slots:
+
     void testRegression15974();
     void testFieldCalculation();
     void testFieldCalculationArea();
@@ -69,6 +72,8 @@ class TestQgsAttributeTable : public QObject
     void testMultiEditMakeUncommittedChanges();
     void testInvalidView();
     void testEnsureEditSelection();
+  private slots:
+    void testFetchAllAttributes();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -893,6 +898,24 @@ void TestQgsAttributeTable::testEnsureEditSelection()
   spy.wait( 1 );
   // ... and the currentEditSelection stays on 2 (since lastEditSelectionFid is persisted)
   QVERIFY( dlg->mMainView->mFeatureListView->currentEditSelection().contains( 2 ) );
+}
+
+void TestQgsAttributeTable::testFetchAllAttributes()
+{
+  QString pointFileName = TEST_DATA_DIR + QStringLiteral( "/points.shp" );
+  std::unique_ptr< QgsVectorLayer > layer = std::make_unique< QgsVectorLayer >( pointFileName );
+  QVERIFY( layer->isValid() );
+
+  QgsAttributeTableConfig config { layer->attributeTableConfig() };
+  config.setColumnHidden( 1, true );
+  layer->setAttributeTableConfig( config );
+
+  std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( layer.get() ) );
+
+  QCOMPARE( dlg->mMainView->masterModel()->data( dlg->mMainView->masterModel()->index( 0, 0 ), Qt::DisplayRole ).toString(), "Jet" );
+  QCOMPARE( dlg->mMainView->masterModel()->data( dlg->mMainView->masterModel()->index( 0, 1 ), Qt::DisplayRole ).toString(), "90" );
+  QCOMPARE( dlg->mMainView->masterModel()->data( dlg->mMainView->masterModel()->index( 0, 2 ), Qt::DisplayRole ).toString(), "3.000" );
+
 }
 
 QGSTEST_MAIN( TestQgsAttributeTable )

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -57,6 +57,11 @@ class TestVectorLayerCache : public QObject
     void testCacheGeom();
     void testFullCacheWithRect(); // Test that if rect is set then no full cache can exist, see #19468
 
+    /**
+     * Test the cache functionality with subset of attributes.
+     */
+    void testMixedAttributesCache();
+
     void onCommittedFeaturesAdded( const QString &, const QgsFeatureList & );
 
   private:
@@ -421,6 +426,62 @@ void TestVectorLayerCache::testFullCacheWithRect()
     QVERIFY( f.hasGeometry() );
   }
   QVERIFY( cache.hasFullCache() );
+
+}
+
+void TestVectorLayerCache::testMixedAttributesCache()
+{
+
+  // Test cache with no subset
+  QgsVectorLayerCache cache( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  QgsFeature f;
+  QgsFeatureIterator it = cache.getFeatures( );
+  it.nextFeature( f );
+
+  QVERIFY( cache.isFidCached( f.id() ) );
+  QVERIFY( cache.mCache[f.id()]->allAttributesFetched() );
+
+  // Test with subset
+  QgsVectorLayerCache cacheSubset( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  cacheSubset.setCacheSubsetOfAttributes( {2} );
+  QgsFeatureIterator itSubset = cacheSubset.getFeatures( );
+  itSubset.nextFeature( f );
+
+  QVERIFY( ! cacheSubset.isFidCached( f.id() ) );
+  cacheSubset.featureAtId( f.id(), f );
+  QVERIFY( cacheSubset.isFidCached( f.id() ) );
+  QVERIFY( ! cacheSubset.mCache[f.id()]->allAttributesFetched() );
+  QVERIFY( f.attribute( 0 ).isNull() );
+  QVERIFY( f.attribute( 1 ).isNull() );
+  QVERIFY( ! f.attribute( 2 ).isNull() );
+
+  cacheSubset.featureAtIdWithAllAttributes( 0, f );
+  QVERIFY( cacheSubset.isFidCached( 0 ) );
+  QVERIFY( cacheSubset.mCache[ 0 ]->allAttributesFetched() );
+  QVERIFY( ! f.attribute( 0 ).isNull() );
+  QVERIFY( ! f.attribute( 1 ).isNull() );
+  QVERIFY( ! f.attribute( 2 ).isNull() );
+
+  cacheSubset.featureAtIdWithAllAttributes( 1, f );
+  QVERIFY( cacheSubset.isFidCached( 1 ) );
+  QVERIFY( cacheSubset.mCache[1]->allAttributesFetched() );
+  QVERIFY( ! f.attribute( 0 ).isNull() );
+  QVERIFY( ! f.attribute( 1 ).isNull() );
+  QVERIFY( ! f.attribute( 2 ).isNull() );
+
+  // Test subset with request
+  QgsVectorLayerCache cacheSubsetWithRequest( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  cacheSubsetWithRequest.setCacheSubsetOfAttributes( {1, 2} );
+  QgsFeatureRequest req;
+  req.setSubsetOfAttributes( { 2 } );
+  QgsFeatureIterator itSubsetWithRequest = cacheSubsetWithRequest.getFeatures( req );
+  itSubsetWithRequest.nextFeature( f );
+
+  QVERIFY( cacheSubset.isFidCached( 0 ) );
+  QVERIFY( ! cacheSubsetWithRequest.mCache[f.id()]->allAttributesFetched() );
+  QVERIFY( f.attribute( 0 ).isNull() );
+  QVERIFY( ! f.attribute( 1 ).isNull() );
+  QVERIFY( ! f.attribute( 2 ).isNull() );
 
 }
 

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -404,7 +404,7 @@ void TestVectorLayerCache::testCacheGeom()
 
 void TestVectorLayerCache::testFullCacheWithRect()
 {
-  QgsVectorLayerCache cache( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  QgsVectorLayerCache cache( mPointsLayer, static_cast<int>( mPointsLayer->dataProvider()->featureCount() ) );
   // cache geometry
   cache.setCacheGeometry( true );
   QVERIFY( ! cache.hasFullCache() );
@@ -433,7 +433,7 @@ void TestVectorLayerCache::testMixedAttributesCache()
 {
 
   // Test cache with no subset
-  QgsVectorLayerCache cache( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  QgsVectorLayerCache cache( mPointsLayer, static_cast<int>( mPointsLayer->dataProvider()->featureCount() ) );
   QgsFeature f;
   QgsFeatureIterator it = cache.getFeatures( );
   it.nextFeature( f );
@@ -442,7 +442,7 @@ void TestVectorLayerCache::testMixedAttributesCache()
   QVERIFY( cache.mCache[f.id()]->allAttributesFetched() );
 
   // Test with subset
-  QgsVectorLayerCache cacheSubset( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  QgsVectorLayerCache cacheSubset( mPointsLayer, static_cast<int>( mPointsLayer->dataProvider()->featureCount() ) );
   cacheSubset.setCacheSubsetOfAttributes( {2} );
   QgsFeatureIterator itSubset = cacheSubset.getFeatures( );
   itSubset.nextFeature( f );
@@ -470,7 +470,7 @@ void TestVectorLayerCache::testMixedAttributesCache()
   QVERIFY( ! f.attribute( 2 ).isNull() );
 
   // Test subset with request
-  QgsVectorLayerCache cacheSubsetWithRequest( mPointsLayer, mPointsLayer->dataProvider()->featureCount() );
+  QgsVectorLayerCache cacheSubsetWithRequest( mPointsLayer, static_cast<int>( mPointsLayer->dataProvider()->featureCount() ) );
   cacheSubsetWithRequest.setCacheSubsetOfAttributes( {1, 2} );
   QgsFeatureRequest req;
   req.setSubsetOfAttributes( { 2 } );


### PR DESCRIPTION
- defer hidden fields fetching
- allow caching of mixed full and subset attributes features

This greatly improves attribute table loading times when there are hidden virtual fields and (in a more limited way) when there are hidden non-virtual fields.

Funded by: QCooperative - QTIBIA Engineering