### PR TITLE
Automatically select the text in the Name field of the New Bookmark dialog

### DIFF
--- a/src/app/qgsbookmarkeditordialog.cpp
+++ b/src/app/qgsbookmarkeditordialog.cpp
@@ -62,6 +62,7 @@ QgsBookmarkEditorDialog::QgsBookmarkEditorDialog( QgsBookmark bookmark, bool inP
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsBookmarkEditorDialog::showHelp );
 
   mName->setFocus();
+  mName->selectAll();
 }
 
 void QgsBookmarkEditorDialog::crsChanged( const QgsCoordinateReferenceSystem &crs )


### PR DESCRIPTION
## Description

This PR adds a simple change to automatically select the text in the Name field of the New Bookmark dialog (the text is the name of the new bookmark, which starts off as "New bookmark"). 

This allows you to click the button to make a bookmark, and immediately start typing a name for the bookmark, without manually dragging over the text in the name field to select it.

The dialog now looks like this when opened:
<img width="601" alt="image" src="https://github.com/qgis/QGIS/assets/296686/ac0f3d9d-ab8d-439f-a0b4-6ec59250f4fa">