### PR TITLE
[GRASS] Use -stable link to manuals

### DIFF
--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -585,7 +585,7 @@ class Grass7Utils:
             return 'https://grass.osgeo.org/grass{}/manuals/'.format(version)
         else:
             # GRASS not available!
-            return 'https://grass.osgeo.org/grass82/manuals/'
+            return 'https://grass.osgeo.org/grass-stable/manuals/'
 
     @staticmethod
     def getSupportedOutputRasterExtensions():


### PR DESCRIPTION
## Description

As [mentioned](https://github.com/qgis/QGIS/issues/53105#issuecomment-1576440100) by @neteler, there is a new URL to link to the latest version of GRASS manuals.

Follow-up https://github.com/qgis/QGIS/pull/53372