### PR TITLE
Remove Move annotation tool (redundant with other annotation tools)

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -255,7 +255,6 @@
         <file>themes/default/mActionAlignTop.svg</file>
         <file>themes/default/mActionAlignVCenter.svg</file>
         <file>themes/default/mActionAllEdits.svg</file>
-        <file>themes/default/mActionAnnotation.svg</file>
         <file>themes/default/mActionArrowDown.svg</file>
         <file>themes/default/mActionArrowLeft.svg</file>
         <file>themes/default/mActionArrowRight.svg</file>

--- a/src/app/maptools/qgsappmaptools.cpp
+++ b/src/app/maptools/qgsappmaptools.cpp
@@ -76,7 +76,6 @@ QgsAppMapTools::QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockW
   mTools.insert( Tool::FormAnnotation, new QgsMapToolFormAnnotation( canvas ) );
   mTools.insert( Tool::HtmlAnnotation, new QgsMapToolHtmlAnnotation( canvas ) );
   mTools.insert( Tool::SvgAnnotation, new QgsMapToolSvgAnnotation( canvas ) );
-  mTools.insert( Tool::Annotation, new QgsMapToolAnnotation( canvas ) );
   mTools.insert( Tool::AddFeature, new QgsMapToolAddFeature( canvas, cadDock, QgsMapToolCapture::CaptureNone ) );
   mTools.insert( Tool::MoveFeature, new QgsMapToolMoveFeature( canvas, QgsMapToolMoveFeature::Move ) );
   mTools.insert( Tool::MoveFeatureCopy, new QgsMapToolMoveFeature( canvas, QgsMapToolMoveFeature::CopyMove ) );

--- a/src/app/maptools/qgsappmaptools.h
+++ b/src/app/maptools/qgsappmaptools.h
@@ -65,7 +65,7 @@ class QgsAppMapTools
       VertexToolActiveLayer,
       RotatePointSymbolsTool,
       OffsetPointSymbolTool,
-      Annotation,
+      Annotation, // Unused
       FormAnnotation,
       HtmlAnnotation,
       SvgAnnotation,

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2946,7 +2946,6 @@ void QgisApp::createActions()
   connect( mActionFormAnnotation, &QAction::triggered, this, &QgisApp::addFormAnnotation );
   connect( mActionHtmlAnnotation, &QAction::triggered, this, &QgisApp::addHtmlAnnotation );
   connect( mActionSvgAnnotation, &QAction::triggered, this, &QgisApp::addSvgAnnotation );
-  connect( mActionAnnotation, &QAction::triggered, this, &QgisApp::modifyAnnotation );
   connect( mActionLabeling, &QAction::triggered, this, &QgisApp::labeling );
   mStatisticalSummaryDockWidget->setToggleVisibilityAction( mActionStatisticalSummary );
   connect( mActionManage3DMapViews, &QAction::triggered, this, &QgisApp::show3DMapViewsManager );
@@ -3890,7 +3889,6 @@ void QgisApp::createToolBars()
   bt->addAction( mActionFormAnnotation );
   bt->addAction( mActionHtmlAnnotation );
   bt->addAction( mActionSvgAnnotation );
-  bt->addAction( mActionAnnotation );
 
   QAction *defAnnotationAction = mActionTextAnnotation;
   switch ( settings.value( QStringLiteral( "UI/annotationTool" ), 0 ).toInt() )
@@ -3906,9 +3904,6 @@ void QgisApp::createToolBars()
       break;
     case 3:
       defAnnotationAction = mActionSvgAnnotation;
-      break;
-    case 4:
-      defAnnotationAction = mActionAnnotation;
       break;
   }
   bt->setDefaultAction( defAnnotationAction );
@@ -4285,7 +4280,6 @@ void QgisApp::setTheme( const QString &themeName )
 #endif
   mActionAddAfsLayer->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddAfsLayer.svg" ) ) );
   mActionAddToOverview->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionInOverview.svg" ) ) );
-  mActionAnnotation->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAnnotation.svg" ) ) );
   mActionFormAnnotation->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFormAnnotation.svg" ) ) );
   mActionHtmlAnnotation->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionHtmlAnnotation.svg" ) ) );
   mActionSvgAnnotation->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSvgAnnotation.svg" ) ) );
@@ -4509,7 +4503,6 @@ void QgisApp::setupCanvasTools()
   mMapTools->mapTool( QgsAppMapTools::FormAnnotation )->setAction( mActionFormAnnotation );
   mMapTools->mapTool( QgsAppMapTools::HtmlAnnotation )->setAction( mActionHtmlAnnotation );
   mMapTools->mapTool( QgsAppMapTools::SvgAnnotation )->setAction( mActionSvgAnnotation );
-  mMapTools->mapTool( QgsAppMapTools::Annotation )->setAction( mActionAnnotation );
   mMapTools->mapTool( QgsAppMapTools::AddFeature )->setAction( mActionAddFeature );
   mMapTools->mapTool( QgsAppMapTools::MoveFeature )->setAction( mActionMoveFeature );
   mMapTools->mapTool( QgsAppMapTools::MoveFeatureCopy )->setAction( mActionMoveFeatureCopy );
@@ -7827,11 +7820,6 @@ void QgisApp::addTextAnnotation()
 void QgisApp::addSvgAnnotation()
 {
   mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::SvgAnnotation ) );
-}
-
-void QgisApp::modifyAnnotation()
-{
-  mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::Annotation ) );
 }
 
 void QgisApp::reprojectAnnotations()
@@ -16749,8 +16737,6 @@ void QgisApp::toolButtonActionTriggered( QAction *action )
     settings.setValue( QStringLiteral( "UI/annotationTool" ), 2 );
   else if ( action == mActionSvgAnnotation )
     settings.setValue( QStringLiteral( "UI/annotationTool" ), 3 );
-  else if ( action == mActionAnnotation )
-    settings.setValue( QStringLiteral( "UI/annotationTool" ), 4 );
   else if ( action == mActionNewSpatiaLiteLayer )
     settings.setValue( QStringLiteral( "UI/defaultNewLayer" ), 0 );
   else if ( action == mActionNewVectorLayer )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1930,7 +1930,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void addTextAnnotation();
     void addHtmlAnnotation();
     void addSvgAnnotation();
-    void modifyAnnotation();
     void reprojectAnnotations();
 
     //! Alerts user when commit errors occurred

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1524,18 +1524,6 @@ Shift+O to turn segments into straight or curve lines.</string>
     <string>Form Annotation</string>
    </property>
   </action>
-  <action name="mActionAnnotation">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionAnnotation.svg</normaloff>:/images/themes/default/mActionAnnotation.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Move Annotation</string>
-   </property>
-  </action>
   <action name="mActionLabeling">
    <property name="icon">
     <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
- Fixes #53777

## Description

The "balloon" move annotation map tool is pretty much useless. Each of the 4 other annotation tools (Text, Html, Form and Svg) are actually subclasses of the move annotation, and for the purpose of moving annotation around, they work just as well, making the basic tool redundant.

