### PR TITLE
add image/webp to supported formats for QGIS Server's GetMap request

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -451,6 +451,7 @@ namespace QgsWms
     //wms:GetMap
     elem = doc.createElement( QStringLiteral( "GetMap" )/*wms:GetMap*/ );
     appendFormat( elem, QStringLiteral( "image/jpeg" ) );
+    appendFormat( elem, QStringLiteral( "image/webp" ) );
     appendFormat( elem, QStringLiteral( "image/png" ) );
     appendFormat( elem, QStringLiteral( "image/png; mode=16bit" ) );
     appendFormat( elem, QStringLiteral( "image/png; mode=8bit" ) );


### PR DESCRIPTION
Adding WebP to list of formats supported by the GetMap request of QGIS Server's WMS is especially helpful when serving ortho imagery with "holes" or non rectangular coverage area as WebP also supports transparency based on alpha channel.