### PR TITLE
Handle grid frame in rect frame computation

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -927,6 +927,9 @@ Returns the map's item based clip path settings.
 .. versionadded:: 3.16
 %End
 
+    virtual double estimatedFrameBleed() const;
+
+
   protected:
 
     virtual void draw( QgsLayoutItemRenderContext &context );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -599,6 +599,27 @@ QgsLayoutItemMapOverview *QgsLayoutItemMap::overview()
   return mOverviewStack->overview( 0 );
 }
 
+double QgsLayoutItemMap::estimatedFrameBleed() const
+{
+  double frameBleed = QgsLayoutItem::estimatedFrameBleed();
+
+  // Check if any of the grids are enabled
+  if ( mGridStack )
+  {
+    for ( int i = 0; i < mGridStack->size(); ++i )
+    {
+      const QgsLayoutItemMapGrid *grid = qobject_cast<QgsLayoutItemMapGrid *>( mGridStack->item( i ) );
+      if ( grid->enabled() )
+      {
+        // Grid bleed is the grid frame width + grid frame offset + half the pen width
+        frameBleed = std::max( frameBleed, grid->frameWidth() + grid->frameMargin() + grid->framePenSize() / 2.0 );
+      }
+    }
+  }
+
+  return frameBleed;
+}
+
 void QgsLayoutItemMap::draw( QgsLayoutItemRenderContext & )
 {
 }

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -609,10 +609,10 @@ double QgsLayoutItemMap::estimatedFrameBleed() const
     for ( int i = 0; i < mGridStack->size(); ++i )
     {
       const QgsLayoutItemMapGrid *grid = qobject_cast<QgsLayoutItemMapGrid *>( mGridStack->item( i ) );
-      if ( grid->enabled() )
+      if ( grid->mEvaluatedEnabled )
       {
         // Grid bleed is the grid frame width + grid frame offset + half the pen width
-        frameBleed = std::max( frameBleed, grid->frameWidth() + grid->frameMargin() + grid->framePenSize() / 2.0 );
+        frameBleed = std::max( frameBleed, grid->mEvaluatedGridFrameWidth + grid->mEvaluatedGridFrameMargin + grid->mEvaluatedGridFrameLineThickness / 2.0 );
       }
     }
   }

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -864,6 +864,9 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
      */
     QgsLayoutItemMapItemClipPathSettings *itemClippingSettings() { return mItemClippingSettings; }
 
+    // Reimplement estimatedFrameBleed to take the grid frame into account
+    double estimatedFrameBleed() const override;
+
   protected:
 
     void draw( QgsLayoutItemRenderContext &context ) override;

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -1304,6 +1304,9 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
 
     friend class TestQgsLayoutMapGrid;
 
+    // Needs access to evaluated properties to compute frame bleed
+    friend class QgsLayoutItemMap;
+
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLayoutItemMapGrid::FrameSideFlags )


### PR DESCRIPTION
## Description

LayoutItems have a `rectWithFrame` method that returns a rect adjusted to contain the item frame. This rect is used to display the MouseHandles (resize rect), and to align the item on guides.

Map items can have not only a frame, but also a grid frame (zebra for instance). This PR fixes the rectWith frame computation to include the map grid frame.