### PR TITLE
[ui] Fix the movel label map tool when used against polygon layers set to perimeter placement

### DIFF
--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -1320,8 +1320,9 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
     indexes[p] = index;
   }
 
-  // Anchor properties are for linestrings only:
-  if ( vlayer->geometryType() == Qgis::GeometryType::Line )
+  // Anchor properties are for linestrings and polygons only:
+  if ( vlayer->geometryType() == Qgis::GeometryType::Line ||
+       vlayer->geometryType() == Qgis::GeometryType::Polygon )
   {
     for ( const QgsPalLayerSettings::Property &p : std::as_const( mPalAnchorProperties ) )
     {

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -247,7 +247,8 @@ void QgsMapToolLabel::createRubberBands()
           // instead, just use the boundary of the polygon for the rubber band
           geom = QgsGeometry( geom.constGet()->boundary() );
         }
-        else if ( geom.type() == Qgis::GeometryType::Line )
+
+        if ( geom.type() == Qgis::GeometryType::Line || geom.type() == Qgis::GeometryType::Polygon )
         {
           mOffsetFromLineStartRubberBand = new QgsRubberBand( mCanvas, Qgis::GeometryType::Point );
           mOffsetFromLineStartRubberBand->setColor( lineColor );

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -88,13 +88,19 @@ void QgsMapToolMoveLabel::cadCanvasMoveEvent( QgsMapMouseEvent *e )
         {
           mAnchorDetached = true;
           isCurvedOrLine = false;
-          mOffsetFromLineStartRubberBand->hide();
+          if ( mOffsetFromLineStartRubberBand )
+          {
+            mOffsetFromLineStartRubberBand->hide();
+          }
         }
         else
         {
           mAnchorDetached = false;
-          mOffsetFromLineStartRubberBand->setToGeometry( featureMapGeometry.nearestPoint( pointMapGeometry ) );
-          mOffsetFromLineStartRubberBand->show();
+          if ( mOffsetFromLineStartRubberBand )
+          {
+            mOffsetFromLineStartRubberBand->setToGeometry( featureMapGeometry.nearestPoint( pointMapGeometry ) );
+            mOffsetFromLineStartRubberBand->show();
+          }
         }
       }
     }

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2224,7 +2224,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   QgsLabelLineSettings lineSettings = mLineSettings;
   lineSettings.updateDataDefinedProperties( mDataDefinedProperties, context.expressionContext() );
 
-  if ( geom.type() == Qgis::GeometryType::Line )
+  if ( geom.type() == Qgis::GeometryType::Line || placement == Qgis::LabelPlacement::Line || placement == Qgis::LabelPlacement::PerimeterCurved )
   {
     switch ( lineSettings.anchorClipping() )
     {

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1408,7 +1408,7 @@ void QgsTextFormatWidget::updatePlacementWidgets()
   mPlacementRepeatGroupBox->setVisible( currentGeometryType == Qgis::GeometryType::Line || ( currentGeometryType == Qgis::GeometryType::Polygon &&
                                         ( currentPlacement == Qgis::LabelPlacement::Line || currentPlacement == Qgis::LabelPlacement::PerimeterCurved ) ) );
   mPlacementOverrunGroupBox->setVisible( currentGeometryType == Qgis::GeometryType::Line && currentPlacement != Qgis::LabelPlacement::Horizontal );
-  mLineAnchorGroupBox->setVisible( currentGeometryType == Qgis::GeometryType::Line );
+  mLineAnchorGroupBox->setVisible( currentGeometryType == Qgis::GeometryType::Line || currentPlacement == Qgis::LabelPlacement::Line || currentPlacement == Qgis::LabelPlacement::PerimeterCurved );
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 
   mMultiLinesFrame->setEnabled( enableMultiLinesFrame );


### PR DESCRIPTION
## Description

This PR fixes an unreported bug whereas the move label map tool would not work when attempting to manually position labels from a polygon layer with labeling placement set to perimeter.

Moving along a perimeter works like a line, whereas it'll snap along the line until you go beyond the snapping threshold:
![Peek 2023-06-20 11-14](https://github.com/qgis/QGIS/assets/1728657/d47b94ff-7ab1-4a2d-9050-b7f3a9bcea8e)

Bonus: this also corrects the label anchoring improperly hidden when setting polygon labels placement to perimeter (another unreported bug).