### PR TITLE
fixed zoom level initialization of MVT layer based on MBTiles datasource

### DIFF
--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -61,12 +61,28 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
   mMatrixSet = QgsVectorTileMatrixSet::fromWebMercator();
 
   bool minZoomOk, maxZoomOk;
-  const int minZoom = reader.metadataValue( QStringLiteral( "minzoom" ) ).toInt( &minZoomOk );
-  const int maxZoom = reader.metadataValue( QStringLiteral( "maxzoom" ) ).toInt( &maxZoomOk );
+  bool needNewMatrixSet = false;
+  int minZoom = reader.metadataValue( QStringLiteral( "minzoom" ) ).toInt( &minZoomOk );
+  int maxZoom = reader.metadataValue( QStringLiteral( "maxzoom" ) ).toInt( &maxZoomOk );
+  
   if ( minZoomOk )
+  {
+    needNewMatrixSet = needNewMatrixSet || mMatrixSet.minimumZoom() > minZoom;
     mMatrixSet.dropMatricesOutsideZoomRange( minZoom, 99 );
+  }
+  else
+    minZoom = mMatrixSet.minimumZoom();
   if ( maxZoomOk )
+  {
+    needNewMatrixSet || mMatrixSet.maximumZoom() < maxZoom;
     mMatrixSet.dropMatricesOutsideZoomRange( 0, maxZoom );
+  }
+  else
+    maxZoom = mMatrixSet.maximumZoom();
+  
+  if ( needNewMatrixSet )
+    mMatrixSet = QgsVectorTileMatrixSet::fromWebMercator( minZoom, maxZoom );
+  
   QgsDebugMsgLevel( QStringLiteral( "zoom range: %1 - %2" ).arg( mMatrixSet.minimumZoom() ).arg( mMatrixSet.maximumZoom() ), 2 );
 
   QgsRectangle r = reader.extent();

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -74,7 +74,7 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
     minZoom = mMatrixSet.minimumZoom();
   if ( maxZoomOk )
   {
-    needNewMatrixSet || mMatrixSet.maximumZoom() < maxZoom;
+    needNewMatrixSet = needNewMatrixSet || mMatrixSet.maximumZoom() < maxZoom;
     mMatrixSet.dropMatricesOutsideZoomRange( 0, maxZoom );
   }
   else

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -64,7 +64,7 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
   bool needNewMatrixSet = false;
   int minZoom = reader.metadataValue( QStringLiteral( "minzoom" ) ).toInt( &minZoomOk );
   int maxZoom = reader.metadataValue( QStringLiteral( "maxzoom" ) ).toInt( &maxZoomOk );
-  
+
   if ( minZoomOk )
   {
     needNewMatrixSet = needNewMatrixSet || mMatrixSet.minimumZoom() > minZoom;
@@ -79,10 +79,10 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QStrin
   }
   else
     maxZoom = mMatrixSet.maximumZoom();
-  
+
   if ( needNewMatrixSet )
     mMatrixSet = QgsVectorTileMatrixSet::fromWebMercator( minZoom, maxZoom );
-  
+
   QgsDebugMsgLevel( QStringLiteral( "zoom range: %1 - %2" ).arg( mMatrixSet.minimumZoom() ).arg( mMatrixSet.maximumZoom() ), 2 );
 
   QgsRectangle r = reader.extent();


### PR DESCRIPTION
By default the matrix set of the MVT layer based on an MBTiles datasource is initialized with zoom levels 0 - 14. When loading a tileset with zoom levels > 14 the matrix set is not adjusted accordingly. 

This proposed changes fix that behavior by reinitializing the matrix set if required.

