### PR TITLE
Flag OneDrive remote folders as remote, slow to open paths on Windows

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -766,7 +766,8 @@ Qgis.DriveType.Fixed.__doc__ = "Fixed drive"
 Qgis.DriveType.Remote.__doc__ = "Remote drive"
 Qgis.DriveType.CdRom.__doc__ = "CD-ROM"
 Qgis.DriveType.RamDisk.__doc__ = "RAM disk"
-Qgis.DriveType.__doc__ = 'Drive types\n\n.. versionadded:: 3.20\n\n' + '* ``Unknown``: ' + Qgis.DriveType.Unknown.__doc__ + '\n' + '* ``Invalid``: ' + Qgis.DriveType.Invalid.__doc__ + '\n' + '* ``Removable``: ' + Qgis.DriveType.Removable.__doc__ + '\n' + '* ``Fixed``: ' + Qgis.DriveType.Fixed.__doc__ + '\n' + '* ``Remote``: ' + Qgis.DriveType.Remote.__doc__ + '\n' + '* ``CdRom``: ' + Qgis.DriveType.CdRom.__doc__ + '\n' + '* ``RamDisk``: ' + Qgis.DriveType.RamDisk.__doc__
+Qgis.DriveType.Cloud.__doc__ = "Cloud storage -- files may be remote or locally stored, depending on user configuration"
+Qgis.DriveType.__doc__ = 'Drive types\n\n.. versionadded:: 3.20\n\n' + '* ``Unknown``: ' + Qgis.DriveType.Unknown.__doc__ + '\n' + '* ``Invalid``: ' + Qgis.DriveType.Invalid.__doc__ + '\n' + '* ``Removable``: ' + Qgis.DriveType.Removable.__doc__ + '\n' + '* ``Fixed``: ' + Qgis.DriveType.Fixed.__doc__ + '\n' + '* ``Remote``: ' + Qgis.DriveType.Remote.__doc__ + '\n' + '* ``CdRom``: ' + Qgis.DriveType.CdRom.__doc__ + '\n' + '* ``RamDisk``: ' + Qgis.DriveType.RamDisk.__doc__ + '\n' + '* ``Cloud``: ' + Qgis.DriveType.Cloud.__doc__
 # --
 Qgis.DriveType.baseClass = Qgis
 QgsNetworkContentFetcherRegistry.FetchingMode = Qgis.ActionStart

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -456,6 +456,7 @@ The development version
       Remote,
       CdRom,
       RamDisk,
+      Cloud,
     };
 
     enum class ActionStart

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -720,6 +720,7 @@ class CORE_EXPORT Qgis
       Remote, //!< Remote drive
       CdRom, //!< CD-ROM
       RamDisk, //!< RAM disk
+      Cloud, //!< Cloud storage -- files may be remote or locally stored, depending on user configuration
     };
     Q_ENUM( DriveType )
 


### PR DESCRIPTION
Refs #51710

Unfortunately detecting these kinds of remote cloud storage locations is very messy. This PR implements some (limited) support for detecting remote onedrive synced folders on Windows, and flagging them as slow so that we skip file scanning for them in the browser.

But I can't find any approach which works for other cloud providers (eg google drive), so this is of limited value only...