### PR TITLE
Improve 2d geometry representation of QgsTiledMeshNodeBoundingVolumeBox

### DIFF
--- a/src/core/tiledmesh/qgstiledmeshboundingvolume.cpp
+++ b/src/core/tiledmesh/qgstiledmeshboundingvolume.cpp
@@ -19,6 +19,8 @@
 #include "qgscircle.h"
 #include "qgscoordinatetransform.h"
 #include "qgsvector3d.h"
+#include "qgsmultipoint.h"
+#include "qgsgeos.h"
 
 QgsAbstractTiledMeshNodeBoundingVolume::~QgsAbstractTiledMeshNodeBoundingVolume() = default;
 
@@ -163,31 +165,15 @@ QgsAbstractGeometry *QgsTiledMeshNodeBoundingVolumeBox::as2DGeometry( const QgsC
     y.append( corners[i].y() );
     z.append( corners[i].z() );
   }
+
   if ( transform.isValid() && !transform.isShortCircuited() )
   {
     transform.transformInPlace( x, y, z, direction );
   }
 
-  const QVector<double> x2DCenter
-  {
-    0.5 * ( x[0] + x[4] ),
-    0.5 * ( x[1] + x[5] ),
-    0.5 * ( x[2] + x[6] ),
-    0.5 * ( x[3] + x[7] ),
-    0.5 * ( x[0] + x[4] ),
-  };
-  const QVector<double> y2DCenter
-  {
-    0.5 * ( y[0] + y[4] ),
-    0.5 * ( y[1] + y[5] ),
-    0.5 * ( y[2] + y[6] ),
-    0.5 * ( y[3] + y[7] ),
-    0.5 * ( y[0] + y[4] ),
-  };
-
-  std::unique_ptr< QgsLineString > ext = std::make_unique< QgsLineString >( x2DCenter, y2DCenter );
-  polygon->setExteriorRing( ext.release() );
-  return polygon.release();
+  std::unique_ptr< QgsMultiPoint > mp = std::make_unique< QgsMultiPoint >( x, y );
+  QgsGeos geosMp( mp.get() );
+  return geosMp.convexHull();
 }
 
 //

--- a/tests/src/python/test_qgstiledmeshboundingvolume.py
+++ b/tests/src/python/test_qgstiledmeshboundingvolume.py
@@ -94,7 +94,7 @@ class TestQgsTiledMeshNodeBoundingVolume(QgisTestCase):
         self.assertEqual(bounds.zMaximum(), 33)
 
         geometry_2d = volume.as2DGeometry()
-        self.assertEqual(geometry_2d.asWkt(), 'Polygon ((11 22, -9 22, 11 -18, -9 -18, 11 22))')
+        self.assertEqual(geometry_2d.asWkt(), 'Polygon ((-9 -18, -9 22, 11 22, 11 -18, -9 -18))')
 
         # with transform
         volume = QgsTiledMeshNodeBoundingVolumeBox(QgsOrientedBox3D([-4595750, 2698725, -3493318],
@@ -113,8 +113,8 @@ class TestQgsTiledMeshNodeBoundingVolume(QgisTestCase):
         self.assertAlmostEqual(bounds.zMaximum(), 3153.6759909, 3)
 
         geometry_2d = volume.as2DGeometry(transform)
-        self.assertEqual(geometry_2d.asWkt(3),
-                         'Polygon ((149.558 -33.421, 149.569 -33.412, 149.586 -33.428, 149.597 -33.42, 149.558 -33.421))')
+        self.assertEqual(geometry_2d.asWkt(5),
+                         'Polygon ((149.58608 -33.44312, 149.55826 -33.43557, 149.55826 -33.40547, 149.56915 -33.39692, 149.59696 -33.40445, 149.59696 -33.43455, 149.58608 -33.44312))')
 
     def test_sphere(self):
         volume = QgsTiledMeshNodeBoundingVolumeSphere(QgsSphere(1, 2, 3, 10))


### PR DESCRIPTION
Use the convex hull of the transformed corners to get a better x-y plane projection representation of the rotated box.

Temporarily includes https://github.com/qgis/QGIS/pull/53862