### PR TITLE
[3.28] Ensure quadrant segments are always at least 8 when doing offset curve

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2421,6 +2421,9 @@ QgsAbstractGeometry *QgsGeos::offsetCurve( double distance, int segments, Qgis::
   geos::unique_ptr offset;
   try
   {
+    // Force quadrant segments to be at least 8, see
+    // https://github.com/qgis/QGIS/issues/53165#issuecomment-1563470832
+    if ( segments < 8 ) segments = 8;
     offset.reset( GEOSOffsetCurve_r( geosinit()->ctxt, mGeos.get(), distance, segments, static_cast< int >( joinStyle ), miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )


### PR DESCRIPTION
Works around a GEOS bug artifacts when using GEOS 3.11.{0,1,2}

Closes GH-53165 in 3.28 branch
Backport of #53234