### PR TITLE
[georeferencer] Use the default QgsMapTool search distance value to move/delete points

### DIFF
--- a/src/app/georeferencer/qgsgeorefdatapoint.h
+++ b/src/app/georeferencer/qgsgeorefdatapoint.h
@@ -109,7 +109,7 @@ class APP_EXPORT QgsGeorefDataPoint : public QObject
     int id() const { return mId; }
     void setId( int id );
 
-    bool contains( QPoint p, QgsGcpPoint::PointType type );
+    bool contains( QPoint p, QgsGcpPoint::PointType type, double &distance );
 
     QgsMapCanvas *srcCanvas() const { return mSrcCanvas; }
     QgsMapCanvas *dstCanvas() const { return mDstCanvas; }

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -688,6 +688,7 @@ void QgsGeoreferencerMainWindow::deleteDataPoint( QPoint coords )
       if ( lastPickedDistance < 0 || lastPickedDistance > distance )
       {
         dataPoint = *it;
+        lastPickedDistance = distance;
       }
     }
   }

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -677,18 +677,28 @@ void QgsGeoreferencerMainWindow::addPoint( const QgsPointXY &sourceCoords, const
 
 void QgsGeoreferencerMainWindow::deleteDataPoint( QPoint coords )
 {
+  QgsGeorefDataPoint *dataPoint = nullptr;
+  double lastPickedDistance = -1.0;
   for ( QgsGCPList::iterator it = mPoints.begin(); it != mPoints.end(); ++it )
   {
     QgsGeorefDataPoint *pt = *it;
-    if ( pt->contains( coords, QgsGcpPoint::PointType::Source ) ) // first operand for removing from GCP table
+    double distance = 0.0;
+    if ( pt->contains( coords, QgsGcpPoint::PointType::Source, distance ) ) // first operand for removing from GCP table
     {
-      delete *it;
-      mPoints.erase( it );
-      mGCPListWidget->setGCPList( &mPoints );
-      mCanvas->refresh();
-      updateGeorefTransform();
-      break;
+      if ( lastPickedDistance < 0 || lastPickedDistance > distance )
+      {
+        dataPoint = *it;
+      }
     }
+  }
+
+  if ( dataPoint )
+  {
+    mPoints.removeAll( dataPoint );
+    delete dataPoint;
+    mGCPListWidget->setGCPList( &mPoints );
+    mCanvas->refresh();
+    updateGeorefTransform();
   }
 }
 
@@ -706,12 +716,17 @@ void QgsGeoreferencerMainWindow::selectPoint( QPoint p )
   const QgsGcpPoint::PointType pointType = sender() == mToolMovePoint ? QgsGcpPoint::PointType::Source : QgsGcpPoint::PointType::Destination;
   QgsGeorefDataPoint *&mvPoint = pointType == QgsGcpPoint::PointType::Source ? mMovingPoint : mMovingPointQgis;
 
+  double lastPickedDistance = -1.0;
   for ( QgsGCPList::const_iterator it = mPoints.constBegin(); it != mPoints.constEnd(); ++it )
   {
-    if ( ( *it )->contains( p, pointType ) )
+    double distance = 0.0;
+    if ( ( *it )->contains( p, pointType, distance ) )
     {
-      mvPoint = *it;
-      break;
+      if ( lastPickedDistance < 0.0 || lastPickedDistance > distance )
+      {
+        lastPickedDistance = distance;
+        mvPoint = *it;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Had a bunch of map to georeference, and I didn't want to kill myself by the end of the process so implemented search radius for the georeferencer move and delete tools.

Fixes https://github.com/qgis/QGIS/issues/45491