### PR TITLE
[Oracle] Fix crashes with shared connection among threads

### DIFF
--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -288,7 +288,7 @@ class QgsOracleConn : public QObject
     bool mTransaction = false;
     int mSavePointId = 1;
 
-    static QMap<QString, QgsOracleConn *> sConnections;
+    static QMap<QPair<QString, QThread *>, QgsOracleConn *> sConnections;
     static int snConnections;
     static QMap<QString, QDateTime> sBrokenConnections;
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -271,19 +271,29 @@ QgsAbstractFeatureSource *QgsOracleProvider::featureSource() const
 
 void QgsOracleProvider::disconnectDb()
 {
-  QgsOracleConn *conn = QgsOracleConn::connectDb( mUri, false );
-  if ( conn )
-    conn->disconnect();
+  if ( mConnection )
+  {
+    mConnection->unref();
+    mConnection = nullptr;
+  }
 }
 
-QgsOracleConn *QgsOracleProvider::connectionRW()
+QgsOracleConn *QgsOracleProvider::connectionRW() const
 {
-  return mTransaction ? mTransaction->connection() : QgsOracleConn::connectDb( mUri, false );
+  if ( mTransaction )
+  {
+    return mTransaction->connection();
+  }
+  else if ( !mConnection )
+  {
+    mConnection = QgsOracleConn::connectDb( mUri, false );
+  }
+  return mConnection;
 }
 
 QgsOracleConn *QgsOracleProvider::connectionRO() const
 {
-  return mTransaction ? mTransaction->connection() : QgsOracleConn::connectDb( mUri, false );
+  return connectionRW();
 }
 
 bool QgsOracleProvider::execLoggedStatic( QSqlQuery &qry, const QString &sql, const QVariantList &args, const QString &uri, const QString &originatorClass, const QString &queryOrigin )

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -379,7 +379,9 @@ class QgsOracleProvider final: public QgsVectorDataProvider
 
     std::shared_ptr<QgsOracleSharedData> mShared;
 
-    QgsOracleConn *connectionRW();
+    mutable QgsOracleConn *mConnection = nullptr;
+
+    QgsOracleConn *connectionRW() const;
     QgsOracleConn *connectionRO() const;
 
     friend class QgsOracleFeatureIterator;

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -19,13 +19,11 @@
 
 #include <QSqlQuery>
 
+class QgsOracleQuery;
+
 struct QgsOracleProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
 {
-
-    QgsOracleProviderResultIterator( int columnCount, const QSqlQuery &query )
-      : mColumnCount( columnCount )
-      , mQuery( query )
-    {}
+    QgsOracleProviderResultIterator( int columnCount, std::unique_ptr<QgsOracleQuery> query );
 
     QVariantList nextRowPrivate() override;
     bool hasNextRowPrivate() const override;
@@ -33,7 +31,7 @@ struct QgsOracleProviderResultIterator: public QgsAbstractDatabaseProviderConnec
   private:
 
     int mColumnCount = 0;
-    QSqlQuery mQuery;
+    std::unique_ptr<QgsOracleQuery> mQuery;
     QVariantList mNextRow;
 
     QVariantList nextRowInternal();


### PR DESCRIPTION

This PR does 2 things:
- regarding db connection API, don't destroy connection while we need it (quite the same as #50194 for mssql)
- Do not share connections between threads

This could potentially fix #36512, #47669, #47225, and #52178

**Funded by Ifremer**