### PR TITLE
Fix build with WITH_BINDINGS=yes and WITH_QTSERIALPORT=no

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -170,6 +170,10 @@ if(NOT WITH_GUI)
   set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_GUI)
 endif()
 
+if(NOT WITH_QTSERIALPORT)
+  set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_QTSERIALPORT)
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/core/project.py.in ${CMAKE_CURRENT_BINARY_DIR}/core/project.py @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/core/pyproject.toml.in ${CMAKE_CURRENT_BINARY_DIR}/core/pyproject.toml @ONLY)
 GENERATE_SIP_PYTHON_MODULE_CODE(qgis._core core/core.sip "${sip_files_core}" cpp_files)

--- a/python/core/auto_generated/sensor/qgsabstractsensor.sip.in
+++ b/python/core/auto_generated/sensor/qgsabstractsensor.sip.in
@@ -32,10 +32,12 @@ An abstract base class for sensor classes
       {
         sipType = sipType_QgsUdpSocketSensor;
       }
+#if defined( HAVE_QTSERIALPORT )
       else if ( item->type() == QLatin1String( "serial_port" ) && dynamic_cast<QgsSerialPortSensor *>( item ) != NULL )
       {
         sipType = sipType_QgsSerialPortSensor;
       }
+#endif
       else
       {
         sipType = sipType_QgsAbstractSensor;

--- a/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
+++ b/python/core/auto_generated/sensor/qgsiodevicesensor.sip.in
@@ -184,6 +184,7 @@ Sets the ``port`` the socket connects to.
 
 };
 
+%If (HAVE_QTSERIALPORT)
 
 class QgsSerialPortSensor : QgsIODeviceSensor
 {
@@ -239,6 +240,7 @@ Sets the serial port the sensor connects to.
 
 
 };
+%End
 
 
 

--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -100,6 +100,7 @@ done:
 %Import QtPositioning/QtPositioningmod.sip
 
 %Feature HAVE_GUI
+%Feature HAVE_QTSERIALPORT
 %Feature ANDROID
 %Feature VECTOR_MAPPED_TYPE
 

--- a/src/core/sensor/qgsabstractsensor.h
+++ b/src/core/sensor/qgsabstractsensor.h
@@ -50,10 +50,12 @@ class CORE_EXPORT QgsAbstractSensor : public QObject
       {
         sipType = sipType_QgsUdpSocketSensor;
       }
+#if defined( HAVE_QTSERIALPORT )
       else if ( item->type() == QLatin1String( "serial_port" ) && dynamic_cast<QgsSerialPortSensor *>( item ) != NULL )
       {
         sipType = sipType_QgsSerialPortSensor;
       }
+#endif
       else
       {
         sipType = sipType_QgsAbstractSensor;

--- a/src/core/sensor/qgsiodevicesensor.h
+++ b/src/core/sensor/qgsiodevicesensor.h
@@ -220,6 +220,7 @@ class CORE_EXPORT QgsUdpSocketSensor : public QgsIODeviceSensor
 };
 
 #if defined( HAVE_QTSERIALPORT )
+SIP_IF_FEATURE( HAVE_QTSERIALPORT )
 
 /**
  * \ingroup core
@@ -279,6 +280,7 @@ class CORE_EXPORT QgsSerialPortSensor : public QgsIODeviceSensor
     QString mPortName;
 
 };
+SIP_END
 #endif
 
 #endif //QGSIODEVICESENSOR_H


### PR DESCRIPTION
```
auto_generated/sensor/qgsabstractsensor.sip: In function ‘const sipTypeDef* sipSubClass_QgsAbstractSensor(void**)’:
auto_generated/sensor/qgsabstractsensor.sip:35: error: ‘QgsSerialPortSensor’ does not name a type; did you mean ‘sipName_QgsSerialPortSensor’?
```

## Description

Allows QGIS 3.32.0 with Python bindings to be compiled without QtSerialPort support enabled.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->

Bug: #53571

