### PR TITLE
qgsrectangle: Consider a NaN rectangle as null

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -479,7 +479,8 @@ class CORE_EXPORT QgsRectangle
     bool isNull() const
     {
       // rectangle created QgsRectangle() or with rect.setMinimal() ?
-      return ( qgsDoubleNear( mXmin, 0.0 ) && qgsDoubleNear( mXmax, 0.0 ) && qgsDoubleNear( mYmin, 0.0 ) && qgsDoubleNear( mYmax, 0.0 ) ) ||
+      return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmin ) ) ||
+             ( qgsDoubleNear( mXmin, 0.0 ) && qgsDoubleNear( mXmax, 0.0 ) && qgsDoubleNear( mYmin, 0.0 ) && qgsDoubleNear( mYmax, 0.0 ) ) ||
              ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
                qgsDoubleNear( mXmax, -std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmax, -std::numeric_limits<double>::max() ) );
     }

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -318,6 +318,7 @@ class TestQgsBox3d(unittest.TestCase):
     def testIsNull(self):
         box1 = QgsBox3d()
         self.assertTrue(box1.isNull())
+        self.assertTrue(box1.toRectangle().isNull())
 
         box2 = QgsBox3d(0, 0, 0, 0, 0, 0)
         self.assertFalse(box2.isNull())


### PR DESCRIPTION
By default, a QgsBox3d contains NaN values. This means a null `QgsRectangle` built from `QgsBox3d` whith `QgsBox3d().toRectangle()` will only contains NaN corrdinates. However `QgsRectangle::isNull()` does not check for NaN coordinates. Therefore,
`QgsBox3d().toRectangle().isNull()` will return False.

This issue is fixed by adding a NaN check to
`QgsRectangle::isNull()`.

cc @benoitdm-oslandia @lbartoletti 