### PR TITLE
[dxf] Fix exporting of simple marker symbol layer with data defined size

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1595,8 +1595,6 @@ bool QgsSimpleMarkerSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScal
           break;
       }
     }
-
-    size *= QgsDxfExport::mapUnitScaleFactor( e.symbologyScale(), mSizeUnit, e.mapUnits(), context.renderContext().mapToPixel().mapUnitsPerPixel() );
   }
 
   if ( mSizeUnit == Qgis::RenderUnit::Millimeters )

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -68,6 +68,7 @@ class TestQgsDxfExport : public QObject
     void testCurveExport_data();
     void testDashedLine();
     void testTransform();
+    void testDataDefinedPoints();
 
   private:
     QgsVectorLayer *mPointLayer = nullptr;
@@ -1279,6 +1280,76 @@ void TestQgsDxfExport::testTransform()
   it = result->getFeatures();
   QVERIFY( it.nextFeature( f2 ) );
   QCOMPARE( f2.geometry().asWkt( 0 ), QStringLiteral( "LineString (960862 6056454, 960915 6056455)" ) );
+}
+
+void TestQgsDxfExport::testDataDefinedPoints()
+{
+  std::unique_ptr<QgsSimpleMarkerSymbolLayer> symbolLayer = std::make_unique<QgsSimpleMarkerSymbolLayer>( Qgis::MarkerShape::Circle, 2.0 );
+  QgsPropertyCollection properties;
+  properties.setProperty( QgsSymbolLayer::PropertySize, QgsProperty::fromExpression( "200" ) );
+  symbolLayer->setDataDefinedProperties( properties );
+
+  QgsMarkerSymbol *symbol = new QgsMarkerSymbol();
+  symbol->changeSymbolLayer( 0, symbolLayer.release() );
+
+  std::unique_ptr< QgsVectorLayer > vl = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point?crs=epsg:2056" ), QString(), QStringLiteral( "memory" ) );
+  const QgsGeometry g1 = QgsGeometry::fromWkt( "POINT (2000000 1000000)" );
+  QgsFeature f1;
+  f1.setGeometry( g1 );
+  const QgsGeometry g2 = QgsGeometry::fromWkt( "POINT (2000100 1000100)" );
+  QgsFeature f2;
+  f2.setGeometry( g2 );
+  vl->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 );
+
+  QgsSingleSymbolRenderer *renderer = new QgsSingleSymbolRenderer( symbol );
+  vl->setRenderer( renderer );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( vl.get() ) );
+  d.setSymbologyExport( Qgis::FeatureSymbologyExport::PerFeature );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( vl->extent().buffered( 100.0 ) );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << vl.get() );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( vl->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+
+  const QString file = getTempFileName( "data_defined_points_dxf" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  QString debugInfo;
+
+  QVERIFY2( fileContainsText( file,
+                              "CONTINUOUS\n"
+                              "420\n"
+                              "2302755\n"
+                              " 90\n"
+                              "     2\n"
+                              " 70\n"
+                              "     1\n"
+                              " 43\n"
+                              "0.0\n"
+                              " 10\n"
+                              "-100.0\n"
+                              " 20\n"
+                              "0.0\n"
+                              " 42\n"
+                              "1.0\n"
+                              " 10\n"
+                              "100.0\n"
+                              " 20\n"
+                              "0.0\n"
+                              " 42\n"
+                              "1.0\n"
+                              "  0\n"
+                              "ENDBLK", &debugInfo ), debugInfo.toUtf8().constData() );
 }
 
 bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &text, QString *debugInfo ) const


### PR DESCRIPTION
## Description

This PR fixes an unreported issue with our DXF export code whereas simple marker with a data-defined size property ends up exported as tiny tiny markers. 