### PR TITLE
[WFS provider] Add "bbox" and "sql" to list of known URI parameters

### DIFF
--- a/src/providers/wfs/qgswfsconstants.cpp
+++ b/src/providers/wfs/qgswfsconstants.cpp
@@ -43,6 +43,7 @@ const QString QgsWFSConstants::URI_PARAM_PAGE_SIZE( "pageSize" );
 const QString QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES( "preferCoordinatesForWfsT11" );
 const QString QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE( "skipInitialGetFeature" );
 const QString QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER( QStringLiteral( "geometryTypeFilter" ) );
+const QString QgsWFSConstants::URI_PARAM_SQL( QStringLiteral( "sql" ) );
 
 const QString QgsWFSConstants::VERSION_AUTO( QStringLiteral( "auto" ) );
 

--- a/src/providers/wfs/qgswfsconstants.h
+++ b/src/providers/wfs/qgswfsconstants.h
@@ -51,6 +51,7 @@ struct QgsWFSConstants
   static const QString URI_PARAM_WFST_1_1_PREFER_COORDINATES;
   static const QString URI_PARAM_SKIP_INITIAL_GET_FEATURE;
   static const QString URI_PARAM_GEOMETRY_TYPE_FILTER;
+  static const QString URI_PARAM_SQL;
 
   //
   static const QString VERSION_AUTO;

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -188,6 +188,7 @@ QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const
     QgsWFSConstants::URI_PARAM_VERSION,
     QgsWFSConstants::URI_PARAM_TYPENAME,
     QgsWFSConstants::URI_PARAM_SRSNAME,
+    QgsWFSConstants::URI_PARAM_BBOX,
     QgsWFSConstants::URI_PARAM_FILTER,
     QgsWFSConstants::URI_PARAM_OUTPUTFORMAT,
     QgsWFSConstants::URI_PARAM_RESTRICT_TO_REQUEST_BBOX,
@@ -201,6 +202,7 @@ QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const
     QgsWFSConstants::URI_PARAM_WFST_1_1_PREFER_COORDINATES,
     QgsWFSConstants::URI_PARAM_SKIP_INITIAL_GET_FEATURE,
     QgsWFSConstants::URI_PARAM_GEOMETRY_TYPE_FILTER,
+    QgsWFSConstants::URI_PARAM_SQL,
   };
 
   QSet<QString> l_unknownParamKeys;


### PR DESCRIPTION
To avoid emiting a warning message if they are used, indicating they are unknown parameters.

Before this PR such messages were emitted:
![grafik](https://github.com/qgis/QGIS/assets/20856381/86452273-095e-4508-9cb3-9d134ca6f91d)

