### PR TITLE
Add includeEnd into the totalFrameCount game

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -324,7 +324,10 @@ long long QgsTemporalNavigationObject::totalFrameCount() const
   else
   {
     const QgsInterval totalAnimationLength = mTemporalExtents.end() - mTemporalExtents.begin();
-    return static_cast< long long >( std::ceil( totalAnimationLength.seconds() / mFrameDuration.seconds() ) );
+    if ( mTemporalExtents.includeEnd() )
+      return static_cast< long long >( std::ceil( ( totalAnimationLength.seconds() + 0.001 ) / mFrameDuration.seconds() ) );
+    else
+      return static_cast< long long >( std::ceil( totalAnimationLength.seconds() / mFrameDuration.seconds() ) );
   }
 }
 

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -29,6 +29,7 @@ QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject 
   const QMap<QString, QgsMapLayer *> mapLayers = project->mapLayers();
   QDateTime minDate;
   QDateTime maxDate;
+  bool includeEnd = false;
 
   for ( auto it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
   {
@@ -38,13 +39,16 @@ QgsDateTimeRange QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject 
       continue;
     const QgsDateTimeRange layerRange = currentLayer->temporalProperties()->calculateTemporalExtent( currentLayer );
 
+    if ( layerRange.includeEnd() )
+      includeEnd = true;
+
     if ( layerRange.begin().isValid() && ( !minDate.isValid() ||  layerRange.begin() < minDate ) )
       minDate = layerRange.begin();
     if ( layerRange.end().isValid() && ( !maxDate.isValid() ||  layerRange.end() > maxDate ) )
       maxDate = layerRange.end();
   }
 
-  return QgsDateTimeRange( minDate, maxDate );
+  return QgsDateTimeRange( minDate, maxDate, true, includeEnd );
 }
 
 QList< QgsDateTimeRange > QgsTemporalUtils::usedTemporalRangesForProject( QgsProject *project )

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -290,9 +290,11 @@ void QgsTemporalControllerWidget::updateTemporalExtent()
   const QDateTime start = mStartDateTime->dateTime();
   const QDateTime end = mEndDateTime->dateTime();
   const bool isTimeInstant = start == end;
-  const QgsDateTimeRange temporalExtent = QgsDateTimeRange( start, end,
-                                          true, !isTimeInstant && mNavigationObject->navigationMode() == QgsTemporalNavigationObject::FixedRange ? false : true );
-  mNavigationObject->setTemporalExtents( temporalExtent );
+  const QgsDateTimeRange overallTemporalExtent = QgsTemporalUtils::calculateTemporalRangeForProject( QgsProject::instance() );
+  QgsDateTimeRange controlledExtent = QgsDateTimeRange( start, end,
+                                      true, !overallTemporalExtent.includeEnd() || ( !isTimeInstant && mNavigationObject->navigationMode() == QgsTemporalNavigationObject::FixedRange ) ? false : true );
+
+  mNavigationObject->setTemporalExtents( controlledExtent );
   mSlider->setRange( 0, mNavigationObject->totalFrameCount() - 1 );
   mSlider->setValue( mNavigationObject->currentFrameNumber() );
 }


### PR DESCRIPTION
Layers with instantanous events (zero length, e.g. vector or mesh layers) missed the last events because totalFrameCount was off by one.

To fix the totalFrameCount, we add a microsecond to the temporal project extent, ONLY when there is a chance that there are any instantaneous events which are ON the temporal project extent.

We trigger the addition of the microsecond by going over alls layer and check for potential events ON the temporal project extent. If so we let the calculateTemporalRangeForProject return a QgsDateTimeRange which includes the end.

This fixes for example: https://github.com/qgis/QGIS/issues/48942

To see it yourself, load both netcdf files from this zip.
[3steps.zip](https://github.com/qgis/QGIS/files/11705613/3steps.zip)
Both have 3 datasets but ugrid3timestepstart24.nc received just 2 steps.

This is also reproducable with a csv with instantanous events (without a length).

The drawback of this pull is that it sometimes adds one step extra...

THIS PR supersedes: https://github.com/qgis/QGIS/pull/52857 which ALWAYS added the extra time step.
Personally I prefer that PR, as it is simpler. 


