### PR TITLE
Display table designer when double clicking a fixed table

### DIFF
--- a/python/gui/auto_generated/layout/qgslayoutview.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutview.sip.in
@@ -550,6 +550,14 @@ Emitted when an ``item`` is "focused" in the view, i.e. it becomes the active
 item and should have its properties displayed in any designer windows.
 %End
 
+    void itemDoubleClicked( QgsLayoutItem *item );
+%Docstring
+Emitted when an ``item`` is double clicked in the view.
+Can be used to perform custom actions, i.e. open the table designer for fixed tables.
+
+.. versionadded:: 3.34
+%End
+
     void willBeDeleted();
 %Docstring
 Emitted in the destructor when the view is about to be deleted,

--- a/python/gui/auto_generated/layout/qgslayoutviewtool.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewtool.sip.in
@@ -170,6 +170,14 @@ Emitted when an ``item`` is "focused" by the tool, i.e. it should become the act
 item and should have its properties displayed in any designer windows.
 %End
 
+    void itemDoubleClicked( QgsLayoutItem *item );
+%Docstring
+Emitted when an ``item`` is double clicked.
+Can be used to perform custom actions, i.e. open the table designer for fixed tables.
+
+.. versionadded:: 3.34
+%End
+
   protected:
 
     void setFlags( QgsLayoutViewTool::Flags flags );

--- a/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewtoolselect.sip.in
@@ -34,6 +34,8 @@ Constructor for QgsLayoutViewToolSelect.
 
     virtual void layoutReleaseEvent( QgsLayoutViewMouseEvent *event );
 
+    virtual void layoutDoubleClickEvent( QgsLayoutViewMouseEvent *event );
+
     virtual void wheelEvent( QWheelEvent *event );
 
     virtual void keyPressEvent( QKeyEvent *event );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -75,6 +75,7 @@
 #include "qgsscreenhelper.h"
 #include "qgsshortcutsmanager.h"
 #include "qgsconfigureshortcutsdialog.h"
+#include "qgslayoutmanualtablewidget.h"
 #include "ui_defaults.h"
 
 #include <QShortcut>
@@ -1388,6 +1389,12 @@ void QgsLayoutDesignerDialog::onItemDoubleClicked( QgsLayoutItem *item )
 {
   // Always show the item properties when it is double clicked
   showItemOptions( item, true );
+
+  // If the item is a manual table, we want to open the table editor
+  if ( QgsLayoutManualTableWidget *editor = qobject_cast< QgsLayoutManualTableWidget * >( mItemPropertiesStack->mainPanel() ) )
+  {
+    editor->openTableDesigner();
+  }
 }
 
 void QgsLayoutDesignerDialog::open()

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -874,6 +874,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   {
     showItemOptions( item, false );
   } );
+  connect( mView, &QgsLayoutView::itemDoubleClicked, this, &QgsLayoutDesignerDialog::onItemDoubleClicked );
 
   // Panel and toolbar submenus
   mToolbarMenu->addAction( mLayoutToolbar->toggleViewAction() );
@@ -1381,6 +1382,12 @@ void QgsLayoutDesignerDialog::showItemOptions( QgsLayoutItem *item, bool bringPa
   if ( bringPanelToFront )
     mItemDock->setUserVisible( true );
 
+}
+
+void QgsLayoutDesignerDialog::onItemDoubleClicked( QgsLayoutItem *item )
+{
+  // Always show the item properties when it is double clicked
+  showItemOptions( item, true );
 }
 
 void QgsLayoutDesignerDialog::open()

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -154,6 +154,12 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     void showItemOptions( QgsLayoutItem *item, bool bringPanelToFront = true );
 
     /**
+     * Perform custom action when an item is double clicked
+     * \since QGIS 3.34
+     */
+    void onItemDoubleClicked( QgsLayoutItem *item );
+
+    /**
      * Selects the specified \a items.
      */
     void selectItems( const QList<QgsLayoutItem *> &items );

--- a/src/gui/layout/qgslayoutmanualtablewidget.cpp
+++ b/src/gui/layout/qgslayoutmanualtablewidget.cpp
@@ -32,7 +32,7 @@ QgsLayoutManualTableWidget::QgsLayoutManualTableWidget( QgsLayoutFrame *frame )
 {
   setupUi( this );
 
-  connect( mSetContentsButton, &QPushButton::clicked, this, &QgsLayoutManualTableWidget::setTableContents );
+  connect( mSetContentsButton, &QPushButton::clicked, this, &QgsLayoutManualTableWidget::openTableDesigner );
   connect( mMarginSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutManualTableWidget::mMarginSpinBox_valueChanged );
   connect( mGridStrokeWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutManualTableWidget::mGridStrokeWidthSpinBox_valueChanged );
   connect( mGridColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutManualTableWidget::mGridColorButton_colorChanged );
@@ -167,7 +167,7 @@ bool QgsLayoutManualTableWidget::setNewItem( QgsLayoutItem *item )
   return true;
 }
 
-void QgsLayoutManualTableWidget::setTableContents()
+void QgsLayoutManualTableWidget::openTableDesigner()
 {
   if ( !mTable )
   {

--- a/src/gui/layout/qgslayoutmanualtablewidget.h
+++ b/src/gui/layout/qgslayoutmanualtablewidget.h
@@ -46,6 +46,11 @@ class GUI_EXPORT QgsLayoutManualTableWidget: public QgsLayoutItemBaseWidget, pub
     void setMasterLayout( QgsMasterLayoutInterface *masterLayout ) override;
     QgsExpressionContext createExpressionContext() const override;
 
+
+  public slots:
+    //! Opens the table editor dialog
+    void openTableDesigner();
+
   protected:
 
     bool setNewItem( QgsLayoutItem *item ) override;
@@ -62,7 +67,6 @@ class GUI_EXPORT QgsLayoutManualTableWidget: public QgsLayoutItemBaseWidget, pub
 
   private slots:
 
-    void setTableContents();
     void mMarginSpinBox_valueChanged( double d );
     void mGridStrokeWidthSpinBox_valueChanged( double d );
     void mGridColorButton_colorChanged( const QColor &newColor );

--- a/src/gui/layout/qgslayoutview.cpp
+++ b/src/gui/layout/qgslayoutview.cpp
@@ -138,6 +138,7 @@ void QgsLayoutView::setTool( QgsLayoutViewTool *tool )
   {
     mTool->deactivate();
     disconnect( mTool, &QgsLayoutViewTool::itemFocused, this, &QgsLayoutView::itemFocused );
+    disconnect( mTool, &QgsLayoutViewTool::itemDoubleClicked, this, &QgsLayoutView::itemDoubleClicked );
   }
 
   if ( mSnapMarker )
@@ -152,6 +153,7 @@ void QgsLayoutView::setTool( QgsLayoutViewTool *tool )
   tool->activate();
   mTool = tool;
   connect( mTool, &QgsLayoutViewTool::itemFocused, this, &QgsLayoutView::itemFocused );
+  connect( mTool, &QgsLayoutViewTool::itemDoubleClicked, this, &QgsLayoutView::itemDoubleClicked );
   emit toolSet( mTool );
 }
 

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -528,6 +528,13 @@ class GUI_EXPORT QgsLayoutView: public QGraphicsView
     void itemFocused( QgsLayoutItem *item );
 
     /**
+     * Emitted when an \a item is double clicked in the view.
+     * Can be used to perform custom actions, i.e. open the table designer for fixed tables.
+     * \since QGIS 3.34
+     */
+    void itemDoubleClicked( QgsLayoutItem *item );
+
+    /**
      * Emitted in the destructor when the view is about to be deleted,
      * but is still in a perfectly valid state.
      */

--- a/src/gui/layout/qgslayoutviewtool.h
+++ b/src/gui/layout/qgslayoutviewtool.h
@@ -190,6 +190,13 @@ class GUI_EXPORT QgsLayoutViewTool : public QObject
      */
     void itemFocused( QgsLayoutItem *item );
 
+    /**
+     * Emitted when an \a item is double clicked.
+     * Can be used to perform custom actions, i.e. open the table designer for fixed tables.
+     * \since QGIS 3.34
+     */
+    void itemDoubleClicked( QgsLayoutItem *item );
+
   protected:
 
     /**

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -292,6 +292,17 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
   mMouseHandles->selectionChanged();
 }
 
+void QgsLayoutViewToolSelect::layoutDoubleClickEvent( QgsLayoutViewMouseEvent *event )
+{
+  QgsLayoutItem *clickedItem = layout()->layoutItemAt( event->layoutPoint() );
+  if ( clickedItem )
+  {
+    emit itemDoubleClicked( clickedItem ) ;
+    return;
+  }
+  event->ignore();
+}
+
 void QgsLayoutViewToolSelect::wheelEvent( QWheelEvent *event )
 {
   if ( mMouseHandles->shouldBlockEvent( event ) )

--- a/src/gui/layout/qgslayoutviewtoolselect.h
+++ b/src/gui/layout/qgslayoutviewtoolselect.h
@@ -45,6 +45,7 @@ class GUI_EXPORT QgsLayoutViewToolSelect : public QgsLayoutViewTool
     void layoutPressEvent( QgsLayoutViewMouseEvent *event ) override;
     void layoutMoveEvent( QgsLayoutViewMouseEvent *event ) override;
     void layoutReleaseEvent( QgsLayoutViewMouseEvent *event ) override;
+    void layoutDoubleClickEvent( QgsLayoutViewMouseEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
     void deactivate() override;


### PR DESCRIPTION
## Description

- Fixes #46462

**Note**: Other layout items might benefit from a custom action on double click. Polyline and polygon items could switch to the node tool when double clicked for instance.