### PR TITLE
De-duplicate layer properties dialog code

### DIFF
--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -9,8 +9,7 @@
 
 
 
-
-class QgsMeshLayerProperties : QgsOptionsDialogBase
+class QgsMeshLayerProperties : QgsLayerPropertiesDialog
 {
 %Docstring(signature="appended")
 
@@ -42,13 +41,6 @@ Adds properties page from a factory
 .. versionadded:: 3.16
 %End
 
-    void loadDefaultStyle();
-%Docstring
-Loads the default style when appropriate button is pressed
-
-.. versionadded:: 3.30
-%End
-
     void saveDefaultStyle();
 %Docstring
 Saves the default style when appropriate button is pressed
@@ -71,6 +63,12 @@ Saves a style when appriate button is pressed
 %End
 
   protected slots:
+    virtual void optionsStackedWidget_CurrentChanged( int index ) ${SIP_FINAL};
+
+    virtual void syncToLayer() ${SIP_FINAL};
+
+    virtual void apply() ${SIP_FINAL};
+
 
 };
 

--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -41,25 +41,28 @@ Adds properties page from a factory
 .. versionadded:: 3.16
 %End
 
-    void saveDefaultStyle();
+ void saveDefaultStyle() /Deprecated/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsMeshLayerProperties.saveStyleAsDefault` instead.
 %End
 
-    void loadStyle();
+ void loadStyle() /Deprecated/;
 %Docstring
 Loads a saved style when appropriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsMeshLayerProperties.loadStyleFromFile` instead.
 %End
 
-    void saveStyleAs();
+ void saveStyleAs() /Deprecated/;
 %Docstring
 Saves a style when appriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsMeshLayerProperties.saveStyleToFile` instead.
 %End
 
   protected slots:

--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -63,6 +63,8 @@ Saves a style when appriate button is pressed
 
     virtual void apply() ${SIP_FINAL};
 
+    virtual void rollback() ${SIP_FINAL};
+
 
 };
 

--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -34,13 +34,6 @@ Constructor
 :param fl: Window flags
 %End
 
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-%Docstring
-Adds properties page from a factory
-
-.. versionadded:: 3.16
-%End
-
  void saveDefaultStyle() /Deprecated/;
 %Docstring
 Saves the default style when appropriate button is pressed

--- a/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
+++ b/python/gui/auto_generated/mesh/qgsmeshlayerproperties.sip.in
@@ -63,8 +63,6 @@ Saves a style when appriate button is pressed
 %End
 
   protected slots:
-    virtual void optionsStackedWidget_CurrentChanged( int index ) ${SIP_FINAL};
-
     virtual void syncToLayer() ${SIP_FINAL};
 
     virtual void apply() ${SIP_FINAL};

--- a/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
+++ b/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
@@ -38,9 +38,9 @@ Constructor for QgsLayerPropertiesDialog.
 :param settings: custom :py:class:`QgsSettings` pointer
 %End
 
-    void setMetadataWidget( QgsMetadataWidget *widget );
+    void setMetadataWidget( QgsMetadataWidget *widget, QWidget *page );
 %Docstring
-Sets the metadata ``widget`` associated with the dialog.
+Sets the metadata ``widget`` and ``page`` associated with the dialog.
 
 This must be called in order for the standard metadata loading/saving functionality to be avialable.
 %End
@@ -114,8 +114,13 @@ Stores the current layer style so that undo operations can be performed.
 %End
 
 
+
+
   protected slots:
 
+
+
+    virtual void optionsStackedWidget_CurrentChanged( int index );
 
 
 };

--- a/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
+++ b/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
@@ -123,6 +123,14 @@ Stores the current layer style so that undo operations can be performed.
     virtual void optionsStackedWidget_CurrentChanged( int index );
 
 
+    void openUrl( const QUrl &url );
+%Docstring
+Handles opening a ``url`` from the dialog.
+
+If the ``url`` refers to a local file then a file explorer will be opened pointing to the file.
+If it refers to a remote link then a web browser will be opened instead.
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
+++ b/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
@@ -120,6 +120,11 @@ Stores the current layer style so that undo operations can be performed.
 
 
 
+    virtual void rollback();
+%Docstring
+Rolls back changes made to the layer.
+%End
+
     virtual void optionsStackedWidget_CurrentChanged( int index );
 
 

--- a/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
+++ b/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
@@ -1,0 +1,129 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgslayerpropertiesdialog.h                                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsLayerPropertiesDialog : QgsOptionsDialogBase /Abstract/
+{
+%Docstring(signature="appended")
+Base class for "layer properties" dialogs, containing common utilities for handling functionality in these dialog.
+
+.. warning::
+
+   This is exposed to SIP bindings for legacy reasons only, and is NOT to be considered as stable API.
+
+.. versionadded:: 3.34
+%End
+
+%TypeHeaderCode
+#include "qgslayerpropertiesdialog.h"
+%End
+  public:
+
+    QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = 0 );
+%Docstring
+Constructor for QgsLayerPropertiesDialog.
+
+:param layer: associated map layer
+:param settingsKey: :py:class:`QgsSettings` subgroup key for saving/restore ui states, e.g. "VectorLayerProperties".
+:param parent: parent object (owner)
+:param fl: widget flags
+:param settings: custom :py:class:`QgsSettings` pointer
+%End
+
+    void setMetadataWidget( QgsMetadataWidget *widget );
+%Docstring
+Sets the metadata ``widget`` associated with the dialog.
+
+This must be called in order for the standard metadata loading/saving functionality to be avialable.
+%End
+
+  public slots:
+
+    void loadMetadataFromFile();
+%Docstring
+Allows the user to load layer metadata from a file.
+
+.. seealso:: :py:func:`saveMetadataToFile`
+%End
+
+    void saveMetadataToFile();
+%Docstring
+Allows the user to save the layer's metadata as a file.
+
+.. seealso:: :py:func:`loadMetadataFromFile`
+%End
+
+    void saveMetadataAsDefault();
+%Docstring
+Saves the current layer metadata as the default for the layer.
+
+:py:func:`~QgsLayerPropertiesDialog.loadDefaultMetadata`
+%End
+
+    void loadDefaultMetadata();
+%Docstring
+Reloads the default layer metadata for the layer.
+
+.. seealso:: :py:func:`saveMetadataAsDefault`
+%End
+
+    void loadStyleFromFile();
+%Docstring
+Allows the user to load layer style from a file.
+
+.. seealso:: :py:func:`saveStyleToFile`
+%End
+
+    void saveStyleToFile();
+%Docstring
+Allows the user to save the layer's style to a file.
+
+.. seealso:: :py:func:`loadStyleFromFile`
+%End
+
+    void saveStyleAsDefault();
+%Docstring
+Saves the current layer style as the default for the layer.
+
+:py:func:`~QgsLayerPropertiesDialog.loadDefaultStyle`
+%End
+
+    void loadDefaultStyle();
+%Docstring
+Reloads the default style for the layer.
+%End
+
+  protected:
+
+    void refocusDialog();
+%Docstring
+Ensures the dialog is focused and activated.
+%End
+
+    void storeCurrentStyleForUndo();
+%Docstring
+Stores the current layer style so that undo operations can be performed.
+%End
+
+
+  protected slots:
+
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgslayerpropertiesdialog.h                                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
+++ b/python/gui/auto_generated/qgslayerpropertiesdialog.sip.in
@@ -27,11 +27,12 @@ Base class for "layer properties" dialogs, containing common utilities for handl
 %End
   public:
 
-    QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = 0 );
+    QgsLayerPropertiesDialog( QgsMapLayer *layer, QgsMapCanvas *canvas, const QString &settingsKey, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = 0 );
 %Docstring
 Constructor for QgsLayerPropertiesDialog.
 
 :param layer: associated map layer
+:param canvas: associated map canvas
 :param settingsKey: :py:class:`QgsSettings` subgroup key for saving/restore ui states, e.g. "VectorLayerProperties".
 :param parent: parent object (owner)
 :param fl: widget flags
@@ -43,6 +44,11 @@ Constructor for QgsLayerPropertiesDialog.
 Sets the metadata ``widget`` and ``page`` associated with the dialog.
 
 This must be called in order for the standard metadata loading/saving functionality to be avialable.
+%End
+
+    virtual void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
+%Docstring
+Adds properties page from a ``factory``.
 %End
 
   public slots:
@@ -112,6 +118,8 @@ Ensures the dialog is focused and activated.
 %Docstring
 Stores the current layer style so that undo operations can be performed.
 %End
+
+
 
 
 

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsRasterLayerProperties : QgsOptionsDialogBase
 {
 %Docstring(signature="appended")

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -35,12 +35,8 @@ Constructor
 :param fl: windows flag
 %End
 
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-%Docstring
-Adds a properties page factory to the raster layer properties dialog.
+    virtual void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory ) ${SIP_FINAL};
 
-.. versionadded:: 3.18
-%End
 
     virtual QgsExpressionContext createExpressionContext() const;
 

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -68,6 +68,10 @@ Saves a style when appriate button is pressed
 %End
 
   protected slots:
+    virtual void apply() ${SIP_FINAL};
+
+    virtual void rollback() ${SIP_FINAL};
+
 
 };
 /************************************************************************

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsRasterLayerProperties : QgsOptionsDialogBase
+class QgsRasterLayerProperties : QgsLayerPropertiesDialog
 {
 %Docstring(signature="appended")
 Property sheet for a raster map layer
@@ -47,13 +47,6 @@ Adds a properties page factory to the raster layer properties dialog.
 
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
-
-    void loadDefaultStyle();
-%Docstring
-Loads the default style when appropriate button is pressed
-
-.. versionadded:: 3.30
-%End
 
     void saveDefaultStyle();
 %Docstring

--- a/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterlayerproperties.sip.in
@@ -48,18 +48,20 @@ Adds a properties page factory to the raster layer properties dialog.
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 
-    void saveDefaultStyle();
+ void saveDefaultStyle() /Deprecated/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsRasterLayerProperties.saveStyleAsDefault` instead
 %End
 
-    void loadStyle();
+ void loadStyle() /Deprecated/;
 %Docstring
 Loads a saved style when appropriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsRasterLayerProperties.loadStyleFromFile` instead.
 %End
 
     void saveStyleAs();

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -12,7 +12,7 @@
 
 
 
-class QgsVectorLayerProperties : QgsOptionsDialogBase
+class QgsVectorLayerProperties : QgsLayerPropertiesDialog
 {
 
 %TypeHeaderCode

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -55,6 +55,12 @@ Saves a style when appriate button is pressed
 
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
+    virtual void syncToLayer() ${SIP_FINAL};
+
+    virtual void apply() ${SIP_FINAL};
+
+    virtual void rollback() ${SIP_FINAL};
+
 
   signals:
 

--- a/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
+++ b/python/gui/auto_generated/vector/qgsvectorlayerproperties.sip.in
@@ -22,11 +22,6 @@ class QgsVectorLayerProperties : QgsLayerPropertiesDialog
 
     QgsVectorLayerProperties( QgsMapCanvas *canvas, QgsMessageBar *messageBar, QgsVectorLayer *lyr = 0, QWidget *parent = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-%Docstring
-Adds a properties page factory to the vector layer properties dialog.
-%End
-
     virtual bool eventFilter( QObject *obj, QEvent *ev );
 
 

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -27,11 +27,12 @@ Vectortile layer properties dialog
 Constructor
 %End
 
-    void saveDefaultStyle();
+ void saveDefaultStyle() /Deprecated/;
 %Docstring
 Saves the default style when appropriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsVectorTileLayerProperties.saveStyleAsDefault` instead.
 %End
 
     void loadStyle();
@@ -41,11 +42,12 @@ Loads a saved style when appropriate button is pressed
 .. versionadded:: 3.30
 %End
 
-    void saveStyleAs();
+ void saveStyleAs() /Deprecated/;
 %Docstring
 Saves a style when appriate button is pressed
 
-.. versionadded:: 3.30
+.. deprecated::
+   use :py:func:`~QgsVectorTileLayerProperties.saveStyleToFile` instead.
 %End
 
 };

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsVectorTileLayerProperties : QgsOptionsDialogBase
+class QgsVectorTileLayerProperties : QgsLayerPropertiesDialog
 {
 %Docstring(signature="appended")
 Vectortile layer properties dialog
@@ -25,13 +25,6 @@ Vectortile layer properties dialog
     QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = 0, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 %Docstring
 Constructor
-%End
-
-    void loadDefaultStyle();
-%Docstring
-Loads the default style when appropriate button is pressed
-
-.. versionadded:: 3.30
 %End
 
     void saveDefaultStyle();

--- a/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
+++ b/python/gui/auto_generated/vectortile/qgsvectortilelayerproperties.sip.in
@@ -48,8 +48,6 @@ Saves a style when appriate button is pressed
 .. versionadded:: 3.30
 %End
 
-  protected slots:
-
 };
 
 /************************************************************************

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -108,6 +108,7 @@
 %Include auto_generated/qgslayermetadatasearchwidget.sip
 %Include auto_generated/qgslayermetadataresultsmodel.sip
 %Include auto_generated/qgslayermetadataresultsproxymodel.sip
+%Include auto_generated/qgslayerpropertiesdialog.sip
 %Include auto_generated/qgslegendfilterbutton.sip
 %Include auto_generated/qgslegendpatchshapebutton.sip
 %Include auto_generated/qgslegendpatchshapewidget.sip

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -18,7 +18,6 @@
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmaplayerstyleguiutils.h"
 #include "qgsgui.h"
-#include "qgsnative.h"
 #include "qgsapplication.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
 #include "qgsmaplayerconfigwidget.h"
@@ -162,7 +161,7 @@ void QgsAnnotationLayerProperties::syncToLayer()
   mInformationTextBrowser->document()->setDefaultStyleSheet( myStyle );
   mInformationTextBrowser->setHtml( mLayer->htmlMetadata() );
   mInformationTextBrowser->setOpenLinks( false );
-  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsAnnotationLayerProperties::urlClicked );
+  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsAnnotationLayerProperties::openUrl );
 
   mCrsSelector->setCrs( mLayer->crs() );
 
@@ -207,15 +206,6 @@ void QgsAnnotationLayerProperties::showHelp()
   {
     QgsHelp::openHelp( QStringLiteral( "working_with_vector_tiles/vector_tiles_properties.html" ) );
   }
-}
-
-void QgsAnnotationLayerProperties::urlClicked( const QUrl &url )
-{
-  const QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsAnnotationLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -26,7 +26,6 @@
 #include "qgspainteffect.h"
 #include "qgsproject.h"
 #include "qgsprojectutils.h"
-#include "qgslayerpropertiesguiutils.h"
 
 #include <QFileDialog>
 #include <QMenu>
@@ -35,7 +34,7 @@
 #include <QUrl>
 
 QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *, QWidget *parent, Qt::WindowFlags flags )
-  : QgsOptionsDialogBase( QStringLiteral( "AnnotationLayerProperties" ), parent, flags )
+  : QgsLayerPropertiesDialog( layer, QStringLiteral( "AnnotationLayerProperties" ), parent, flags )
   , mLayer( layer )
   , mMapCanvas( canvas )
 {
@@ -55,14 +54,6 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
 
   mOptsPage_Information->setContentsMargins( 0, 0, 0, 0 );
 
-  mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, nullptr );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsAnnotationLayerProperties::syncToLayer );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsAnnotationLayerProperties::apply );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::storeCurrentStyleForUndo, this, [ = ]
-  {
-    mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
-  } );
-
   // update based on layer's current state
   syncToLayer();
 
@@ -77,11 +68,11 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
-  menuStyle->addAction( tr( "Load Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadStyleFromFile );
-  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsAnnotationLayerProperties::loadStyleFromFile );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsAnnotationLayerProperties::saveStyleToFile );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
-  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsAnnotationLayerProperties::saveStyleAsDefault );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsAnnotationLayerProperties::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsAnnotationLayerProperties::aboutToShowStyleMenu );
 

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -22,13 +22,14 @@
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsapplication.h"
-#include "qgsmaplayerloadstyledialog.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsdatumtransformdialog.h"
 #include "qgspainteffect.h"
 #include "qgsproject.h"
 #include "qgsprojectutils.h"
+#include "qgslayerpropertiesguiutils.h"
+
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -56,6 +57,9 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
 
   mOptsPage_Information->setContentsMargins( 0, 0, 0, 0 );
 
+  mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, nullptr );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsAnnotationLayerProperties::syncToLayer );
+
   // update based on layer's current state
   syncToLayer();
 
@@ -74,7 +78,7 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsAnnotationLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsAnnotationLayerProperties::saveDefaultStyle );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsAnnotationLayerProperties::loadDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsAnnotationLayerProperties::aboutToShowStyleMenu );
 
@@ -185,26 +189,6 @@ void QgsAnnotationLayerProperties::syncToLayer()
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->syncToLayer( mLayer );
-}
-
-
-void QgsAnnotationLayerProperties::loadDefaultStyle()
-{
-  bool defaultLoadedFlag = false;
-  const QString myMessage = mLayer->loadDefaultStyle( defaultLoadedFlag );
-  // reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-  }
-  else
-  {
-    // otherwise let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
 }
 
 void QgsAnnotationLayerProperties::saveDefaultStyle()

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -14,8 +14,6 @@
  ***************************************************************************/
 
 #include "qgsannotationlayerproperties.h"
-
-#include "qgsfileutils.h"
 #include "qgshelp.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmaplayerstyleguiutils.h"
@@ -80,7 +78,7 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadStyleFromFile );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsAnnotationLayerProperties::saveStyleAs );
+  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
@@ -194,37 +192,6 @@ void QgsAnnotationLayerProperties::syncToLayer()
 
   for ( QgsMapLayerConfigWidget *w : std::as_const( mConfigWidgets ) )
     w->syncToLayer( mLayer );
-}
-
-void QgsAnnotationLayerProperties::saveStyleAs()
-{
-  QgsSettings settings;
-  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString outputFileName = QFileDialog::getSaveFileName(
-                             this,
-                             tr( "Save layer properties as style file" ),
-                             lastUsedDir,
-                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
-  if ( outputFileName.isEmpty() )
-    return;
-
-  // ensure the user never omits the extension from the file name
-  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
-
-  apply(); // make sure the style to save is up-to-date
-
-  // then export style
-  bool defaultLoadedFlag = false;
-  QString message;
-  message = mLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
-
-  if ( defaultLoadedFlag )
-  {
-    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
-  }
-  else
-    QMessageBox::information( this, tr( "Save Style" ), message );
 }
 
 void QgsAnnotationLayerProperties::aboutToShowStyleMenu()

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -59,6 +59,7 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, nullptr );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsAnnotationLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsAnnotationLayerProperties::apply );
 
   // update based on layer's current state
   syncToLayer();
@@ -77,7 +78,7 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsAnnotationLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsAnnotationLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsAnnotationLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsAnnotationLayerProperties::aboutToShowStyleMenu );
@@ -189,29 +190,6 @@ void QgsAnnotationLayerProperties::syncToLayer()
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->syncToLayer( mLayer );
-}
-
-void QgsAnnotationLayerProperties::saveDefaultStyle()
-{
-  apply(); // make sure the style to save is up-to-date
-
-  // a flag passed by reference
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  // after calling this the above flag will be set true for success
-  // or false if the save operation failed
-  const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    // let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
 }
 
 void QgsAnnotationLayerProperties::loadStyle()

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -130,21 +130,12 @@ void QgsAnnotationLayerProperties::apply()
   mLayer->triggerRepaint();
 }
 
-void QgsAnnotationLayerProperties::onCancel()
+void QgsAnnotationLayerProperties::rollback()
 {
+  QgsLayerPropertiesDialog::rollback();
+
   if ( mBackupCrs != mLayer->crs() )
     mLayer->setCrs( mBackupCrs );
-
-  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
-  {
-    // need to reset style to previous - style applied directly to the layer (not in apply())
-    QString myMessage;
-    QDomDocument doc( QStringLiteral( "qgis" ) );
-    int errorLine, errorColumn;
-    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
-    mLayer->importNamedStyle( doc, myMessage );
-    syncToLayer();
-  }
 }
 
 void QgsAnnotationLayerProperties::syncToLayer()

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -223,11 +223,3 @@ void QgsAnnotationLayerProperties::crsChanged( const QgsCoordinateReferenceSyste
   QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mMapCanvas, tr( "Select transformation for the layer" ) );
   mLayer->setCrs( crs );
 }
-
-void QgsAnnotationLayerProperties::optionsStackedWidget_CurrentChanged( int index )
-{
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  mBtnStyle->setVisible( true );
-}
-

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -48,9 +48,6 @@ class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui
     void urlClicked( const QUrl &url );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
-  protected slots:
-    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
-
   private:
     void syncToLayer() FINAL;
 

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -45,7 +45,6 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void apply();
     void onCancel();
 
-    void loadStyle();
     void saveStyleAs();
     void aboutToShowStyleMenu();
     void showHelp();

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -37,8 +37,6 @@ class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui
     QgsAnnotationLayerProperties( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
     ~QgsAnnotationLayerProperties() override;
 
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-
   private slots:
     void apply() FINAL;
     void rollback() FINAL;
@@ -55,11 +53,7 @@ class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui
 
     QPushButton *mBtnStyle = nullptr;
 
-    QgsMapCanvas *mMapCanvas = nullptr;
-
     std::unique_ptr< QgsPaintEffect > mPaintEffect;
-
-    QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 
     QgsCoordinateReferenceSystem mBackupCrs;
 

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -41,7 +41,7 @@ class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui
 
   private slots:
     void apply() FINAL;
-    void onCancel();
+    void rollback() FINAL;
 
     void aboutToShowStyleMenu();
     void showHelp();

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -20,9 +20,8 @@
 
 #include "ui_qgsannotationlayerpropertiesbase.h"
 
-#include "qgsmaplayerstylemanager.h"
-
 #include "qgsannotationlayer.h"
+#include "qgsmaplayerstyle.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -31,7 +30,7 @@ class QgsAnnotationLayer;
 class QgsMetadataWidget;
 class QgsMapLayerConfigWidgetFactory;
 class QgsMapLayerConfigWidget;
-
+class QgsLayerPropertiesGuiUtils;
 
 class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::QgsAnnotationLayerPropertiesBase
 {
@@ -46,7 +45,6 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void apply();
     void onCancel();
 
-    void loadDefaultStyle();
     void saveDefaultStyle();
     void loadStyle();
     void saveStyleAs();
@@ -63,6 +61,8 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
   private:
     QgsAnnotationLayer *mLayer = nullptr;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     QPushButton *mBtnStyle = nullptr;
 

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -45,7 +45,6 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void apply();
     void onCancel();
 
-    void saveDefaultStyle();
     void loadStyle();
     void saveStyleAs();
     void aboutToShowStyleMenu();

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -45,7 +45,6 @@ class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui
 
     void aboutToShowStyleMenu();
     void showHelp();
-    void urlClicked( const QUrl &url );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
   private:

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -16,12 +16,11 @@
 #ifndef QGSANNOTATIONLAYERPROPERTIES_H
 #define QGSANNOTATIONLAYERPROPERTIES_H
 
-#include "qgsoptionsdialogbase.h"
+#include "qgslayerpropertiesdialog.h"
 
 #include "ui_qgsannotationlayerpropertiesbase.h"
 
 #include "qgsannotationlayer.h"
-#include "qgsmaplayerstyle.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -30,9 +29,8 @@ class QgsAnnotationLayer;
 class QgsMetadataWidget;
 class QgsMapLayerConfigWidgetFactory;
 class QgsMapLayerConfigWidget;
-class QgsLayerPropertiesGuiUtils;
 
-class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::QgsAnnotationLayerPropertiesBase
+class QgsAnnotationLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsAnnotationLayerPropertiesBase
 {
     Q_OBJECT
   public:
@@ -42,7 +40,7 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
   private slots:
-    void apply();
+    void apply() FINAL;
     void onCancel();
 
     void aboutToShowStyleMenu();
@@ -54,22 +52,14 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
   private:
-    void syncToLayer();
+    void syncToLayer() FINAL;
 
   private:
     QgsAnnotationLayer *mLayer = nullptr;
 
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
-
     QPushButton *mBtnStyle = nullptr;
 
     QgsMapCanvas *mMapCanvas = nullptr;
-
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 
     std::unique_ptr< QgsPaintEffect > mPaintEffect;
 

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -45,7 +45,6 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void apply();
     void onCancel();
 
-    void saveStyleAs();
     void aboutToShowStyleMenu();
     void showHelp();
     void urlClicked( const QUrl &url );

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -75,6 +75,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsPointCloudLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsPointCloudLayerProperties::apply );
 
   // update based on lyr's current state
   syncToLayer();
@@ -93,7 +94,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsPointCloudLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsPointCloudLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsPointCloudLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsPointCloudLayerProperties::aboutToShowStyleMenu );
@@ -231,29 +232,6 @@ void QgsPointCloudLayerProperties::syncToLayer()
     w->syncToLayer( mLayer );
 
   mStatisticsCalculationWarningLabel->setHidden( mLayer->statisticsCalculationState() != QgsPointCloudLayer::PointCloudStatisticsCalculationState::Calculated );
-}
-
-void QgsPointCloudLayerProperties::saveDefaultStyle()
-{
-  apply(); // make sure the style to save is up-to-date
-
-  // a flag passed by reference
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  // after calling this the above flag will be set true for success
-  // or false if the save operation failed
-  const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    // let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
 }
 
 void QgsPointCloudLayerProperties::loadStyle()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -70,7 +70,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
-  setMetadataWidget( mMetadataWidget );
+  setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
   // update based on lyr's current state
   syncToLayer();
@@ -276,15 +276,6 @@ void QgsPointCloudLayerProperties::crsChanged( const QgsCoordinateReferenceSyste
   QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mMapCanvas, tr( "Select transformation for the layer" ) );
   mLayer->setCrs( crs );
   mMetadataWidget->crsChanged();
-}
-
-void QgsPointCloudLayerProperties::optionsStackedWidget_CurrentChanged( int index )
-{
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  const bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
-  mBtnStyle->setVisible( ! isMetadataPanel );
-  mBtnMetadata->setVisible( isMetadataPanel );
 }
 
 //

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -41,7 +41,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   setupUi( this );
 
   connect( this, &QDialog::accepted, this, &QgsPointCloudLayerProperties::apply );
-  connect( this, &QDialog::rejected, this, &QgsPointCloudLayerProperties::onCancel );
+  connect( this, &QDialog::rejected, this, &QgsPointCloudLayerProperties::rollback );
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsPointCloudLayerProperties::apply );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPointCloudLayerProperties::showHelp );
   connect( pbnQueryBuilder, &QPushButton::clicked, this, &QgsPointCloudLayerProperties::pbnQueryBuilder_clicked );
@@ -178,21 +178,12 @@ void QgsPointCloudLayerProperties::apply()
   mLayer->triggerRepaint();
 }
 
-void QgsPointCloudLayerProperties::onCancel()
+void QgsPointCloudLayerProperties::rollback()
 {
   if ( mBackupCrs != mLayer->crs() )
     mLayer->setCrs( mBackupCrs );
 
-  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
-  {
-    // need to reset style to previous - style applied directly to the layer (not in apply())
-    QString myMessage;
-    QDomDocument doc( QStringLiteral( "qgis" ) );
-    int errorLine, errorColumn;
-    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
-    mLayer->importNamedStyle( doc, myMessage );
-    syncToLayer();
-  }
+  QgsLayerPropertiesDialog::rollback();
 }
 
 void QgsPointCloudLayerProperties::syncToLayer()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -101,8 +101,8 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsPointCloudLayerProperties::saveMetadataAs );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
   menuMetadata->addAction( tr( "Save as Default" ), this, &QgsPointCloudLayerProperties::saveDefaultMetadata );
   menuMetadata->addAction( tr( "Restore Default" ), this, &QgsPointCloudLayerProperties::loadDefaultMetadata );
@@ -346,34 +346,6 @@ void QgsPointCloudLayerProperties::aboutToShowStyleMenu()
   // re-add style manager actions!
   m->addSeparator();
   QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
-}
-
-void QgsPointCloudLayerProperties::saveMetadataAs()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  const QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
-                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
-  if ( myOutputFileName.isNull() ) //dialog canceled
-  {
-    return;
-  }
-
-  mMetadataWidget->acceptMetadata();
-
-  //ensure the user never omitted the extension from the file name
-  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
-  {
-    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
-  }
-
-  bool defaultLoadedFlag = false;
-  const QString message = mLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
-  if ( defaultLoadedFlag )
-    myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
-  else
-    QMessageBox::information( this, tr( "Save Metadata" ), message );
 }
 
 void QgsPointCloudLayerProperties::saveDefaultMetadata()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -14,8 +14,6 @@
  ***************************************************************************/
 
 #include "qgspointcloudlayerproperties.h"
-
-#include "qgsfileutils.h"
 #include "qgshelp.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmaplayerstyleguiutils.h"
@@ -95,7 +93,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadStyleFromFile );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsPointCloudLayerProperties::saveStyleAs );
+  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
@@ -239,33 +237,7 @@ void QgsPointCloudLayerProperties::syncToLayer()
 
 void QgsPointCloudLayerProperties::saveStyleAs()
 {
-  QgsSettings settings;
-  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString outputFileName = QFileDialog::getSaveFileName(
-                             this,
-                             tr( "Save layer properties as style file" ),
-                             lastUsedDir,
-                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
-  if ( outputFileName.isEmpty() )
-    return;
-
-  // ensure the user never omits the extension from the file name
-  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
-
-  apply(); // make sure the style to save is up-to-date
-
-  // then export style
-  bool defaultLoadedFlag = false;
-  QString message;
-  message = mLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
-
-  if ( defaultLoadedFlag )
-  {
-    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
-  }
-  else
-    QMessageBox::information( this, tr( "Save Style" ), message );
+  mLayerPropertiesUtils->saveStyleToFile();
 }
 
 void QgsPointCloudLayerProperties::aboutToShowStyleMenu()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -19,7 +19,6 @@
 #include "qgsmaplayerstyleguiutils.h"
 #include "qgspointcloudlayer.h"
 #include "qgsgui.h"
-#include "qgsnative.h"
 #include "qgsapplication.h"
 #include "qgsmetadatawidget.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
@@ -210,7 +209,7 @@ void QgsPointCloudLayerProperties::syncToLayer()
   mInformationTextBrowser->document()->setDefaultStyleSheet( myStyle );
   mInformationTextBrowser->setHtml( mLayer->htmlMetadata() );
   mInformationTextBrowser->setOpenLinks( false );
-  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsPointCloudLayerProperties::urlClicked );
+  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsPointCloudLayerProperties::openUrl );
 
   mCrsSelector->setCrs( mLayer->crs() );
 
@@ -250,15 +249,6 @@ void QgsPointCloudLayerProperties::showHelp()
   {
     QgsHelp::openHelp( QStringLiteral( "working_with_point_clouds/point_clouds.html" ) );
   }
-}
-
-void QgsPointCloudLayerProperties::urlClicked( const QUrl &url )
-{
-  const QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsPointCloudLayerProperties::pbnQueryBuilder_clicked()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -34,9 +34,8 @@
 #include <QUrl>
 
 QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *, QWidget *parent, Qt::WindowFlags flags )
-  : QgsLayerPropertiesDialog( lyr, QStringLiteral( "PointCloudLayerProperties" ), parent, flags )
+  : QgsLayerPropertiesDialog( lyr, canvas, QStringLiteral( "PointCloudLayerProperties" ), parent, flags )
   , mLayer( lyr )
-  , mMapCanvas( canvas )
 {
   setupUi( this );
 
@@ -48,7 +47,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
 
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsPointCloudLayerProperties::crsChanged );
 
-  mScaleRangeWidget->setMapCanvas( mMapCanvas );
+  mScaleRangeWidget->setMapCanvas( mCanvas );
   chkUseScaleDependentRendering->setChecked( lyr->hasScaleBasedVisibility() );
   mScaleRangeWidget->setScaleRange( lyr->minimumScale(), lyr->maximumScale() );
 
@@ -64,7 +63,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   metadataFrame->setContentsMargins( 0, 0, 0, 0 );
   mMetadataWidget = new QgsMetadataWidget( this, mLayer );
   mMetadataWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
-  mMetadataWidget->setMapCanvas( mMapCanvas );
+  mMetadataWidget->setMapCanvas( mCanvas );
   layout->addWidget( mMetadataWidget );
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
@@ -139,25 +138,6 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
     title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
   restoreOptionsBaseUi( title );
-}
-
-void QgsPointCloudLayerProperties::addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory )
-{
-  if ( !factory->supportsLayer( mLayer ) || !factory->supportLayerPropertiesDialog() )
-  {
-    return;
-  }
-
-  QgsMapLayerConfigWidget *page = factory->createWidget( mLayer, mMapCanvas, false, this );
-  mConfigWidgets << page;
-
-  const QString beforePage = factory->layerPropertiesPagePositionHint();
-  if ( beforePage.isEmpty() )
-    addPage( factory->title(), factory->title(), factory->icon(), page );
-  else
-    insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage );
-
-  page->syncToLayer( mLayer );
 }
 
 void QgsPointCloudLayerProperties::apply()
@@ -254,7 +234,7 @@ void QgsPointCloudLayerProperties::pbnQueryBuilder_clicked()
 
 void QgsPointCloudLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
-  QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mMapCanvas, tr( "Select transformation for the layer" ) );
+  QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mCanvas, tr( "Select transformation for the layer" ) );
   mLayer->setCrs( crs );
   mMetadataWidget->crsChanged();
 }

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -74,6 +74,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsPointCloudLayerProperties::syncToLayer );
 
   // update based on lyr's current state
   syncToLayer();
@@ -93,7 +94,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsPointCloudLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsPointCloudLayerProperties::saveDefaultStyle );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsPointCloudLayerProperties::loadDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsPointCloudLayerProperties::aboutToShowStyleMenu );
 
@@ -230,26 +231,6 @@ void QgsPointCloudLayerProperties::syncToLayer()
     w->syncToLayer( mLayer );
 
   mStatisticsCalculationWarningLabel->setHidden( mLayer->statisticsCalculationState() != QgsPointCloudLayer::PointCloudStatisticsCalculationState::Calculated );
-}
-
-
-void QgsPointCloudLayerProperties::loadDefaultStyle()
-{
-  bool defaultLoadedFlag = false;
-  const QString myMessage = mLayer->loadDefaultStyle( defaultLoadedFlag );
-  // reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-  }
-  else
-  {
-    // otherwise let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
 }
 
 void QgsPointCloudLayerProperties::saveDefaultStyle()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -104,8 +104,8 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsPointCloudLayerProperties::saveDefaultMetadata );
-  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsPointCloudLayerProperties::loadDefaultMetadata );
+  menuMetadata->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataAsDefault );
+  menuMetadata->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultMetadata );
 
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
@@ -346,33 +346,6 @@ void QgsPointCloudLayerProperties::aboutToShowStyleMenu()
   // re-add style manager actions!
   m->addSeparator();
   QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
-}
-
-void QgsPointCloudLayerProperties::saveDefaultMetadata()
-{
-  mMetadataWidget->acceptMetadata();
-
-  bool defaultSavedFlag = false;
-  const QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
-  if ( !defaultSavedFlag )
-  {
-    QMessageBox::warning( this, tr( "Default Metadata" ), errorMsg );
-  }
-}
-
-void QgsPointCloudLayerProperties::loadDefaultMetadata()
-{
-  bool defaultLoadedFlag = false;
-  const QString myMessage = mLayer->loadNamedMetadata( mLayer->metadataUri(), defaultLoadedFlag );
-  //reset if the default metadata was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    mMetadataWidget->setMetadata( &mLayer->metadata() );
-  }
-  else
-  {
-    QMessageBox::information( this, tr( "Default Metadata" ), myMessage );
-  }
 }
 
 void QgsPointCloudLayerProperties::showHelp()

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -98,13 +98,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     /**
-     * Loads a saved style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void loadStyle();
-
-    /**
      * Saves a style when appriate button is pressed
      *
      * \since QGIS 3.30

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -101,7 +101,6 @@ class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui
 
     void aboutToShowStyleMenu();
     void showHelp();
-    void urlClicked( const QUrl &url );
     void pbnQueryBuilder_clicked();
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -93,8 +93,6 @@ class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui
   public:
     QgsPointCloudLayerProperties( QgsPointCloudLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-
   private slots:
     void apply() FINAL;
     void rollback() FINAL;
@@ -113,10 +111,7 @@ class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 
-    QgsMapCanvas *mMapCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
-
-    QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 
     QgsCoordinateReferenceSystem mBackupCrs;
 

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -32,7 +32,7 @@ class QgsPointCloudLayer;
 class QgsMetadataWidget;
 class QgsMapLayerConfigWidgetFactory;
 class QgsMapLayerConfigWidget;
-
+class QgsLayerPropertiesGuiUtils;
 
 class QgsPointCloudAttributeStatisticsModel : public QAbstractTableModel
 {
@@ -130,7 +130,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void onCancel();
 
     void aboutToShowStyleMenu();
-    void loadMetadata();
     void saveMetadataAs();
     void saveDefaultMetadata();
     void loadDefaultMetadata();
@@ -147,6 +146,8 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
   private:
     QgsPointCloudLayer *mLayer = nullptr;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     QPushButton *mBtnStyle = nullptr;
     QPushButton *mBtnMetadata = nullptr;

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -16,11 +16,10 @@
 #ifndef QGSPOINTCLOUDLAYERPROPERTIES_H
 #define QGSPOINTCLOUDLAYERPROPERTIES_H
 
-#include "qgsoptionsdialogbase.h"
+#include "qgslayerpropertiesdialog.h"
 
 #include "ui_qgspointcloudlayerpropertiesbase.h"
 
-#include "qgsmaplayerstylemanager.h"
 #include <QAbstractTableModel>
 
 #include "qgspointcloudlayer.h"
@@ -88,7 +87,7 @@ class QgsPointCloudClassificationStatisticsModel : public QAbstractTableModel
     QList<int> mClassifications;
 };
 
-class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::QgsPointCloudLayerPropertiesBase
+class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsPointCloudLayerPropertiesBase
 {
     Q_OBJECT
   public:
@@ -96,15 +95,8 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
-    /**
-     * Saves a style when appriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void saveStyleAs();
-
   private slots:
-    void apply();
+    void apply() FINAL;
     void onCancel();
 
     void aboutToShowStyleMenu();
@@ -117,12 +109,10 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
   private:
-    void syncToLayer();
+    void syncToLayer() FINAL;
 
   private:
     QgsPointCloudLayer *mLayer = nullptr;
-
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     QPushButton *mBtnStyle = nullptr;
     QPushButton *mBtnMetadata = nullptr;
@@ -131,12 +121,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
-
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 
     QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -94,7 +94,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
   public:
     QgsPointCloudLayerProperties( QgsPointCloudLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 
-
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     /**

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -130,8 +130,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void onCancel();
 
     void aboutToShowStyleMenu();
-    void saveDefaultMetadata();
-    void loadDefaultMetadata();
     void showHelp();
     void urlClicked( const QUrl &url );
     void pbnQueryBuilder_clicked();

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -98,13 +98,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     /**
-     * Saves the default style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void saveDefaultStyle();
-
-    /**
      * Loads a saved style when appropriate button is pressed
      *
      * \since QGIS 3.30

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -105,17 +105,12 @@ class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui
     void pbnQueryBuilder_clicked();
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
-  protected slots:
-    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
-
   private:
     void syncToLayer() FINAL;
 
   private:
     QgsPointCloudLayer *mLayer = nullptr;
 
-    QPushButton *mBtnStyle = nullptr;
-    QPushButton *mBtnMetadata = nullptr;
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -98,13 +98,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     /**
-     * Loads the default style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void loadDefaultStyle();
-
-    /**
      * Saves the default style when appropriate button is pressed
      *
      * \since QGIS 3.30

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -97,7 +97,7 @@ class QgsPointCloudLayerProperties : public QgsLayerPropertiesDialog, private Ui
 
   private slots:
     void apply() FINAL;
-    void onCancel();
+    void rollback() FINAL;
 
     void aboutToShowStyleMenu();
     void showHelp();

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -130,7 +130,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void onCancel();
 
     void aboutToShowStyleMenu();
-    void saveMetadataAs();
     void saveDefaultMetadata();
     void loadDefaultMetadata();
     void showHelp();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8292,13 +8292,13 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
       break;
 
     case Qgis::LayerType::Mesh:
-      QgsMeshLayerProperties( layer, mMapCanvas ).saveStyleAs();
+      QgsMeshLayerProperties( layer, mMapCanvas ).saveStyleToFile();
       break;
 
     case Qgis::LayerType::VectorTile:
       QgsVectorTileLayerProperties( qobject_cast<QgsVectorTileLayer *>( layer ),
                                     mMapCanvas,
-                                    visibleMessageBar() ).saveStyleAs();
+                                    visibleMessageBar() ).saveStyleToFile();
       break;
 
     case Qgis::LayerType::PointCloud:
@@ -8309,9 +8309,9 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
 
     // Not available for these
     case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::TiledMesh:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Group:
-    default:
       break;
   }
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -125,6 +125,7 @@
 #include "elevation/qgselevationprofilewidget.h"
 
 #include "layers/qgsapplayerhandling.h"
+#include "qgsmaplayerstylemanager.h"
 
 #include "canvas/qgscanvasrefreshblocker.h"
 
@@ -8303,7 +8304,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
     case Qgis::LayerType::PointCloud:
       QgsPointCloudLayerProperties( qobject_cast<QgsPointCloudLayer *>( layer ),
                                     mMapCanvas,
-                                    visibleMessageBar() ).saveStyleAs();
+                                    visibleMessageBar() ).saveStyleToFile();
       break;
 
     // Not available for these

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -589,7 +589,7 @@ set(QGIS_GUI_SRCS
   qgslayermetadataresultsmodel.cpp
   qgslayermetadatasourceselectprovider.cpp
   qgslayermetadataresultsproxymodel.cpp
-  qgslayerpropertiesguiutils.cpp
+  qgslayerpropertiesdialog.cpp
   qgslistwidget.cpp
   qgslegendfilterbutton.cpp
   qgslegendpatchshapebutton.cpp
@@ -863,7 +863,7 @@ set(QGIS_GUI_HDRS
   qgslayermetadataresultsmodel.h
   qgslayermetadataresultsproxymodel.h
   qgslayermetadatasourceselectprovider.h
-  qgslayerpropertiesguiutils.h
+  qgslayerpropertiesdialog.h
   qgslegendfilterbutton.h
   qgslegendpatchshapebutton.h
   qgslegendpatchshapewidget.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -589,6 +589,7 @@ set(QGIS_GUI_SRCS
   qgslayermetadataresultsmodel.cpp
   qgslayermetadatasourceselectprovider.cpp
   qgslayermetadataresultsproxymodel.cpp
+  qgslayerpropertiesguiutils.cpp
   qgslistwidget.cpp
   qgslegendfilterbutton.cpp
   qgslegendpatchshapebutton.cpp
@@ -862,6 +863,7 @@ set(QGIS_GUI_HDRS
   qgslayermetadataresultsmodel.h
   qgslayermetadataresultsproxymodel.h
   qgslayermetadatasourceselectprovider.h
+  qgslayerpropertiesguiutils.h
   qgslegendfilterbutton.h
   qgslegendpatchshapebutton.h
   qgslegendpatchshapewidget.h

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -398,8 +398,10 @@ void QgsMeshLayerProperties::onTimeReferenceChange()
   mTemporalDateTimeEnd->setDateTime( timeExtent.end() );
 }
 
-void QgsMeshLayerProperties::onCancel()
+void QgsMeshLayerProperties::rollback()
 {
   if ( mBackupCrs != mMeshLayer->crs() )
     mMeshLayer->setCrs( mBackupCrs );
+
+  QgsLayerPropertiesDialog::rollback();
 }

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -19,7 +19,6 @@
 #include <typeinfo>
 
 #include "qgsapplication.h"
-#include "qgsfileutils.h"
 #include "qgshelp.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
@@ -150,7 +149,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadStyleFromFile );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsMeshLayerProperties::saveStyleAs );
+  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
@@ -276,33 +275,7 @@ void QgsMeshLayerProperties::loadStyle()
 
 void QgsMeshLayerProperties::saveStyleAs()
 {
-  QgsSettings settings;
-  QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString outputFileName = QFileDialog::getSaveFileName(
-                             this,
-                             tr( "Save layer properties as style file" ),
-                             lastUsedDir,
-                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
-  if ( outputFileName.isEmpty() )
-    return;
-
-  // ensure the user never omits the extension from the file name
-  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
-
-  apply(); // make sure the style to save is up-to-date
-
-  // then export style
-  bool defaultLoadedFlag = false;
-  QString message;
-  message = mMeshLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
-
-  if ( defaultLoadedFlag )
-  {
-    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
-  }
-  else
-    QMessageBox::information( this, tr( "Save Style" ), message );
+  mLayerPropertiesUtils->saveStyleToFile();
 }
 
 void QgsMeshLayerProperties::apply()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -32,7 +32,6 @@
 #include "qgsmeshlayertemporalproperties.h"
 #include "qgssettings.h"
 #include "qgsdatumtransformdialog.h"
-#include "qgsmaplayerconfigwidgetfactory.h"
 #include "qgsmetadatawidget.h"
 
 #include <QDesktopServices>
@@ -40,9 +39,8 @@
 #include <QMessageBox>
 
 QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent, Qt::WindowFlags fl )
-  : QgsLayerPropertiesDialog( lyr, QStringLiteral( "MeshLayerProperties" ), parent, fl )
+  : QgsLayerPropertiesDialog( lyr, canvas, QStringLiteral( "MeshLayerProperties" ), parent, fl )
   , mMeshLayer( qobject_cast<QgsMeshLayer *>( lyr ) )
-  , mCanvas( canvas )
 {
   Q_ASSERT( mMeshLayer );
 
@@ -73,7 +71,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   connect( lyr->styleManager(), &QgsMapLayerStyleManager::currentStyleChanged, this, &QgsMeshLayerProperties::syncAndRepaint );
 
   connect( this, &QDialog::accepted, this, &QgsMeshLayerProperties::apply );
-  connect( this, &QDialog::rejected, this, &QgsMeshLayerProperties::onCancel );
+  connect( this, &QDialog::rejected, this, &QgsMeshLayerProperties::rollback );
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsMeshLayerProperties::apply );
 
   connect( mMeshLayer, &QgsMeshLayer::dataChanged, this, &QgsMeshLayerProperties::syncAndRepaint );
@@ -161,26 +159,6 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   if ( !mMeshLayer->styleManager()->isDefault( mMeshLayer->styleManager()->currentStyle() ) )
     title += QStringLiteral( " (%1)" ).arg( mMeshLayer->styleManager()->currentStyle() );
   restoreOptionsBaseUi( title );
-}
-
-void QgsMeshLayerProperties::addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory )
-{
-  if ( !factory->supportsLayer( mMeshLayer ) || !factory->supportLayerPropertiesDialog() )
-  {
-    return;
-  }
-
-  QgsMapLayerConfigWidget *page = factory->createWidget( mMeshLayer, mCanvas, false, this );
-  mConfigWidgets << page;
-
-  const QString beforePage = factory->layerPropertiesPagePositionHint();
-  if ( beforePage.isEmpty() )
-    addPage( factory->title(), factory->title(), factory->icon(), page );
-  else
-    insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage );
-
-  page->syncToLayer( mMeshLayer );
-
 }
 
 void QgsMeshLayerProperties::syncToLayer()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -117,7 +117,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mTemporalDateTimeEnd->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
   mTemporalDateTimeReference->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
-  setMetadataWidget( mMetadataWidget );
+  setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
   // update based on lyr's current state
   syncToLayer();
@@ -183,15 +183,6 @@ void QgsMeshLayerProperties::addPropertiesPageFactory( const QgsMapLayerConfigWi
 
   page->syncToLayer( mMeshLayer );
 
-}
-
-void QgsMeshLayerProperties::optionsStackedWidget_CurrentChanged( int index )
-{
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
-  mBtnStyle->setVisible( ! isMetadataPanel );
-  mBtnMetadata->setVisible( isMetadataPanel );
 }
 
 void QgsMeshLayerProperties::syncToLayer()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -33,8 +33,6 @@
 #include "qgssettings.h"
 #include "qgsdatumtransformdialog.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
-#include "qgsgui.h"
-#include "qgsnative.h"
 #include "qgsmetadatawidget.h"
 
 #include <QDesktopServices>
@@ -199,7 +197,7 @@ void QgsMeshLayerProperties::syncToLayer()
   mInformationTextBrowser->document()->setDefaultStyleSheet( myStyle );
   mInformationTextBrowser->setHtml( mMeshLayer->htmlMetadata() );
   mInformationTextBrowser->setOpenLinks( false );
-  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsMeshLayerProperties::urlClicked );
+  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsMeshLayerProperties::openUrl );
 
   QgsDebugMsgLevel( QStringLiteral( "populate source tab" ), 4 );
   /*
@@ -398,15 +396,6 @@ void QgsMeshLayerProperties::onTimeReferenceChange()
   const QgsDateTimeRange &timeExtent = mMeshLayer->dataProvider()->temporalCapabilities()->timeExtent( mTemporalDateTimeReference->dateTime() );
   mTemporalDateTimeStart->setDateTime( timeExtent.begin() );
   mTemporalDateTimeEnd->setDateTime( timeExtent.end() );
-}
-
-void QgsMeshLayerProperties::urlClicked( const QUrl &url )
-{
-  QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsMeshLayerProperties::onCancel()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -36,14 +36,13 @@
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsmetadatawidget.h"
-#include "qgslayerpropertiesguiutils.h"
 
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QMessageBox>
 
 QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent, Qt::WindowFlags fl )
-  : QgsOptionsDialogBase( QStringLiteral( "MeshLayerProperties" ), parent, fl )
+  : QgsLayerPropertiesDialog( lyr, QStringLiteral( "MeshLayerProperties" ), parent, fl )
   , mMeshLayer( qobject_cast<QgsMeshLayer *>( lyr ) )
   , mCanvas( canvas )
 {
@@ -118,13 +117,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mTemporalDateTimeEnd->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
   mTemporalDateTimeReference->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
-  mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mMeshLayer, mMetadataWidget );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsMeshLayerProperties::syncToLayer );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsMeshLayerProperties::apply );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::storeCurrentStyleForUndo, this, [ = ]
-  {
-    mOldStyle = mMeshLayer->styleManager()->style( mMeshLayer->styleManager()->currentStyle() );
-  } );
+  setMetadataWidget( mMetadataWidget );
 
   // update based on lyr's current state
   syncToLayer();
@@ -148,11 +141,11 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
-  menuStyle->addAction( tr( "Load Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadStyleFromFile );
-  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsMeshLayerProperties::loadStyleFromFile );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsMeshLayerProperties::saveStyleToFile );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
-  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsMeshLayerProperties::saveStyleAsDefault );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsMeshLayerProperties::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsMeshLayerProperties::aboutToShowStyleMenu );
 
@@ -160,8 +153,8 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsMeshLayerProperties::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsMeshLayerProperties::saveMetadataToFile );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -258,24 +251,19 @@ void QgsMeshLayerProperties::syncToLayer()
   mStaticDatasetGroupBox->setChecked( !mMeshLayer->temporalProperties()->isActive() );
 }
 
-void QgsMeshLayerProperties::loadDefaultStyle()
-{
-  mLayerPropertiesUtils->loadDefaultStyle();
-}
-
 void QgsMeshLayerProperties::saveDefaultStyle()
 {
-  mLayerPropertiesUtils->saveStyleAsDefault();
+  saveStyleAsDefault();
 }
 
 void QgsMeshLayerProperties::loadStyle()
 {
-  mLayerPropertiesUtils->loadStyleFromFile();
+  loadStyleFromFile();
 }
 
 void QgsMeshLayerProperties::saveStyleAs()
 {
-  mLayerPropertiesUtils->saveStyleToFile();
+  saveStyleToFile();
 }
 
 void QgsMeshLayerProperties::apply()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -120,6 +120,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mTemporalDateTimeReference->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mMeshLayer, mMetadataWidget );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsMeshLayerProperties::syncToLayer );
 
   // update based on lyr's current state
   syncToLayer();
@@ -147,7 +148,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsMeshLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsMeshLayerProperties::saveDefaultStyle );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsMeshLayerProperties::loadDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsMeshLayerProperties::aboutToShowStyleMenu );
 
@@ -255,22 +256,7 @@ void QgsMeshLayerProperties::syncToLayer()
 
 void QgsMeshLayerProperties::loadDefaultStyle()
 {
-  bool defaultLoadedFlag = false;
-  QString myMessage = mMeshLayer->loadDefaultStyle( defaultLoadedFlag );
-  // reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-    apply();
-  }
-  else
-  {
-    // otherwise let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->loadDefaultStyle();
 }
 
 void QgsMeshLayerProperties::saveDefaultStyle()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -155,8 +155,8 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsMeshLayerProperties::saveMetadataAs );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -510,34 +510,6 @@ void QgsMeshLayerProperties::urlClicked( const QUrl &url )
     QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
   else
     QDesktopServices::openUrl( url );
-}
-
-void QgsMeshLayerProperties::saveMetadataAs()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
-                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
-  if ( myOutputFileName.isNull() ) //dialog canceled
-  {
-    return;
-  }
-
-  mMetadataWidget->acceptMetadata();
-
-  //ensure the user never omitted the extension from the file name
-  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
-  {
-    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
-  }
-
-  bool defaultLoadedFlag = false;
-  QString message = mMeshLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
-  if ( defaultLoadedFlag )
-    myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
-  else
-    QMessageBox::information( this, tr( "Save Metadata" ), message );
 }
 
 void QgsMeshLayerProperties::onCancel()

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -121,6 +121,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mMeshLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsMeshLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsMeshLayerProperties::apply );
 
   // update based on lyr's current state
   syncToLayer();
@@ -147,7 +148,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsMeshLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsMeshLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsMeshLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsMeshLayerProperties::aboutToShowStyleMenu );
@@ -261,25 +262,7 @@ void QgsMeshLayerProperties::loadDefaultStyle()
 
 void QgsMeshLayerProperties::saveDefaultStyle()
 {
-  apply(); // make sure the style to save is up-to-date
-
-  // a flag passed by reference
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  // after calling this the above flag will be set true for success
-  // or false if the save operation failed
-  QString myMessage = mMeshLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    // let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->saveStyleAsDefault();
 }
 
 void QgsMeshLayerProperties::loadStyle()

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -78,6 +78,7 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
   protected slots:
     void syncToLayer() FINAL;
     void apply() FINAL;
+    void rollback() FINAL;
 
   private slots:
 
@@ -89,7 +90,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     void aboutToShowStyleMenu();
     //! Reloads temporal properties from the provider
     void reloadTemporalProperties();
-    void rollback() FINAL;
 
     void onTimeReferenceChange();
 

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -18,9 +18,7 @@
 #define QGSMESHLAYERPROPERTIES_H
 
 #include "ui_qgsmeshlayerpropertiesbase.h"
-
-#include "qgsmaplayerstylemanager.h"
-#include "qgsoptionsdialogbase.h"
+#include "qgslayerpropertiesdialog.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
 
@@ -33,7 +31,6 @@ class QgsMeshLayer3DRendererWidget;
 class QgsMeshStaticDatasetWidget;
 class QgsMapLayerConfigWidgetFactory;
 class QgsMetadataWidget;
-class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
@@ -44,7 +41,7 @@ class QgsLayerPropertiesGuiUtils;
  *
  * \since QGIS 3.16 in the GUI API
  */
-class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private Ui::QgsMeshLayerPropertiesBase
+class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsMeshLayerPropertiesBase
 {
     Q_OBJECT
 
@@ -65,13 +62,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
      * \since QGIS 3.16
      */
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-
-    /**
-     * Loads the default style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void loadDefaultStyle();
 
     /**
      * Saves the default style when appropriate button is pressed
@@ -95,14 +85,12 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void saveStyleAs();
 
   protected slots:
-    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
+    void optionsStackedWidget_CurrentChanged( int index ) FINAL;
+    void syncToLayer() FINAL;
+    void apply() FINAL;
 
   private slots:
-    //! Synchronizes widgets state with associated mesh layer
-    void syncToLayer();
 
-    //!Applies the settings made in the dialog without closing the box
-    void apply();
     //! Synchronizes GUI state with associated mesh layer and trigger repaint
     void syncAndRepaint();
     //! Changes layer coordinate reference system
@@ -127,16 +115,8 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     //! Pointer to the mesh layer that this property dialog changes the behavior of.
     QgsMeshLayer *mMeshLayer = nullptr;
 
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
-
     //! Pointer to mesh 3d styling widget
     QgsMeshLayer3DRendererWidget *mMesh3DWidget = nullptr;
-
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 
     QPushButton *mBtnStyle = nullptr;
     QPushButton *mBtnMetadata = nullptr;

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -98,8 +98,7 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     void aboutToShowStyleMenu();
     //! Reloads temporal properties from the provider
     void reloadTemporalProperties();
-    //! \brief Called when cancel button is pressed
-    void onCancel();
+    void rollback() FINAL;
 
     void onTimeReferenceChange();
 

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -66,23 +66,23 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     /**
      * Saves the default style when appropriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use saveStyleAsDefault() instead.
      */
-    void saveDefaultStyle();
+    Q_DECL_DEPRECATED void saveDefaultStyle() SIP_DEPRECATED;
 
     /**
      * Loads a saved style when appropriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use loadStyleFromFile() instead.
      */
-    void loadStyle();
+    Q_DECL_DEPRECATED void loadStyle() SIP_DEPRECATED;
 
     /**
      * Saves a style when appriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use saveStyleToFile() instead.
      */
-    void saveStyleAs();
+    Q_DECL_DEPRECATED void saveStyleAs() SIP_DEPRECATED;
 
   protected slots:
     void syncToLayer() FINAL;

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -85,7 +85,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     void saveStyleAs();
 
   protected slots:
-    void optionsStackedWidget_CurrentChanged( int index ) FINAL;
     void syncToLayer() FINAL;
     void apply() FINAL;
 
@@ -118,8 +117,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     //! Pointer to mesh 3d styling widget
     QgsMeshLayer3DRendererWidget *mMesh3DWidget = nullptr;
 
-    QPushButton *mBtnStyle = nullptr;
-    QPushButton *mBtnMetadata = nullptr;
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -26,10 +26,8 @@ class QgsMapLayer;
 class QgsMapCanvas;
 class QgsMeshLayer;
 class QgsRendererMeshPropertiesWidget;
-class QgsMapLayerConfigWidget;
 class QgsMeshLayer3DRendererWidget;
 class QgsMeshStaticDatasetWidget;
-class QgsMapLayerConfigWidgetFactory;
 class QgsMetadataWidget;
 
 /**
@@ -55,13 +53,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
      * \param fl Window flags
      */
     QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
-
-    /**
-     * Adds properties page from a factory
-     *
-     * \since QGIS 3.16
-     */
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
     /**
      * Saves the default style when appropriate button is pressed
@@ -106,8 +97,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     //! Pointer to the mesh styling widget
     QgsRendererMeshPropertiesWidget *mRendererMeshPropertiesWidget = nullptr;
 
-    QList<QgsMapLayerConfigWidget *> mConfigWidgets;
-
     //! Pointer to the mesh layer that this property dialog changes the behavior of.
     QgsMeshLayer *mMeshLayer = nullptr;
 
@@ -117,7 +106,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 
-    QgsMapCanvas *mCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
 
     bool mIsMapSettingsTemporal = false;

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -117,7 +117,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void onTimeReferenceChange();
 
     void urlClicked( const QUrl &url );
-    void saveMetadataAs();
 
   private:
     //! Pointer to the mesh styling widget

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -33,6 +33,7 @@ class QgsMeshLayer3DRendererWidget;
 class QgsMeshStaticDatasetWidget;
 class QgsMapLayerConfigWidgetFactory;
 class QgsMetadataWidget;
+class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
@@ -116,7 +117,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void onTimeReferenceChange();
 
     void urlClicked( const QUrl &url );
-    void loadMetadata();
     void saveMetadataAs();
 
   private:
@@ -127,6 +127,8 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     //! Pointer to the mesh layer that this property dialog changes the behavior of.
     QgsMeshLayer *mMeshLayer = nullptr;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     //! Pointer to mesh 3d styling widget
     QgsMeshLayer3DRendererWidget *mMesh3DWidget = nullptr;

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -103,8 +103,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsLayerPropertiesDialog, priva
 
     void onTimeReferenceChange();
 
-    void urlClicked( const QUrl &url );
-
   private:
     //! Pointer to the mesh styling widget
     QgsRendererMeshPropertiesWidget *mRendererMeshPropertiesWidget = nullptr;

--- a/src/gui/qgslayerpropertiesdialog.cpp
+++ b/src/gui/qgslayerpropertiesdialog.cpp
@@ -19,21 +19,23 @@
 #include "qgsmaplayer.h"
 #include "qgsmetadatawidget.h"
 #include "qgsfileutils.h"
+#include "qstackedwidget.h"
 
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
 
-QgsLayerPropertiesDialog::QgsLayerPropertiesDialog( QgsMapLayer *layer , const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
-    : QgsOptionsDialogBase(settingsKey, parent, fl, settings )
+QgsLayerPropertiesDialog::QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
+  : QgsOptionsDialogBase( settingsKey, parent, fl, settings )
   , mLayer( layer )
 {
 
 }
 
-void QgsLayerPropertiesDialog::setMetadataWidget(QgsMetadataWidget *widget)
+void QgsLayerPropertiesDialog::setMetadataWidget( QgsMetadataWidget *widget, QWidget *page )
 {
-    mMetadataWidget = widget;
+  mMetadataWidget = widget;
+  mMetadataPage = page;
 }
 
 void QgsLayerPropertiesDialog::loadMetadataFromFile()
@@ -271,4 +273,16 @@ void QgsLayerPropertiesDialog::storeCurrentStyleForUndo()
     return;
 
   mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
+}
+
+void QgsLayerPropertiesDialog::optionsStackedWidget_CurrentChanged( int index )
+{
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
+  if ( mMetadataPage && mBtnStyle && mBtnMetadata )
+  {
+    const bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mMetadataPage ) );
+    mBtnStyle->setVisible( ! isMetadataPanel );
+    mBtnMetadata->setVisible( isMetadataPanel );
+  }
 }

--- a/src/gui/qgslayerpropertiesdialog.cpp
+++ b/src/gui/qgslayerpropertiesdialog.cpp
@@ -15,6 +15,7 @@
 
 #include "qgslayerpropertiesdialog.h"
 #include "qgsmaplayerstylemanager.h"
+#include "qgsnative.h"
 #include "qgssettings.h"
 #include "qgsmaplayer.h"
 #include "qgsmetadatawidget.h"
@@ -24,6 +25,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QDesktopServices>
 
 QgsLayerPropertiesDialog::QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
   : QgsOptionsDialogBase( settingsKey, parent, fl, settings )
@@ -285,4 +287,13 @@ void QgsLayerPropertiesDialog::optionsStackedWidget_CurrentChanged( int index )
     mBtnStyle->setVisible( ! isMetadataPanel );
     mBtnMetadata->setVisible( isMetadataPanel );
   }
+}
+
+void QgsLayerPropertiesDialog::openUrl( const QUrl &url )
+{
+  QFileInfo file( url.toLocalFile() );
+  if ( file.exists() && !file.isDir() )
+    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+  else
+    QDesktopServices::openUrl( url );
 }

--- a/src/gui/qgslayerpropertiesdialog.h
+++ b/src/gui/qgslayerpropertiesdialog.h
@@ -149,6 +149,11 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
      */
     virtual void apply() SIP_SKIP = 0;
 
+    /**
+     * Rolls back changes made to the layer.
+     */
+    virtual void rollback();
+
     void optionsStackedWidget_CurrentChanged( int index ) override;
 
     /**

--- a/src/gui/qgslayerpropertiesdialog.h
+++ b/src/gui/qgslayerpropertiesdialog.h
@@ -25,6 +25,9 @@
 
 class QgsMapLayer;
 class QgsMetadataWidget;
+class QgsMapLayerConfigWidget;
+class QgsMapLayerConfigWidgetFactory;
+class QgsMapCanvas;
 
 /**
  * \ingroup gui
@@ -43,12 +46,13 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
      * Constructor for QgsLayerPropertiesDialog.
      *
      * \param layer associated map layer
+     * \param canvas associated map canvas
      * \param settingsKey QgsSettings subgroup key for saving/restore ui states, e.g. "VectorLayerProperties".
      * \param parent parent object (owner)
      * \param fl widget flags
      * \param settings custom QgsSettings pointer
      */
-    QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = nullptr );
+    QgsLayerPropertiesDialog( QgsMapLayer *layer, QgsMapCanvas *canvas, const QString &settingsKey, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = nullptr );
 
     /**
      * Sets the metadata \a widget and \a page associated with the dialog.
@@ -56,6 +60,11 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
      * This must be called in order for the standard metadata loading/saving functionality to be avialable.
      */
     void setMetadataWidget( QgsMetadataWidget *widget, QWidget *page );
+
+    /**
+     * Adds properties page from a \a factory.
+     */
+    virtual void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
   public slots:
 
@@ -136,6 +145,12 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
 
     //! Metadata button
     QPushButton *mBtnMetadata = nullptr;
+
+    //! Associated map canvas
+    QgsMapCanvas *mCanvas = nullptr;
+
+    //! Layer config widgets
+    QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 
   protected slots:
 

--- a/src/gui/qgslayerpropertiesdialog.h
+++ b/src/gui/qgslayerpropertiesdialog.h
@@ -51,11 +51,11 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
     QgsLayerPropertiesDialog( QgsMapLayer *layer, const QString &settingsKey, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = Qt::WindowFlags(), QgsSettings *settings = nullptr );
 
     /**
-     * Sets the metadata \a widget associated with the dialog.
+     * Sets the metadata \a widget and \a page associated with the dialog.
      *
      * This must be called in order for the standard metadata loading/saving functionality to be avialable.
      */
-    void setMetadataWidget( QgsMetadataWidget *widget );
+    void setMetadataWidget( QgsMetadataWidget *widget, QWidget *page );
 
   public slots:
 
@@ -131,6 +131,12 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
     */
     QgsMapLayerStyle mOldStyle;
 
+    //! Style button
+    QPushButton *mBtnStyle = nullptr;
+
+    //! Metadata button
+    QPushButton *mBtnMetadata = nullptr;
+
   protected slots:
 
     /**
@@ -143,11 +149,14 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
      */
     virtual void apply() SIP_SKIP = 0;
 
+    void optionsStackedWidget_CurrentChanged( int index ) override;
+
   private:
 
     QPointer< QgsMapLayer> mLayer;
 
     QgsMetadataWidget *mMetadataWidget = nullptr;
+    QWidget *mMetadataPage = nullptr;
 
 };
 

--- a/src/gui/qgslayerpropertiesdialog.h
+++ b/src/gui/qgslayerpropertiesdialog.h
@@ -151,6 +151,14 @@ class GUI_EXPORT QgsLayerPropertiesDialog : public QgsOptionsDialogBase SIP_ABST
 
     void optionsStackedWidget_CurrentChanged( int index ) override;
 
+    /**
+     * Handles opening a \a url from the dialog.
+     *
+     * If the \a url refers to a local file then a file explorer will be opened pointing to the file.
+     * If it refers to a remote link then a web browser will be opened instead.
+     */
+    void openUrl( const QUrl &url );
+
   private:
 
     QPointer< QgsMapLayer> mLayer;

--- a/src/gui/qgslayerpropertiesguiutils.cpp
+++ b/src/gui/qgslayerpropertiesguiutils.cpp
@@ -98,6 +98,41 @@ void QgsLayerPropertiesGuiUtils::saveMetadataToFile()
   refocusParent();
 }
 
+void QgsLayerPropertiesGuiUtils::saveMetadataAsDefault()
+{
+  if ( !mLayer )
+    return;
+
+  mMetadataWidget->acceptMetadata();
+
+  bool defaultSavedFlag = false;
+  const QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
+  if ( !defaultSavedFlag )
+  {
+    QMessageBox::warning( mParentWidget, tr( "Default Metadata" ), errorMsg );
+    refocusParent();
+  }
+}
+
+void QgsLayerPropertiesGuiUtils::loadDefaultMetadata()
+{
+  if ( !mLayer )
+    return;
+
+  bool defaultLoadedFlag = false;
+  const QString message = mLayer->loadNamedMetadata( mLayer->metadataUri(), defaultLoadedFlag );
+  //reset if the default metadata was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    mMetadataWidget->setMetadata( &mLayer->metadata() );
+  }
+  else
+  {
+    QMessageBox::information( mParentWidget, tr( "Default Metadata" ), message );
+    refocusParent();
+  }
+}
+
 void QgsLayerPropertiesGuiUtils::refocusParent()
 {
   mParentWidget->activateWindow(); // set focus back to properties dialog

--- a/src/gui/qgslayerpropertiesguiutils.cpp
+++ b/src/gui/qgslayerpropertiesguiutils.cpp
@@ -1,0 +1,66 @@
+/***************************************************************************
+  qgslayerpropertiesguiutils.cpp
+  --------------------------------------
+  Date                 : June 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayerpropertiesguiutils.h"
+#include "qgssettings.h"
+#include "qgsmaplayer.h"
+#include "qgsmetadatawidget.h"
+
+#include <QDir>
+#include <QFileDialog>
+#include <QMessageBox>
+
+QgsLayerPropertiesGuiUtils::QgsLayerPropertiesGuiUtils( QWidget *parent, QgsMapLayer *layer, QgsMetadataWidget *metadataWidget )
+  : QObject( parent )
+  , mParentWidget( parent )
+  , mLayer( layer )
+  , mMetadataWidget( metadataWidget )
+{
+
+}
+
+void QgsLayerPropertiesGuiUtils::loadMetadata()
+{
+  if ( !mLayer )
+    return;
+
+  QgsSettings settings;  // where we keep last used filter in persistent state
+  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  const QString fileName = QFileDialog::getOpenFileName( mParentWidget, tr( "Load Layer Metadata" ), lastUsedDir,
+                           tr( "QGIS Layer Metadata File" ) + " (*.qmd)" );
+  if ( fileName.isNull() )
+  {
+    return;
+  }
+
+  bool defaultLoadedFlag = false;
+  const QString message = mLayer->loadNamedMetadata( fileName, defaultLoadedFlag );
+
+  //reset if the default style was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    mMetadataWidget->setMetadata( &mLayer->metadata() );
+  }
+  else
+  {
+    //let the user know what went wrong
+    QMessageBox::warning( mParentWidget, tr( "Load Metadata" ), message );
+  }
+
+  settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( fileName ).path() );
+
+  mParentWidget->activateWindow(); // set focus back to properties dialog
+}

--- a/src/gui/qgslayerpropertiesguiutils.cpp
+++ b/src/gui/qgslayerpropertiesguiutils.cpp
@@ -33,7 +33,7 @@ QgsLayerPropertiesGuiUtils::QgsLayerPropertiesGuiUtils( QWidget *parent, QgsMapL
 
 void QgsLayerPropertiesGuiUtils::loadMetadataFromFile()
 {
-  if ( !mLayer )
+  if ( !mLayer || !mMetadataWidget )
     return;
 
   QgsSettings settings;  // where we keep last used filter in persistent state
@@ -67,7 +67,7 @@ void QgsLayerPropertiesGuiUtils::loadMetadataFromFile()
 
 void QgsLayerPropertiesGuiUtils::saveMetadataToFile()
 {
-  if ( !mLayer )
+  if ( !mLayer || !mMetadataWidget )
     return;
 
   QgsSettings settings;  // where we keep last used filter in persistent state
@@ -100,7 +100,7 @@ void QgsLayerPropertiesGuiUtils::saveMetadataToFile()
 
 void QgsLayerPropertiesGuiUtils::saveMetadataAsDefault()
 {
-  if ( !mLayer )
+  if ( !mLayer || !mMetadataWidget )
     return;
 
   mMetadataWidget->acceptMetadata();
@@ -116,7 +116,7 @@ void QgsLayerPropertiesGuiUtils::saveMetadataAsDefault()
 
 void QgsLayerPropertiesGuiUtils::loadDefaultMetadata()
 {
-  if ( !mLayer )
+  if ( !mLayer || !mMetadataWidget )
     return;
 
   bool defaultLoadedFlag = false;
@@ -130,6 +130,28 @@ void QgsLayerPropertiesGuiUtils::loadDefaultMetadata()
   {
     QMessageBox::information( mParentWidget, tr( "Default Metadata" ), message );
     refocusParent();
+  }
+}
+
+void QgsLayerPropertiesGuiUtils::loadDefaultStyle()
+{
+  if ( !mLayer )
+    return;
+
+  bool defaultLoadedFlag = false;
+  const QString message = mLayer->loadDefaultStyle( defaultLoadedFlag );
+  // reset if the default style was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    emit syncDialogToLayer();
+  }
+  else
+  {
+    // otherwise let the user know what went wrong
+    QMessageBox::information( mParentWidget,
+                              tr( "Default Style" ),
+                              message
+                            );
   }
 }
 

--- a/src/gui/qgslayerpropertiesguiutils.cpp
+++ b/src/gui/qgslayerpropertiesguiutils.cpp
@@ -133,6 +133,33 @@ void QgsLayerPropertiesGuiUtils::loadDefaultMetadata()
   }
 }
 
+void QgsLayerPropertiesGuiUtils::saveStyleAsDefault()
+{
+  if ( !mLayer )
+    return;
+
+  emit applyDialogToLayer(); // make sure the style to save is up-to-date
+
+  // a flag passed by reference
+  bool defaultSavedFlag = false;
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
+  // after calling this the above flag will be set true for success
+  // or false if the save operation failed
+  const QString message = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
+  if ( !defaultSavedFlag )
+  {
+    // let the user know what went wrong
+    QMessageBox::information( mParentWidget,
+                              tr( "Default Style" ),
+                              message
+                            );
+    refocusParent();
+  }
+}
+
 void QgsLayerPropertiesGuiUtils::loadDefaultStyle()
 {
   if ( !mLayer )
@@ -152,6 +179,7 @@ void QgsLayerPropertiesGuiUtils::loadDefaultStyle()
                               tr( "Default Style" ),
                               message
                             );
+    refocusParent();
   }
 }
 

--- a/src/gui/qgslayerpropertiesguiutils.cpp
+++ b/src/gui/qgslayerpropertiesguiutils.cpp
@@ -133,6 +133,42 @@ void QgsLayerPropertiesGuiUtils::loadDefaultMetadata()
   }
 }
 
+void QgsLayerPropertiesGuiUtils::loadStyleFromFile()
+{
+  if ( !mLayer )
+    return;
+
+  QgsSettings settings;
+  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString fileName = QFileDialog::getOpenFileName(
+                       mParentWidget,
+                       tr( "Load layer properties from style file" ),
+                       lastUsedDir,
+                       tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( fileName.isEmpty() )
+    return;
+
+  // ensure the user never omits the extension from the file name
+  if ( !fileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive ) )
+    fileName += QLatin1String( ".qml" );
+
+  emit storeCurrentStyleForUndo();
+
+  bool defaultLoadedFlag = false;
+  const QString message = mLayer->loadNamedStyle( fileName, defaultLoadedFlag );
+  if ( defaultLoadedFlag )
+  {
+    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( fileName ).absolutePath() );
+    emit syncDialogToLayer();
+  }
+  else
+  {
+    QMessageBox::information( mParentWidget, tr( "Load Style" ), message );
+    refocusParent();
+  }
+}
+
 void QgsLayerPropertiesGuiUtils::saveStyleAsDefault()
 {
   if ( !mLayer )

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -51,11 +51,22 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
   public slots:
 
     /**
-     * Triggers the option to load layer metadata from a file.
+     * Allows the user to load layer metadata from a file.
+     *
+     * \see saveMetadataToFile()
      */
-    void loadMetadata();
+    void loadMetadataFromFile();
+
+    /**
+     * Allows the user to save the layer's metadata as a file.
+     *
+     * \see loadMetadataFromFile()
+     */
+    void saveMetadataToFile();
 
   private:
+    void refocusParent();
+
     QWidget *mParentWidget = nullptr;
 
     QPointer< QgsMapLayer> mLayer;

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -79,6 +79,13 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
     void loadDefaultMetadata();
 
     /**
+     * Saves the current layer style as the default for the layer.
+     *
+     * loadDefaultStyle()
+     */
+    void saveStyleAsDefault();
+
+    /**
      * Reloads the default style for the layer.
      */
     void loadDefaultStyle();
@@ -89,6 +96,11 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
      * Emitted when the dialog should be resynced to the layer.
      */
     void syncDialogToLayer();
+
+    /**
+     * Emitted when the current dialog state should be applied to the layer.
+     */
+    void applyDialogToLayer();
 
   private:
     void refocusParent();

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -79,6 +79,11 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
     void loadDefaultMetadata();
 
     /**
+     * Allows the user to load layer style from a file.
+     */
+    void loadStyleFromFile();
+
+    /**
      * Saves the current layer style as the default for the layer.
      *
      * loadDefaultStyle()
@@ -101,6 +106,12 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
      * Emitted when the current dialog state should be applied to the layer.
      */
     void applyDialogToLayer();
+
+    /**
+     * Emitted when the dialog should save the current layer style to a temporary
+     * location to allow for undo rollback operations.
+     */
+    void storeCurrentStyleForUndo();
 
   private:
     void refocusParent();

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+  qgslayerpropertiesguiutils.h
+  --------------------------------------
+  Date                 : June 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERPROPERTIESGUIUTILS_H
+#define QGSLAYERPROPERTIESGUIUTILS_H
+
+#define SIP_NO_FILE
+
+#include "qgsgui.h"
+
+#include <QObject>
+#include <QPointer>
+
+class QgsMapLayer;
+class QgsMetadataWidget;
+
+/**
+ * \ingroup gui
+ * \class QgsLayerPropertiesGuiUtils
+ * \brief Contains common utilities for handling functionality in a layer properties dialog.
+ * \note Not available in Python bindings
+ * \since QGIS 3.34
+ */
+class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsLayerPropertiesGuiUtils.
+     *
+     * \param parent parent widget (usually the layer properties dialog)
+     * \param layer associated map layer
+     * \param metadataWidget linked QgsMetadataWidget
+     */
+    QgsLayerPropertiesGuiUtils( QWidget *parent, QgsMapLayer *layer, QgsMetadataWidget *metadataWidget );
+
+  public slots:
+
+    /**
+     * Triggers the option to load layer metadata from a file.
+     */
+    void loadMetadata();
+
+  private:
+    QWidget *mParentWidget = nullptr;
+
+    QPointer< QgsMapLayer> mLayer;
+
+    QgsMetadataWidget *mMetadataWidget = nullptr;
+
+};
+
+#endif // QGSLAYERPROPERTIESGUIUTILS_H

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -64,6 +64,20 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
      */
     void saveMetadataToFile();
 
+    /**
+     * Saves the current layer metadata as the default for the layer.
+     *
+     * loadDefaultMetadata()
+     */
+    void saveMetadataAsDefault();
+
+    /**
+     * Reloads the default layer metadata for the layer.
+     *
+     * \see saveMetadataAsDefault()
+     */
+    void loadDefaultMetadata();
+
   private:
     void refocusParent();
 

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -80,8 +80,17 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
 
     /**
      * Allows the user to load layer style from a file.
+     *
+     * \see saveStyleToFile()
      */
     void loadStyleFromFile();
+
+    /**
+     * Allows the user to save the layer's style to a file.
+     *
+     * \see loadStyleFromFile()
+     */
+    void saveStyleToFile();
 
     /**
      * Saves the current layer style as the default for the layer.

--- a/src/gui/qgslayerpropertiesguiutils.h
+++ b/src/gui/qgslayerpropertiesguiutils.h
@@ -78,6 +78,18 @@ class GUI_EXPORT QgsLayerPropertiesGuiUtils : public QObject
      */
     void loadDefaultMetadata();
 
+    /**
+     * Reloads the default style for the layer.
+     */
+    void loadDefaultStyle();
+
+  signals:
+
+    /**
+     * Emitted when the dialog should be resynced to the layer.
+     */
+    void syncDialogToLayer();
+
   private:
     void refocusParent();
 

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -20,19 +20,14 @@
 #include <QFileDialog>
 
 #include "qgsmaplayerstylemanagerwidget.h"
-#include "qgssettings.h"
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsmaplayerstylemanager.h"
-#include "qgsvectordataprovider.h"
-#include "qgsrasterdataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectortilelayer.h"
-#include "qgsrasterlayer.h"
 #include "qgsapplication.h"
-#include "qgsproviderregistry.h"
 #include "qgsvectorlayerproperties.h"
 #include "qgsvectortilelayerproperties.h"
 #include "qgsrasterlayerproperties.h"
@@ -196,25 +191,25 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
       break;
 
     case Qgis::LayerType::Raster:
-      QgsRasterLayerProperties( mLayer, mMapCanvas ).saveDefaultStyle();
+      QgsRasterLayerProperties( mLayer, mMapCanvas ).saveStyleAsDefault();
       break;
 
     case Qgis::LayerType::Mesh:
-      QgsMeshLayerProperties( mLayer, mMapCanvas ).saveDefaultStyle();
+      QgsMeshLayerProperties( mLayer, mMapCanvas ).saveStyleAsDefault();
       break;
 
     case Qgis::LayerType::VectorTile:
       QgsVectorTileLayerProperties( qobject_cast<QgsVectorTileLayer *>( mLayer ),
                                     mMapCanvas,
-                                    mMapLayerConfigWidgetContext.messageBar() ).saveDefaultStyle();
+                                    mMapLayerConfigWidgetContext.messageBar() ).saveStyleAsDefault();
       break;
 
     // Not available for these
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::TiledMesh:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Group:
-    default:
       break;
   }
 }
@@ -250,9 +245,9 @@ void QgsMapLayerStyleManagerWidget::loadDefault()
     // Not available for these
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::TiledMesh:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Group:
-    default:
       break;
   }
 }
@@ -276,21 +271,21 @@ void QgsMapLayerStyleManagerWidget::saveStyle()
       break;
 
     case Qgis::LayerType::Mesh:
-      QgsMeshLayerProperties( mLayer, mMapCanvas ).saveStyleAs();
+      QgsMeshLayerProperties( mLayer, mMapCanvas ).saveStyleToFile();
       break;
 
     case Qgis::LayerType::VectorTile:
       QgsVectorTileLayerProperties( qobject_cast<QgsVectorTileLayer *>( mLayer ),
                                     mMapCanvas,
-                                    mMapLayerConfigWidgetContext.messageBar() ).saveStyleAs();
+                                    mMapLayerConfigWidgetContext.messageBar() ).saveStyleToFile();
       break;
 
     // Not available for these
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::TiledMesh:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Group:
-    default:
       break;
   }
 }
@@ -310,11 +305,11 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
       break;
 
     case Qgis::LayerType::Raster:
-      QgsRasterLayerProperties( mLayer, mMapCanvas ).loadStyle();
+      QgsRasterLayerProperties( mLayer, mMapCanvas ).loadStyleFromFile();
       break;
 
     case Qgis::LayerType::Mesh:
-      QgsMeshLayerProperties( mLayer, mMapCanvas ).loadStyle();
+      QgsMeshLayerProperties( mLayer, mMapCanvas ).loadStyleFromFile();
       break;
 
     case Qgis::LayerType::VectorTile:
@@ -326,9 +321,9 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
     // Not available for these
     case Qgis::LayerType::PointCloud:
     case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::TiledMesh:
     case Qgis::LayerType::Plugin:
     case Qgis::LayerType::Group:
-    default:
       break;
   }
 }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -529,12 +529,13 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mRasterLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsRasterLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsRasterLayerProperties::apply );
 
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsRasterLayerProperties::aboutToShowStyleMenu );
@@ -1623,28 +1624,8 @@ void QgsRasterLayerProperties::loadDefaultStyle()
 
 void QgsRasterLayerProperties::saveDefaultStyle()
 {
-
-  apply(); // make sure the style to save is up-to-date
-
-  // a flag passed by reference
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  // after calling this the above flag will be set true for success
-  // or false if the save operation failed
-  QString myMessage = mRasterLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    //let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->saveStyleAsDefault();
 }
-
 
 void QgsRasterLayerProperties::loadStyle()
 {

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -32,7 +32,6 @@
 #include "qgsmetadataurlitemdelegate.h"
 #include "qgsmultibandcolorrenderer.h"
 #include "qgsmultibandcolorrendererwidget.h"
-#include "qgsnative.h"
 #include "qgspalettedrendererwidget.h"
 #include "qgsprovidersourcewidgetproviderregistry.h"
 #include "qgsprovidersourcewidget.h"
@@ -516,7 +515,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     mMetadataViewer->setZoomFactor( mMetadataViewer->zoomFactor() * 0.9 );
   }
   mMetadataViewer->page()->setLinkDelegationPolicy( QWebPage::LinkDelegationPolicy::DelegateAllLinks );
-  connect( mMetadataViewer->page(), &QWebPage::linkClicked, this, &QgsRasterLayerProperties::urlClicked );
+  connect( mMetadataViewer->page(), &QWebPage::linkClicked, this, &QgsRasterLayerProperties::openUrl );
   mMetadataViewer->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
   mMetadataViewer->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
 
@@ -1254,15 +1253,6 @@ void QgsRasterLayerProperties::buttonBuildPyramids_clicked()
 
   //populate the metadata tab's text browser widget with gdal metadata info
   updateInformationContent();
-}
-
-void QgsRasterLayerProperties::urlClicked( const QUrl &url )
-{
-  QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsRasterLayerProperties::mRenderTypeComboBox_currentIndexChanged( int index )

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1714,25 +1714,15 @@ void QgsRasterLayerProperties::updateInformationContent()
   mMetadataFilled = true;
 }
 
-void QgsRasterLayerProperties::onCancel()
+void QgsRasterLayerProperties::rollback()
 {
-
   // Give the user a chance to save the raster attribute table edits.
   if ( mRasterAttributeTableWidget && mRasterAttributeTableWidget->isDirty() )
   {
     mRasterAttributeTableWidget->setEditable( false, false );
   }
+  QgsLayerPropertiesDialog::rollback();
 
-  if ( mOldStyle.xmlData() != mRasterLayer->styleManager()->style( mRasterLayer->styleManager()->currentStyle() ).xmlData() )
-  {
-    // need to reset style to previous - style applied directly to the layer (not in apply())
-    QString myMessage;
-    QDomDocument doc( QStringLiteral( "qgis" ) );
-    int errorLine, errorColumn;
-    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
-    mRasterLayer->importNamedStyle( doc, myMessage );
-    syncToLayer();
-  }
   if ( mBackupCrs != mRasterLayer->crs() )
     mRasterLayer->setCrs( mBackupCrs );
 }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -526,7 +526,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   mRenderTypeComboBox_currentIndexChanged( widgetIndex );
 
-  setMetadataWidget( mMetadataWidget );
+  setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyleFromFile );
@@ -1455,11 +1455,7 @@ void QgsRasterLayerProperties::setTransparencyToEdited( int row )
 
 void QgsRasterLayerProperties::optionsStackedWidget_CurrentChanged( int index )
 {
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
-  mBtnStyle->setVisible( ! isMetadataPanel );
-  mBtnMetadata->setVisible( isMetadataPanel );
+  QgsLayerPropertiesDialog::optionsStackedWidget_CurrentChanged( index );
 
   if ( !mHistogramWidget )
     return;

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -134,14 +134,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mSourceGroupBox->hide();
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
-  QMenu *menuStyle = new QMenu( this );
-  menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs );
-  menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultStyle );
-  mBtnStyle->setMenu( menuStyle );
-  connect( menuStyle, &QMenu::aboutToShow, this, &QgsRasterLayerProperties::aboutToShowStyleMenu );
   buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
 
   connect( lyr->styleManager(), &QgsMapLayerStyleManager::currentStyleChanged, this, &QgsRasterLayerProperties::syncToLayer );
@@ -536,6 +528,16 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mRenderTypeComboBox_currentIndexChanged( widgetIndex );
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mRasterLayer, mMetadataWidget );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsRasterLayerProperties::syncToLayer );
+
+  QMenu *menuStyle = new QMenu( this );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs );
+  menuStyle->addSeparator();
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
+  mBtnStyle->setMenu( menuStyle );
+  connect( menuStyle, &QMenu::aboutToShow, this, &QgsRasterLayerProperties::aboutToShowStyleMenu );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
@@ -1616,21 +1618,7 @@ void QgsRasterLayerProperties::removeSelectedMetadataUrl()
 //
 void QgsRasterLayerProperties::loadDefaultStyle()
 {
-  bool defaultLoadedFlag = false;
-  QString myMessage = mRasterLayer->loadDefaultStyle( defaultLoadedFlag );
-  //reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-  }
-  else
-  {
-    //otherwise let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->loadDefaultStyle();
 }
 
 void QgsRasterLayerProperties::saveDefaultStyle()

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -542,8 +542,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultMetadata );
-  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultMetadata );
+  menuMetadata->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataAsDefault );
+  menuMetadata->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultMetadata );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -1754,41 +1754,6 @@ void QgsRasterLayerProperties::restoreWindowModality()
   raise();
   activateWindow();
 }
-
-//
-//
-// Next four methods for saving and restoring QMD metadata
-//
-//
-
-
-void QgsRasterLayerProperties::saveDefaultMetadata()
-{
-  mMetadataWidget->acceptMetadata();
-
-  bool defaultSavedFlag = false;
-  QString errorMsg = mRasterLayer->saveDefaultMetadata( defaultSavedFlag );
-  if ( !defaultSavedFlag )
-  {
-    QMessageBox::warning( this, tr( "Default Metadata" ), errorMsg );
-  }
-}
-
-void QgsRasterLayerProperties::loadDefaultMetadata()
-{
-  bool defaultLoadedFlag = false;
-  QString myMessage = mRasterLayer->loadNamedMetadata( mRasterLayer->metadataUri(), defaultLoadedFlag );
-  //reset if the default metadata was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    mMetadataWidget->setMetadata( &mRasterLayer->metadata() );
-  }
-  else
-  {
-    QMessageBox::information( this, tr( "Default Metadata" ), myMessage );
-  }
-}
-
 
 void QgsRasterLayerProperties::toggleBuildPyramidsButton()
 {

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -539,8 +539,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsRasterLayerProperties::saveMetadataAs );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
   menuMetadata->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultMetadata );
   menuMetadata->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultMetadata );
@@ -1761,33 +1761,6 @@ void QgsRasterLayerProperties::restoreWindowModality()
 //
 //
 
-void QgsRasterLayerProperties::saveMetadataAs()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
-                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
-  if ( myOutputFileName.isNull() ) //dialog canceled
-  {
-    return;
-  }
-
-  mMetadataWidget->acceptMetadata();
-
-  //ensure the user never omitted the extension from the file name
-  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
-  {
-    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
-  }
-
-  bool defaultLoadedFlag = false;
-  QString message = mRasterLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
-  if ( defaultLoadedFlag )
-    myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
-  else
-    QMessageBox::information( this, tr( "Save Metadata" ), message );
-}
 
 void QgsRasterLayerProperties::saveDefaultMetadata()
 {

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -149,8 +149,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     void updateProperty();
 
     void apply() FINAL;
-    //! \brief Called when cancel button is pressed
-    void onCancel();
+    void rollback() FINAL;
     //! \brief this slot asks the rasterlayer to construct pyramids
     void buttonBuildPyramids_clicked();
     //! \brief slot executed when user changes the layer's CRS

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -199,8 +199,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     //! Make GUI reflect the layer's state
     void syncToLayer() FINAL;
 
-    void urlClicked( const QUrl &url );
-
     // Update the preview of the map tip
     void updateMapTipPreview();
     // Resize the map tip preview

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -207,8 +207,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     void resizeMapTip();
 
   private:
-    QPushButton *mBtnStyle = nullptr;
-    QPushButton *mBtnMetadata = nullptr;
+
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -185,11 +185,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! Restore dialog modality and focus, usually after a pixel clicked to pick transparency color
     void restoreWindowModality();
 
-    //! Save the default metadata.
-    void saveDefaultMetadata();
-    //! Load the default metadata.
-    void loadDefaultMetadata();
-
     //! Help button
     void showHelp();
 

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -21,7 +21,7 @@
 #ifndef QGSRASTERLAYERPROPERTIES_H
 #define QGSRASTERLAYERPROPERTIES_H
 
-#include "qgsoptionsdialogbase.h"
+#include "qgslayerpropertiesdialog.h"
 #include "ui_qgsrasterlayerpropertiesbase.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
@@ -47,7 +47,6 @@ class QgsPropertyOverrideButton;
 class QgsRasterTransparencyWidget;
 class QgsRasterAttributeTableWidget;
 class QgsWebView;
-class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
@@ -56,7 +55,7 @@ class QgsLayerPropertiesGuiUtils;
  * \since QGIS 3.12 (in the GUI API)
  */
 
-class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private Ui::QgsRasterLayerPropertiesBase, private QgsExpressionContextGenerator
+class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsRasterLayerPropertiesBase, private QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -92,13 +91,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QgsExpressionContext createExpressionContext() const override;
 
     bool eventFilter( QObject *obj, QEvent *ev ) override;
-
-    /**
-     * Loads the default style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void loadDefaultStyle();
 
     /**
      * Saves the default style when appropriate button is pressed
@@ -156,8 +148,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     void updateProperty();
 
-    //! \brief Applies the settings made in the dialog without closing the box
-    void apply();
+    void apply() FINAL;
     //! \brief Called when cancel button is pressed
     void onCancel();
     //! \brief this slot asks the rasterlayer to construct pyramids
@@ -206,7 +197,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     void aboutToShowStyleMenu();
 
     //! Make GUI reflect the layer's state
-    void syncToLayer();
+    void syncToLayer() FINAL;
 
     void urlClicked( const QUrl &url );
 
@@ -225,8 +216,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     //! A list of additional pages provided by plugins
     QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
-
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     //! \brief  A constant that signals property not used
     const QString TRSTRING_NOT_SET;
@@ -296,12 +285,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QgsRasterHistogramWidget *mHistogramWidget = nullptr;
 
     QVector<bool> mTransparencyToEdited;
-
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 
     bool mDisableRenderTypeComboBoxCurrentIndexChanged = false;
 

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -95,16 +95,16 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     /**
      * Saves the default style when appropriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use saveStyleAsDefault() instead
      */
-    void saveDefaultStyle();
+    Q_DECL_DEPRECATED void saveDefaultStyle() SIP_DEPRECATED;
 
     /**
      * Loads a saved style when appropriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use loadStyleFromFile() instead.
      */
-    void loadStyle();
+    Q_DECL_DEPRECATED void loadStyle() SIP_DEPRECATED;
 
     /**
      * Saves a style when appriate button is pressed

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -111,6 +111,8 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
   protected slots:
     //! \brief auto slot executed when the active page in the main widget stack is changed
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
+    void apply() FINAL;
+    void rollback() FINAL;
 
   private:
 
@@ -143,8 +145,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
 
     void updateProperty();
 
-    void apply() FINAL;
-    void rollback() FINAL;
     //! \brief this slot asks the rasterlayer to construct pyramids
     void buttonBuildPyramids_clicked();
     //! \brief slot executed when user changes the layer's CRS

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -185,8 +185,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! Restore dialog modality and focus, usually after a pixel clicked to pick transparency color
     void restoreWindowModality();
 
-    //! Save a metadata.
-    void saveMetadataAs();
     //! Save the default metadata.
     void saveDefaultMetadata();
     //! Load the default metadata.

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -28,7 +28,6 @@
 #include "qgsresamplingutils.h"
 #include "qgsrasterpipe.h"
 #include "qgsexpressioncontextgenerator.h"
-#include "qgsmaplayerstyle.h"
 
 class QgsPointXY;
 class QgsMapLayer;
@@ -82,11 +81,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
      */
     QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
 
-    /**
-     * Adds a properties page factory to the raster layer properties dialog.
-     * \since QGIS 3.18
-     */
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
+    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory ) FINAL;
 
     QgsExpressionContext createExpressionContext() const override;
 
@@ -210,9 +205,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
 
     QStandardItemModel *mMetadataUrlModel = nullptr;
 
-    //! A list of additional pages provided by plugins
-    QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
-
     //! \brief  A constant that signals property not used
     const QString TRSTRING_NOT_SET;
 
@@ -275,8 +267,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsLayerPropertiesDialog, pri
     QLinearGradient highlightGradient();
     qreal mGradientHeight;
     qreal mGradientWidth;
-
-    QgsMapCanvas *mMapCanvas = nullptr;
 
     QgsRasterHistogramWidget *mHistogramWidget = nullptr;
 

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -24,13 +24,11 @@
 #include "qgsoptionsdialogbase.h"
 #include "ui_qgsrasterlayerpropertiesbase.h"
 #include "qgsguiutils.h"
-#include "qgshelp.h"
-#include "qgsmaplayerstylemanager.h"
-#include "qgsmaptoolemitpoint.h"
 #include "qgis_gui.h"
 #include "qgsresamplingutils.h"
 #include "qgsrasterpipe.h"
 #include "qgsexpressioncontextgenerator.h"
+#include "qgsmaplayerstyle.h"
 
 class QgsPointXY;
 class QgsMapLayer;
@@ -49,7 +47,7 @@ class QgsPropertyOverrideButton;
 class QgsRasterTransparencyWidget;
 class QgsRasterAttributeTableWidget;
 class QgsWebView;
-
+class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
@@ -187,8 +185,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! Restore dialog modality and focus, usually after a pixel clicked to pick transparency color
     void restoreWindowModality();
 
-    //! Load a saved metadata file.
-    void loadMetadata();
     //! Save a metadata.
     void saveMetadataAs();
     //! Save the default metadata.
@@ -236,6 +232,8 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     //! A list of additional pages provided by plugins
     QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     //! \brief  A constant that signals property not used
     const QString TRSTRING_NOT_SET;

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -381,7 +381,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   teMetadataViewer->document()->setDefaultStyleSheet( myStyle );
   teMetadataViewer->setHtml( htmlMetadata() );
   teMetadataViewer->setOpenLinks( false );
-  connect( teMetadataViewer, &QTextBrowser::anchorClicked, this, &QgsVectorLayerProperties::urlClicked );
+  connect( teMetadataViewer, &QTextBrowser::anchorClicked, this, &QgsVectorLayerProperties::openUrl );
   mMetadataFilled = true;
 
   QgsSettings settings;
@@ -914,15 +914,6 @@ void QgsVectorLayerProperties::onCancel()
 
   if ( mBackupCrs != mLayer->crs() )
     mLayer->setCrs( mBackupCrs );
-}
-
-void QgsVectorLayerProperties::urlClicked( const QUrl &url )
-{
-  QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsVectorLayerProperties::pbnQueryBuilder_clicked()

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -879,7 +879,7 @@ void QgsVectorLayerProperties::apply()
   QgsProject::instance()->setDirty( true );
 }
 
-void QgsVectorLayerProperties::onCancel()
+void QgsVectorLayerProperties::rollback()
 {
   if ( mOldJoins != mLayer->vectorJoins() )
   {
@@ -902,15 +902,7 @@ void QgsVectorLayerProperties::onCancel()
     mLayer->setSubsetString( mOriginalSubsetSQL );
   }
 
-  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
-  {
-    // need to reset style to previous - style applied directly to the layer (not in apply())
-    QString myMessage;
-    QDomDocument doc( QStringLiteral( "qgis" ) );
-    int errorLine, errorColumn;
-    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
-    mLayer->importNamedStyle( doc, myMessage );
-  }
+  QgsLayerPropertiesDialog::rollback();
 
   if ( mBackupCrs != mLayer->crs() )
     mLayer->setCrs( mBackupCrs );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -68,7 +68,6 @@
 #include "qgsnative.h"
 #include "qgssubsetstringeditorproviderregistry.h"
 #include "qgsprovidersourcewidgetproviderregistry.h"
-#include "qgslayerpropertiesguiutils.h"
 #include "qgswebview.h"
 #include "qgswebframe.h"
 #if WITH_QTWEBKIT
@@ -98,7 +97,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   QWidget *parent,
   Qt::WindowFlags fl
 )
-  : QgsOptionsDialogBase( QStringLiteral( "VectorLayerProperties" ), parent, fl )
+  : QgsLayerPropertiesDialog( lyr, QStringLiteral( "VectorLayerProperties" ), parent, fl )
   , mCanvas( canvas )
   , mMessageBar( messageBar )
   , mLayer( lyr )
@@ -238,21 +237,15 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mTemporalWidget = new QgsVectorLayerTemporalPropertiesWidget( this, mLayer );
   temporalLayout->addWidget( mTemporalWidget );
 
-  mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorLayerProperties::syncToLayer );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsVectorLayerProperties::apply );
-  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::storeCurrentStyleForUndo, this, [ = ]
-  {
-    mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
-  } );
+  setMetadataWidget( mMetadataWidget );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsVectorLayerProperties::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorLayerProperties::saveMetadataToFile );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataAsDefault );
-  menuMetadata->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultMetadata );
+  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveMetadataAsDefault );
+  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultMetadata );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -1102,7 +1095,7 @@ void QgsVectorLayerProperties::saveDefaultStyle()
     }
   }
 
-  mLayerPropertiesUtils->saveStyleAsDefault();
+  QgsLayerPropertiesDialog::saveStyleAsDefault();
 }
 
 void QgsVectorLayerProperties::saveStyleAs()

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -241,6 +241,10 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorLayerProperties::syncToLayer );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsVectorLayerProperties::apply );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::storeCurrentStyleForUndo, this, [ = ]
+  {
+    mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
+  } );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -242,8 +242,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorLayerProperties::saveMetadataAs );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
   menuMetadata->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultMetadata );
   menuMetadata->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultMetadata );
@@ -1106,47 +1106,6 @@ void QgsVectorLayerProperties::saveDefaultStyle()
   {
     QMessageBox::warning( this, tr( "Default Style" ), errorMsg );
   }
-}
-
-void QgsVectorLayerProperties::saveMetadataAs()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
-                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
-  if ( myOutputFileName.isNull() ) //dialog canceled
-  {
-    return;
-  }
-
-  mMetadataWidget->acceptMetadata();
-
-  //ensure the user never omitted the extension from the file name
-  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
-  {
-    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
-  }
-
-  QString myMessage;
-  bool defaultLoadedFlag = false;
-  myMessage = mLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
-
-  //reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-  }
-  else
-  {
-    //let the user know what went wrong
-    QMessageBox::information( this, tr( "Save Metadata" ), myMessage );
-  }
-
-  QFileInfo myFI( myOutputFileName );
-  QString myPath = myFI.path();
-  // Persist last used dir
-  myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), myPath );
 }
 
 void QgsVectorLayerProperties::saveDefaultMetadata()

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -237,7 +237,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mTemporalWidget = new QgsVectorLayerTemporalPropertiesWidget( this, mLayer );
   temporalLayout->addWidget( mTemporalWidget );
 
-  setMetadataWidget( mMetadataWidget );
+  setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
@@ -1889,11 +1889,7 @@ void QgsVectorLayerProperties::pbnUpdateExtents_clicked()
 
 void QgsVectorLayerProperties::optionsStackedWidget_CurrentChanged( int index )
 {
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
-  mBtnStyle->setVisible( ! isMetadataPanel );
-  mBtnMetadata->setVisible( isMetadataPanel );
+  QgsLayerPropertiesDialog::optionsStackedWidget_CurrentChanged( index );
 
   if ( index == mOptStackedWidget->indexOf( mOptsPage_Information ) && ! mMetadataFilled )
   {

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -245,8 +245,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultMetadata );
-  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultMetadata );
+  menuMetadata->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataAsDefault );
+  menuMetadata->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultMetadata );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -1107,34 +1107,6 @@ void QgsVectorLayerProperties::saveDefaultStyle()
     QMessageBox::warning( this, tr( "Default Style" ), errorMsg );
   }
 }
-
-void QgsVectorLayerProperties::saveDefaultMetadata()
-{
-  mMetadataWidget->acceptMetadata();
-
-  bool defaultSavedFlag = false;
-  QString errorMsg = mLayer->saveDefaultMetadata( defaultSavedFlag );
-  if ( !defaultSavedFlag )
-  {
-    QMessageBox::warning( this, tr( "Default Metadata" ), errorMsg );
-  }
-}
-
-void QgsVectorLayerProperties::loadDefaultMetadata()
-{
-  bool defaultLoadedFlag = false;
-  QString myMessage = mLayer->loadNamedMetadata( mLayer->metadataUri(), defaultLoadedFlag );
-  //reset if the default metadata was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    mMetadataWidget->setMetadata( &mLayer->metadata() );
-  }
-  else
-  {
-    QMessageBox::information( this, tr( "Default Metadata" ), myMessage );
-  }
-}
-
 
 void QgsVectorLayerProperties::saveStyleAs()
 {

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -239,6 +239,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   temporalLayout->addWidget( mTemporalWidget );
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorLayerProperties::syncToLayer );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -240,6 +240,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsVectorLayerProperties::apply );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
@@ -1048,7 +1049,6 @@ void QgsVectorLayerProperties::loadDefaultStyle()
 
 void QgsVectorLayerProperties::saveDefaultStyle()
 {
-  apply();
   QString errorMsg;
   const QgsVectorDataProvider *provider = mLayer->dataProvider();
   if ( !provider )
@@ -1068,6 +1068,7 @@ void QgsVectorLayerProperties::saveDefaultStyle()
         return;
       case 2:
       {
+        apply();
         QString errorMessage;
         if ( QgsProviderRegistry::instance()->styleExists( mLayer->providerType(), mLayer->source(), QString(), errorMessage ) )
         {
@@ -1097,16 +1098,7 @@ void QgsVectorLayerProperties::saveDefaultStyle()
     }
   }
 
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  errorMsg = mLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    QMessageBox::warning( this, tr( "Default Style" ), errorMsg );
-  }
+  mLayerPropertiesUtils->saveStyleAsDefault();
 }
 
 void QgsVectorLayerProperties::saveStyleAs()

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -72,9 +72,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     QgsVectorLayerProperties( QgsMapCanvas *canvas, QgsMessageBar *messageBar, QgsVectorLayer *lyr = nullptr, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
-    //! Adds a properties page factory to the vector layer properties dialog.
-    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
-
     bool eventFilter( QObject *obj, QEvent *ev ) override;
 
     /**
@@ -192,7 +189,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     void setPbnQueryBuilderEnabled();
 
-    QgsMapCanvas *mCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
     QgsVectorLayer *mLayer = nullptr;
 
@@ -224,9 +220,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     //! List of joins of a layer at the time of creation of the dialog. Used to return joins to previous state if dialog is canceled
     QList< QgsVectorLayerJoinInfo > mOldJoins;
-
-    //! A list of additional pages provided by plugins
-    QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
 
     void initDiagramTab();
 

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -104,19 +104,16 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
   protected slots:
     void optionsStackedWidget_CurrentChanged( int index ) final;
+    void syncToLayer() FINAL;
+    void apply() FINAL;
+    void rollback() FINAL;
 
   private slots:
 
     void insertFieldOrExpression();
 
-    void syncToLayer() FINAL;
-
     //! Gets metadata about the layer in nice formatted html
     QString htmlMetadata();
-
-    void apply() FINAL;
-
-    void rollback() FINAL;
 
     //
     //methods reimplemented from qt designer base class

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -133,7 +133,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void pbnQueryBuilder_clicked();
     void pbnIndex_clicked();
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
-    void saveMetadataAs();
     void saveDefaultMetadata();
     void loadDefaultMetadata();
     void pbnUpdateExtents_clicked();

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -21,13 +21,12 @@
 
 #include <QStandardItemModel>
 
-#include "qgsoptionsdialogbase.h"
 #include "ui_qgsvectorlayerpropertiesbase.h"
 #include "qgsguiutils.h"
 #include "qgsmaplayerserverproperties.h"
 #include "qgsvectorlayerjoininfo.h"
 #include "qgslayertreefilterproxymodel.h"
-#include "qgsmaplayerstyle.h"
+#include "qgslayerpropertiesdialog.h"
 
 class QgsMapLayer;
 
@@ -50,13 +49,12 @@ class QgsMaskingWidget;
 class QgsVectorLayerTemporalPropertiesWidget;
 class QgsProviderSourceWidget;
 class QgsWebView;
-class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
  * \class QgsVectorLayerProperties
  */
-class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorLayerPropertiesBase, private QgsExpressionContextGenerator
+class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsVectorLayerPropertiesBase, private QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -114,14 +112,12 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     void insertFieldOrExpression();
 
-    //! Reset to original (vector layer) values
-    void syncToLayer();
+    void syncToLayer() FINAL;
 
     //! Gets metadata about the layer in nice formatted html
     QString htmlMetadata();
 
-    //! Called when apply button is pressed or dialog is accepted
-    void apply();
+    void apply() FINAL;
 
     //! Called when cancel button is pressed
     void onCancel();
@@ -203,8 +199,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsMessageBar *mMessageBar = nullptr;
     QgsVectorLayer *mLayer = nullptr;
 
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
-
     bool mMetadataFilled = false;
 
     QString mOriginalSubsetSQL;
@@ -238,12 +232,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     //! A list of additional pages provided by plugins
     QList<QgsMapLayerConfigWidget *> mLayerPropertiesPages;
-
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 
     void initDiagramTab();
 

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -203,8 +203,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     QString mOriginalSubsetSQL;
 
-    QPushButton *mBtnStyle = nullptr;
-    QPushButton *mBtnMetadata = nullptr;
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -119,8 +119,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     void apply() FINAL;
 
-    //! Called when cancel button is pressed
-    void onCancel();
+    void rollback() FINAL;
 
     //
     //methods reimplemented from qt designer base class

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -50,6 +50,7 @@ class QgsMaskingWidget;
 class QgsVectorLayerTemporalPropertiesWidget;
 class QgsProviderSourceWidget;
 class QgsWebView;
+class QgsLayerPropertiesGuiUtils;
 
 /**
  * \ingroup gui
@@ -132,7 +133,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void pbnQueryBuilder_clicked();
     void pbnIndex_clicked();
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
-    void loadMetadata();
     void saveMetadataAs();
     void saveDefaultMetadata();
     void loadDefaultMetadata();
@@ -205,6 +205,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsMapCanvas *mCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
     QgsVectorLayer *mLayer = nullptr;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     bool mMetadataFilled = false;
 

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -133,8 +133,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void pbnQueryBuilder_clicked();
     void pbnIndex_clicked();
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
-    void saveDefaultMetadata();
-    void loadDefaultMetadata();
     void pbnUpdateExtents_clicked();
 
     void mButtonAddJoin_clicked();

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -176,8 +176,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
     void onAuxiliaryLayerAddField();
 
-    void urlClicked( const QUrl &url );
-
     // Update the preview of the map tip
     void updateMapTipPreview();
     // Resize the map tip preview

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -102,6 +102,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorTileLayerProperties::syncToLayer );
 
   // update based on lyr's current state
   syncToLayer();
@@ -123,7 +124,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsVectorTileLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorTileLayerProperties::saveDefaultStyle );
-  menuStyle->addAction( tr( "Restore Default" ), this, &QgsVectorTileLayerProperties::loadDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsVectorTileLayerProperties::aboutToShowStyleMenu );
 
@@ -239,21 +240,7 @@ void QgsVectorTileLayerProperties::syncToLayer()
 
 void QgsVectorTileLayerProperties::loadDefaultStyle()
 {
-  bool defaultLoadedFlag = false;
-  const QString myMessage = mLayer->loadDefaultStyle( defaultLoadedFlag );
-  // reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    syncToLayer();
-  }
-  else
-  {
-    // otherwise let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->loadDefaultStyle();
 }
 
 void QgsVectorTileLayerProperties::saveDefaultStyle()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -53,7 +53,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   mOptsPage_Labeling->layout()->setContentsMargins( 0, 0, 0, 0 );
 
   connect( this, &QDialog::accepted, this, &QgsVectorTileLayerProperties::apply );
-  connect( this, &QDialog::rejected, this, &QgsVectorTileLayerProperties::onCancel );
+  connect( this, &QDialog::rejected, this, &QgsVectorTileLayerProperties::rollback );
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsVectorTileLayerProperties::apply );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVectorTileLayerProperties::showHelp );
 
@@ -158,20 +158,6 @@ void QgsVectorTileLayerProperties::apply()
   mLayer->setScaleBasedVisibility( chkUseScaleDependentRendering->isChecked() );
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
-}
-
-void QgsVectorTileLayerProperties::onCancel()
-{
-  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
-  {
-    // need to reset style to previous - style applied directly to the layer (not in apply())
-    QString myMessage;
-    QDomDocument doc( QStringLiteral( "qgis" ) );
-    int errorLine, errorColumn;
-    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
-    mLayer->importNamedStyle( doc, myMessage );
-    syncToLayer();
-  }
 }
 
 void QgsVectorTileLayerProperties::syncToLayer()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -14,8 +14,6 @@
  ***************************************************************************/
 
 #include "qgsvectortilelayerproperties.h"
-
-#include "qgsfileutils.h"
 #include "qgshelp.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmaplayerstyleguiutils.h"
@@ -126,7 +124,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsVectorTileLayerProperties::loadStyle );
-  menuStyle->addAction( tr( "Save Style…" ), this, &QgsVectorTileLayerProperties::saveStyleAs );
+  menuStyle->addAction( tr( "Save Style…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleToFile );
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
@@ -336,33 +334,7 @@ void QgsVectorTileLayerProperties::loadStyle()
 
 void QgsVectorTileLayerProperties::saveStyleAs()
 {
-  QgsSettings settings;
-  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString outputFileName = QFileDialog::getSaveFileName(
-                             this,
-                             tr( "Save layer properties as style file" ),
-                             lastUsedDir,
-                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
-  if ( outputFileName.isEmpty() )
-    return;
-
-  // ensure the user never omits the extension from the file name
-  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
-
-  apply(); // make sure the style to save is up-to-date
-
-  // then export style
-  bool defaultLoadedFlag = false;
-  QString message;
-  message = mLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
-
-  if ( defaultLoadedFlag )
-  {
-    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
-  }
-  else
-    QMessageBox::information( this, tr( "Save Style" ), message );
+  mLayerPropertiesUtils->saveStyleToFile();
 }
 
 void QgsVectorTileLayerProperties::aboutToShowStyleMenu()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -38,9 +38,8 @@
 #include <QTextStream>
 
 QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent, Qt::WindowFlags flags )
-  : QgsLayerPropertiesDialog( lyr, QStringLiteral( "VectorTileLayerProperties" ), parent, flags )
+  : QgsLayerPropertiesDialog( lyr, canvas, QStringLiteral( "VectorTileLayerProperties" ), parent, flags )
   , mLayer( lyr )
-  , mMapCanvas( canvas )
 {
   setupUi( this );
 
@@ -60,7 +59,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsVectorTileLayerProperties::crsChanged );
 
   // scale based layer visibility related widgets
-  mScaleRangeWidget->setMapCanvas( mMapCanvas );
+  mScaleRangeWidget->setMapCanvas( mCanvas );
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
   // switching vertical tabs between icon/text to icon-only modes (splitter collapsed to left),
@@ -92,7 +91,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   metadataFrame->setContentsMargins( 0, 0, 0, 0 );
   mMetadataWidget = new QgsMetadataWidget( this, mLayer );
   mMetadataWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
-  mMetadataWidget->setMapCanvas( mMapCanvas );
+  mMetadataWidget->setMapCanvas( mCanvas );
   layout->addWidget( mMetadataWidget );
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
@@ -197,7 +196,7 @@ void QgsVectorTileLayerProperties::syncToLayer()
 
   if ( mSourceWidget )
   {
-    mSourceWidget->setMapCanvas( mMapCanvas );
+    mSourceWidget->setMapCanvas( mCanvas );
     mSourceWidget->setSourceUri( mLayer->source() );
   }
 
@@ -335,7 +334,7 @@ void QgsVectorTileLayerProperties::showHelp()
 
 void QgsVectorTileLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
-  QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mMapCanvas, tr( "Select Transformation" ) );
+  QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mCanvas, tr( "Select Transformation" ) );
   mLayer->setCrs( crs );
   mMetadataWidget->crsChanged();
 }

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -98,7 +98,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
-  setMetadataWidget( mMetadataWidget );
+  setMetadataWidget( mMetadataWidget, mOptsPage_Metadata );
 
   // update based on lyr's current state
   syncToLayer();
@@ -364,11 +364,3 @@ void QgsVectorTileLayerProperties::crsChanged( const QgsCoordinateReferenceSyste
   mMetadataWidget->crsChanged();
 }
 
-void QgsVectorTileLayerProperties::optionsStackedWidget_CurrentChanged( int index )
-{
-  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
-
-  const bool isMetadataPanel = ( index == mOptStackedWidget->indexOf( mOptsPage_Metadata ) );
-  mBtnStyle->setVisible( ! isMetadataPanel );
-  mBtnMetadata->setVisible( isMetadataPanel );
-}

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -131,8 +131,8 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorTileLayerProperties::saveMetadataAs );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadataFromFile );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveMetadataToFile );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 
@@ -399,34 +399,6 @@ void QgsVectorTileLayerProperties::aboutToShowStyleMenu()
   // re-add style manager actions!
   m->addSeparator();
   QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
-}
-
-void QgsVectorTileLayerProperties::saveMetadataAs()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  const QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save Layer Metadata as QMD" ),
-                             myLastUsedDir, tr( "QMD File" ) + " (*.qmd)" );
-  if ( myOutputFileName.isNull() ) //dialog canceled
-  {
-    return;
-  }
-
-  mMetadataWidget->acceptMetadata();
-
-  //ensure the user never omitted the extension from the file name
-  if ( !myOutputFileName.endsWith( QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata ), Qt::CaseInsensitive ) )
-  {
-    myOutputFileName += QgsMapLayer::extensionPropertyType( QgsMapLayer::Metadata );
-  }
-
-  bool defaultLoadedFlag = false;
-  const QString message = mLayer->saveNamedMetadata( myOutputFileName, defaultLoadedFlag );
-  if ( defaultLoadedFlag )
-    myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
-  else
-    QMessageBox::information( this, tr( "Save Metadata" ), message );
 }
 
 void QgsVectorTileLayerProperties::showHelp()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -103,6 +103,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorTileLayerProperties::syncToLayer );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsVectorTileLayerProperties::apply );
 
   // update based on lyr's current state
   syncToLayer();
@@ -123,7 +124,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   menuStyle->addAction( tr( "Load Style…" ), this, &QgsVectorTileLayerProperties::loadStyle );
   menuStyle->addAction( tr( "Save Style…" ), this, &QgsVectorTileLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorTileLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Save as Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::saveStyleAsDefault );
   menuStyle->addAction( tr( "Restore Default" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadDefaultStyle );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsVectorTileLayerProperties::aboutToShowStyleMenu );
@@ -245,25 +246,7 @@ void QgsVectorTileLayerProperties::loadDefaultStyle()
 
 void QgsVectorTileLayerProperties::saveDefaultStyle()
 {
-  apply(); // make sure the style to save is up-to-date
-
-  // a flag passed by reference
-  bool defaultSavedFlag = false;
-  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
-  // remove the NOWARN_DEPRECATED tags
-  Q_NOWARN_DEPRECATED_PUSH
-  // after calling this the above flag will be set true for success
-  // or false if the save operation failed
-  const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
-  Q_NOWARN_DEPRECATED_POP
-  if ( !defaultSavedFlag )
-  {
-    // let the user know what went wrong
-    QMessageBox::information( this,
-                              tr( "Default Style" ),
-                              myMessage
-                            );
-  }
+  mLayerPropertiesUtils->saveStyleAsDefault();
 }
 
 void QgsVectorTileLayerProperties::loadStyle()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -104,6 +104,10 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::syncDialogToLayer, this, &QgsVectorTileLayerProperties::syncToLayer );
   connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::applyDialogToLayer, this, &QgsVectorTileLayerProperties::apply );
+  connect( mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::storeCurrentStyleForUndo, this, [ = ]
+  {
+    mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
+  } );
 
   // update based on lyr's current state
   syncToLayer();

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -23,7 +23,6 @@
 #include "qgsvectortilelayer.h"
 #include "qgsvectortileutils.h"
 #include "qgsgui.h"
-#include "qgsnative.h"
 #include "qgsapplication.h"
 #include "qgsjsonutils.h"
 #include "qgsmetadatawidget.h"
@@ -81,7 +80,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
     mMetadataViewer->setZoomFactor( mMetadataViewer->zoomFactor() * 0.9 );
   }
   mMetadataViewer->page()->setLinkDelegationPolicy( QWebPage::LinkDelegationPolicy::DelegateAllLinks );
-  connect( mMetadataViewer->page(), &QWebPage::linkClicked, this, &QgsVectorTileLayerProperties::urlClicked );
+  connect( mMetadataViewer->page(), &QWebPage::linkClicked, this, &QgsVectorTileLayerProperties::openUrl );
   mMetadataViewer->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
   mMetadataViewer->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
 
@@ -346,15 +345,6 @@ void QgsVectorTileLayerProperties::showHelp()
   {
     QgsHelp::openHelp( QStringLiteral( "working_with_vector_tiles/vector_tiles_properties.html" ) );
   }
-}
-
-void QgsVectorTileLayerProperties::urlClicked( const QUrl &url )
-{
-  const QFileInfo file( url.toLocalFile() );
-  if ( file.exists() && !file.isDir() )
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
-  else
-    QDesktopServices::openUrl( url );
 }
 
 void QgsVectorTileLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -33,6 +33,8 @@
 #include "qgsmapboxglstyleconverter.h"
 #include "qgsprovidersourcewidget.h"
 #include "qgsdatumtransformdialog.h"
+#include "qgslayerpropertiesguiutils.h"
+
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -99,6 +101,8 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
 
+  mLayerPropertiesUtils = new QgsLayerPropertiesGuiUtils( this, mLayer, mMetadataWidget );
+
   // update based on lyr's current state
   syncToLayer();
 
@@ -127,7 +131,7 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsVectorTileLayerProperties::loadMetadata );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), mLayerPropertiesUtils, &QgsLayerPropertiesGuiUtils::loadMetadata );
   mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorTileLayerProperties::saveMetadataAs );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
@@ -395,40 +399,6 @@ void QgsVectorTileLayerProperties::aboutToShowStyleMenu()
   // re-add style manager actions!
   m->addSeparator();
   QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
-}
-
-void QgsVectorTileLayerProperties::loadMetadata()
-{
-  QgsSettings myQSettings;  // where we keep last used filter in persistent state
-  const QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
-
-  const QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer metadata from metadata file" ), myLastUsedDir,
-                             tr( "QGIS Layer Metadata File" ) + " (*.qmd)" );
-  if ( myFileName.isNull() )
-  {
-    return;
-  }
-
-  QString myMessage;
-  bool defaultLoadedFlag = false;
-  myMessage = mLayer->loadNamedMetadata( myFileName, defaultLoadedFlag );
-
-  //reset if the default style was loaded OK only
-  if ( defaultLoadedFlag )
-  {
-    mMetadataWidget->setMetadata( &mLayer->metadata() );
-  }
-  else
-  {
-    //let the user know what went wrong
-    QMessageBox::warning( this, tr( "Load Metadata" ), myMessage );
-  }
-
-  const QFileInfo myFI( myFileName );
-  const QString myPath = myFI.path();
-  myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), myPath );
-
-  activateWindow(); // set focus back to properties dialog
 }
 
 void QgsVectorTileLayerProperties::saveMetadataAs()

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -45,9 +45,9 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
     /**
      * Saves the default style when appropriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use saveStyleAsDefault() instead.
      */
-    void saveDefaultStyle();
+    Q_DECL_DEPRECATED void saveDefaultStyle() SIP_DEPRECATED;
 
     /**
      * Loads a saved style when appropriate button is pressed
@@ -59,9 +59,9 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
     /**
      * Saves a style when appriate button is pressed
      *
-     * \since QGIS 3.30
+     * \deprecated use saveStyleToFile() instead.
      */
-    void saveStyleAs();
+    Q_DECL_DEPRECATED void saveStyleAs() SIP_DEPRECATED;
 
   private slots:
     void apply() FINAL;

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -72,9 +72,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
     void urlClicked( const QUrl &url );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
-  protected slots:
-    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
-
   private:
     void syncToLayer() FINAL;
 

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -84,7 +84,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
     QAction *mActionLoadMetadata = nullptr;
     QAction *mActionSaveMetadataAs = nullptr;
 
-    QgsMapCanvas *mMapCanvas = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
 
     QgsProviderSourceWidget *mSourceWidget = nullptr;

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -69,7 +69,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
 
     void aboutToShowStyleMenu();
     void showHelp();
-    void urlClicked( const QUrl &url );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
   private:

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -28,6 +28,7 @@ class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileLayer;
 class QgsMetadataWidget;
 class QgsProviderSourceWidget;
+class QgsLayerPropertiesGuiUtils;
 
 
 /**
@@ -76,7 +77,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     void onCancel();
 
     void aboutToShowStyleMenu();
-    void loadMetadata();
     void saveMetadataAs();
     void showHelp();
     void urlClicked( const QUrl &url );
@@ -90,6 +90,8 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
 
   private:
     QgsVectorTileLayer *mLayer = nullptr;
+
+    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     QgsVectorTileBasicRendererWidget *mRendererWidget = nullptr;
     QgsVectorTileBasicLabelingWidget *mLabelingWidget = nullptr;

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -77,7 +77,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     void onCancel();
 
     void aboutToShowStyleMenu();
-    void saveMetadataAs();
     void showHelp();
     void urlClicked( const QUrl &url );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -65,7 +65,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog,
 
   private slots:
     void apply() FINAL;
-    void onCancel();
 
     void aboutToShowStyleMenu();
     void showHelp();

--- a/src/gui/vectortile/qgsvectortilelayerproperties.h
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.h
@@ -16,9 +16,8 @@
 #ifndef QGSVECTORTILELAYERPROPERTIES_H
 #define QGSVECTORTILELAYERPROPERTIES_H
 
-#include "qgsoptionsdialogbase.h"
 #include "ui_qgsvectortilelayerpropertiesbase.h"
-#include "qgsmaplayerstyle.h"
+#include "qgslayerpropertiesdialog.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -28,7 +27,6 @@ class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileLayer;
 class QgsMetadataWidget;
 class QgsProviderSourceWidget;
-class QgsLayerPropertiesGuiUtils;
 
 
 /**
@@ -37,19 +35,12 @@ class QgsLayerPropertiesGuiUtils;
  * \brief Vectortile layer properties dialog
  * \since QGIS 3.28
  */
-class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorTileLayerPropertiesBase
+class GUI_EXPORT QgsVectorTileLayerProperties : public QgsLayerPropertiesDialog, private Ui::QgsVectorTileLayerPropertiesBase
 {
     Q_OBJECT
   public:
     //! Constructor
     QgsVectorTileLayerProperties( QgsVectorTileLayer *lyr, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
-
-    /**
-     * Loads the default style when appropriate button is pressed
-     *
-     * \since QGIS 3.30
-     */
-    void loadDefaultStyle();
 
     /**
      * Saves the default style when appropriate button is pressed
@@ -73,7 +64,7 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     void saveStyleAs();
 
   private slots:
-    void apply();
+    void apply() FINAL;
     void onCancel();
 
     void aboutToShowStyleMenu();
@@ -85,12 +76,10 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
     void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
 
   private:
-    void syncToLayer();
+    void syncToLayer() FINAL;
 
   private:
     QgsVectorTileLayer *mLayer = nullptr;
-
-    QgsLayerPropertiesGuiUtils *mLayerPropertiesUtils = nullptr;
 
     QgsVectorTileBasicRendererWidget *mRendererWidget = nullptr;
     QgsVectorTileBasicLabelingWidget *mLabelingWidget = nullptr;
@@ -105,11 +94,6 @@ class GUI_EXPORT QgsVectorTileLayerProperties : public QgsOptionsDialogBase, pri
 
     QgsProviderSourceWidget *mSourceWidget = nullptr;
 
-    /**
-     * Previous layer style. Used to reset style to previous state if new style
-     * was loaded but dialog is canceled.
-    */
-    QgsMapLayerStyle mOldStyle;
 };
 
 #endif // QGSVECTORTILELAYERPROPERTIES_H


### PR DESCRIPTION
Start a new class for common functionality across layer properties dialogs, and consolidate all duplicate metadata and style handling methods in there.