### PR TITLE
Hookup tiled mesh layer data provider creation, add empty shell for a future Cesium tiles provider

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2648,6 +2648,7 @@ void QgisApp::dataSourceManager( const QString &pageName )
           addPointCloudLayer( uri, baseName, providerKey );
           break;
 
+        case Qgis::LayerType::TiledMesh:
         case Qgis::LayerType::Plugin:
         case Qgis::LayerType::Annotation:
         case Qgis::LayerType::Group:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -336,6 +336,7 @@ set(QGIS_CORE_SRCS
   textrenderer/qgstextrendererutils.cpp
   textrenderer/qgstextshadowsettings.cpp
 
+  tiledmesh/qgscesiumtilesdataprovider.cpp
   tiledmesh/qgstiledmeshdataprovider.cpp
   tiledmesh/qgstiledmeshlayer.cpp
 
@@ -1890,6 +1891,7 @@ set(QGIS_CORE_HDRS
   textrenderer/qgstextrendererutils.h
   textrenderer/qgstextshadowsettings.h
 
+  tiledmesh/qgscesiumtilesdataprovider.h
   tiledmesh/qgstiledmeshdataprovider.h
   tiledmesh/qgstiledmeshlayer.h
 

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -38,6 +38,8 @@
 #include "qgsxyzvectortiledataprovider.h"
 #include "qgsvtpkvectortiledataprovider.h"
 
+#include "qgscesiumtilesdataprovider.h"
+
 #ifdef HAVE_EPT
 #include "providers/ept/qgseptprovider.h"
 #endif
@@ -225,6 +227,12 @@ void QgsProviderRegistry::init()
   }
 #endif
   registerUnusableUriHandler( new PdalUnusableUriHandlerInterface() );
+
+  {
+    const QgsScopedRuntimeProfile profile( QObject::tr( "Create tiled mesh providers" ) );
+    QgsProviderMetadata *metadata = new QgsCesiumTilesProviderMetadata();
+    mProviders[ metadata->key() ] = metadata;
+  }
 
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();

--- a/src/core/tiledmesh/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledmesh/qgscesiumtilesdataprovider.cpp
@@ -26,7 +26,7 @@
 
 ///@cond PRIVATE
 
-#define PROVIDER_KEY QStringLiteral( "cesium" )
+#define PROVIDER_KEY QStringLiteral( "cesiumtiles" )
 #define PROVIDER_DESCRIPTION QStringLiteral( "Cesium 3D Tiles data provider" )
 
 QgsCesiumTilesDataProvider::QgsCesiumTilesDataProvider( const QString &uri, const ProviderOptions &providerOptions, ReadFlags flags )

--- a/src/core/tiledmesh/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledmesh/qgscesiumtilesdataprovider.cpp
@@ -1,0 +1,183 @@
+/***************************************************************************
+                         qgscesiumtilesdataprovider.cpp
+                         --------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscesiumtilesdataprovider.h"
+#include "qgsproviderutils.h"
+#include "qgsapplication.h"
+#include "qgsprovidersublayerdetails.h"
+#include "qgsthreadingutils.h"
+
+#include <QUrl>
+#include <QIcon>
+
+///@cond PRIVATE
+
+#define PROVIDER_KEY QStringLiteral( "cesium" )
+#define PROVIDER_DESCRIPTION QStringLiteral( "Cesium 3D Tiles data provider" )
+
+QgsCesiumTilesDataProvider::QgsCesiumTilesDataProvider( const QString &uri, const ProviderOptions &providerOptions, ReadFlags flags )
+  : QgsTiledMeshDataProvider( uri, providerOptions, flags )
+{
+
+}
+
+QgsCesiumTilesDataProvider::~QgsCesiumTilesDataProvider() = default;
+
+QgsCoordinateReferenceSystem QgsCesiumTilesDataProvider::crs() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  // TODO
+  return QgsCoordinateReferenceSystem();
+}
+
+QgsRectangle QgsCesiumTilesDataProvider::extent() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  // TODO
+  return QgsRectangle();
+}
+
+bool QgsCesiumTilesDataProvider::isValid() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  // TODO
+  return true;
+}
+
+QString QgsCesiumTilesDataProvider::name() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return PROVIDER_KEY;
+}
+
+QString QgsCesiumTilesDataProvider::description() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QObject::tr( "Cesium 3D Tiles" );
+}
+
+//
+// QgsCesiumTilesProviderMetadata
+//
+
+QgsCesiumTilesProviderMetadata::QgsCesiumTilesProviderMetadata():
+  QgsProviderMetadata( PROVIDER_KEY, PROVIDER_DESCRIPTION )
+{
+}
+
+QIcon QgsCesiumTilesProviderMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "xxxcesiumxxx.svg" ) );
+}
+
+QgsCesiumTilesDataProvider *QgsCesiumTilesProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
+{
+  return new QgsCesiumTilesDataProvider( uri, options, flags );
+}
+
+QList<QgsProviderSublayerDetails> QgsCesiumTilesProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags, QgsFeedback * ) const
+{
+  const QVariantMap parts = decodeUri( uri );
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "tileset.json" ), Qt::CaseInsensitive ) == 0 )
+  {
+    QgsProviderSublayerDetails details;
+    details.setUri( uri );
+    details.setProviderKey( PROVIDER_KEY );
+    details.setType( Qgis::LayerType::TiledMesh );
+    details.setName( QgsProviderUtils::suggestLayerNameFromFilePath( uri ) );
+    return {details};
+  }
+  else
+  {
+    return {};
+  }
+}
+
+int QgsCesiumTilesProviderMetadata::priorityForUri( const QString &uri ) const
+{
+  const QVariantMap parts = decodeUri( uri );
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "tileset.json" ), Qt::CaseInsensitive ) == 0 )
+    return 100;
+
+  return 0;
+}
+
+QList<Qgis::LayerType> QgsCesiumTilesProviderMetadata::validLayerTypesForUri( const QString &uri ) const
+{
+  const QVariantMap parts = decodeUri( uri );
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "tileset.json" ), Qt::CaseInsensitive ) == 0 )
+    return QList< Qgis::LayerType>() << Qgis::LayerType::TiledMesh;
+
+  return QList< Qgis::LayerType>();
+}
+
+QVariantMap QgsCesiumTilesProviderMetadata::decodeUri( const QString &uri ) const
+{
+  QVariantMap uriComponents;
+  QUrl url = QUrl::fromUserInput( uri );
+  uriComponents.insert( QStringLiteral( "file-name" ), url.fileName() );
+  uriComponents.insert( QStringLiteral( "path" ), uri );
+  return uriComponents;
+}
+
+QString QgsCesiumTilesProviderMetadata::filters( Qgis::FileFilterType type )
+{
+  switch ( type )
+  {
+    case Qgis::FileFilterType::Vector:
+    case Qgis::FileFilterType::Raster:
+    case Qgis::FileFilterType::Mesh:
+    case Qgis::FileFilterType::MeshDataset:
+    case Qgis::FileFilterType::VectorTile:
+    case Qgis::FileFilterType::PointCloud:
+      return QString();
+
+    case Qgis::FileFilterType::TiledMesh:
+      return QObject::tr( "Cesium 3D Tiles" ) + QStringLiteral( " (tileset.json TILESET.JSON)" );
+  }
+  return QString();
+}
+
+QgsProviderMetadata::ProviderCapabilities QgsCesiumTilesProviderMetadata::providerCapabilities() const
+{
+  return FileBasedUris;
+}
+
+QList<Qgis::LayerType> QgsCesiumTilesProviderMetadata::supportedLayerTypes() const
+{
+  return { Qgis::LayerType::TiledMesh };
+}
+
+QString QgsCesiumTilesProviderMetadata::encodeUri( const QVariantMap &parts ) const
+{
+  const QString path = parts.value( QStringLiteral( "path" ) ).toString();
+  return path;
+}
+
+QgsProviderMetadata::ProviderMetadataCapabilities QgsCesiumTilesProviderMetadata::capabilities() const
+{
+  return ProviderMetadataCapability::LayerTypesForUri
+         | ProviderMetadataCapability::PriorityForUri
+         | ProviderMetadataCapability::QuerySublayers;
+}
+
+///@endcond

--- a/src/core/tiledmesh/qgscesiumtilesdataprovider.h
+++ b/src/core/tiledmesh/qgscesiumtilesdataprovider.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+                         qgscesiumtilesdataprovider.h
+                         --------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ******************************************************************
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCESIUMTILESDATAPROVIDER_H
+#define QGSCESIUMTILESDATAPROVIDER_H
+
+#include "qgis_core.h"
+#include "qgstiledmeshdataprovider.h"
+#include "qgis.h"
+#include "qgsprovidermetadata.h"
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+class CORE_EXPORT QgsCesiumTilesDataProvider: public QgsTiledMeshDataProvider
+{
+    Q_OBJECT
+  public:
+
+
+    //! Constructor for QgsCesiumTilesDataProvider
+    QgsCesiumTilesDataProvider( const QString &uri,
+                                const QgsDataProvider::ProviderOptions &providerOptions,
+                                QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
+
+    ~QgsCesiumTilesDataProvider() override;
+
+    QgsCoordinateReferenceSystem crs() const override;
+    QgsRectangle extent() const override;
+    bool isValid() const override;
+    QString name() const override;
+    QString description() const override;
+
+};
+
+
+class QgsCesiumTilesProviderMetadata : public QgsProviderMetadata
+{
+    Q_OBJECT
+
+  public:
+    QgsCesiumTilesProviderMetadata();
+    QIcon icon() const override;
+    QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
+    QgsCesiumTilesDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
+    QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+    int priorityForUri( const QString &uri ) const override;
+    QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const override;
+    QString encodeUri( const QVariantMap &parts ) const override;
+    QVariantMap decodeUri( const QString &uri ) const override;
+    QString filters( Qgis::FileFilterType type ) override;
+    ProviderCapabilities providerCapabilities() const override;
+    QList< Qgis::LayerType > supportedLayerTypes() const override;
+};
+
+///@endcond
+
+#endif // QGSCESIUMTILESDATAPROVIDER_H

--- a/src/core/tiledmesh/qgstiledmeshlayer.cpp
+++ b/src/core/tiledmesh/qgstiledmeshlayer.cpp
@@ -22,6 +22,8 @@
 #include "qgsproviderregistry.h"
 #include "qgslayermetadataformatter.h"
 #include "qgsxmlutils.h"
+#include "qgsruntimeprofiler.h"
+#include "qgsapplication.h"
 
 QgsTiledMeshLayer::QgsTiledMeshLayer( const QString &uri,
                                       const QString &baseName,
@@ -274,7 +276,7 @@ void QgsTiledMeshLayer::setTransformContext( const QgsCoordinateTransformContext
 }
 
 void QgsTiledMeshLayer::setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
-    const QgsDataProvider::ProviderOptions &, QgsDataProvider::ReadFlags flags )
+    const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -282,19 +284,17 @@ void QgsTiledMeshLayer::setDataSourcePrivate( const QString &dataSource, const Q
   mProviderKey = provider;
   mDataSource = dataSource;
 
-#if 0
   if ( mPreloadedProvider )
   {
-    mDataProvider.reset( qobject_cast< QgsPointCloudDataProvider * >( mPreloadedProvider.release() ) );
+    mDataProvider.reset( qobject_cast< QgsTiledMeshDataProvider * >( mPreloadedProvider.release() ) );
   }
   else
   {
     std::unique_ptr< QgsScopedRuntimeProfile > profile;
     if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
       profile = std::make_unique< QgsScopedRuntimeProfile >( tr( "Create %1 provider" ).arg( provider ), QStringLiteral( "projectload" ) );
-    mDataProvider.reset( qobject_cast<QgsPointCloudDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options, flags ) ) );
+    mDataProvider.reset( qobject_cast<QgsTiledMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options, flags ) ) );
   }
-#endif
 
   if ( !mDataProvider )
   {

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -232,6 +232,10 @@ void QgsDataSourceManagerDialog::makeConnections( QgsAbstractDataSourceWidget *d
         // for compatibility with older API, we ignore these signals and rely on the older granular signals (eg "addVectorLayer").
         // otherwise we will be emitting double signals for the old/new signal for these layer types
         break;
+
+      case Qgis::LayerType::TiledMesh:
+        emit addLayer( type, url, baseName, providerKey );
+        break;
     }
   } );
 

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -196,13 +196,17 @@ class TestQgsProviderRegistry(unittest.TestCase):
         Test fileTiledMeshFilters()
         """
         registry = QgsProviderRegistry.instance()
-        self.assertFalse(registry.fileTiledMeshFilters())
+        self.assertEqual(registry.fileTiledMeshFilters(),
+                         'All Supported Files (tileset.json TILESET.JSON);;'
+                         'All Files (*.*);;'
+                         'Cesium 3D Tiles (tileset.json TILESET.JSON)')
 
         registry.registerProvider(TestProviderTiledMeshMetadata('slpk'))
         self.assertEqual(
             registry.fileTiledMeshFilters(),
-            'All Supported Files (*.slpk *.SLPK);;'
+            'All Supported Files (tileset.json TILESET.JSON *.slpk *.SLPK);;'
             'All Files (*.*);;'
+            'Cesium 3D Tiles (tileset.json TILESET.JSON);;'
             'Scene Layer Packages (*.slpk *.SLPK)'
         )
 

--- a/tests/src/python/test_qgstiledmeshlayer.py
+++ b/tests/src/python/test_qgstiledmeshlayer.py
@@ -15,10 +15,13 @@ from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtGui import QPainter
 
 from qgis.core import (
+    Qgis,
     QgsTiledMeshLayer,
     QgsReadWriteContext,
     QgsLayerNotesUtils,
-    QgsMapLayer
+    QgsMapLayer,
+    QgsTiledMeshDataProvider,
+    QgsProviderRegistry
 )
 from qgis.testing import start_app, unittest
 
@@ -29,12 +32,22 @@ start_app()
 
 class TestQgsTiledMeshLayer(unittest.TestCase):
 
+    def test_data_provider(self):
+        """
+        Test data provider creation
+        """
+        layer = QgsTiledMeshLayer('/home/me/test/tileset.json', 'my layer', 'cesium')
+        self.assertEqual(layer.providerType(), 'cesium')
+        self.assertIsInstance(layer.dataProvider(), QgsTiledMeshDataProvider)
+        self.assertEqual(layer.dataProvider().name(), 'cesium')
+        self.assertEqual(layer.dataProvider().dataSourceUri(), '/home/me/test/tileset.json')
+
     def test_read_write_xml(self):
         """
         Test saving and restoring layer from xml
         """
-        layer = QgsTiledMeshLayer('uri', 'my layer', 'tiled_mesh')
-        self.assertEqual(layer.providerType(), 'tiled_mesh')
+        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesium')
+        self.assertEqual(layer.providerType(), 'cesium')
         layer.setOpacity(0.25)
         layer.setBlendMode(QPainter.CompositionMode_Darken)
 
@@ -44,7 +57,7 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
 
         layer2 = QgsTiledMeshLayer('uri2', 'my layer 2', 'xtiled_meshx')
         layer2.readXml(elem, QgsReadWriteContext())
-        self.assertEqual(layer2.providerType(), 'tiled_mesh')
+        self.assertEqual(layer2.providerType(), 'cesium')
         self.assertEqual(layer2.opacity(), 0.25)
         self.assertEqual(layer2.blendMode(),
                          QPainter.CompositionMode_Darken)
@@ -53,14 +66,14 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
         """
         Test cloning layers
         """
-        layer = QgsTiledMeshLayer('uri', 'my layer', 'tiled_mesh')
-        self.assertEqual(layer.providerType(), 'tiled_mesh')
+        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesium')
+        self.assertEqual(layer.providerType(), 'cesium')
         layer.setOpacity(0.25)
         layer.setBlendMode(QPainter.CompositionMode_Darken)
 
         layer2 = layer.clone()
         self.assertEqual(layer2.source(), 'uri')
-        self.assertEqual(layer2.providerType(), 'tiled_mesh')
+        self.assertEqual(layer2.providerType(), 'cesium')
         self.assertEqual(layer2.opacity(), 0.25)
         self.assertEqual(layer2.blendMode(),
                          QPainter.CompositionMode_Darken)
@@ -131,6 +144,26 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
             layer.writeSymbology(elem, doc, error, context, QgsMapLayer.Notes))
         layer2.readSymbology(elem, error, context, QgsMapLayer.Notes)
         self.assertEqual(QgsLayerNotesUtils.layerNotes(layer2), 'my notes')
+
+    def test_cesium_provider_metadata(self):
+        """
+        Test cesium provider metadata methods
+        """
+        self.assertIn(
+            'cesium',
+            QgsProviderRegistry.instance().providersForLayerType(Qgis.LayerType.TiledMesh)
+        )
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('cesium')
+        self.assertIsNotNone(metadata)
+
+        self.assertEqual(metadata.decodeUri('/home/me/test/tileset.json'),
+                         {'file-name': 'tileset.json', 'path': '/home/me/test/tileset.json'})
+        self.assertEqual(
+            metadata.encodeUri(
+                {'file-name': 'tileset.json', 'path': '/home/me/test/tileset.json'}
+            ),
+            '/home/me/test/tileset.json')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgstiledmeshlayer.py
+++ b/tests/src/python/test_qgstiledmeshlayer.py
@@ -36,18 +36,18 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
         """
         Test data provider creation
         """
-        layer = QgsTiledMeshLayer('/home/me/test/tileset.json', 'my layer', 'cesium')
-        self.assertEqual(layer.providerType(), 'cesium')
+        layer = QgsTiledMeshLayer('/home/me/test/tileset.json', 'my layer', 'cesiumtiles')
+        self.assertEqual(layer.providerType(), 'cesiumtiles')
         self.assertIsInstance(layer.dataProvider(), QgsTiledMeshDataProvider)
-        self.assertEqual(layer.dataProvider().name(), 'cesium')
+        self.assertEqual(layer.dataProvider().name(), 'cesiumtiles')
         self.assertEqual(layer.dataProvider().dataSourceUri(), '/home/me/test/tileset.json')
 
     def test_read_write_xml(self):
         """
         Test saving and restoring layer from xml
         """
-        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesium')
-        self.assertEqual(layer.providerType(), 'cesium')
+        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesiumtiles')
+        self.assertEqual(layer.providerType(), 'cesiumtiles')
         layer.setOpacity(0.25)
         layer.setBlendMode(QPainter.CompositionMode_Darken)
 
@@ -57,7 +57,7 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
 
         layer2 = QgsTiledMeshLayer('uri2', 'my layer 2', 'xtiled_meshx')
         layer2.readXml(elem, QgsReadWriteContext())
-        self.assertEqual(layer2.providerType(), 'cesium')
+        self.assertEqual(layer2.providerType(), 'cesiumtiles')
         self.assertEqual(layer2.opacity(), 0.25)
         self.assertEqual(layer2.blendMode(),
                          QPainter.CompositionMode_Darken)
@@ -66,14 +66,14 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
         """
         Test cloning layers
         """
-        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesium')
-        self.assertEqual(layer.providerType(), 'cesium')
+        layer = QgsTiledMeshLayer('uri', 'my layer', 'cesiumtiles')
+        self.assertEqual(layer.providerType(), 'cesiumtiles')
         layer.setOpacity(0.25)
         layer.setBlendMode(QPainter.CompositionMode_Darken)
 
         layer2 = layer.clone()
         self.assertEqual(layer2.source(), 'uri')
-        self.assertEqual(layer2.providerType(), 'cesium')
+        self.assertEqual(layer2.providerType(), 'cesiumtiles')
         self.assertEqual(layer2.opacity(), 0.25)
         self.assertEqual(layer2.blendMode(),
                          QPainter.CompositionMode_Darken)
@@ -150,11 +150,11 @@ class TestQgsTiledMeshLayer(unittest.TestCase):
         Test cesium provider metadata methods
         """
         self.assertIn(
-            'cesium',
+            'cesiumtiles',
             QgsProviderRegistry.instance().providersForLayerType(Qgis.LayerType.TiledMesh)
         )
 
-        metadata = QgsProviderRegistry.instance().providerMetadata('cesium')
+        metadata = QgsProviderRegistry.instance().providerMetadata('cesiumtiles')
         self.assertIsNotNone(metadata)
 
         self.assertEqual(metadata.decodeUri('/home/me/test/tileset.json'),


### PR DESCRIPTION
Another non-functional building block for future tiled mesh data providers.

(The next PR will be where the interesting stuff starts, because that's when I plan on refactoring a bunch of the existing layer/provider handling code to make it easier to introduce new layer types without introducing a ton of code duplication...)