### PR TITLE
Dxf dialog usability

### DIFF
--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -35,12 +35,12 @@ class APP_EXPORT QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBa
 
   private slots:
     void buttonBox_accepted();
-    void pbBrowseDrawing_clicked();
     void pbImportDrawing_clicked();
     void pbLoadDatabase_clicked();
     void pbSelectAll_clicked();
     void pbDeselectAll_clicked();
     void mDatabaseFileWidget_textChanged( const QString &filename );
+    void drawingFileWidgetFileChanged( const QString &filename );
     void leLayerGroup_textChanged( const QString &text );
     void showHelp();
     void layersClicked( QTableWidgetItem *item );

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -33,23 +33,19 @@
       <item row="3" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLineEdit" name="leDrawing">
-          <property name="readOnly">
-           <bool>true</bool>
+         <widget class="QgsFileWidget" name="mDatabaseFileWidget" native="true">
+          <property name="dialogTitle" stdset="0">
+           <string>Select DWG/DXF file</string>
+          </property>
+          <property name="filter" stdset="0">
+           <string notr="true">*.dwg;;*.DWG;;*.dxf;;*.DXF</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pbImportDrawing">
+         <widget class="QPushButton" name="pbLoadDatabase">
           <property name="text">
-           <string>Reload</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pbBrowseDrawing">
-          <property name="text">
-           <string>Import</string>
+           <string>Load layers</string>
           </property>
          </widget>
         </item>
@@ -58,17 +54,17 @@
       <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Source drawing</string>
+         <string>Target package</string>
         </property>
         <property name="buddy">
-         <cstring>leDrawing</cstring>
+         <cstring>mSourceDrawingFileWidget</cstring>
         </property>
        </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Target package</string>
+         <string>Source drawing</string>
         </property>
        </widget>
       </item>
@@ -85,7 +81,7 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QgsFileWidget" name="mDatabaseFileWidget" native="true">
+         <widget class="QgsFileWidget" name="mSourceDrawingFileWidget" native="true">
           <property name="dialogTitle" stdset="0">
            <string>Select GeoPackage Database</string>
           </property>
@@ -95,9 +91,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pbLoadDatabase">
+         <widget class="QPushButton" name="pbImportDrawing">
           <property name="text">
-           <string>Load layers</string>
+           <string>Import</string>
           </property>
          </widget>
         </item>
@@ -249,6 +245,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsMapCanvas</class>
+   <extends>QGraphicsView</extends>
+   <header>qgsmapcanvas.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
@@ -265,19 +267,13 @@
    <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsMapCanvas</class>
-   <extends>QGraphicsView</extends>
-   <header>qgsmapcanvas.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>pbLoadDatabase</tabstop>
-  <tabstop>mCrsSelector</tabstop>
-  <tabstop>leDrawing</tabstop>
+  <tabstop>mSourceDrawingFileWidget</tabstop>
   <tabstop>pbImportDrawing</tabstop>
-  <tabstop>pbBrowseDrawing</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>mDatabaseFileWidget</tabstop>
+  <tabstop>pbLoadDatabase</tabstop>
   <tabstop>mBlockModeComboBox</tabstop>
   <tabstop>cbUseCurves</tabstop>
   <tabstop>leLayerGroup</tabstop>

--- a/tests/src/app/testqgsdwgimportdialog.cpp
+++ b/tests/src/app/testqgsdwgimportdialog.cpp
@@ -75,7 +75,7 @@ void TestQgsDwgImportDialog::importDwgDocument()
 
   // Set source drawing and import
   QString uri = QString( mDataDir + "/entities.dwg" );
-  dwgImportDialog.leDrawing->setText( uri );
+  dwgImportDialog.mSourceDrawingFileWidget->setFilePath( uri );
   dwgImportDialog.pbImportDrawing_clicked();
 
   // Check that a default group name was assigned
@@ -115,7 +115,7 @@ void TestQgsDwgImportDialog::importDwgDocumentExpandBlockGeometries()
 
   // Set source drawing and import
   QString uri = QString( mDataDir + "/entities.dwg" );
-  dwgImportDialog.leDrawing->setText( uri );
+  dwgImportDialog.mSourceDrawingFileWidget->setFilePath( uri );
   dwgImportDialog.pbImportDrawing_clicked();
 
   // Check that a default group name was assigned
@@ -157,7 +157,7 @@ void TestQgsDwgImportDialog::importDwgDocumentBlockOnlyInsertPoints()
 
   // Set source drawing and import
   QString uri = QString( mDataDir + "/entities.dwg" );
-  dwgImportDialog.leDrawing->setText( uri );
+  dwgImportDialog.mSourceDrawingFileWidget->setFilePath( uri );
   dwgImportDialog.pbImportDrawing_clicked();
 
   // Check that a default group name was assigned


### PR DESCRIPTION
## Status quo:

Currently the DWG/DXF import dialog has some small usability issues: 
- Files paths are not remembered upon reopening of the dialog, re-doing an import will require to specify all paths again.
- Import procedure could be more user friendly and let you start by choosing the drawing to import, instead of the geopackage which is mostly just a middle to be able to get the geometries into QGIS. Now you are forced to follow this procedure:
  - Specify a geopackage in which to import the geometries
  - After that it becomes possible to select a dxf/dwg file
- It is not possible to paste a path directly in the  source drawing line edit (but this is possible for the gpkg).
- A status label is saying that the the drawing has changed even if it is not the case:
![image](https://github.com/qgis/QGIS/assets/9881900/ff19799f-98ae-4b63-8453-3c378076f68c)


## This PR:

Is based on #52460 and propose following changes:
- Put the drawing selection on the top of the dialog (all I want is importing it after all!)
- Use a file widget instead of plain line edit
- Remember the last drawing path when closing the widget
- Automatically propose a geopackage with the same name of the drawing
- Fix the erroneous label in case of unmodified drawing (milliseconds rounding issue)

![Peek 2023-06-16 16-55](https://github.com/qgis/QGIS/assets/9881900/57751964-be8f-4c44-a272-480afc98984a)
