### PR TITLE
CSV: fix update on types auto detection

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -370,7 +370,15 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes, bool forceFullScan, 
 
   // Open the file and get number of rows, etc. We assume that the
   // file has a header row and process accordingly. Caller should make
-  // sure that the delimited file is properly formed.
+  // sure that the delimited file is properly formed.  const QUrl url { mFile->url() };
+
+  // Reset is required because the quick scan might already have read the whole file
+  if ( forceFullScan )
+  {
+    const QUrl url { mFile->url() };
+    mFile.reset( new QgsDelimitedTextFile( ) );
+    mFile->setFromUrl( url );
+  }
 
   if ( mGeomRep == GeomAsWkt )
   {

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -111,7 +111,7 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     int mExampleRowCount = 20;
     int mBadRowCount = 0;
     QgsFields mFields; //!< Stores the fields as returned by the provider to determine if their types were overridden
-    QSet<int> mOverriddenFields; //!< Stores user-overridden fields
+    QMap<int, QString> mOverriddenFields; //!< Stores user-overridden field types
     static constexpr int DEFAULT_MAX_FIELDS = 10000;
     int mMaxFields = DEFAULT_MAX_FIELDS; //!< To avoid Denial Of Service (at least in source select). Configurable through /max_fields settings sub-key.
     QString mSettingsKey;


### PR DESCRIPTION
Fix #53802

Also fixes unreported:

- auto detection do not rewind, possibily leading to wrong detection and totally failing on small files
- manually overridden fields not retained when changing options
- manually overridden fields not retained when changing file source
