### PR TITLE
Make the snapping priority label clearer

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -155,7 +155,7 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
     QActionGroup *snappingPriorityActionGroup = new QActionGroup( snappingPriorityMenu );
     QAction *featuresAction = new QAction( tr( "Prioritize Snapping to Features" ), snappingPriorityActionGroup );
     featuresAction->setCheckable( true );
-    QAction *anglesAction = new QAction( tr( "Prioritize Snapping to Angle" ), snappingPriorityActionGroup );
+    QAction *anglesAction = new QAction( tr( "Prioritize Snapping to Common Angles" ), snappingPriorityActionGroup );
     anglesAction->setCheckable( true );
     snappingPriorityActionGroup->addAction( featuresAction );
     snappingPriorityActionGroup->addAction( anglesAction );


### PR DESCRIPTION
keeps naming coherent with previous menus and avoids confusion between common angles and angles as a corner (refs https://github.com/qgis/QGIS/pull/53151#discussion_r1205253134)