### PR TITLE
[Backport release-3_32] GRASS: Fix v.reclass (make the 'column' parameter optional)

### DIFF
--- a/python/plugins/grassprovider/description/v.reclass.txt
+++ b/python/plugins/grassprovider/description/v.reclass.txt
@@ -3,6 +3,6 @@ Changes vector category values for an existing vector map according to results o
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input layer|-1|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid|True|0,1,2,3|True
-QgsProcessingParameterField|column|The name of the column whose values are to be used as new categories|None|input|-1|False|False
+QgsProcessingParameterField|column|The name of the column whose values are to be used as new categories|None|input|-1|False|True
 QgsProcessingParameterFile|rules|Reclass rule file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterVectorDestination|output|Reclassified


### PR DESCRIPTION
Manual backport of #53643
