### PR TITLE
Mesh rendering high dpi

### DIFF
--- a/src/core/mesh/qgsmeshlayerinterpolator.cpp
+++ b/src/core/mesh/qgsmeshlayerinterpolator.cpp
@@ -101,6 +101,8 @@ QgsRasterBlock *QgsMeshLayerInterpolator::block( int, const QgsRectangle &extent
   if ( mDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnVertices )
     Q_ASSERT( mDatasetValues.count() == mTriangularMesh.vertices().count() );
 
+  double pixelRatio = mContext.devicePixelRatio();
+
   for ( int i = 0; i < indexCount; ++i )
   {
     if ( feedback && feedback->isCanceled() )
@@ -134,7 +136,7 @@ QgsRasterBlock *QgsMeshLayerInterpolator::block( int, const QgsRectangle &extent
 
     // Get the BBox of the element in pixels
     int topLim, bottomLim, leftLim, rightLim;
-    QgsMeshLayerUtils::boundingBoxToScreenRectangle( mContext.mapToPixel(), mOutputSize, bbox, leftLim, rightLim, topLim, bottomLim );
+    QgsMeshLayerUtils::boundingBoxToScreenRectangle( mContext.mapToPixel(), mOutputSize, bbox, leftLim, rightLim, topLim, bottomLim, pixelRatio );
 
     double value( 0 ), value1( 0 ), value2( 0 ), value3( 0 );
     const int faceIdx = mTriangularMesh.trianglesToNativeFaces()[triangleIndex];
@@ -155,7 +157,7 @@ QgsRasterBlock *QgsMeshLayerInterpolator::block( int, const QgsRectangle &extent
       for ( int k = leftLim; k <= rightLim; k++ )
       {
         double val;
-        const QgsPointXY p = mContext.mapToPixel().toMapCoordinates( k, j );
+        const QgsPointXY p = mContext.mapToPixel().toMapCoordinates( k / pixelRatio, j / pixelRatio );
         if ( mDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnVertices )
           val = QgsMeshLayerUtils::interpolateFromVerticesData(
                   p1,

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -108,7 +108,7 @@ void QgsMeshLayerRenderer::calculateOutputSize()
   const QgsRenderContext &context = *renderContext();
   const QgsRectangle extent = context.mapExtent();
   const QgsMapToPixel mapToPixel = context.mapToPixel();
-  const QgsRectangle screenBBox = QgsMeshLayerUtils::boundingBoxToScreenRectangle( mapToPixel, extent );
+  const QgsRectangle screenBBox = QgsMeshLayerUtils::boundingBoxToScreenRectangle( mapToPixel, extent, context.devicePixelRatio() );
   const int width = int( screenBBox.width() );
   const int height = int( screenBBox.height() );
   mOutputSize = QSize( width, height );
@@ -569,7 +569,8 @@ void QgsMeshLayerRenderer::renderScalarDatasetOnFaces( const QgsMeshRendererScal
   renderer.setOpacity( scalarSettings.opacity() );
 
   std::unique_ptr<QgsRasterBlock> bl( renderer.block( 0, context.mapExtent(), mOutputSize.width(), mOutputSize.height(), mFeedback.get() ) );
-  const QImage img = bl->image();
+  QImage img = bl->image();
+  img.setDevicePixelRatio( context.devicePixelRatio() );
 
   context.painter()->drawImage( 0, 0, img );
 }

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -199,13 +199,14 @@ QVector<double> QgsMeshLayerUtils::calculateMagnitudes( const QgsMeshDataBlock &
 
 QgsRectangle QgsMeshLayerUtils::boundingBoxToScreenRectangle(
   const QgsMapToPixel &mtp,
-  const QgsRectangle &bbox
+  const QgsRectangle &bbox,
+  double devicePixelRatio
 )
 {
-  const QgsPointXY topLeft = mtp.transform( bbox.xMinimum(), bbox.yMaximum() );
-  const QgsPointXY topRight = mtp.transform( bbox.xMaximum(), bbox.yMaximum() );
-  const QgsPointXY bottomLeft = mtp.transform( bbox.xMinimum(), bbox.yMinimum() );
-  const QgsPointXY bottomRight = mtp.transform( bbox.xMaximum(), bbox.yMinimum() );
+  const QgsPointXY topLeft = mtp.transform( bbox.xMinimum(), bbox.yMaximum() ) * devicePixelRatio;
+  const QgsPointXY topRight = mtp.transform( bbox.xMaximum(), bbox.yMaximum() ) * devicePixelRatio;
+  const QgsPointXY bottomLeft = mtp.transform( bbox.xMinimum(), bbox.yMinimum() ) * devicePixelRatio;
+  const QgsPointXY bottomRight = mtp.transform( bbox.xMaximum(), bbox.yMinimum() ) * devicePixelRatio;
 
   const double xMin = std::min( {topLeft.x(), topRight.x(), bottomLeft.x(), bottomRight.x()} );
   const double xMax = std::max( {topLeft.x(), topRight.x(), bottomLeft.x(), bottomRight.x()} );
@@ -223,9 +224,10 @@ void QgsMeshLayerUtils::boundingBoxToScreenRectangle(
   int &leftLim,
   int &rightLim,
   int &bottomLim,
-  int &topLim )
+  int &topLim,
+  double devicePixelRatio )
 {
-  const QgsRectangle screenBBox = boundingBoxToScreenRectangle( mtp, bbox );
+  const QgsRectangle screenBBox = boundingBoxToScreenRectangle( mtp, bbox, devicePixelRatio );
 
   bottomLim = std::max( int( screenBBox.yMinimum() ), 0 );
   topLim = std::min( int( screenBBox.yMaximum() ), outputSize.height() - 1 );

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -127,7 +127,8 @@ class CORE_EXPORT QgsMeshLayerUtils
       int &leftLim,
       int &rightLim,
       int &bottomLim,
-      int &topLim );
+      int &topLim,
+      double devicePixelRatio = 1.0 );
 
     /**
      * Transformes the bounding box to rectangle in screen coordinates (in pixels)
@@ -136,7 +137,8 @@ class CORE_EXPORT QgsMeshLayerUtils
      */
     static QgsRectangle boundingBoxToScreenRectangle(
       const QgsMapToPixel &mtp,
-      const QgsRectangle &bbox
+      const QgsRectangle &bbox,
+      double devicePixelRatio = 1.0
     );
 
     /**


### PR DESCRIPTION
Before this PR, mesh layers was not really with high dpi capabilities. Indeed, with dpi screen, rendering was done with pixels corresponding to the device independent pixels with a pixel ratio of 1. Then image was transformed by Qt to fit the screen.
With this PR, mesh rendering is done considering the real device pixels.

Note this PR also fixes the global map shading for mesh layer with high dpi, following #53575

Before (Zoomed): 
<img src="https://github.com/qgis/QGIS/assets/7416892/a4987cb9-d704-4059-8c9b-1d4c5b986f43" width=250>

After (Zoomed):
<img src="https://github.com/qgis/QGIS/assets/7416892/1c726c6b-3675-429a-925e-96e08f5b1940" width=250>



