### PR TITLE
When testing custom coordinate transforms in dialog, always use EPSG:4326

### DIFF
--- a/src/gui/qgscrsdefinitionwidget.cpp
+++ b/src/gui/qgscrsdefinitionwidget.cpp
@@ -254,7 +254,24 @@ void QgsCrsDefinitionWidget::pbnCalculate_clicked()
     return;
   }
 
-  const QgsCoordinateTransform transform( target.toGeographicCrs(), target, QgsCoordinateTransformContext() );
+  QgsCoordinateReferenceSystem source;
+  try
+  {
+    if ( target.celestialBodyName() == QLatin1String( "Earth" ) )
+    {
+      source = QgsCoordinateReferenceSystem( "EPSG:4326" );
+    }
+    else
+    {
+      source = target.toGeographicCrs();
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+    source = target.toGeographicCrs();
+  }
+
+  const QgsCoordinateTransform transform( source, target, QgsCoordinateTransformContext() );
   try
   {
     const QgsPointXY res = transform.transform( QgsPointXY( longitude, latitude ) );


### PR DESCRIPTION
... for the input coordinates IF the crs definition has an Earth celestial body

Only use geodetic crs associated with the actual crs definition for non-Earth bodies.

This matches the dialog text better, which describe the input coordinates as "Geographic / WGS84"

Fixes #52184
