### PR TITLE
Fix adding a relation within multiple edition

### DIFF
--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -287,7 +287,7 @@ QgsFeatureIds QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &ge
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeatureList.first().attribute( fieldPair.referencedField() ) );
 
     QgsFeature linkFeature;
-    if ( !vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry, &linkFeature, this, false, true ) )
+    if ( !vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry, &linkFeature, this, true, true ) )
       return QgsFeatureIds();
 
     addedFeatureIds.insert( linkFeature.id() );


### PR DESCRIPTION
## Description

### Context

A 1-N relation between a layer A ("projet" in example) and layer B ("document" in example) where one feature in layer A can have multiple linked features in layer B.

### Bug

1. Correctly configure the relation between the layers and the relational widget in layer A
2. Select multiple features from layer A
3. Clic on the multiple edition tool
4. Add a new relational feature (in layer B)

![image](https://github.com/qgis/QGIS/assets/34267385/7203aee7-47c3-456f-9f7b-ddf5522eb765)

5. Fill-in the attributes of the new feature (layer B)

![image](https://github.com/qgis/QGIS/assets/34267385/bcae15c6-bb79-4ca6-819c-d33e981be8e0)

6. EXPECTED: the new feature should be copied for every feature selected in layer A  
   BUG: the attributes are not copied

![image](https://github.com/qgis/QGIS/assets/34267385/655e7379-b0fa-4ac4-aaae-0aba860ec773)

### Fix

The first feature is correctly added but the other features were added too early, before the user had filled-in the attributes.

This was due to the modality of the attribute form when adding the layer B feature.

With this form now modal, QGIS waits to have all the attributes for all the features to be filled-in.

![image](https://github.com/qgis/QGIS/assets/34267385/cf9086f2-0faf-40f8-89c2-7d9ffacca5af)

![image](https://github.com/qgis/QGIS/assets/34267385/2c220aa8-72ff-4c8d-ae9f-fd2b3c887718)


