### PR TITLE
Avoid data loss for query items

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -650,17 +650,17 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
 
   mHttpHeaders.setFromUrlQuery( query );
 
-  const auto constQueryItems = query.queryItems( QUrl::ComponentFormattingOption::FullyDecoded );
+  const auto constQueryItems = query.queryItems();
   for ( const QPair<QString, QString> &item : constQueryItems )
   {
     if ( !item.first.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
     {
       if ( item.first == QLatin1String( "username" ) )
-        mUsername = item.second;
+        mUsername = query.queryItemValue( QStringLiteral( "username" ), QUrl::ComponentFormattingOption::FullyDecoded );
       else if ( item.first == QLatin1String( "password" ) )
-        mPassword = item.second;
+        mPassword = query.queryItemValue( QStringLiteral( "password" ), QUrl::ComponentFormattingOption::FullyDecoded );
       else if ( item.first == QLatin1String( "authcfg" ) )
-        mAuthConfigId = item.second;
+        mAuthConfigId = query.queryItemValue( QStringLiteral( "authcfg" ), QUrl::ComponentFormattingOption::FullyDecoded );
       else
         mParams.insert( item.first, item.second );
     }

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -492,6 +492,11 @@ void TestQgsDataSourceUri::checkAuthParams()
   QCOMPARE( uri4.param( QStringLiteral( "password" ) ), QStringLiteral( "😁😂😍" ) );
   QCOMPARE( uri4.password(), QStringLiteral( "😁😂😍" ) );
 
+  // issue GH #53654
+  QgsDataSourceUri uri5;
+  uri5.setEncodedUri( QStringLiteral( "zmax=14&zmin=0&styleUrl=http://localhost:8000/&f=application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
+  QCOMPARE( uri5.param( QStringLiteral( "f" ) ), QStringLiteral( "application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
+
 }
 
 void TestQgsDataSourceUri::checkParameterKeys()

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -497,6 +497,9 @@ void TestQgsDataSourceUri::checkAuthParams()
   uri5.setEncodedUri( QStringLiteral( "zmax=14&zmin=0&styleUrl=http://localhost:8000/&f=application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
   QCOMPARE( uri5.param( QStringLiteral( "f" ) ), QStringLiteral( "application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
 
+  uri5.setEncodedUri( QStringLiteral( "zmax=14&zmin=0&styleUrl=http://localhost:8000/&f=application/vnd.geoserver.mbstyle+json" ) );
+  QCOMPARE( uri5.param( QStringLiteral( "f" ) ), QStringLiteral( "application/vnd.geoserver.mbstyle+json" ) );
+
 }
 
 void TestQgsDataSourceUri::checkParameterKeys()

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -500,6 +500,20 @@ void TestQgsDataSourceUri::checkAuthParams()
   uri5.setEncodedUri( QStringLiteral( "zmax=14&zmin=0&styleUrl=http://localhost:8000/&f=application/vnd.geoserver.mbstyle+json" ) );
   QCOMPARE( uri5.param( QStringLiteral( "f" ) ), QStringLiteral( "application/vnd.geoserver.mbstyle+json" ) );
 
+  // round trip through encodedUri/setEncodedUri should not lose "%2B" or "+"
+  QgsDataSourceUri uri6;
+  uri6.setParam( QStringLiteral( "percent" ), QStringLiteral( "application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
+  uri6.setParam( QStringLiteral( "explicit" ), QStringLiteral( "application/vnd.geoserver.mbstyle+json" ) );
+  QCOMPARE( uri6.param( QStringLiteral( "percent" ) ), QStringLiteral( "application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
+  QCOMPARE( uri6.param( QStringLiteral( "explicit" ) ), QStringLiteral( "application/vnd.geoserver.mbstyle+json" ) );
+
+  const QByteArray encodedTwo = uri6.encodedUri();
+
+  QgsDataSourceUri uri7;
+  uri7.setEncodedUri( encodedTwo );
+  QCOMPARE( uri7.param( QStringLiteral( "percent" ) ), QStringLiteral( "application%2Fvnd.geoserver.mbstyle%2Bjson" ) );
+  QCOMPARE( uri7.param( QStringLiteral( "explicit" ) ), QStringLiteral( "application/vnd.geoserver.mbstyle+json" ) );
+
 }
 
 void TestQgsDataSourceUri::checkParameterKeys()


### PR DESCRIPTION
Fix https://github.com/qgis/QGIS/issues/53654

Use the [default](https://doc.qt.io/qt-6/qurlquery.html#queryItems) `PrettyDecoded` instead of `FullyDecoded` for query items.

From the [docs](https://doc.qt.io/qt-5/qurl.html#query):

> Note that use of [QUrl::FullyDecoded](https://doc.qt.io/qt-5/qurl.html#ComponentFormattingOption-enum) in queries is discouraged, as queries often contain data that is supposed to remain percent-encoded, **including the use of the "%2B" sequence to represent a plus character ('+')**.

Test added.