### PR TITLE
Correctly cleanup project archive files before attempting to clear/replace archive

### DIFF
--- a/python/core/auto_generated/project/qgsprojectstylesettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectstylesettings.sip.in
@@ -120,6 +120,13 @@ Sets the default symbol opacity.
 Resets the settings to a default state.
 %End
 
+    void removeProjectStyle();
+%Docstring
+Removes and deletes the project style database.
+
+.. versionadded:: 3.32
+%End
+
     void setProjectStyle( QgsStyle *style /Transfer/ );
 %Docstring
 Sets the style database to use for the project style.

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -2279,6 +2279,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
                            QgsMapLayer::ReadFlags layerReadFlags,
                            int totalProviderCount );
 
+    /**
+     * Releases any handles to files stored in the project archive, so that the
+     * archive can be safely removed.
+     */
+    void releaseHandlesToProjectArchive();
+
     Qgis::ProjectCapabilities mCapabilities;
 
     std::unique_ptr< QgsMapLayerStore > mLayerStore;

--- a/src/core/project/qgsprojectstylesettings.cpp
+++ b/src/core/project/qgsprojectstylesettings.cpp
@@ -130,6 +130,16 @@ void QgsProjectStyleSettings::reset()
   emit styleDatabasesChanged();
 }
 
+void QgsProjectStyleSettings::removeProjectStyle()
+{
+  if ( mProjectStyle )
+  {
+    mCombinedStyleModel->removeStyle( mProjectStyle );
+    delete mProjectStyle;
+    mProjectStyle = nullptr;
+  }
+}
+
 void QgsProjectStyleSettings::setProjectStyle( QgsStyle *style )
 {
   if ( mProjectStyle )

--- a/src/core/project/qgsprojectstylesettings.h
+++ b/src/core/project/qgsprojectstylesettings.h
@@ -123,6 +123,13 @@ class CORE_EXPORT QgsProjectStyleSettings : public QObject
     void reset();
 
     /**
+     * Removes and deletes the project style database.
+     *
+     * \since QGIS 3.32
+     */
+    void removeProjectStyle();
+
+    /**
      * Sets the style database to use for the project style.
      *
      * \see projectStyle()


### PR DESCRIPTION
Otherwise the temporary archive directory cannot be removed, resulting in many "QTemporaryDir: Unable to remove" warnings and leftover temporary directories

Refs #53034
