### PR TITLE
Fix a use after free issue in app cleanup 

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2158,6 +2158,8 @@ QgisApp::~QgisApp()
   mMapStylingDock = nullptr;
   delete mCoordsEdit;
   mCoordsEdit = nullptr;
+  delete mLayerTreeView;
+  mLayerTreeView = nullptr;
 
   QgsGui::nativePlatformInterface()->cleanup();
 

--- a/src/core/symbology/qgscombinedstylemodel.cpp
+++ b/src/core/symbology/qgscombinedstylemodel.cpp
@@ -69,7 +69,7 @@ void QgsCombinedStyleModel::addStyle( QgsStyle *style )
   addSourceModel( titleModel );
   mTitleModels.insert( style, titleModel );
 
-  QgsStyleModel *styleModel = new QgsStyleModel( style );
+  QgsStyleModel *styleModel = new QgsStyleModel( style, this );
 
   for ( QSize size : std::as_const( mAdditionalSizes ) )
   {


### PR DESCRIPTION
The project and layertree were being destroyed before the layer tree view was being removed, which meant that in some
circumstances the view would attempt to read previously destroyed layer tree nodes

Explicitly delete the layer tree view before we cleanup QgsApplication to avoid this.