### PR TITLE
Add provider connection implementation for tiled mesh connections

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -337,6 +337,7 @@ set(QGIS_CORE_SRCS
   textrenderer/qgstextshadowsettings.cpp
 
   tiledmesh/qgscesiumtilesdataprovider.cpp
+  tiledmesh/qgstiledmeshconnection.cpp
   tiledmesh/qgstiledmeshdataprovider.cpp
   tiledmesh/qgstiledmeshlayer.cpp
 
@@ -1892,6 +1893,7 @@ set(QGIS_CORE_HDRS
   textrenderer/qgstextshadowsettings.h
 
   tiledmesh/qgscesiumtilesdataprovider.h
+  tiledmesh/qgstiledmeshconnection.h
   tiledmesh/qgstiledmeshdataprovider.h
   tiledmesh/qgstiledmeshlayer.h
 

--- a/src/core/tiledmesh/qgstiledmeshconnection.cpp
+++ b/src/core/tiledmesh/qgstiledmeshconnection.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+    qgstiledmeshconnection.cpp
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshconnection.h"
+
+#include "qgsdatasourceuri.h"
+#include "qgshttpheaders.h"
+#include "qgssettingsentryimpl.h"
+
+
+#include <QFileInfo>
+
+///@cond PRIVATE
+
+
+const QgsSettingsEntryString *QgsTiledMeshProviderConnection::settingsProvider = new QgsSettingsEntryString( QStringLiteral( "provider" ), sTreeConnectionTiledMesh );
+const QgsSettingsEntryString *QgsTiledMeshProviderConnection::settingsUrl = new QgsSettingsEntryString( QStringLiteral( "url" ), sTreeConnectionTiledMesh );
+const QgsSettingsEntryString *QgsTiledMeshProviderConnection::settingsAuthcfg = new QgsSettingsEntryString( QStringLiteral( "authcfg" ), sTreeConnectionTiledMesh );
+const QgsSettingsEntryString *QgsTiledMeshProviderConnection::settingsUsername = new QgsSettingsEntryString( QStringLiteral( "username" ), sTreeConnectionTiledMesh );
+const QgsSettingsEntryString *QgsTiledMeshProviderConnection::settingsPassword = new QgsSettingsEntryString( QStringLiteral( "password" ), sTreeConnectionTiledMesh );
+const QgsSettingsEntryVariantMap *QgsTiledMeshProviderConnection::settingsHeaders = new QgsSettingsEntryVariantMap( QStringLiteral( "http-header" ), sTreeConnectionTiledMesh );
+
+///@endcond
+
+QString QgsTiledMeshProviderConnection::encodedUri( const QgsTiledMeshProviderConnection::Data &data )
+{
+  QgsDataSourceUri uri;
+
+  if ( !data.url.isEmpty() )
+    uri.setParam( QStringLiteral( "url" ), data.url );
+  if ( !data.authCfg.isEmpty() )
+    uri.setAuthConfigId( data.authCfg );
+  if ( !data.username.isEmpty() )
+    uri.setUsername( data.username );
+  if ( !data.password.isEmpty() )
+    uri.setPassword( data.password );
+
+  uri.setHttpHeaders( data.httpHeaders );
+
+  return uri.encodedUri();
+}
+
+QgsTiledMeshProviderConnection::Data QgsTiledMeshProviderConnection::decodedUri( const QString &uri )
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( uri );
+
+  QgsTiledMeshProviderConnection::Data conn;
+  conn.url = dsUri.param( QStringLiteral( "url" ) );
+  conn.authCfg = dsUri.authConfigId();
+  conn.username = dsUri.username();
+  conn.password = dsUri.password();
+  conn.httpHeaders = dsUri.httpHeaders();
+
+  return conn;
+}
+
+QString QgsTiledMeshProviderConnection::encodedLayerUri( const QgsTiledMeshProviderConnection::Data &data )
+{
+  QgsDataSourceUri uri;
+
+  uri.setParam( QStringLiteral( "url" ), data.url );
+  if ( !data.authCfg.isEmpty() )
+    uri.setAuthConfigId( data.authCfg );
+  if ( !data.username.isEmpty() )
+    uri.setUsername( data.username );
+  if ( !data.password.isEmpty() )
+    uri.setPassword( data.password );
+
+  uri.setHttpHeaders( data.httpHeaders );
+
+  return uri.encodedUri();
+}
+
+QStringList QgsTiledMeshProviderConnection::connectionList()
+{
+  return QgsTiledMeshProviderConnection::sTreeConnectionTiledMesh->items();
+}
+
+QgsTiledMeshProviderConnection::Data QgsTiledMeshProviderConnection::connection( const QString &name )
+{
+  if ( !settingsUrl->exists( name ) )
+    return QgsTiledMeshProviderConnection::Data();
+
+  QgsTiledMeshProviderConnection::Data conn;
+  conn.provider = settingsProvider->value( name );
+  conn.url = settingsUrl->value( name );
+  conn.authCfg = settingsAuthcfg->value( name );
+  conn.username = settingsUsername->value( name );
+  conn.password = settingsPassword->value( name );
+
+  if ( settingsHeaders->exists( name ) )
+    conn.httpHeaders = QgsHttpHeaders( settingsHeaders->value( name ) );
+
+  return conn;
+}
+
+void QgsTiledMeshProviderConnection::addConnection( const QString &name, const Data &conn )
+{
+  settingsProvider->setValue( conn.provider, name );
+  settingsUrl->setValue( conn.url, name );
+  settingsAuthcfg->setValue( conn.authCfg, name );
+  settingsUsername->setValue( conn.username, name );
+  settingsPassword->setValue( conn.password, name );
+  settingsHeaders->setValue( conn.httpHeaders.headers(), name );
+}
+
+QString QgsTiledMeshProviderConnection::selectedConnection()
+{
+  return sTreeConnectionTiledMesh->selectedItem();
+}
+
+void QgsTiledMeshProviderConnection::setSelectedConnection( const QString &name )
+{
+  sTreeConnectionTiledMesh->setSelectedItem( name );
+}
+
+QgsTiledMeshProviderConnection::QgsTiledMeshProviderConnection( const QString &name )
+  : QgsAbstractProviderConnection( name )
+{
+  const QgsTiledMeshProviderConnection::Data connectionData = connection( name );
+  mProvider = connectionData.provider;
+  setUri( encodedUri( connectionData ) );
+}
+
+QgsTiledMeshProviderConnection::QgsTiledMeshProviderConnection( const QString &uri, const QString &provider, const QVariantMap &configuration )
+  : QgsAbstractProviderConnection( uri, configuration )
+  , mProvider( provider )
+{
+}
+
+void QgsTiledMeshProviderConnection::store( const QString &name ) const
+{
+  QgsTiledMeshProviderConnection::Data connectionData = decodedUri( uri() );
+  connectionData.provider = mProvider;
+  addConnection( name, connectionData );
+}
+
+void QgsTiledMeshProviderConnection::remove( const QString &name ) const
+{
+  sTreeConnectionTiledMesh->deleteItem( name );
+}

--- a/src/core/tiledmesh/qgstiledmeshconnection.h
+++ b/src/core/tiledmesh/qgstiledmeshconnection.h
@@ -1,0 +1,168 @@
+/***************************************************************************
+    qgstiledmeshconnection.h
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHCONNECTION_H
+#define QGSTILEDMESHCONNECTION_H
+
+#include "qgis_core.h"
+#include "qgssettingstree.h"
+#include "qgssettingstreenode.h"
+
+#define SIP_NO_FILE
+
+#include <QStringList>
+
+#include "qgsabstractproviderconnection.h"
+#include "qgshttpheaders.h"
+
+class QgsSettingsEntryString;
+class QgsSettingsEntryInteger;
+class QgsSettingsEntryVariantMap;
+
+/**
+ * \brief Represents connections to tiled mesh data sources.
+ *
+ * \ingroup core
+ * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.34
+ */
+class CORE_EXPORT QgsTiledMeshProviderConnection : public QgsAbstractProviderConnection
+{
+
+  public:
+
+#ifndef SIP_RUN
+
+    ///@cond PRIVATE
+    static inline QgsSettingsTreeNamedListNode *sTreeConnectionTiledMesh = QgsSettingsTree::sTreeConnections->createNamedListNode( QStringLiteral( "tiled-mesh" ), Qgis::SettingsTreeNodeOption::NamedListSelectedItemSetting );
+
+    static const QgsSettingsEntryString *settingsProvider;
+    static const QgsSettingsEntryString *settingsUrl;
+    static const QgsSettingsEntryString *settingsAuthcfg;
+    static const QgsSettingsEntryString *settingsUsername;
+    static const QgsSettingsEntryString *settingsPassword;
+    static const QgsSettingsEntryVariantMap *settingsHeaders;
+
+    ///@endcond PRIVATE
+#endif
+
+    /**
+     * Constructor for QgsTiledMeshProviderConnection, using the stored settings with the specified connection \a name.
+     */
+    QgsTiledMeshProviderConnection( const QString &name );
+
+    /**
+     * Constructor for QgsTiledMeshProviderConnection, using the a specific connection \a uri, \a provider name and \a configuration.
+     */
+    QgsTiledMeshProviderConnection( const QString &uri, const QString &provider, const QVariantMap &configuration );
+
+    virtual void store( const QString &name ) const override;
+    virtual void remove( const QString &name ) const override;
+
+    /**
+     * Returns the data provider associated with the connection.
+     */
+    QString providerKey() const { return mProvider; }
+
+    /**
+    * \brief Represents decoded data of a tiled mesh connection.
+    *
+    * \ingroup core
+    * \note Not available in Python bindings.
+    *
+    * \since QGIS 3.34
+    */
+    struct Data
+    {
+      //! Provider key
+      QString provider;
+
+      //! Source URI
+      QString url;
+
+      //! Authentication configuration ID
+      QString authCfg;
+
+      //! HTTP Basic username
+      QString username;
+
+      //! HTTP Basic password
+      QString password;
+
+      //! HTTP headers
+      QgsHttpHeaders httpHeaders;
+
+    };
+
+    /**
+     * Returns connection \a data encoded as a string.
+     *
+     * \see encodedLayerUri()
+     * \see decodedUri()
+     */
+    static QString encodedUri( const Data &data );
+
+    /**
+     * Returns a connection \a uri decoded to a data structure.
+     *
+     * \see encodedUri()
+     * \see encodedLayerUri()
+     */
+    static Data decodedUri( const QString &uri );
+
+    /**
+     * Returns connection \a data encoded as a string containing a URI for a QgsTiledMeshLayer.
+     *
+     * \see encodedUri()
+     * \see decodedUri()
+     */
+    static QString encodedLayerUri( const Data &data );
+
+    /**
+     * Returns a list of the stored connection names.
+     */
+    static QStringList connectionList();
+
+    /**
+     * Returns connection details for the stored connection with the specified \a name.
+     */
+    static Data connection( const QString &name );
+
+    /**
+     * Stores a new \a connection, under the specified connection \a name.
+     */
+    static void addConnection( const QString &name, const Data &connection );
+
+    /**
+     * Returns the name of the last used connection.
+     *
+     * \see setSelectedConnection()
+     */
+    static QString selectedConnection();
+
+    /**
+     * Stores the \a name of the last used connection.
+     *
+     * \see selectedConnection()
+     */
+    static void setSelectedConnection( const QString &name );
+
+  private:
+
+    QString mProvider;
+};
+
+#endif // QGSTILEDMESHCONNECTION_H

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -192,6 +192,7 @@ set(TESTS
  testqgstemporalnavigationobject.cpp
  testqgstemporalproperty.cpp
  testqgstemporalrangeobject.cpp
+ testqgstiledmeshconnection.cpp
  testqgstiledownloadmanager.cpp
  testqgstracer.cpp
  testqgstranslateproject.cpp

--- a/tests/src/core/testqgstiledmeshconnection.cpp
+++ b/tests/src/core/testqgstiledmeshconnection.cpp
@@ -1,0 +1,133 @@
+/***************************************************************************
+     testqgstiledmeshconnection.cpp
+     --------------------
+    Date                 : June 2023
+    Copyright            : (C) 2023 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+#include <QtConcurrent>
+#include "qgstiledmeshconnection.h"
+#include "qgssettings.h"
+
+class TestQgsTiledMeshConnection : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+    void encodeDecode();
+    void testConnections();
+
+};
+
+
+void TestQgsTiledMeshConnection::initTestCase()
+{
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  QgsSettings().clear();
+}
+
+void TestQgsTiledMeshConnection::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsTiledMeshConnection::encodeDecode()
+{
+  QgsTiledMeshProviderConnection::Data data;
+  data.provider = QStringLiteral( "test_provider" );
+  data.url = QStringLiteral( "http://testurl" );
+  data.authCfg = QStringLiteral( "my_auth" );
+  data.username = QStringLiteral( "my_user" );
+  data.password = QStringLiteral( "my_pw" );
+  data.httpHeaders.insert( QStringLiteral( "my_header" ), QStringLiteral( "value" ) );
+
+  QCOMPARE( QgsTiledMeshProviderConnection::encodedUri( data ), QStringLiteral( "url=http://testurl&username=my_user&password=my_pw&authcfg=my_auth&http-header:my_header=value" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::encodedLayerUri( data ), QStringLiteral( "url=http://testurl&username=my_user&password=my_pw&authcfg=my_auth&http-header:my_header=value" ) );
+
+  const QgsTiledMeshProviderConnection::Data data2 = QgsTiledMeshProviderConnection::decodedUri( QStringLiteral( "url=http://testurl&username=my_user&password=my_pw&authcfg=my_auth&http-header:my_header=value" ) );
+  QCOMPARE( data2.url, QStringLiteral( "http://testurl" ) );
+  QCOMPARE( data2.authCfg, QStringLiteral( "my_auth" ) );
+  QCOMPARE( data2.username, QStringLiteral( "my_user" ) );
+  QCOMPARE( data2.password, QStringLiteral( "my_pw" ) );
+  QCOMPARE( data2.httpHeaders.headers().value( QStringLiteral( "my_header" ) ).toString(), QStringLiteral( "value" ) );
+}
+
+void TestQgsTiledMeshConnection::testConnections()
+{
+  QVERIFY( QgsTiledMeshProviderConnection::connectionList().isEmpty() );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "does not exist" ) ).url, QString() );
+
+  QgsTiledMeshProviderConnection conn = QgsTiledMeshProviderConnection( QStringLiteral( "my connection" ) );
+  QCOMPARE( conn.uri(), QString() );
+
+
+  QgsTiledMeshProviderConnection::Data data;
+  data.provider = QStringLiteral( "test_provider" );
+  data.url = QStringLiteral( "http://testurl" );
+  data.authCfg = QStringLiteral( "my_auth" );
+  data.username = QStringLiteral( "my_user" );
+  data.password = QStringLiteral( "my_pw" );
+  data.httpHeaders.insert( QStringLiteral( "my_header" ), QStringLiteral( "value" ) );
+
+  QgsTiledMeshProviderConnection::addConnection( QStringLiteral( "my connection" ), data );
+  QCOMPARE( QgsTiledMeshProviderConnection::connectionList(), {QStringLiteral( "my connection" )} );
+
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "my connection" ) ).provider, QStringLiteral( "test_provider" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "my connection" ) ).url, QStringLiteral( "http://testurl" ) );
+
+  // retrieve stored connection
+  conn = QgsTiledMeshProviderConnection( QStringLiteral( "my connection" ) );
+  QCOMPARE( conn.uri(), QStringLiteral( "url=http://testurl&username=my_user&password=my_pw&authcfg=my_auth&http-header:my_header=value" ) );
+  QCOMPARE( qgis::down_cast< QgsTiledMeshProviderConnection * >( &conn )->providerKey(), QStringLiteral( "test_provider" ) );
+
+  // add a second connection
+  QgsTiledMeshProviderConnection::Data data2;
+  data2.provider = QStringLiteral( "test_provider2" );
+  data2.url = QStringLiteral( "http://testurl2" );
+  data2.authCfg = QStringLiteral( "my_auth2" );
+  data2.username = QStringLiteral( "my_user2" );
+  data2.password = QStringLiteral( "my_pw2" );
+  data2.httpHeaders.insert( QStringLiteral( "my_header" ), QStringLiteral( "value2" ) );
+  // construct connection using encoded uri
+  QgsTiledMeshProviderConnection conn2( QgsTiledMeshProviderConnection::encodedUri( data2 ), QStringLiteral( "test_provider2" ), {} );
+  QCOMPARE( conn2.uri(), QStringLiteral( "url=http://testurl2&username=my_user2&password=my_pw2&authcfg=my_auth2&http-header:my_header=value2" ) );
+  QCOMPARE( qgis::down_cast< QgsTiledMeshProviderConnection * >( &conn2 )->providerKey(), QStringLiteral( "test_provider2" ) );
+  conn2.store( QStringLiteral( "second connection" ) );
+
+  // retrieve stored connections
+  QCOMPARE( qgis::listToSet( QgsTiledMeshProviderConnection::connectionList() ), qgis::listToSet( QStringList() << QStringLiteral( "my connection" ) << QStringLiteral( "second connection" ) ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "my connection" ) ).provider, QStringLiteral( "test_provider" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "my connection" ) ).url, QStringLiteral( "http://testurl" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "second connection" ) ).provider, QStringLiteral( "test_provider2" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::connection( QStringLiteral( "second connection" ) ).url, QStringLiteral( "http://testurl2" ) );
+
+  QgsTiledMeshProviderConnection::setSelectedConnection( QStringLiteral( "second connection" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::selectedConnection(), QStringLiteral( "second connection" ) );
+  QgsTiledMeshProviderConnection::setSelectedConnection( QStringLiteral( "my connection" ) );
+  QCOMPARE( QgsTiledMeshProviderConnection::selectedConnection(), QStringLiteral( "my connection" ) );
+}
+
+
+QGSTEST_MAIN( TestQgsTiledMeshConnection )
+#include "testqgstiledmeshconnection.moc"


### PR DESCRIPTION
This provider connection implementation differs a little from the other existing implementations, in that it's designed to be generic for all tiled mesh connections and not tied to one particular data provider. (i.e. all stored tiled mesh connections, regardless of the actual service type, will be exposed through the same browser root group)
