### PR TITLE
Add some German hardcoded localized variants of the strings

### DIFF
--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -249,7 +249,11 @@ bool QgsRasterLayerElevationProperties::layerLooksLikeDem( QgsRasterLayer *layer
       QStringLiteral( "mnt" ),
       QStringLiteral( "mns" ),
       QStringLiteral( "rge" ),
-      QStringLiteral( "alti" ) };
+      QStringLiteral( "alti" ),
+      // German hints
+      QStringLiteral( "dhm" ),
+      QStringLiteral( "dgm" ),
+      QStringLiteral( "dom" ) };
   const QString layerName = layer->name();
   for ( const QString &candidate : sPartialCandidates )
   {

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -253,7 +253,9 @@ bool QgsRasterLayerElevationProperties::layerLooksLikeDem( QgsRasterLayer *layer
       // German hints
       QStringLiteral( "dhm" ),
       QStringLiteral( "dgm" ),
-      QStringLiteral( "dom" ) };
+      QStringLiteral( "dom" ),
+      QStringLiteral( "Höhe" ),
+      QStringLiteral( "Hoehe" ) };
   const QString layerName = layer->name();
   for ( const QString &candidate : sPartialCandidates )
   {

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -619,13 +619,17 @@ void QgsVectorLayerTemporalProperties::guessDefaultsFromFields( const QgsFields 
   static const QStringList sStartCandidates{ QStringLiteral( "start" ),
       QStringLiteral( "begin" ),
       QStringLiteral( "from" ),
+      QStringLiteral( "since" ),
       // German candidates
       QStringLiteral( "anfang" ),
-      QStringLiteral( "von" ) };
+      QStringLiteral( "von" ),
+      QStringLiteral( "ab" ),
+      QStringLiteral( "seit" ) };
 
   static const QStringList sEndCandidates{ QStringLiteral( "end" ),
       QStringLiteral( "last" ),
       QStringLiteral( "to" ),
+      QStringLiteral( "stop" ),
       // German candidates
       QStringLiteral( "ende" ),
       QStringLiteral( "bis" ) };

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -618,11 +618,18 @@ void QgsVectorLayerTemporalProperties::guessDefaultsFromFields( const QgsFields 
   // but adding hardcoded localized variants of the strings is encouraged.
   static const QStringList sStartCandidates{ QStringLiteral( "start" ),
       QStringLiteral( "begin" ),
-      QStringLiteral( "from" )};
+      QStringLiteral( "from" ),
+      // German candidates
+      QStringLiteral( "anfang" ),
+      QStringLiteral( "von" ) };
 
   static const QStringList sEndCandidates{ QStringLiteral( "end" ),
       QStringLiteral( "last" ),
-      QStringLiteral( "to" )};
+      QStringLiteral( "to" ),
+      // German candidates
+      QStringLiteral( "ende" ),
+      QStringLiteral( "bis" ) };
+
 
   static const QStringList sSingleFieldCandidates{ QStringLiteral( "event" ) };
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1181,7 +1181,12 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
                                   QStringLiteral( "nom" ),
                                   QStringLiteral( "street" ),
                                   QStringLiteral( "road" ),
-                                  QStringLiteral( "label" ) };
+                                  QStringLiteral( "label" ),
+                                  // German candidates
+                                  QStringLiteral( "titel" ),
+                                  QStringLiteral( "beschreibung" ),
+                                  QStringLiteral( "strasse" ),
+                                  QStringLiteral( "beschriftung" ) };
 
   // anti-names
   // this list of strings indicates parts of field names which make the name "less interesting".
@@ -1190,7 +1195,11 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
   // best choice to default to
   static QStringList sAntiCandidates{ QStringLiteral( "type" ),
                                       QStringLiteral( "class" ),
-                                      QStringLiteral( "cat" )
+                                      QStringLiteral( "cat" ),
+                                      // German anti-candidates
+                                      QStringLiteral( "typ" ),
+                                      QStringLiteral( "klasse" ),
+                                      QStringLiteral( "kategorie" )
                                     };
 
   QString bestCandidateName;

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1183,7 +1183,7 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
                                   QStringLiteral( "road" ),
                                   QStringLiteral( "label" ),
                                   // German candidates
-                                  QStringLiteral( "titel" ),
+                                  QStringLiteral( "titel" ),  //#spellok
                                   QStringLiteral( "beschreibung" ),
                                   QStringLiteral( "strasse" ),
                                   QStringLiteral( "beschriftung" ) };

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1190,7 +1190,7 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
 
   // anti-names
   // this list of strings indicates parts of field names which make the name "less interesting".
-  // For instance, we'd normally like to default to a field called "name" or "id", but if instead we
+  // For instance, we'd normally like to default to a field called "name" or "title", but if instead we
   // find one called "typename" or "typeid", then that's most likely a classification of the feature and not the
   // best choice to default to
   static QStringList sAntiCandidates{ QStringLiteral( "type" ),


### PR DESCRIPTION
~~and add "id" back to candidates of `QgsVectorLayerUtils::guessFriendlyIdentifierField` (seems like it was accidentally lost in https://github.com/qgis/QGIS/pull/41372).~~

