### PR TITLE
qgselevationprofilewidget: Reset the profile curve on clear

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -717,6 +717,7 @@ void QgsElevationProfileWidget::clear()
   mCanvas->clear();
   mNudgeLeftAction->setEnabled( false );
   mNudgeRightAction->setEnabled( false );
+  mProfileCurve = QgsGeometry();
 }
 
 void QgsElevationProfileWidget::exportAsPdf()


### PR DESCRIPTION
## Description

When the elevation profile is cleared, the canvas is cleared but the associated geometry is not cleared. Therefore, when a layer, it turned on, it gets redrawn.

This issue is fixed by clearing the geometry (`mProfileCurve`) when the profile tool is cleared.

Closes: https://github.com/qgis/QGIS/issues/48117
