### PR TITLE
Enable QgsLayoutChecker also without tests

### DIFF
--- a/python/core/auto_generated/qgsmultirenderchecker.sip.in
+++ b/python/core/auto_generated/qgsmultirenderchecker.sip.in
@@ -142,9 +142,6 @@ without requiring a transparent background for the image
 
 };
 
-%Feature TESTS
-%If (TESTS)
-
 
 class QgsLayoutChecker : QgsMultiRenderChecker
 {
@@ -191,8 +188,6 @@ page in the layout.
 %End
 
 };
-
-%End
 
 
 /************************************************************************

--- a/src/core/qgsmultirenderchecker.h
+++ b/src/core/qgsmultirenderchecker.h
@@ -160,9 +160,6 @@ class CORE_EXPORT QgsMultiRenderChecker
     bool mIsCiRun = false;
 };
 
-SIP_FEATURE( TESTS )
-SIP_IF_FEATURE( TESTS )
-
 ///@cond PRIVATE
 
 /**
@@ -215,8 +212,6 @@ class CORE_EXPORT QgsLayoutChecker : public QgsMultiRenderChecker
     int mDotsPerMeter;
 };
 ///@endcond
-
-SIP_END
 
 
 #endif // QGSMULTIRENDERCHECKER_H


### PR DESCRIPTION
## Description

Make sure QgsLayoutChecker bindings are always built, they can also be used by downstream tests, not only by QGIS tests

CC @DelazJ 