### PR TITLE
Fix a bunch of debug spam when running processing algorithms on debug builds

### DIFF
--- a/src/analysis/processing/qgsalgorithmdistancewithin.cpp
+++ b/src/analysis/processing/qgsalgorithmdistancewithin.cpp
@@ -118,6 +118,7 @@ void QgsDistanceWithinAlgorithm::processByIteratingOverTargetSource( const QgsPr
 
   QgsFeatureIterator fIt = targetSource->getFeatures( request );
   const double step = targetSource->featureCount() > 0 ? 100.0 / targetSource->featureCount() : 1;
+  const QgsCoordinateReferenceSystem targetSourceCrs = targetSource->sourceCrs();
   int current = 0;
   QgsFeature f;
   while ( fIt.nextFeature( f ) )
@@ -135,7 +136,7 @@ void QgsDistanceWithinAlgorithm::processByIteratingOverTargetSource( const QgsPr
       currentDistance = distanceProperty.valueAsDouble( expressionContext, currentDistance );
     }
 
-    request = QgsFeatureRequest().setDistanceWithin( f.geometry(), currentDistance ).setNoAttributes().setDestinationCrs( targetSource->sourceCrs(), context.transformContext() );
+    request = QgsFeatureRequest().setDistanceWithin( f.geometry(), currentDistance ).setNoAttributes().setDestinationCrs( targetSourceCrs, context.transformContext() );
     // we only care IF there's ANY features within the target distance here, so fetch at most 1 feature
     request.setLimit( 1 );
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1596,6 +1596,12 @@ QString QgsProcessingUtils::resolveDefaultEncoding( const QString &defaultEncodi
 QgsProcessingFeatureSource::QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource, long long featureLimit, const QString &filterExpression )
   : mSource( originalSource )
   , mOwnsSource( ownsOriginalSource )
+  , mSourceCrs( mSource->sourceCrs() )
+  , mSourceFields( mSource->fields() )
+  , mSourceWkbType( mSource->wkbType() )
+  , mSourceName( mSource->sourceName() )
+  , mSourceExtent( mSource->sourceExtent() )
+  , mSourceSpatialIndexPresence( mSource->hasSpatialIndex() )
   , mInvalidGeometryCheck( QgsWkbTypes::geometryType( mSource->wkbType() ) == Qgis::GeometryType::Point
                            ? QgsFeatureRequest::GeometryNoCheck // never run geometry validity checks for point layers!
                            : context.invalidGeometryCheck() )
@@ -1669,17 +1675,17 @@ QgsFeatureIterator QgsProcessingFeatureSource::getFeatures( const QgsFeatureRequ
 
 QgsCoordinateReferenceSystem QgsProcessingFeatureSource::sourceCrs() const
 {
-  return mSource->sourceCrs();
+  return mSourceCrs;
 }
 
 QgsFields QgsProcessingFeatureSource::fields() const
 {
-  return mSource->fields();
+  return mSourceFields;
 }
 
 Qgis::WkbType QgsProcessingFeatureSource::wkbType() const
 {
-  return mSource->wkbType();
+  return mSourceWkbType;
 }
 
 long long QgsProcessingFeatureSource::featureCount() const
@@ -1695,7 +1701,7 @@ long long QgsProcessingFeatureSource::featureCount() const
 
 QString QgsProcessingFeatureSource::sourceName() const
 {
-  return mSource->sourceName();
+  return mSourceName;
 }
 
 QSet<QVariant> QgsProcessingFeatureSource::uniqueValues( int fieldIndex, int limit ) const
@@ -1783,7 +1789,7 @@ QVariant QgsProcessingFeatureSource::maximumValue( int fieldIndex ) const
 
 QgsRectangle QgsProcessingFeatureSource::sourceExtent() const
 {
-  return mSource->sourceExtent();
+  return mSourceExtent;
 }
 
 QgsFeatureIds QgsProcessingFeatureSource::allFeatureIds() const
@@ -1809,7 +1815,7 @@ QgsFeatureIds QgsProcessingFeatureSource::allFeatureIds() const
 
 QgsFeatureSource::SpatialIndexPresence QgsProcessingFeatureSource::hasSpatialIndex() const
 {
-  return mSource->hasSpatialIndex();
+  return mSourceSpatialIndexPresence;
 }
 
 QgsExpressionContextScope *QgsProcessingFeatureSource::createExpressionContextScope() const

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -738,6 +738,13 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
 
     QgsFeatureSource *mSource = nullptr;
     bool mOwnsSource = false;
+    QgsCoordinateReferenceSystem mSourceCrs;
+    QgsFields mSourceFields;
+    Qgis::WkbType mSourceWkbType = Qgis::WkbType::Unknown;
+    QString mSourceName;
+    QgsRectangle mSourceExtent;
+    QgsFeatureSource::SpatialIndexPresence mSourceSpatialIndexPresence = QgsFeatureSource::SpatialIndexPresence::SpatialIndexUnknown;
+
     QgsFeatureRequest::InvalidGeometryCheck mInvalidGeometryCheck = QgsFeatureRequest::GeometryNoCheck;
     std::function< void( const QgsFeature & ) > mInvalidGeometryCallback;
     std::function< void( const QgsFeature & ) > mTransformErrorCallback;


### PR DESCRIPTION
Prefetch once upfront properties for feature sources so that we aren't bombarded by the QObject thread warnings constantly
