### PR TITLE
do not use field alias for the display role in the field mapping model (fix #53028)

### DIFF
--- a/src/gui/qgsfieldmappingmodel.cpp
+++ b/src/gui/qgsfieldmappingmodel.cpp
@@ -125,7 +125,7 @@ QVariant QgsFieldMappingModel::data( const QModelIndex &index, int role ) const
           }
           case ColumnDataIndex::DestinationName:
           {
-            return f.field.displayName();
+            return f.field.displayNameWithAlias();
           }
           case ColumnDataIndex::DestinationType:
           {

--- a/tests/src/python/test_qgsfieldmappingwidget.py
+++ b/tests/src/python/test_qgsfieldmappingwidget.py
@@ -91,7 +91,7 @@ class TestPyQgsFieldMappingModel(unittest.TestCase):
         self.assertEqual(model.data(model.index(0, 7), Qt.DisplayRole), 'my comment')
 
         self.assertEqual(model.data(model.index(1, 0), Qt.DisplayRole), '"source_field1"')
-        self.assertEqual(model.data(model.index(1, 1), Qt.DisplayRole), 'my alias')
+        self.assertEqual(model.data(model.index(1, 1), Qt.DisplayRole), 'destination_field2 (my alias)')
         self.assertEqual(model.data(model.index(1, 6), Qt.DisplayRole), 'my alias')
         self.assertFalse(model.data(model.index(1, 7), Qt.DisplayRole))
 
@@ -172,7 +172,7 @@ class TestPyQgsFieldMappingModel(unittest.TestCase):
         self.assertEqual(model.data(model.index(0, 0), Qt.DisplayRole), '"source_field2"')
         self.assertEqual(model.data(model.index(0, 1), Qt.DisplayRole), 'destination_field1')
         self.assertEqual(model.data(model.index(1, 0), Qt.DisplayRole), '"source_field1"')
-        self.assertEqual(model.data(model.index(1, 1), Qt.DisplayRole), 'my alias')
+        self.assertEqual(model.data(model.index(1, 1), Qt.DisplayRole), 'destination_field2 (my alias)')
         self.assertEqual(model.data(model.index(2, 0), Qt.DisplayRole), '"source_field3"')
         self.assertEqual(model.data(model.index(2, 1), Qt.DisplayRole), 'destination_field3')
 


### PR DESCRIPTION
## Description
Field mapping model uses a field alias for display role, as a result even if user changes field name they won't see a new field name in the widget. This is confusing and might look like it is not possible to change a field name.

It is proposed to use field name and alias for display role, this way changes in the field name will be immediately reflected in the widget and at the same time fiels alias will provide more context.

Fixes #53028.