### PR TITLE
Partially fix sizes of layer tree icons on hidpi displays

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -334,6 +334,28 @@ Sets map of map layer style overrides (key: layer ID, value: style name) where a
 .. versionadded:: 2.10
 %End
 
+    void addTargetScreenProperties( const QgsScreenProperties &properties );
+%Docstring
+Adds additional target screen ``properties`` to use when generating icons for Qt.DecorationRole data.
+
+This allows icons to be generated at an icon device pixel ratio and DPI which
+corresponds exactly to the view's screen properties in which this model is used.
+
+.. versionadded:: 3.32
+%End
+
+    QSet< QgsScreenProperties > targetScreenProperties() const;
+%Docstring
+Returns the target screen properties to use when generating icons.
+
+This allows icons to be generated at an icon device pixel ratio and DPI which
+corresponds exactly to the view's screen properties in which this model is used.
+
+.. seealso:: :py:func:`addTargetScreenProperties`
+
+.. versionadded:: 3.32
+%End
+
     static int scaleIconSize( int standardSize );
 %Docstring
 Scales an layer tree model icon size to compensate for display pixel density, making the icon
@@ -476,6 +498,7 @@ Filter nodes from :py:class:`QgsMapLayerLegend` according to the current filteri
     void legendInvalidateMapBasedData();
 
   protected:
+
 
 
 

--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -174,6 +174,8 @@ Default implementation does nothing.
 
       const QgsTextDocumentMetrics *textDocumentMetrics;
 
+      QgsScreenProperties screenProperties;
+
     };
 
     struct ItemMetrics

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -737,6 +737,19 @@ void QgsLayerTreeModel::setLayerStyleOverrides( const QMap<QString, QString> &ov
   mLayerStyleOverrides = overrides;
 }
 
+void QgsLayerTreeModel::addTargetScreenProperties( const QgsScreenProperties &properties )
+{
+  if ( mTargetScreenProperties.contains( properties ) )
+    return;
+
+  mTargetScreenProperties.insert( properties );
+}
+
+QSet<QgsScreenProperties> QgsLayerTreeModel::targetScreenProperties() const
+{
+  return mTargetScreenProperties;
+}
+
 int QgsLayerTreeModel::scaleIconSize( int standardSize )
 {
   return QgsApplication::scaleIconSize( standardSize, true );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1522,6 +1522,12 @@ QgsRenderContext *QgsLayerTreeModel::createTemporaryRenderContext() const
   // setup temporary render context
   std::unique_ptr<QgsRenderContext> context( new QgsRenderContext );
   context->setScaleFactor( dpi / 25.4 );
+
+  if ( !mTargetScreenProperties.isEmpty() )
+  {
+    mTargetScreenProperties.begin()->updateRenderContextForScreen( *context );
+  }
+
   context->setRendererScale( scale );
   context->setMapToPixel( QgsMapToPixel( mupp ) );
   context->setFlag( Qgis::RenderContextFlag::RenderSymbolPreview );

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -301,6 +301,27 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     void setLayerStyleOverrides( const QMap<QString, QString> &overrides );
 
     /**
+     * Adds additional target screen \a properties to use when generating icons for Qt::DecorationRole data.
+     *
+     * This allows icons to be generated at an icon device pixel ratio and DPI which
+     * corresponds exactly to the view's screen properties in which this model is used.
+     *
+     * \since QGIS 3.32
+     */
+    void addTargetScreenProperties( const QgsScreenProperties &properties );
+
+    /**
+     * Returns the target screen properties to use when generating icons.
+     *
+     * This allows icons to be generated at an icon device pixel ratio and DPI which
+     * corresponds exactly to the view's screen properties in which this model is used.
+     *
+     * \see addTargetScreenProperties()
+     * \since QGIS 3.32
+     */
+    QSet< QgsScreenProperties > targetScreenProperties() const;
+
+    /**
      * Scales an layer tree model icon size to compensate for display pixel density, making the icon
      * size hi-dpi friendly, whilst still resulting in pixel-perfect sizes for low-dpi
      * displays.
@@ -534,6 +555,8 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     int mLegendMapViewDpi = 0;
     double mLegendMapViewScale = 0;
     QTimer mDeferLegendInvalidationTimer;
+
+    QSet< QgsScreenProperties > mTargetScreenProperties;
 
   private slots:
     void legendNodeSizeChanged();

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -546,7 +546,7 @@ QVariant QgsSymbolLegendNode::data( int role ) const
   }
   else if ( role == Qt::DecorationRole )
   {
-    if ( mPixmap.isNull() || mPixmap.size() != mIconSize )
+    if ( mPixmap.isNull() )
     {
       QPixmap pix;
       if ( mItem.symbol() )
@@ -634,8 +634,6 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
 
   return true;
 }
-
-
 
 QSizeF QgsSymbolLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemContext *ctx, double itemHeight ) const
 {
@@ -881,6 +879,15 @@ void QgsSymbolLegendNode::invalidateMapBasedData()
   }
 }
 
+void QgsSymbolLegendNode::setIconSize( QSize sz )
+{
+  if ( mIconSize == sz )
+    return;
+
+  mIconSize = sz;
+  mPixmap = QPixmap();
+  emit dataChanged();
+}
 
 void QgsSymbolLegendNode::updateLabel()
 {

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -760,7 +760,7 @@ QSizeF QgsSymbolLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemC
 
       context->setPainter( &imagePainter );
       imagePainter.translate( maxBleed, maxBleed );
-      s->drawPreviewIcon( &imagePainter, symbolSize, context, false, nullptr, &patchShape );
+      s->drawPreviewIcon( &imagePainter, symbolSize, context, false, nullptr, &patchShape, ctx->screenProperties );
       imagePainter.translate( -maxBleed, -maxBleed );
       context->setPainter( ctx->painter );
       //reduce opacity of image
@@ -779,12 +779,12 @@ QSizeF QgsSymbolLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemC
       const QSize maxSize( symbolSize.width() + maxBleed * 2, symbolSize.height() + maxBleed * 2 );
       p->save();
       p->setClipRect( -maxBleed, -maxBleed, maxSize.width(), maxSize.height(), Qt::IntersectClip );
-      s->drawPreviewIcon( p, symbolSize, context, false, nullptr, &patchShape );
+      s->drawPreviewIcon( p, symbolSize, context, false, nullptr, &patchShape, ctx->screenProperties );
       p->restore();
     }
     else
     {
-      s->drawPreviewIcon( p, QSize( static_cast< int >( std::round( width * dotsPerMM ) ), static_cast< int >( std::round( height * dotsPerMM ) ) ), context, false, nullptr, &patchShape );
+      s->drawPreviewIcon( p, QSize( static_cast< int >( std::round( width * dotsPerMM ) ), static_cast< int >( std::round( height * dotsPerMM ) ) ), context, false, nullptr, &patchShape, ctx->screenProperties );
     }
 
     if ( !mTextOnSymbolLabel.isEmpty() )

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -548,7 +548,6 @@ QVariant QgsSymbolLegendNode::data( int role ) const
   {
     if ( mPixmap.isNull() )
     {
-      QPixmap pix;
       if ( mItem.symbol() )
       {
         std::unique_ptr<QgsRenderContext> context( createTemporaryRenderContext() );
@@ -557,11 +556,11 @@ QVariant QgsSymbolLegendNode::data( int role ) const
         double width = 0.0;
         double height = 0.0;
         const std::unique_ptr<QgsSymbol> symbol( QgsSymbolLayerUtils::restrictedSizeSymbol( mItem.symbol(), MINIMUM_SIZE, MAXIMUM_SIZE, context.get(), width, height ) );
-        pix = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol ? symbol.get() : mItem.symbol(), mIconSize, 0, context.get() );
+        mPixmap = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol ? symbol.get() : mItem.symbol(), mIconSize, 0, context.get() );
 
         if ( !mTextOnSymbolLabel.isEmpty() && context )
         {
-          QPainter painter( &pix );
+          QPainter painter( &mPixmap );
           painter.setRenderHint( QPainter::Antialiasing );
           context->setPainter( &painter );
           bool isNullSize = false;
@@ -576,11 +575,9 @@ QVariant QgsSymbolLegendNode::data( int role ) const
       }
       else
       {
-        pix = QPixmap( mIconSize );
-        pix.fill( Qt::transparent );
+        mPixmap = QPixmap( mIconSize );
+        mPixmap.fill( Qt::transparent );
       }
-
-      mPixmap = pix;
     }
     return mPixmap;
   }

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -250,6 +250,13 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
        */
       const QgsTextDocumentMetrics *textDocumentMetrics = nullptr;
 
+      /**
+       * Destination screen properties.
+       *
+       * \since QGIS 3.32
+       */
+      QgsScreenProperties screenProperties;
+
     };
 
     struct ItemMetrics

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -426,7 +426,7 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
      * Set the icon size
      * \since QGIS 2.10
      */
-    void setIconSize( QSize sz ) { mIconSize = sz; }
+    void setIconSize( QSize sz );
     //! \since QGIS 2.10
     QSize iconSize() const { return mIconSize; }
 

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -94,6 +94,8 @@ void QgsLayerTreeView::setModel( QAbstractItemModel *model )
   }
          );
 
+  treeModel->addTargetScreenProperties( QgsScreenProperties( screen() ) );
+
   mProxyModel = new QgsLayerTreeProxyModel( treeModel, this );
 
   connect( mProxyModel, &QAbstractItemModel::rowsInserted, this, &QgsLayerTreeView::modelRowsInserted );


### PR DESCRIPTION
There's still an issue where the marker symbol size can jump around randomly, but I see that on current stable releases on low-dpi screens too... 