### PR TITLE
[cleanup] QgsOgrFeatureIterator(): remove (hopefully!) useless code in subset string case

### DIFF
--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -110,10 +110,6 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
       mOgrLayer = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, mSource->mSubsetString );
       // If the mSubsetString was a full SELECT ...., then mOgrLayer will be a OGR SQL layer != mOgrLayerOri
 
-      mFieldsWithoutFid.clear();
-      for ( int i = ( mFirstFieldIsFid ) ? 1 : 0; i < mSource->mFields.size(); i++ )
-        mFieldsWithoutFid.append( mSource->mFields.at( i ) );
-
       if ( !mOgrLayer )
       {
         close();

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -547,6 +547,16 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         got = [feat for feat in vl.getFeatures(QgsFeatureRequest(1))]
         self.assertEqual(len(got), 1)  # this is the current behavior, broken
 
+        # Test setSubsetString() with a SELECT ... statement not selecting
+        # the FID column
+        vl = QgsVectorLayer(f'{tmpfile}', 'test', 'ogr')
+        vl.setSubsetString("SELECT name FROM test_layer WHERE name = 'two'")
+        got = [feat for feat in vl.getFeatures()]
+        self.assertEqual(len(got), 1)
+
+        attributes = got[0].attributes()
+        self.assertEqual(attributes[0], 'two')
+
     def testEditSubsetString(self):
 
         tmpfile = os.path.join(self.basetestpath, 'testEditSubsetString.gpkg')


### PR DESCRIPTION
Those lines where introduced per commit 5a9067e722be, but it is likely that a following commit (391ec8a5dd4508f75b6538ab7be309379695add4 potentially) make that useless.

I've added an extra test in addition to the one of 80e19b63280b54ffbc3ab5347872af7fdf57131c to test the case where the FID column is not selected
