### PR TITLE
Update v.neighbors

### DIFF
--- a/python/plugins/grassprovider/description/v.neighbors.txt
+++ b/python/plugins/grassprovider/description/v.neighbors.txt
@@ -2,6 +2,7 @@ v.neighbors
 Makes each cell value a function of attribute values and stores in an output raster map.
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input vector layer|-1|None|False
-QgsProcessingParameterEnum|method|Neighborhood operation|count|False|0|False
+QgsProcessingParameterEnum|method|Method for aggregate statistics (count if non given)|count;sum;average;median;mode;minimum;maximum;range;stddev;variance;diversity|False|0|False
+QgsProcessingParameterField|points_column|Column name of points map to use for statistics|None|input|0|False|True
 QgsProcessingParameterNumber|size|Neighborhood diameter in map units|QgsProcessingParameterNumber.Double|0.1|False|0.0|None
 QgsProcessingParameterRasterDestination|output|Neighborhood


### PR DESCRIPTION
Additional options for GRASS v.neighbors aggregate statistics.

## Description

GRASS v.neighbors (Neighborhood analysis tool for vector point maps) in QGIS, only have the default `count` method for aggregate statistics.

This PR adds the `sum`, `average`, `median`, `mode`, `minimum`, `maximum`, `range`, `stddev`, `variance`, `diversity` options, based on GRASS manual: https://grass.osgeo.org/grass82/manuals/v.neighbors.html
