### PR TITLE
Implement tiled mesh source select and browser item provider

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -128,6 +128,7 @@ if(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/gui/settings
       ${CMAKE_SOURCE_DIR}/src/gui/symbology
       ${CMAKE_SOURCE_DIR}/src/gui/tableeditor
+      ${CMAKE_SOURCE_DIR}/src/gui/tiledmesh
       ${CMAKE_SOURCE_DIR}/src/gui/vector
       ${CMAKE_SOURCE_DIR}/src/gui/vectortile
       ${CMAKE_SOURCE_DIR}/src/analysis

--- a/python/gui/auto_generated/qgsmanageconnectionsdialog.sip.in
+++ b/python/gui/auto_generated/qgsmanageconnectionsdialog.sip.in
@@ -34,7 +34,8 @@ class QgsManageConnectionsDialog : QDialog
       XyzTiles,
       ArcgisMapServer,
       ArcgisFeatureServer,
-      VectorTile
+      VectorTile,
+      TiledMesh,
     };
 
     QgsManageConnectionsDialog( QWidget *parent /TransferThis/ = 0, Mode mode = Export, Type type = WMS, const QString &fileName = QString() );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -338,6 +338,7 @@ set(QGIS_CORE_SRCS
 
   tiledmesh/qgscesiumtilesdataprovider.cpp
   tiledmesh/qgstiledmeshconnection.cpp
+  tiledmesh/qgstiledmeshdataitems.cpp
   tiledmesh/qgstiledmeshdataprovider.cpp
   tiledmesh/qgstiledmeshlayer.cpp
   tiledmesh/qgstiledmeshlayerrenderer.cpp
@@ -1897,6 +1898,7 @@ set(QGIS_CORE_HDRS
   tiledmesh/qgscesiumtilesdataprovider.h
   tiledmesh/qgstiledmeshconnection.h
   tiledmesh/qgstiledmeshdataprovider.h
+  tiledmesh/qgstiledmeshdataitems.h
   tiledmesh/qgstiledmeshlayer.h
   tiledmesh/qgstiledmeshlayerrenderer.h
   tiledmesh/qgstiledmeshprovidermetadata.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -340,6 +340,7 @@ set(QGIS_CORE_SRCS
   tiledmesh/qgstiledmeshconnection.cpp
   tiledmesh/qgstiledmeshdataprovider.cpp
   tiledmesh/qgstiledmeshlayer.cpp
+  tiledmesh/qgstiledmeshlayerrenderer.cpp
 
   sensor/qgssensormodel.cpp
   sensor/qgssensormanager.cpp
@@ -1896,6 +1897,7 @@ set(QGIS_CORE_HDRS
   tiledmesh/qgstiledmeshconnection.h
   tiledmesh/qgstiledmeshdataprovider.h
   tiledmesh/qgstiledmeshlayer.h
+  tiledmesh/qgstiledmeshlayerrenderer.h
 
   sensor/qgssensormodel.h
   sensor/qgssensormanager.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -341,6 +341,7 @@ set(QGIS_CORE_SRCS
   tiledmesh/qgstiledmeshdataprovider.cpp
   tiledmesh/qgstiledmeshlayer.cpp
   tiledmesh/qgstiledmeshlayerrenderer.cpp
+  tiledmesh/qgstiledmeshprovidermetadata.cpp
 
   sensor/qgssensormodel.cpp
   sensor/qgssensormanager.cpp
@@ -1898,6 +1899,7 @@ set(QGIS_CORE_HDRS
   tiledmesh/qgstiledmeshdataprovider.h
   tiledmesh/qgstiledmeshlayer.h
   tiledmesh/qgstiledmeshlayerrenderer.h
+  tiledmesh/qgstiledmeshprovidermetadata.h
 
   sensor/qgssensormodel.h
   sensor/qgssensormanager.h

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -39,6 +39,7 @@
 #include "qgsvtpkvectortiledataprovider.h"
 
 #include "qgscesiumtilesdataprovider.h"
+#include "qgstiledmeshprovidermetadata.h"
 
 #ifdef HAVE_EPT
 #include "providers/ept/qgseptprovider.h"
@@ -230,7 +231,10 @@ void QgsProviderRegistry::init()
 
   {
     const QgsScopedRuntimeProfile profile( QObject::tr( "Create tiled mesh providers" ) );
-    QgsProviderMetadata *metadata = new QgsCesiumTilesProviderMetadata();
+    QgsProviderMetadata *metadata = new QgsTiledMeshProviderMetadata();
+    mProviders[ metadata->key() ] = metadata;
+
+    metadata = new QgsCesiumTilesProviderMetadata();
     mProviders[ metadata->key() ] = metadata;
   }
 

--- a/src/core/tiledmesh/qgstiledmeshdataitems.cpp
+++ b/src/core/tiledmesh/qgstiledmeshdataitems.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+    qgstiledmeshdataitems.cpp
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstiledmeshdataitems.h"
+#include "qgstiledmeshconnection.h"
+#include "qgsdataprovider.h"
+
+///@cond PRIVATE
+
+QgsTiledMeshRootItem::QgsTiledMeshRootItem( QgsDataItem *parent, QString name, QString path )
+  : QgsConnectionsRootItem( parent, name, path, QStringLiteral( "tiled-mesh" ) )
+{
+  mCapabilities |= Qgis::BrowserItemCapability::Fast;
+  mIconName = QStringLiteral( "mIconTiledMeshLayer.svg" );
+  populate();
+}
+
+QVector<QgsDataItem *> QgsTiledMeshRootItem::createChildren()
+{
+  QVector<QgsDataItem *> connections;
+  const auto connectionList = QgsTiledMeshProviderConnection::connectionList();
+  for ( const QString &connName : connectionList )
+  {
+    const QgsTiledMeshProviderConnection::Data connectionData = QgsTiledMeshProviderConnection::connection( connName );
+    const QString uri = QgsTiledMeshProviderConnection::encodedLayerUri( connectionData );
+    QgsDataItem *conn = new QgsTiledMeshLayerItem( this, connName, mPath + '/' + connName, uri, connectionData.provider );
+    connections.append( conn );
+  }
+  return connections;
+}
+
+
+// ---------------------------------------------------------------------------
+
+
+QgsTiledMeshLayerItem::QgsTiledMeshLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri, const QString &provider )
+  : QgsLayerItem( parent, name, path, encodedUri, Qgis::BrowserLayerType::TiledMesh, provider )
+{
+  setState( Qgis::BrowserItemState::Populated );
+
+  // TODO icon should be taken from associated provider metadata
+  mIconName = QStringLiteral( "mIconTiledMeshLayer.svg" );
+}
+
+
+// ---------------------------------------------------------------------------
+
+QString QgsTiledMeshDataItemProvider::name()
+{
+  return QStringLiteral( "Tiled Mesh" );
+}
+
+QString QgsTiledMeshDataItemProvider::dataProviderKey() const
+{
+  return QStringLiteral( "tiled-mesh" );
+}
+
+int QgsTiledMeshDataItemProvider::capabilities() const
+{
+  return QgsDataProvider::Net;
+}
+
+QgsDataItem *QgsTiledMeshDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
+{
+  if ( path.isEmpty() )
+    return new QgsTiledMeshRootItem( parentItem, QStringLiteral( "Tiled Mesh" ), QStringLiteral( "tiled-mesh:" ) );
+
+  return nullptr;
+}
+
+///@endcond

--- a/src/core/tiledmesh/qgstiledmeshdataitems.h
+++ b/src/core/tiledmesh/qgstiledmeshdataitems.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+    qgstiledmeshdataitems.h
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSTILEDMESHDATAITEMS_H
+#define QGSTILEDMESHDATAITEMS_H
+
+#include "qgsconnectionsitem.h"
+#include "qgslayeritem.h"
+#include "qgsdataitemprovider.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+//! Root item for tiled mesh connections
+class CORE_EXPORT QgsTiledMeshRootItem : public QgsConnectionsRootItem
+{
+    Q_OBJECT
+  public:
+    QgsTiledMeshRootItem( QgsDataItem *parent, QString name, QString path );
+
+    QVector<QgsDataItem *> createChildren() override;
+
+    QVariant sortKey() const override { return 8; }
+
+};
+
+//! Item implementation for tiled mesh layers
+class CORE_EXPORT QgsTiledMeshLayerItem : public QgsLayerItem
+{
+    Q_OBJECT
+  public:
+    QgsTiledMeshLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri, const QString &provider );
+
+};
+
+
+//! Provider for tiled mesh root data item
+class QgsTiledMeshDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    QString name() override;
+    QString dataProviderKey() const override;
+    int capabilities() const override;
+
+    QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
+};
+
+///@endcond
+
+#endif // QGSTILEDMESHDATAITEMS_H

--- a/src/core/tiledmesh/qgstiledmeshlayer.cpp
+++ b/src/core/tiledmesh/qgstiledmeshlayer.cpp
@@ -24,6 +24,7 @@
 #include "qgsxmlutils.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsapplication.h"
+#include "qgstiledmeshlayerrenderer.h"
 
 QgsTiledMeshLayer::QgsTiledMeshLayer( const QString &uri,
                                       const QString &baseName,
@@ -76,11 +77,11 @@ QgsRectangle QgsTiledMeshLayer::extent() const
   return mDataProvider->extent();
 }
 
-QgsMapLayerRenderer *QgsTiledMeshLayer::createMapRenderer( QgsRenderContext & )
+QgsMapLayerRenderer *QgsTiledMeshLayer::createMapRenderer( QgsRenderContext &context )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return nullptr;
+  return new QgsTiledMeshLayerRenderer( this, context );
 }
 
 QgsTiledMeshDataProvider *QgsTiledMeshLayer::dataProvider()

--- a/src/core/tiledmesh/qgstiledmeshlayerrenderer.cpp
+++ b/src/core/tiledmesh/qgstiledmeshlayerrenderer.cpp
@@ -28,7 +28,7 @@ QgsTiledMeshLayerRenderer::QgsTiledMeshLayerRenderer( QgsTiledMeshLayer *layer, 
 {
   // We must not keep pointer to mLayer (it's dangerous) - we must copy anything we need for rendering
   // or use some locking to prevent read/write from multiple threads
-  if ( !layer || !layer->dataProvider() ) // || !layer->renderer() )
+  if ( !layer->dataProvider() ) // || !layer->renderer() )
     return;
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );

--- a/src/core/tiledmesh/qgstiledmeshlayerrenderer.cpp
+++ b/src/core/tiledmesh/qgstiledmeshlayerrenderer.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+                         qgstiledmeshlayerrenderer.cpp
+                         --------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstiledmeshlayerrenderer.h"
+#include "qgstiledmeshlayer.h"
+#include "qgsfeedback.h"
+#include "qgsmapclippingutils.h"
+#include "qgsrendercontext.h"
+
+QgsTiledMeshLayerRenderer::QgsTiledMeshLayerRenderer( QgsTiledMeshLayer *layer, QgsRenderContext &context )
+  : QgsMapLayerRenderer( layer->id(), &context )
+  , mFeedback( new QgsFeedback )
+{
+  // We must not keep pointer to mLayer (it's dangerous) - we must copy anything we need for rendering
+  // or use some locking to prevent read/write from multiple threads
+  if ( !layer || !layer->dataProvider() ) // || !layer->renderer() )
+    return;
+
+  mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );
+
+  mReadyToCompose = false;
+}
+
+QgsTiledMeshLayerRenderer::~QgsTiledMeshLayerRenderer() = default;
+
+bool QgsTiledMeshLayerRenderer::render()
+{
+  // Set up the render configuration options
+  QPainter *painter = renderContext()->painter();
+
+  QgsScopedQPainterState painterState( painter );
+  renderContext()->setPainterFlagsUsingContext( painter );
+
+  if ( !mClippingRegions.empty() )
+  {
+    bool needsPainterClipPath = false;
+    const QPainterPath path = QgsMapClippingUtils::calculatePainterClipRegion( mClippingRegions, *renderContext(), Qgis::LayerType::VectorTile, needsPainterClipPath );
+    if ( needsPainterClipPath )
+      renderContext()->painter()->setClipPath( path, Qt::IntersectClip );
+  }
+
+  // if the previous layer render was relatively quick (e.g. less than 3 seconds), the we show any previously
+  // cached version of the layer during rendering instead of the usual progressive updates
+  if ( mRenderTimeHint > 0 && mRenderTimeHint <= MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE )
+  {
+    mBlockRenderUpdates = true;
+    mElapsedTimer.start();
+  }
+
+  mReadyToCompose = true;
+  return false;
+}
+
+void QgsTiledMeshLayerRenderer::setLayerRenderingTimeHint( int time )
+{
+  mRenderTimeHint = time;
+}

--- a/src/core/tiledmesh/qgstiledmeshlayerrenderer.h
+++ b/src/core/tiledmesh/qgstiledmeshlayerrenderer.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+                         qgstiledmeshlayerrenderer.h
+                         --------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHLAYERRENDERER_H
+#define QGSTILEDMESHLAYERRENDERER_H
+
+#include "qgis_core.h"
+#include "qgsmaplayerrenderer.h"
+
+#include <memory>
+#include <QElapsedTimer>
+
+#define SIP_NO_FILE
+
+class QgsTiledMeshLayer;
+class QgsFeedback;
+class QgsMapClippingRegion;
+
+/**
+ * \ingroup core
+ *
+ * \brief Implementation of threaded 2D rendering for tiled mesh layers.
+ *
+ * \note The API is considered EXPERIMENTAL and can be changed without a notice
+ * \note Not available in Python bindings
+ *
+ * \since QGIS 3.34
+ */
+class CORE_EXPORT QgsTiledMeshLayerRenderer: public QgsMapLayerRenderer
+{
+  public:
+
+    //! Ctor
+    explicit QgsTiledMeshLayerRenderer( QgsTiledMeshLayer *layer, QgsRenderContext &context );
+    ~QgsTiledMeshLayerRenderer();
+
+    bool render() override;
+    void setLayerRenderingTimeHint( int time ) override;
+
+    QgsFeedback *feedback() const override { return mFeedback.get(); }
+
+  private:
+    QList< QgsMapClippingRegion > mClippingRegions;
+
+    int mRenderTimeHint = 0;
+    bool mBlockRenderUpdates = false;
+    QElapsedTimer mElapsedTimer;
+
+    std::unique_ptr<QgsFeedback> mFeedback = nullptr;
+};
+
+#endif // QGSTILEDMESHLAYERRENDERER_H

--- a/src/core/tiledmesh/qgstiledmeshprovidermetadata.cpp
+++ b/src/core/tiledmesh/qgstiledmeshprovidermetadata.cpp
@@ -16,6 +16,7 @@
 #include "qgstiledmeshprovidermetadata.h"
 #include "qgstiledmeshconnection.h"
 #include "qgsapplication.h"
+#include "qgstiledmeshdataitems.h"
 
 #include <QIcon>
 
@@ -36,7 +37,10 @@ QIcon QgsTiledMeshProviderMetadata::icon() const
 
 QList<QgsDataItemProvider *> QgsTiledMeshProviderMetadata::dataItemProviders() const
 {
-  return {}; // TODO;
+  return
+  {
+    new QgsTiledMeshDataItemProvider()
+  };
 }
 
 QMap<QString, QgsAbstractProviderConnection *> QgsTiledMeshProviderMetadata::connections( bool cached )

--- a/src/core/tiledmesh/qgstiledmeshprovidermetadata.cpp
+++ b/src/core/tiledmesh/qgstiledmeshprovidermetadata.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+  qgstiledmeshprovidermetadata.cpp
+  --------------------------------------
+  Date                 : June 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshprovidermetadata.h"
+#include "qgstiledmeshconnection.h"
+#include "qgsapplication.h"
+
+#include <QIcon>
+
+///@cond PRIVATE
+
+#define PROVIDER_KEY QStringLiteral( "tiledmesh" )
+#define PROVIDER_DESCRIPTION QStringLiteral( "Tiled mesh provider" )
+
+QgsTiledMeshProviderMetadata::QgsTiledMeshProviderMetadata()
+  : QgsProviderMetadata( PROVIDER_KEY, PROVIDER_DESCRIPTION )
+{
+}
+
+QIcon QgsTiledMeshProviderMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "mIconTiledMeshLayer.svg" ) );
+}
+
+QList<QgsDataItemProvider *> QgsTiledMeshProviderMetadata::dataItemProviders() const
+{
+  return {}; // TODO;
+}
+
+QMap<QString, QgsAbstractProviderConnection *> QgsTiledMeshProviderMetadata::connections( bool cached )
+{
+  return connectionsProtected<QgsTiledMeshProviderConnection, QgsTiledMeshProviderConnection>( cached );
+}
+
+QgsAbstractProviderConnection *QgsTiledMeshProviderMetadata::createConnection( const QString &name )
+{
+  return new QgsTiledMeshProviderConnection( name );
+}
+
+void QgsTiledMeshProviderMetadata::deleteConnection( const QString &name )
+{
+  deleteConnectionProtected<QgsTiledMeshProviderConnection>( name );
+}
+
+void QgsTiledMeshProviderMetadata::saveConnection( const QgsAbstractProviderConnection *connection, const QString &name )
+{
+  saveConnectionProtected( connection, name );
+}
+
+QgsProviderMetadata::ProviderCapabilities QgsTiledMeshProviderMetadata::providerCapabilities() const
+{
+  return QgsProviderMetadata::ProviderCapabilities();
+}
+
+
+///@endcond

--- a/src/core/tiledmesh/qgstiledmeshprovidermetadata.h
+++ b/src/core/tiledmesh/qgstiledmeshprovidermetadata.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+  qgstiledmeshprovidermetadata.h
+  --------------------------------------
+  Date                 : June 2023
+  Copyright            : (C) 2023 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHPROVIDERMETADATA_H
+#define QGSTILEDMESHPROVIDERMETADATA_H
+
+
+#include "qgsprovidermetadata.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+/**
+ * This metadata class is responsible for generic tiled mesh handling.
+ *
+ * Specific tiled mesh data provider classes will also implement their own
+ * QgsProviderMetadata.
+ */
+class QgsTiledMeshProviderMetadata : public QgsProviderMetadata
+{
+    Q_OBJECT
+  public:
+    QgsTiledMeshProviderMetadata();
+    QIcon icon() const override;
+    QList< QgsDataItemProvider * > dataItemProviders() const override;
+
+    // handling of stored connections
+
+    QMap<QString, QgsAbstractProviderConnection *> connections( bool cached ) override;
+    QgsAbstractProviderConnection *createConnection( const QString &name ) override;
+    void deleteConnection( const QString &name ) override;
+    void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) override;
+
+    ProviderCapabilities providerCapabilities() const override;
+};
+
+///@endcond
+
+#endif // QGSTILEDMESHPROVIDERMETADATA_H

--- a/src/core/tiledmesh/qgstiledmeshprovidermetadata.h
+++ b/src/core/tiledmesh/qgstiledmeshprovidermetadata.h
@@ -27,6 +27,8 @@
  *
  * Specific tiled mesh data provider classes will also implement their own
  * QgsProviderMetadata.
+ *
+ * \since QGIS 3.34
  */
 class QgsTiledMeshProviderMetadata : public QgsProviderMetadata
 {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -460,6 +460,10 @@ set(QGIS_GUI_SRCS
   tableeditor/qgstableeditorformattingwidget.cpp
   tableeditor/qgstableeditorwidget.cpp
 
+  tiledmesh/qgstiledmeshconnectiondialog.cpp
+  tiledmesh/qgstiledmeshproviderguimetadata.cpp
+  tiledmesh/qgstiledmeshsourceselect.cpp
+
   vectortile/qgsarcgisvectortileconnectiondialog.cpp
   vectortile/qgsvectortilebasiclabelingwidget.cpp
   vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -1470,6 +1474,10 @@ set(QGIS_GUI_HDRS
   tableeditor/qgstableeditorformattingwidget.h
   tableeditor/qgstableeditorwidget.h
 
+  tiledmesh/qgstiledmeshconnectiondialog.h
+  tiledmesh/qgstiledmeshproviderguimetadata.h
+  tiledmesh/qgstiledmeshsourceselect.h
+
   vectortile/qgsarcgisvectortileconnectiondialog.h
   vectortile/qgsvectortilebasiclabelingwidget.h
   vectortile/qgsvectortilebasicrendererwidget.h
@@ -1616,6 +1624,7 @@ target_include_directories(qgis_gui PUBLIC
   ${CMAKE_SOURCE_DIR}/src/gui/sensor
   ${CMAKE_SOURCE_DIR}/src/gui/settings
   ${CMAKE_SOURCE_DIR}/src/gui/tableeditor
+  ${CMAKE_SOURCE_DIR}/src/gui/tiledmesh
   ${CMAKE_SOURCE_DIR}/src/gui/vector
   ${CMAKE_SOURCE_DIR}/src/gui/vectortile
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -461,6 +461,7 @@ set(QGIS_GUI_SRCS
   tableeditor/qgstableeditorwidget.cpp
 
   tiledmesh/qgstiledmeshconnectiondialog.cpp
+  tiledmesh/qgstiledmeshdataitemguiprovider.cpp
   tiledmesh/qgstiledmeshproviderguimetadata.cpp
   tiledmesh/qgstiledmeshsourceselect.cpp
 
@@ -1475,6 +1476,7 @@ set(QGIS_GUI_HDRS
   tableeditor/qgstableeditorwidget.h
 
   tiledmesh/qgstiledmeshconnectiondialog.h
+  tiledmesh/qgstiledmeshdataitemguiprovider.h
   tiledmesh/qgstiledmeshproviderguimetadata.h
   tiledmesh/qgstiledmeshsourceselect.h
 

--- a/src/gui/qgsmanageconnectionsdialog.h
+++ b/src/gui/qgsmanageconnectionsdialog.h
@@ -51,7 +51,8 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
       XyzTiles,
       ArcgisMapServer, // TODO QGIS 4: remove
       ArcgisFeatureServer,
-      VectorTile
+      VectorTile,
+      TiledMesh, //!< Tiled mesh connection (since QGIS 3.34)
     };
 
     /**
@@ -77,6 +78,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     QDomDocument saveXyzTilesConnections( const QStringList &connections );
     QDomDocument saveArcgisConnections( const QStringList &connections );
     QDomDocument saveVectorTileConnections( const QStringList &connections );
+    QDomDocument saveTiledMeshConnections( const QStringList &connections );
 
     void loadOWSConnections( const QDomDocument &doc, const QStringList &items, const QString &service );
     void loadWfsConnections( const QDomDocument &doc, const QStringList &items );
@@ -87,6 +89,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     void loadXyzTilesConnections( const QDomDocument &doc, const QStringList &items );
     void loadArcgisConnections( const QDomDocument &doc, const QStringList &items, const QString &service );
     void loadVectorTileConnections( const QDomDocument &doc, const QStringList &items );
+    void loadTiledMeshConnections( const QDomDocument &doc, const QStringList &items );
 
     QString mFileName;
     Mode mDialogMode;

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -29,6 +29,7 @@
 #include "qgspointcloudproviderguimetadata.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
 
+#include "qgstiledmeshproviderguimetadata.h"
 #include "qgsmbtilesvectortileguiprovider.h"
 #include "qgsvtpkvectortileguiprovider.h"
 
@@ -116,6 +117,9 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
     QgsProviderGuiMetadata *pointcloud = new QgsPointCloudProviderGuiMetadata();
     mProviders[ pointcloud->key() ] = pointcloud;
   }
+
+  QgsProviderGuiMetadata *tiledMesh = new QgsTiledMeshProviderGuiMetadata();
+  mProviders[ tiledMesh->key() ] = tiledMesh;
 
 #ifdef HAVE_STATIC_PROVIDERS
   QgsProviderGuiMetadata *wms = new QgsWmsProviderGuiMetadata();

--- a/src/gui/tiledmesh/qgstiledmeshconnectiondialog.cpp
+++ b/src/gui/tiledmesh/qgstiledmeshconnectiondialog.cpp
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgstiledmeshconnectiondialog.cpp
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshconnectiondialog.h"
+#include "qgstiledmeshconnection.h"
+#include "qgsgui.h"
+#include <QMessageBox>
+#include <QPushButton>
+
+///@cond PRIVATE
+
+QgsTiledMeshConnectionDialog::QgsTiledMeshConnectionDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+
+  connect( mEditName, &QLineEdit::textChanged, this, &QgsTiledMeshConnectionDialog::updateOkButtonState );
+  connect( mEditUrl, &QLineEdit::textChanged, this, &QgsTiledMeshConnectionDialog::updateOkButtonState );
+}
+
+void QgsTiledMeshConnectionDialog::setConnection( const QString &name, const QString &uri )
+{
+  mEditName->setText( name );
+
+  const QgsTiledMeshProviderConnection::Data conn = QgsTiledMeshProviderConnection::decodedUri( uri );
+  mEditUrl->setText( conn.url );
+
+  mAuthSettings->setUsername( conn.username );
+  mAuthSettings->setPassword( conn.password );
+  mEditReferer->setText( conn.httpHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
+  mAuthSettings->setConfigId( conn.authCfg );
+}
+
+QString QgsTiledMeshConnectionDialog::connectionUri() const
+{
+  QgsTiledMeshProviderConnection::Data conn;
+  conn.url = mEditUrl->text();
+
+  conn.username = mAuthSettings->username();
+  conn.password = mAuthSettings->password();
+  conn.httpHeaders[QgsHttpHeaders::KEY_REFERER] = mEditReferer->text();
+  conn.authCfg = mAuthSettings->configId( );
+
+  return QgsTiledMeshProviderConnection::encodedUri( conn );
+}
+
+QString QgsTiledMeshConnectionDialog::connectionName() const
+{
+  return mEditName->text();
+}
+
+void QgsTiledMeshConnectionDialog::updateOkButtonState()
+{
+  const bool enabled = !mEditName->text().isEmpty() && !mEditUrl->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
+}
+
+void QgsTiledMeshConnectionDialog::accept()
+{
+  QDialog::accept();
+}
+
+///@endcond

--- a/src/gui/tiledmesh/qgstiledmeshconnectiondialog.h
+++ b/src/gui/tiledmesh/qgstiledmeshconnectiondialog.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+    qgstiledmeshconnectiondialog.h
+    ---------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHCONNECTIONDIALOG_H
+#define QGSTILEDMESHCONNECTIONDIALOG_H
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+#include <QDialog>
+
+#include "ui_qgstiledmeshconnectiondialog.h"
+
+
+class QgsTiledMeshConnectionDialog : public QDialog, public Ui::QgsTiledMeshConnectionDialog
+{
+    Q_OBJECT
+  public:
+    explicit QgsTiledMeshConnectionDialog( QWidget *parent = nullptr );
+
+    void setConnection( const QString &name, const QString &uri );
+
+    QString connectionUri() const;
+    QString connectionName() const;
+
+    void accept() override;
+
+  private slots:
+    void updateOkButtonState();
+
+};
+
+///@endcond
+
+#endif // QGSTILEDMESHCONNECTIONDIALOG_H

--- a/src/gui/tiledmesh/qgstiledmeshdataitemguiprovider.cpp
+++ b/src/gui/tiledmesh/qgstiledmeshdataitemguiprovider.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+  qgstiledmeshdataitemguiprovider.cpp
+  --------------------------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshdataitemguiprovider.h"
+#include "qgstiledmeshdataitems.h"
+#include "qgstiledmeshconnection.h"
+#include "qgstiledmeshconnectiondialog.h"
+#include "qgsmanageconnectionsdialog.h"
+
+#include <QMessageBox>
+#include <QFileDialog>
+
+///@cond PRIVATE
+
+void QgsTiledMeshDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+{
+  if ( QgsTiledMeshLayerItem *layerItem = qobject_cast< QgsTiledMeshLayerItem * >( item ) )
+  {
+    QAction *actionEdit = new QAction( tr( "Edit Connection…" ), menu );
+    connect( actionEdit, &QAction::triggered, this, [layerItem] { editConnection( layerItem ); } );
+    menu->addAction( actionEdit );
+
+    QAction *actionDelete = new QAction( tr( "Remove Connection" ), menu );
+    connect( actionDelete, &QAction::triggered, this, [layerItem] { deleteConnection( layerItem ); } );
+    menu->addAction( actionDelete );
+  }
+
+  if ( QgsTiledMeshRootItem *rootItem = qobject_cast< QgsTiledMeshRootItem * >( item ) )
+  {
+    QAction *actionNewCesium = new QAction( tr( "New Cesium 3D Tiles Connection…" ), menu );
+    connect( actionNewCesium, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
+    menu->addAction( actionNewCesium );
+
+    menu->addSeparator();
+
+    QAction *actionSave = new QAction( tr( "Save Connections…" ), menu );
+    connect( actionSave, &QAction::triggered, this, [] { saveConnections(); } );
+    menu->addAction( actionSave );
+
+    QAction *actionLoadXyzTilesServers = new QAction( tr( "Load Connections…" ), menu );
+    connect( actionLoadXyzTilesServers, &QAction::triggered, this, [rootItem] { loadConnections( rootItem ); } );
+    menu->addAction( actionLoadXyzTilesServers );
+  }
+}
+
+void QgsTiledMeshDataItemGuiProvider::editConnection( QgsDataItem *item )
+{
+  const QgsTiledMeshProviderConnection::Data connection = QgsTiledMeshProviderConnection::connection( item->name() );
+  const QString uri = QgsTiledMeshProviderConnection::encodedUri( connection );
+
+  QgsTiledMeshConnectionDialog dlg;
+
+  dlg.setConnection( item->name(), uri );
+  if ( !dlg.exec() )
+    return;
+
+  QgsTiledMeshProviderConnection( QString() ).remove( item->name() );
+
+  QgsTiledMeshProviderConnection::Data newConnection = QgsTiledMeshProviderConnection::decodedUri( dlg.connectionUri() );
+  newConnection.provider = connection.provider;
+
+  QgsTiledMeshProviderConnection::addConnection( dlg.connectionName(), newConnection );
+
+  item->parent()->refreshConnections();
+}
+
+void QgsTiledMeshDataItemGuiProvider::deleteConnection( QgsDataItem *item )
+{
+  if ( QMessageBox::question( nullptr, tr( "Remove Connection" ), tr( "Are you sure you want to remove the connection “%1”?" ).arg( item->name() ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsTiledMeshProviderConnection( QString() ).remove( item->name() );
+
+  item->parent()->refreshConnections();
+}
+
+void QgsTiledMeshDataItemGuiProvider::newConnection( QgsDataItem *item )
+{
+  QgsTiledMeshConnectionDialog dlg;
+  if ( !dlg.exec() )
+    return;
+
+  QgsTiledMeshProviderConnection::Data conn = QgsTiledMeshProviderConnection::decodedUri( dlg.connectionUri() );
+  conn.provider = QStringLiteral( "cesium" );
+
+  QgsTiledMeshProviderConnection::addConnection( dlg.connectionName(), conn );
+
+  item->refreshConnections();
+}
+
+void QgsTiledMeshDataItemGuiProvider::saveConnections()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::TiledMesh );
+  dlg.exec();
+}
+
+void QgsTiledMeshDataItemGuiProvider::loadConnections( QgsDataItem *item )
+{
+  const QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                           tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::TiledMesh, fileName );
+  if ( dlg.exec() == QDialog::Accepted )
+    item->refreshConnections();
+}
+
+///@endcond

--- a/src/gui/tiledmesh/qgstiledmeshdataitemguiprovider.h
+++ b/src/gui/tiledmesh/qgstiledmeshdataitemguiprovider.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgstiledmeshproviderguimetadata.h
+  qgstiledmeshdataitemguiprovider.h
   --------------------------------------
     begin                : June 2023
     copyright            : (C) 2023 by Nyall Dawson
@@ -13,26 +13,35 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSTILEDMESHPROVIDERGUIMETADATA_H
-#define QGSTILEDMESHPROVIDERGUIMETADATA_H
+#ifndef QGSTILEDMESHDATAITEMGUIPROVIDER_H
+#define QGSTILEDMESHDATAITEMGUIPROVIDER_H
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-#include <QList>
-#include <QMainWindow>
+#include "qgsdataitemguiprovider.h"
 
-#include "qgsproviderguimetadata.h"
 
-class QgsTiledMeshProviderGuiMetadata: public QgsProviderGuiMetadata
+class QgsTiledMeshDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 {
+    Q_OBJECT
   public:
-    QgsTiledMeshProviderGuiMetadata();
 
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+    QString name() override { return QStringLiteral( "Tiled Mesh" ); }
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+
+  private:
+    static void editConnection( QgsDataItem *item );
+    static void deleteConnection( QgsDataItem *item );
+    static void newConnection( QgsDataItem *item );
+    static void newArcGISConnection( QgsDataItem *item );
+    static void saveConnections();
+    static void loadConnections( QgsDataItem *item );
+
 };
 
 ///@endcond
 
-#endif // QGSTILEDMESHPROVIDERGUIMETADATA_H
+#endif // QGSTILEDMESHDATAITEMGUIPROVIDER_H

--- a/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.cpp
+++ b/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.cpp
@@ -17,6 +17,7 @@
 #include "qgssourceselectprovider.h"
 #include "qgsapplication.h"
 #include "qgstiledmeshsourceselect.h"
+#include "qgstiledmeshdataitemguiprovider.h"
 
 ///@cond PRIVATE
 
@@ -37,6 +38,11 @@ class QgsTiledMeshSourceSelectProvider : public QgsSourceSelectProvider
 QgsTiledMeshProviderGuiMetadata::QgsTiledMeshProviderGuiMetadata()
   : QgsProviderGuiMetadata( QStringLiteral( "tiledmesh" ) )
 {
+}
+
+QList<QgsDataItemGuiProvider *> QgsTiledMeshProviderGuiMetadata::dataItemGuiProviders()
+{
+  return { new QgsTiledMeshDataItemGuiProvider() };
 }
 
 QList<QgsSourceSelectProvider *> QgsTiledMeshProviderGuiMetadata::sourceSelectProviders()

--- a/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.cpp
+++ b/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+  qgstiledmeshproviderguimetadata.cpp
+  --------------------------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshproviderguimetadata.h"
+#include "qgssourceselectprovider.h"
+#include "qgsapplication.h"
+#include "qgstiledmeshsourceselect.h"
+
+///@cond PRIVATE
+
+class QgsTiledMeshSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    QString providerKey() const override { return QStringLiteral( "tiledmesh" ); }
+    QString text() const override { return QObject::tr( "Tiled Mesh" ); }
+    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 51; }
+    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddTiledMeshLayer.svg" ) ); }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsTiledMeshSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+QgsTiledMeshProviderGuiMetadata::QgsTiledMeshProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QStringLiteral( "tiledmesh" ) )
+{
+}
+
+QList<QgsSourceSelectProvider *> QgsTiledMeshProviderGuiMetadata::sourceSelectProviders()
+{
+  return { new QgsTiledMeshSourceSelectProvider };
+}
+
+///@endcond

--- a/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.h
+++ b/src/gui/tiledmesh/qgstiledmeshproviderguimetadata.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+  qgstiledmeshproviderguimetadata.h
+  --------------------------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHPROVIDERGUIMETADATA_H
+#define QGSTILEDMESHPROVIDERGUIMETADATA_H
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+#include <QList>
+#include <QMainWindow>
+
+#include "qgsproviderguimetadata.h"
+
+class QgsTiledMeshProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsTiledMeshProviderGuiMetadata();
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+};
+
+///@endcond
+
+#endif // QGSTILEDMESHPROVIDERGUIMETADATA_H

--- a/src/gui/tiledmesh/qgstiledmeshsourceselect.cpp
+++ b/src/gui/tiledmesh/qgstiledmeshsourceselect.cpp
@@ -1,0 +1,218 @@
+/***************************************************************************
+                         qgstiledmeshsourceselect.cpp
+                         ---------------------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledmeshsourceselect.h"
+#include "qgstiledmeshconnection.h"
+#include "qgsgui.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderutils.h"
+#include "qgsmanageconnectionsdialog.h"
+#include "qgstiledmeshconnectiondialog.h"
+
+#include <QMenu>
+#include <QMessageBox>
+
+///@cond PRIVATE
+
+QgsTiledMeshSourceSelect::QgsTiledMeshSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
+  : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+{
+  setupUi( this );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  setWindowTitle( tr( "Add Tiled Mesh Layer" ) );
+
+  mRadioSourceService->setChecked( true );
+  mStackedWidget->setCurrentIndex( 1 );
+
+  connect( mRadioSourceFile, &QRadioButton::toggled, this, [this]
+  {
+    mStackedWidget->setCurrentIndex( 0 );
+
+    emit enableButtons( !mFileWidget->filePath().isEmpty() );
+  } );
+  connect( mRadioSourceService, &QRadioButton::toggled, this, [this]
+  {
+    mStackedWidget->setCurrentIndex( 1 );
+
+    emit enableButtons( !cmbConnections->currentText().isEmpty() );
+  } );
+
+  btnNew->setPopupMode( QToolButton::InstantPopup );
+  QMenu *newMenu = new QMenu( btnNew );
+
+  QAction *actionNew = new QAction( tr( "New Cesium 3D Tiles Connection…" ), this );
+  connect( actionNew, &QAction::triggered, this, &QgsTiledMeshSourceSelect::btnNewCesium3DTiles_clicked );
+  newMenu->addAction( actionNew );
+
+  btnNew->setMenu( newMenu );
+
+  connect( btnEdit, &QToolButton::clicked, this, &QgsTiledMeshSourceSelect::btnEdit_clicked );
+  connect( btnDelete, &QToolButton::clicked, this, &QgsTiledMeshSourceSelect::btnDelete_clicked );
+  connect( btnSave, &QToolButton::clicked, this, &QgsTiledMeshSourceSelect::btnSave_clicked );
+  connect( btnLoad, &QToolButton::clicked, this, &QgsTiledMeshSourceSelect::btnLoad_clicked );
+  connect( cmbConnections, &QComboBox::currentTextChanged, this, &QgsTiledMeshSourceSelect::cmbConnections_currentTextChanged );
+  setupButtons( buttonBox );
+
+  populateConnectionList();
+
+  mFileWidget->setDialogTitle( tr( "Open Tiled Mesh Dataset" ) );
+  mFileWidget->setFilter( QgsProviderRegistry::instance()->fileTiledMeshFilters() );
+  mFileWidget->setStorageMode( QgsFileWidget::GetFile );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
+  {
+    emit enableButtons( !path.isEmpty() );
+  } );
+}
+
+void QgsTiledMeshSourceSelect::btnNewCesium3DTiles_clicked()
+{
+  QgsTiledMeshConnectionDialog nc( this );
+  if ( nc.exec() )
+  {
+    QgsTiledMeshProviderConnection::Data connectionData = QgsTiledMeshProviderConnection::decodedUri( nc.connectionUri() );
+    connectionData.provider = QStringLiteral( "cesiumtiles" );
+
+    QgsTiledMeshProviderConnection::addConnection( nc.connectionName(), connectionData );
+    populateConnectionList();
+    emit connectionsChanged();
+  }
+}
+
+void QgsTiledMeshSourceSelect::btnEdit_clicked()
+{
+  const QgsTiledMeshProviderConnection::Data connection = QgsTiledMeshProviderConnection::connection( cmbConnections->currentText() );
+  const QString uri = QgsTiledMeshProviderConnection::encodedUri( connection );
+  const QString provider = connection.provider;
+
+  QgsTiledMeshConnectionDialog nc( this );
+  nc.setConnection( cmbConnections->currentText(), uri );
+  if ( nc.exec() )
+  {
+    QgsTiledMeshProviderConnection::Data connectionData = QgsTiledMeshProviderConnection::decodedUri( nc.connectionUri() );
+    connectionData.provider = provider;
+
+    QgsTiledMeshProviderConnection::addConnection( nc.connectionName(), connectionData );
+    populateConnectionList();
+    emit connectionsChanged();
+  }
+
+}
+
+void QgsTiledMeshSourceSelect::btnDelete_clicked()
+{
+  const QString msg = tr( "Are you sure you want to remove the %1 connection and all associated settings?" )
+                      .arg( cmbConnections->currentText() );
+  if ( QMessageBox::Yes != QMessageBox::question( this, tr( "Confirm Delete" ), msg, QMessageBox::Yes | QMessageBox::No ) )
+    return;
+
+  QgsTiledMeshProviderConnection( QString() ).remove( cmbConnections->currentText() );
+
+  populateConnectionList();
+  emit connectionsChanged();
+}
+
+void QgsTiledMeshSourceSelect::btnSave_clicked()
+{
+  QgsManageConnectionsDialog dlg( this, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::TiledMesh );
+  dlg.exec();
+}
+
+void QgsTiledMeshSourceSelect::btnLoad_clicked()
+{
+  const QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
+                           tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( this, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::TiledMesh, fileName );
+  dlg.exec();
+  populateConnectionList();
+}
+
+void QgsTiledMeshSourceSelect::addButtonClicked()
+{
+  if ( mRadioSourceService->isChecked() )
+  {
+    const QgsTiledMeshProviderConnection::Data connection = QgsTiledMeshProviderConnection::connection( cmbConnections->currentText() );
+    const QString uri = QgsTiledMeshProviderConnection::encodedUri( connection );
+    emit addLayer( Qgis::LayerType::TiledMesh, uri, cmbConnections->currentText(), connection.provider );
+  }
+  else if ( mRadioSourceFile->isChecked() )
+  {
+    const QString filePath = mFileWidget->filePath();
+    const QList< QgsProviderRegistry::ProviderCandidateDetails > providers = QgsProviderRegistry::instance()->preferredProvidersForUri( filePath );
+    QString providerKey;
+    for ( const QgsProviderRegistry::ProviderCandidateDetails &details : providers )
+    {
+      if ( details.layerTypes().contains( Qgis::LayerType::TiledMesh ) )
+      {
+        providerKey = details.metadata()->key();
+      }
+    }
+
+    QVariantMap parts;
+    parts.insert( QStringLiteral( "path" ), filePath );
+    const QString uri = QgsProviderRegistry::instance()->encodeUri( providerKey, parts );
+
+    emit addLayer( Qgis::LayerType::TiledMesh, uri, QgsProviderUtils::suggestLayerNameFromFilePath( filePath ), providerKey );
+  }
+}
+
+void QgsTiledMeshSourceSelect::populateConnectionList()
+{
+  cmbConnections->blockSignals( true );
+  cmbConnections->clear();
+  cmbConnections->addItems( QgsTiledMeshProviderConnection::connectionList() );
+  cmbConnections->blockSignals( false );
+
+  btnEdit->setDisabled( cmbConnections->count() == 0 );
+  btnDelete->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
+  cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
+}
+
+void QgsTiledMeshSourceSelect::setConnectionListPosition()
+{
+  const QString toSelect = QgsTiledMeshProviderConnection::selectedConnection();
+
+  cmbConnections->setCurrentIndex( cmbConnections->findText( toSelect ) );
+
+  if ( cmbConnections->currentIndex() < 0 )
+  {
+    if ( toSelect.isNull() )
+      cmbConnections->setCurrentIndex( 0 );
+    else
+      cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
+  }
+
+  emit enableButtons( !cmbConnections->currentText().isEmpty() );
+}
+
+void QgsTiledMeshSourceSelect::cmbConnections_currentTextChanged( const QString &text )
+{
+  QgsTiledMeshProviderConnection::setSelectedConnection( text );
+  emit enableButtons( !text.isEmpty() );
+}
+
+///@endcond

--- a/src/gui/tiledmesh/qgstiledmeshsourceselect.h
+++ b/src/gui/tiledmesh/qgstiledmeshsourceselect.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+                         qgstiledmeshsourceselect.h
+                         ---------------------------------
+    begin                : June 2023
+    copyright            : (C) 2023 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDMESHSOURCESELECT_H
+#define QGSTILEDMESHSOURCESELECT_H
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+#include "qgsabstractdatasourcewidget.h"
+#include "ui_qgstiledmeshsourceselectbase.h"
+
+/*!
+ * \brief Dialog to create connections to tiled mesh servers.
+ *
+ * This dialog allows the user to define and save connection information
+ * for tiled mesh servers.
+ *
+ * The user can then connect and add layers from the tiled mesh server
+ * to the map canvas.
+ */
+class QgsTiledMeshSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsTiledMeshSourceSelectBase
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsTiledMeshSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
+
+    //! Determines the layers the user selected
+    void addButtonClicked() override;
+
+  private slots:
+
+    //! Opens the create connection dialog to build a new connection
+    void btnNewCesium3DTiles_clicked();
+    //! Opens a dialog to edit an existing connection
+    void btnEdit_clicked();
+    //! Deletes the selected connection
+    void btnDelete_clicked();
+    //! Saves connections to the file
+    void btnSave_clicked();
+    //! Loads connections from the file
+    void btnLoad_clicked();
+    //! Stores the selected datasource whenerver it is changed
+    void cmbConnections_currentTextChanged( const QString &text );
+
+  private:
+    void populateConnectionList();
+    void setConnectionListPosition();
+};
+
+///@endcond
+
+#endif // QGSTILEDMESHSOURCESELECT_H

--- a/src/ui/qgstiledmeshconnectiondialog.ui
+++ b/src/ui/qgstiledmeshconnectiondialog.ui
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsTiledMeshConnectionDialog</class>
+ <widget class="QDialog" name="QgsTiledMeshConnectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>659</width>
+    <height>442</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Vector Tiles Connection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Connection Details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="6" column="0">
+       <widget class="QLabel" name="lblReferer">
+        <property name="text">
+         <string>Referer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mEditReferer</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mEditName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QLineEdit" name="mEditReferer">
+        <property name="toolTip">
+         <string>Optional custom referer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the connection</string>
+        </property>
+        <property name="placeholderText">
+         <string>http://example.com/tileset.json</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mEditName</tabstop>
+  <tabstop>mEditUrl</tabstop>
+  <tabstop>mEditReferer</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsTiledMeshConnectionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>381</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsTiledMeshConnectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>292</x>
+     <y>387</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgstiledmeshsourceselectbase.ui
+++ b/src/ui/qgstiledmeshsourceselectbase.ui
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsTiledMeshSourceSelectBase</class>
+ <widget class="QDialog" name="QgsTiledMeshSourceSelectBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>553</width>
+    <height>383</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="srcGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Source Type</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout1">
+      <item>
+       <widget class="QRadioButton" name="mRadioSourceFile">
+        <property name="text">
+         <string>F&amp;ile</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="mRadioSourceService">
+        <property name="text">
+         <string>Service</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="fileGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Source</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Tiled mesh dataset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="mConnectionsGroupBox">
+         <property name="title">
+          <string>Connections</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0" colspan="7">
+           <widget class="QComboBox" name="cmbConnections"/>
+          </item>
+          <item row="1" column="5">
+           <widget class="QToolButton" name="btnLoad">
+            <property name="toolTip">
+             <string>Load connections from file</string>
+            </property>
+            <property name="text">
+             <string>Load</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>171</width>
+              <height>30</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="2">
+           <widget class="QToolButton" name="btnEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Edit selected service connection</string>
+            </property>
+            <property name="text">
+             <string>Edit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QToolButton" name="btnDelete">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Remove connection to selected service</string>
+            </property>
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QToolButton" name="btnNew">
+            <property name="toolTip">
+             <string>Create a new service connection</string>
+            </property>
+            <property name="text">
+             <string>&amp;New</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QToolButton" name="btnSave">
+            <property name="toolTip">
+             <string>Save connections to file</string>
+            </property>
+            <property name="text">
+             <string>Save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>cmbConnections</tabstop>
+  <tabstop>btnNew</tabstop>
+  <tabstop>btnEdit</tabstop>
+  <tabstop>btnDelete</tabstop>
+  <tabstop>btnLoad</tabstop>
+  <tabstop>btnSave</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -101,7 +101,7 @@ class TestQgsProviderRegistry(unittest.TestCase):
         """
         providers = QgsProviderRegistry.instance().providerList()
         for p in providers:
-            if p in ('vectortile', 'arcgisvectortileservice'):
+            if p in ('vectortile', 'arcgisvectortileservice', 'tiledmesh'):
                 continue
 
             self.assertTrue(QgsProviderRegistry.instance().createProvider(p, ''))


### PR DESCRIPTION
This PR adds a generic source select provider and browser item provider for tiled mesh data sources. I've implemented this in a non-provider specific way, so that we avoid having to eg have a separate data source manager tab and browser item per tiled mesh data provider type. (In other words -- all the tiled mesh data provider sources will be all grouped together (like point clouds or vector tiles), not exposed as separate objects (like vector layer data providers are) ).

