### PR TITLE
Don't open datasets when populating browser directories to determine layer drop support

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1864,6 +1864,10 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
 bool QgsDatabaseItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiContext )
 {
+  // WARNING: This method will be called from the MAIN THREAD AND WILL BLOCK QGIS WHILE THE
+  // BROWSER IS BEING POPULATED
+  // We are limited to VERY VERY cheap calculations only!!
+  // DO NOT UNDER *****ANY***** CIRCUMSTANCES OPEN DATASETS HERE!!!!
   QgsFileDataCollectionItem *fileDataCollectionItem = qobject_cast< QgsFileDataCollectionItem * >( item );
   if ( !fileDataCollectionItem )
     return false;
@@ -1871,11 +1875,15 @@ bool QgsDatabaseItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiCo
   if ( qobject_cast< QgsGeoPackageCollectionItem * >( item ) )
     return false; // GPKG is handled elsewhere (QgsGeoPackageItemGuiProvider)
 
-  if ( fileDataCollectionItem->databaseConnectionCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::CreateVectorTable ) )
+  if ( fileDataCollectionItem->canAddVectorLayers() )
   {
     return true;
   }
 
+  // WARNING: This method will be called from the MAIN THREAD AND WILL BLOCK QGIS WHILE THE
+  // BROWSER IS BEING POPULATED
+  // We are limited to VERY VERY cheap calculations only!!
+  // DO NOT UNDER *****ANY***** CIRCUMSTANCES OPEN DATASETS HERE!!!!
   return false;
 }
 

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -134,6 +134,24 @@ class CORE_EXPORT QgsFileDataCollectionItem final: public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
     bool hasDragEnabled() const override;
+
+    /**
+     * Returns TRUE if the file is likely to support addition of vector layers.
+     *
+     * This method is designed to be cheap to evaluate, so that it is safe to call
+     * within the main thread.
+     *
+     * By default it relies solely on a basic check of the associated driver's theoretical
+     * capabilities, and does not actually open the dataset to determine whether the particular
+     * file definitely can support layer additions.
+     *
+     * If a connection has previously been opened for this item, then the results will
+     * be updated to use the actual capabilities determined by that connection.
+     *
+     * \since QGIS 3.32
+     */
+    bool canAddVectorLayers() const;
+
     QgsMimeDataUtils::UriList mimeUris() const override;
     QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 
@@ -159,6 +177,8 @@ class CORE_EXPORT QgsFileDataCollectionItem final: public QgsDataCollectionItem
     mutable bool mHasCachedCapabilities = false;
     mutable QgsAbstractDatabaseProviderConnection::Capabilities mCachedCapabilities;
     mutable Qgis::DatabaseProviderConnectionCapabilities2 mCachedCapabilities2;
+    mutable bool mHasCachedDropSupport = false;
+    mutable bool mCachedSupportsDrop = false;
 };
 
 


### PR DESCRIPTION
This is rather tricky -- qt needs to know in advance whether a model item supports drops, so we need to determine
whether we'll allow item drops as soon as we create any layer items in the browser.

Unfortunately, determining this accurately requires opening a dataset for files associated with OGR vector layers. And this can be expensive to do, eg when a folder contains many GDB files.

And since the item flags must be determined upfront, we **can't** do anything clever like delay determination of the drop capabilities until the user actually WANTS to drop content over a particular item.

So, avoid the upfront cost of opening datasets by limiting ourselves to very cheap tests of files when populating directories. Specifically, we now only:

- check if the file is read only
- check if the associated GDAL driver reflects support for multiple layers in its metadata

It's not perfect, but the best tradeoff we can do right now!

Refs https://github.com/qgis/QGIS/issues/53265