### PR TITLE
Add boundingboxintersects test for some geometries 

### DIFF
--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -55,6 +55,7 @@ class TestQgsCurvePolygon: public QObject
     void testClosestSegment();
     void testBoundary();
     void testBoundingBox();
+    void testBoundingBoxIntersects();
     void testRoundness();
     void testDropZValue();
     void testDropMValue();
@@ -1253,6 +1254,20 @@ void TestQgsCurvePolygon::testBoundingBox()
   QGSCOMPARENEAR( bBox.xMaximum(), 1.012344, 0.001 );
   QGSCOMPARENEAR( bBox.yMinimum(), 0.000000, 0.001 );
   QGSCOMPARENEAR( bBox.yMaximum(), 18, 0.001 );
+}
+
+void TestQgsCurvePolygon::testBoundingBoxIntersects()
+{
+  QgsCurvePolygon poly;
+  QVERIFY( !poly.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+
+  QgsCircularString *ext = new QgsCircularString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0, 1 ) << QgsPoint( 1, 10, 2 )
+                  << QgsPoint( 0, 18, 3 ) << QgsPoint( -1, 4, 4 ) << QgsPoint( 0, 0, 1 ) );
+  poly.setExteriorRing( ext );
+
+  QVERIFY( poly.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !poly.boundingBoxIntersects( QgsRectangle( 1.1, -5, 6, -2 ) ) );
 }
 
 void TestQgsCurvePolygon::testRoundness()

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -1429,6 +1429,14 @@ void TestQgsGeometryCollection::geometryCollection()
   QVERIFY( b1.boundingBoxIntersects( QgsRectangle( -5, -2, 1.5, 2.5 ) ) );
   QVERIFY( b1.boundingBoxIntersects( QgsRectangle( 3, 7, 5, 8 ) ) );
   QCOMPARE( b1.boundingBox(), QgsRectangle( 1, 2, 111, 12 ) );
+
+  b1.clear();
+  QVERIFY( b1.boundingBox().isNull() );
+  transformLine.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 10, 17, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 12, 17, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 12, 15, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) );
+  b1.addGeometry( transformLine.clone() );
+  QgsPolygon polygon;
+  QVERIFY( polygon.fromWkt( "Polygon( (5 10 0, 5 15 0, 10 15 0, 10 10 0, 5 10 0) )" ) );
+  QVERIFY( b1.boundingBoxIntersects( polygon.boundingBox() ) );
 }
 
 

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -1419,6 +1419,16 @@ void TestQgsGeometryCollection::geometryCollection()
 
   TestFailTransformer failTransformer;
   QVERIFY( !transformCollect2.transform( &failTransformer ) );
+
+  // bounding box intersects test
+  QgsGeometryCollection b1;
+  QVERIFY( !b1.boundingBoxIntersects( QgsRectangle( 0, 0, 0, 0 ) ) );
+  transformLine.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4, Qgis::WkbType::PointZM ) << QgsPoint( 11, 12, 13, 14, Qgis::WkbType::PointZM ) << QgsPoint( 111, 12, 23, 24, Qgis::WkbType::PointZM ) );
+  b1.addGeometry( transformLine.clone() );
+  QVERIFY( !b1.boundingBoxIntersects( QgsRectangle( -5, -2, 0.5, 1.5 ) ) );
+  QVERIFY( b1.boundingBoxIntersects( QgsRectangle( -5, -2, 1.5, 2.5 ) ) );
+  QVERIFY( b1.boundingBoxIntersects( QgsRectangle( 3, 7, 5, 8 ) ) );
+  QCOMPARE( b1.boundingBox(), QgsRectangle( 1, 2, 111, 12 ) );
 }
 
 


### PR DESCRIPTION
This adds some `boundingboxinterects` test for:

- `QgsGeometryCollection`
- `QgsCurvePolygon`
- `QgsCompoundCurve`
