### PR TITLE
Processing: determine and set default encoding from locale

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -575,6 +575,16 @@ In particular, this function upgrades encoded data defined values to :py:class:`
 .. versionadded:: 3.30
 %End
 
+    static QString resolveDefaultEncoding();
+%Docstring
+Returns the default encoding.
+
+The default encoding could be the one from "/Processing/encoding" or when it's not an allowed encoding name
+like "System", the default encoding system (mostly UTF-8 on Unix-like, windows-1252 on Windows).
+
+.. versionadded:: 3.32
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -575,7 +575,7 @@ In particular, this function upgrades encoded data defined values to :py:class:`
 .. versionadded:: 3.30
 %End
 
-    static QString resolveDefaultEncoding();
+    static QString resolveDefaultEncoding( const QString &defaultEncoding = "System" );
 %Docstring
 Returns the default encoding.
 

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -71,7 +71,7 @@ def createContext(feedback=None):
     context.setInvalidGeometryCheck(invalid_features_method)
 
     settings = QgsSettings()
-    context.setDefaultEncoding(settings.value("/Processing/encoding", QgsProcessingUtils.resolveDefaultEncoding()))
+    context.setDefaultEncoding(QgsProcessingUtils.resolveDefaultEncoding(settings.value("/Processing/encoding")))
 
     context.setExpressionContext(createExpressionContext())
 

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -29,12 +29,13 @@ from qgis.core import (QgsDataProvider,
                        QgsProject,
                        QgsSettings,
                        QgsProcessingContext,
+                       QgsProcessingUtils,
                        QgsFeatureRequest,
                        QgsExpressionContext,
                        QgsExpressionContextUtils,
                        QgsExpressionContextScope)
 from qgis.gui import QgsSublayersDialog
-from qgis.PyQt.QtCore import QCoreApplication, QTextCodec
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.utils import iface
 
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -70,11 +71,7 @@ def createContext(feedback=None):
     context.setInvalidGeometryCheck(invalid_features_method)
 
     settings = QgsSettings()
-    default_codec = "System"
-    system_codec = QTextCodec.codecForLocale()
-    if (system_codec):
-        default_codec = system_codec.name().data().decode()
-    context.setDefaultEncoding(settings.value("/Processing/encoding", default_codec))
+    context.setDefaultEncoding(settings.value("/Processing/encoding", QgsProcessingUtils.resolveDefaultEncoding()))
 
     context.setExpressionContext(createExpressionContext())
 

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -34,7 +34,7 @@ from qgis.core import (QgsDataProvider,
                        QgsExpressionContextUtils,
                        QgsExpressionContextScope)
 from qgis.gui import QgsSublayersDialog
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, QTextCodec
 from qgis.utils import iface
 
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -70,7 +70,11 @@ def createContext(feedback=None):
     context.setInvalidGeometryCheck(invalid_features_method)
 
     settings = QgsSettings()
-    context.setDefaultEncoding(settings.value("/Processing/encoding", "System"))
+    default_codec = "System"
+    system_codec = QTextCodec.codecForLocale()
+    if (system_codec):
+        default_codec = system_codec.name().data().decode()
+    context.setDefaultEncoding(settings.value("/Processing/encoding", default_codec))
 
     context.setExpressionContext(createExpressionContext())
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1540,6 +1540,7 @@ QString QgsProcessingUtils::resolveDefaultEncoding( const QString &defaultEncodi
     {
       return systemCodec;
     }
+    return QString( "UTF-8" );
   }
 
   return defaultEncoding;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -37,6 +37,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgsannotationlayer.h"
 #include <QRegularExpression>
+#include <QTextCodec>
 #include <QUuid>
 
 QList<QgsRasterLayer *> QgsProcessingUtils::compatibleRasterLayers( QgsProject *project, bool sort )
@@ -1528,6 +1529,20 @@ QVariantMap QgsProcessingUtils::preprocessQgisProcessParameters( const QVariantM
     }
   }
   return output;
+}
+
+QString QgsProcessingUtils::resolveDefaultEncoding( const QString &defaultEncoding )
+{
+  if ( ! QTextCodec::availableCodecs().contains( defaultEncoding.toLatin1() ) )
+  {
+    const QString systemCodec = QTextCodec::codecForLocale()->name();
+    if ( ! systemCodec.isEmpty() )
+    {
+      return systemCodec;
+    }
+  }
+
+  return defaultEncoding;
 }
 
 //

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -560,6 +560,16 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QVariantMap preprocessQgisProcessParameters( const QVariantMap &parameters, bool &ok, QString &error );
 
+    /**
+     * Returns the default encoding.
+     *
+     * The default encoding could be the one from "/Processing/encoding" or when it's not an allowed encoding name
+     * like "System", the default encoding system (mostly UTF-8 on Unix-like, windows-1252 on Windows).
+     *
+     * \since QGIS 3.32
+     */
+    static QString resolveDefaultEncoding(const QString &defaultEncoding = "System");
+
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -568,7 +568,7 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \since QGIS 3.32
      */
-    static QString resolveDefaultEncoding(const QString &defaultEncoding = "System");
+    static QString resolveDefaultEncoding( const QString &defaultEncoding = "System" );
 
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -28,6 +28,8 @@
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QCheckBox>
+#include <QLocale>
+#include <QTextCodec>
 #include <QUrl>
 
 ///@cond NOT_STABLE
@@ -52,6 +54,14 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
 
   QgsSettings settings;
   mEncoding = settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString();
+  if ( mEncoding == "System" )
+  {
+    const QString systemCodec = QTextCodec::codecForLocale()->name();
+    if ( ! systemCodec.isEmpty() )
+    {
+      mEncoding = systemCodec;
+    }
+  }
 
   if ( !mParameter->defaultValueForGui().isValid() )
   {

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -54,12 +54,14 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
 
   QgsSettings settings;
   mEncoding = settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString();
-  if ( mEncoding == "System" )
+
+  if ( ( mEncoding == "System" ) || ( ! QTextCodec::availableCodecs().contains( mEncoding.toLatin1() ) ) )
   {
     const QString systemCodec = QTextCodec::codecForLocale()->name();
     if ( ! systemCodec.isEmpty() )
     {
       mEncoding = systemCodec;
+      settings.setValue( QStringLiteral( "/Processing/encoding" ), mEncoding );
     }
   }
 
@@ -613,6 +615,15 @@ void QgsProcessingLayerOutputDestinationWidget::selectEncoding()
   if ( dialog.exec() )
   {
     mEncoding = dialog.encoding();
+    if ( ( mEncoding == "System" ) || ( ! QTextCodec::availableCodecs().contains( mEncoding.toLatin1() ) ) )
+    {
+      const QString systemCodec = QTextCodec::codecForLocale()->name();
+      if ( ! systemCodec.isEmpty() )
+      {
+        mEncoding = systemCodec;
+      }
+    }
+
     QgsSettings settings;
     settings.setValue( QStringLiteral( "/Processing/encoding" ), mEncoding );
     emit destinationChanged();

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -53,17 +53,8 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
   mSelectButton->setPopupMode( QToolButton::InstantPopup );
 
   QgsSettings settings;
-  mEncoding = settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString();
-
-  if ( ( mEncoding == "System" ) || ( ! QTextCodec::availableCodecs().contains( mEncoding.toLatin1() ) ) )
-  {
-    const QString systemCodec = QTextCodec::codecForLocale()->name();
-    if ( ! systemCodec.isEmpty() )
-    {
-      mEncoding = systemCodec;
-      settings.setValue( QStringLiteral( "/Processing/encoding" ), mEncoding );
-    }
-  }
+  mEncoding = QgsProcessingUtils::resolveDefaultEncoding( settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString() );
+  settings.setValue( QStringLiteral( "/Processing/encoding" ), mEncoding );
 
   if ( !mParameter->defaultValueForGui().isValid() )
   {
@@ -614,18 +605,11 @@ void QgsProcessingLayerOutputDestinationWidget::selectEncoding()
   QgsEncodingSelectionDialog dialog( this, tr( "File encoding" ), mEncoding );
   if ( dialog.exec() )
   {
-    mEncoding = dialog.encoding();
-    if ( ( mEncoding == "System" ) || ( ! QTextCodec::availableCodecs().contains( mEncoding.toLatin1() ) ) )
-    {
-      const QString systemCodec = QTextCodec::codecForLocale()->name();
-      if ( ! systemCodec.isEmpty() )
-      {
-        mEncoding = systemCodec;
-      }
-    }
+    mEncoding = QgsProcessingUtils::resolveDefaultEncoding( dialog.encoding() );
 
     QgsSettings settings;
     settings.setValue( QStringLiteral( "/Processing/encoding" ), mEncoding );
+
     emit destinationChanged();
   }
 }

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -8693,7 +8693,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -8797,7 +8797,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
   QCOMPARE( skipSpy2.count(), 0 );
@@ -8829,7 +8829,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
   QCOMPARE( skipSpy3.count(), 1 );
@@ -8887,7 +8887,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -8899,7 +8899,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -8914,7 +8914,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
   panel.setValue( QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
@@ -8924,7 +8924,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -8936,7 +8936,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -8953,7 +8953,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.shp" ) ) );
 
   // optional, test skipping
@@ -8972,7 +8972,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
   QCOMPARE( skipSpy2.count(), 0 );
@@ -9004,7 +9004,7 @@ void TestProcessingGui::testOutputDefinitionWidgetVectorOut()
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
   QCOMPARE( skipSpy3.count(), 1 );
@@ -9040,7 +9040,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -9054,7 +9054,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.tif" ) );
   QVERIFY( !panel.outputIsSkipped() );
   panel.setValue( QStringLiteral( "/home/me/test.tif" ) );
@@ -9066,7 +9066,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   panel.setValue( QStringLiteral( "test.tif" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.tif" ) ) );
 
   // optional, test skipping
@@ -9085,7 +9085,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
   QCOMPARE( skipSpy2.count(), 0 );
@@ -9117,7 +9117,7 @@ void TestProcessingGui::testOutputDefinitionWidgetRasterOut()
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
   QCOMPARE( skipSpy3.count(), 1 );
@@ -9153,7 +9153,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   panel.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -9167,7 +9167,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.las" ) );
   QVERIFY( !panel.outputIsSkipped() );
   panel.setValue( QStringLiteral( "/home/me/test.las" ) );
@@ -9179,7 +9179,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   panel.setValue( QStringLiteral( "test.las" ) );
   v = panel.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QString( TEST_DATA_DIR + QStringLiteral( "/test.las" ) ) );
 
   // optional, test skipping
@@ -9198,7 +9198,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   panel2.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel2.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel2.outputIsSkipped() );
   QCOMPARE( skipSpy2.count(), 0 );
@@ -9230,7 +9230,7 @@ void TestProcessingGui::testOutputDefinitionWidgetPointCloudOut()
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   v = panel3.value();
   QCOMPARE( v.userType(), QMetaType::type( "QgsProcessingOutputLayerDefinition" ) );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "UTF-8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel3.outputIsSkipped() );
   QCOMPARE( skipSpy3.count(), 1 );


### PR DESCRIPTION
## Description

A Shapefile can have a `.cpg` file to determine its encoding. However, in processing, this file is not created when the encoding is set to the magic "System" value.

This PR aims to propose to determine the system encoding automatically using QT's `codecForLocale`.

So, even when using the magic "System" value, the `.cpg` file will be created with the true system encoding name.

Fixes #50603
