### PR TITLE
PostgreSQL: add PQbackendPID to Query Logger

### DIFF
--- a/python/core/auto_generated/qgsdbquerylog.sip.in
+++ b/python/core/auto_generated/qgsdbquerylog.sip.in
@@ -48,6 +48,8 @@ Constructor for QgsDatabaseQueryLogEntry.
 
     bool canceled;
 
+    QString backendPID;
+
 };
 
 

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.cpp
@@ -64,6 +64,7 @@ QgsDatabaseQueryLoggerQueryGroup::QgsDatabaseQueryLoggerQueryGroup( const QgsDat
   : QgsDevToolsModelGroup( QString() )
   , mSql( query.query )
   , mQueryId( query.queryId )
+  , mBackendPID( query.backendPID )
 {
 #if 0
   std::unique_ptr< QgsNetworkLoggerRequestDetailsGroup > detailsGroup = std::make_unique< QgsNetworkLoggerRequestDetailsGroup >( request );
@@ -88,8 +89,18 @@ QVariant QgsDatabaseQueryLoggerQueryGroup::data( int role ) const
   switch ( role )
   {
     case Qt::DisplayRole:
-      return QStringLiteral( "%1 %2" ).arg( QString::number( mQueryId ),
-                                            mSql );
+    {
+      if ( mBackendPID.isEmpty() )
+      {
+        return QStringLiteral( "%1 %2" ).arg( QString::number( mQueryId ), mSql );
+      }
+      else
+      {
+        return QStringLiteral( "%1 %2 %3" ).arg( QString::number( mQueryId ),
+               mBackendPID,
+               mSql );
+      }
+    }
 
     case QgsDevToolsModelNode::RoleSort:
       return mQueryId;
@@ -220,6 +231,11 @@ void QgsDatabaseQueryLoggerQueryGroup::setFinished( const QgsDatabaseQueryLogEnt
   }
   mElapsed = static_cast<qint64>( query.finishedTime - query.startedTime );
   addKeyValueNode( QObject::tr( "Total time (ms)" ), QLocale().toString( mElapsed ) );
+  if ( !query.backendPID.isEmpty() )
+  {
+    mBackendPID = query.backendPID;
+    addKeyValueNode( QObject::tr( "Backend PID" ), query.backendPID );
+  }
 }
 
 void QgsDatabaseQueryLoggerQueryGroup::setStatus( QgsDatabaseQueryLoggerQueryGroup::Status status )

--- a/src/app/devtools/querylogger/qgsdatabasequeryloggernode.h
+++ b/src/app/devtools/querylogger/qgsdatabasequeryloggernode.h
@@ -118,6 +118,7 @@ class QgsDatabaseQueryLoggerQueryGroup final : public QgsDevToolsModelGroup
 
     QString mSql;
     int mQueryId = 0;
+    QString mBackendPID;
     QByteArray mData;
     Status mStatus = Status::Pending;
     qint64 mElapsed = -1;

--- a/src/core/qgsdbquerylog.h
+++ b/src/core/qgsdbquerylog.h
@@ -95,6 +95,11 @@ class CORE_EXPORT QgsDatabaseQueryLogEntry
      */
     bool canceled = false;
 
+    /**
+     * Server-side process ID.
+     */
+    QString backendPID;
+
   private:
 
     static QAtomicInt sQueryId;
@@ -256,6 +261,11 @@ class QgsDatabaseQueryLogWrapper
     void setCanceled( )
     {
       mEntry.canceled = true;
+    }
+
+    void setBackendPID( const QString &backendPID )
+    {
+      mEntry.backendPID = backendPID;
     }
 
   private:

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -317,6 +317,7 @@ class QgsPostgresConn : public QObject
     bool closeCursor( const QString &cursorName );
 
     QString uniqueCursorName();
+    QString backendPID();
 
 #if 0
     PGconn *pgConnection() { return mConn; }
@@ -546,6 +547,8 @@ class QgsPostgresConn : public QObject
      */
     bool mSwapEndian;
     void deduceEndian();
+
+    QString mConnBackendPID;
 
     static QAtomicInt sNextCursorId;
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -303,6 +303,8 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature &feature )
         logWrapper.setError( error );
       }
 
+      logWrapper.setBackendPID( mConn->backendPID() );
+
       QgsPostgresResult queryResult;
       long long fetchedRows { 0 };
       for ( ;; )


### PR DESCRIPTION
PR adds the PQbackendPID to the Query Logger.

Also makes minor changes to the Query Logger interface.
PQbackendPID - added between the query number and the SQL query:
![0024](https://github.com/qgis/QGIS/assets/31573086/9f2705cf-d36e-4c5a-840f-0e21cb5ef8fe)

A bonus is the ability to filter by PQbackendPID:
![0025](https://github.com/qgis/QGIS/assets/31573086/4e80a136-2ab9-4831-accc-1351fedaad35)
