### PR TITLE
Make sure that empty chunk nodes do not affect the parent nodes' bounding box calculation

### DIFF
--- a/src/3d/chunks/qgschunknode_p.cpp
+++ b/src/3d/chunks/qgschunknode_p.cpp
@@ -270,7 +270,7 @@ void QgsChunkNode::updateParentBoundingBoxesRecursively() const
     {
       const QgsAABB childBBox = currentNodeChildren[i]->bbox();
 
-      // Nodes without data have and empty bbox and should be skipped
+      // Nodes without data have an empty bbox and should be skipped
       if ( childBBox.isEmpty() )
         continue;
 

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -388,14 +388,13 @@ Qt3DCore::QEntity *QgsRuleBased3DRenderer::createEntity( const Qgs3DMapSettings 
   if ( !vl )
     return nullptr;
 
-  // we start with a maximal z range (based on a number similar to the radius of the Earth),
-  // because we can't know this upfront. There's too many
+  // we start with a maximal z range because we can't know this upfront. There's too many
   // factors to consider eg vertex z data, terrain heights, data defined offsets and extrusion heights,...
   // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
   // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
   // height will exceed this amount!
-  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -5000000;
-  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 5000000;
+  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -100000;
+  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 100000;
 
   return new QgsRuleBasedChunkedEntity( vl, MINIMUM_VECTOR_Z_ESTIMATE, MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mRootRule, map );
 }

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -70,14 +70,13 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( const Qgs3DMapSetting
   if ( !mSymbol || !vl )
     return nullptr;
 
-  // we start with a maximal z range (based on a number similar to the radius of the Earth),
-  // because we can't know this upfront. There's too many
+  // we start with a maximal z range because we can't know this upfront. There's too many
   // factors to consider eg vertex z data, terrain heights, data defined offsets and extrusion heights,...
   // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
   // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
   // height will exceed this amount!
-  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -5000000;
-  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 5000000;
+  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -100000;
+  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 100000;
   return new QgsVectorLayerChunkedEntity( vl, MINIMUM_VECTOR_Z_ESTIMATE, MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mSymbol.get(), map );
 }
 

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -125,6 +125,9 @@ Qt3DCore::QEntity *QgsVectorLayerChunkLoader::createEntity( Qt3DCore::QEntity *p
   if ( mHandler->featureCount() == 0 )
   {
     // an empty node, so we return no entity. This tags the node as having no data and effectively removes it.
+    // we just make sure first that its initial estimated vertical range does not affect its parents' bboxes calculation
+    mNode->setExactBbox( QgsAABB() );
+    mNode->updateParentBoundingBoxesRecursively();
     return nullptr;
   }
 


### PR DESCRIPTION
## Description
Empty nodes have an initial bbox with a huge elevation range which should be shrunk once actual values are available. Such nodes without data would still be taken into account when updating their parent node's elevation range though, causing some erroneous near/far plane calculations.

Fixes #52817

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
