### PR TITLE
Let QGIS make use of System's Default Proxy always

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -427,7 +427,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAuthSettings->setWarningText( QgsAuthSettingsWidget::formattedWarning( QgsAuthSettingsWidget::UserSettings ) );
 
   //Web proxy settings
-  grpProxy->setChecked( mSettings->value( QStringLiteral( "proxy/proxyEnabled" ), false ).toBool() );
+  grpProxy->setChecked( mSettings->value( QStringLiteral( "proxy/proxyEnabled" ), true ).toBool() );
   leProxyHost->setText( mSettings->value( QStringLiteral( "proxy/proxyHost" ), QString() ).toString() );
   leProxyPort->setText( mSettings->value( QStringLiteral( "proxy/proxyPort" ), QString() ).toString() );
 


### PR DESCRIPTION
(also for discussion, OR if people think this change will be a problem for some users...)

QGIS always had NO proxy settings enabled.
In my experience with users is that it is hard for them to 'just install QGIS and use it' when they are behind a proxy...

So we tell QGIS/Qt to use the Default System Proxy, IF set in the environment.
For what I understand, this is what for example Google Chrome is also doing: just listen to the System's Proxy

Reasoning is, that now for people behind a (institutional web) proxy they have to find out how to set the proxy (and which one). While in all/most environments these settings are available in the environment.

And users NOT having a proxy will not be affected by this change (?).