### PR TITLE
Missing one #ifndef QT_NO_SSL in qgsauthmanager.cpp

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1586,9 +1586,9 @@ bool QgsAuthManager::eraseAuthenticationDatabase( bool backup, QString *backuppa
   clearAllCachedConfigs();
   updateConfigAuthMethods();
 
-  #ifndef QT_NO_SSL
+#ifndef QT_NO_SSL
   initSslCaches();
-  #endif
+#endif
 
   emit authDatabaseChanged();
 

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1587,7 +1587,7 @@ bool QgsAuthManager::eraseAuthenticationDatabase( bool backup, QString *backuppa
   updateConfigAuthMethods();
 
   #ifndef QT_NO_SSL
-      initSslCaches();
+  initSslCaches();
   #endif
 
   emit authDatabaseChanged();

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1585,7 +1585,10 @@ bool QgsAuthManager::eraseAuthenticationDatabase( bool backup, QString *backuppa
 
   clearAllCachedConfigs();
   updateConfigAuthMethods();
-  initSslCaches();
+
+  #ifndef QT_NO_SSL
+      initSslCaches();
+  #endif
 
   emit authDatabaseChanged();
 


### PR DESCRIPTION
I'm trying to build QGis Core for WebAssembly. Qt doesn't seem to support OpenSSL in Wasm yet.