### PR TITLE
update pdal_wrench to 1.0.1

### DIFF
--- a/external/pdal_wrench/alg.hpp
+++ b/external/pdal_wrench/alg.hpp
@@ -49,6 +49,11 @@ struct Alg
 
     bool verbose = false;        // write extra debugging output from the algorithm
 
+    point_count_t totalPoints = 0;   // calculated number of points from the input data
+    BOX3D bounds;                    // calculated 3D bounding box from the input data
+    SpatialReference crs;            // CRS of the input data (only valid when needsSingleCrs==true)
+
+
     pdal::ProgramArgs programArgs;
 
     Alg() = default;
@@ -74,7 +79,7 @@ struct Alg
      * Prepares pipelines that the algorithm needs to run and populates the given vector.
      * Pipelines are then run in a thread pool.
      */
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) = 0;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) = 0;
     /**
      * Runs and post-processing code when pipelines are done executing.
      */
@@ -94,7 +99,7 @@ struct Info : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };
 
@@ -116,7 +121,7 @@ struct Translate : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };
 
@@ -141,7 +146,7 @@ struct Density : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 
     // new
@@ -164,7 +169,7 @@ struct Boundary : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 
 };
@@ -187,7 +192,7 @@ struct Clip : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 
     // new
@@ -210,7 +215,7 @@ struct Merge : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 
 };
 
@@ -236,7 +241,7 @@ struct Thin : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };
 
@@ -267,7 +272,7 @@ struct ToRaster : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };
 
@@ -296,7 +301,7 @@ struct ToRasterTin : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };
 
@@ -316,6 +321,6 @@ struct ToVector : public Alg
     // impl
     virtual void addArgs() override;
     virtual bool checkArgs() override;
-    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints) override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
     virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
 };

--- a/external/pdal_wrench/boundary.cpp
+++ b/external/pdal_wrench/boundary.cpp
@@ -109,7 +109,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, double r
     return manager;
 }
 
-void Boundary::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &)
+void Boundary::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {
@@ -148,14 +148,10 @@ void Boundary::finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines
     if (pipelines.empty())
         return;
 
-    // TODO: may be copc reader too... we could get input's CRS from QuickInfo
-    PipelineManager *pm = pipelines[0].get();
-    std::string crs_wkt = pm->getMetadata().findChild("readers.las").findChild("spatialreference").value();
-
     GDALAllRegister();
 
     OGRSpatialReferenceH hSrs;
-    hSrs = OSRNewSpatialReference(crs_wkt.c_str());
+    hSrs = OSRNewSpatialReference(crs.getWKT().c_str());
     assert(hSrs);
 
     OGRwkbGeometryType wkbType = /*wkt.find("MULTI") == std::string::npos ? wkbPolygon :*/ wkbMultiPolygon;
@@ -194,8 +190,13 @@ void Boundary::finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines
         {
             std::cerr << "Failed to parse geometry: " << wkt << std::endl;
         }
+        if ( wkbFlatten(OGR_G_GetGeometryType(geom)) == wkbPolygon)
+        {
+            // this function takes ownership of "geom" and then creates new instance
+            geom = OGR_G_ForceToMultiPolygon(geom);
+        }
         OGRFeatureH hFeature = OGR_F_Create(OGR_L_GetLayerDefn(hLayer));
-        if (OGR_F_SetGeometry(hFeature, geom) != OGRERR_NONE)
+        if (OGR_F_SetGeometryDirectly(hFeature, geom) != OGRERR_NONE)
         {
             std::cerr << "Could not set geometry " << wkt << std::endl;
         }

--- a/external/pdal_wrench/clip.cpp
+++ b/external/pdal_wrench/clip.cpp
@@ -154,7 +154,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, const pd
 }
 
 
-void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &totalPoints)
+void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     pdal::Options crop_opts;
     BOX2D bbox;

--- a/external/pdal_wrench/density.cpp
+++ b/external/pdal_wrench/density.cpp
@@ -154,7 +154,7 @@ std::unique_ptr<PipelineManager> Density::pipeline(ParallelJobInfo *tile) const
 }
 
 
-void Density::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints)
+void Density::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {

--- a/external/pdal_wrench/info.cpp
+++ b/external/pdal_wrench/info.cpp
@@ -101,7 +101,7 @@ static void formatCrsInfo(const std::string &crsWkt, std::string &crs, std::stri
 }
 
 
-void Info::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>&, const BOX3D &, point_count_t &)
+void Info::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>&)
 {
     if (ends_with(inputFile, ".vpc"))
     {
@@ -119,15 +119,15 @@ void Info::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>&, cons
             box.grow(f.bbox);
         }
 
-        std::string crs;
+        std::string crsName;
         std::string units;
-        formatCrsInfo(vpc.crsWkt, crs, units);
+        formatCrsInfo(vpc.crsWkt, crsName, units);
 
         std::cout << "VPC           " << vpc.files.size() << " files" << std::endl;
         std::cout << "count         " << total << std::endl;
         std::cout << "extent        " << box.minx << " " << box.miny << " " << box.minz << std::endl;
         std::cout << "              " << box.maxx << " " << box.maxy << " " << box.maxz << std::endl;
-        std::cout << "crs           " << crs << std::endl;
+        std::cout << "crs           " << crsName << std::endl;
         std::cout << "units         " << units << std::endl;
 
         // list individual files

--- a/external/pdal_wrench/main.cpp
+++ b/external/pdal_wrench/main.cpp
@@ -19,44 +19,57 @@ TODO:
 #include <iostream>
 #include <vector>
 
+#include <pdal/util/FileUtils.hpp>
+
 #include "alg.hpp"
 #include "vpc.hpp"
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
 
-// TODO: make it windows/unicode friendly
-//#ifdef _WIN32
-//int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] )
-//#else
+void printUsage()
+{
+    std::cout << "usage: pdal_wrench <command> [<args>]" << std::endl;
+    std::cout << "       pdal_wrench [--help]" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Available commands:" << std::endl;
+    std::cout << "   boundary        Exports a polygon file containing boundary" << std::endl;
+    std::cout << "   build_vpc       Creates a virtual point cloud" << std::endl;
+    std::cout << "   clip            Outputs only points that are inside of the clipping polygons" << std::endl;
+    std::cout << "   density         Exports a raster where each cell contains number of points" << std::endl;
+    std::cout << "   info            Prints basic metadata from the point cloud file" << std::endl;
+    std::cout << "   merge           Merges multiple point cloud files to a single one" << std::endl;
+    std::cout << "   thin            Creates a thinned version of the point cloud (with fewer points)" << std::endl;
+    std::cout << "   tile            Creates square tiles from input data" << std::endl;
+    std::cout << "   to_raster       Exports point cloud data to a 2D raster grid" << std::endl;
+    std::cout << "   to_raster_tin   Exports point cloud data to a 2D raster grid using triangulation" << std::endl;
+    std::cout << "   to_vector       Exports point cloud data to a vector layer with 3D points" << std::endl;
+    std::cout << "   translate       Converts to a different file format, reproject, and more" << std::endl;
+}
+
+
+#if defined(_WIN32) && defined(_MSC_VER)
+int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] )
+#else
 int main(int argc, char* argv[])
-//#endif
+#endif
 {
     if (argc < 2)
     {
-        std::cerr << "need to specify command:" << std::endl;
-        std::cerr << " - boundary" << std::endl;
-        std::cerr << " - clip" << std::endl;
-        std::cerr << " - density" << std::endl;
-        std::cerr << " - build_vpc" << std::endl;
-        std::cerr << " - info" << std::endl;
-        std::cerr << " - merge" << std::endl;
-        std::cerr << " - thin" << std::endl;
-        std::cerr << " - tile" << std::endl;
-        std::cerr << " - to_raster" << std::endl;
-        std::cerr << " - to_raster_tin" << std::endl;
-        std::cerr << " - to_vector" << std::endl;
-        std::cerr << " - translate" << std::endl;
+        printUsage();
         return 1;
     }
-    std::string cmd = argv[1];
+    std::string cmd = pdal::FileUtils::fromNative(argv[1]);
 
-    // TODO: use untwine::fromNative(argv[i])
     std::vector<std::string> args;
     for ( int i = 2; i < argc; ++i )
-        args.push_back(argv[i]);
+        args.push_back(pdal::FileUtils::fromNative(argv[i]));
 
-    if (cmd == "density")
+    if (cmd == "--help" || cmd == "help")
+    {
+        printUsage();
+    }
+    else if (cmd == "density")
     {
         Density density;
         runAlg(args, density);

--- a/external/pdal_wrench/merge.cpp
+++ b/external/pdal_wrench/merge.cpp
@@ -105,7 +105,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile)
     return manager;
 }
 
-void Merge::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &totalPoints)
+void Merge::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     ParallelJobInfo tile(ParallelJobInfo::Single, BOX2D(), filterExpression, filterBounds);
     tile.inputFilenames = inputFiles;

--- a/external/pdal_wrench/thin.cpp
+++ b/external/pdal_wrench/thin.cpp
@@ -146,7 +146,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, std::str
 }
 
 
-void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &)
+void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {

--- a/external/pdal_wrench/tile/tile.cpp
+++ b/external/pdal_wrench/tile/tile.cpp
@@ -680,7 +680,7 @@ static void tilingPass2(BaseInfo &m_b, TileGrid &m_grid, FileInfo &m_srsFileInfo
           pdal::PointId pointId = view->size();
           for (size_t i = 0; i < ptCnt; i+= readChunkSize)
           {
-              size_t nPointsToRead = std::min(readChunkSize, ptCnt-i);
+              size_t nPointsToRead = (std::min)(readChunkSize, ptCnt-i);
               fileReader.read(contentPtr, nPointsToRead*m_b.pointSize);
               for (std::size_t a = 0; a < nPointsToRead; ++a)
               {

--- a/external/pdal_wrench/to_raster.cpp
+++ b/external/pdal_wrench/to_raster.cpp
@@ -178,7 +178,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, double r
 }
 
 
-void ToRaster::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints)
+void ToRaster::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {

--- a/external/pdal_wrench/to_raster_tin.cpp
+++ b/external/pdal_wrench/to_raster_tin.cpp
@@ -178,7 +178,7 @@ std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, double resoluti
 }
 
 
-void ToRasterTin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &bounds, point_count_t &totalPoints)
+void ToRasterTin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {
@@ -313,7 +313,7 @@ void ToRasterTin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>
     }
 }
 
-void ToRasterTin::finalize(std::vector<std::unique_ptr<PipelineManager>>& )
+void ToRasterTin::finalize(std::vector<std::unique_ptr<PipelineManager>>&)
 {
     if (!tileOutputFiles.empty())
     {

--- a/external/pdal_wrench/to_vector.cpp
+++ b/external/pdal_wrench/to_vector.cpp
@@ -91,7 +91,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, const st
 }
 
 
-void ToVector::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &)
+void ToVector::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {

--- a/external/pdal_wrench/translate.cpp
+++ b/external/pdal_wrench/translate.cpp
@@ -148,7 +148,7 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, std::str
 }
 
 
-void Translate::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines, const BOX3D &, point_count_t &)
+void Translate::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines)
 {
     if (ends_with(inputFile, ".vpc"))
     {

--- a/external/pdal_wrench/utils.cpp
+++ b/external/pdal_wrench/utils.cpp
@@ -109,7 +109,7 @@ void runPipelineParallel(point_count_t totalPoints, bool isStreaming, std::vecto
 
     sProgressBar.init(isStreaming ? num_chunks : pipelines.size());
 
-    int nThreads = std::min( (int)pipelines.size(), max_threads );
+    int nThreads = (std::min)( (int)pipelines.size(), max_threads );
     ThreadPool p(nThreads);
     for (size_t i = 0; i < pipelines.size(); ++i)
     {

--- a/external/pdal_wrench/utils.hpp
+++ b/external/pdal_wrench/utils.hpp
@@ -199,7 +199,7 @@ public:
     mutex.lock();
     current += count;
 
-    int new_percent = (int)std::round(std::min(1.0,((double)current/(double)total))*100)/2;
+    int new_percent = (int)std::round((std::min)(1.0,((double)current/(double)total))*100)/2;
     while (new_percent > last_percent)
     {
         ++last_percent;


### PR DESCRIPTION
## Description

Update pdal_wrench to the latest release:
 - write correct CRS to the output layer in boundary tool (fixes #53241)
 - fix warning about writing polygon to a multi-polygon layer in boundary tool
 - support non-ascii paths on windows