### PR TITLE
[themes] Fix combobox styling not reflecting the editable state

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -334,15 +334,6 @@ QComboBox::icon {
     padding-left:0.3em;
 }
 
-QComboBox:editable {
-    background-color: @darkgradient;
-}
-QComboBox:editable QLineEdit {
-    background-color: transparent;
-    color:@itembackground;
-    border: 0;
-}
-
 QComboBox QAbstractItemView, QComboBox QListView {
     border: none;
     border-radius: 0;
@@ -358,7 +349,20 @@ QComboBox::drop-down {
      width: 0.8em;
      border: 0px;
 }
-
+QComboBox::drop-down:editable {
+     subcontrol-origin: padding;
+     subcontrol-position: top right;
+     width: 0.8em;
+     background-color: @darkgradient;
+     color:@itembackground;
+     border-style: solid;
+     border: 1px solid @itembackground;
+     border-radius: 0.1em;
+}
+QComboBox::drop-down:editable:disabled {
+     background-color: transparent !important;
+     border-color: transparent !important;
+}
 QComboBox::down-arrow
 {
     image: url(@theme_path/icons/arrow-down.svg);
@@ -385,6 +389,18 @@ QComboBox::indicator {
     selection-background-color:transparent;
     color:transparent;
     selection-color:transparent;
+}
+
+QComboBox:editable {
+    padding: 0.12em;
+    border-width: 1px;
+    border-color: @itemdarkbackground;
+    border-style: solid;
+    border-radius: 0.2em;
+    background-color:@itembackground;
+    selection-background-color: @selection;
+    selection-color: @itemdarkbackground;
+    color: @text;
 }
 
 /* ==================================================================================== */

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -47,13 +47,13 @@ QMenuBar::item
 
 QMenuBar::item:selected
 {
-    background: @background;
+    background: @selection;
     color: @text;
 }
 
 QMenuBar::item:pressed
 {
-    background: @background;
+    background: @selection;
     color: @text;
 }
 
@@ -343,17 +343,6 @@ QComboBox::icon {
     padding-left:0.3em;
 }
 
-QComboBox:editable {
-    background-color: @darkgradient;
-}
-QComboBox:editable QLineEdit {
-    background-color: transparent;
-    color:@text;
-    selection-background-color: @selection;
-    selection-color: @text;
-    border: 0;
-}
-
 QComboBox QAbstractItemView, QComboBox QListView {
     border: none;
     border-radius: 0px;
@@ -369,7 +358,18 @@ QComboBox::drop-down {
      width: 0.8em;
      border: 0px;
 }
-
+QComboBox::drop-down:editable {
+     subcontrol-origin: padding;
+     subcontrol-position: top right;
+     width: 0.8em;
+     background-color: @darkgradient;
+     color:@itembackground;
+     border: 1px solid #888;
+}
+QComboBox::drop-down:editable:disabled {
+     background-color: transparent !important;
+     border-color: transparent !important;
+}
 QComboBox::down-arrow
 {
     image: url(@theme_path/icons/arrow-down.svg);
@@ -396,6 +396,15 @@ QComboBox::indicator {
     selection-background-color:transparent;
     color:transparent;
     selection-color:transparent;
+}
+
+QComboBox:editable {
+    padding: 0.12em;
+    border: 1px solid #111;
+    background-color: #888;
+    selection-background-color: @selection;
+    selection-color: @text;
+    color: #111;
 }
 
 /* ==================================================================================== */


### PR DESCRIPTION
## Description

Not sure why it took me 5 years to notice, but turns out our non-default themes didn't properly reflect the editable state of combobox widgets. This PR fixes that issue:

![image](https://github.com/qgis/QGIS/assets/1728657/88413b72-8ab7-46bf-a9fe-f62ab3529aca)

This provides a much better UX as users are instantly aware of what can be edited vs. a fixed list. E.g., the refactor alg:

![image](https://github.com/qgis/QGIS/assets/1728657/ae32c406-462b-463c-809b-381a1faaeda0)