### PR TITLE
add fix to postgresql provider for bbox across 180°

### DIFF
--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -611,9 +611,9 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
   // even with 1000 points it takes < 1ms.
   // TODO: how to effectively and precisely reproject bounding box?
   const int nPoints = 1000;
-  const double d = std::sqrt( ( rect.width() * ( yMax - yMin ) ) / std::pow( std::sqrt( static_cast< double >( nPoints ) ) - 1, 2.0 ) );
-  const int nXPoints = std::min( static_cast< int >( std::ceil( rect.width() / d ) ) + 1, 1000 );
-  const int nYPoints = std::min( static_cast< int >( std::ceil( ( yMax - yMin ) / d ) ) + 1, 1000 );
+  const double dst = std::sqrt( ( rect.width() * ( yMax - yMin ) ) / std::pow( std::sqrt( static_cast< double >( nPoints ) ) - 1, 2.0 ) );
+  const int nXPoints = std::min( static_cast< int >( std::ceil( rect.width() / dst ) ) + 1, 1000 );
+  const int nYPoints = std::min( static_cast< int >( std::ceil( ( yMax - yMin ) / dst ) ) + 1, 1000 );
 
   QgsRectangle bb_rect;
   bb_rect.setMinimal();
@@ -673,7 +673,8 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
       continue;
     }
 
-    if ( handle180Crossover )
+    if ( handle180Crossover && ( ( direction == Qgis::TransformDirection::Forward && d->mDestCRS.isGeographic() ) ||
+                                 ( direction == Qgis::TransformDirection::Reverse && d->mSourceCRS.isGeographic() ) ) )
     {
       //if crossing the date line, temporarily add 360 degrees to -ve longitudes
       bb_rect.combineExtentWith( x[i] >= 0.0 ? x[i] : x[i] + 360.0, y[i] );
@@ -690,7 +691,8 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
     throw QgsCsException( QObject::tr( "Could not transform bounding box to target CRS" ) );
   }
 
-  if ( handle180Crossover )
+  if ( handle180Crossover && ( ( direction == Qgis::TransformDirection::Forward && d->mDestCRS.isGeographic() ) ||
+                               ( direction == Qgis::TransformDirection::Reverse && d->mSourceCRS.isGeographic() ) ) )
   {
     //subtract temporary addition of 360 degrees from longitudes
     if ( bb_rect.xMinimum() > 180.0 )

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -133,10 +133,13 @@ QgsAbstractFeatureIterator::RequestToSourceCrsResult QgsAbstractFeatureIterator:
 
     case Qgis::SpatialFilterType::BoundingBox:
     {
-      QgsRectangle newRect = transform.transformBoundingBox( request.filterRect(), Qgis::TransformDirection::Reverse );
+      QgsRectangle newRect = transform.transformBoundingBox( request.filterRect(), Qgis::TransformDirection::Reverse, true );
+      qDebug() << "============ updateRequestToSourceCrs BoundingBox transform from :" << transform.sourceCrs().userFriendlyIdentifier() << "to" << transform.destinationCrs().userFriendlyIdentifier()
+               << "==== Rectangle:" << request.filterRect().toString() << " ==> " << newRect.toString();
       request.setFilterRect( newRect );
       return RequestToSourceCrsResult::Success;
     }
+
     case Qgis::SpatialFilterType::DistanceWithin:
     {
       // we can't safely handle a distance within query, as we cannot transform the
@@ -144,7 +147,9 @@ QgsAbstractFeatureIterator::RequestToSourceCrsResult QgsAbstractFeatureIterator:
 
       // in this case we transform the request's distance within requirement to a "worst case" bounding box filter, so
       // that the request itself can still take advantage of spatial indices even when we have to do the distance within check locally
-      QgsRectangle newRect = transform.transformBoundingBox( request.filterRect(), Qgis::TransformDirection::Reverse );
+      QgsRectangle newRect = transform.transformBoundingBox( request.filterRect(), Qgis::TransformDirection::Reverse, true );
+      qDebug() << "============ updateRequestToSourceCrs DistanceWithin transform from :" << transform.sourceCrs().userFriendlyIdentifier() << "to" << transform.destinationCrs().userFriendlyIdentifier()
+               << "==== Rectangle:" << request.filterRect().toString() << " ==> " << newRect.toString();
       request.setFilterRect( newRect );
 
       return RequestToSourceCrsResult::DistanceWithinMustBeCheckedManually;
@@ -161,7 +166,10 @@ QgsRectangle QgsAbstractFeatureIterator::filterRectToSourceCrs( const QgsCoordin
 
   QgsCoordinateTransform extentTransform = transform;
   extentTransform.setBallparkTransformsAreAppropriate( true );
-  return extentTransform.transformBoundingBox( mRequest.filterRect(), Qgis::TransformDirection::Reverse );
+  QgsRectangle newRect = extentTransform.transformBoundingBox( mRequest.filterRect(), Qgis::TransformDirection::Reverse, true );
+  qDebug() << "============ updateRequestToSourceCrs filterRectToSourceCrs transform from :" << extentTransform.sourceCrs().userFriendlyIdentifier() << "to" << extentTransform.destinationCrs().userFriendlyIdentifier()
+           << "==== Rectangle:" << mRequest.filterRect().toString() << " ==> " << newRect.toString();
+  return newRect;
 }
 
 void QgsAbstractFeatureIterator::ref()

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -474,6 +474,13 @@ bool QgsPostgresFeatureIterator::close()
 QString QgsPostgresFeatureIterator::whereClauseRect()
 {
   QgsRectangle rect = mFilterRect;
+
+  // in case coordinates are around 180.0°
+  if ( rect.xMinimum() > rect.xMaximum() && mSource->mCrs.isGeographic() )
+  {
+    rect.setXMaximum( rect.xMaximum() + 360.0 );
+  }
+
   if ( mSource->mSpatialColType == SctGeography )
   {
     rect = QgsRectangle( -180.0, -90.0, 180.0, 90.0 ).intersect( rect );

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2837,18 +2837,18 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 self.assertTrue(vl.isValid())
                 self.assertEqual(vl.hasSpatialIndex(), spatial_index)
 
-    def testBBoxFilterOnGeographyType(self):
-        """Test bounding box filter on geography type"""
-
+    def _doTestBBoxFilter(self, connString):
         vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."testgeog" (geog) sql=',
+            self.dbconn + connString,
             'test', 'postgres')
 
         self.assertTrue(vl.isValid())
 
-        def _test(vl, extent, ids):
-            request = QgsFeatureRequest().setFilterRect(extent)
+        def _test(vl, extent, ids, proj=None):
+            request = QgsFeatureRequest()
+            if proj:
+                request.setDestinationCrs(QgsCoordinateReferenceSystem(proj), QgsProject.instance().transformContext())
+            request.setFilterRect(extent)
             values = {feat['pk']: 'x' for feat in vl.getFeatures(request)}
             expected = {x: 'x' for x in ids}
             self.assertEqual(values, expected)
@@ -2867,7 +2867,37 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         _test(vl, QgsRectangle(40 - 5, -60 - 5, 40 + 5, -60 + 5), [3])
         _test(vl, QgsRectangle(40 - 5, -60 - 9.99, 40 + 5, -60 + 0.01), [3])
 
-        _test(vl, QgsRectangle(-181, -90, 181, 90), [1, 2, 3])  # no use of spatial index currently
+        _test(vl, QgsRectangle(-181, -90, 181, 90), [1, 2, 3, 4])  # no use of spatial index currently
+
+        # ================ tests with bbox around 180.
+        # in 3857: -20037699.584651027, 5621430.516018896, -20037317.10092746, 5621612.352543215
+        # in 4326: 179.99828204512598973 44.99942215015313707, -179.99828204512638763 45.00057718454320366
+
+        # good order with xMin < xMax
+        _test(vl, QgsRectangle(180.0 - 0.0017, 45.0 - 0.0001,
+                               180.0 + 0.0017, 45.0 + 0.0001), [4])
+
+        # good order but with xMin > xMax and normalization ==> nothing found
+        _test(vl, QgsRectangle(180.0 - 0.0017, 45.0 - 0.0001,
+                               -(180.0 - 0.0017), 45.0 + 0.0001), [])
+
+        # good order but with xMin > xMax and without normalization
+        _test(vl, QgsRectangle(180.0 - 0.0017, 45.0 - 0.0001,
+                               -(180.0 - 0.0017), 45.0 + 0.0001, False), [4])
+
+        # now from 3857
+        _test(vl, QgsRectangle(-20037699.584651027, 5621430.516018896, -20037317.10092746, 5621612.352543215), [4], "EPSG:3857")
+
+    def testBBoxFilterOnGeographyType(self):
+        """Test bounding box filter on geography type"""
+
+        self._doTestBBoxFilter(' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."testgeog" (geog) sql=')
+
+    def testBBoxFilterOnGeometryType(self):
+        """Test bounding box filter on somegeometry type"""
+
+        self._doTestBBoxFilter(
+            ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someBorderlineData" (geom) sql=')
 
     def testReadCustomSRID(self):
         """Test that we can correctly read the SRS from a custom SRID"""

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -94,6 +94,35 @@ INSERT INTO qgis_test."some_poly_data" (pk, geom) VALUES
 ;
 
 
+-- Name: someBorderlineData; Type: TABLE; Schema: qgis_test; Owner: postgres; Tablespace:
+--
+
+CREATE TABLE qgis_test."someBorderlineData" (
+    pk SERIAL NOT NULL,
+    cnt integer,
+    name text DEFAULT 'qgis',
+    name2 text DEFAULT 'qgis',
+    num_char text,
+    dt timestamp without time zone,
+    "date" date,
+    "time" time without time zone,
+    geom public.geometry(Point,4326)
+);
+
+-- Data for Name: someBorderlineData; Type: TABLE DATA; Schema: qgis_test; Owner: postgres
+--
+
+INSERT INTO qgis_test."someBorderlineData" (pk, cnt, name, name2, num_char, dt, "date", "time", geom) VALUES
+(1, -200, NULL, 'NuLl', '5', TIMESTAMP '2020-05-04 12:13:14', '2020-05-02', '12:13:01', 'srid=4326;POINT(40 0)'),
+(2,  300, 'Pear', 'PEaR', '3', NULL, NULL, NULL, 'srid=4326;POINT(40 60)'),
+(3,  100, 'Orange', 'oranGe', '1', TIMESTAMP '2020-05-03 12:13:14', '2020-05-03', '12:13:14', 'srid=4326;POINT(40 -60)'),
+(4,  400, 'Border line', 'point', '4', TIMESTAMP '2021-05-04 13:13:14', '2021-05-04', '13:13:14', 'srid=4326;POINT(180 45)')
+;
+
+
+-- Name: array_tbl; Type: TABLE; Schema: qgis_test; Owner: postgres; Tablespace:
+--
+
 CREATE TABLE qgis_test.array_tbl (id serial PRIMARY KEY, location int[], geom geometry(Point,3857));
 
 INSERT INTO qgis_test.array_tbl (location, geom) VALUES ('{1, 2, 3}', 'srid=3857;Point(913209.0358 5606025.2373)'::geometry);
@@ -727,11 +756,11 @@ VALUES ('SRID=4326;POINT(9 45)'::geometry, 'I have a name'), ('SRID=4326;POINT(1
 --
 
 CREATE TABLE qgis_test.referenced_layer_1(
-  pk_ref_1 serial primary key 
+  pk_ref_1 serial primary key
 );
 
 CREATE TABLE qgis_test.referenced_layer_2(
-  pk_ref_2 serial primary key 
+  pk_ref_2 serial primary key
 );
 
 CREATE TABLE qgis_test.referencing_layer(
@@ -739,9 +768,9 @@ CREATE TABLE qgis_test.referencing_layer(
   fk_ref_1 integer,
   fk_ref_2 integer,
     CONSTRAINT fk_ref_1
-      FOREIGN KEY(fk_ref_1) 
+      FOREIGN KEY(fk_ref_1)
     REFERENCES qgis_test.referenced_layer_1(pk_ref_1),
     CONSTRAINT fk_ref_2
-      FOREIGN KEY(fk_ref_2) 
+      FOREIGN KEY(fk_ref_2)
     REFERENCES qgis_test.referenced_layer_2(pk_ref_2)
 );

--- a/tests/testdata/provider/testdata_pg_geography.sql
+++ b/tests/testdata/provider/testdata_pg_geography.sql
@@ -10,5 +10,6 @@ CREATE TABLE qgis_test.testgeog
 INSERT INTO qgis_test.testgeog(geog) VALUES ('POINT(40 0)'::geography);
 INSERT INTO qgis_test.testgeog(geog) VALUES ('POINT(40 60)'::geography);
 INSERT INTO qgis_test.testgeog(geog) VALUES ('POINT(40 -60)'::geography);
+INSERT INTO qgis_test.testgeog(geog) VALUES ('POINT(180 45)'::geography);
 
 CREATE INDEX testgeog_geog_idx ON qgis_test.testgeog USING GIST ( geog );


### PR DESCRIPTION
When the feature request has a bbox filter across the 180°, it failed to select the features. When the QgsCoordinateTransform::transformBoundingBox function is called the handle180Crossover parameter was not set to true.

Also add a check in QgsPostgresFeatureIterator::whereClauseRect to handle correct bbox coordinates when xMin > xMax

[X] should be backported
