### PR TITLE
Move handling of vsi archive paths to QgsGdalUtils and add support for 7z and rar archives for GDAL 3.7

### DIFF
--- a/python/core/auto_generated/browser/qgszipitem.sip.in
+++ b/python/core/auto_generated/browser/qgszipitem.sip.in
@@ -47,7 +47,12 @@ Constructor
 
     static QStringList sProviderNames;
 
-    static QString vsiPrefix( const QString &uri );
+ static QString vsiPrefix( const QString &uri ) /Deprecated/;
+%Docstring
+
+.. deprecated::
+   Will be removed in QGIS 4.0
+%End
 
     static QgsDataItem *itemFromPath( QgsDataItem *parent, const QString &path, const QString &name ) /Factory/;
 %Docstring

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -59,6 +59,7 @@
 #include "qgsfieldformatter.h"
 #include "qgsabstractdatabaseproviderconnection.h"
 #include "qgsrasterlayerelevationproperties.h"
+#include "qgsgdalutils.h"
 
 #include <QObject>
 #include <QMessageBox>
@@ -283,7 +284,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addOgrVectorLayers( const QStringLis
       baseName = QgsProviderUtils::suggestLayerNameFromFilePath( srcWithoutLayername );
 
       // if needed prompt for zipitem layers
-      QString vsiPrefix = qgsVsiPrefix( uri );
+      const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( uri );
       if ( ! uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) &&
            ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
       {
@@ -871,7 +872,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
   CPLPushErrorHandler( CPLQuietErrorHandler );
 
   // if needed prompt for zipitem layers
-  QString vsiPrefix = qgsVsiPrefix( fileName );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( fileName );
   if ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) )
   {
     if ( askUserForZipItemLayers( fileName, {} ) )
@@ -1055,7 +1056,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addGdalRasterLayers( const QStringList
     QString errMsg;
 
     // if needed prompt for zipitem layers
-    QString vsiPrefix = qgsVsiPrefix( uri );
+    const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( uri );
     if ( ( !uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) || uri.endsWith( QLatin1String( ".zip" ) ) || uri.endsWith( QLatin1String( ".tar" ) ) ) &&
          ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
     {

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -286,7 +286,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::addOgrVectorLayers( const QStringLis
       // if needed prompt for zipitem layers
       const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( uri );
       if ( ! uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) &&
-           ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
+           QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
       {
         if ( askUserForZipItemLayers( uri, { Qgis::LayerType::Vector} ) )
           continue;
@@ -873,7 +873,7 @@ QList< QgsMapLayer * > QgsAppLayerHandling::openLayer( const QString &fileName, 
 
   // if needed prompt for zipitem layers
   const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( fileName );
-  if ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) )
+  if ( QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
   {
     if ( askUserForZipItemLayers( fileName, {} ) )
     {
@@ -1057,8 +1057,10 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addGdalRasterLayers( const QStringList
 
     // if needed prompt for zipitem layers
     const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( uri );
-    if ( ( !uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) || uri.endsWith( QLatin1String( ".zip" ) ) || uri.endsWith( QLatin1String( ".tar" ) ) ) &&
-         ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
+    if ( ( !uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive )
+           || uri.endsWith( QLatin1String( ".zip" ) )
+           || uri.endsWith( QLatin1String( ".tar" ) ) ) &&
+         QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
     {
       if ( askUserForZipItemLayers( uri, { Qgis::LayerType::Raster } ) )
         continue;

--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -24,6 +24,7 @@
 #include "qgszipitem.h"
 #include "qgsprojectitem.h"
 #include "qgsfileutils.h"
+#include "qgsgdalutils.h"
 #include <QFileSystemWatcher>
 #include <QDir>
 #include <QMouseEvent>
@@ -304,11 +305,9 @@ QVector<QgsDataItem *> QgsDirectoryItem::createChildren()
     const QString path = dir.absoluteFilePath( name );
     const QFileInfo fileInfo( path );
 
-    if ( fileInfo.suffix().compare( QLatin1String( "zip" ), Qt::CaseInsensitive ) == 0 ||
-         fileInfo.suffix().compare( QLatin1String( "tar" ), Qt::CaseInsensitive ) == 0 )
+    if ( QgsGdalUtils::isVsiArchiveFileExtension( fileInfo.suffix() ) )
     {
-      QgsDataItem *item = QgsZipItem::itemFromPath( this, path, name, path );
-      if ( item )
+      if ( QgsDataItem *item = QgsZipItem::itemFromPath( this, path, name, path ) )
       {
         children.append( item );
         continue;

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -27,9 +27,7 @@
 #include "qgsrelationshipsitem.h"
 #include "qgsproviderutils.h"
 #include "qgsprovidermetadata.h"
-#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,4,0)
 #include "qgsgdalutils.h"
-#endif
 #include <QUrlQuery>
 
 //
@@ -221,7 +219,7 @@ QgsFileDataCollectionItem::QgsFileDataCollectionItem( QgsDataItem *parent, const
   else
     setCapabilities( Qgis::BrowserItemCapability::Fast | Qgis::BrowserItemCapability::Fertile );
 
-  if ( !qgsVsiPrefix( path ).isEmpty() )
+  if ( !QgsGdalUtils::vsiPrefixForPath( path ).isEmpty() )
   {
     mIconName = QStringLiteral( "/mIconZip.svg" );
   }

--- a/src/core/browser/qgszipitem.cpp
+++ b/src/core/browser/qgszipitem.cpp
@@ -58,7 +58,7 @@ void QgsZipItem::init()
 {
   mType = Qgis::BrowserItemType::Collection; //Zip??
   mIconName = QStringLiteral( "/mIconZip.svg" );
-  mVsiPrefix = vsiPrefix( mFilePath );
+  mVsiPrefix = QgsGdalUtils::vsiPrefixForPath( mFilePath );
 
   setCapabilities( capabilities2() | Qgis::BrowserItemCapability::ItemRepresentsFile );
 
@@ -165,7 +165,7 @@ QgsDataItem *QgsZipItem::itemFromPath( QgsDataItem *parent, const QString &fileP
   const QgsSettings settings;
   const QString scanZipSetting = settings.value( QStringLiteral( "qgis/scanZipInBrowser2" ), "basic" ).toString();
   QStringList zipFileList;
-  const QString vsiPrefix = QgsZipItem::vsiPrefix( filePath );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( filePath );
   QgsZipItem *zipItem = nullptr;
   bool populated = false;
 
@@ -175,8 +175,8 @@ QgsDataItem *QgsZipItem::itemFromPath( QgsDataItem *parent, const QString &fileP
   if ( scanZipSetting == QLatin1String( "no" ) )
     return nullptr;
 
-  // don't scan if this file is not a /vsizip/ or /vsitar/ item
-  if ( ( vsiPrefix != QLatin1String( "/vsizip/" ) && vsiPrefix != QLatin1String( "/vsitar/" ) ) )
+  // don't scan if this file is not a vsi container archive item
+  if ( !QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
     return nullptr;
 
   zipItem = new QgsZipItem( parent, name, filePath, path );

--- a/src/core/browser/qgszipitem.cpp
+++ b/src/core/browser/qgszipitem.cpp
@@ -20,6 +20,7 @@
 #include "qgsdataitemprovider.h"
 #include "qgsdataitemproviderregistry.h"
 #include "qgssettings.h"
+#include "qgsgdalutils.h"
 
 #include <QFileInfo>
 
@@ -80,6 +81,11 @@ QgsMimeDataUtils::UriList QgsZipItem::mimeUris() const
   u.uri = path();
   u.filePath = path();
   return { u };
+}
+
+QString QgsZipItem::vsiPrefix( const QString &uri )
+{
+  return QgsGdalUtils::vsiPrefixForPath( uri );
 }
 
 QVector<QgsDataItem *> QgsZipItem::createChildren()

--- a/src/core/browser/qgszipitem.h
+++ b/src/core/browser/qgszipitem.h
@@ -60,7 +60,10 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     static QVector<dataItem_t *> sDataItemPtr SIP_SKIP;
     static QStringList sProviderNames;
 
-    static QString vsiPrefix( const QString &uri ) { return qgsVsiPrefix( uri ); }
+    /**
+     * \deprecated Will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED static QString vsiPrefix( const QString &uri ) SIP_DEPRECATED;
 
     /**
      * Creates a new data item from the specified path.

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2874,7 +2874,7 @@ bool QgsGdalProvider::isValidRasterFileName( QString const &fileNameQString, QSt
 
   // Try to open using VSIFileHandler (see qgsogrprovider.cpp)
   // TODO suppress error messages and report in debug, like in OGR provider
-  QString vsiPrefix = qgsVsiPrefix( fileName );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( fileName );
   if ( !vsiPrefix.isEmpty() )
   {
     if ( !fileName.startsWith( vsiPrefix ) )
@@ -3216,7 +3216,7 @@ bool QgsGdalProvider::initIfNeeded()
   QString gdalUri = dataSourceUri( true );
 
   // Try to open using VSIFileHandler (see qgsogrprovider.cpp)
-  QString vsiPrefix = qgsVsiPrefix( gdalUri );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( gdalUri );
   if ( !vsiPrefix.isEmpty() )
   {
     if ( !gdalUri.startsWith( vsiPrefix ) )
@@ -4228,7 +4228,7 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
   QVariantMap uriParts = decodeUri( gdalUri );
 
   // Try to open using VSIFileHandler
-  QString vsiPrefix = qgsVsiPrefix( gdalUri );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( gdalUri );
   if ( !vsiPrefix.isEmpty() )
   {
     if ( !gdalUri.startsWith( vsiPrefix ) )

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4386,12 +4386,16 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
         if ( feedback && feedback->isCanceled() )
           break;
 
-        // skip directories (files ending with /)
-        if ( file.right( 1 ) != QLatin1String( "/" ) )
-        {
-          uriParts.insert( QStringLiteral( "vsiSuffix" ), QStringLiteral( "/%1" ).arg( file ) );
-          res << querySublayers( encodeUri( uriParts ), flags, feedback );
-        }
+        // skip directories (files ending with /), unless they are .gdb directories
+        if ( file.right( 1 ) == QLatin1String( "/" ) && !file.endsWith( QStringLiteral( ".gdb/" ), Qt::CaseInsensitive ) )
+          continue;
+
+        // skip the child files from .gdb directories
+        if ( file.right( 1 ) != QLatin1String( "/" ) && file.contains( QStringLiteral( ".gdb" ), Qt::CaseInsensitive ) )
+          continue;
+
+        uriParts.insert( QStringLiteral( "vsiSuffix" ), QStringLiteral( "/%1" ).arg( file ) );
+        res << querySublayers( encodeUri( uriParts ), flags, feedback );
       }
       CSLDestroy( papszSiblingFiles );
       return res;

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -25,6 +25,7 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsgdalproviderbase.h"
+#include "qgsgdalutils.h"
 #include "qgssettings.h"
 
 #include <mutex>
@@ -401,7 +402,7 @@ QVariantMap QgsGdalProviderBase::decodeGdalUri( const QString &uri )
     authcfg = match.captured( 1 );
   }
 
-  QString vsiPrefix = qgsVsiPrefix( path );
+  QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( path );
   QString vsiSuffix;
   if ( path.startsWith( vsiPrefix, Qt::CaseInsensitive ) )
   {

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -303,9 +303,7 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const QString &uri, unsigned int nOp
   {
     const QString vsiPrefix = parts.value( QStringLiteral( "vsiPrefix" ) ).toString();
     const QString vsiSuffix = parts.value( QStringLiteral( "vsiSuffix" ) ).toString();
-    if ( vsiSuffix.isEmpty() && ( vsiPrefix == QLatin1String( "/vsizip/" )
-                                  || vsiPrefix == QLatin1String( "/vsigzip/" )
-                                  || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
+    if ( vsiSuffix.isEmpty() && QgsGdalUtils::isVsiArchivePrefix( vsiPrefix ) )
     {
       // in the case that a direct path to a vsi supported archive was specified BUT
       // no file suffix was given, see if there's only one valid file we could read anyway and

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3592,7 +3592,7 @@ void QgsOgrProvider::open( OpenMode mode )
 
   // Try to open using VSIFileHandler
   //   see http://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip
-  QString vsiPrefix = qgsVsiPrefix( dataSourceUri( true ) );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( dataSourceUri( true ) );
   if ( !vsiPrefix.isEmpty() || mFilePath.startsWith( QLatin1String( "/vsicurl/" ) ) )
   {
     // GDAL>=1.8.0 has write support for zip, but read and write operations

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -152,7 +152,7 @@ QVariantMap QgsOgrProviderMetadata::decodeUri( const QString &uri ) const
     authcfg = match.captured( 1 );
   }
 
-  QString vsiPrefix = qgsVsiPrefix( path );
+  QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( path );
   QString vsiSuffix;
   if ( path.startsWith( vsiPrefix, Qt::CaseInsensitive ) )
   {
@@ -1185,7 +1185,7 @@ QList<QgsProviderSublayerDetails> QgsOgrProviderMetadata::querySublayers( const 
   QVariantMap uriParts = decodeUri( uri );
 
   // Try to open using VSIFileHandler
-  QString vsiPrefix = qgsVsiPrefix( uriParts.value( QStringLiteral( "path" ) ).toString() );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( uriParts.value( QStringLiteral( "path" ) ).toString() );
   if ( !vsiPrefix.isEmpty() && uriParts.value( QStringLiteral( "vsiPrefix" ) ).toString().isEmpty() )
   {
     if ( !uri.startsWith( vsiPrefix ) )

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -27,6 +27,7 @@
 #include <QDateTime>
 #include "qgsconfig.h"
 #include "qgslogger.h"
+#include "qgsgdalutils.h"
 #include "qgswkbtypes.h"
 
 #include <gdal.h>
@@ -191,27 +192,7 @@ bool qgsVariantGreaterThan( const QVariant &lhs, const QVariant &rhs )
 
 QString qgsVsiPrefix( const QString &path )
 {
-  if ( path.startsWith( QLatin1String( "/vsizip/" ), Qt::CaseInsensitive ) )
-    return QStringLiteral( "/vsizip/" );
-  else if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
-  {
-    // GDAL 3.1 Shapefile driver directly handles .shp.zip files
-    if ( GDALIdentifyDriverEx( path.toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr ) )
-      return QString();
-    return QStringLiteral( "/vsizip/" );
-  }
-  else if ( path.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
-    return QStringLiteral( "/vsizip/" );
-  else if ( path.startsWith( QLatin1String( "/vsitar/" ), Qt::CaseInsensitive ) ||
-            path.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) ||
-            path.endsWith( QLatin1String( ".tar.gz" ), Qt::CaseInsensitive ) ||
-            path.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) )
-    return QStringLiteral( "/vsitar/" );
-  else if ( path.startsWith( QLatin1String( "/vsigzip/" ), Qt::CaseInsensitive ) ||
-            path.endsWith( QLatin1String( ".gz" ), Qt::CaseInsensitive ) )
-    return QStringLiteral( "/vsigzip/" );
-  else
-    return QString();
+  return QgsGdalUtils::vsiPrefixForPath( path );
 }
 
 uint qHash( const QVariant &variant )

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -749,6 +749,50 @@ QString QgsGdalUtils::vsiPrefixForPath( const QString &path )
   return QString();
 }
 
+QStringList QgsGdalUtils::vsiArchivePrefixes()
+{
+  QStringList res { QStringLiteral( "/vsizip/" ),
+                    QStringLiteral( "/vsitar/" ),
+                    QStringLiteral( "/vsigzip/" ),
+                  };
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+  res.append( QStringLiteral( "/vsi7z/" ) );
+  res.append( QStringLiteral( "/vsirar/" ) );
+#endif
+  return res;
+}
+
+bool QgsGdalUtils::isVsiArchivePrefix( const QString &prefix )
+{
+  return vsiArchivePrefixes().contains( prefix );
+}
+
+QStringList QgsGdalUtils::vsiArchiveFileExtensions()
+{
+  QStringList res { QStringLiteral( ".zip" ),
+                    QStringLiteral( ".tar" ),
+                    QStringLiteral( ".tar.gz" ),
+                    QStringLiteral( ".tgz" ),
+                    QStringLiteral( ".gz" ),
+                  };
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0)
+  res.append( { QStringLiteral( ".7z" ),
+                QStringLiteral( ".lpk" ),
+                QStringLiteral( ".lpkx" ),
+                QStringLiteral( ".mpk" ),
+                QStringLiteral( ".mpkx" ),
+                QStringLiteral( ".rar" )
+              } );
+#endif
+  return res;
+}
+
+bool QgsGdalUtils::isVsiArchiveFileExtension( const QString &extension )
+{
+  const QString extWithDot = extension.startsWith( '.' ) ? extension : ( '.' + extension );
+  return vsiArchiveFileExtensions().contains( extWithDot.toLower() );
+}
+
 bool QgsGdalUtils::vrtMatchesLayerType( const QString &vrtPath, Qgis::LayerType type )
 {
   CPLPushErrorHandler( CPLQuietErrorHandler );

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -221,6 +221,14 @@ class CORE_EXPORT QgsGdalUtils
     static QStringList multiLayerFileExtensions();
 
     /**
+     * Returns a the vsi prefix which corresponds to a file \a path, or an empty
+     * string if the path is not associated with a vsi prefix.
+     *
+     * \since QGIS 3.32
+     */
+    static QString vsiPrefixForPath( const QString &path );
+
+    /**
      * Returns TRUE if the VRT file at the specified path is a VRT matching
      * the given layer \a type.
      *

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -229,6 +229,34 @@ class CORE_EXPORT QgsGdalUtils
     static QString vsiPrefixForPath( const QString &path );
 
     /**
+     * Returns a list of vsi prefixes which correspond to archive style containers (eg vsizip).
+     *
+     * \since QGIS 3.32
+     */
+    static QStringList vsiArchivePrefixes();
+
+    /**
+     * Returns TRUE if \a prefix is a supported archive style container prefix (e.g. "/vsizip/").
+     *
+     * \since QGIS 3.32
+     */
+    static bool isVsiArchivePrefix( const QString &prefix );
+
+    /**
+     * Returns a list of file extensions which correspond to archive style containers supported by GDAL (e.g. "zip").
+     *
+     * \since QGIS 3.32
+     */
+    static QStringList vsiArchiveFileExtensions();
+
+    /**
+     * Returns TRUE if a file \a extension is a supported archive style container (e.g. ".zip").
+     *
+     * \since QGIS 3.32
+     */
+    static bool isVsiArchiveFileExtension( const QString &extension );
+
+    /**
      * Returns TRUE if the VRT file at the specified path is a VRT matching
      * the given layer \a type.
      *

--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgsapplication.h"
+#include "qgsgdalutils.h"
 #include <QDir>
 #include <QFileInfo>
 #include <QUrl>
@@ -81,7 +82,7 @@ QString QgsPathResolver::readPath( const QString &f ) const
   }
 
   // if this is a VSIFILE, remove the VSI prefix and append to final result
-  QString vsiPrefix = qgsVsiPrefix( src );
+  QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( src );
   if ( ! vsiPrefix.isEmpty() )
   {
     // unfortunately qgsVsiPrefix returns prefix also for files like "/x/y/z.gz"
@@ -298,7 +299,7 @@ QString QgsPathResolver::writePath( const QString &s ) const
     srcPath = srcFileInfo.canonicalFilePath();
 
   // if this is a VSIFILE, remove the VSI prefix and append to final result
-  const QString vsiPrefix = qgsVsiPrefix( src );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( src );
   if ( ! vsiPrefix.isEmpty() )
   {
     srcPath.remove( 0, vsiPrefix.size() );

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -22,6 +22,7 @@
 
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgsgdalutils.h"
 
 #include <gdal.h>
 #include <cpl_minixml.h>
@@ -329,7 +330,7 @@ void QgsGdalSourceSelect::fillOpenOptions()
     return;
 
   const QString firstDataSource = mDataSources.at( 0 );
-  const QString vsiPrefix = qgsVsiPrefix( firstDataSource );
+  const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( firstDataSource );
   const QString scheme = QUrl( firstDataSource ).scheme();
   const bool isRemoteNonVsiCurlUrl = vsiPrefix.isEmpty() && ( scheme.startsWith( QLatin1String( "http" ) ) || scheme == QLatin1String( "ftp" ) );
   if ( isRemoteNonVsiCurlUrl )


### PR DESCRIPTION
Cleans up some handling of vsi archives, and adds in support for the 7z and rar archive types now supported by GDAL 3.7+.

