### PR TITLE
set default value for CRS parameter in Define Shapefile projection algorithm (fix #53309)

### DIFF
--- a/python/plugins/processing/algs/qgis/DefineProjection.py
+++ b/python/plugins/processing/algs/qgis/DefineProjection.py
@@ -51,7 +51,7 @@ class DefineProjection(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,
                                                             self.tr('Input Shapefile'), types=[QgsProcessing.TypeVectorAnyGeometry]))
-        self.addParameter(QgsProcessingParameterCrs(self.CRS, 'CRS'))
+        self.addParameter(QgsProcessingParameterCrs(self.CRS, 'CRS', 'EPSG:4326'))
         self.addOutput(QgsProcessingOutputVectorLayer(self.INPUT,
                                                       self.tr('Layer with projection')))
 


### PR DESCRIPTION
## Description

If a default value for parameter is not set, the parameter should be marked as optional in order to have proper support for invalid CRS in the widget. If widget does not allow invalid CRS but invalid CRS is set, it will fail to validate selection.

Fixes #53309.