### PR TITLE
[testing] Do not rely on the presence of report

### DIFF
--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -77,7 +77,7 @@ class TestCase(_TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.report:
+        if hasattr(cls, 'report') and cls.report:
             cls.write_local_html_report(cls.report)
 
     @classmethod


### PR DESCRIPTION
The testing library is used sometimes in plugins and if only `setUp` is overwritten, `report` is missing and the default `tearDown` fails due to missing report. This patch makes it easier to use.

```
    @classmethod
    def tearDownClass(cls):
>       if cls.report:
E       AttributeError: type object 'MyTest' has no attribute 'report'
```