### PR TITLE
Remove hardcoded blocker to creation of vertical/compound CRS 

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -808,9 +808,14 @@ Attempts to retrieve datum ensemble details from the CRS.
 If the CRS does not use a datum ensemble then an invalid :py:class:`QgsDatumEnsemble` will
 be returned.
 
+.. note::
+
+   In the case of a compound crs, this method will always return the datum ensemble for the horizontal component.
+
 .. warning::
 
    This method requires PROJ 8.0 or later
+
 
 :raises QgsNotSupportedException: on QGIS builds based on PROJ 7 or earlier.
 
@@ -967,6 +972,10 @@ Returns an ordered list of the axis directions reflecting the native axis order 
     Qgis::DistanceUnit mapUnits() const;
 %Docstring
 Returns the units for the projection used by the CRS.
+
+.. note::
+
+   In the case of a compound CRS, this method will always return the units for the horizontal component.
 %End
 
     QgsRectangle bounds() const;

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -136,6 +136,17 @@ Returns a list of all known celestial bodies.
 .. versionadded:: 3.20
 %End
 
+    QSet< QString > authorities() const;
+%Docstring
+Returns a list of all known authorities.
+
+.. note::
+
+   authority names will always be returned in lower case
+
+.. versionadded:: 3.34
+%End
+
   signals:
 
     void userCrsChanged( const QString &id );

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -669,7 +669,7 @@ bool QgsCoordinateReferenceSystem::loadFromDatabase( const QString &db, const QS
 
       {
         QgsProjUtils::proj_pj_unique_ptr crs( proj_create_from_database( QgsProjContext::get(), auth.toLatin1(), code.toLatin1(), PJ_CATEGORY_CRS, false, nullptr ) );
-        d->setPj( QgsProjUtils::crsToSingleCrs( crs.get() ) );
+        d->setPj( QgsProjUtils::unboundCrs( crs.get() ) );
       }
 
       d->mIsValid = d->hasPj();
@@ -1665,7 +1665,7 @@ void QgsCoordinateReferenceSystem::setMapUnits()
   // prefer horizontal CRS units, if present
   QgsProjUtils::proj_pj_unique_ptr crs( QgsProjUtils::crsToHorizontalCrs( d->threadLocalProjObject() ) );
   if ( !crs )
-    crs = QgsProjUtils::crsToSingleCrs( d->threadLocalProjObject() );
+    crs = QgsProjUtils::unboundCrs( d->threadLocalProjObject() );
 
   if ( !crs )
   {
@@ -2320,7 +2320,7 @@ bool QgsCoordinateReferenceSystem::loadFromAuthCode( const QString &auth, const 
     return false;
   }
 
-  crs = QgsProjUtils::crsToSingleCrs( crs.get() );
+  crs = QgsProjUtils::unboundCrs( crs.get() );
 
   QString proj4 = getFullProjString( crs.get() );
   proj4.replace( QLatin1String( "+type=crs" ), QString() );
@@ -2543,7 +2543,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
           break;
       }
 
-      crs = QgsProjUtils::crsToSingleCrs( crs.get() );
+      crs = QgsProjUtils::unboundCrs( crs.get() );
 
       QString proj4 = getFullProjString( crs.get() );
       proj4.replace( QLatin1String( "+type=crs" ), QString() );
@@ -2854,7 +2854,7 @@ bool QgsCoordinateReferenceSystem::createFromProjObject( PJ *object )
       return false;
   }
 
-  d->setPj( QgsProjUtils::crsToSingleCrs( object ) );
+  d->setPj( QgsProjUtils::unboundCrs( object ) );
 
   if ( !d->hasPj() )
   {

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1652,7 +1652,17 @@ void QgsCoordinateReferenceSystem::setMapUnits()
   }
 
   PJ_CONTEXT *context = QgsProjContext::get();
-  QgsProjUtils::proj_pj_unique_ptr crs( QgsProjUtils::crsToSingleCrs( d->threadLocalProjObject() ) );
+  // prefer horizontal CRS units, if present
+  QgsProjUtils::proj_pj_unique_ptr crs( QgsProjUtils::crsToHorizontalCrs( d->threadLocalProjObject() ) );
+  if ( !crs )
+    crs = QgsProjUtils::crsToSingleCrs( d->threadLocalProjObject() );
+
+  if ( !crs )
+  {
+    d->mMapUnits = Qgis::DistanceUnit::Unknown;
+    return;
+  }
+
   QgsProjUtils::proj_pj_unique_ptr coordinateSystem( proj_crs_get_coordinate_system( context, crs.get() ) );
   if ( !coordinateSystem )
   {

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2306,6 +2306,9 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
 
 bool QgsCoordinateReferenceSystem::loadFromAuthCode( const QString &auth, const QString &code )
 {
+  if ( !QgsApplication::coordinateReferenceSystemRegistry()->authorities().contains( auth.toLower() ) )
+    return false;
+
   d.detach();
   d->mIsValid = false;
   d->mWktPreferred.clear();

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -745,6 +745,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * If the CRS does not use a datum ensemble then an invalid QgsDatumEnsemble will
      * be returned.
      *
+     * \note In the case of a compound crs, this method will always return the datum ensemble for the horizontal component.
+     *
      * \warning This method requires PROJ 8.0 or later
      *
      * \throws QgsNotSupportedException on QGIS builds based on PROJ 7 or earlier.
@@ -891,6 +893,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Returns the units for the projection used by the CRS.
+     *
+     * \note In the case of a compound CRS, this method will always return the units for the horizontal component.
      */
     Qgis::DistanceUnit mapUnits() const;
 

--- a/src/core/proj/qgscoordinatereferencesystemregistry.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemregistry.cpp
@@ -409,3 +409,23 @@ QList< QgsCelestialBody> QgsCoordinateReferenceSystemRegistry::celestialBodies()
   throw QgsNotSupportedException( QObject::tr( "Retrieving celestial bodies requires a QGIS build based on PROJ 8.1 or later" ) );
 #endif
 }
+
+QSet<QString> QgsCoordinateReferenceSystemRegistry::authorities() const
+{
+  static std::once_flag initialized;
+  std::call_once( initialized, [ = ]
+  {
+    QgsScopedRuntimeProfile profile( QObject::tr( "Initialize authorities" ) );
+
+    PJ_CONTEXT *pjContext = QgsProjContext::get();
+    PROJ_STRING_LIST authorities = proj_get_authorities_from_database( pjContext );
+
+    for ( auto authIter = authorities; authIter && *authIter; ++authIter )
+    {
+      const QString authority( *authIter );
+      mKnownAuthorities.insert( authority.toLower() );
+    }
+  } );
+
+  return mKnownAuthorities;
+}

--- a/src/core/proj/qgscoordinatereferencesystemregistry.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemregistry.cpp
@@ -425,6 +425,8 @@ QSet<QString> QgsCoordinateReferenceSystemRegistry::authorities() const
       const QString authority( *authIter );
       mKnownAuthorities.insert( authority.toLower() );
     }
+
+    proj_string_list_destroy( authorities );
   } );
 
   return mKnownAuthorities;

--- a/src/core/proj/qgscoordinatereferencesystemregistry.h
+++ b/src/core/proj/qgscoordinatereferencesystemregistry.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QSet>
 #include "qgscoordinatereferencesystem.h"
 
 class QgsCelestialBody;
@@ -145,6 +146,15 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
      */
     QList< QgsCelestialBody > celestialBodies() const;
 
+    /**
+     * Returns a list of all known authorities.
+     *
+     * \note authority names will always be returned in lower case
+     *
+     * \since QGIS 3.34
+     */
+    QSet< QString > authorities() const;
+
   signals:
 
     /**
@@ -191,6 +201,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
 
     mutable QList< QgsCelestialBody > mCelestialBodies;
     mutable QMap< QString, QgsProjOperation > mProjOperations;
+    mutable QSet< QString > mKnownAuthorities;
 
 };
 

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -180,7 +180,7 @@ bool QgsProjUtils::isDynamic( const PJ *crs )
   return isDynamic;
 }
 
-QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToSingleCrs( const PJ *crs )
+QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToHorizontalCrs( const PJ *crs )
 {
   if ( !crs )
     return nullptr;
@@ -188,9 +188,6 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToSingleCrs( const PJ *crs )
   PJ_CONTEXT *context = QgsProjContext::get();
   switch ( proj_get_type( crs ) )
   {
-    case PJ_TYPE_BOUND_CRS:
-      return QgsProjUtils::proj_pj_unique_ptr( proj_get_source_crs( context, crs ) );
-
     case PJ_TYPE_COMPOUND_CRS:
     {
       int i = 0;
@@ -202,6 +199,31 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToSingleCrs( const PJ *crs )
       }
       return res;
     }
+
+    case PJ_TYPE_VERTICAL_CRS:
+      return nullptr;
+
+    // maybe other types to handle??
+
+    default:
+      return crsToSingleCrs( crs );
+  }
+
+#ifndef _MSC_VER  // unreachable
+  return nullptr;
+#endif
+}
+
+QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToSingleCrs( const PJ *crs )
+{
+  if ( !crs )
+    return nullptr;
+
+  PJ_CONTEXT *context = QgsProjContext::get();
+  switch ( proj_get_type( crs ) )
+  {
+    case PJ_TYPE_BOUND_CRS:
+      return QgsProjUtils::proj_pj_unique_ptr( proj_get_source_crs( context, crs ) );
 
     // maybe other types to handle??
 

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -145,9 +145,12 @@ bool QgsProjUtils::isDynamic( const PJ *crs )
   bool isDynamic = false;
   PJ_CONTEXT *context = QgsProjContext::get();
 
-  proj_pj_unique_ptr horiz = crsToSingleCrs( crs );
+  // prefer horizontal crs if possible
+  proj_pj_unique_ptr candidate = crsToHorizontalCrs( crs );
+  if ( !crs )
+    candidate = crsToSingleCrs( crs );
 
-  proj_pj_unique_ptr datum( horiz ? proj_crs_get_datum( context, horiz.get() ) : nullptr );
+  proj_pj_unique_ptr datum( candidate ? proj_crs_get_datum( context, candidate.get() ) : nullptr );
   if ( datum )
   {
     const PJ_TYPE type = proj_get_type( datum.get() );
@@ -165,7 +168,7 @@ bool QgsProjUtils::isDynamic( const PJ *crs )
   }
   else
   {
-    proj_pj_unique_ptr ensemble( horiz ? proj_crs_get_datum_ensemble( context, horiz.get() ) : nullptr );
+    proj_pj_unique_ptr ensemble( candidate ? proj_crs_get_datum_ensemble( context, candidate.get() ) : nullptr );
     if ( ensemble )
     {
       proj_pj_unique_ptr member( proj_datum_ensemble_get_member( context, ensemble.get(), 0 ) );
@@ -243,7 +246,7 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToDatumEnsemble( const PJ *crs
 
 #if PROJ_VERSION_MAJOR>=8
   PJ_CONTEXT *context = QgsProjContext::get();
-  QgsProjUtils::proj_pj_unique_ptr singleCrs = crsToSingleCrs( crs );
+  QgsProjUtils::proj_pj_unique_ptr singleCrs = crsToHorizontalCrs( crs );
   if ( !singleCrs )
     return nullptr;
 

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -247,10 +247,10 @@ QgsProjUtils::proj_pj_unique_ptr QgsProjUtils::crsToDatumEnsemble( const PJ *crs
 #if PROJ_VERSION_MAJOR>=8
   PJ_CONTEXT *context = QgsProjContext::get();
   QgsProjUtils::proj_pj_unique_ptr candidate = crsToHorizontalCrs( crs );
-  if ( !candidate) // purely vertical CRS
+  if ( !candidate ) // purely vertical CRS
     candidate = unboundCrs( crs );
 
-  if ( !candidate)
+  if ( !candidate )
     return nullptr;
 
   return QgsProjUtils::proj_pj_unique_ptr( proj_crs_get_datum_ensemble( context, candidate.get() ) );

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -181,6 +181,8 @@ class CORE_EXPORT QgsProjUtils
     /**
      * Given a PROJ \a crs, attempt to retrieve the datum ensemble from it.
      *
+     * \note In the case of a compound \a crs, this method will always return the datum ensemble for the horizontal component.
+     *
      * \warning This method requires PROJ 8.0 or later
      *
      * \throws QgsNotSupportedException on QGIS builds based on PROJ 7 or earlier.

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -173,10 +173,12 @@ class CORE_EXPORT QgsProjUtils
     static proj_pj_unique_ptr crsToHorizontalCrs( const PJ *crs );
 
     /**
-     * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract a single crs
-     * from it.
+     * Given a PROJ crs (which may be a compound or bound crs, or some other type), ensure that it is not
+     * a bound CRS object.
+     *
+     * Bound CRS objects will be returned as their source CRS, other types will be returned as a direct clone.
      */
-    static proj_pj_unique_ptr crsToSingleCrs( const PJ *crs );
+    static proj_pj_unique_ptr unboundCrs( const PJ *crs );
 
     /**
      * Given a PROJ \a crs, attempt to retrieve the datum ensemble from it.

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -165,6 +165,14 @@ class CORE_EXPORT QgsProjUtils
     static bool isDynamic( const PJ *crs );
 
     /**
+     * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract the horizontal crs
+     * from it.
+     *
+     * If \a crs does not contain a horizontal CRS (i.e. it is a vertical CRS) NULLPTR will be returned.
+     */
+    static proj_pj_unique_ptr crsToHorizontalCrs( const PJ *crs );
+
+    /**
      * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract a single crs
      * from it.
      */

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -42,6 +42,8 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void idCtor();
     void copyCtor();
     void assignmentCtor();
+    void compoundCrs();
+    void verticalCrs();
     void coordinateEpoch();
     void saveAsUserCrs();
     void createFromId();
@@ -252,6 +254,26 @@ void TestQgsCoordinateReferenceSystem::assignmentCtor()
   myCrs3.setCoordinateEpoch( 2021.2 );
   QCOMPARE( myCrs.coordinateEpoch(), 2021.3 );
   QCOMPARE( myCrs3.coordinateEpoch(), 2021.2 );
+}
+
+void TestQgsCoordinateReferenceSystem::compoundCrs()
+{
+  QgsCoordinateReferenceSystem crs;
+  crs.createFromString( QStringLiteral( "EPSG:5500" ) );
+  QVERIFY( crs.isValid() );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5500" ) );
+  QVERIFY( crs.isValid() );
+}
+
+void TestQgsCoordinateReferenceSystem::verticalCrs()
+{
+  QgsCoordinateReferenceSystem crs;
+  crs.createFromString( QStringLiteral( "EPSG:5703" ) );
+  QVERIFY( crs.isValid() );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) );
+  QVERIFY( crs.isValid() );
 }
 
 void TestQgsCoordinateReferenceSystem::coordinateEpoch()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1432,6 +1432,14 @@ void TestQgsCoordinateReferenceSystem::mapUnits()
   myCrs.createFromString( QStringLiteral( "EPSG:4619" ) );
   QCOMPARE( myCrs.mapUnits(), Qgis::DistanceUnit::Degrees );
 
+  // compound CRS
+  myCrs.createFromString( QStringLiteral( "EPSG:5500" ) );
+  QCOMPARE( myCrs.mapUnits(), Qgis::DistanceUnit::Degrees );
+
+  // vertical CRS
+  myCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:5703" ) );
+  QCOMPARE( myCrs.mapUnits(), Qgis::DistanceUnit::Meters );
+
   // custom CRS using "m" unit keyword
   myCrs.createFromWkt( QStringLiteral( R"""(PROJCS["MGI / Austria Lambert", GEOGCS["MGI", DATUM["Militar-Geographische Institut", SPHEROID["Bessel 1841", 6377397.155, 299.1528128, AUTHORITY["EPSG","7004"]], TOWGS84[601.705, 84.263, 485.227, 4.7354, -1.3145, -5.393, -2.3887], AUTHORITY["EPSG","6312"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic longitude", EAST], AXIS["Geodetic latitude", NORTH], AUTHORITY["EPSG","4312"]], PROJECTION["Lambert_Conformal_Conic_2SP", AUTHORITY["EPSG","9802"]], PARAMETER["central_meridian", 13.333333333333336], PARAMETER["latitude_of_origin", 47.5], PARAMETER["standard_parallel_1", 48.99999999999999], PARAMETER["false_easting", 400000.0], PARAMETER["false_northing", 400000.0], PARAMETER["scale_factor", 1.0], PARAMETER["standard_parallel_2", 46.0], UNIT["m", 1.0], AXIS["Easting", EAST], AXIS["Northing", NORTH], AUTHORITY["EPSG","31287"]])""" ) );
   QVERIFY( myCrs.isValid() );

--- a/tests/src/core/testqgscoordinatereferencesystemregistry.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystemregistry.cpp
@@ -35,6 +35,7 @@ class TestQgsCoordinateReferenceSystemRegistry: public QObject
     void changeUserCrs();
     void removeUserCrs();
     void projOperations();
+    void authorities();
 
   private:
 
@@ -314,6 +315,15 @@ void TestQgsCoordinateReferenceSystemRegistry::projOperations()
   QCOMPARE( operations.value( QStringLiteral( "lcc" ) ).id(), QStringLiteral( "lcc" ) );
   QCOMPARE( operations.value( QStringLiteral( "lcc" ) ).description(), QStringLiteral( "Lambert Conformal Conic" ) );
   QVERIFY( operations.value( QStringLiteral( "lcc" ) ).details().contains( QStringLiteral( "Conic" ) ) );
+}
+
+void TestQgsCoordinateReferenceSystemRegistry::authorities()
+{
+  const QSet< QString > authorities = QgsApplication::coordinateReferenceSystemRegistry()->authorities();
+
+  QVERIFY( authorities.contains( QStringLiteral( "epsg" ) ) );
+  QVERIFY( authorities.contains( QStringLiteral( "proj" ) ) );
+  QVERIFY( authorities.contains( QStringLiteral( "esri" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystemRegistry )

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -35,6 +35,8 @@ class TestQgsProjUtils: public QObject
     void axisOrderIsSwapped();
     void searchPath();
     void gridsUsed();
+    void toHorizontalCrs();
+    void toSingleCrs();
 
 };
 
@@ -114,6 +116,46 @@ void TestQgsProjUtils::gridsUsed()
   QCOMPARE( grids.at( 0 ).shortName, QStringLiteral( "au_icsm_GDA94_GDA2020_conformal_and_distortion.tif" ) );
   QVERIFY( grids.at( 0 ).directDownload );
   QVERIFY( !grids.at( 0 ).url.isEmpty() );
+}
+
+void TestQgsProjUtils::toHorizontalCrs()
+{
+  PJ_CONTEXT *context = QgsProjContext::get();
+
+  // compound crs
+  QgsProjUtils::proj_pj_unique_ptr crs( proj_create( context, "urn:ogc:def:crs:EPSG::5500" ) );
+  QgsProjUtils::proj_pj_unique_ptr horizontalCrs( QgsProjUtils::crsToHorizontalCrs( crs.get() ) );
+  QCOMPARE( QString( proj_get_id_code( horizontalCrs.get(), 0 ) ), QStringLiteral( "4759" ) );
+
+  // horizontal CRS
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4759" ) );
+  horizontalCrs = QgsProjUtils::crsToHorizontalCrs( crs.get() );
+  QCOMPARE( QString( proj_get_id_code( horizontalCrs.get(), 0 ) ), QStringLiteral( "4759" ) );
+
+  // vertical only CRS
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::5703" ) );
+  horizontalCrs = QgsProjUtils::crsToHorizontalCrs( crs.get() );
+  QVERIFY( !horizontalCrs );
+}
+
+void TestQgsProjUtils::toSingleCrs()
+{
+  PJ_CONTEXT *context = QgsProjContext::get();
+
+  // compound crs
+  QgsProjUtils::proj_pj_unique_ptr crs( proj_create( context, "urn:ogc:def:crs:EPSG::5500" ) );
+  QgsProjUtils::proj_pj_unique_ptr singleCrs( QgsProjUtils::crsToSingleCrs( crs.get() ) );
+  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "5500" ) );
+
+  // horizontal CRS
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4759" ) );
+  singleCrs = QgsProjUtils::crsToSingleCrs( crs.get() );
+  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "4759" ) );
+
+  // vertical only CRS
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::5703" ) );
+  singleCrs = QgsProjUtils::crsToSingleCrs( crs.get() );
+  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "5703" ) );
 }
 
 QGSTEST_MAIN( TestQgsProjUtils )

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -36,7 +36,7 @@ class TestQgsProjUtils: public QObject
     void searchPath();
     void gridsUsed();
     void toHorizontalCrs();
-    void toSingleCrs();
+    void toUnboundCrs();
 
 };
 
@@ -138,24 +138,24 @@ void TestQgsProjUtils::toHorizontalCrs()
   QVERIFY( !horizontalCrs );
 }
 
-void TestQgsProjUtils::toSingleCrs()
+void TestQgsProjUtils::toUnboundCrs()
 {
   PJ_CONTEXT *context = QgsProjContext::get();
 
   // compound crs
   QgsProjUtils::proj_pj_unique_ptr crs( proj_create( context, "urn:ogc:def:crs:EPSG::5500" ) );
-  QgsProjUtils::proj_pj_unique_ptr singleCrs( QgsProjUtils::crsToSingleCrs( crs.get() ) );
-  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "5500" ) );
+  QgsProjUtils::proj_pj_unique_ptr unbound( QgsProjUtils::unboundCrs( crs.get() ) );
+  QCOMPARE( QString( proj_get_id_code( unbound.get(), 0 ) ), QStringLiteral( "5500" ) );
 
   // horizontal CRS
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4759" ) );
-  singleCrs = QgsProjUtils::crsToSingleCrs( crs.get() );
-  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "4759" ) );
+  unbound = QgsProjUtils::unboundCrs( crs.get() );
+  QCOMPARE( QString( proj_get_id_code( unbound.get(), 0 ) ), QStringLiteral( "4759" ) );
 
   // vertical only CRS
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::5703" ) );
-  singleCrs = QgsProjUtils::crsToSingleCrs( crs.get() );
-  QCOMPARE( QString( proj_get_id_code( singleCrs.get(), 0 ) ), QStringLiteral( "5703" ) );
+  unbound = QgsProjUtils::unboundCrs( crs.get() );
+  QCOMPARE( QString( proj_get_id_code( unbound.get(), 0 ) ), QStringLiteral( "5703" ) );
 }
 
 QGSTEST_MAIN( TestQgsProjUtils )


### PR DESCRIPTION
Allow creation of QgsCoordinateReferenceSystem objects which represent compound or vertical only CRS.

This is a preliminary step only which removes a hardcoded demotion of crs objects to horizontal only crs, which was present since the original PROJ 6 migration due to legacy reasons (and to maintain consistent results with builds based on PROJ 4). (In other words, it does not permit actually transforming vertical CRS !)
