### PR TITLE
[Oracle] Fix crash when using an auth config id

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -73,8 +73,11 @@ QgsOracleConn::QgsOracleConn( QgsDataSourceUri uri, bool transaction )
 {
   QgsDebugMsgLevel( QStringLiteral( "New Oracle connection for " ) + uri.connectionInfo( false ), 2 );
 
-  mConnInfo = uri.connectionInfo( true );
-  uri = QgsDataSourceUri( mConnInfo );
+  // will be used for logging and access connection from connection pool by name,
+  // so we don't want login/password here
+  mConnInfo = uri.connectionInfo( false );
+
+  uri = QgsDataSourceUri( uri.connectionInfo( true ) );
 
   QString database = databaseName( uri.database(), uri.host(), uri.port() );
   QgsDebugMsgLevel( QStringLiteral( "New Oracle database " ) + database, 2 );


### PR DESCRIPTION
Unreported issue, since #53201 QGIS was crashing when testing connection or exploring database from the browser AND user was using a auth configuration id

**Funded by Métropôle de Bordeaux**
