### PR TITLE
qgsrasterattributetable.cpp: Fix potential uses of nullptr

### DIFF
--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1531,35 +1531,38 @@ QgsRasterRenderer *QgsRasterAttributeTable::createRenderer( QgsRasterDataProvide
     pseudoColorRenderer->setClassificationMax( maximumValue() );
     // Use discrete for single colors, interpolated for ramps
     pseudoColorRenderer->createShader( ramp, hasRamp() ? QgsColorRampShader::Type::Interpolated : QgsColorRampShader::Type::Discrete, QgsColorRampShader::ClassificationMode::Continuous, ramp->stops().count() + 2, true );
-    pseudoColorRenderer->shader()->setMaximumValue( maximumValue() );
-    pseudoColorRenderer->shader()->setMinimumValue( minimumValue() );
-    // Set labels
-    if ( QgsColorRampShader *shaderFunction = static_cast<QgsColorRampShader *>( pseudoColorRenderer->shader()->rasterShaderFunction() ) )
+    if ( pseudoColorRenderer->shader() )
     {
-      shaderFunction->setMinimumValue( minimumValue() );
-      shaderFunction->setMaximumValue( maximumValue() );
-      const bool labelsAreUsable { ramp->count() > 2 && labels.count() == ramp->count() - 1 };
-
-      if ( labelsAreUsable )
+      pseudoColorRenderer->shader()->setMaximumValue( maximumValue() );
+      pseudoColorRenderer->shader()->setMinimumValue( minimumValue() );
+      // Set labels
+      if ( QgsColorRampShader *shaderFunction = static_cast<QgsColorRampShader *>( pseudoColorRenderer->shader()->rasterShaderFunction() ) )
       {
-        QList<QgsColorRampShader::ColorRampItem> newItemList;
-        const double range { maximumValue() - minimumValue() };
-        int stopIdx { 0 };
-        for ( const QString &label : std::as_const( labels ) )
-        {
-          if ( stopIdx >= ramp->count() - 2 )
-          {
-            break;
-          }
-          double value { minimumValue() + ramp->stops().at( stopIdx ).offset * range };
-          QgsColorRampShader::ColorRampItem item { value, ramp->stops().at( stopIdx ).color, label };
-          newItemList.push_back( item );
-          stopIdx++;
-        }
+        shaderFunction->setMinimumValue( minimumValue() );
+        shaderFunction->setMaximumValue( maximumValue() );
+        const bool labelsAreUsable { ramp->count() > 2 && labels.count() == ramp->count() - 1 };
 
-        QgsColorRampShader::ColorRampItem item { maximumValue(), ramp->color2(), labels.last() };
-        newItemList.push_back( item );
-        shaderFunction->setColorRampItemList( newItemList );
+        if ( labelsAreUsable )
+        {
+          QList<QgsColorRampShader::ColorRampItem> newItemList;
+          const double range { maximumValue() - minimumValue() };
+          int stopIdx { 0 };
+          for ( const QString &label : std::as_const( labels ) )
+          {
+            if ( stopIdx >= ramp->count() - 2 )
+            {
+              break;
+            }
+            double value { minimumValue() + ramp->stops().at( stopIdx ).offset * range };
+            QgsColorRampShader::ColorRampItem item { value, ramp->stops().at( stopIdx ).color, label };
+            newItemList.push_back( item );
+            stopIdx++;
+          }
+
+          QgsColorRampShader::ColorRampItem item { maximumValue(), ramp->color2(), labels.last() };
+          newItemList.push_back( item );
+          shaderFunction->setColorRampItemList( newItemList );
+        }
       }
     }
     renderer.reset( pseudoColorRenderer.release() );


### PR DESCRIPTION
## Description

A QgsSingleBandPseudoColorRenderer could return a nullptr QgsRasterShader. wAdds an if to avoid a potential SIGSEGV.

Sponsored by: Grass community and Oslandia