### PR TITLE
OGR Field domain creation: properly convert QVariant to expect OGR data type

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 #include <QTextCodec>
 #include <QUuid>
 #include <cpl_error.h>
@@ -232,7 +233,7 @@ int QgsOgrUtils::OGRTZFlagFromQt( const QDateTime &datetime )
   return 100 + datetime.offsetFromUtc() / ( 60 * 15 );
 }
 
-std::unique_ptr< OGRField > QgsOgrUtils::variantToOGRField( const QVariant &value )
+std::unique_ptr< OGRField > QgsOgrUtils::variantToOGRField( const QVariant &value, OGRFieldType type )
 {
   std::unique_ptr< OGRField > res = std::make_unique< OGRField >();
 
@@ -242,51 +243,172 @@ std::unique_ptr< OGRField > QgsOgrUtils::variantToOGRField( const QVariant &valu
       OGR_RawField_SetUnset( res.get() );
       break;
     case QVariant::Bool:
-      res->Integer = value.toBool() ? 1 : 0;
+    {
+      const int val = value.toBool() ? 1 : 0;
+      if ( type == OFTInteger )
+        res->Integer = val;
+      else if ( type == OFTInteger64 )
+        res->Integer64 = val;
+      else if ( type == OFTReal )
+        res->Real = val;
+      else
+      {
+        QgsDebugError( "Unsupported output data type for Bool" );
+        return nullptr;
+      }
       break;
+    }
     case QVariant::Int:
-      res->Integer = value.toInt();
+    {
+      const int val = value.toInt();
+      if ( type == OFTInteger )
+        res->Integer = val;
+      else if ( type == OFTInteger64 )
+        res->Integer64 = val;
+      else if ( type == OFTReal )
+        res->Real = val;
+      else
+      {
+        QgsDebugError( "Unsupported output data type for Int" );
+        return nullptr;
+      }
       break;
+    }
     case QVariant::LongLong:
-      res->Integer64 = value.toLongLong();
+    {
+      const qint64 val = value.toLongLong();
+      if ( type == OFTInteger )
+      {
+        if ( val <= std::numeric_limits<int>::max() &&
+             val >= std::numeric_limits<int>::min() )
+        {
+          res->Integer = static_cast<int>( val );
+        }
+        else
+        {
+          QgsDebugError( "Value does not fit on Integer" );
+          return nullptr;
+        }
+      }
+      else if ( type == OFTInteger64 )
+        res->Integer64 = val;
+      else if ( type == OFTReal )
+      {
+        res->Real = static_cast<double>( val );
+      }
+      else
+      {
+        QgsDebugError( "Unsupported output data type for LongLong" );
+        return nullptr;
+      }
       break;
+    }
     case QVariant::Double:
-      res->Real = value.toDouble();
+    {
+      double val = value.toDouble();
+      if ( type == OFTInteger )
+      {
+        if ( val <= std::numeric_limits<int>::max() &&
+             val >= std::numeric_limits<int>::min() )
+        {
+          res->Integer = static_cast<int>( val );
+        }
+        else
+        {
+          QgsDebugError( "Value does not fit on Integer" );
+          return nullptr;
+        }
+      }
+      else if ( type == OFTInteger64 )
+      {
+        if ( val <= static_cast<double>( std::numeric_limits<qint64>::max() ) &&
+             val >= static_cast<double>( std::numeric_limits<qint64>::min() ) )
+        {
+          res->Integer64 = static_cast<qint64>( val );
+        }
+        else
+        {
+          QgsDebugError( "Value does not fit on Integer64" );
+          return nullptr;
+        }
+      }
+      else if ( type == OFTReal )
+      {
+        res->Real = val;
+      }
+      else
+      {
+        QgsDebugError( "Unsupported output data type for LongLong" );
+        return nullptr;
+      }
       break;
+    }
     case QVariant::Char:
     case QVariant::String:
-      res->String = CPLStrdup( value.toString().toUtf8().constData() );
+    {
+      if ( type == OFTString )
+        res->String = CPLStrdup( value.toString().toUtf8().constData() );
+      else
+      {
+        QgsDebugError( "Unsupported output data type for String" );
+        return nullptr;
+      }
       break;
+    }
     case QVariant::Date:
     {
-      const QDate date = value.toDate();
-      res->Date.Day = date.day();
-      res->Date.Month = date.month();
-      res->Date.Year = date.year();
-      res->Date.TZFlag = 0;
+      if ( type == OFTDate )
+      {
+        const QDate date = value.toDate();
+        res->Date.Day = date.day();
+        res->Date.Month = date.month();
+        res->Date.Year = static_cast<GInt16>( date.year() );
+        res->Date.TZFlag = 0;
+      }
+      else
+      {
+        QgsDebugError( "Unsupported output data type for Date" );
+        return nullptr;
+      }
       break;
     }
     case QVariant::Time:
     {
-      const QTime time = value.toTime();
-      res->Date.Hour = time.hour();
-      res->Date.Minute = time.minute();
-      res->Date.Second = static_cast<float>( time.second() + static_cast< double >( time.msec() ) / 1000 );
-      res->Date.TZFlag = 0;
+      if ( type == OFTTime )
+      {
+        const QTime time = value.toTime();
+        res->Date.Hour = time.hour();
+        res->Date.Minute = time.minute();
+        res->Date.Second = static_cast<float>( time.second() + static_cast< double >( time.msec() ) / 1000 );
+        res->Date.TZFlag = 0;
+      }
+      else
+      {
+        QgsDebugError( "Unsupported output data type for Time" );
+        return nullptr;
+      }
       break;
     }
     case QVariant::DateTime:
     {
-      const QDateTime dt = value.toDateTime();
-      const QDate date = dt.date();
-      res->Date.Day = date.day();
-      res->Date.Month = date.month();
-      res->Date.Year = static_cast<GInt16>( date.year() );
-      const QTime time = dt.time();
-      res->Date.Hour = time.hour();
-      res->Date.Minute = time.minute();
-      res->Date.Second = static_cast<float>( time.second() + static_cast< double >( time.msec() ) / 1000 );
-      res->Date.TZFlag = OGRTZFlagFromQt( dt );
+      if ( type == OFTDateTime )
+      {
+        const QDateTime dt = value.toDateTime();
+        const QDate date = dt.date();
+        res->Date.Day = date.day();
+        res->Date.Month = date.month();
+        res->Date.Year = static_cast<GInt16>( date.year() );
+        const QTime time = dt.time();
+        res->Date.Hour = time.hour();
+        res->Date.Minute = time.minute();
+        res->Date.Second = static_cast<float>( time.second() + static_cast< double >( time.msec() ) / 1000 );
+        res->Date.TZFlag = OGRTZFlagFromQt( dt );
+      }
+      else
+      {
+        QgsDebugError( "Unsupported output data type for DateTime" );
+        return nullptr;
+      }
       break;
     }
 
@@ -2196,8 +2318,10 @@ OGRFieldDomainH QgsOgrUtils::convertFieldDomain( const QgsFieldDomain *domain )
 
     case Qgis::FieldDomainType::Range:
     {
-      std::unique_ptr< OGRField > min = variantToOGRField( qgis::down_cast< const QgsRangeFieldDomain * >( domain )->minimum() );
-      std::unique_ptr< OGRField > max = variantToOGRField( qgis::down_cast< const QgsRangeFieldDomain * >( domain )->maximum() );
+      std::unique_ptr< OGRField > min = variantToOGRField( qgis::down_cast< const QgsRangeFieldDomain * >( domain )->minimum(), domainFieldType );
+      std::unique_ptr< OGRField > max = variantToOGRField( qgis::down_cast< const QgsRangeFieldDomain * >( domain )->maximum(), domainFieldType );
+      if ( !min || !max )
+        return nullptr;
       res = OGR_RangeFldDomain_Create(
               domain->name().toUtf8().constData(),
               domain->description().toUtf8().constData(),

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -200,11 +200,13 @@ class CORE_EXPORT QgsOgrUtils
     static QVariant OGRFieldtoVariant( const OGRField *value, OGRFieldType type );
 
     /**
-     * Converts a QVariant to an OGRField value.
+     * Converts a QVariant to an OGRField value of specified type.
+     *
+     * Returns nullptr in case of error
      *
      * \since QGIS 3.26
      */
-    static std::unique_ptr<OGRField> variantToOGRField( const QVariant &value );
+    static std::unique_ptr<OGRField> variantToOGRField( const QVariant &value, OGRFieldType type );
 
     /**
      * Gets the value of OGRField::Date::TZFlag from the timezone of a QDateTime.

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -821,27 +821,101 @@ void TestQgsOgrUtils::ogrFieldToVariant()
 
 void TestQgsOgrUtils::variantToOgrField()
 {
-  std::unique_ptr<OGRField> field( QgsOgrUtils::variantToOGRField( QVariant() ) );
+  std::unique_ptr<OGRField> field( QgsOgrUtils::variantToOGRField( QVariant(), OFTInteger ) );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
 
-  field = QgsOgrUtils::variantToOGRField( QVariant( true ) );
+  field = QgsOgrUtils::variantToOGRField( QVariant( true ), OFTInteger );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant( 1 ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( false ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( true ), OFTInteger64 );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant( 1 ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( true ), OFTReal );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTReal ), QVariant( 1 ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( false ), OFTInteger );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant( 0 ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( 11 ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( false ), OFTString );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTString ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 11 ), OFTInteger );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant( 11 ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( 11LL ) );
-  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant( 11LL ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( 5.5 ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 11 ), OFTInteger64 );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant( 11 ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 11 ), OFTReal );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTReal ), QVariant( 11 ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( 11 ), OFTString );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTString ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1234567890123LL ), OFTInteger64 );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant( 1234567890123LL ) );
+
+  // Does not fit
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1234567890123LL ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1234567890123LL ), OFTReal );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTReal ), QVariant( 1234567890123.0 ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1234567890123LL ), OFTString );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTString ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 5.5 ), OFTReal );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTReal ), QVariant( 5.5 ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( QStringLiteral( "abc" ) ) );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 5.0 ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant( 5 ) );
+
+  // Does not fit
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1e30 ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( 5.0 ), OFTInteger64 );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant( 5 ) );
+
+  // Does not fit
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1e100 ), OFTInteger64 );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger64 ), QVariant() );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( 1e100 ), OFTString );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTString ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( QStringLiteral( "abc" ) ), OFTString );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTString ), QVariant( QStringLiteral( "abc" ) ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( QDate( 2021, 2, 3 ) ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( QStringLiteral( "abc" ) ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( QDate( 2021, 2, 3 ) ), OFTDate );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTDate ), QVariant( QDate( 2021, 2, 3 ) ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( QTime( 12, 13, 14, 50 ) ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( QDate( 2021, 2, 3 ) ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( QTime( 12, 13, 14, 50 ) ), OFTTime );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTTime ), QVariant( QTime( 12, 13, 14, 50 ) ) );
-  field = QgsOgrUtils::variantToOGRField( QVariant( QDateTime( QDate( 2021, 2, 3 ), QTime( 12, 13, 14, 50 ) ) ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( QTime( 12, 13, 14, 50 ) ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
+
+  field = QgsOgrUtils::variantToOGRField( QVariant( QDateTime( QDate( 2021, 2, 3 ), QTime( 12, 13, 14, 50 ) ) ), OFTDateTime );
   QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTDateTime ), QVariant( QDateTime( QDate( 2021, 2, 3 ), QTime( 12, 13, 14, 50 ) ) ) );
+
+  // Incompatible data type
+  field = QgsOgrUtils::variantToOGRField( QVariant( QDateTime( QDate( 2021, 2, 3 ), QTime( 12, 13, 14, 50 ) ) ), OFTInteger );
+  QCOMPARE( QgsOgrUtils::OGRFieldtoVariant( field.get(), OFTInteger ), QVariant() );
+
 }
 
 void TestQgsOgrUtils::testOgrFieldTypeToQVariantType_data()


### PR DESCRIPTION
(fixes #52318)

This fixes the main issues: crashes / data corruption.

Note however that currently the GeoPackage driver doesn't really support storing the data type of a field domain, so on reading, range domains are always read as of type Real (unless there is a layer field associated with that domain). An idea could be to (ab)use the description field of the GeoPackage system table to include a conventional suffix like " (type Integer)" that would be automatically set and stripped off by the OGR GPKG driver.

It could also be nice that the QGIS GUI only proposes types that make sense for the underlying provider, but there's a lack of infrastructure for that.
