### PR TITLE
Fix loss of selection signal when QgsCrsSelectionWidget is not

### DIFF
--- a/src/gui/qgsprojectionselectiondialog.cpp
+++ b/src/gui/qgsprojectionselectiondialog.cpp
@@ -88,6 +88,7 @@ QgsCrsSelectionWidget::QgsCrsSelectionWidget( QWidget *parent )
   {
     if ( !mBlockSignals )
     {
+      mDeferredInvalidCrsSet = false;
       emit crsChanged();
       emit hasValidSelectionChanged( hasValidSelection() );
     }


### PR DESCRIPTION
permitting invalid crs selection yet an invalid crs has been set as the selected crs via api

Refs #53309

Accompanies https://github.com/qgis/QGIS/pull/53388 , by addressing the limitation in the underlying widget class itself too.