### PR TITLE
Deprecate layer type specific signals from QgsAbstractDataSourceWidget and move toward generic signal for all layer types

### DIFF
--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -93,9 +93,12 @@ This signal is normally forwarded the app and used to refresh browser items
 Emitted when a DB layer has been selected for addition
 %End
 
-    void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey );
+ void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) /Deprecated/;
 %Docstring
 Emitted when a raster layer has been selected for addition
+
+.. deprecated::
+   use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
     void addRasterLayers( const QStringList &layersList );
@@ -107,33 +110,53 @@ Emitted when one or more GDAL supported layers are selected for addition
 .. versionadded:: 3.20
 %End
 
-    void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() );
+ void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) /Deprecated/;
 %Docstring
 Emitted when a vector layer has been selected for addition.
 
 If ``providerKey`` is not specified, the default provider key associated with the source
 will be used.
+
+.. deprecated::
+   use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
-    void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey );
+ void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
 %Docstring
 Emitted when a mesh layer has been selected for addition.
 
-.. versionadded:: 3.4
+.. deprecated::
+   use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
-    void addVectorTileLayer( const QString &url, const QString &baseName );
+ void addVectorTileLayer( const QString &url, const QString &baseName ) /Deprecated/;
 %Docstring
 Emitted when a vector tile layer has been selected for addition.
 
-.. versionadded:: 3.14
+.. deprecated::
+   use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
 %End
 
-    void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey );
+ void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) /Deprecated/;
 %Docstring
 Emitted when a point cloud layer has been selected for addition.
 
-.. versionadded:: 3.18
+.. deprecated::
+   use :py:func:`~QgsAbstractDataSourceWidget.addLayer` instead.
+%End
+
+    void addLayer( Qgis::LayerType type, const QString &url, const QString &baseName, const QString &providerKey );
+%Docstring
+Emitted when a layer has been selected for addition.
+
+This is a generic method, intended for replacing the specific layer type signals implemented above.
+
+.. warning::
+
+   For QGIS versions < 4.x, the specific layer type added signals must be emitted for vector, raster,
+   mesh, vector tile and point cloud layers in addition to this signal.
+
+.. versionadded:: 3.34
 %End
 
     void addVectorLayers( const QStringList &layerList, const QString &encoding, const QString &dataSourceType );

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -216,11 +216,18 @@ void QgsOgrDbSourceSelect::addButtonClicked()
     // Use OGR
     for ( const LayerInfo &info : std::as_const( selectedVectors ) )
     {
+      Q_NOWARN_DEPRECATED_PUSH
       emit addVectorLayer( info.first, info.second );
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::Vector, info.first, info.second, QStringLiteral( "ogr" ) );
+
     }
     for ( const LayerInfo &info : std::as_const( selectedRasters ) )
     {
+      Q_NOWARN_DEPRECATED_PUSH
       emit addRasterLayer( info.first, info.second, QStringLiteral( "gdal" ) );
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::Raster, info.first, info.second, QStringLiteral( "gdal" ) );
     }
     if ( widgetMode() == QgsProviderRegistry::WidgetMode::None && ! mHoldDialogOpen->isChecked() )
     {

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -81,7 +81,11 @@ void QgsPointCloudSourceSelect::addButtonClicked()
       // maybe we should raise an assert if preferredProviders size is 0 or >1? Play it safe for now...
       if ( preferredProviders.empty() )
         continue;
+
+      Q_NOWARN_DEPRECATED_PUSH
       emit addPointCloudLayer( path, QFileInfo( path ).baseName(), preferredProviders.at( 0 ).metadata()->key() ) ;
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::PointCloud, path, QFileInfo( path ).baseName(), preferredProviders.at( 0 ).metadata()->key() );
     }
   }
   else if ( mDataSourceType == QLatin1String( "remote" ) )
@@ -121,7 +125,10 @@ void QgsPointCloudSourceSelect::addButtonClicked()
       {
         baseName = QFileInfo( mPath ).baseName();
       }
+      Q_NOWARN_DEPRECATED_PUSH
       emit addPointCloudLayer( mPath, baseName, preferredProviders.at( 0 ).metadata()->key() ) ;
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::PointCloud, mPath, baseName, preferredProviders.at( 0 ).metadata()->key() );
     }
   }
 }

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -22,7 +22,6 @@
 #include "qgis_sip.h"
 #include "qgis_gui.h"
 
-#include "qgsproviderguimetadata.h"
 #include "qgsproviderregistry.h"
 #include "qgsguiutils.h"
 #include <QDialog>
@@ -108,8 +107,12 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     //! Emitted when a DB layer has been selected for addition
     void addDatabaseLayers( const QStringList &paths, const QString &providerKey );
 
-    //! Emitted when a raster layer has been selected for addition
-    void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey );
+    /**
+     * Emitted when a raster layer has been selected for addition
+     *
+     * \deprecated use addLayer() instead.
+     */
+    Q_DECL_DEPRECATED void addRasterLayer( const QString &rasterLayerPath, const QString &baseName, const QString &providerKey ) SIP_DEPRECATED;
 
     /**
      * Emitted when one or more GDAL supported layers are selected for addition
@@ -123,26 +126,43 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      *
      * If \a providerKey is not specified, the default provider key associated with the source
      * will be used.
+     *
+     * \deprecated use addLayer() instead.
      */
-    void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() );
+    Q_DECL_DEPRECATED void addVectorLayer( const QString &uri, const QString &layerName, const QString &providerKey = QString() ) SIP_DEPRECATED;
 
     /**
      * Emitted when a mesh layer has been selected for addition.
-     * \since QGIS 3.4
+     *
+     * \deprecated use addLayer() instead.
      */
-    void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey );
+    Q_DECL_DEPRECATED void addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) SIP_DEPRECATED;
 
     /**
      * Emitted when a vector tile layer has been selected for addition.
-     * \since QGIS 3.14
+     *
+     * \deprecated use addLayer() instead.
      */
-    void addVectorTileLayer( const QString &url, const QString &baseName );
+    Q_DECL_DEPRECATED void addVectorTileLayer( const QString &url, const QString &baseName ) SIP_DEPRECATED;
 
     /**
      * Emitted when a point cloud layer has been selected for addition.
-     * \since QGIS 3.18
+     *
+     * \deprecated use addLayer() instead.
      */
-    void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey );
+    Q_DECL_DEPRECATED void addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey ) SIP_DEPRECATED;
+
+    /**
+     * Emitted when a layer has been selected for addition.
+     *
+     * This is a generic method, intended for replacing the specific layer type signals implemented above.
+     *
+     * \warning For QGIS versions < 4.x, the specific layer type added signals must be emitted for vector, raster,
+     * mesh, vector tile and point cloud layers in addition to this signal.
+     *
+     * \since QGIS 3.34
+     */
+    void addLayer( Qgis::LayerType type, const QString &url, const QString &baseName, const QString &providerKey );
 
     /**
      * Emitted when one or more OGR supported layers are selected for addition

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -19,7 +19,6 @@
 #include "qgsdatasourcemanagerdialog.h"
 #include "ui_qgsdatasourcemanagerdialog.h"
 #include "qgsbrowserdockwidget.h"
-#include "qgslayermetadatasearchwidget.h"
 #include "qgssettings.h"
 #include "qgsproviderregistry.h"
 #include "qgssourceselectprovider.h"
@@ -163,19 +162,9 @@ void QgsDataSourceManagerDialog::reset()
   }
 }
 
-void QgsDataSourceManagerDialog::rasterLayerAdded( const QString &uri, const QString &baseName, const QString &providerKey )
-{
-  emit addRasterLayer( uri, baseName, providerKey );
-}
-
 void QgsDataSourceManagerDialog::rasterLayersAdded( const QStringList &layersList )
 {
   emit addRasterLayers( layersList );
-}
-
-void QgsDataSourceManagerDialog::vectorLayerAdded( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey )
-{
-  emit addVectorLayer( vectorLayerPath, baseName, providerKey );
 }
 
 void QgsDataSourceManagerDialog::vectorLayersAdded( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType )
@@ -223,30 +212,73 @@ void QgsDataSourceManagerDialog::makeConnections( QgsAbstractDataSourceWidget *d
            this, &QgsDataSourceManagerDialog::addDatabaseLayers );
   connect( dlg, &QgsAbstractDataSourceWidget::progressMessage,
            this, &QgsDataSourceManagerDialog::showStatusMessage );
+
+  connect( dlg, &QgsAbstractDataSourceWidget::addLayer, this, [ = ]( Qgis::LayerType type, const QString & url, const QString & baseName, const QString & providerKey )
+  {
+    Q_UNUSED( url )
+    Q_UNUSED( baseName )
+    Q_UNUSED( providerKey )
+
+    switch ( type )
+    {
+      case Qgis::LayerType::Vector:
+      case Qgis::LayerType::Raster:
+      case Qgis::LayerType::Plugin:
+      case Qgis::LayerType::Mesh:
+      case Qgis::LayerType::VectorTile:
+      case Qgis::LayerType::Annotation:
+      case Qgis::LayerType::PointCloud:
+      case Qgis::LayerType::Group:
+        // for compatibility with older API, we ignore these signals and rely on the older granular signals (eg "addVectorLayer").
+        // otherwise we will be emitting double signals for the old/new signal for these layer types
+        break;
+    }
+  } );
+
   // Vector
+  Q_NOWARN_DEPRECATED_PUSH
   connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayer, this, [ = ]( const QString & vectorLayerPath, const QString & baseName, const QString & specifiedProvider )
   {
     const QString key = specifiedProvider.isEmpty() ? providerKey : specifiedProvider;
-    this->vectorLayerAdded( vectorLayerPath, baseName, key );
+    emit addLayer( Qgis::LayerType::Vector, vectorLayerPath, baseName, key );
   }
          );
+  Q_NOWARN_DEPRECATED_POP
   connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayers,
            this, &QgsDataSourceManagerDialog::vectorLayersAdded );
   connect( dlg, &QgsAbstractDataSourceWidget::connectionsChanged, this, &QgsDataSourceManagerDialog::connectionsChanged );
+
   // Raster
-  connect( dlg, &QgsAbstractDataSourceWidget::addRasterLayer,
-           this, [ = ]( const QString & uri, const QString & baseName, const QString & providerKey )
+  Q_NOWARN_DEPRECATED_PUSH
+  connect( dlg, &QgsAbstractDataSourceWidget::addRasterLayer, this, [ = ]( const QString & rasterLayerPath, const QString & baseName, const QString & providerKey )
   {
-    addRasterLayer( uri, baseName, providerKey );
+    emit addLayer( Qgis::LayerType::Raster, rasterLayerPath, baseName, providerKey );
   } );
+  Q_NOWARN_DEPRECATED_POP
   connect( dlg, &QgsAbstractDataSourceWidget::addRasterLayers,
            this, &QgsDataSourceManagerDialog::rasterLayersAdded );
+
   // Mesh
-  connect( dlg, &QgsAbstractDataSourceWidget::addMeshLayer, this, &QgsDataSourceManagerDialog::addMeshLayer );
+  Q_NOWARN_DEPRECATED_PUSH
+  connect( dlg, &QgsAbstractDataSourceWidget::addMeshLayer, this, [ = ]( const QString & url, const QString & baseName, const QString & providerKey )
+  {
+    emit addLayer( Qgis::LayerType::Mesh, url, baseName, providerKey );
+  } );
+  Q_NOWARN_DEPRECATED_POP
   // Vector tile
-  connect( dlg, &QgsAbstractDataSourceWidget::addVectorTileLayer, this, &QgsDataSourceManagerDialog::addVectorTileLayer );
+  Q_NOWARN_DEPRECATED_PUSH
+  connect( dlg, &QgsAbstractDataSourceWidget::addVectorTileLayer, this, [ = ]( const QString & url, const QString & baseName )
+  {
+    emit addLayer( Qgis::LayerType::VectorTile, url, baseName, QString() );
+  } );
+  Q_NOWARN_DEPRECATED_POP
   // Point Cloud
-  connect( dlg, &QgsAbstractDataSourceWidget::addPointCloudLayer, this, &QgsDataSourceManagerDialog::addPointCloudLayer );
+  Q_NOWARN_DEPRECATED_PUSH
+  connect( dlg, &QgsAbstractDataSourceWidget::addPointCloudLayer, this, [ = ]( const QString & url, const QString & baseName, const QString & providerKey )
+  {
+    emit addLayer( Qgis::LayerType::PointCloud, url, baseName, providerKey );
+  } );
+  Q_NOWARN_DEPRECATED_POP
   // Virtual
   connect( dlg, &QgsAbstractDataSourceWidget::replaceVectorLayer,
            this, &QgsDataSourceManagerDialog::replaceSelectedVectorLayer );

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -85,16 +85,12 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
 
     // TODO: use this with an internal source select dialog instead of forwarding the whole raster selection to app
 
-    //! A raster layer was added: for signal forwarding to QgisApp
-    void rasterLayerAdded( QString const &uri, QString const &baseName, QString const &providerKey );
-
     /**
      * One or more raster layer were added: for signal forwarding to QgisApp
      * \since QGIS 3.20
      */
     void rasterLayersAdded( const QStringList &layersList );
-    //! A vector layer was added: for signal forwarding to QgisApp
-    void vectorLayerAdded( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey );
+
     //! One or more vector layer were added: for signal forwarding to QgisApp
     void vectorLayersAdded( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType );
     //! Reset current page to previously selected page
@@ -117,33 +113,19 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
   signals:
 
     /**
+     * Emitted when a layer has been selected for addition.
+     *
+     * This is a generic method, intended for replacing the specific layer type signals implemented below.
+     *
+     * \since QGIS 3.34
+     */
+    void addLayer( Qgis::LayerType type, const QString &url, const QString &baseName, const QString &providerKey );
+
+    /**
      * Emitted when a one or more layer were selected for addition: for signal forwarding to QgisApp
      * \since QGIS 3.20
      */
     void addRasterLayers( const QStringList &layersList );
-    //! Emitted when a raster layer was selected for addition: for signal forwarding to QgisApp
-    void addRasterLayer( const QString &uri, const QString &baseName, const QString &providerKey );
-
-    //! Emitted when a vector layer was selected for addition: for signal forwarding to QgisApp
-    void addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey );
-
-    /**
-     * Emitted when a mesh layer was selected for addition: for signal forwarding to QgisApp
-     * \since QGIS 3.4
-     */
-    void addMeshLayer( const QString &uri, const QString &baseName, const QString &providerKey );
-
-    /**
-     * Emitted when a vector tile layer was selected for addition: for signal forwarding to QgisApp
-     * \since QGIS 3.14
-     */
-    void addVectorTileLayer( const QString &uri, const QString &baseName );
-
-    /**
-     * Emitted when a point cloud layer was selected for addition: for signal forwarding to QgisApp
-     * \since QGIS 3.18
-     */
-    void addPointCloudLayer( const QString &pointCloudLayerPath, const QString &baseName, const QString &providerKey );
 
     //! Replace the selected layer by a vector layer defined by uri, layer name, data source uri
     void replaceSelectedVectorLayer( const QString &oldId, const QString &uri, const QString &layerName, const QString &provider );

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -207,17 +207,26 @@ void QgsLayerMetadataSearchWidget::addButtonClicked()
       {
         case Qgis::LayerType::Raster:
         {
+          Q_NOWARN_DEPRECATED_PUSH
           emit addRasterLayer( metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
+          Q_NOWARN_DEPRECATED_POP
+          emit addLayer( metadataResult.layerType(), metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
           break;
         }
         case Qgis::LayerType::Vector:
         {
+          Q_NOWARN_DEPRECATED_PUSH
           emit addVectorLayer( metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
+          Q_NOWARN_DEPRECATED_POP
+          emit addLayer( metadataResult.layerType(), metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
           break;
         }
         case Qgis::LayerType::Mesh:
         {
+          Q_NOWARN_DEPRECATED_PUSH
           emit addMeshLayer( metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
+          Q_NOWARN_DEPRECATED_POP
+          emit addLayer( metadataResult.layerType(), metadataResult.uri(), metadataResult.identifier(), metadataResult.dataProviderName() );
           break;
         }
         default:  // unsupported

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -186,9 +186,11 @@ void QgsVectorTileSourceSelect::addButtonClicked()
 {
   if ( mRadioSourceService->isChecked() )
   {
-
     const QString uri = QgsVectorTileProviderConnection::encodedUri( QgsVectorTileProviderConnection::connection( cmbConnections->currentText() ) );
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorTileLayer( uri, cmbConnections->currentText() );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::VectorTile, uri, cmbConnections->currentText(), QString() );
   }
   else if ( mRadioSourceFile->isChecked() )
   {
@@ -207,7 +209,10 @@ void QgsVectorTileSourceSelect::addButtonClicked()
     parts.insert( QStringLiteral( "path" ), filePath );
     const QString uri = QgsProviderRegistry::instance()->encodeUri( providerKey, parts );
 
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorTileLayer( uri, QgsProviderUtils::suggestLayerNameFromFilePath( filePath ) );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::VectorTile, uri, cmbConnections->currentText(), QString() );
   }
 }
 

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -337,11 +337,17 @@ void QgsArcGisRestSourceSelect::addButtonClicked()
     switch ( serviceType )
     {
       case Qgis::ArcGisRestServiceType::FeatureServer:
+        Q_NOWARN_DEPRECATED_PUSH
         emit addVectorLayer( uri, layerName );
+        Q_NOWARN_DEPRECATED_POP
+        emit addLayer( Qgis::LayerType::Vector, uri, layerName, QStringLiteral( "arcgisfeatureserver" ) );
         break;
 
       case Qgis::ArcGisRestServiceType::MapServer:
+        Q_NOWARN_DEPRECATED_PUSH
         emit addRasterLayer( uri, layerName, QStringLiteral( "arcgismapserver" ) );
+        Q_NOWARN_DEPRECATED_POP
+        emit addLayer( Qgis::LayerType::Raster, uri, layerName, QStringLiteral( "arcgismapserver" ) );
         break;
 
       case Qgis::ArcGisRestServiceType::ImageServer:
@@ -469,7 +475,10 @@ void QgsArcGisRestSourceSelect::buildQueryButtonClicked()
   {
     const QString sql = w->expressionText();
     ds.setSql( sql );
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( ds.uri( false ), layerName );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Vector, ds.uri( false ), layerName, QStringLiteral( "arcgisfeatureserver" ) );
   }
 }
 

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -168,7 +168,10 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
 
   // add the layer to the map
+  Q_NOWARN_DEPRECATED_PUSH
   emit addVectorLayer( datasourceUrl, txtLayerName->text() );
+  Q_NOWARN_DEPRECATED_POP
+  emit addLayer( Qgis::LayerType::Vector, datasourceUrl, txtLayerName->text(), QStringLiteral( "delimitedtext" ) );
 
   // clear the file and layer name show something has happened, ready for another file
 

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -65,9 +65,9 @@ void QgsGpxSourceSelect::addButtonClicked()
     Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mGpxPath + "?type=track",
                          fileInfo.baseName() + ", tracks", QStringLiteral( "gpx" ) );
+    Q_NOWARN_DEPRECATED_POP
     emit addLayer( Qgis::LayerType::Vector, mGpxPath + "?type=track",
                    fileInfo.baseName() + ", tracks", QStringLiteral( "gpx" ) );
-    Q_NOWARN_DEPRECATED_POP
   }
   if ( cbGPXRoutes->isChecked() )
   {

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -61,14 +61,32 @@ void QgsGpxSourceSelect::addButtonClicked()
   }
 
   if ( cbGPXTracks->isChecked() )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mGpxPath + "?type=track",
                          fileInfo.baseName() + ", tracks", QStringLiteral( "gpx" ) );
+    emit addLayer( Qgis::LayerType::Vector, mGpxPath + "?type=track",
+                   fileInfo.baseName() + ", tracks", QStringLiteral( "gpx" ) );
+    Q_NOWARN_DEPRECATED_POP
+  }
   if ( cbGPXRoutes->isChecked() )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mGpxPath + "?type=route",
                          fileInfo.baseName() + ", routes", QStringLiteral( "gpx" ) );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Vector, mGpxPath + "?type=route",
+                   fileInfo.baseName() + ", routes", QStringLiteral( "gpx" ) );
+  }
   if ( cbGPXWaypoints->isChecked() )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mGpxPath + "?type=waypoint",
                          fileInfo.baseName() + ", waypoints", QStringLiteral( "gpx" ) );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Vector, mGpxPath + "?type=waypoint",
+                   fileInfo.baseName() + ", waypoints", QStringLiteral( "gpx" ) );
+  }
 }
 
 void QgsGpxSourceSelect::enableRelevantControls()

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -49,6 +49,9 @@ void QgsMdalSourceSelect::addButtonClicked()
 
   for ( const QString &path : QgsFileWidget::splitFilePaths( mMeshPath ) )
   {
+    Q_NOWARN_DEPRECATED_PUSH
     emit addMeshLayer( path, QFileInfo( path ).completeBaseName(), QStringLiteral( "mdal" ) );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Mesh, path, QFileInfo( path ).completeBaseName(), QStringLiteral( "mdal" ) );
   }
 }

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -419,7 +419,10 @@ void QgsPgSourceSelect::addButtonClicked()
       for ( const auto &u : std::as_const( rasterTables ) )
       {
         // Use "gdal" to proxy rasters to GDAL provider, or "postgresraster" for native PostGIS raster provider
+        Q_NOWARN_DEPRECATED_PUSH
         emit addRasterLayer( u.second, u.first, QLatin1String( "postgresraster" ) );
+        Q_NOWARN_DEPRECATED_POP
+        emit addLayer( Qgis::LayerType::Raster, u.second, u.first, QLatin1String( "postgresraster" ) );
       }
     }
 

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -87,7 +87,7 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   mQueryEdit->setLineNumbersVisible( true );
 
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );
-  connect( mAddLayerBtn, &QAbstractButton::clicked, this, [ = ] { addLayer( true ); } );
+  connect( mAddLayerBtn, &QAbstractButton::clicked, this, [ = ] { addLayerPrivate( true ); } );
   connect( mRemoveLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::removeLayer );
   connect( mImportLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::importLayer );
   connect( mLayersTable->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &QgsVirtualLayerSourceSelect::tableRowChanged );
@@ -307,7 +307,7 @@ void QgsVirtualLayerSourceSelect::testQuery()
   }
 }
 
-void QgsVirtualLayerSourceSelect::addLayer( bool browseForLayer )
+void QgsVirtualLayerSourceSelect::addLayerPrivate( bool browseForLayer )
 {
   mLayersTable->insertRow( mLayersTable->rowCount() );
 
@@ -418,7 +418,7 @@ void QgsVirtualLayerSourceSelect::updateLayersList()
 void QgsVirtualLayerSourceSelect::addEmbeddedLayer( const QString &name, const QString &provider, const QString &encoding, const QString &source )
 {
   // insert a new row
-  addLayer();
+  addLayerPrivate();
   const int n = mLayersTable->rowCount() - 1;
   // local name
   mLayersTable->item( n, LayerColumn::Name )->setText( name );
@@ -488,7 +488,10 @@ void QgsVirtualLayerSourceSelect::addButtonClicked()
     }
     else
     {
+      Q_NOWARN_DEPRECATED_PUSH
       emit addVectorLayer( def.toString(), layerName, QStringLiteral( "virtual" ) );
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::Vector, def.toString(), layerName, QStringLiteral( "virtual" ) );
     }
   }
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::None )

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -80,7 +80,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void testQuery();
     void browseCRS();
     void layerComboChanged( int );
-    void addLayer( bool browseForLayer = false );
+    void addLayerPrivate( bool browseForLayer = false );
     void removeLayer();
     void importLayer();
     void tableRowChanged( const QModelIndex &current, const QModelIndex &previous );

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -164,7 +164,10 @@ void QgsWCSSourceSelect::addButtonClicked()
   cache = QgsNetworkAccessManager::cacheLoadControlName( selectedCacheLoadControl() );
   uri.setParam( QStringLiteral( "cache" ), cache );
 
+  Q_NOWARN_DEPRECATED_PUSH
   emit addRasterLayer( uri.encodedUri(), identifier, QStringLiteral( "wcs" ) );
+  Q_NOWARN_DEPRECATED_POP
+  emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(), identifier, QStringLiteral( "wcs" ) );
 }
 
 

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -26,7 +26,6 @@
 #include "qgsprojectionselectiondialog.h"
 #include "qgsproject.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgscoordinatetransform.h"
 #include "qgslogger.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgsoapifprovider.h"
@@ -543,7 +542,10 @@ void QgsWFSSourceSelect::addButtonClicked()
                                        isOapif() ? sql : QString(),
                                        cbxFeatureCurrentViewExtent->isChecked() );
 
+    Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mUri, layerName, isOapif() ? QgsOapifProvider::OAPIF_PROVIDER_KEY : QgsWFSProvider::WFS_PROVIDER_KEY );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Vector, mUri, layerName, isOapif() ? QgsOapifProvider::OAPIF_PROVIDER_KEY : QgsWFSProvider::WFS_PROVIDER_KEY );
   }
 
   if ( ! mHoldDialogOpen->isChecked() && widgetMode() == QgsProviderRegistry::WidgetMode::None )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -618,9 +618,14 @@ void QgsWMSSourceSelect::addButtonClicked()
       individualUri.setParam( QStringLiteral( "layers" ), layers.at( i ) );
       individualUri.setParam( QStringLiteral( "styles" ), styles.at( i ) );
 
+      Q_NOWARN_DEPRECATED_PUSH
       emit addRasterLayer( individualUri.encodedUri(),
                            titles.at( i ),
                            QStringLiteral( "wms" ) );
+      Q_NOWARN_DEPRECATED_POP
+      emit addLayer( Qgis::LayerType::Raster, individualUri.encodedUri(),
+                     titles.at( i ),
+                     QStringLiteral( "wms" ) );
     }
 
   }
@@ -629,9 +634,14 @@ void QgsWMSSourceSelect::addButtonClicked()
     uri.setParam( QStringLiteral( "layers" ), layers );
     uri.setParam( QStringLiteral( "styles" ), styles );
 
+    Q_NOWARN_DEPRECATED_PUSH
     emit addRasterLayer( uri.encodedUri(),
                          leLayerName->text().isEmpty() ? titles.join( QLatin1Char( '/' ) ) : leLayerName->text(),
                          QStringLiteral( "wms" ) );
+    Q_NOWARN_DEPRECATED_POP
+    emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(),
+                   leLayerName->text().isEmpty() ? titles.join( QLatin1Char( '/' ) ) : leLayerName->text(),
+                   QStringLiteral( "wms" ) );
   }
 }
 

--- a/src/providers/wms/qgsxyzsourceselect.cpp
+++ b/src/providers/wms/qgsxyzsourceselect.cpp
@@ -134,7 +134,10 @@ void QgsXyzSourceSelect::btnLoad_clicked()
 void QgsXyzSourceSelect::addButtonClicked()
 {
   const bool isCustom = cmbConnections->currentData().toString() == QLatin1String( "~~custom~~" );
+  Q_NOWARN_DEPRECATED_PUSH
   emit addRasterLayer( mSourceWidget->sourceUri(), isCustom ? tr( "XYZ Layer" ) : cmbConnections->currentText(), QStringLiteral( "wms" ) );
+  Q_NOWARN_DEPRECATED_POP
+  emit addLayer( Qgis::LayerType::Raster, mSourceWidget->sourceUri(), isCustom ? tr( "XYZ Layer" ) : cmbConnections->currentText(), QStringLiteral( "wms" ) );
 }
 
 void QgsXyzSourceSelect::populateConnectionList()


### PR DESCRIPTION
The intention here is to remove some unnecessarily layer-type specific code and replace with generic methods that can handle any layer type.