### PR TITLE
quote filter command line argument when printing pdal_wrench command in the algorithm log

### DIFF
--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -137,7 +137,7 @@ QVariantMap QgsPdalAlgorithmBase::processAlgorithm( const QVariantMap &parameter
   const QString wrenchPath = wrenchExecutableBinary();
 
   QStringList logArgs;
-  QRegularExpression re( "[\\s\\\"\\'\\(\\)\\&;]" );
+  const thread_local QRegularExpression re( "[\\s\\\"\\'\\(\\)\\&;]" );
   for ( const QString &arg : processArgs )
   {
     if ( arg.contains( re ) )

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -21,6 +21,8 @@
 #include "qgsrunprocess.h"
 #include "qgspointcloudexpression.h"
 
+#include <QRegularExpression>
+
 ///@cond PRIVATE
 
 //
@@ -134,7 +136,21 @@ QVariantMap QgsPdalAlgorithmBase::processAlgorithm( const QVariantMap &parameter
   const QStringList processArgs = createArgumentLists( parameters, context, feedback );
   const QString wrenchPath = wrenchExecutableBinary();
 
-  feedback->pushCommandInfo( QObject::tr( "wrench command: " ) + wrenchPath + ' ' + processArgs.join( ' ' ) );
+  QStringList logArgs;
+  QRegularExpression re( "[\\s\\\"\\'\\(\\)\\&;]" );
+  for ( const QString &arg : processArgs )
+  {
+    if ( arg.contains( re ) )
+    {
+      logArgs << QStringLiteral( "\"%1\"" ).arg( arg );
+    }
+    else
+    {
+      logArgs << arg;
+    }
+  }
+
+  feedback->pushCommandInfo( QObject::tr( "wrench command: " ) + wrenchPath + ' ' + logArgs.join( ' ' ) );
 
   double progress = 0;
   QString buffer;


### PR DESCRIPTION
## Description
When running PDAL algotrithms with filter expression set and if this expression has spaces (or other characters like `&`) command executed correctly from the Processing toolbox. But when user tries to copy-paste the command and execute it, it will fail.

To prevent this we need to quote filter parameter in the command which is printed in the algorithm log.