### PR TITLE
[gui][editor widgets] Show value relation description when hovering the combobox

### DIFF
--- a/python/gui/auto_generated/qgstooltipcombobox.sip.in
+++ b/python/gui/auto_generated/qgstooltipcombobox.sip.in
@@ -1,0 +1,44 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgstooltipcombobox.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsToolTipComboBox : QComboBox
+{
+%Docstring(signature="appended")
+QComboBox subclass which features a tooltip when mouse hovering the combobox.
+The tooltip string is taken from the current item's Qt.ToolTipRole data.
+
+.. versionadded:: 3.32
+%End
+
+%TypeHeaderCode
+#include "qgstooltipcombobox.h"
+%End
+  public:
+
+    QgsToolTipComboBox( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsToolTipComboBox.
+%End
+
+    virtual bool event( QEvent *event );
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgstooltipcombobox.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -228,6 +228,7 @@
 %Include auto_generated/qgstemporalcontrollerwidget.sip
 %Include auto_generated/qgstextformatwidget.sip
 %Include auto_generated/qgstextpreview.sip
+%Include auto_generated/qgstooltipcombobox.sip
 %Include auto_generated/qgstreewidgetitem.sip
 %Include auto_generated/qgsunitselectionwidget.sip
 %Include auto_generated/qgsuserinputwidget.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -712,6 +712,7 @@ set(QGIS_GUI_SRCS
   qgstemporalcontrollerwidget.cpp
   qgstextformatwidget.cpp
   qgstextpreview.cpp
+  qgstooltipcombobox.cpp
   qgstreewidgetitem.cpp
   qgsunitselectionwidget.cpp
   qgsuserinputwidget.cpp
@@ -989,6 +990,7 @@ set(QGIS_GUI_HDRS
   qgstemporalcontrollerwidget.h
   qgstextformatwidget.h
   qgstextpreview.h
+  qgstooltipcombobox.h
   qgstreewidgetitem.h
   qgsunitselectionwidget.h
   qgsuserinputwidget.h

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -291,7 +291,7 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
   }
   else
   {
-    QComboBox *combo = new QComboBox( parent );
+    QgsToolTipComboBox *combo = new QgsToolTipComboBox( parent );
     combo->setMinimumContentsLength( 1 );
     combo->setSizeAdjustPolicy( QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon );
     return combo;
@@ -301,7 +301,7 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
 void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
 {
 
-  mComboBox = qobject_cast<QComboBox *>( editor );
+  mComboBox = qobject_cast<QgsToolTipComboBox *>( editor );
   mTableWidget = qobject_cast<QgsFilteredTableWidget *>( editor );
   mLineEdit = qobject_cast<QLineEdit *>( editor );
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -20,9 +20,9 @@
 
 #include "qgseditorwidgetwrapper.h"
 #include "qgsvaluerelationfieldformatter.h"
+#include "qgstooltipcombobox.h"
 #include "qgis_gui.h"
 
-class QComboBox;
 class QLineEdit;
 class QgsValueRelationWidgetFactory;
 class QgsFilterLineEdit;
@@ -206,7 +206,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     //! Sets the values for the widgets, re-creates the cache when required
     void populate( );
 
-    QComboBox *mComboBox = nullptr;
+    QgsToolTipComboBox *mComboBox = nullptr;
     QgsFilteredTableWidget *mTableWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
 

--- a/src/gui/qgstooltipcombobox.cpp
+++ b/src/gui/qgstooltipcombobox.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************
+                              qgscheckablecombobox.cpp
+                              ------------------------
+  begin                : May 25, 2023
+  copyright            : (C) 2017 by Mathieu Pellerin
+  email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstooltipcombobox.h"
+
+#include <QEvent>
+#include <QHelpEvent>
+#include <QPoint>
+#include <QToolTip>
+
+
+QgsToolTipComboBox::QgsToolTipComboBox( QWidget *parent )
+  : QComboBox( parent )
+{
+}
+
+bool QgsToolTipComboBox::event( QEvent *event )
+{
+  if ( event->type() == QEvent::ToolTip )
+  {
+    const QString description = currentData( Qt::ToolTipRole ).toString();
+    if ( !description.isEmpty() )
+    {
+      QHelpEvent *helpEvent = static_cast< QHelpEvent *>( event );
+      QPoint pos = mapToGlobal( helpEvent->pos() );
+      QToolTip::showText( pos, description );
+    }
+    return true;
+  }
+  return QComboBox::event( event );
+}

--- a/src/gui/qgstooltipcombobox.h
+++ b/src/gui/qgstooltipcombobox.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+                              qgstooltipcombobox.h
+                              ------------------------
+  begin                : May 25, 2023
+  copyright            : (C) 2017 by Mathieu Pellerin
+  email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTOOLTIPCOMBOBOX_H
+#define QGSTOOLTIPCOMBOBOX_H
+
+#include <QComboBox>
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgis.h"
+
+class QEvent;
+
+/**
+ * \class QgsToolTipComboBox
+ * \ingroup gui
+ * \brief QComboBox subclass which features a tooltip when mouse hovering the combobox.
+ * The tooltip string is taken from the current item's Qt.ToolTipRole data.
+ * \since QGIS 3.32
+ */
+class GUI_EXPORT QgsToolTipComboBox : public QComboBox
+{
+    Q_OBJECT
+
+  public:
+
+    //! Constructor for QgsToolTipComboBox.
+    QgsToolTipComboBox( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    bool event( QEvent *event ) override;
+
+};
+
+#endif // QGSTOOLTIPCOMBOBOX_H


### PR DESCRIPTION
## Description

This PR implements description tooltip when hovering the value relation editor widget's combobox (https://github.com/qgis/QGIS/issues/52688):

![image](https://github.com/qgis/QGIS/assets/1728657/be53a5f2-e5e9-4e17-81a6-071dcee57ba2)

The description tooltip matches that of the currently selected item's description (which is defined as the 'description column' in the value relation configuration panel).
