### PR TITLE
Cache database connection capabilities for browser items so we don't create a new connection on every call to the qt model flags

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1668,12 +1668,10 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
     if ( conn && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::CreateVectorTable ) )
     {
-
       QAction *newTableAction = new QAction( QObject::tr( "New Table…" ), menu );
 
       QObject::connect( newTableAction, &QAction::triggered, item, [ item, context]
       {
-
         std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2( item->databaseConnection() );
         // This should never happen but let's play safe
         if ( ! conn2 )
@@ -1866,14 +1864,14 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
 bool QgsDatabaseItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiContext )
 {
-  if ( !qobject_cast< QgsFileDataCollectionItem * >( item ) )
+  QgsFileDataCollectionItem *fileDataCollectionItem = qobject_cast< QgsFileDataCollectionItem * >( item );
+  if ( !fileDataCollectionItem )
     return false;
 
   if ( qobject_cast< QgsGeoPackageCollectionItem * >( item ) )
     return false; // GPKG is handled elsewhere (QgsGeoPackageItemGuiProvider)
 
-  std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( item->databaseConnection() );
-  if ( conn && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::CreateVectorTable ) )
+  if ( fileDataCollectionItem->databaseConnectionCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::CreateVectorTable ) )
   {
     return true;
   }

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -290,7 +290,13 @@ QVector<QgsDataItem *> QgsFileDataCollectionItem::createChildren()
   }
 
   std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( databaseConnection() );
-  if ( conn && ( conn->capabilities() & QgsAbstractDatabaseProviderConnection::Capability::ListFieldDomains ) )
+  if ( conn )
+  {
+    mCachedCapabilities = conn->capabilities();
+    mCachedCapabilities2 = conn->capabilities2();
+    mHasCachedCapabilities = true;
+  }
+  if ( conn && ( mCachedCapabilities & QgsAbstractDatabaseProviderConnection::Capability::ListFieldDomains ) )
   {
     QString domainError;
     QStringList fieldDomains;
@@ -311,7 +317,7 @@ QVector<QgsDataItem *> QgsFileDataCollectionItem::createChildren()
       children.append( domainsItem.release() );
     }
   }
-  if ( conn && ( conn->capabilities() & QgsAbstractDatabaseProviderConnection::Capability::RetrieveRelationships ) )
+  if ( conn && ( mCachedCapabilities & QgsAbstractDatabaseProviderConnection::Capability::RetrieveRelationships ) )
   {
     QString relationError;
     QList< QgsWeakRelation > relations;
@@ -400,6 +406,36 @@ QgsAbstractDatabaseProviderConnection *QgsFileDataCollectionItem::databaseConnec
     }
   }
   return conn;
+}
+
+QgsAbstractDatabaseProviderConnection::Capabilities QgsFileDataCollectionItem::databaseConnectionCapabilities() const
+{
+  if ( mHasCachedCapabilities )
+    return mCachedCapabilities;
+
+  std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( databaseConnection() );
+  if ( conn )
+  {
+    mCachedCapabilities = conn->capabilities();
+    mCachedCapabilities2 = conn->capabilities2();
+    mHasCachedCapabilities = true;
+  }
+  return mCachedCapabilities;
+}
+
+Qgis::DatabaseProviderConnectionCapabilities2 QgsFileDataCollectionItem::databaseConnectionCapabilities2() const
+{
+  if ( mHasCachedCapabilities )
+    return mCachedCapabilities2;
+
+  std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( databaseConnection() );
+  if ( conn )
+  {
+    mCachedCapabilities = conn->capabilities();
+    mCachedCapabilities2 = conn->capabilities2();
+    mHasCachedCapabilities = true;
+  }
+  return mCachedCapabilities2;
 }
 
 //

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -22,6 +22,7 @@
 #include "qgsdatacollectionitem.h"
 #include "qgslayeritem.h"
 #include "qgsprovidersublayerdetails.h"
+#include "qgsabstractdatabaseproviderconnection.h"
 #include <QString>
 #include <QVector>
 
@@ -136,9 +137,28 @@ class CORE_EXPORT QgsFileDataCollectionItem final: public QgsDataCollectionItem
     QgsMimeDataUtils::UriList mimeUris() const override;
     QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 
+    /**
+     * Returns the associated connection capabilities, if a databaseConnection() is available.
+     *
+     * \see databaseConnectionCapabilities2()
+     * \since QGIS 3.32
+     */
+    QgsAbstractDatabaseProviderConnection::Capabilities databaseConnectionCapabilities() const;
+
+    /**
+     * Returns extended connection capabilities, if a databaseConnection() is available.
+     *
+     * \see databaseConnectionCapabilities()
+     * \since QGIS 3.32
+     */
+    Qgis::DatabaseProviderConnectionCapabilities2 databaseConnectionCapabilities2() const;
+
   private:
 
     QList< QgsProviderSublayerDetails> mSublayers;
+    mutable bool mHasCachedCapabilities = false;
+    mutable QgsAbstractDatabaseProviderConnection::Capabilities mCachedCapabilities;
+    mutable Qgis::DatabaseProviderConnectionCapabilities2 mCachedCapabilities2;
 };
 
 


### PR DESCRIPTION
Greatly speeds up browser when a large number of files are visible

Fixes #53265
