### PR TITLE
When an algorithm is added to a model with optional layer parameters, leave the default values for these as empty 

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -6142,9 +6142,18 @@ QString QgsProcessingMapLayerWidgetWrapper::modelerExpressionFormatString() cons
   return tr( "path to a map layer" );
 }
 
-QgsProcessingModelChildParameterSource::Source QgsProcessingMapLayerWidgetWrapper::defaultModelSource( const QgsProcessingParameterDefinition * ) const
+QgsProcessingModelChildParameterSource::Source QgsProcessingMapLayerWidgetWrapper::defaultModelSource( const QgsProcessingParameterDefinition *parameter ) const
 {
-  return QgsProcessingModelChildParameterSource::ModelParameter;
+  // non-optional layer sources default to a matching model input layer, but optional layer parameters
+  // should default to static values. We don't want all optional layer parameters to have values set by default!
+  if ( !( parameter->flags() & QgsProcessingParameterDefinition::Flag::FlagOptional ) )
+  {
+    return QgsProcessingModelChildParameterSource::ModelParameter;
+  }
+  else
+  {
+    return QgsProcessingModelChildParameterSource::StaticValue;
+  }
 }
 
 QString QgsProcessingMapLayerWidgetWrapper::parameterType() const

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -740,6 +740,8 @@ void TestProcessingGui::testModelerWrapper()
   model.addModelParameter( new QgsProcessingParameterFileDestination( "test_dest", "p3" ), testDestParam );
   QgsProcessingModelParameter testLayerParam( "p4" );
   model.addModelParameter( new QgsProcessingParameterMapLayer( "p4", "test_layer" ), testLayerParam );
+  QgsProcessingModelParameter testOptionalLayerParam( "p5" );
+  model.addModelParameter( new QgsProcessingParameterMapLayer( "p5", "test_layer2", QVariant(), true ), testLayerParam );
 
   // try to create a parameter widget, no factories registered
   QgsProcessingGuiRegistry registry;
@@ -763,6 +765,11 @@ void TestProcessingGui::testModelerWrapper()
   QVERIFY( w );
   // a layer parameter should default to "model input" type
   QCOMPARE( w->value().value< QgsProcessingModelChildParameterSource>().source(), QgsProcessingModelChildParameterSource::ModelParameter );
+  delete w;
+  // but an optionl layer parameter should NOT -- we don't want to autofill values for optional layers by default
+  w = registry.createModelerParameterWidget( &model, QStringLiteral( "a" ), model.parameterDefinition( "p5" ), context );
+  QVERIFY( w );
+  QCOMPARE( w->value().value< QgsProcessingModelChildParameterSource>().source(), QgsProcessingModelChildParameterSource::StaticValue );
   delete w;
 
   // widget tests


### PR DESCRIPTION
...instead of setting them to model input layers

We don't want to auto-fill optional layer parameters by default
