### PR TITLE
Fix color widget span in gradient color ramp dialog

### DIFF
--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -87,7 +87,7 @@
      <item>
       <widget class="QComboBox" name="cboType">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -147,8 +147,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>850</width>
-        <height>494</height>
+        <width>856</width>
+        <height>488</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -170,58 +170,71 @@
           <string>Gradient Stop</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Relative &amp;position</string>
-            </property>
-            <property name="buddy">
-             <cstring>mPositionSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QPushButton" name="mDeleteStopButton">
-            <property name="text">
-             <string>&amp;Delete Stop</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="6">
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <item row="1" column="0">
            <widget class="QgsCompoundColorWidget" name="mColorWidget" native="true">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QgsDoubleSpinBox" name="mPositionSpinBox">
-            <property name="suffix">
-             <string> %</string>
+          <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
             </property>
-            <property name="decimals">
-             <number>1</number>
+            <property name="rightMargin">
+             <number>6</number>
             </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="2">
-           <widget class="QComboBox" name="mStopColorSpec"/>
-          </item>
-          <item row="0" column="3">
-           <widget class="QComboBox" name="mStopDirection"/>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Relative &amp;position</string>
+              </property>
+              <property name="buddy">
+               <cstring>mPositionSpinBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsDoubleSpinBox" name="mPositionSpinBox">
+              <property name="suffix">
+               <string> %</string>
+              </property>
+              <property name="decimals">
+               <number>1</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mStopColorSpec"/>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mStopDirection"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="mDeleteStopButton">
+              <property name="text">
+               <string>&amp;Delete Stop</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -187,7 +187,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="5">
+          <item row="1" column="0" colspan="6">
            <widget class="QgsCompoundColorWidget" name="mColorWidget" native="true">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>


### PR DESCRIPTION
This should avoid the offset between the color settings and the "delete stop" button
![image](https://github.com/qgis/QGIS/assets/7983394/fa092178-25e6-4555-8357-026f0a0d38a7)

~~I need to check what is going on, but not sure that the continuous widget expanding that way (despite the horizontal spacer on its right) is great. Maybe use a fixed size and/or align it to the right...???~~ Done and a bit more.