### PR TITLE
Fix parallel loading with postgres provider

### DIFF
--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -79,6 +79,7 @@ Abstract base class for spatial data provider implementations.
       SkipFullScan,
       ForceReadOnly,
       SkipCredentialsRequest,
+      ParallelThreadLoading,
     };
     typedef QFlags<QgsDataProvider::ReadFlag> ReadFlags;
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1368,6 +1368,7 @@ void QgsProject::preloadProviders( const QVector<QDomNode> &parallelLayerNodes,
 
     // Requesting credential from worker thread could lead to deadlocks because the main thread is waiting for worker thread to fininsh
     layerToLoad.flags.setFlag( QgsDataProvider::SkipCredentialsRequest, true );
+    layerToLoad.flags.setFlag( QgsDataProvider::ParallelThreadLoading, true );
 
     layersToLoad.insert( layerToLoad.layerId, layerToLoad );
   }
@@ -1426,6 +1427,7 @@ void QgsProject::preloadProviders( const QVector<QDomNode> &parallelLayerNodes,
       const LayerToLoad &lay =  it.value();
       QgsDataProvider::ReadFlags providerFlags = lay.flags;
       providerFlags.setFlag( QgsDataProvider::SkipCredentialsRequest, false );
+      providerFlags.setFlag( QgsDataProvider::ParallelThreadLoading, false );
       QgsScopedRuntimeProfile profile( "Create data providers/" + lay.layerId, QStringLiteral( "projectload" ) );
       std::unique_ptr<QgsDataProvider> provider( QgsProviderRegistry::instance()->createProvider( lay.provider, lay.dataSource, lay.options, providerFlags ) );
       i++;

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -128,6 +128,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
       SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) (since QGIS 3.24)
       ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode (since QGIS 3.28)
       SkipCredentialsRequest =  1 << 6, //! Skip credentials if the provided one are not valid, let the provider be invalid, avoiding to block the thread creating the provider if it is not the main thread (since QGIS 3.32).
+      ParallelThreadLoading = 1 << 7, //! Provider is created in a parallel thread than the one where it will live (since QGIS 3.32.1).
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -112,7 +112,7 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsMapScales = n
 
 const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsLayerParallelLoadingMaxCount = new QgsSettingsEntryInteger( QStringLiteral( "provider-parallel-loading-max-count" ), QgsSettingsTree::sTreeCore, QThread::idealThreadCount(), QStringLiteral( "Maximum thread used to load layers in parallel" ), Qgis::SettingsOption(), 1 );
 
-const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsLayerParallelLoading = new QgsSettingsEntryBool( QStringLiteral( "provider-parallel-loading" ), QgsSettingsTree::sTreeCore, true, QStringLiteral( "Load layers in parallel (only available for some providers (GDAL, OGR and PostgreSQL)" ), Qgis::SettingsOption() );
+const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsLayerParallelLoading = new QgsSettingsEntryBool( QStringLiteral( "provider-parallel-loading" ), QgsSettingsTree::sTreeCore, true, QStringLiteral( "Load layers in parallel (only available for some providers (GDAL and PostgreSQL)" ), Qgis::SettingsOption() );
 
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -450,7 +450,7 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 
     QString paramValue( const QString &fieldvalue, const QString &defaultValue ) const;
 
-    QgsPostgresConn *mConnectionRO = nullptr ; //!< Read-only database connection (initially)
+    mutable QgsPostgresConn *mConnectionRO = nullptr ; //!< Read-only database connection (initially)
     QgsPostgresConn *mConnectionRW = nullptr ; //!< Read-write database connection (on update)
 
     QgsPostgresConn *connectionRO() const;


### PR DESCRIPTION
Provider parallel loading, introduced by #53069 , created a regression with PostgreSQL. Indeed, postgres connection was not anymore shared as they are created in parallel threads. With a big count of postgres layers, limitation of connection count is reached quickly and creates issue with servers.

This PR fix this issue by removing the connection at the end of the provider creation if we it is loading in parallel. Then, a connection is created when needed in the main thread allowing the connection to be shared.

fix #53621 