### PR TITLE
Fix groups with rotated item

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemgroup.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemgroup.sip.in
@@ -73,6 +73,10 @@ Returns a list of items contained by the group.
 
     virtual ExportLayerBehavior exportLayerBehavior() const;
 
+
+    virtual QRectF rectWithFrame() const;
+
+
   protected:
     virtual void draw( QgsLayoutItemRenderContext &context );
 

--- a/src/core/layout/qgslayoutitemgroup.h
+++ b/src/core/layout/qgslayoutitemgroup.h
@@ -76,20 +76,22 @@ class CORE_EXPORT QgsLayoutItemGroup: public QgsLayoutItem
 
     void finalizeRestoreFromXml() override;
     ExportLayerBehavior exportLayerBehavior() const override;
+
+    QRectF rectWithFrame() const override;
+
   protected:
     void draw( QgsLayoutItemRenderContext &context ) override;
     bool writePropertiesToElement( QDomElement &parentElement, QDomDocument &document, const QgsReadWriteContext &context ) const override;
     bool readPropertiesFromElement( const QDomElement &itemElement, const QDomDocument &document, const QgsReadWriteContext &context ) override;
 
-  private:
+  private slots:
+    void updateBoundingRect();
 
-    void resetBoundingRect();
-    void updateBoundingRect( QgsLayoutItem *item );
-    void setSceneRect( const QRectF &rectangle );
+  private:
 
     QList< QString > mItemUuids;
     QList< QPointer< QgsLayoutItem >> mItems;
-    QRectF mBoundingRectangle;
+    QRectF mRectWithFrame;
 };
 
 #endif //QGSLAYOUTITEMGROUP_H

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -218,9 +218,25 @@ void QgsLayoutMouseHandles::expandItemList( const QList<QGraphicsItem *> &items,
     {
       // if a group is selected, we don't draw the bounds of the group - instead we draw the bounds of the grouped items
       const QList<QgsLayoutItem *> groupItems = static_cast< QgsLayoutItemGroup * >( item )->items();
-      collected.reserve( collected.size() + groupItems.size() );
-      for ( QgsLayoutItem *groupItem : groupItems )
-        collected.append( groupItem );
+      expandItemList( groupItems, collected );
+    }
+    else
+    {
+      collected << item;
+    }
+  }
+}
+
+
+void QgsLayoutMouseHandles::expandItemList( const QList<QgsLayoutItem *> &items, QList<QGraphicsItem *> &collected ) const
+{
+  for ( QGraphicsItem *item : items )
+  {
+    if ( item->type() == QgsLayoutItemRegistry::LayoutGroup )
+    {
+      // if a group is selected, we don't draw the bounds of the group - instead we draw the bounds of the grouped items
+      const QList<QgsLayoutItem *> groupItems = static_cast< QgsLayoutItemGroup * >( item )->items();
+      expandItemList( groupItems, collected );
     }
     else
     {

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -75,6 +75,7 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     bool itemIsGroupMember( QGraphicsItem *item ) override;
     QRectF itemRect( QGraphicsItem *item ) const override;
     void expandItemList( const QList< QGraphicsItem * > &items, QList< QGraphicsItem * > &collected ) const override;
+    void expandItemList( const QList< QgsLayoutItem * > &items, QList< QGraphicsItem * > &collected ) const;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
     void showStatusMessage( const QString &message ) override;


### PR DESCRIPTION
## Description

Fix Layout item group rect when child items have mixed rotation (see below)

![qgis-dev-bin_3vqnbKymOZ](https://github.com/qgis/QGIS/assets/9693475/014badfc-129b-4847-931b-5459e2c19cc7)


Resizing a group or a multi selection with mixed rotation is still glitchy and should be addressed in a later PR