### PR TITLE
Fix grass provider points to out of date help documents

### DIFF
--- a/python/plugins/grassprovider/Grass7AlgorithmProvider.py
+++ b/python/plugins/grassprovider/Grass7AlgorithmProvider.py
@@ -54,9 +54,8 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
                 self.tr('Log console output'), False))
             ProcessingConfig.addSetting(Setting(
                 self.name(),
-                Grass7Utils.GRASS_HELP_PATH,
-                self.tr('Location of GRASS docs'),
-                Grass7Utils.grassHelpPath()))
+                Grass7Utils.GRASS_HELP_URL,
+                self.tr('Location of GRASS docs'), ''))
             # Add settings for using r.external/v.external instead of r.in.gdal/v.in.ogr
             # but set them to False by default because the {r,v}.external implementations
             # have some bugs on windows + there are algorithms that can't be used with
@@ -80,7 +79,7 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
     def unload(self):
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_COMMANDS)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_CONSOLE)
-        ProcessingConfig.removeSetting(Grass7Utils.GRASS_HELP_PATH)
+        ProcessingConfig.removeSetting(Grass7Utils.GRASS_HELP_URL)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_USE_REXTERNAL)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_USE_VEXTERNAL)
 

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -47,7 +47,7 @@ class Grass7Utils:
     GRASS_REGION_CELLSIZE = 'GRASS7_REGION_CELLSIZE'
     GRASS_LOG_COMMANDS = 'GRASS7_LOG_COMMANDS'
     GRASS_LOG_CONSOLE = 'GRASS7_LOG_CONSOLE'
-    GRASS_HELP_PATH = 'GRASS_HELP_PATH'
+    GRASS_HELP_URL = 'GRASS_HELP_URL'
     GRASS_USE_REXTERNAL = 'GRASS_USE_REXTERNAL'
     GRASS_USE_VEXTERNAL = 'GRASS_USE_VEXTERNAL'
 
@@ -561,9 +561,9 @@ class Grass7Utils:
 
     @staticmethod
     def grassHelpPath():
-        helpPath = ProcessingConfig.getSetting(Grass7Utils.GRASS_HELP_PATH)
+        helpPath = ProcessingConfig.getSetting(Grass7Utils.GRASS_HELP_URL)
 
-        if helpPath is None:
+        if not helpPath:
             if isWindows() or isMac():
                 if Grass7Utils.path is not None:
                     localPath = os.path.join(Grass7Utils.path, 'docs/html')
@@ -578,14 +578,14 @@ class Grass7Utils:
                         helpPath = os.path.abspath(path)
                         break
 
-        if helpPath is not None:
+        if helpPath:
             return helpPath
         elif Grass7Utils.version:
             version = Grass7Utils.version.replace('.', '')[:2]
             return 'https://grass.osgeo.org/grass{}/manuals/'.format(version)
         else:
             # GRASS not available!
-            return 'https://grass.osgeo.org/grass78/manuals/'
+            return 'https://grass.osgeo.org/grass82/manuals/'
 
     @staticmethod
     def getSupportedOutputRasterExtensions():


### PR DESCRIPTION
Instead of storing the calculated default URL for the help documentation within the user's profile, make the help PATH setting an optional override. This avoids the setting persisting an older help URL when the user's grass installation is updated to a newer version.

Change the existing setting key to a new one so that the setting is reset for all users, so that old profile settings don't apply and override the default.

Fixes #53105
