### PR TITLE
Fix global map shading to work with high DPI

### DIFF
--- a/python/core/auto_generated/qgselevationmap.sip.in
+++ b/python/core/auto_generated/qgselevationmap.sip.in
@@ -37,7 +37,7 @@ in meters.
 Default constructor
 %End
 
-    explicit QgsElevationMap( const QSize &size );
+    explicit QgsElevationMap( const QSize &size, float devicePixelRatio = 1.0 );
 %Docstring
 Constructs an elevation map with the given width and height
 %End

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -304,7 +304,7 @@ void QgsMapRendererCustomPainterJob::doRender()
   const QgsElevationShadingRenderer mapShadingRenderer = mSettings.elevationShadingRenderer();
   std::unique_ptr<QgsElevationMap> mainElevationMap;
   if ( mapShadingRenderer.isActive() )
-    mainElevationMap.reset( new QgsElevationMap( mSettings.outputSize() ) );
+    mainElevationMap.reset( new QgsElevationMap( mSettings.deviceOutputSize(), mSettings.devicePixelRatio() ) );
 
   for ( LayerRenderJob &job : mLayerJobs )
   {

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -416,7 +416,7 @@ QImage *QgsMapRendererJob::allocateImage( QString layerId )
 
 QgsElevationMap *QgsMapRendererJob::allocateElevationMap( QString layerId )
 {
-  std::unique_ptr<QgsElevationMap> elevationMap = std::make_unique<QgsElevationMap>( mSettings.deviceOutputSize() );
+  std::unique_ptr<QgsElevationMap> elevationMap = std::make_unique<QgsElevationMap>( mSettings.deviceOutputSize(), mSettings.devicePixelRatio() );
   if ( !elevationMap->isValid() )
   {
     mErrors.append( Error( layerId, tr( "Insufficient memory for elevation map %1x%2" ).arg( mSettings.outputSize().width() ).arg( mSettings.outputSize().height() ) ) );
@@ -1142,7 +1142,7 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings,
   const QgsElevationShadingRenderer mapShadingRenderer = settings.elevationShadingRenderer();
   std::unique_ptr<QgsElevationMap> mainElevationMap;
   if ( mapShadingRenderer.isActive() )
-    mainElevationMap.reset( new QgsElevationMap( settings.outputSize() ) );
+    mainElevationMap.reset( new QgsElevationMap( settings.deviceOutputSize(), settings.devicePixelRatio() ) );
 
   QPainter painter( &image );
 

--- a/src/core/qgselevationmap.cpp
+++ b/src/core/qgselevationmap.cpp
@@ -26,10 +26,11 @@ static const int ELEVATION_OFFSET = 7900;
 static const int ELEVATION_SCALE = 1000;
 
 
-QgsElevationMap::QgsElevationMap( const QSize &size )
+QgsElevationMap::QgsElevationMap( const QSize &size, float devicePixelRatio )
   : mElevationImage( size, QImage::Format_ARGB32 )
 {
   mElevationImage.fill( 0 );
+  mElevationImage.setDevicePixelRatio( devicePixelRatio );
 }
 
 QgsElevationMap::QgsElevationMap( const QImage &image )

--- a/src/core/qgselevationmap.h
+++ b/src/core/qgselevationmap.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsElevationMap
     QgsElevationMap() = default;
 
     //! Constructs an elevation map with the given width and height
-    explicit QgsElevationMap( const QSize &size );
+    explicit QgsElevationMap( const QSize &size, float devicePixelRatio = 1.0 );
 
     /**
      * Constructs an elevation map from an existing raw elevation \a image.

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -424,8 +424,8 @@ void QgsRasterLayerRenderer::drawElevationMap()
     else
       dpiScalefactor = 1.0;
 
-    int outputWidth = static_cast<int>( static_cast<double>( mRasterViewPort->mWidth )  / dpiScalefactor ) ;
-    int outputHeight =  static_cast<int>( static_cast<double>( mRasterViewPort->mHeight ) / dpiScalefactor );
+    int outputWidth = static_cast<int>( static_cast<double>( mRasterViewPort->mWidth )  / dpiScalefactor * renderContext()->devicePixelRatio() );
+    int outputHeight =  static_cast<int>( static_cast<double>( mRasterViewPort->mHeight ) / dpiScalefactor * renderContext()->devicePixelRatio() );
 
     QSize viewSize = renderContext()->deviceOutputSize();
     int viewWidth =  static_cast<int>( viewSize.width() / dpiScalefactor );
@@ -576,7 +576,9 @@ void QgsRasterLayerRenderer::drawElevationMap()
           QgsGdalUtils::blockToSingleBandMemoryDataset( mRasterViewPort->mDrawnExtent, elevationBlock.get() );
 
         std::unique_ptr<QgsRasterBlock> rotatedElevationBlock =
-          std::make_unique<QgsRasterBlock>( elevationBlock->dataType(), right - left + 1, bottom - top + 1 );
+          std::make_unique<QgsRasterBlock>( elevationBlock->dataType(),
+                                            ( right - left ) * renderContext()->devicePixelRatio() + 1,
+                                            ( bottom - top ) * renderContext()->devicePixelRatio() + 1 );
 
         rotatedElevationBlock->setNoDataValue( elevationBlock->noDataValue() );
 
@@ -600,8 +602,8 @@ void QgsRasterLayerRenderer::drawElevationMap()
 
       renderContext()->elevationMap()->fillWithRasterBlock(
         elevationBlock.get(),
-        topLeft.y(),
-        topLeft.x(),
+        topLeft.y() * renderContext()->devicePixelRatio(),
+        topLeft.x() * renderContext()->devicePixelRatio(),
         mElevationScale,
         mElevationOffset );
     }


### PR DESCRIPTION
Global map shading based on elevation has been broken - no shading appeared when device pixel ratio is not 1.0 (the elevation map was having incompatible size set).

This PR fixes the issue and also related problems with high DPI support:
- point cloud elevations were incorrectly placed (the internal QImage in elevation maps needs correctly set device pixel ratio, otherwise QPainter used for point cloud elevation writes is scaled)
- raster elevations were incorrectly placed (both "normal" and rotated case)
