### PR TITLE
do not explicitly mark source widget as valid as this overrides validation result (fix #52622)

### DIFF
--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -71,8 +71,6 @@ void QgsXyzSourceWidget::setSourceUri( const QString &uri )
   mAuthSettings->setConfigId( mSourceParts.value( QStringLiteral( "authcfg" ) ).toString() );
 
   setInterpretation( mSourceParts.value( QStringLiteral( "interpretation" ) ).toString() );
-
-  mIsValid = true;
 }
 
 QString QgsXyzSourceWidget::sourceUri() const


### PR DESCRIPTION
## Description
When adding an XYZ layer from the Datasource Manager by enetering an URL directly, the "Add" button remains disabled even if entered URL is valid. It also remains disabled when connection selected from the combobox.

Seems this happens because source widget is validated, but then explicitly marked as a valid overriding validation results and not emiting a signal.

Fixes #52622.