### PR TITLE
Fix  map and elevation profile data defined background color

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -873,10 +873,12 @@ Sets whether this item has a background drawn under it or not.
 .. seealso:: :py:func:`setBackgroundColor`
 %End
 
-    QColor backgroundColor() const;
+    QColor backgroundColor( bool useDataDefined = true ) const;
 %Docstring
 Returns the background color for this item. This is only used if :py:func:`~QgsLayoutItem.hasBackground`
 returns ``True``.
+
+:param useDataDefined: If true, then returns the data defined override for the background color
 
 .. seealso:: :py:func:`setBackgroundColor`
 

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1518,6 +1518,12 @@ void QgsLayoutItem::refreshFrame( bool updateItem )
   }
 }
 
+QColor QgsLayoutItem::backgroundColor( bool useDataDefined ) const
+{
+  return useDataDefined ? brush().color() : mBackgroundColor;
+}
+
+
 void QgsLayoutItem::refreshBackgroundColor( bool updateItem )
 {
   //data defined fill color set?

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -841,10 +841,11 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     /**
      * Returns the background color for this item. This is only used if hasBackground()
      * returns TRUE.
+     * \param useDataDefined If true, then returns the data defined override for the background color
      * \see setBackgroundColor()
      * \see hasBackground()
      */
-    QColor backgroundColor() const { return mBackgroundColor; }
+    QColor backgroundColor( bool useDataDefined = true ) const;
 
     /**
      * Sets the background \a color for this item.

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -745,7 +745,7 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiNonPositionElements()
   };
   block( true );
 
-  mBackgroundColorButton->setColor( mItem->backgroundColor() );
+  mBackgroundColorButton->setColor( mItem->backgroundColor( false ) );
   mFrameColorButton->setColor( mItem->frameStrokeColor() );
   mStrokeUnitsComboBox->setUnit( mItem->frameStrokeWidth().units() );
   mStrokeWidthSpinBox->setValue( mItem->frameStrokeWidth().length() );

--- a/tests/src/python/test_qgslayoutitem.py
+++ b/tests/src/python/test_qgslayoutitem.py
@@ -100,7 +100,8 @@ class TestQgsLayoutItem(unittest.TestCase):
 
         item.dataDefinedProperties().setProperty(QgsLayoutObject.BackgroundColor, QgsProperty.fromExpression("'blue'"))
         item.refreshDataDefinedProperty()
-        self.assertEqual(item.backgroundColor(), QColor(255, 0, 0))  # should not change
+        self.assertEqual(item.backgroundColor(False), QColor(255, 0, 0))  # should not change
+        self.assertEqual(item.backgroundColor(True).name(), item.brush().color().name())
         self.assertEqual(item.brush().color().name(), QColor(0, 0, 255).name())
 
     def testSelected(self):


### PR DESCRIPTION
- Fixes #45135

## Description

`QgsLayoutItemMap` and `QgsLayoutItemElevationProfile` rely on `QgsLayoutItem::backgroundColor` to get their background.

This PR adds a bool parameter `useDataDefined` to `QgsLayoutItem::backgroundColor`. When true (default), the dataDefined overriden color is returned.