### PR TITLE
[feature] Add DataSource URI methods to AWS S3 Authentication Plugin

### DIFF
--- a/src/auth/awss3/core/qgsauthawss3method.h
+++ b/src/auth/awss3/core/qgsauthawss3method.h
@@ -46,6 +46,9 @@ class QgsAuthAwsS3Method : public QgsAuthMethod
     bool updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
                                const QString &dataprovider = QString() ) override;
 
+    bool updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg,
+                                   const QString &dataprovider = QString() ) override;
+
     void clearCachedConfig( const QString &authcfg ) override;
     void updateMethodConfig( QgsAuthMethodConfig &mconfig ) override;
 


### PR DESCRIPTION
## Description
fixes #53637

This PR adds an implementation of the `updateDataSourceUriItems` interface to the AWS S3 authentication plugin.

This reads the credentials from the auth manager and creates a [pre-signed url](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) which can be used by any HTTP client, and so can be treated like any other http resource by GDAL or other provider backend.

With this added, it will be much easier to work with resources from authenticated S3 services without having to set environment variables like is detailled [here] (https://opengislab.com/blog/2021/4/17/hosting-and-accessing-cloud-optimized-geotiffs-on-aws-s3), and allows for multiple resources to be added into a project from different S3 services each with their own credentials.

This is what I'm using as a test harness, and can probably be reworked into a proper unit test but I wasnt sure how to handle the external resource part of it.
```python
import sys
import os
sys.path.append('/usr/lib/qgis')
sys.path.append('/usr/share/qgis/python/plugins')

os.environ["QT_QPA_PLATFORM"] = "offscreen"

print('--- STARTING ---')

from qgis.core import (
    QgsApplication,
    QgsRasterLayer,
    QgsAuthMethodConfig
)

from qgis.testing import start_app

app = start_app()

authm = QgsApplication.authManager()
authm.setMasterPassword('masterpassword', True)

path = "https://[S3_URL_HERE] authcfg='s3-test'"
username = ""
password = ""
region = ""

print('Setting up auth method...')
auth_config = QgsAuthMethodConfig("AWSS3")
auth_config.setId('s3-test')
auth_config.setConfig("username", username)
auth_config.setConfig("password", password)
auth_config.setConfig("region", region)
auth_config.setName("test_awss3_auth_config")

authm.storeAuthenticationConfig(auth_config)

raster_layer = QgsRasterLayer(path, 'test')
print('Read Layer')
print(raster_layer.isValid())
print(raster_layer.extent())
```

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
