### PR TITLE
[OGR provider] Optimize feature requests with OrderBy clauses on a GeoPackage dataset

### DIFF
--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -28,6 +28,8 @@
 #include "qgsgeometryengine.h"
 #include "qgsdbquerylog.h"
 
+#include <sqlite3.h>
+
 #include <QTextCodec>
 #include <QFile>
 
@@ -142,6 +144,132 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
                    !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) ||
                    ( mSource->mOgrGeometryTypeFilter != wkbUnknown );
 
+  bool filterExpressionAlreadyTakenIntoAccount = false;
+
+#if SQLITE_VERSION_NUMBER >= 3030000L
+  // For GeoPackage, try to compile order by expressions as a SQL statement
+  // Only SQLite >= 3.30.0 supports NULLS FIRST / NULLS LAST
+  // A potential further optimization would be to translate mFilterRect
+  // as a JOIN with the GPKG RTree when it exists, instead of having just OGR
+  // evaluating it as a post processing.
+  const auto constOrderBy = request.orderBy();
+  if ( !constOrderBy.isEmpty() &&
+       source->mDriverName == QLatin1String( "GPKG" ) &&
+       ( request.filterType() == QgsFeatureRequest::FilterNone ||
+         request.filterType() == QgsFeatureRequest::FilterExpression ) &&
+       ( mSource->mSubsetString.isEmpty() ||
+         !mSource->mSubsetString.startsWith( QLatin1String( "SELECT " ), Qt::CaseInsensitive ) ) )
+  {
+    QByteArray sql = QByteArray( "SELECT " );
+    for ( int i = 0; i < source->mFields.size(); ++i )
+    {
+      if ( i > 0 )
+        sql += QByteArray( ", " );
+      sql += QgsOgrProviderUtils::quotedIdentifier( source->mFields[i].name().toUtf8(), source->mDriverName );
+    }
+    if ( strcmp( OGR_L_GetGeometryColumn( mOgrLayer ), "" ) != 0 )
+    {
+      sql += QByteArray( ", " );
+      sql += QgsOgrProviderUtils::quotedIdentifier( OGR_L_GetGeometryColumn( mOgrLayer ), source->mDriverName );
+    }
+    sql += QByteArray( " FROM " );
+    sql += QgsOgrProviderUtils::quotedIdentifier( OGR_L_GetName( mOgrLayer ), source->mDriverName );
+
+    if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+    {
+      QgsSQLiteExpressionCompiler compiler(
+        source->mFields,
+        request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
+      QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
+      if ( result == QgsSqlExpressionCompiler::Complete || result == QgsSqlExpressionCompiler::Partial )
+      {
+        QString whereClause = compiler.result();
+        sql += QByteArray( " WHERE " );
+        if ( mSource->mSubsetString.isEmpty() )
+        {
+          sql += whereClause.toUtf8();
+        }
+        else
+        {
+          sql += QByteArray( "(" );
+          sql += mSource->mSubsetString.toUtf8();
+          sql += QByteArray( ") AND (" );
+          sql += whereClause.toUtf8();
+          sql += QByteArray( ")" );
+        }
+        mExpressionCompiled = ( result == QgsSqlExpressionCompiler::Complete );
+        mCompileStatus = ( mExpressionCompiled ? Compiled : PartiallyCompiled );
+      }
+      else
+      {
+        sql.clear();
+      }
+    }
+    else if ( !mSource->mSubsetString.isEmpty() )
+    {
+      sql += QByteArray( " WHERE " );
+      sql += mSource->mSubsetString.toUtf8();
+    }
+
+    if ( !sql.isEmpty() )
+    {
+      sql += QByteArray( " ORDER BY " );
+      bool firstOrderBy = true;
+      for ( const QgsFeatureRequest::OrderByClause &clause : constOrderBy )
+      {
+        QgsExpression expression = clause.expression();
+        QgsSQLiteExpressionCompiler compiler(
+          source->mFields, request.flags() & QgsFeatureRequest::IgnoreStaticNodesDuringExpressionCompilation );
+        QgsSqlExpressionCompiler::Result result = compiler.compile( &expression );
+        if ( result == QgsSqlExpressionCompiler::Complete &&
+             expression.rootNode()->nodeType() == QgsExpressionNode::ntColumnRef )
+        {
+          if ( !firstOrderBy )
+            sql += QByteArray( ", " );
+          sql += compiler.result().toUtf8();
+          sql += QByteArray( " COLLATE NOCASE" );
+          sql += clause.ascending() ? QByteArray( " ASC" ) : QByteArray( " DESC" );
+          if ( clause.nullsFirst() )
+            sql += QByteArray( " NULLS FIRST" );
+          else
+            sql += QByteArray( " NULLS LAST" );
+        }
+        else
+        {
+          sql.clear();
+          break;
+        }
+        firstOrderBy = false;
+      }
+    }
+
+    if ( !sql.isEmpty() )
+    {
+      mOrderByCompiled = true;
+
+      if ( mOrderByCompiled && request.limit() >= 0 )
+      {
+        sql += QByteArray( " LIMIT " );
+        sql += QString::number( request.limit() ).toUtf8();
+      }
+      QgsDebugMsgLevel( QStringLiteral( "Using optimized orderBy as: %1" ).arg( QString::fromUtf8( sql ) ), 4 );
+      filterExpressionAlreadyTakenIntoAccount = true;
+      if ( mOgrLayerOri && mOgrLayer != mOgrLayerOri )
+      {
+        GDALDatasetReleaseResultSet( mConn->ds, mOgrLayer );
+        mOgrLayer = mOgrLayerOri;
+      }
+      mOgrLayerOri = mOgrLayer;
+      mOgrLayer = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, sql );
+      if ( !mOgrLayer )
+      {
+        close();
+        return;
+      }
+    }
+  }
+#endif
+
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();
 
   // ensure that all attributes required for expression filter are being fetched
@@ -218,7 +346,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
       break;
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( request.filterType() == QgsFeatureRequest::FilterExpression && !filterExpressionAlreadyTakenIntoAccount )
   {
     QgsSqlExpressionCompiler *compiler = nullptr;
     if ( source->mDriverName == QLatin1String( "SQLite" ) || source->mDriverName == QLatin1String( "GPKG" ) )
@@ -312,6 +440,13 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
 QgsOgrFeatureIterator::~QgsOgrFeatureIterator()
 {
   close();
+}
+
+bool QgsOgrFeatureIterator::prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys )
+{
+  Q_UNUSED( orderBys )
+  // Preparation has already been done in the constructor, so we just communicate the result
+  return mOrderByCompiled;
 }
 
 bool QgsOgrFeatureIterator::nextFeatureFilterExpression( QgsFeature &f )

--- a/src/core/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.h
@@ -86,6 +86,8 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
     bool fetchFeature( QgsFeature &feature ) override;
     bool nextFeatureFilterExpression( QgsFeature &f ) override;
 
+    bool prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys ) override;
+
   private:
 
     bool readFeature( const gdal::ogr_feature_unique_ptr &fet, QgsFeature &feature ) const;
@@ -101,6 +103,7 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
     bool mFetchGeometry = false;
 
     bool mExpressionCompiled = false;
+    bool mOrderByCompiled = false;
     // use std::set to get sorted ids (needed for efficient QgsFeatureRequest::FilterFids requests on OSM datasource)
     std::set<QgsFeatureId> mFilterFids;
     std::set<QgsFeatureId>::iterator mFilterFidsIt;

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -1336,7 +1336,7 @@ QString QgsOgrProviderUtils::quotedValue( const QVariant &value )
   }
 }
 
-OGRLayerH QgsOgrProviderUtils::setSubsetString( OGRLayerH layer, GDALDatasetH ds, QTextCodec *encoding, const QString &subsetString )
+QString QgsOgrProviderUtils::cleanSubsetString( const QString &subsetString )
 {
   // Remove any comments
   QStringList lines {subsetString.split( QChar( '\n' ) )};
@@ -1365,7 +1365,12 @@ OGRLayerH QgsOgrProviderUtils::setSubsetString( OGRLayerH layer, GDALDatasetH ds
     }
   }
 
-  const QString cleanedSubsetString {lines.join( QChar( '\n' ) ).trimmed() };
+  return lines.join( QChar( '\n' ) ).trimmed();
+}
+
+OGRLayerH QgsOgrProviderUtils::setSubsetString( OGRLayerH layer, GDALDatasetH ds, QTextCodec *encoding, const QString &subsetString )
+{
+  const QString cleanedSubsetString {cleanSubsetString( subsetString )};
 
   QByteArray layerName = OGR_FD_GetName( OGR_L_GetLayerDefn( layer ) );
   GDALDriverH driver = GDALGetDatasetDriver( ds );

--- a/src/core/providers/ogr/qgsogrproviderutils.h
+++ b/src/core/providers/ogr/qgsogrproviderutils.h
@@ -154,6 +154,9 @@ class CORE_EXPORT QgsOgrProviderUtils
                                    bool firstAttrIsFid,
                                    const QString &subsetString );
 
+    //! Remove comments from subset string (typically a full SELECT) and trim
+    static QString cleanSubsetString( const QString &subsetString );
+
     /**
      * Sets a subset string for an OGR \a layer.
      * Might return either layer, or a new OGR SQL result layer


### PR DESCRIPTION
(fixes #53198)

OrderBy clauses are translated into a
"SELECT ... FROM ... [WHERE ...] ORDER BY ... [LIMIT x]" SQL statement
evaluated by GDAL

On a 3.2 million feature GeoPackage, this decreases the RAM consumption
from 6 GB to 0.5 GB, and is 50% faster. If a limit clause is added with
a small number, then the speed-up is massive.
