### PR TITLE
Measure Tool - Disable comma field separator when it is used as decimal separator

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -2602,7 +2602,7 @@ void QgsOptions::alwaysUseDecimalPointChanged( bool checked )
   // In the Measure Tool copy feature,
   // comma is only allowed as field separator if the locale do not use it as decimal separator
   // or if the user has overridden the decimal separator to always be a point
-  mSeparatorComma->setEnabled( checked || QLocale().decimalPoint() != QLatin1Char( ',' ) );
+  mSeparatorComma->setEnabled( checked || QLocale().decimalPoint() != QStringLiteral( "," ) );
 
   // If comma was checked and is now disabled, switch to semicolon
   if ( mSeparatorComma->isChecked() && !mSeparatorComma->isEnabled() )

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -666,6 +666,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     mSeparatorOther->setChecked( true );
     mSeparatorCustom->setText( sep );
   }
+  mAlwaysUseDecimalPoint->setChecked( QgsMeasureDialog::settingClipboardAlwaysUseDecimalPoint->value() );
+  connect( mAlwaysUseDecimalPoint, &QCheckBox::toggled, this, &QgsOptions::alwaysUseDecimalPointChanged );
+  alwaysUseDecimalPointChanged( mAlwaysUseDecimalPoint->isChecked() );
 
   // set the default icon size
   cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "/qgis/toolbarIconSize" ), QGIS_ICON_SIZE ).toString() ) );
@@ -1683,6 +1686,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/measure/keepbaseunit" ), baseUnit );
 
   QgsMeasureDialog::settingClipboardHeader->setValue( mIncludeHeader->isChecked() );
+  QgsMeasureDialog::settingClipboardAlwaysUseDecimalPoint->setValue( mAlwaysUseDecimalPoint->isChecked() );
   QString separator;
   if ( mSeparatorTab->isChecked() )
     separator = QStringLiteral( "\t" );
@@ -2593,6 +2597,19 @@ void QgsOptions::moveLocalizedDataPathDown()
   }
 }
 
+void QgsOptions::alwaysUseDecimalPointChanged( bool checked )
+{
+  // In the Measure Tool copy feature,
+  // comma is only allowed as field separator if the locale do not use it as decimal separator
+  // or if the user has overridden the decimal separator to always be a point
+  mSeparatorComma->setEnabled( checked || QLocale().decimalPoint() != QLatin1Char( ',' ) );
+
+  // If comma was checked and is now disabled, switch to semicolon
+  if ( mSeparatorComma->isChecked() && !mSeparatorComma->isEnabled() )
+  {
+    mSeparatorSemicolon->setChecked( true );
+  }
+}
 
 QListWidgetItem *QgsOptions::addScaleToScaleList( const QString &newScale )
 {

--- a/src/app/options/qgsoptions.h
+++ b/src/app/options/qgsoptions.h
@@ -253,6 +253,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void addLocalizedDataPath();
     void moveLocalizedDataPathUp();
     void moveLocalizedDataPathDown();
+    void alwaysUseDecimalPointChanged( bool checked );
 
   private:
     QgsSettings *mSettings = nullptr;

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -750,8 +750,8 @@ void QgsMeasureDialog::copyMeasurements()
   auto replaceDecimalSeparator = [ alwaysUseDecimalPoint ]( const QString & value ) -> QString
   {
     QString result = value;
-    if ( alwaysUseDecimalPoint && QLocale().decimalPoint() != QLatin1Char( '.' ) )
-      result.replace( QLocale().decimalPoint(), QLatin1Char( '.' ) );
+    if ( alwaysUseDecimalPoint && QLocale().decimalPoint() != QStringLiteral( "." ) )
+      result.replace( QLocale().decimalPoint(), QStringLiteral( "." ) );
     return result;
   };
 

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -721,15 +721,14 @@ double QgsMeasureDialog::convertArea( double area, Qgis::AreaUnit toUnit ) const
 
 void QgsMeasureDialog::copyMeasurements()
 {
-  bool includeHeader = settingClipboardHeader->value();
-  bool alwaysUseDecimalPoint = settingClipboardAlwaysUseDecimalPoint->value();
-
+  const bool includeHeader = settingClipboardHeader->value();
+  const bool alwaysUseDecimalPoint = settingClipboardAlwaysUseDecimalPoint->value();
 
   // Get the separator
   QString separator = settingClipboardSeparator->value();
 
   // If the field separator is a comma and the locale uses a comma as decimal separator, change to a semicolon
-  if ( separator == QStringLiteral( "," ) && !alwaysUseDecimalPoint && QLocale().decimalPoint() == QLatin1Char( ',' ) )
+  if ( separator == QStringLiteral( "," ) && !alwaysUseDecimalPoint && QLocale().decimalPoint() == QStringLiteral( "," ) )
     separator = QStringLiteral( ";" );
 
   if ( separator.isEmpty() )

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -38,6 +38,7 @@ const QgsSettingsEntryBool *QgsMeasureDialog::settingClipboardHeader = new QgsSe
 
 const QgsSettingsEntryString *QgsMeasureDialog::settingClipboardSeparator = new QgsSettingsEntryString( QStringLiteral( "clipboard-separator" ), QgsSettingsTree::sTreeMeasure, QStringLiteral( "\t" ), QObject::tr( "Separator between the measure columns copied to the clipboard" ) );
 
+const QgsSettingsEntryBool *QgsMeasureDialog::settingClipboardAlwaysUseDecimalPoint = new QgsSettingsEntryBool( QStringLiteral( "clipboard-use-decimal-point" ), QgsSettingsTree::sTreeMeasure, false, QObject::tr( "Whether to use the locale decimal separator or always use the decimal point. Needed to export data as csv with a locale that uses a comma as its decimal separator." ) );
 
 QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
   : QDialog( tool->canvas()->topLevelWidget(), f )
@@ -721,9 +722,16 @@ double QgsMeasureDialog::convertArea( double area, Qgis::AreaUnit toUnit ) const
 void QgsMeasureDialog::copyMeasurements()
 {
   bool includeHeader = settingClipboardHeader->value();
+  bool alwaysUseDecimalPoint = settingClipboardAlwaysUseDecimalPoint->value();
+
 
   // Get the separator
   QString separator = settingClipboardSeparator->value();
+
+  // If the field separator is a comma and the locale uses a comma as decimal separator, change to a semicolon
+  if ( separator == QStringLiteral( "," ) && !alwaysUseDecimalPoint && QLocale().decimalPoint() == QLatin1Char( ',' ) )
+    separator = QStringLiteral( ";" );
+
   if ( separator.isEmpty() )
     separator = QStringLiteral( "\t" );
 
@@ -738,11 +746,20 @@ void QgsMeasureDialog::copyMeasurements()
     text += mTable->headerItem()->text( Columns::Distance ) + QStringLiteral( "\n" );
   }
 
+
+  auto replaceDecimalSeparator = [ alwaysUseDecimalPoint ]( const QString & value ) -> QString
+  {
+    QString result = value;
+    if ( alwaysUseDecimalPoint && QLocale().decimalPoint() != QLatin1Char( '.' ) )
+      result.replace( QLocale().decimalPoint(), QLatin1Char( '.' ) );
+    return result;
+  };
+
   while ( *it )
   {
-    text += ( *it )->text( Columns::X ) + separator;
-    text += ( *it )->text( Columns::Y ) + separator;
-    text += ( *it )->text( Columns::Distance ) + QStringLiteral( "\n" );
+    text += replaceDecimalSeparator( ( *it )->text( Columns::X ) ) + separator;
+    text += replaceDecimalSeparator( ( *it )->text( Columns::Y ) ) + separator;
+    text += replaceDecimalSeparator( ( *it )->text( Columns::Distance ) ) + QStringLiteral( "\n" );
     it++;
   }
 

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -38,6 +38,7 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     static const QgsSettingsEntryBool *settingClipboardHeader;
     static const QgsSettingsEntryString *settingClipboardSeparator;
+    static const QgsSettingsEntryBool *settingClipboardAlwaysUseDecimalPoint;
 
     //! Constructor
     QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f = Qt::WindowFlags() );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3062,32 +3062,32 @@
                  <property name="title">
                   <string>Measure Tool Copy Settings</string>
                  </property>
-                 <layout class="QFormLayout" name="formLayout">
+                 <layout class="QGridLayout" name="gridLayout_20">
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_22">
-                    <property name="toolTip">
-                     <string>C</string>
-                    </property>
                     <property name="text">
                      <string>Include header</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="mIncludeHeader">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_23">
+                    <property name="text">
+                     <string>Separator</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QCheckBox" name="mAlwaysUseDecimalPoint">
                     <property name="text">
                      <string/>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_23">
-                    <property name="text">
-                     <string>Separator</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
+                  <item row="2" column="1">
                    <layout class="QGridLayout" name="gridLayout_6">
                     <item row="0" column="0">
                      <widget class="QRadioButton" name="mSeparatorComma">
@@ -3155,6 +3155,23 @@
                      </layout>
                     </item>
                    </layout>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="mIncludeHeader">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_24">
+                    <property name="toolTip">
+                     <string>Use a dot as the decimal separator, even if the current locale uses a different character</string>
+                    </property>
+                    <property name="text">
+                     <string>Always use decimal point</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -5249,20 +5266,15 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsAuthSettingsWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsauthsettingswidget.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
@@ -5276,6 +5288,17 @@ p, li { white-space: pre-wrap; }
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -5285,12 +5308,6 @@ p, li { white-space: pre-wrap; }
    <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">qgsvariableeditorwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
- Fixes #53814 

## Description

This PR adds a new setting in the Measure Tool Copy Settings section


![image](https://github.com/qgis/QGIS/assets/9693475/3db7a6f7-dce1-462e-a872-22f72def134b)


When `Always use decimal point` is checked, coordinates are copied to the clipboard with a dot separator, even if the current locale uses a comma.

Besides, if the current locale uses a comma and the checkbox is NOT checked, the comma field separator cannot be selected.
