### PR TITLE
Clarify CRS' hasAxisInverted

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -915,9 +915,12 @@ the projection method used by the CRS.
 
     bool hasAxisInverted() const;
 %Docstring
-Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS.
+Returns whether the axis order is inverted for the CRS compared to the order east/north (longitude/latitude).
+E.g. with WMS 1.3 the axis order for EPSG:4326 is north/east (latitude/longitude), i.e. inverted.
 
 :return: ``True`` if CRS axis is inverted
+
+.. seealso:: :py:func:`axisOrdering`
 %End
 
     SIP_PYOBJECT axisOrdering() const /TypeHint="List[Qgis.CrsAxisDirection]"/;

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -838,6 +838,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     /**
      * Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS, i.e. if "north" is the first axis, instead of "east".
      * \returns TRUE if CRS axis is inverted
+     *
+     * \see axisOrdering()
      */
     bool hasAxisInverted() const;
 

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -836,7 +836,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QgsProjOperation operation() const;
 
     /**
-     * Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS, i.e. if "north" is the first axis, instead of "east".
+     * Returns whether the axis order is inverted for the CRS compared to the order east/north (longitude/latitude).
+     * E.g. with WMS 1.3 the axis order for EPSG:4326 is north/east (latitude/longitude), i.e. inverted.
      * \returns TRUE if CRS axis is inverted
      *
      * \see axisOrdering()

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -836,7 +836,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QgsProjOperation operation() const;
 
     /**
-     * Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS.
+     * Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS, i.e. if "north" is the first axis, instead of "east".
      * \returns TRUE if CRS axis is inverted
      */
     bool hasAxisInverted() const;


### PR DESCRIPTION
false by default but it can be set true if https://github.com/qgis/QGIS/blob/29d1de4dff40f8854529ab334a3146445a87e4ca/src/core/proj/qgscoordinatereferencesystem.cpp#L788-L797 -> https://github.com/qgis/QGIS/blob/29d1de4dff40f8854529ab334a3146445a87e4ca/src/core/proj/qgsprojutils.cpp#L137 finds the first axis to read "north".

**I have not compiled nor ran any tests**, the change seems trivial from a code perspective as it only touched a function description. D:

If this is not a good addition please suggest an alternative wording. Right now the documentation is missing any information about how the axis (axes rather?) are inverted and what it means.