### PR TITLE
Layout move preview

### DIFF
--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -217,11 +217,8 @@ void QgsLayoutMouseHandles::drawMovePreview( QPainter *painter )
   }
 
   double destinationDpi = QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter ) * 25.4;
-  double widthInPixels = 0;
-  double heightInPixels = 0;
-
-  widthInPixels = boundingRect().width() * QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter );
-  heightInPixels = boundingRect().height() * QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter );
+  double widthInPixels = boundingRect().width() * destinationDpi;
+  double heightInPixels = boundingRect().height() * destinationDpi;
 
   // limit size of image for better performance
   if ( ( widthInPixels > CACHE_SIZE_LIMIT || heightInPixels > CACHE_SIZE_LIMIT ) )

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -245,10 +245,10 @@ void QgsLayoutMouseHandles::drawMovePreview( QPainter *painter )
   // create image if not already cached
   if ( mItemCachedImage.isNull() )
   {
-    QImage image = QImage( widthInPixels, heightInPixels, QImage::Format_ARGB32 );
+    QImage image = QImage( static_cast<int>( widthInPixels ), static_cast<int>( heightInPixels ), QImage::Format_ARGB32 );
     image.fill( Qt::transparent );
-    image.setDotsPerMeterX( 1000 * destinationDpi * 25.4 );
-    image.setDotsPerMeterY( 1000 * destinationDpi * 25.4 );
+    image.setDotsPerMeterX( static_cast<int>( 1000 * destinationDpi * 25.4 ) );
+    image.setDotsPerMeterY( static_cast<int>( 1000 * destinationDpi * 25.4 ) );
     QPainter p( &image );
     p.setRenderHint( QPainter::Antialiasing, true );
     QgsRenderContext context = QgsLayoutUtils::createRenderContextForLayout( mLayout, &p, destinationDpi );
@@ -295,8 +295,8 @@ void QgsLayoutMouseHandles::drawMovePreview( QPainter *painter )
   painter->setOpacity( 0.5 );
   painter->setRenderHint( QPainter::Antialiasing, true );
   painter->scale( 1 / context.scaleFactor(), 1 / context.scaleFactor() );
-  painter->drawImage( boundingRect().x() * context.scaleFactor(),
-                      boundingRect().y() * context.scaleFactor(), mItemCachedImage );
+  painter->drawImage( QPointF( boundingRect().x() * context.scaleFactor(),
+                               boundingRect().y() * context.scaleFactor() ), mItemCachedImage );
 }
 
 void QgsLayoutMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -217,8 +217,8 @@ void QgsLayoutMouseHandles::drawMovePreview( QPainter *painter )
   }
 
   double destinationDpi = QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter ) * 25.4;
-  double widthInPixels = boundingRect().width() * destinationDpi;
-  double heightInPixels = boundingRect().height() * destinationDpi;
+  double widthInPixels = boundingRect().width() * QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter );
+  double heightInPixels = boundingRect().height() * QgsLayoutUtils::scaleFactorFromItemStyle( nullptr, painter );
 
   // limit size of image for better performance
   if ( ( widthInPixels > CACHE_SIZE_LIMIT || heightInPixels > CACHE_SIZE_LIMIT ) )
@@ -259,7 +259,6 @@ void QgsLayoutMouseHandles::drawMovePreview( QPainter *painter )
     expandItemList( selectedItems, itemsToDraw );
 
     // Draw a semi-transparent version of the selected items
-    // painter->setOpacity( 0.5 );
     // the MouseHandles can be rotated if a single rotated item is selected, so we need
     // so we need to compensate for the rotation before applying the translation offset
     p.rotate( -rotation() );

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -85,6 +85,7 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     void endItemCommand( QGraphicsItem *item ) override;
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
+    void drawMovePreview( QPainter *painter ) override;
   public slots:
 
     //! Sets up listeners to sizeChanged signal for all selected items

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -86,6 +86,7 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
     void drawMovePreview( QPainter *painter ) override;
+    void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
   public slots:
 
     //! Sets up listeners to sizeChanged signal for all selected items
@@ -101,6 +102,8 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     QGraphicsLineItem *mVerticalSnapLine = nullptr;
 
     std::unique_ptr< QgsAbstractLayoutUndoCommand > mItemCommand;
+
+    QImage mItemCachedImage;
 };
 
 ///@endcond PRIVATE

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -42,6 +42,11 @@ void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHan
     return;
   }
 
+  if ( showTemporaryBoundingBoxes && mIsDragging )
+  {
+    drawMovePreview( painter );
+  }
+
   if ( showStaticBoundingBoxes )
   {
     //draw resize handles around bounds of entire selection
@@ -197,6 +202,11 @@ void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
     path.addPolygon( itemBounds );
     painter->drawPath( path );
   }
+}
+
+void QgsGraphicsViewMouseHandles::drawMovePreview( QPainter * )
+{
+  // Default implementation does nothing
 }
 
 double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -44,7 +44,11 @@ void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHan
 
   if ( showTemporaryBoundingBoxes && mIsDragging )
   {
-    drawMovePreview( painter );
+    // Do not draw the preview if the user just clicked without moving the mouse
+    if ( transform().dx() != 0 || transform().dy() != 0 )
+    {
+      drawMovePreview( painter );
+    }
   }
 
   if ( showStaticBoundingBoxes )

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -111,6 +111,9 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     void paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes,
                         bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr );
 
+    //! Draw move previews
+    virtual void drawMovePreview( QPainter *painter );
+
     //! Sets the mouse cursor for the QGraphicsView attached to the composition
     virtual void setViewportCursor( Qt::CursorShape cursor ) = 0;
 


### PR DESCRIPTION
## Description

Draw a preview when dragging items instead of only the bounding boxes (works for groups (even nested ones) and multi selection, with or without mixed rotations)

![move_preview](https://github.com/qgis/QGIS/assets/9693475/3249b227-317a-4848-b363-4bbff6dc3add)


