### PR TITLE
store component position not only in the graphic item but also in the component itself

### DIFF
--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -265,6 +265,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       }
 
       item->setPos( pos );
+      item->component()->setPosition( pos );
       outputItems.insert( outputIt.key(), item );
       addItem( new QgsModelArrowItem( mChildAlgorithmItems[it.value().childId()], Qt::BottomEdge, idx, QgsModelArrowItem::Marker::Circle, item, QgsModelArrowItem::Marker::Circle ) );
 


### PR DESCRIPTION
## Description

When assigining an initial position for output block in Processing Modeler it should be stored not only at the graphic item level but also at the modeler component level. This is needed to ensure correct calculation of the item position when moving it.

Fixes #51757.