### PR TITLE
Add optional tile padding boundary to QgsRasterIterator

### DIFF
--- a/python/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -19,9 +19,11 @@ Iterator for sequentially processing raster cells.
 %End
   public:
 
-    QgsRasterIterator( QgsRasterInterface *input );
+    QgsRasterIterator( QgsRasterInterface *input, int tileOverlapPixels = 0 );
 %Docstring
 Constructor for QgsRasterIterator, iterating over the specified ``input`` raster source.
+
+Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
 %End
 
     static QgsRectangle subRegion( const QgsRectangle &rasterExtent, int rasterWidth, int rasterHeight, const QgsRectangle &subRegion, int &subRegionWidth /Out/, int &subRegionHeight /Out/, int &subRegionLeft /Out/, int &subRegionTop /Out/ );

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -117,6 +117,10 @@ class CORE_EXPORT QgsRasterIterator
      * \param topLeftCol top left column
      * \param topLeftRow top left row
      * \param blockExtent optional storage for exact extent of returned raster block
+     * \param tileColumns optional storage for number of columns in the iterated tile (excluding any tile overlap pixels)
+     * \param tileRows optional storage for number of rows in the iterated tile (excluding any tile overlap pixels)
+     * \param tileTopLeftColumn optional storage for the top left column in the iterated tile (excluding any tile overlap pixels)
+     * \param tileTopLeftRow optional storage for the top left row in the iterated tile (excluding any tile overlap pixels)
      * \returns FALSE if the last part was already returned
      * \note Not available in Python bindings
      * \since QGIS 3.2
@@ -125,7 +129,8 @@ class CORE_EXPORT QgsRasterIterator
                              int &nCols, int &nRows,
                              std::unique_ptr< QgsRasterBlock > &block,
                              int &topLeftCol, int &topLeftRow,
-                             QgsRectangle *blockExtent = nullptr ) SIP_SKIP;
+                             QgsRectangle *blockExtent = nullptr,
+                             int *tileColumns = nullptr, int *tileRows = nullptr, int *tileTopLeftColumn = nullptr, int *tileTopLeftRow = nullptr ) SIP_SKIP;
 
     /**
      * Cancels the raster iteration and resets the iterator.
@@ -192,7 +197,7 @@ class CORE_EXPORT QgsRasterIterator
 
     //! Remove part into and release memory
     void removePartInfo( int bandNumber );
-    bool readNextRasterPartInternal( int bandNumber, int &nCols, int &nRows, std::unique_ptr<QgsRasterBlock> *block, int &topLeftCol, int &topLeftRow, QgsRectangle *blockExtent );
+    bool readNextRasterPartInternal( int bandNumber, int &nCols, int &nRows, std::unique_ptr<QgsRasterBlock> *block, int &topLeftCol, int &topLeftRow, QgsRectangle *blockExtent, int &tileColumns, int &tileRows, int &tileTopLeftColumn, int &tileTopLeftRow );
 };
 
 #endif // QGSRASTERITERATOR_H

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -37,8 +37,10 @@ class CORE_EXPORT QgsRasterIterator
 
     /**
      * Constructor for QgsRasterIterator, iterating over the specified \a input raster source.
+     *
+     * Since QGIS 3.34 the tileOverlapPixels can be used to specify a margin in pixels for retrieving pixels overlapping into neighbor cells.
      */
-    QgsRasterIterator( QgsRasterInterface *input );
+    QgsRasterIterator( QgsRasterInterface *input, int tileOverlapPixels = 0 );
 
     /**
      * Given an overall raster extent and width and height in pixels, calculates the sub region
@@ -184,6 +186,7 @@ class CORE_EXPORT QgsRasterIterator
     QgsRectangle mExtent;
     QgsRasterBlockFeedback *mFeedback = nullptr;
 
+    int mTileOverlapPixels = 0;
     int mMaximumTileWidth;
     int mMaximumTileHeight;
 

--- a/tests/src/core/testqgsrasteriterator.cpp
+++ b/tests/src/core/testqgsrasteriterator.cpp
@@ -445,14 +445,23 @@ void TestQgsRasterIterator::testPixelOverlap()
   int nRows;
   int topLeftCol;
   int topLeftRow;
+  int tileCols;
+  int tileRows;
+  int tileTopLeftCol;
+  int tileTopLeftRow;
+
   QgsRectangle blockExtent;
   std::unique_ptr< QgsRasterBlock > block;
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3020 );
   QCOMPARE( nRows, 2520 );
   QCOMPARE( topLeftCol, 0 );
   QCOMPARE( topLeftRow, 0 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 0 );
+  QCOMPARE( tileTopLeftRow, 0 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -467,11 +476,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3040 );
   QCOMPARE( nRows, 2520 );
   QCOMPARE( topLeftCol, 2980 );
   QCOMPARE( topLeftRow, 0 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 3000 );
+  QCOMPARE( tileTopLeftRow, 0 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -482,11 +495,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 1220 );
   QCOMPARE( nRows, 2520 );
   QCOMPARE( topLeftCol, 5980 );
   QCOMPARE( topLeftRow, 0 );
+  QCOMPARE( tileCols, 1200 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 6000 );
+  QCOMPARE( tileTopLeftRow, 0 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -497,11 +514,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3020 );
   QCOMPARE( nRows, 2540 );
   QCOMPARE( topLeftCol, 0 );
   QCOMPARE( topLeftRow, 2480 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 0 );
+  QCOMPARE( tileTopLeftRow, 2500 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -512,11 +533,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3040 );
   QCOMPARE( nRows, 2540 );
   QCOMPARE( topLeftCol, 2980 );
   QCOMPARE( topLeftRow, 2480 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 3000 );
+  QCOMPARE( tileTopLeftRow, 2500 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -527,11 +552,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 1220 );
   QCOMPARE( nRows, 2540 );
   QCOMPARE( topLeftCol, 5980 );
   QCOMPARE( topLeftRow, 2480 );
+  QCOMPARE( tileCols, 1200 );
+  QCOMPARE( tileRows, 2500 );
+  QCOMPARE( tileTopLeftCol, 6000 );
+  QCOMPARE( tileTopLeftRow, 2500 );
   QVERIFY( block.get() );
   QCOMPARE( block->width(), 1220 );
   QCOMPARE( block->height(), 2540 );
@@ -540,11 +569,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3020 );
   QCOMPARE( nRows, 470 );
   QCOMPARE( topLeftCol, 0 );
   QCOMPARE( topLeftRow, 4980 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 450 );
+  QCOMPARE( tileTopLeftCol, 0 );
+  QCOMPARE( tileTopLeftRow, 5000 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -555,11 +588,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 3040 );
   QCOMPARE( nRows, 470 );
   QCOMPARE( topLeftCol, 2980 );
   QCOMPARE( topLeftRow, 4980 );
+  QCOMPARE( tileCols, 3000 );
+  QCOMPARE( tileRows, 450 );
+  QCOMPARE( tileTopLeftCol, 3000 );
+  QCOMPARE( tileTopLeftRow, 5000 );
   QVERIFY( block.get() );
   QCOMPARE( block->width(), 3040 );
   QCOMPARE( block->height(), 470 );
@@ -568,11 +605,15 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QCOMPARE( nCols, 1220 );
   QCOMPARE( nRows, 470 );
   QCOMPARE( topLeftCol, 5980 );
   QCOMPARE( topLeftRow, 4980 );
+  QCOMPARE( tileCols, 1200 );
+  QCOMPARE( tileRows, 450 );
+  QCOMPARE( tileTopLeftCol, 6000 );
+  QCOMPARE( tileTopLeftRow, 5000 );
   QVERIFY( block.get() );
   QVERIFY( block->isValid() );
   QCOMPARE( block->value( 1, 1 ), 1.0 );
@@ -583,7 +624,7 @@ void TestQgsRasterIterator::testPixelOverlap()
   QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
   QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
 
-  QVERIFY( !it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( !it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent, &tileCols, &tileRows, &tileTopLeftCol, &tileTopLeftRow ) );
   QVERIFY( !block.get() );
 }
 

--- a/tests/src/core/testqgsrasteriterator.cpp
+++ b/tests/src/core/testqgsrasteriterator.cpp
@@ -41,6 +41,7 @@ class TestQgsRasterIterator : public QObject
     void testBasic();
     void testNoBlock();
     void testSubRegion();
+    void testPixelOverlap();
 
   private:
 
@@ -422,6 +423,168 @@ void TestQgsRasterIterator::testSubRegion()
   QCOMPARE( subRectLeft, 0 );
   QCOMPARE( subRectTop, 0 );
 
+}
+
+void TestQgsRasterIterator::testPixelOverlap()
+{
+  QgsRasterDataProvider *provider = mpRasterLayer->dataProvider();
+  QVERIFY( provider );
+  QgsRasterIterator it( provider, 20 );
+
+  QCOMPARE( it.input(), provider );
+
+  it.setMaximumTileHeight( 2500 );
+  QCOMPARE( it.maximumTileHeight(), 2500 );
+
+  it.setMaximumTileWidth( 3000 );
+  QCOMPARE( it.maximumTileWidth(), 3000 );
+
+  it.startRasterRead( 1, mpRasterLayer->width(), mpRasterLayer->height(), mpRasterLayer->extent() );
+
+  int nCols;
+  int nRows;
+  int topLeftCol;
+  int topLeftRow;
+  QgsRectangle blockExtent;
+  std::unique_ptr< QgsRasterBlock > block;
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3020 );
+  QCOMPARE( nRows, 2520 );
+  QCOMPARE( topLeftCol, 0 );
+  QCOMPARE( topLeftRow, 0 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 3020 );
+  QCOMPARE( block->height(), 2520 );
+  QCOMPARE( blockExtent.xMinimum(), 497470.0 );
+  QCOMPARE( blockExtent.xMaximum(), 497772.0 );
+  QCOMPARE( blockExtent.yMinimum(), 7050878.0 );
+  QCOMPARE( blockExtent.yMaximum(), 7051130.0 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3040 );
+  QCOMPARE( nRows, 2520 );
+  QCOMPARE( topLeftCol, 2980 );
+  QCOMPARE( topLeftRow, 0 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 3040 );
+  QCOMPARE( block->height(), 2520 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 1220 );
+  QCOMPARE( nRows, 2520 );
+  QCOMPARE( topLeftCol, 5980 );
+  QCOMPARE( topLeftRow, 0 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 1220 );
+  QCOMPARE( block->height(), 2520 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3020 );
+  QCOMPARE( nRows, 2540 );
+  QCOMPARE( topLeftCol, 0 );
+  QCOMPARE( topLeftRow, 2480 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 3020 );
+  QCOMPARE( block->height(), 2540 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3040 );
+  QCOMPARE( nRows, 2540 );
+  QCOMPARE( topLeftCol, 2980 );
+  QCOMPARE( topLeftRow, 2480 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 3040 );
+  QCOMPARE( block->height(), 2540 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 1220 );
+  QCOMPARE( nRows, 2540 );
+  QCOMPARE( topLeftCol, 5980 );
+  QCOMPARE( topLeftRow, 2480 );
+  QVERIFY( block.get() );
+  QCOMPARE( block->width(), 1220 );
+  QCOMPARE( block->height(), 2540 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3020 );
+  QCOMPARE( nRows, 470 );
+  QCOMPARE( topLeftCol, 0 );
+  QCOMPARE( topLeftRow, 4980 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 3020 );
+  QCOMPARE( block->height(), 470 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 3040 );
+  QCOMPARE( nRows, 470 );
+  QCOMPARE( topLeftCol, 2980 );
+  QCOMPARE( topLeftRow, 4980 );
+  QVERIFY( block.get() );
+  QCOMPARE( block->width(), 3040 );
+  QCOMPARE( block->height(), 470 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QCOMPARE( nCols, 1220 );
+  QCOMPARE( nRows, 470 );
+  QCOMPARE( topLeftCol, 5980 );
+  QCOMPARE( topLeftRow, 4980 );
+  QVERIFY( block.get() );
+  QVERIFY( block->isValid() );
+  QCOMPARE( block->value( 1, 1 ), 1.0 );
+  QCOMPARE( block->width(), 1220 );
+  QCOMPARE( block->height(), 470 );
+  QCOMPARE( blockExtent.xMinimum(), mpRasterLayer->extent().xMinimum() + topLeftCol * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.yMinimum(), mpRasterLayer->extent().yMaximum() - ( nRows + topLeftRow )* mpRasterLayer->rasterUnitsPerPixelY() );
+  QCOMPARE( blockExtent.width(), nCols * mpRasterLayer->rasterUnitsPerPixelX() );
+  QCOMPARE( blockExtent.height(), nRows * mpRasterLayer->rasterUnitsPerPixelY() );
+
+  QVERIFY( !it.readNextRasterPart( 1, nCols, nRows, block, topLeftCol, topLeftRow, &blockExtent ) );
+  QVERIFY( !block.get() );
 }
 
 


### PR DESCRIPTION
Allows returned blocks to overlap by the specified number of pixels. Useful for algorithms which need to consider neighbouring pixels in a tiled approach, without tile boundary artefacts.
