### PR TITLE
MSSQL: fix geom type detection when no metadata are used

### DIFF
--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -66,7 +66,7 @@ void QgsMssqlGeomColumnTypeThread::run()
                                             " [%1].HasM"
                                             " FROM %2"
                                             " WHERE [%1] IS NOT NULL %4"
-                                            " GROUP BY [%1].STGeometryType(), [%1].STSrid" )
+                                            " GROUP BY [%1].STGeometryType(), [%1].STSrid, [%1].HasZ, [%1].HasM" )
                             .arg( layerProperty.geometryColName,
                                   table,
                                   mUseEstimatedMetadata ? "TOP 1" : "",

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1940,6 +1940,10 @@ QgsCoordinateReferenceSystem QgsMssqlProvider::crs() const
       if ( mCrs.isValid() )
         return mCrs;
     }
+    else  // try to load as EPSG
+    {
+      mCrs = QgsCoordinateReferenceSystem::fromEpsgId( mSRId );
+    }
   }
   return mCrs;
 }


### PR DESCRIPTION
Fix #53614

