### PR TITLE
Formatted number should use the locale decimal separator

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2071,7 +2071,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
         numberFormat.append( '+' );
       }
       numberFormat.append( "%1" );
-      labelText = numberFormat.arg( d, 0, 'f', decimalPlaces );
+      labelText = numberFormat.arg( QLocale().toString( d, 'f', decimalPlaces ) );
     }
   }
 


### PR DESCRIPTION
- Fixes #53840 

## Description

When checking "Formatted numbers" in layer properties/Labels/Formatting, floating numbers now use the locale decimal separator.

This PR simply replace the call to `QString::arg` with `QLocale().toString()`.