### PR TITLE
Add setX, setY, setZ functions to QgsVector3D

### DIFF
--- a/python/core/auto_generated/qgsvector3d.sip.in
+++ b/python/core/auto_generated/qgsvector3d.sip.in
@@ -53,6 +53,27 @@ Returns Y coordinate
 Returns Z coordinate
 %End
 
+    void setX( double x );
+%Docstring
+Sets X coordinate
+
+.. versionadded:: 3.34
+%End
+
+    void setY( double y );
+%Docstring
+Sets Y coordinate
+
+.. versionadded:: 3.34
+%End
+
+    void setZ( double z );
+%Docstring
+Sets Z coordinate
+
+.. versionadded:: 3.34
+%End
+
     void set( double x, double y, double z );
 %Docstring
 Sets vector coordinates

--- a/src/core/qgsvector3d.h
+++ b/src/core/qgsvector3d.h
@@ -52,6 +52,24 @@ class CORE_EXPORT QgsVector3D
     //! Returns Z coordinate
     double z() const { return mZ; }
 
+    /**
+     * Sets X coordinate
+     * \since QGIS 3.34
+     */
+    void setX( double x ) { mX = x; }
+
+    /**
+     * Sets Y coordinate
+     * \since QGIS 3.34
+     */
+    void setY( double y ) { mY = y; }
+
+    /**
+     * Sets Z coordinate
+     * \since QGIS 3.34
+     */
+    void setZ( double z ) { mZ = z; }
+
     //! Sets vector coordinates
     void set( double x, double y, double z )
     {

--- a/tests/src/core/testqgsvector.cpp
+++ b/tests/src/core/testqgsvector.cpp
@@ -32,6 +32,7 @@ class TestQgsVector : public QObject
 
     // vector3d
     void vector3d();
+    void setters();
 };
 
 void TestQgsVector::initTestCase()
@@ -83,6 +84,31 @@ void TestQgsVector::vector3d()
   QCOMPARE( QgsVector3D::perpendicularPoint( QgsVector3D( 0.0, 0.0, 0.0 ), QgsVector3D( 0.0, 5.0, 0.0 ), QgsVector3D( 1.0, 4.0, 0.0 ) ), QgsVector3D( 0.0, 4.0, 0.0 ) );
   QCOMPARE( QgsVector3D::perpendicularPoint( QgsVector3D( 0.0, 0.0, 5.0 ), QgsVector3D( 0.0, 0.0, 10.0 ), QgsVector3D( 2.0, 4.0, 7 ) ), QgsVector3D( 0.0, 0.0, 7.0 ) );
   QCOMPARE( QgsVector3D::perpendicularPoint( QgsVector3D( 0.0, 0.0, 5.0 ), QgsVector3D( 0.0, 5.0, 10.0 ), QgsVector3D( 1.0, 4.0, 5.0 ) ).toString( 2 ), QgsVector3D( 0.0, 2.0, 7.0 ).toString( 2 ) );
+}
+
+void TestQgsVector::setters()
+{
+  QgsVector3D p1( 1.0, 2.0, 3.0 );
+
+  p1.setX( 5.0 );
+  QCOMPARE( p1.x(), 5.0 );
+  QCOMPARE( p1.y(), 2.0 );
+  QCOMPARE( p1.z(), 3.0 );
+
+  p1.setY( 6.0 );
+  QCOMPARE( p1.x(), 5.0 );
+  QCOMPARE( p1.y(), 6.0 );
+  QCOMPARE( p1.z(), 3.0 );
+
+  p1.setZ( 7.0 );
+  QCOMPARE( p1.x(), 5.0 );
+  QCOMPARE( p1.y(), 6.0 );
+  QCOMPARE( p1.z(), 7.0 );
+
+  p1.set( 8.0, 9.0, 10.0 );
+  QCOMPARE( p1.x(), 8.0 );
+  QCOMPARE( p1.y(), 9.0 );
+  QCOMPARE( p1.z(), 10.0 );
 }
 
 QGSTEST_MAIN( TestQgsVector )


### PR DESCRIPTION
There was only set() function that sets all components, but it may be useful to set just one of them...