### PR TITLE
Handle multi selection from layout item list (element tree)

### DIFF
--- a/src/gui/layout/qgslayoutitemslistview.cpp
+++ b/src/gui/layout/qgslayoutitemslistview.cpp
@@ -135,9 +135,13 @@ void QgsLayoutItemsListView::updateSelection()
 
   // Build the list of selected items
   QList<QgsLayoutItem *> selectedItems;
-  for ( QModelIndex index : selectionModel()->selectedIndexes() )
+  for ( const QModelIndex &index : selectionModel()->selectedIndexes() )
+  {
     if ( QgsLayoutItem *item = mModel->itemFromIndex( index ) )
+    {
       selectedItems << item;
+    }
+  }
 
 
   bool itemSelected = false;
@@ -199,18 +203,16 @@ void QgsLayoutItemsListView::onItemFocused( QgsLayoutItem *focusedItem )
   }
 
   // Select rows in the item list for every selected items in the graphics view
-  for ( QgsLayoutItem *item : mLayout->itemsModel()->zOrderList() )
+  const QList< QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems();
+  for ( QgsLayoutItem *item : selectedItems )
   {
-    if ( item->isSelected() )
+    const QModelIndex firstCol = mModel->indexForItem( item );
+    if ( firstCol.isValid() )
     {
-      QModelIndex firstCol = mModel->indexForItem( item );
-      if ( firstCol.isValid() )
-      {
-        // Select the whole row
-        QItemSelection selection;
-        selection.select( firstCol, firstCol.siblingAtColumn( mModel->columnCount( firstCol.parent() ) - 1 ) );
-        selectionModel()->select( selection, QItemSelectionModel::Select );
-      }
+      // Select the whole row
+      QItemSelection selection;
+      selection.select( firstCol, firstCol.siblingAtColumn( mModel->columnCount( firstCol.parent() ) - 1 ) );
+      selectionModel()->select( selection, QItemSelectionModel::Select );
     }
   }
   // Reset the updating flag

--- a/src/gui/layout/qgslayoutitemslistview.cpp
+++ b/src/gui/layout/qgslayoutitemslistview.cpp
@@ -18,6 +18,7 @@
 #include "qgslayoutmodel.h"
 #include "qgslayoutdesignerinterface.h"
 #include "qgslayoutview.h"
+#include "qgslayoutitemgroup.h"
 #include <QHeaderView>
 #include <QMenu>
 #include <QMouseEvent>
@@ -33,6 +34,11 @@ QgsLayoutItemsListViewModel::QgsLayoutItemsListViewModel( QgsLayoutModel *model,
 QgsLayoutItem *QgsLayoutItemsListViewModel::itemFromIndex( const QModelIndex &index ) const
 {
   return mModel->itemFromIndex( mapToSource( index ) );
+}
+
+QModelIndex QgsLayoutItemsListViewModel::indexForItem( QgsLayoutItem *item, const int column ) const
+{
+  return mapFromSource( mModel->indexForItem( item, column ) );
 }
 
 void QgsLayoutItemsListViewModel::setSelected( const QModelIndex &index )
@@ -89,7 +95,13 @@ QgsLayoutItemsListView::QgsLayoutItemsListView( QWidget *parent, QgsLayoutDesign
   setDragDropMode( QAbstractItemView::InternalMove );
   setContextMenuPolicy( Qt::CustomContextMenu );
   setIndentation( 0 );
+
+  // Allow multi selection from the list view
+  setSelectionMode( QAbstractItemView::ExtendedSelection );
+  setSelectionBehavior( QAbstractItemView::SelectRows );
+
   connect( this, &QWidget::customContextMenuRequested, this, &QgsLayoutItemsListView::showContextMenu );
+  connect( mDesigner->view(), &QgsLayoutView::itemFocused, this, &QgsLayoutItemsListView::onItemFocused );
 }
 
 void QgsLayoutItemsListView::setCurrentLayout( QgsLayout *layout )
@@ -104,7 +116,105 @@ void QgsLayoutItemsListView::setCurrentLayout( QgsLayout *layout )
   setColumnWidth( 1, Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'x' ) * 4 );
   header()->setSectionsMovable( false );
 
-  connect( selectionModel(), &QItemSelectionModel::currentChanged, mModel, &QgsLayoutItemsListViewModel::setSelected );
+  connect( selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsLayoutItemsListView::updateSelection );
+}
+
+void QgsLayoutItemsListView::updateSelection()
+{
+  // Do nothing if we are currenlty updating the selection
+  // because user has selected/deselected some items in the
+  // graphics view
+  if ( !mModel || mUpdatingFromView )
+    return;
+
+  // Set the updating flag
+  mUpdatingSelection = true;
+
+  // Deselect all items from the layout (prevent firing signals, selection will be changed)
+  whileBlocking( mLayout )->deselectAll();
+
+  // Build the list of selected items
+  QList<QgsLayoutItem *> selectedItems;
+  for ( QModelIndex index : selectionModel()->selectedIndexes() )
+    if ( QgsLayoutItem *item = mModel->itemFromIndex( index ) )
+      selectedItems << item;
+
+
+  bool itemSelected = false;
+
+  // Check if the clicked item was selected or deselected
+  if ( selectionModel()->isSelected( selectionModel()->currentIndex() ) )
+  {
+    // It it was selected, set it as the layout's selected item;
+    // This will show the item properties
+    QgsLayoutItem *currentItem = mModel->itemFromIndex( selectionModel()->currentIndex() );
+    mLayout->setSelectedItem( currentItem );
+    itemSelected = true;
+  }
+  for ( QgsLayoutItem *item : selectedItems )
+  {
+    if ( !itemSelected )
+    {
+      // If clicked item was actually deselected, set the first selected item in the list
+      // as the layout's selected item
+      mLayout->setSelectedItem( item );
+      itemSelected = true;
+    }
+    else
+    {
+      item->setSelected( true );
+    }
+
+    // find top level group this item is contained within, and mark the group as selected
+    QgsLayoutItemGroup *group = item->parentGroup();
+    while ( group && group->parentGroup() )
+    {
+      group = group->parentGroup();
+    }
+    if ( group && group != item )
+      group->setSelected( true );
+
+  }
+  // Reset the updating flag
+  mUpdatingSelection = false;
+}
+
+void QgsLayoutItemsListView::onItemFocused( QgsLayoutItem *focusedItem )
+{
+  // Do nothing if we are in the middle of selecting items in the layoutView
+  if ( !mModel || mUpdatingSelection )
+    return;
+
+  // Set the updating flag
+  mUpdatingFromView = true;
+
+  // Deselect all items in list
+  clearSelection();
+
+  // Set the current index to the focused item
+  QModelIndex index = mModel->indexForItem( focusedItem );
+  if ( index.isValid() )
+  {
+    setCurrentIndex( index );
+  }
+
+  // Select rows in the item list for every selected items in the graphics view
+  for ( QgsLayoutItem *item : mLayout->itemsModel()->zOrderList() )
+  {
+    if ( item->isSelected() )
+    {
+      QModelIndex firstCol = mModel->indexForItem( item );
+      if ( firstCol.isValid() )
+      {
+        // Select the whole row
+        QItemSelection selection;
+        selection.select( firstCol, firstCol.siblingAtColumn( mModel->columnCount( firstCol.parent() ) - 1 ) );
+        selectionModel()->select( selection, QItemSelectionModel::Select );
+      }
+    }
+  }
+  // Reset the updating flag
+  mUpdatingFromView = false;
 }
 
 void QgsLayoutItemsListView::showContextMenu( QPoint point )

--- a/src/gui/layout/qgslayoutitemslistview.h
+++ b/src/gui/layout/qgslayoutitemslistview.h
@@ -47,6 +47,8 @@ class GUI_EXPORT QgsLayoutItemsListViewModel : public QSortFilterProxyModel
 
     //! Returns the layout item listed at the specified index
     QgsLayoutItem *itemFromIndex( const QModelIndex &index ) const;
+    //! Returns the model index matching the specified layout item
+    QModelIndex indexForItem( QgsLayoutItem *item, const int column = 0 ) const;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
   public slots:
@@ -85,11 +87,19 @@ class GUI_EXPORT QgsLayoutItemsListView : public QTreeView
 
     void showContextMenu( QPoint point );
 
+    //! Update LayoutView selection from the item list
+    void updateSelection();
+    //! Update item list selected from the layout view
+    void onItemFocused( QgsLayoutItem *focusedItem );
+
   private:
 
     QgsLayout *mLayout = nullptr;
     QgsLayoutItemsListViewModel *mModel = nullptr;
     QgsLayoutDesignerInterface *mDesigner = nullptr;
+
+    bool mUpdatingSelection = false;
+    bool mUpdatingFromView = false;
 };
 
 #endif // QGSLAYOUTITEMSLISTVIEW_H


### PR DESCRIPTION
- Fixes #47513
- Fixes #49309



## Description

This PR brings better synchronization between the Layout graphics view and the item list.
It allows to select multiple items from the item list.


### Demonstration
![multi-selection](https://github.com/qgis/QGIS/assets/9693475/56c5b3ad-0bae-4d8c-bd62-233c0f166a1e)
