### PR TITLE
Followup CAD floater bearing

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -335,17 +335,6 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   }
 
   {
-    QAction *action = new QAction( tr( "Show common snapping angle" ), mFloaterActionsMenu );
-    action->setCheckable( true );
-    mFloaterActionsMenu->addAction( action );
-    connect( action, &QAction::toggled, this, [ = ]( bool checked )
-    {
-      mFloater->setItemVisibility( QgsAdvancedDigitizingFloater::FloaterItem::CommonAngleSnapping, checked );
-    } );
-    action->setChecked( QgsSettings().value( QStringLiteral( "/Cad/CommonAngleSnappingShowInFloater" ), false ).toBool() );
-  }
-
-  {
     QAction *action = new QAction( tr( "Show bearing/azimuth" ), mFloaterActionsMenu );
     action->setCheckable( true );
     mFloaterActionsMenu->addAction( action );
@@ -354,6 +343,17 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
       mFloater->setItemVisibility( QgsAdvancedDigitizingFloater::FloaterItem::Bearing, checked );
     } );
     action->setChecked( QgsSettings().value( QStringLiteral( "/Cad/BearingShowInFloater" ), false ).toBool() );
+  }
+
+  {
+    QAction *action = new QAction( tr( "Show common snapping angle" ), mFloaterActionsMenu );
+    action->setCheckable( true );
+    mFloaterActionsMenu->addAction( action );
+    connect( action, &QAction::toggled, this, [ = ]( bool checked )
+    {
+      mFloater->setItemVisibility( QgsAdvancedDigitizingFloater::FloaterItem::CommonAngleSnapping, checked );
+    } );
+    action->setChecked( QgsSettings().value( QStringLiteral( "/Cad/CommonAngleSnappingShowInFloater" ), false ).toBool() );
   }
 
   updateCapacity( true );

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>310</width>
-    <height>204</height>
+    <height>233</height>
    </rect>
   </property>
   <property name="palette">
@@ -257,7 +257,7 @@
    <item row="8" column="1">
     <widget class="QLabel" name="mBearingLabel">
      <property name="text">
-      <string>🧭</string>
+      <string>↻</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Small UX changes:

- new b/w icon for the bearing (the colored one was odd in that context)
- reorder last options to match the visualization order in the floater

![immagine](https://github.com/qgis/QGIS/assets/142164/ebcc809b-8883-48c7-b2ce-e841eda34541)
