### PR TITLE
Bugfix gh53633 mssql add zm to select and fix m detection

### DIFF
--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -97,23 +97,19 @@ void QgsMssqlGeomColumnTypeThread::run()
 
         while ( q.next() )
         {
-          QString type = q.value( 0 ).toString().toUpper();
-          const QString srid = q.value( 1 ).toString();
           const bool hasZ { q.value( 2 ).toString() == '1' };
           const bool hasM { q.value( 3 ).toString() == '1' };
+          const int dimensions { 2 + ( ( hasZ &&hasM ) ? 2 : ( ( hasZ || hasM ) ? 1 : 0 ) ) };
+          QString typeName { q.value( 0 ).toString().toUpper() };
+          if ( hasM && ! typeName.endsWith( 'M' ) )
+          {
+            typeName.append( 'M' );
+          }
+          const QString type { QgsMssqlProvider::typeFromMetadata( typeName, dimensions ) };
+          const QString srid = q.value( 1 ).toString();
 
           if ( type.isEmpty() )
             continue;
-
-          if ( hasZ )
-          {
-            type.append( 'Z' );
-          }
-
-          if ( hasM )
-          {
-            type.append( 'M' );
-          }
 
           types << type;
           srids << srid;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -329,18 +329,8 @@ void QgsMssqlProvider::loadMetadata()
   {
     mGeometryColName = query.value( 0 ).toString();
     mSRId = query.value( 1 ).toInt();
-    QString detectedType = query.value( 2 ).toString();
-    const QString dim = query.value( 3 ).toString();
-    if ( dim == QLatin1String( "3" ) && !detectedType.endsWith( 'M' ) )
-      detectedType += QLatin1Char( 'Z' );
-    else if ( dim == QLatin1String( "4" ) )
-    {
-      if ( detectedType.endsWith( 'M' ) )
-      {
-        detectedType.chop( 1 );
-      }
-      detectedType += QLatin1String( "ZM" );
-    }
+    const int dimensions = query.value( 3 ).toInt();
+    const QString detectedType { QgsMssqlProvider::typeFromMetadata( query.value( 2 ).toString().toUpper(), dimensions ) };
     mWkbType = getWkbType( detectedType );
   }
 }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -334,7 +334,13 @@ void QgsMssqlProvider::loadMetadata()
     if ( dim == QLatin1String( "3" ) && !detectedType.endsWith( 'M' ) )
       detectedType += QLatin1Char( 'Z' );
     else if ( dim == QLatin1String( "4" ) )
+    {
+      if ( detectedType.endsWith( 'M' ) )
+      {
+        detectedType.chop( 1 );
+      }
       detectedType += QLatin1String( "ZM" );
+    }
     mWkbType = getWkbType( detectedType );
   }
 }
@@ -3101,6 +3107,29 @@ QString QgsMssqlProviderMetadata::encodeUri( const QVariantMap &parts ) const
 QList<Qgis::LayerType> QgsMssqlProviderMetadata::supportedLayerTypes() const
 {
   return { Qgis::LayerType::Vector };
+}
+
+QString QgsMssqlProvider::typeFromMetadata( const QString &typeName, int numCoords )
+{
+
+  QString type { typeName };
+  const bool hasM { typeName.endsWith( 'M', Qt::CaseInsensitive ) };
+  if ( numCoords == 4 )
+  {
+    if ( hasM )
+    {
+      type.chop( 1 );
+    }
+    type.append( QStringLiteral( "ZM" ) );
+  }
+  else if ( numCoords == 3 )
+  {
+    if ( ! hasM )
+    {
+      type.append( QStringLiteral( "Z" ) );
+    }
+  }
+  return type;
 }
 
 bool QgsMssqlProviderMetadata::execLogged( QSqlQuery &qry, const QString &sql, const QString &uri, const QString &queryOrigin ) const

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -136,6 +136,9 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     //! Convert a QgsField to work with MSSQL
     static bool convertField( QgsField &field );
 
+    // Parse type name and num coordinates as stored in geometry_columns tabe and returns normalized (M, Z or ZM) type name
+    static QString typeFromMetadata( const QString &typeName, int numCoords );
+
     //! Convert values to quoted values for database work
     static QString quotedValue( const QVariant &value );
     static QString quotedIdentifier( const QString &value );
@@ -333,6 +336,7 @@ class QgsMssqlProviderMetadata final: public QgsProviderMetadata
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;
     QList< Qgis::LayerType > supportedLayerTypes() const override;
+
 
   private:
 

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -30,6 +30,7 @@
 #include "qgsproject.h"
 #include "qgsgui.h"
 #include "qgsiconutils.h"
+#include "qgsmssqlprovider.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -57,11 +58,29 @@ QWidget *QgsMssqlSourceSelectDelegate::createEditor( QWidget *parent, const QSty
     for ( const Qgis::WkbType type :
           {
             Qgis::WkbType::Point,
+            Qgis::WkbType::PointZ,
+            Qgis::WkbType::PointM,
+            Qgis::WkbType::PointZM,
             Qgis::WkbType::LineString,
+            Qgis::WkbType::LineStringZ,
+            Qgis::WkbType::LineStringM,
+            Qgis::WkbType::LineStringZM,
             Qgis::WkbType::Polygon,
+            Qgis::WkbType::PolygonZ,
+            Qgis::WkbType::PolygonM,
+            Qgis::WkbType::PolygonZM,
             Qgis::WkbType::MultiPoint,
+            Qgis::WkbType::MultiPointZ,
+            Qgis::WkbType::MultiPointM,
+            Qgis::WkbType::MultiPointZM,
             Qgis::WkbType::MultiLineString,
+            Qgis::WkbType::MultiLineStringZ,
+            Qgis::WkbType::MultiLineStringM,
+            Qgis::WkbType::MultiLineStringZM,
             Qgis::WkbType::MultiPolygon,
+            Qgis::WkbType::MultiPolygonZ,
+            Qgis::WkbType::MultiPolygonM,
+            Qgis::WkbType::MultiPolygonZM,
             Qgis::WkbType::NoGeometry
           } )
     {
@@ -427,20 +446,11 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
       layer.tableName = q.value( 1 ).toString();
       layer.geometryColName = q.value( 2 ).toString();
       layer.srid = q.value( 3 ).toString();
-      layer.type = q.value( 4 ).toString();
       layer.isView = q.value( 5 ).toBool();
       layer.pkCols = QStringList(); //TODO
       layer.isGeography = false;
       const int dimensions { q.value( 6 ).toInt( ) };
-
-      if ( dimensions >= 3 )
-      {
-        layer.type = layer.type.append( 'Z' );
-      }
-      if ( dimensions == 4 )
-      {
-        layer.type = layer.type.append( 'M' );
-      }
+      layer.type = QgsMssqlProvider::typeFromMetadata( q.value( 4 ).toString().toUpper(), dimensions );
 
       QString type = layer.type;
       QString srid = layer.srid;


### PR DESCRIPTION
Fix #53633

Plus fixes unreported 'M' detection issue when reading type from metadata (geometry_columns table)

Moved the parsing logic to a single static method, hopefully making this process more consistent and more robust.

