### PR TITLE
QgsBrowserGuiModel::flags(): cache value for faster browser redrawn (refs #53265)

### DIFF
--- a/src/gui/qgsbrowserguimodel.cpp
+++ b/src/gui/qgsbrowserguimodel.cpp
@@ -32,6 +32,13 @@ QgsDataItemGuiContext QgsBrowserGuiModel::createDataItemContext() const
   return context;
 }
 
+struct QgsBrowserGuiModelCachedAcceptDropValue
+{
+  bool acceptDrop;
+  int numberOfProviders;
+};
+Q_DECLARE_METATYPE( QgsBrowserGuiModelCachedAcceptDropValue )
+
 Qt::ItemFlags QgsBrowserGuiModel::flags( const QModelIndex &index ) const
 {
   if ( !index.isValid() )
@@ -58,16 +65,25 @@ Qt::ItemFlags QgsBrowserGuiModel::flags( const QModelIndex &index ) const
     // Cache the value of acceptDrop(), as it can be slow to evaluate.
     // e.g. for a OGR datasource, this requires to open it. And this method
     // is called each time the browser is redrawn.
-    QVariant cached = ptr->property( "_qgs_accept_drop_cached" );
-    if ( cached.isValid() )
+    // We cache the number of providers too, to be able to invalidate the
+    // cached value if new providers are installed.
+    QVariant cachedProperty = ptr->property( "_qgs_accept_drop_cached" );
+    const QList<QgsDataItemGuiProvider *> providers = QgsGui::dataItemGuiProviderRegistry()->providers();
+    bool refreshAcceptDrop = true;
+    if ( cachedProperty.isValid() )
     {
-      if ( cached.toBool() )
-        flags |= Qt::ItemIsDropEnabled;
+      QgsBrowserGuiModelCachedAcceptDropValue cached = cachedProperty.value<QgsBrowserGuiModelCachedAcceptDropValue>();
+      if ( cached.numberOfProviders == providers.size() )
+      {
+        refreshAcceptDrop = false;
+        if ( cached.acceptDrop )
+          flags |= Qt::ItemIsDropEnabled;
+      }
     }
-    else
+
+    if ( refreshAcceptDrop )
     {
       // new support
-      const QList<QgsDataItemGuiProvider *> providers = QgsGui::dataItemGuiProviderRegistry()->providers();
       for ( QgsDataItemGuiProvider *provider : providers )
       {
         if ( provider->acceptDrop( ptr, createDataItemContext() ) )
@@ -77,7 +93,12 @@ Qt::ItemFlags QgsBrowserGuiModel::flags( const QModelIndex &index ) const
         }
       }
 
-      ptr->setProperty( "_qgs_accept_drop_cached", ( flags & Qt::ItemIsDropEnabled ) != 0 );
+      QgsBrowserGuiModelCachedAcceptDropValue cached;
+      cached.acceptDrop = ( flags & Qt::ItemIsDropEnabled ) != 0;
+      cached.numberOfProviders = providers.size();
+      QVariant var;
+      var.setValue( cached );
+      ptr->setProperty( "_qgs_accept_drop_cached", var );
     }
   }
   return flags;


### PR DESCRIPTION
@nyalldawson I see you've assigned yourself just when I was debugging this myself too. (my fault, should have assigned myself)

I couldn't reproduce the big lag @jfbourdon mentions (the folder with the 130 .gdb opens in < 2 seconds for me), but when panning it, I could see that each .gdb item displayed was opened to call its acceptDrop() method, which caused a small but perceptible lag.

Not totally sure about my fix. I considered adding a setter/getter in QgsDataItem itself, but that didn't feel much elegant to put there the result of caching.