### PR TITLE
do not raise error in processing algoirthm if map tool can not be restored  (fix #53294)

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -403,7 +403,10 @@ class ProcessingPlugin(QObject):
                             canvas.mapTool().reset()
                         except Exception:
                             pass
-                        canvas.setMapTool(prevMapTool)
+                        try:
+                            canvas.setMapTool(prevMapTool)
+                        except RuntimeError:
+                            pass
                 else:
                     feedback = MessageBarProgress(algname=alg.displayName())
                     context = dataobjects.createContext(feedback)

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -125,7 +125,10 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
                     canvas.mapTool().reset()
                 except:
                     pass
-                canvas.setMapTool(prevMapTool)
+                try:
+                    canvas.setMapTool(prevMapTool)
+                except RuntimeError:
+                    pass
 
 
 class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):


### PR DESCRIPTION
## Description
Do not raise an exception in Processing if previously used map tool can not be restored after closing algorithm dialog. This may happen when underlying map tool was destroyed before closing algorithm dialog.

Fixes #53294.