### PR TITLE
Avoid UI lock when closing Execute SQL window

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -662,9 +662,11 @@ ignored if not supported by the backend).
 %End
 
 
-    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const throw( QgsProviderConnectionException );
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = 0 ) const throw( QgsProviderConnectionException );
 %Docstring
 Returns information on a ``table`` in the given ``schema``.
+
+Since QGIS 3.32 the optional ``feedback`` argument can be used to cancel the request.
 
 :raises QgsProviderConnectionException: if any errors are encountered or if the table does not exist.
 
@@ -694,9 +696,11 @@ Returns information about the existing schemas.
 :raises QgsProviderConnectionException: if any errors are encountered.
 %End
 
-    virtual QgsFields fields( const QString &schema, const QString &table ) const throw( QgsProviderConnectionException );
+    virtual QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = 0 ) const throw( QgsProviderConnectionException );
 %Docstring
 Returns the fields of a ``table`` and ``schema``.
+
+Since QGIS 3.32 the optional ``feedback`` argument can be used to cancel the request.
 
 .. note::
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -198,7 +198,7 @@ void QgsGeoPackageProviderConnection::deleteSpatialIndex( const QString &schema,
                          QgsSqliteUtils::quotedString( geometryColumn ) ) );
 }
 
-QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const
 {
 
   // List of GPKG quoted system and dummy tables names to be excluded from the tables listing
@@ -224,6 +224,8 @@ QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConne
 
     for ( const auto &row : std::as_const( results ) )
     {
+      if ( feedback && feedback->isCanceled() )
+        break;
 
       if ( row.size() != 6 )
       {

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -68,10 +68,10 @@ void QgsGeoPackageProviderConnection::remove( const QString &name ) const
   settings.remove( name );
 }
 
-QgsAbstractDatabaseProviderConnection::TableProperty QgsGeoPackageProviderConnection::table( const QString &schema, const QString &name ) const
+QgsAbstractDatabaseProviderConnection::TableProperty QgsGeoPackageProviderConnection::table( const QString &schema, const QString &name, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
-  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema ) };
+  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema, TableFlags(), feedback ) };
   for ( const auto &t : constTables )
   {
     if ( t.tableName() == name )
@@ -511,7 +511,7 @@ QList<QgsLayerMetadataProviderResult> QgsGeoPackageProviderConnection::searchLay
 }
 
 
-QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const QString &table ) const
+QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const QString &table, QgsFeedback * ) const
 {
   Q_UNUSED( schema )
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -44,7 +44,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     bool spatialIndexExists( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     void deleteSpatialIndex( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QIcon icon() const override;
     QgsFields fields( const QString &schema, const QString &table ) const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -35,7 +35,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
   public:
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
-    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
+    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
@@ -46,7 +46,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
         const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QIcon icon() const override;
-    QgsFields fields( const QString &schema, const QString &table ) const override;
+    QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const override;
     QList<QgsLayerMetadataProviderResult> searchLayerMetadata( const QgsMetadataSearchContext &searchContext, const QString &searchString, const QgsRectangle &geographicExtent, QgsFeedback *feedback ) const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -183,7 +183,7 @@ QString QgsOgrProviderConnection::tableUri( const QString &, const QString &name
   return QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) )->encodeUri( parts );
 }
 
-QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOgrProviderConnection::tables( const QString &, const TableFlags &flags ) const
+QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOgrProviderConnection::tables( const QString &, const TableFlags &flags, QgsFeedback *feedback ) const
 {
   QList<QgsAbstractDatabaseProviderConnection::TableProperty> tableInfo;
 
@@ -191,11 +191,14 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOgrProviderConnec
   const QList< QgsProviderSublayerDetails > subLayers = metadata->querySublayers(
         uri(),
         ( flags & TableFlag::IncludeSystemTables ) ? Qgis::SublayerQueryFlag::IncludeSystemTables : Qgis::SublayerQueryFlags(),
-        nullptr );
+        feedback );
 
   tableInfo.reserve( subLayers.size() );
   for ( const QgsProviderSublayerDetails &subLayer : subLayers )
   {
+    if ( feedback && feedback->isCanceled() )
+      break;
+
     tableInfo.append( table( QString(), subLayer.name() ) );
   }
 

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -214,7 +214,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOgrProviderConnec
   return tableInfo;
 }
 
-QgsAbstractDatabaseProviderConnection::TableProperty QgsOgrProviderConnection::table( const QString &, const QString &table ) const
+QgsAbstractDatabaseProviderConnection::TableProperty QgsOgrProviderConnection::table( const QString &, const QString &table, QgsFeedback * ) const
 {
   const QVariantMap parts = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) )->decodeUri( uri() );
   const QString path = parts.value( QStringLiteral( "path" ) ).toString();

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -75,7 +75,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void remove( const QString &name ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
     QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -76,7 +76,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     QString tableUri( const QString &schema, const QString &name ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
         const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
-    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
+    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1270,7 +1270,7 @@ void QgsAbstractDatabaseProviderConnection::renameField( const QString &schema, 
   }
 }
 
-QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsAbstractDatabaseProviderConnection::tables( const QString &, const QgsAbstractDatabaseProviderConnection::TableFlags & ) const
+QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsAbstractDatabaseProviderConnection::tables( const QString &, const QgsAbstractDatabaseProviderConnection::TableFlags &, QgsFeedback * ) const
 {
   checkCapability( Capability::Tables );
   return QList<QgsAbstractDatabaseProviderConnection::TableProperty>();

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1277,10 +1277,10 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsAbstractDatabaseP
 }
 
 
-QgsAbstractDatabaseProviderConnection::TableProperty QgsAbstractDatabaseProviderConnection::table( const QString &schema, const QString &name ) const
+QgsAbstractDatabaseProviderConnection::TableProperty QgsAbstractDatabaseProviderConnection::table( const QString &schema, const QString &name, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
-  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema ) };
+  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema, TableFlags(), feedback ) };
   for ( const auto &t : constTables )
   {
     if ( t.tableName() == name )
@@ -1334,7 +1334,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty::GeometryColumnType> 
 }
 
 
-QgsFields QgsAbstractDatabaseProviderConnection::fields( const QString &schema, const QString &tableName ) const
+QgsFields QgsAbstractDatabaseProviderConnection::fields( const QString &schema, const QString &tableName, QgsFeedback * ) const
 {
   QgsVectorLayer::LayerOptions options { false, true };
   options.skipCrsValidation = true;

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -789,11 +789,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     /**
      * Returns information on a \a table in the given \a schema.
      *
+     * Since QGIS 3.32 the optional \a feedback argument can be used to cancel the request.
+     *
      * \throws QgsProviderConnectionException if any errors are encountered or if the table does not exist.
      * \note Not available in Python bindings
      * \since QGIS 3.12
      */
-    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const SIP_THROW( QgsProviderConnectionException );
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns information on the tables in the given schema.
@@ -817,6 +819,8 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     /**
      * Returns the fields of a \a table and \a schema.
      *
+     * Since QGIS 3.32 the optional \a feedback argument can be used to cancel the request.
+     *
      * \note the default implementation creates a temporary vector layer, providers may
      * choose to override this method for a greater efficiency of to overcome provider's
      * behavior when the layer does not expose all fields (GPKG for example hides geometry
@@ -824,7 +828,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \throws QgsProviderConnectionException if any errors are encountered.
      * \since QGIS 3.16
      */
-    virtual QgsFields fields( const QString &schema, const QString &table ) const SIP_THROW( QgsProviderConnectionException );
+    virtual QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
      * Returns a list of native types supported by the connection.

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -780,10 +780,11 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      *
      * \param schema name of the schema (ignored if not supported by the backend)
      * \param flags filter tables by flags, this option completely overrides search options stored in the connection
+     * \param feedback can be used to cancel the request (since QGIS 3.32)
      * \throws QgsProviderConnectionException if any errors are encountered.
      * \note Not available in Python bindings
      */
-    virtual QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(), const QgsAbstractDatabaseProviderConnection::TableFlags &flags = QgsAbstractDatabaseProviderConnection::TableFlags() ) const SIP_SKIP;
+    virtual QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(), const QgsAbstractDatabaseProviderConnection::TableFlags &flags = QgsAbstractDatabaseProviderConnection::TableFlags(), QgsFeedback *feedback = nullptr ) const SIP_SKIP;
 
     /**
      * Returns information on a \a table in the given \a schema.

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -633,12 +633,19 @@ void QgsConnectionsApiFetcher::fetchTokens()
         QStringList fieldNames;
         try
         {
-          const QgsFields fields( mConnection->fields( schema, table ) );
-          if ( mStopFetching ) { return; }
+          const QgsFields fields( mConnection->fields( schema, table, mFeedback.get() ) );
+          if ( mStopFetching )
+          {
+            return;
+          }
+
           for ( const auto &field : std::as_const( fields ) )
           {
             fieldNames.push_back( field.name() );
-            if ( mStopFetching ) { return; }
+            if ( mStopFetching )
+            {
+              return;
+            }
           }
           emit tokensReady( fieldNames );
         }

--- a/src/gui/qgsqueryresultwidget.h
+++ b/src/gui/qgsqueryresultwidget.h
@@ -57,9 +57,10 @@ class GUI_EXPORT QgsConnectionsApiFetcher: public QObject
 
   public:
 
-    //! Constructs a result fetcher from \a connection.
-    QgsConnectionsApiFetcher( const QgsAbstractDatabaseProviderConnection *connection )
-      : mConnection( connection )
+    //! Constructs a result fetcher from connection with the specified \a uri and \a providerKey.
+    QgsConnectionsApiFetcher( const QString &uri, const QString &providerKey )
+      : mUri( uri )
+      , mProviderKey( providerKey )
     {}
 
     //! Start fetching
@@ -78,8 +79,10 @@ class GUI_EXPORT QgsConnectionsApiFetcher: public QObject
 
   private:
 
-    const QgsAbstractDatabaseProviderConnection *mConnection = nullptr;
+    QString mUri;
+    QString mProviderKey;
     QAtomicInt mStopFetching = 0;
+    std::unique_ptr< QgsFeedback > mFeedback;
 
 };
 
@@ -216,8 +219,9 @@ class GUI_EXPORT QgsQueryResultWidget: public QWidget, private Ui::QgsQueryResul
     std::unique_ptr<QgsAbstractDatabaseProviderConnection> mConnection;
     std::unique_ptr<QgsQueryResultModel> mModel;
     std::unique_ptr<QgsFeedback> mFeedback;
-    std::unique_ptr<QgsConnectionsApiFetcher> mApiFetcher;
-    QThread mApiFetcherWorkerThread;
+
+    QPointer< QgsConnectionsApiFetcher > mApiFetcher;
+
     bool mWasCanceled = false;
     mutable QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions mSqlVectorLayerOptions;
     bool mFirstRowFetched = false;

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -405,7 +405,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsHanaProviderConne
   return tables;
 }
 
-QgsAbstractDatabaseProviderConnection::TableProperty QgsHanaProviderConnection::table( const QString &schema, const QString &table ) const
+QgsAbstractDatabaseProviderConnection::TableProperty QgsHanaProviderConnection::table( const QString &schema, const QString &table, QgsFeedback * ) const
 {
   const QString geometryColumn = QgsDataSourceUri( uri() ).geometryColumn();
   auto layerFilter = [&table, &geometryColumn]( const QgsHanaLayerProperty & layer )
@@ -419,7 +419,7 @@ QgsAbstractDatabaseProviderConnection::TableProperty QgsHanaProviderConnection::
   return constTables[0];
 }
 
-QList<QgsHanaProviderConnection::TableProperty> QgsHanaProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsHanaProviderConnection::TableProperty> QgsHanaProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback * ) const
 {
   return tablesWithFilter( schema, flags );
 }
@@ -445,7 +445,7 @@ QStringList QgsHanaProviderConnection::schemas( ) const
   }
 }
 
-QgsFields QgsHanaProviderConnection::fields( const QString &schema, const QString &table ) const
+QgsFields QgsHanaProviderConnection::fields( const QString &schema, const QString &table, QgsFeedback * ) const
 {
   QgsHanaConnectionRef conn = createConnection();
   const QString geometryColumn = QgsDataSourceUri( uri() ).geometryColumn();

--- a/src/providers/hana/qgshanaproviderconnection.h
+++ b/src/providers/hana/qgshanaproviderconnection.h
@@ -71,11 +71,11 @@ class QgsHanaProviderConnection : public QgsAbstractDatabaseProviderConnection
     void dropSchema( const QString &name, bool force = false ) const override;
     void renameSchema( const QString &name, const QString &newName ) const override;
     QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
-    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
+    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema,
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QStringList schemas( ) const override;
-    QgsFields fields( const QString &schema, const QString &table ) const override;
+    QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
     QIcon icon() const override;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -350,7 +350,7 @@ long long QgssMssqlProviderResultIterator::rowCountPrivate() const
 }
 
 
-QList<QgsMssqlProviderConnection::TableProperty> QgsMssqlProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsMssqlProviderConnection::TableProperty> QgsMssqlProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
   QList<QgsMssqlProviderConnection::TableProperty> tables;
@@ -427,6 +427,9 @@ QList<QgsMssqlProviderConnection::TableProperty> QgsMssqlProviderConnection::tab
   const QList<QVariantList> results { executeSqlPrivate( query, false ).rows() };
   for ( const auto &row : results )
   {
+    if ( feedback && feedback->isCanceled() )
+      break;
+
     Q_ASSERT( row.count( ) == 6 );
     QgsMssqlProviderConnection::TableProperty table;
     table.setSchema( row[0].toString() );

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -69,7 +69,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     void dropSchema( const QString &name, bool force = false ) const override;
     QgsAbstractDatabaseProviderConnection::QueryResult execSql( const QString &sql, QgsFeedback *feedback ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema,
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QStringList schemas( ) const override;
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -1506,7 +1506,7 @@ QString QgsOracleProviderConnection::tableUri( const QString &schema, const QStr
 }
 
 
-QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOracleProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOracleProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
   QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables;
@@ -1531,6 +1531,9 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsOracleProviderCon
 
   for ( auto &pr : properties )
   {
+    if ( feedback && feedback->isCanceled() )
+      break;
+
     // Classify
     TableFlags prFlags;
     if ( pr.isView )

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -65,7 +65,7 @@ class QgsOracleProviderConnection : public QgsAbstractDatabaseProviderConnection
     void deleteSpatialIndex( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     QStringList schemas() const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema,
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
     QIcon icon() const override;

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2049,14 +2049,14 @@ void QgsPostgresConn::deduceEndian()
   closeCursor( QStringLiteral( "oidcursor" ) );
 }
 
-void QgsPostgresConn::retrieveLayerTypes( QgsPostgresLayerProperty &layerProperty, bool useEstimatedMetadata )
+void QgsPostgresConn::retrieveLayerTypes( QgsPostgresLayerProperty &layerProperty, bool useEstimatedMetadata, QgsFeedback *feedback )
 {
   QVector<QgsPostgresLayerProperty *> vect;
   vect << &layerProperty;
-  retrieveLayerTypes( vect, useEstimatedMetadata );
+  retrieveLayerTypes( vect, useEstimatedMetadata, feedback );
 }
 
-void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &layerProperties, bool useEstimatedMetadata )
+void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &layerProperties, bool useEstimatedMetadata, QgsFeedback *feedback )
 {
   QString table;
   QString query;
@@ -2221,6 +2221,9 @@ void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &l
 
   for ( int i = 0; i < res.PQntuples(); i++ )
   {
+    if ( feedback && feedback->isCanceled() )
+      break;
+
     int idx = res.PQgetvalue( i, 0 ).toInt();
     auto srids_and_types = QgsPostgresStringUtils::parseArray( res.PQgetvalue( i, 1 ) );
     QgsPostgresLayerProperty &layerProperty = *layerProperties[idx];

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -398,12 +398,12 @@ class QgsPostgresConn : public QObject
     /**
      * Determine type and srid of a layer from data (possibly estimated)
      */
-    void retrieveLayerTypes( QgsPostgresLayerProperty &layerProperty, bool useEstimatedMetadata );
+    void retrieveLayerTypes( QgsPostgresLayerProperty &layerProperty, bool useEstimatedMetadata, QgsFeedback *feedback = nullptr );
 
     /**
      * Determine type and srid of a vector of layers from data (possibly estimated)
      */
-    void retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &layerProperties, bool useEstimatedMetadata );
+    void retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &layerProperties, bool useEstimatedMetadata, QgsFeedback *feedback = nullptr );
 
     /**
      * Gets information about the spatial tables

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1828,19 +1828,22 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsPostgresProviderConnection::
   } );
 }
 
-QgsFields QgsPostgresProviderConnection::fields( const QString &schema, const QString &tableName ) const
+QgsFields QgsPostgresProviderConnection::fields( const QString &schema, const QString &tableName, QgsFeedback *feedback ) const
 {
   // Try the base implementation first and fall back to a more complex approach for the
   // few PG-specific corner cases that do not work with the base implementation.
   try
   {
-    return QgsAbstractDatabaseProviderConnection::fields( schema, tableName );
+    return QgsAbstractDatabaseProviderConnection::fields( schema, tableName, feedback );
   }
   catch ( QgsProviderConnectionException &ex )
   {
     // This table might expose multiple geometry columns (different geom type or SRID)
     // but we are only interested in fields here, so let's pick the first one.
-    TableProperty tableInfo { table( schema, tableName ) };
+    TableProperty tableInfo { table( schema, tableName, feedback ) };
+    if ( feedback && feedback->isCanceled() )
+      return QgsFields();
+
     try
     {
       QgsDataSourceUri tUri { tableUri( schema, tableName ) };

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -598,14 +598,17 @@ void QgsPostgresProviderConnection::setFieldComment( const QString &fieldName, c
                          ) );
 }
 
-QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
   QList<QgsPostgresProviderConnection::TableProperty> tables;
   QString errCause;
   // TODO: set flags from the connection if flags argument is 0
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ) );
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( dsUri.connectionInfo( false ), -1, false, feedback );
+  if ( feedback && feedback->isCanceled() )
+    return {};
+
   if ( !conn )
   {
     errCause = QObject::tr( "Connection failed: %1" ).arg( uri() );
@@ -662,7 +665,7 @@ QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnectio
                                       ( pr.types.value( 0, Qgis::WkbType::Unknown ) == Qgis::WkbType::Unknown ||
                                         pr.srids.value( 0, std::numeric_limits<int>::min() ) == std::numeric_limits<int>::min() ) ) )
           {
-            conn->retrieveLayerTypes( pr, useEstimatedMetadata );
+            conn->retrieveLayerTypes( pr, useEstimatedMetadata, feedback );
           }
           QgsPostgresProviderConnection::TableProperty property;
           property.setFlags( prFlags );

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -56,7 +56,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
                             const QMap<QString, QVariant> *options ) const override;
 
     QString tableUri( const QString &schema, const QString &name ) const override;
-    QgsFields fields( const QString &schema, const QString &table ) const override;
+    QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -71,7 +71,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     void deleteSpatialIndex( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     void setFieldComment( const QString &fieldName, const QString &schema, const QString &tableName, const QString &comment ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema,
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QStringList schemas( ) const override;
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -288,7 +288,7 @@ bool QgsSpatiaLiteProviderConnection::spatialIndexExists( const QString &schema,
   return !res.isEmpty() && !res.at( 0 ).isEmpty() && res.at( 0 ).at( 0 ).toInt() == 1;
 }
 
-QList<QgsSpatiaLiteProviderConnection::TableProperty> QgsSpatiaLiteProviderConnection::tables( const QString &schema, const TableFlags &flags ) const
+QList<QgsSpatiaLiteProviderConnection::TableProperty> QgsSpatiaLiteProviderConnection::tables( const QString &schema, const TableFlags &flags, QgsFeedback *feedback ) const
 {
   checkCapability( Capability::Tables );
   if ( ! schema.isEmpty() )
@@ -356,6 +356,9 @@ QList<QgsSpatiaLiteProviderConnection::TableProperty> QgsSpatiaLiteProviderConne
       const QList<QgsSpatiaLiteConnection::TableEntry> constTables = connection.tables();
       for ( const QgsSpatiaLiteConnection::TableEntry &entry : constTables )
       {
+        if ( feedback && feedback->isCanceled() )
+          break;
+
         QString tableName { tableNotLowercaseNames.value( entry.tableName, entry.tableName ) };
         dsUri.setDataSource( QString(), tableName, entry.column, QString(), QString() );
         QgsSpatiaLiteProviderConnection::TableProperty property;

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -75,7 +75,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     void createSpatialIndex( const QString &schema, const QString &name, const QgsAbstractDatabaseProviderConnection::SpatialIndexOptions &options = QgsAbstractDatabaseProviderConnection::SpatialIndexOptions() ) const override;
     bool spatialIndexExists( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
-        const TableFlags &flags = TableFlags() ) const override;
+        const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QIcon icon() const override;
     void deleteField( const QString &fieldName, const QString &schema, const QString &tableName, bool force ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;

--- a/tests/src/gui/testqgsqueryresultwidget.cpp
+++ b/tests/src/gui/testqgsqueryresultwidget.cpp
@@ -140,7 +140,7 @@ void TestQgsQueryResultWidget::testCodeEditorApis()
 {
   auto w = std::make_unique<QgsQueryResultWidget>( nullptr, makeConn() );
   bool exited = false;
-  connect( w->mApiFetcher.get(), &QgsConnectionsApiFetcher::fetchingFinished, w.get(), [ & ] { exited = true; } );
+  connect( w->mApiFetcher, &QgsConnectionsApiFetcher::fetchingFinished, w.get(), [ & ] { exited = true; } );
   while ( ! exited )
     QgsApplication::processEvents();
   QVERIFY( w->mSqlEditor->extraKeywords().contains( QStringLiteral( "qgis_test" ) ) );
@@ -153,7 +153,7 @@ void TestQgsQueryResultWidget::testCodeEditorApis()
   {
     QTest::mousePress( w->mStopButton, Qt::MouseButton::LeftButton );
   } );
-  connect( w->mApiFetcher.get(), &QgsConnectionsApiFetcher::fetchingFinished, w.get(), [ & ] { exited = true; } );
+  connect( w->mApiFetcher, &QgsConnectionsApiFetcher::fetchingFinished, w.get(), [ & ] { exited = true; } );
   while ( ! exited )
     QgsApplication::processEvents();
 


### PR DESCRIPTION
Currently, closing an Execute SQL window can lock up the QGIS UI for a lengthy period of time.

This is caused by the background thread which collects available tokens for a connection -- it is triggered when the window is opened and the window will wait until the thread is finished during destruction. For remote/large database connections, the token collection can be very slow, and accordingly the window destruction will block the main thread.

This PR improves the situation through a number of approaches:

1. It implements more responsive cancelation of the token collection by adding QgsFeedback arguments to the QgsAbstractDatabaseProviderConnection methods used during the token collection. The feedback objects are used to provide responsive cancellation of the connection methods in the various database connection subclasses. (Noting that there's still parts of eg the postgres connection implementation which can't be responsively canceled, e.g. where we have no choice but to wait for a query to finish executing remotely)
2. A feedback object is added to QgsConnectionsApiFetcher and used when canceling QgsConnectionsApiFetcher, so that the fetcher's calls to the  QgsAbstractDatabaseProviderConnection methods will be aborted quickly.
3. Reworking QgsQueryResultWidget's handling of the api fetcher object and thread, so that the thread and fetcher lifetime isn't bound to the widget. This allows us to destroy the widget before the thread exits, so that we immediately allow the main thread loop to continue when the Execute SQL dialog is closed and allow the thread/fetcher to gracefully cleanup in the background as soon as they can.
