### PR TITLE
correctly handle "Save only selected features" option in Package layers alg (fix #50400)

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -344,8 +344,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
       case Qgis::LayerType::Vector:
       {
         QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer.get() );
-        const bool onlySaveSelected = vectorLayer->selectedFeatureCount() > 0 && selectedFeaturesOnly;
-        if ( !packageVectorLayer( vectorLayer, packagePath, context, &multiStepFeedback, saveStyles, saveMetadata, onlySaveSelected ) )
+        if ( !packageVectorLayer( vectorLayer, packagePath, context, &multiStepFeedback, saveStyles, saveMetadata, selectedFeaturesOnly ) )
           errored = true;
         else
           outputLayers.append( QStringLiteral( "%1|layername=%2" ).arg( packagePath, layer->name() ) );

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -473,7 +473,7 @@ void TestQgsProcessingAlgsPt1::packageAlg()
   selectedPolygonsPackagedLayer = std::make_unique< QgsVectorLayer >( outputGpkg + "|layername=polygons", "polygons", "ogr" );
   QVERIFY( selectedPolygonsPackagedLayer->isValid() );
   QCOMPARE( selectedPolygonsPackagedLayer->wkbType(), mPolygonLayer->wkbType() );
-  QCOMPARE( selectedPolygonsPackagedLayer->featureCount(), 10 ); // With enabled SELECTED_FEATURES_ONLY all features should be saved when there is no selection
+  QCOMPARE( selectedPolygonsPackagedLayer->featureCount(), 0 ); // With enabled SELECTED_FEATURES_ONLY no features should be saved when there is no selection
 }
 
 void TestQgsProcessingAlgsPt1::rasterLayerProperties()


### PR DESCRIPTION
## Description

Package layers algorithm handles "Save only selected features" option in a confusing way: if layer does not have selected features, all layer features will be saved while user expects that an empty layer will be created.

Fixes #50400.