### PR TITLE
[xyz] Fix tile caching of redirected XYZ URLs

### DIFF
--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -666,6 +666,7 @@ enum QgsWmsTileAttribute
   TileIndex = QNetworkRequest::User + 1,
   TileRect  = QNetworkRequest::User + 2,
   TileRetry = QNetworkRequest::User + 3,
+  TileUrl   = QNetworkRequest::User + 4, //!< Original requested tile URL, before any redirects are applied
 };
 
 enum QgsWmsDpiMode

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4645,6 +4645,7 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString 
     request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileIndex ), r.index );
     request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRect ), r.rect );
     request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), 0 );
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileUrl ), r.url );
 
     QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
     connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
@@ -4719,6 +4720,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 #ifdef QGISDEBUG
   int retry = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileRetry ) ).toInt();
 #endif
+  QUrl tileUrl = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileUrl ) ).value<QUrl>();
 
   QgsDebugMsgLevel( QStringLiteral( "tile reply %1 (%2) tile:%3(retry %4) rect:%5,%6 %7,%8) fromcache:%9 %10 url:%11" )
                     .arg( tileReqNo ).arg( mTileReqNo ).arg( tileNo ).arg( retry )
@@ -4743,6 +4745,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileIndex ), tileNo );
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRect ), r );
       request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), 0 );
+      request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileUrl ), tileUrl );
 
       mReplies.removeOne( reply );
       reply->deleteLater();
@@ -4844,7 +4847,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
                     .arg( r.width() ).arg( r.height() ) );
 #endif
 
-        QgsTileCache::insertTile( reply->url(), myLocalImage );
+        QgsTileCache::insertTile( tileUrl, myLocalImage );
 
         if ( mFeedback )
           mFeedback->onNewData();


### PR DESCRIPTION
## Description

Our WMS provider's XYZ handling of tile cache fails when the XYZ URL is redirected. E.g., this URL:

https://www.google.cn/maps/vt?lyrs=s@189&gl=cn&x={x}&y={y}&z={z}

Redirects to a google.com URL, and breaks our tile cache check as the cache stores the redirected URL, not the requested URL.

On this line (https://github.com/qgis/QGIS/blob/master/src/providers/wms/qgswmsprovider.cpp#L987), we check for tile cache against the non-redirected URL, which inevitably ends up with a negative check.

The solution is to insure that the QgsTileCache stores the original tile URL. 