### PR TITLE
Do not display the password in the dialog when requesting credentials

### DIFF
--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -18,6 +18,7 @@
 #include "qgscredentialdialog.h"
 
 #include "qgsauthmanager.h"
+#include "qgsdatasourceuri.h"
 #include "qgslogger.h"
 #include "qgsapplication.h"
 #include "qgsgui.h"
@@ -92,7 +93,7 @@ QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
   // Keep a cache of ignored connections, and ignore them for 10 seconds.
   connect( mIgnoreButton, &QPushButton::clicked, this, [ = ]( bool )
   {
-    const QString realm { labelRealm->text() };
+    const QString realm { mRealm };
     {
       const QMutexLocker locker( &sIgnoredConnectionsCacheMutex );
       // Insert the realm in the cache of ignored connections
@@ -148,7 +149,8 @@ void QgsCredentialDialog::requestCredentials( const QString &realm, QString *use
   stackedWidget->setCurrentIndex( 0 );
   mIgnoreButton->show();
   chkbxPasswordHelperEnable->setChecked( QgsApplication::authManager()->passwordHelperEnabled() );
-  labelRealm->setText( realm );
+  labelRealm->setText( QgsDataSourceUri::removePassword( realm ) );
+  mRealm = realm;
   leUsername->setText( *username );
   lePassword->setText( *password );
   labelMessage->setText( message );

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -76,6 +76,8 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
     //! mutex for the static ignored connections cache
     static QMutex sIgnoredConnectionsCacheMutex;
 
+    QString mRealm;
+
     ConnectionsIgnoreMode mIgnoreMode = ConnectionsIgnoreMode::IgnoreTemporarily;
 
 };


### PR DESCRIPTION
A few people make a screenshot of the error when they can't connect to the database to ask to the sysadmin why they can't connect...

But then the screenshot is showing their password in clear text :(

![ksnip_20230707-144332](https://github.com/qgis/QGIS/assets/1609292/0026e5b3-7a40-4437-a6a4-d30dd72028df)


Edit : The text is used again at the end when we accept the dialog, I will change that