### PR TITLE
add "resample" to the list of tags for GDAL's warp algorithm (fix #49208)

### DIFF
--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -163,7 +163,7 @@ class warp(GdalAlgorithm):
         return 'gdalwarp'
 
     def tags(self):
-        tags = self.tr('transform,reproject,crs,srs').split(',')
+        tags = self.tr('transform,reproject,crs,srs,resample').split(',')
         tags.extend(super().tags())
         return tags
 


### PR DESCRIPTION
## Description
GDAL warp algorithm can be used to perform resampling of a raster layer, but it does not have any tags indicating this possibility. As a result users struggle to find this functionality via Processing toolbox search.

Fixes #49208.