### PR TITLE
HANA: Set sessionVariable:APPLICATION in connection string

### DIFF
--- a/src/providers/hana/qgshanaconnectionstringbuilder.cpp
+++ b/src/providers/hana/qgshanaconnectionstringbuilder.cpp
@@ -15,6 +15,7 @@
  *
  ***************************************************************************/
 #include "qgshanaconnectionstringbuilder.h"
+#include "qgis.h"
 #include <QRegularExpression>
 
 QgsHanaConnectionStringBuilder::QgsHanaConnectionStringBuilder( const QgsDataSourceUri &uri )
@@ -115,6 +116,7 @@ QString QgsHanaConnectionStringBuilder::toString() const
   }
 
   addProperty( QStringLiteral( "CHAR_AS_UTF8" ), QStringLiteral( "1" ) );
+  addProperty( QStringLiteral( "sessionVariable:APPLICATION" ), QStringLiteral( "QGIS %1" ).arg( Qgis::version() ) );
 
   return props.join( QLatin1Char( ';' ) );
 }


### PR DESCRIPTION
This PR allows to inform HANA that a connected client is QGIS.

No backport is needed.