### PR TITLE
Correctly split 3D feature

### DIFF
--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -113,7 +113,14 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
     QgsPointSequence topologyTestPoints;
     vlayer->beginEditCommand( tr( "Features split" ) );
-    const Qgis::GeometryOperationResult returnCode = vlayer->splitFeatures( captureCurve(), topologyTestPoints, true, topologicalEditing );
+
+    // we need to drop Z value to properly split 3D feature in 2D. If not, generated vertices Z value
+    // will be assigned with the mean value between the interpolated Z values of the intersecting point
+    // and the default Z value, which is not what we want
+    QgsCompoundCurve *curve = captureCurve()->clone();
+    curve->dropZValue();
+
+    const Qgis::GeometryOperationResult returnCode = vlayer->splitFeatures( curve, topologyTestPoints, true, topologicalEditing );
     if ( returnCode == Qgis::GeometryOperationResult::Success )
     {
       vlayer->endEditCommand();

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -117,10 +117,10 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     // we need to drop Z value to properly split 3D feature in 2D. If not, generated vertices Z value
     // will be assigned with the mean value between the interpolated Z values of the intersecting point
     // and the default Z value, which is not what we want
-    QgsCompoundCurve *curve = captureCurve()->clone();
+    std::unique_ptr<QgsCompoundCurve> curve( captureCurve()->clone() );
     curve->dropZValue();
 
-    const Qgis::GeometryOperationResult returnCode = vlayer->splitFeatures( curve, topologyTestPoints, true, topologicalEditing );
+    const Qgis::GeometryOperationResult returnCode = vlayer->splitFeatures( curve.get(), topologyTestPoints, true, topologicalEditing );
     if ( returnCode == Qgis::GeometryOperationResult::Success )
     {
       vlayer->endEditCommand();

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -981,9 +981,7 @@ bool QgsGeos::topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPoin
       {
         for ( unsigned int i = 0; i < sequenceSize; ++i )
         {
-          if ( GEOSCoordSeq_getX_r( geosinit()->ctxt, lineSequence, i, &x ) != 0
-               && GEOSCoordSeq_getY_r( geosinit()->ctxt, lineSequence, i, &y ) != 0
-               && GEOSCoordSeq_getZ_r( geosinit()->ctxt, lineSequence, i, &z ) != 0 )
+          if ( GEOSCoordSeq_getXYZ_r( geosinit()->ctxt, lineSequence, i, &x, &y, &z ) )
           {
             testPoints.push_back( QgsPoint( x, y, z ) );
           }

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -976,17 +976,16 @@ bool QgsGeos::topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPoin
 
       const GEOSCoordSequence *lineSequence = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, currentIntersectGeom );
       unsigned int sequenceSize = 0;
-      double x, y;
+      double x, y, z;
       if ( GEOSCoordSeq_getSize_r( geosinit()->ctxt, lineSequence, &sequenceSize ) != 0 )
       {
         for ( unsigned int i = 0; i < sequenceSize; ++i )
         {
-          if ( GEOSCoordSeq_getX_r( geosinit()->ctxt, lineSequence, i, &x ) != 0 )
+          if ( GEOSCoordSeq_getX_r( geosinit()->ctxt, lineSequence, i, &x ) != 0
+               && GEOSCoordSeq_getY_r( geosinit()->ctxt, lineSequence, i, &y ) != 0
+               && GEOSCoordSeq_getZ_r( geosinit()->ctxt, lineSequence, i, &z ) != 0 )
           {
-            if ( GEOSCoordSeq_getY_r( geosinit()->ctxt, lineSequence, i, &y ) != 0 )
-            {
-              testPoints.push_back( QgsPoint( x, y ) );
-            }
+            testPoints.push_back( QgsPoint( x, y, z ) );
           }
         }
       }

--- a/tests/src/app/testqgsmaptoolsplitfeatures.cpp
+++ b/tests/src/app/testqgsmaptoolsplitfeatures.cpp
@@ -75,11 +75,11 @@ void TestQgsMapToolSplitFeatures::initTestCase()
   mMultiLineStringLayer->addFeature( lineF1 );
   mMultiLineStringLayer->addFeature( lineF2 );
 
-  mPolygonLayer = new QgsVectorLayer( QStringLiteral( "Polygon?crs=EPSG:3946" ), QStringLiteral( "layer polygon" ), QStringLiteral( "memory" ) );
+  mPolygonLayer = new QgsVectorLayer( QStringLiteral( "PolygonZ?crs=EPSG:3946" ), QStringLiteral( "layer polygon" ), QStringLiteral( "memory" ) );
   QVERIFY( mPolygonLayer->isValid() );
   mPolygonLayer->startEditing();
-  polygonF1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 5, 0 10, 10 10, 10 5, 0 5))" ) ) );
-  polygonF2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 0, 0 5, 10 5, 10 0, 0 0))" ) ) );
+  polygonF1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "PolygonZ ((0 5 10, 0 10 20, 10 10 30, 10 5 20, 0 5 10))" ) ) );
+  polygonF2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "PolygonZ ((0 0 10, 0 5 20, 10 5 30, 10 0 20, 0 0 10))" ) ) );
   mPolygonLayer->addFeature( polygonF1 );
   mPolygonLayer->addFeature( polygonF2 );
 
@@ -188,8 +188,8 @@ void TestQgsMapToolSplitFeatures::testSplitPolygon()
 
   QVERIFY( mPolygonLayer->undoStack()->index() == 3 );
   QVERIFY( mPolygonLayer->featureCount() == 3 );
-  QCOMPARE( mPolygonLayer->getFeature( polygonF1.id() ).geometry().asWkt(), QStringLiteral( "Polygon ((4 10, 4 5, 0 5, 0 10, 4 10))" ) );
-  QCOMPARE( mPolygonLayer->getFeature( polygonF2.id() ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 0 5, 10 5, 10 0, 0 0))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( polygonF1.id() ).geometry().asWkt(), QStringLiteral( "PolygonZ ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( polygonF2.id() ).geometry().asWkt(), QStringLiteral( "PolygonZ ((0 0 10, 0 5 20, 10 5 30, 10 0 20, 0 0 10))" ) );
 
   // no change to other layers
   QVERIFY( mMultiLineStringLayer->undoStack()->index() == 2 );
@@ -232,8 +232,8 @@ void TestQgsMapToolSplitFeatures::testSplitPolygonTopologicalEditing()
 
   QVERIFY( mPolygonLayer->undoStack()->index() == 3 );
   QVERIFY( mPolygonLayer->featureCount() == 3 );
-  QCOMPARE( mPolygonLayer->getFeature( polygonF1.id() ).geometry().asWkt(), QStringLiteral( "Polygon ((4 10, 4 5, 0 5, 0 10, 4 10))" ) );
-  QCOMPARE( mPolygonLayer->getFeature( polygonF2.id() ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 0 5, 4 5, 10 5, 10 0, 0 0))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( polygonF1.id() ).geometry().asWkt(), QStringLiteral( "PolygonZ ((4 10 24, 4 5 14, 0 5 10, 0 10 20, 4 10 24))" ) );
+  QCOMPARE( mPolygonLayer->getFeature( polygonF2.id() ).geometry().asWkt(), QStringLiteral( "PolygonZ ((0 0 10, 0 5 20, 4 5 14, 10 5 30, 10 0 20, 0 0 10))" ) );
 
   QVERIFY( mMultiLineStringLayer->undoStack()->index() == 3 );
   QCOMPARE( mMultiLineStringLayer->getFeature( lineF2.id() ).geometry().asWkt(), QStringLiteral( "MultiLineString ((0 5, 4 5, 10 5),(10 5, 15 5))" ) );


### PR DESCRIPTION
Fixes #52145 : When we split a feature with Z values, we need to do it with a splitting line without Z, so geos correctly assign the new intersecting point Z value with the interpolated Z value of adjacent vertices. If not it would compute the mean value with the default Z value.