### PR TITLE
Don't try to create database connections for dxf files in browser

### DIFF
--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -370,7 +370,8 @@ QgsAbstractDatabaseProviderConnection *QgsFileDataCollectionItem::databaseConnec
   }
 
   const QString driverName = GDALGetDriverShortName( hDriver );
-  if ( driverName == QLatin1String( "PDF" ) )
+  if ( driverName == QLatin1String( "PDF" )
+       || driverName == QLatin1String( "DXF" ) )
   {
     // unwanted drivers -- it's slow to create connections for these, and we don't really want
     // to expose database capabilities for them (even though they kind of are database formats)


### PR DESCRIPTION
This is very slow to do, and can grind the browser to a halt for folders with many dxf files
