### PR TITLE
Fix global map shading panning

### DIFF
--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -365,6 +365,7 @@ void QgsMapRendererCustomPainterJob::doRender()
   if ( mapShadingRenderer.isActive() &&  mainElevationMap )
   {
     QImage image( mainElevationMap->rawElevationImage().size(), QImage::Format_RGB32 );
+    image.setDevicePixelRatio( mSettings.devicePixelRatio() );
     image.fill( Qt::white );
     mapShadingRenderer.renderShading( *mainElevationMap.get(), image, QgsRenderContext::fromMapSettings( mSettings ) );
     mPainter->save();


### PR DESCRIPTION
With high dpi screen, when panning the canvas with global map shading, the preview shading is not drawn to the correct scale:
![Peek 28-06-2023 23-11](https://github.com/qgis/QGIS/assets/7416892/af334286-667f-4e92-a737-9013ec0e73f2)

This PR fixes this issue.
