### PR TITLE
[dxf] Use a single reference block when exporting markers with only data defined size and/or angle

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -535,6 +535,11 @@ write as DXF
 Gets line width
 %End
 
+    virtual double dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
+%Docstring
+Gets marker size
+%End
+
     virtual double dxfOffset( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
 %Docstring
 Gets offset
@@ -1043,6 +1048,8 @@ Writes the symbol layer definition as a SLD XML element.
 
     virtual QgsMapUnitScale mapUnitScale() const;
 
+    virtual double dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
+    virtual double dxfAngle( QgsSymbolRenderContext &context ) const;
 
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) = 0;
 %Docstring

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -552,6 +552,8 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
 
     QHash< const QgsSymbolLayer *, QString > mLineStyles; //symbol layer name types
     QHash< const QgsSymbolLayer *, QString > mPointSymbolBlocks; //reference to point symbol blocks
+    QHash< const QgsSymbolLayer *, double > mPointSymbolBlockSizes; //reference to point symbol size used to create its block
+    QHash< const QgsSymbolLayer *, double > mPointSymbolBlockAngles; //reference to point symbol size used to create its block
 
     //AC1009
     void writeHeader( const QString &codepage );
@@ -611,7 +613,8 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
 
     QList< QPair< QgsSymbolLayer *, QgsSymbol * > > symbolLayers( QgsRenderContext &context );
     static int nLineTypes( const QList< QPair< QgsSymbolLayer *, QgsSymbol *> > &symbolLayers );
-    static bool hasDataDefinedProperties( const QgsSymbolLayer *sl, const QgsSymbol *symbol );
+    static bool hasBlockBreakingDataDefinedProperties( const QgsSymbolLayer *sl, const QgsSymbol *symbol );
+
     double dashSize() const;
     double dotSize() const;
     double dashSeparatorSize() const;

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -167,6 +167,13 @@ double QgsSymbolLayer::dxfWidth( const QgsDxfExport &e, QgsSymbolRenderContext &
   return 1.0;
 }
 
+double QgsSymbolLayer::dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const
+{
+  Q_UNUSED( e )
+  Q_UNUSED( context )
+  return 1.0;
+}
+
 double QgsSymbolLayer::dxfOffset( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const
 {
   Q_UNUSED( e )
@@ -899,6 +906,40 @@ void QgsMarkerSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, const
 QList<QgsSymbolLayerReference> QgsSymbolLayer::masks() const
 {
   return {};
+}
+
+double QgsMarkerSymbolLayer::dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const
+{
+  double size = mSize;
+  if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertySize ) )
+  {
+    bool ok = false;
+    size = mDataDefinedProperties.valueAsDouble( QgsSymbolLayer::PropertySize, context.renderContext().expressionContext(), mSize, &ok );
+
+    if ( ok )
+    {
+      switch ( mScaleMethod )
+      {
+        case Qgis::ScaleMethod::ScaleArea:
+          size = std::sqrt( size );
+          break;
+        case Qgis::ScaleMethod::ScaleDiameter:
+          break;
+      }
+    }
+  }
+  return size * QgsDxfExport::mapUnitScaleFactor( e.symbologyScale(), mSizeUnit, e.mapUnits(), context.renderContext().mapToPixel().mapUnitsPerPixel() );
+}
+
+double QgsMarkerSymbolLayer::dxfAngle( QgsSymbolRenderContext &context ) const
+{
+  double angle = mAngle;
+  if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyAngle ) )
+  {
+    context.setOriginalValueVariable( mAngle );
+    angle = mDataDefinedProperties.valueAsDouble( QgsSymbolLayer::PropertyAngle, context.renderContext().expressionContext(), mAngle );
+  }
+  return angle;
 }
 
 void QgsSymbolLayer::prepareMasks( const QgsSymbolRenderContext &context )

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -541,6 +541,9 @@ class CORE_EXPORT QgsSymbolLayer
     //! Gets line width
     virtual double dxfWidth( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
 
+    //! Gets marker size
+    virtual double dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
+
     //! Gets offset
     virtual double dxfOffset( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
 
@@ -967,6 +970,8 @@ class CORE_EXPORT QgsMarkerSymbolLayer : public QgsSymbolLayer
     Qgis::RenderUnit outputUnit() const override;
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
+    virtual double dxfSize( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const override;
+    virtual double dxfAngle( QgsSymbolRenderContext &context ) const override;
 
     /**
      * Returns the approximate bounding box of the marker symbol layer, taking into account


### PR DESCRIPTION
## Description

This PR improves QGIS' dxf export of point layers by maintaining the use of block references for points having data-defined size and/or angle properties. To do so, we rely on the INSERT's angle code (50) and X/Y scale (41, 42).

The main benefit is allowing for the exported DXF to keep points's symbol layers grouped under a single block within one layer:

![image](https://github.com/qgis/QGIS/assets/1728657/802c9045-8dbd-48f4-857e-9856d0217aab)

