### PR TITLE
Improve QgsBrowserModel::parent

### DIFF
--- a/src/core/browser/qgsbrowsermodel.cpp
+++ b/src/core/browser/qgsbrowsermodel.cpp
@@ -569,7 +569,7 @@ QModelIndex QgsBrowserModel::parent( const QModelIndex &index ) const
   if ( !item )
     return QModelIndex();
 
-  return findItem( item->parent() );
+  return findItem( item->parent(), item->parent() ? item->parent()->parent() : nullptr );
 }
 
 QModelIndex QgsBrowserModel::findItem( QgsDataItem *item, QgsDataItem *parent ) const


### PR DESCRIPTION
If we already know the grandparent of the item, don't recursively hunt through every item in the model for the parent
