### PR TITLE
Detect phrases in french raster layer names as hints that a layer represents an elevation surface

### DIFF
--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -243,6 +243,7 @@ bool QgsRasterLayerElevationProperties::layerLooksLikeDem( QgsRasterLayer *layer
       QStringLiteral( "elev" ),
       QStringLiteral( "srtm" ),
       // French hints
+      QStringLiteral( "mne" ),
       QStringLiteral( "mnt" ),
       QStringLiteral( "mns" ),
       QStringLiteral( "rge" ),

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -241,7 +241,12 @@ bool QgsRasterLayerElevationProperties::layerLooksLikeDem( QgsRasterLayer *layer
   static const QStringList sPartialCandidates{ QStringLiteral( "dem" ),
       QStringLiteral( "height" ),
       QStringLiteral( "elev" ),
-      QStringLiteral( "srtm" ) };
+      QStringLiteral( "srtm" ),
+      // French hints
+      QStringLiteral( "mnt" ),
+      QStringLiteral( "mns" ),
+      QStringLiteral( "rge" ),
+      QStringLiteral( "alti" ) };
   const QString layerName = layer->name();
   for ( const QString &candidate : sPartialCandidates )
   {


### PR DESCRIPTION
- `mnt` stand for `dtm`
- `mns` for `dsm`
- `rge` -> https://geoservices.ign.fr/rgealti
- `alti` for `elev`

We (well, me in my work) use `sl` for "Surface Libre" which is the free surface elevation (mainly computed using flood model). 
But I'm afraid this will detect too many false positive.
I wonder if this list could be exposed to user in settings