### PR TITLE
Move QgsWmsRestorer in QGIS Server DXF export one level up

### DIFF
--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -18,6 +18,7 @@ email                : david dot marteau at 3liz dot com
 #include "qgsdxfwriter.h"
 #include "qgsdxfexport.h"
 #include "qgswmsrenderer.h"
+#include "qgswmsrestorer.h"
 
 namespace QgsWms
 {
@@ -35,6 +36,11 @@ namespace QgsWms
 
     // Write output
     QgsRenderer renderer( context );
+
+    //Layer settings need to be kept until QgsDxfExport::writeToFile has finished
+    std::unique_ptr<QgsWmsRestorer> restorer;
+    restorer.reset( new QgsWmsRestorer( context ) );
+
     std::unique_ptr<QgsDxfExport> dxf = renderer.getDxf();
     response.setHeader( "Content-Type", "application/dxf" );
     dxf->writeToFile( response.io(), request.wmsParameters().dxfCodec() );

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -38,7 +38,7 @@ namespace QgsWms
     QgsRenderer renderer( context );
 
     //Layer settings need to be kept until QgsDxfExport::writeToFile has finished
-    std::unique_ptr<QgsWmsRestorer> restorer;
+    std::unique_ptr<QgsWmsRestorer> restorer = std::make_unique<QgsWmsRestorer>( context );
     restorer.reset( new QgsWmsRestorer( context ) );
 
     std::unique_ptr<QgsDxfExport> dxf = renderer.getDxf();

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1026,10 +1026,6 @@ namespace QgsWms
 
   std::unique_ptr<QgsDxfExport> QgsRenderer::getDxf()
   {
-    // init layer restorer before doing anything
-    std::unique_ptr<QgsWmsRestorer> restorer;
-    restorer.reset( new QgsWmsRestorer( mContext ) );
-
     // configure layers
     QList<QgsMapLayer *> layers = mContext.layersToRender();
     configureLayers( layers );


### PR DESCRIPTION
Move QgsWmsRestorer in QGIS Server DXF export one level up. Otherwise, the temporal layer settings are already reverted before the dxf will be generated. Fixes the bug where the FILTER-parameter is not applied to dxf export in GetMap
