### PR TITLE
Add search radius to QgsLayoutViewToolSelect

### DIFF
--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -241,16 +241,14 @@ Note that template UUIDs are only available while a layout is being restored fro
 %Docstring
 Returns the topmost layout item at a specified ``position``. Ignores paper items.
 If ``ignoreLocked`` is set to ``True`` any locked items will be ignored.
-
-.. versionadded:: 3.32
+Since QGIS 3.34 the ``searchTolerance`` parameter was added, which can be used to specify a search tolerance in layout units.
 %End
 
     QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 %Docstring
 Returns the topmost layout item at a specified ``position`` which is below a specified ``item``. Ignores paper items.
 If ``ignoreLocked`` is set to ``True`` any locked items will be ignored.
-
-.. versionadded:: 3.32
+Since QGIS 3.34 the ``searchTolerance`` parameter was added, which can be used to specify a search tolerance in layout units.
 %End
 
     void setUnits( Qgis::LayoutUnit units );

--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -237,16 +237,20 @@ Note that template UUIDs are only available while a layout is being restored fro
 .. seealso:: :py:func:`itemByUuid`
 %End
 
-    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 %Docstring
 Returns the topmost layout item at a specified ``position``. Ignores paper items.
 If ``ignoreLocked`` is set to ``True`` any locked items will be ignored.
+
+.. versionadded:: 3.32
 %End
 
-    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 %Docstring
 Returns the topmost layout item at a specified ``position`` which is below a specified ``item``. Ignores paper items.
 If ``ignoreLocked`` is set to ``True`` any locked items will be ignored.
+
+.. versionadded:: 3.32
 %End
 
     void setUnits( Qgis::LayoutUnit units );

--- a/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
@@ -48,6 +48,13 @@ Constructor for QgsLayoutViewToolSelect.
 Sets the a ``layout``.
 %End
 
+    double searchToleranceInLayoutUnits();
+%Docstring
+Compute the search tolerance in layout units from the view current scale
+
+.. versionadded:: 3.34
+%End
+
 };
 
 /************************************************************************

--- a/src/core/layout/qgslayout.cpp
+++ b/src/core/layout/qgslayout.cpp
@@ -298,15 +298,23 @@ QgsLayoutMultiFrame *QgsLayout::multiFrameByUuid( const QString &uuid, bool incl
   return nullptr;
 }
 
-QgsLayoutItem *QgsLayout::layoutItemAt( QPointF position, const bool ignoreLocked ) const
+QgsLayoutItem *QgsLayout::layoutItemAt( QPointF position, const bool ignoreLocked, double searchTolerance ) const
 {
-  return layoutItemAt( position, nullptr, ignoreLocked );
+  return layoutItemAt( position, nullptr, ignoreLocked, searchTolerance );
 }
 
-QgsLayoutItem *QgsLayout::layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, const bool ignoreLocked ) const
+QgsLayoutItem *QgsLayout::layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, const bool ignoreLocked, double searchTolerance ) const
 {
   //get a list of items which intersect the specified position, in descending z order
-  const QList<QGraphicsItem *> itemList = items( position, Qt::IntersectsItemShape, Qt::DescendingOrder );
+  QList<QGraphicsItem *> itemList;
+  if ( searchTolerance == 0 )
+  {
+    itemList = items( position, Qt::IntersectsItemShape, Qt::DescendingOrder );
+  }
+  else
+  {
+    itemList = items( QRectF( position.x() - searchTolerance, position.y() - searchTolerance, 2 * searchTolerance, 2 * searchTolerance ), Qt::IntersectsItemShape, Qt::DescendingOrder );
+  }
 
   bool foundBelowItem = false;
   for ( QGraphicsItem *graphicsItem : itemList )

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -303,14 +303,14 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
     /**
      * Returns the topmost layout item at a specified \a position. Ignores paper items.
      * If \a ignoreLocked is set to TRUE any locked items will be ignored.
-     * \since QGIS 3.32 searchTolerance parameter was added, which can be used to specify a search tolerance in layout units
+     * Since QGIS 3.34 the \a searchTolerance parameter was added, which can be used to specify a search tolerance in layout units.
      */
     QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 
     /**
      * Returns the topmost layout item at a specified \a position which is below a specified \a item. Ignores paper items.
      * If \a ignoreLocked is set to TRUE any locked items will be ignored.
-     * \since QGIS 3.32 searchTolerance parameter was added, which can be used to specify a search tolerance in layout units
+     * Since QGIS 3.34 the \a searchTolerance parameter was added, which can be used to specify a search tolerance in layout units.
      */
     QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -303,14 +303,16 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
     /**
      * Returns the topmost layout item at a specified \a position. Ignores paper items.
      * If \a ignoreLocked is set to TRUE any locked items will be ignored.
+     * \since QGIS 3.32 searchTolerance parameter was added, which can be used to specify a search tolerance in layout units
      */
-    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 
     /**
      * Returns the topmost layout item at a specified \a position which is below a specified \a item. Ignores paper items.
      * If \a ignoreLocked is set to TRUE any locked items will be ignored.
+     * \since QGIS 3.32 searchTolerance parameter was added, which can be used to specify a search tolerance in layout units
      */
-    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false, double searchTolerance = 0 ) const;
 
     /**
      * Sets the native measurement \a units for the layout. These also form the default unit

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -99,7 +99,17 @@ void QgsLayoutMouseHandles::setViewportCursor( Qt::CursorShape cursor )
 
 QList<QGraphicsItem *> QgsLayoutMouseHandles::sceneItemsAtPoint( QPointF scenePoint )
 {
-  QList< QGraphicsItem * > items = mLayout->items( scenePoint );
+  QList< QGraphicsItem * > items;
+  if ( QgsLayoutViewToolSelect *tool = qobject_cast< QgsLayoutViewToolSelect *>( mView->tool() ) )
+  {
+    const double searchTolerance = tool->searchToleranceInLayoutUnits();
+    const QRectF area( scenePoint.x() - searchTolerance, scenePoint.y() - searchTolerance, 2 * searchTolerance, 2 * searchTolerance );
+    items = mLayout->items( area );
+  }
+  else
+  {
+    items = mLayout->items( scenePoint );
+  }
   items.erase( std::remove_if( items.begin(), items.end(), []( QGraphicsItem * item )
   {
     return !dynamic_cast<QgsLayoutItem *>( item );

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -157,7 +157,12 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
     {
       selectedItem->setSelected( true );
     }
-    event->ignore();
+
+    // Due to the selection tolerance, items can be selected while the mouse is not over them,
+    // so we cannot just forward the mouse press event by calling event->ignore().
+    // We call startMove to simulate a mouse press event on the handles
+    mMouseHandles->startMove( view()->mapToScene( event->pos() ) );
+
     emit itemFocused( selectedItem );
   }
 }

--- a/src/gui/layout/qgslayoutviewtoolselect.h
+++ b/src/gui/layout/qgslayoutviewtoolselect.h
@@ -61,6 +61,12 @@ class GUI_EXPORT QgsLayoutViewToolSelect : public QgsLayoutViewTool
     //! Sets the a \a layout.
     void setLayout( QgsLayout *layout );
 
+    /**
+     * Compute the search tolerance in layout units from the view current scale
+     * \since QGIS 3.34
+     */
+    double searchToleranceInLayoutUnits();
+
   private:
 
     bool mIsSelecting = false;
@@ -75,6 +81,9 @@ class GUI_EXPORT QgsLayoutViewToolSelect : public QgsLayoutViewTool
     QPointF mRubberBandStartPos;
 
     QPointer< QgsLayoutMouseHandles > mMouseHandles; //owned by scene
+
+    //! Search tolerance in millimeters for selecting items
+    static const double sSearchToleranceInMillimeters;
 };
 
 #endif // QGSLAYOUTVIEWTOOLSELECT_H

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -465,7 +465,6 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
 
   //save current cursor position
   mMouseMoveStartPos = event->lastScenePos();
-  mLastMouseEventPos = event->lastScenePos();
   //save current item geometry
   mBeginMouseEventPos = event->lastScenePos();
   mBeginHandlePos = scenePos();
@@ -526,8 +525,6 @@ void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *even
     //resize from center if alt depressed
     resizeMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::AltModifier );
   }
-
-  mLastMouseEventPos = event->lastScenePos();
 }
 
 void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -95,6 +95,9 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
 
     bool shouldBlockEvent( QInputEvent *event ) const;
 
+    //! Initializes a drag operation \since QGIS 3.34
+    void startMove( QPointF sceneCoordPos );
+
   public slots:
 
     //! Redraws handles when selected item size changes

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -216,9 +216,6 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     //! Start point of the last mouse move action (in scene coordinates)
     QPointF mMouseMoveStartPos;
 
-    //! Position of the last mouse move event (in scene coordinates)
-    QPointF mLastMouseEventPos;
-
     MouseAction mCurrentMouseMoveAction = NoAction;
 
     //! True if user is currently dragging items


### PR DESCRIPTION
## Description

- Display the Move cursor when hovering unselected items
- Add a small search radius to the QgsLayoutViewToolSelect, which makes selecting polyline items easier