### PR TITLE
qgstabbarproxystyle: Fix tab size if the font is not overriden

### DIFF
--- a/src/gui/qgstabbarproxystyle.cpp
+++ b/src/gui/qgstabbarproxystyle.cpp
@@ -83,13 +83,21 @@ QSize QgsTabBar::tabSizeHint( int index ) const
 {
   if ( mTabBarStyle->tabStyles().contains( index ) )
   {
-    const QSize s = QTabBar::tabSizeHint( index );
-    const QFontMetrics fm( font() );
-    const int w = fm.horizontalAdvance( tabText( index ) );
-    const QFont f = mTabBarStyle->tabStyles().value( index ).font;
-    const QFontMetrics bfm( f );
-    const int bw = bfm.horizontalAdvance( tabText( index ) );
-    return QSize( s.width() - w + bw, s.height() );
+    const QgsAttributeEditorElement::LabelStyle tabStyle = mTabBarStyle->tabStyles().value( index );
+    if ( tabStyle.overrideFont )
+    {
+      const QSize s = QTabBar::tabSizeHint( index );
+      const QFontMetrics fm( font() );
+      const int w = fm.horizontalAdvance( tabText( index ) );
+      const QFont f = tabStyle.font;
+      const QFontMetrics bfm( f );
+      const int bw = bfm.horizontalAdvance( tabText( index ) );
+      return QSize( s.width() - w + bw, s.height() );
+    }
+    else
+    {
+      return QTabBar::tabSizeHint( index );
+    }
   }
   else
   {


### PR DESCRIPTION
`QgsTabBar::tabSizeHint` computes the size hint for a tab. However it takes into account the `LabelStyle` font even if the font is not overriden. This results in a wrong tab size if the tabSize font size is different from the default font.

This issues is fixed by taking into account the `tabStyle` font only if the default font is overriden.

Fixes:
https://github.com/qgis/QGIS/commit/78fc3cae7e2beed3b570425ba7aaa3e67299f943

Closes: https://github.com/qgis/QGIS/issues/53181

