### PR TITLE
Add layers to elevation profiles, further UX tweaks

### DIFF
--- a/python/core/auto_generated/qgselevationutils.sip.in
+++ b/python/core/auto_generated/qgselevationutils.sip.in
@@ -30,6 +30,22 @@ This method considers the elevation (or z) range available from layers contained
 returns the maximal combined elevation range of these layers.
 %End
 
+    static bool canEnableElevationForLayer( QgsMapLayer *layer );
+%Docstring
+Returns ``True`` if elevation can be enabled for a map ``layer``.
+
+.. versionadded:: 3.32
+%End
+
+    static bool enableElevationForLayer( QgsMapLayer *layer );
+%Docstring
+Automatically enables elevation for a map ``layer``, using reasonable defaults.
+
+Returns ``True`` if the elevation was enabled successfully.
+
+.. versionadded:: 3.32
+%End
+
 };
 
 

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -23,6 +23,7 @@
 #include "qgsgeometry.h"
 #include "qobjectuniqueptr.h"
 #include "qgselevationprofilelayertreeview.h"
+#include "ui_qgselevationprofileaddlayersdialogbase.h"
 
 #include <QWidgetAction>
 #include <QElapsedTimer>
@@ -50,6 +51,7 @@ class QLabel;
 class QgsProfilePoint;
 class QgsSettingsEntryDouble;
 class QgsSettingsEntryBool;
+class QgsMapLayerProxyModel;
 
 class QgsAppElevationProfileLayerTreeView : public QgsElevationProfileLayerTreeView
 {
@@ -61,6 +63,26 @@ class QgsAppElevationProfileLayerTreeView : public QgsElevationProfileLayerTreeV
   protected:
 
     void contextMenuEvent( QContextMenuEvent *event ) override;
+};
+
+class QgsElevationProfileLayersDialog: public QDialog, private Ui::QgsElevationProfileAddLayersDialogBase
+{
+    Q_OBJECT
+
+  public:
+    QgsElevationProfileLayersDialog( QWidget *parent = nullptr );
+    void setVisibleLayers( const QList<QgsMapLayer *> &layers );
+    void setHiddenLayers( const QList<QgsMapLayer *> &layers );
+    QList< QgsMapLayer * > selectedLayers() const;
+
+  private slots:
+
+    void filterVisible( bool enabled );
+
+  private:
+
+    QgsMapLayerProxyModel *mModel = nullptr;
+    QList< QgsMapLayer * > mVisibleLayers;
 };
 
 class QgsElevationProfileWidget : public QWidget
@@ -93,6 +115,7 @@ class QgsElevationProfileWidget : public QWidget
     void toggleDockModeRequested( bool docked );
 
   private slots:
+    void addLayers();
     void updateCanvasLayers();
     void onTotalPendingJobsCountChanged( int count );
     void setProfileCurve( const QgsGeometry &curve, bool resetView );

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -116,6 +116,7 @@ class QgsElevationProfileWidget : public QWidget
 
   private slots:
     void addLayers();
+    void addLayersInternal( const QList<QgsMapLayer *> &layers );
     void updateCanvasLayers();
     void onTotalPendingJobsCountChanged( int count );
     void setProfileCurve( const QgsGeometry &curve, bool resetView );

--- a/src/core/qgselevationutils.h
+++ b/src/core/qgselevationutils.h
@@ -40,6 +40,22 @@ class CORE_EXPORT QgsElevationUtils
      */
     static QgsDoubleRange calculateZRangeForProject( QgsProject *project );
 
+    /**
+     * Returns TRUE if elevation can be enabled for a map \a layer.
+     *
+     * \since QGIS 3.32
+     */
+    static bool canEnableElevationForLayer( QgsMapLayer *layer );
+
+    /**
+     * Automatically enables elevation for a map \a layer, using reasonable defaults.
+     *
+     * Returns TRUE if the elevation was enabled successfully.
+     *
+     * \since QGIS 3.32
+     */
+    static bool enableElevationForLayer( QgsMapLayer *layer );
+
 };
 
 

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -252,6 +252,27 @@ bool QgsElevationProfileLayerTreeModel::setData( const QModelIndex &index, const
   return QgsLayerTreeModel::setData( index, value, role );
 }
 
+bool QgsElevationProfileLayerTreeModel::canDropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) const
+{
+  if ( action == Qt::IgnoreAction )
+    return true;
+
+  if ( !data->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
+    return false;
+
+  // don't accept moves from other layer trees -- only allow internal drag
+  if ( action == Qt::MoveAction )
+  {
+    const QString source = data->data( QStringLiteral( "application/qgis.layertree.source" ) );
+    if ( source.isEmpty() || source != QStringLiteral( ":0x%1" ).arg( reinterpret_cast<quintptr>( this ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) ) )
+    {
+      return false;
+    }
+  }
+
+  return QgsLayerTreeModel::canDropMimeData( data, action, row, column, parent );
+}
+
 bool QgsElevationProfileLayerTreeModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )
 {
   if ( action == Qt::IgnoreAction )
@@ -260,10 +281,48 @@ bool QgsElevationProfileLayerTreeModel::dropMimeData( const QMimeData *data, Qt:
   if ( !data->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
     return false;
 
-  // don't accept drags from other layer trees -- only allow internal drag
+  // don't accept moves from other layer trees -- only allow internal drag
   const QString source = data->data( QStringLiteral( "application/qgis.layertree.source" ) );
   if ( source.isEmpty() || source != QStringLiteral( ":0x%1" ).arg( reinterpret_cast<quintptr>( this ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) ) )
-    return false;
+  {
+    if ( action == Qt::CopyAction )
+    {
+      QByteArray encodedLayerTreeData = data->data( QStringLiteral( "application/qgis.layertreemodeldata" ) );
+
+      QDomDocument layerTreeDoc;
+      if ( !layerTreeDoc.setContent( QString::fromUtf8( encodedLayerTreeData ) ) )
+        return false;
+
+      QDomElement rootLayerTreeElem = layerTreeDoc.documentElement();
+      if ( rootLayerTreeElem.tagName() != QLatin1String( "layer_tree_model_data" ) )
+        return false;
+
+      QList<QgsMapLayer *> layersToAdd;
+
+      QDomElement elem = rootLayerTreeElem.firstChildElement();
+      while ( !elem.isNull() )
+      {
+        std::unique_ptr< QgsLayerTreeNode > node( QgsLayerTreeNode::readXml( elem, QgsProject::instance() ) );
+        if ( node && QgsLayerTree::isLayer( node.get() ) )
+        {
+          if ( QgsMapLayer *layer = qobject_cast< QgsLayerTreeLayer * >( node.get() )->layer() )
+          {
+            layersToAdd << layer;
+          }
+        }
+        elem = elem.nextSiblingElement();
+      }
+
+      if ( !layersToAdd.empty() )
+        emit addLayers( layersToAdd );
+
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
 
   return QgsLayerTreeModel::dropMimeData( data, action, row, column, parent );
 }
@@ -353,6 +412,7 @@ QgsElevationProfileLayerTreeView::QgsElevationProfileLayerTreeView( QgsLayerTree
   , mLayerTree( rootNode )
 {
   mModel = new QgsElevationProfileLayerTreeModel( rootNode, this );
+  connect( mModel, &QgsElevationProfileLayerTreeModel::addLayers, this, &QgsElevationProfileLayerTreeView::addLayers );
   mProxyModel = new QgsElevationProfileLayerTreeProxyModel( mModel, this );
 
   setHeaderHidden( true );

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -417,6 +417,11 @@ void QgsElevationProfileLayerTreeView::populateInitialLayers( QgsProject *projec
   }
 }
 
+QgsElevationProfileLayerTreeProxyModel *QgsElevationProfileLayerTreeView::proxyModel()
+{
+  return mProxyModel;
+}
+
 void QgsElevationProfileLayerTreeView::resizeEvent( QResizeEvent *event )
 {
   header()->setMinimumSectionSize( viewport()->width() );

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -58,8 +58,19 @@ class GUI_EXPORT QgsElevationProfileLayerTreeModel : public QgsLayerTreeModel
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
+    bool canDropMimeData( const QMimeData *data, Qt::DropAction action,
+                          int row, int column, const QModelIndex &parent ) const override;
     bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
     QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+
+  signals:
+
+    /**
+     * Emitted when layers should be added to the profile, e.g. via a drag and drop action.
+     *
+     * \since QGIS 3.32
+     */
+    void addLayers( const QList< QgsMapLayer * > &layers );
 
   private:
 
@@ -135,6 +146,15 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QTreeView
      * \since QGIS 3.32
      */
     QgsElevationProfileLayerTreeProxyModel *proxyModel();
+
+  signals:
+
+    /**
+     * Emitted when layers should be added to the profile, e.g. via a drag and drop action.
+     *
+     * \since QGIS 3.32
+     */
+    void addLayers( const QList< QgsMapLayer * > &layers );
 
   protected:
 

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -129,6 +129,13 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QTreeView
      */
     void populateInitialLayers( QgsProject *project );
 
+    /**
+     * Returns the view's proxy model.
+     *
+     * \since QGIS 3.32
+     */
+    QgsElevationProfileLayerTreeProxyModel *proxyModel();
+
   protected:
 
     void resizeEvent( QResizeEvent *event ) override;

--- a/src/ui/qgselevationprofileaddlayersdialogbase.ui
+++ b/src/ui/qgselevationprofileaddlayersdialogbase.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsElevationProfileAddLayersDialogBase</class>
+ <widget class="QDialog" name="QgsElevationProfileAddLayersDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>270</width>
+    <height>194</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add Layers to Elevation Profile</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <item row="1" column="0">
+    <widget class="QListView" name="listMapLayers">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QgsFilterLineEdit" name="mFilterLineEdit">
+     <property name="placeholderText">
+      <string>Search</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="mCheckBoxVisibleLayers">
+     <property name="toolTip">
+      <string>If checked, only layers visible within the map will be listed</string>
+     </property>
+     <property name="text">
+      <string>Show visible layers only</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mFilterLineEdit</tabstop>
+  <tabstop>listMapLayers</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsElevationProfileAddLayersDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsElevationProfileAddLayersDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
1. Adds an explicit "Add Layers" button to elevation profile dock. This provides a user-friendly why of adding new layers to a plot - clicking it will show a filtered list of possible layers which can be added to the plot, but which currently aren't in the plot. (I.e it will include all raster layers from the project which aren't marked as having elevation data.) Selecting layers will cause them to automatically be marked as having elevation data and immediately added to the plot.
2. Layers can now be added to elevation plots via drag and drop from layer tree. Unfortunately due to qt api limitations, we can't just enable direct drag and drop from the layer tree -- users have to explicitly hold the "Ctrl" key while dragging in order to force the copy action.