### PR TITLE
do not call deduceEndian() if PGver >= 7.4

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -425,7 +425,21 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
 
   QgsDebugMsgLevel( QStringLiteral( "Connection to the database was successful" ), 2 );
 
-  deduceEndian();
+  mPostgresqlVersion = PQserverVersion( mConn );
+  if ( mPostgresqlVersion < 70400 )
+  {
+    deduceEndian();
+  }
+  else
+  {
+    // todo - std::endian
+    int testInt = 1;
+    //               mem addr: -->
+    // testInt(little-endian): 01 0...0 00
+    //    testInt(big-endian): 00 0...0 01
+    //                  *char: ^^
+    mSwapEndian = *( char * )&testInt == 1;
+  }
 
   /* Check to see if we have working PostGIS support */
   if ( !postgisVersion().isNull() )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -432,7 +432,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   }
   else
   {
-    // todo - std::endian
+    // todo - use std::endian when we require C++20
     int testInt = 1;
     //               mem addr: -->
     // testInt(little-endian): 01 0...0 00


### PR DESCRIPTION
Starting with version [7.4](https://www.postgresql.org/docs/7.4/sql-declare.html#:~:text=the%20value%20(in-,big%2Dendian,-byte%20order).), the PostgreSQL server uses the big-endian format for transferring binary data ([7.3](https://www.postgresql.org/docs/7.3/sql-declare.html#:~:text=endian%22%20versus%20%22-,little,-%2Dendian%22) - the server data format was used).
Therefore, there is no need to use the deduceEndian() function...
