### PR TITLE
enable elevation properties for raster outputs produced by export raster algs

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -99,6 +99,11 @@ QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap
   const double resolution = parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context );
   const int tileSize = parameterAsInt( parameters, QStringLiteral( "TILE_SIZE" ), context );
 
+  if ( attribute == 'Z' )
+  {
+    enableElevationPropertiesPostProcessor( true );
+  }
+
   QStringList args = { QStringLiteral( "to_raster" ),
                        QStringLiteral( "--input=%1" ).arg( layer->source() ),
                        QStringLiteral( "--output=%1" ).arg( outputFile ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -97,6 +97,8 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
   const double resolution = parameterAsDouble( parameters, QStringLiteral( "RESOLUTION" ), context );
   const int tileSize = parameterAsInt( parameters, QStringLiteral( "TILE_SIZE" ), context );
 
+  enableElevationPropertiesPostProcessor( true );
+
   QStringList args = { QStringLiteral( "to_raster_tin" ),
                        QStringLiteral( "--input=%1" ).arg( layer->source() ),
                        QStringLiteral( "--output=%1" ).arg( outputFile ),

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -41,6 +41,8 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
   protected:
     void setOutputValue( const QString &name, const QVariant &value );
 
+    void enableElevationPropertiesPostProcessor( bool enable );
+
     /**
      * Creates common advanced parameters, such as expression and rectangle filters
      */
@@ -78,6 +80,7 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
 
   private:
     QMap<QString, QVariant> mOutputValues;
+    bool mEnableElevationProperties = false;
 };
 
 ///@endcond PRIVATE


### PR DESCRIPTION
## Description
For raster layers created by "Export to raster" (if "Z" attribute was used) and "Expor to raster (using triangulation)" enable "Represents elevation surface" property. This makes them automatically picked up by the elevation profile tool and by the global terrain shading.