### PR TITLE
Tweaking user profile selector dialog and settings

### DIFF
--- a/python/core/auto_generated/qgsuserprofilemanager.sip.in
+++ b/python/core/auto_generated/qgsuserprofilemanager.sip.in
@@ -145,7 +145,7 @@ Set the default profile name from the current active profile.
 
     QString lastProfileName() const;
 %Docstring
-Returns the name of the most recently closed profile. Empty if its the first time QGIS has been run.
+Returns the name of the most recently closed profile. Empty if it is the first time QGIS is run.
 
 .. versionadded:: 3.32
 %End

--- a/src/app/options/qgsuserprofileoptions.cpp
+++ b/src/app/options/qgsuserprofileoptions.cpp
@@ -35,9 +35,10 @@ QgsUserProfileOptionsWidget::QgsUserProfileOptionsWidget( QWidget *parent )
   mDefaultProfileComboBox->setEnabled( false );
   connect( mDefaultProfile, &QRadioButton::toggled, mDefaultProfileComboBox, &QComboBox::setEnabled );
 
-  // Disable Profile selector groupbox if Ask user is not selected
-  mProfileSelectorGroupBox->setEnabled( false );
-  connect( mAskUser, &QRadioButton::toggled, mProfileSelectorGroupBox, &QGroupBox::setEnabled );
+  // Disable Profile selector items if Ask user is not selected
+  mIconSizeLabel->setEnabled( false );
+  mIconSize->setEnabled( false );
+  connect( mAskUser, &QRadioButton::toggled, this, &QgsUserProfileOptionsWidget::onAskUserChanged );
 
   // Connect icon size and allow profile creation
   mIconSize->setCurrentText( QString::number( QSettings().value( QStringLiteral( "/selector/iconSize" ), 24 ).toInt() ) );
@@ -49,7 +50,7 @@ QgsUserProfileOptionsWidget::QgsUserProfileOptionsWidget( QWidget *parent )
   } );
 
   // Connect change icon button
-  connect( mChangeIconButton, &QToolButton::clicked, this, &QgsUserProfileOptionsWidget::onChangeIconClicked );
+  connect( mActiveProfileIconButton, &QToolButton::clicked, this, &QgsUserProfileOptionsWidget::onChangeIconClicked );
   connect( mResetIconButton, &QToolButton::clicked, this, &QgsUserProfileOptionsWidget::onResetIconClicked );
 
   // Init radio buttons
@@ -76,8 +77,8 @@ QgsUserProfileOptionsWidget::QgsUserProfileOptionsWidget( QWidget *parent )
   mDefaultProfileComboBox->setCurrentText( manager->defaultProfileName() );
 
   // Init Active profile name and icon
-  mChangeIconButton->setIcon( manager->userProfile()->icon() );
-  mActiveProfileGroupBox->setTitle( tr( "Active Profile (%1)", "Active profile name" ).arg( manager->userProfile()->name() ) );
+  mActiveProfileIconButton->setIcon( manager->userProfile()->icon() );
+  mActiveProfileIconLabel->setText( tr( "Active Profile (%1) icon", "Active profile icon" ).arg( manager->userProfile()->name() ) );
 }
 
 void QgsUserProfileOptionsWidget::apply()
@@ -116,11 +117,10 @@ void QgsUserProfileOptionsWidget::onChangeIconClicked()
     QFile::copy( iconPath, dstPath );
 
     // Update the button icon
-    mChangeIconButton->setIcon( QIcon( iconPath ) );
+    mActiveProfileIconButton->setIcon( QIcon( iconPath ) );
     mDefaultProfileComboBox->setItemIcon( mDefaultProfileComboBox->findText( activeProfile->name() ), activeProfile->icon() );
   }
 }
-
 
 void QgsUserProfileOptionsWidget::onResetIconClicked()
 {
@@ -132,10 +132,15 @@ void QgsUserProfileOptionsWidget::onResetIconClicked()
     dir.remove( file );
   }
   // Update the button icon
-  mChangeIconButton->setIcon( activeProfile->icon() );
+  mActiveProfileIconButton->setIcon( activeProfile->icon() );
   mDefaultProfileComboBox->setItemIcon( mDefaultProfileComboBox->findText( activeProfile->name() ), activeProfile->icon() );
 }
 
+void QgsUserProfileOptionsWidget::onAskUserChanged()
+{
+  mIconSizeLabel->setEnabled( mAskUser->isChecked() );
+  mIconSize->setEnabled( mAskUser->isChecked() );
+}
 
 //
 // QgsUserProfileOptionsFactory

--- a/src/app/options/qgsuserprofileoptions.h
+++ b/src/app/options/qgsuserprofileoptions.h
@@ -45,6 +45,8 @@ class APP_EXPORT QgsUserProfileOptionsWidget : public QgsOptionsPageWidget, priv
     //! Reset the profile icon to default
     void onResetIconClicked();
 
+    // Show or hide user selector dialog icon setting
+    void onAskUserChanged();
 };
 
 

--- a/src/core/qgsuserprofilemanager.h
+++ b/src/core/qgsuserprofilemanager.h
@@ -144,7 +144,7 @@ class CORE_EXPORT QgsUserProfileManager : public QObject
     void setDefaultFromActive();
 
     /**
-     * Returns the name of the most recently closed profile. Empty if its the first time QGIS has been run.
+     * Returns the name of the most recently closed profile. Empty if it is the first time QGIS is run.
      * \since QGIS 3.32
      */
     QString lastProfileName() const;

--- a/src/ui/qgsuserprofileoptionswidgetbase.ui
+++ b/src/ui/qgsuserprofileoptionswidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>462</width>
-    <height>378</height>
+    <height>340</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,7 +42,7 @@
       <item row="2" column="0" colspan="2">
        <widget class="QRadioButton" name="mAskUser">
         <property name="text">
-         <string>Let user choose profile at start up</string>
+         <string>Choose profile at start up</string>
         </property>
        </widget>
       </item>
@@ -76,13 +76,13 @@
    <item>
     <widget class="QGroupBox" name="mProfileSelectorGroupBox">
      <property name="title">
-      <string>Profile Selector</string>
+      <string>Profile Display</string>
      </property>
-     <layout class="QFormLayout" name="formLayout">
+     <layout class="QGridLayout" name="gridLayout1">
       <item row="0" column="0">
        <widget class="QLabel" name="mIconSizeLabel">
         <property name="text">
-         <string>Icon size</string>
+         <string>Default icon size</string>
         </property>
        </widget>
       </item>
@@ -93,6 +93,9 @@
           <width>50</width>
           <height>16777215</height>
          </size>
+        </property>
+        <property name="toolTip">
+         <string>Select size of icons in the user profile selector dialog</string>
         </property>
         <item>
          <property name="text">
@@ -121,28 +124,16 @@
         </item>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="mActiveProfileGroupBox">
-     <property name="title">
-      <string>Active Profile</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="mChangeIconLabel">
+      <item row="1" column="0">
+       <widget class="QLabel" name="mActiveProfileIconLabel">
         <property name="text">
-         <string>Change icon</string>
+         <string>Active profile icon</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QToolButton" name="mChangeIconButton">
+      <item row="1" column="1">
+       <widget class="QToolButton" name="mActiveProfileIconButton">
         <property name="toolTip">
-         <string/>
-        </property>
-        <property name="text">
          <string>Change profile icon</string>
         </property>
         <property name="icon">
@@ -157,7 +148,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="2">
        <widget class="QToolButton" name="mResetIconButton">
         <property name="toolTip">
          <string>Reset icon</string>
@@ -168,7 +159,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -192,7 +183,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>
@@ -204,7 +195,7 @@
   <tabstop>mDefaultProfile</tabstop>
   <tabstop>mDefaultProfileComboBox</tabstop>
   <tabstop>mAskUser</tabstop>
-  <tabstop>mChangeIconButton</tabstop>
+  <tabstop>mActiveProfileIconButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
+    <width>332</width>
     <height>417</height>
    </rect>
   </property>
@@ -75,7 +75,7 @@
    </palette>
   </property>
   <property name="windowTitle">
-   <string>Profiles</string>
+   <string>User Profile Selector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -138,66 +138,37 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="mAddProfileButton">
-       <property name="text">
-        <string>Add new profile</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mOkButton">
-       <property name="text">
-        <string>Ok</string>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="shortcut">
-        <string>Return</string>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QToolButton" name="mAddProfileButton">
+     <property name="text">
+      <string>Add new profile</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../images/images.qrc">
+       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextBesideIcon</enum>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+      </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -206,17 +177,33 @@
  </resources>
  <connections>
   <connection>
-   <sender>mOkButton</sender>
-   <signal>clicked()</signal>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
    <receiver>QgsUserProfileSelectionDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>285</x>
-     <y>390</y>
+     <x>145</x>
+     <y>392</y>
     </hint>
     <hint type="destinationlabel">
-     <x>156</x>
+     <x>165</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsUserProfileSelectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>145</x>
+     <y>392</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>165</x>
      <y>208</y>
     </hint>
    </hints>


### PR DESCRIPTION
- Simplify labels
- Group items with relabeling
- Provide clearer name to selector dialog (we need one for[ the docs](https://github.com/qgis/QGIS-Documentation/pull/8353))

top (before) - bottom (PR) - _I tried but failed to have the help button of this tab point to the user profiles section in docs_
![image](https://github.com/qgis/QGIS/assets/7983394/ec74c9f4-9da3-4958-9862-460cdadf9266)

left (before) - right (PR minus the Help button. I am getting a segmentation fault whenever I click the Help here and have no clue how to fix it - see [here the commit](https://github.com/DelazJ/QGIS/commit/22e1c4df223c8d1e2b7f79f56ae30b82c2298d78))
![image](https://github.com/qgis/QGIS/assets/7983394/0ec7e999-5f37-4344-9475-42f623549a64)

