### PR TITLE
GRASS: Fix v.reclass (make the 'column' parameter optional)

### DIFF
--- a/python/plugins/grassprovider/description/v.reclass.txt
+++ b/python/plugins/grassprovider/description/v.reclass.txt
@@ -3,6 +3,6 @@ Changes vector category values for an existing vector map according to results o
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input layer|-1|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid|True|0,1,2,3|True
-QgsProcessingParameterField|column|The name of the column whose values are to be used as new categories|None|input|-1|False|False
+QgsProcessingParameterField|column|The name of the column whose values are to be used as new categories|None|input|-1|False|True
 QgsProcessingParameterFile|rules|Reclass rule file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterVectorDestination|output|Reclassified


### PR DESCRIPTION
## Description

Either 'rules' or 'column' option must be specified for the v.reclass GRASS-GIS module, so both the 'rules' and 'column' parameters must be optional in the corresponding QGIS processing algorithm.

See https://github.com/OSGeo/grass/blob/5cb4e430b5e405bce4ab30e6d20c15222b10815f/vector/v.reclass/main.c#L103-L107
```c
    if ((!(rules_opt->answer) && !(col_opt->answer)) ||
        (rules_opt->answer && col_opt->answer)) {
        G_fatal_error(_("Either '%s' or '%s' must be specified"),
                      rules_opt->key, col_opt->key);
    }
```

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
