### PR TITLE
Fix common angle keyboard shortcuts

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -1064,7 +1064,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr<QgsMessageBarItem> mErrorMessage;
 
     // UI
-    QMap< QAction *, double > mCommonAngleActions; // map the common angle actions with their angle values
+    QMap< double, QAction *> mCommonAngleActions; // map the common angle actions with their angle values
     QAction *mLineExtensionAction;
     QAction *mXyVertexAction;
 


### PR DESCRIPTION

Respect order of angle values (instead of actions) when cycling through the options.