### PR TITLE
Small additions to QgsBox3d and QgsOrientedBox3D API

### DIFF
--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -385,13 +385,13 @@ If the specified precision is less than 0, a suitable minimum precision is used.
 .. versionadded:: 3.34
 %End
 
-    QgsBox3d operator-( const QgsVector3D &v ) const;
+    QgsBox3D operator-( const QgsVector3D &v ) const;
 
-    QgsBox3d operator+( const QgsVector3D &v ) const;
+    QgsBox3D operator+( const QgsVector3D &v ) const;
 
-    QgsBox3d &operator-=( const QgsVector3D &v );
+    QgsBox3D &operator-=( const QgsVector3D &v );
 
-    QgsBox3d &operator+=( const QgsVector3D &v );
+    QgsBox3D &operator+=( const QgsVector3D &v );
 
 };
 

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsBox3D
 {
 %Docstring(signature="appended")
@@ -383,6 +384,14 @@ If the specified precision is less than 0, a suitable minimum precision is used.
 
 .. versionadded:: 3.34
 %End
+
+    QgsBox3d operator-( const QgsVector3D &v ) const;
+
+    QgsBox3d operator+( const QgsVector3D &v ) const;
+
+    QgsBox3d &operator-=( const QgsVector3D &v );
+
+    QgsBox3d &operator+=( const QgsVector3D &v );
 
 };
 

--- a/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
@@ -90,6 +90,22 @@ Returns the overall bounding box of the object.
 Returns an array of all corners as 3D vectors.
 %End
 
+    QgsVector3D size() const;
+%Docstring
+Returns size of sides of the box.
+%End
+
+    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const;
+%Docstring
+Reprojects corners of this box using the given coordinate transform
+and returns axis-aligned box containing reprojected corners.
+%End
+
+    QgsOrientedBox3D transformed( const QgsMatrix4x4 &tr ) const;
+%Docstring
+Returns box transformed by a 4x4 matrix.
+%End
+
 };
 
 

--- a/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
@@ -95,13 +95,15 @@ Returns an array of all corners as 3D vectors.
 Returns size of sides of the box.
 %End
 
-    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const;
+    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const throw( QgsCsException );
 %Docstring
-Reprojects corners of this box using the given coordinate transform
+Reprojects corners of this box using the given coordinate ``transform``
 and returns axis-aligned box containing reprojected corners.
+
+:raises QgsCsException: 
 %End
 
-    QgsOrientedBox3D transformed( const QgsMatrix4x4 &tr ) const;
+    QgsOrientedBox3D transformed( const QgsMatrix4x4 &transform ) const;
 %Docstring
 Returns box transformed by a 4x4 matrix.
 %End

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -18,6 +18,7 @@
 #include "qgsbox3d.h"
 #include "qgspoint.h"
 #include "qgslogger.h"
+#include "qgsvector3d.h"
 
 QgsBox3D::QgsBox3D( double xmin, double ymin, double zmin, double xmax, double ymax, double zmax, bool normalize )
   : mBounds2d( xmin, ymin, xmax, ymax, false )
@@ -301,4 +302,34 @@ QString QgsBox3D::toString( int precision ) const
   QgsDebugMsgLevel( QStringLiteral( "Extents : %1" ).arg( rep ), 4 );
 
   return rep;
+}
+
+QgsBox3d QgsBox3d::operator-( const QgsVector3D &v ) const
+{
+  return QgsBox3d( mBounds2d.xMinimum() - v.x(), mBounds2d.yMinimum() - v.y(), mZmin - v.z(),
+                   mBounds2d.xMaximum() - v.x(), mBounds2d.yMaximum() - v.y(), mZmax - v.z() );
+}
+
+QgsBox3d QgsBox3d::operator+( const QgsVector3D &v ) const
+{
+  return QgsBox3d( mBounds2d.xMinimum() + v.x(), mBounds2d.yMinimum() + v.y(), mZmin + v.z(),
+                   mBounds2d.xMaximum() + v.x(), mBounds2d.yMaximum() + v.y(), mZmax + v.z() );
+}
+
+QgsBox3d &QgsBox3d::operator-=( const QgsVector3D &v )
+{
+  mBounds2d.set( mBounds2d.xMinimum() - v.x(), mBounds2d.yMinimum() - v.y(),
+                 mBounds2d.xMaximum() - v.x(), mBounds2d.yMaximum() - v.y() );
+  mZmin -= v.z();
+  mZmax -= v.z();
+  return *this;
+}
+
+QgsBox3d &QgsBox3d::operator+=( const QgsVector3D &v )
+{
+  mBounds2d.set( mBounds2d.xMinimum() + v.x(), mBounds2d.yMinimum() + v.y(),
+                 mBounds2d.xMaximum() + v.x(), mBounds2d.yMaximum() + v.y() );
+  mZmin += v.z();
+  mZmax += v.z();
+  return *this;
 }

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -304,19 +304,19 @@ QString QgsBox3D::toString( int precision ) const
   return rep;
 }
 
-QgsBox3d QgsBox3d::operator-( const QgsVector3D &v ) const
+QgsBox3D QgsBox3D::operator-( const QgsVector3D &v ) const
 {
-  return QgsBox3d( mBounds2d.xMinimum() - v.x(), mBounds2d.yMinimum() - v.y(), mZmin - v.z(),
+  return QgsBox3D( mBounds2d.xMinimum() - v.x(), mBounds2d.yMinimum() - v.y(), mZmin - v.z(),
                    mBounds2d.xMaximum() - v.x(), mBounds2d.yMaximum() - v.y(), mZmax - v.z() );
 }
 
-QgsBox3d QgsBox3d::operator+( const QgsVector3D &v ) const
+QgsBox3D QgsBox3D::operator+( const QgsVector3D &v ) const
 {
-  return QgsBox3d( mBounds2d.xMinimum() + v.x(), mBounds2d.yMinimum() + v.y(), mZmin + v.z(),
+  return QgsBox3D( mBounds2d.xMinimum() + v.x(), mBounds2d.yMinimum() + v.y(), mZmin + v.z(),
                    mBounds2d.xMaximum() + v.x(), mBounds2d.yMaximum() + v.y(), mZmax + v.z() );
 }
 
-QgsBox3d &QgsBox3d::operator-=( const QgsVector3D &v )
+QgsBox3D &QgsBox3D::operator-=( const QgsVector3D &v )
 {
   mBounds2d.set( mBounds2d.xMinimum() - v.x(), mBounds2d.yMinimum() - v.y(),
                  mBounds2d.xMaximum() - v.x(), mBounds2d.yMaximum() - v.y() );
@@ -325,7 +325,7 @@ QgsBox3d &QgsBox3d::operator-=( const QgsVector3D &v )
   return *this;
 }
 
-QgsBox3d &QgsBox3d::operator+=( const QgsVector3D &v )
+QgsBox3D &QgsBox3D::operator+=( const QgsVector3D &v )
 {
   mBounds2d.set( mBounds2d.xMinimum() + v.x(), mBounds2d.yMinimum() + v.y(),
                  mBounds2d.xMaximum() + v.x(), mBounds2d.yMaximum() + v.y() );

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -388,25 +388,25 @@ class CORE_EXPORT QgsBox3D
      * Returns a box offset from this one in the direction of the reversed vector.
      * \since QGIS 3.34
      */
-    QgsBox3d operator-( const QgsVector3D &v ) const;
+    QgsBox3D operator-( const QgsVector3D &v ) const;
 
     /**
      * Returns a box offset from this one in the direction of the vector.
      * \since QGIS 3.34
      */
-    QgsBox3d operator+( const QgsVector3D &v ) const;
+    QgsBox3D operator+( const QgsVector3D &v ) const;
 
     /**
      * Moves this box in the direction of the reversed vector.
      * \since QGIS 3.34
      */
-    QgsBox3d &operator-=( const QgsVector3D &v );
+    QgsBox3D &operator-=( const QgsVector3D &v );
 
     /**
      * Moves this box in the direction of the vector.
      * \since QGIS 3.34
      */
-    QgsBox3d &operator+=( const QgsVector3D &v );
+    QgsBox3D &operator+=( const QgsVector3D &v );
 
   private:
 

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -25,6 +25,8 @@
 
 #include "qgspoint.h"
 
+class QgsVector3D;
+
 /**
  * \ingroup core
  * \brief A 3-dimensional box composed of x, y, z coordinates.
@@ -381,6 +383,30 @@ class CORE_EXPORT QgsBox3D
      * \since QGIS 3.34
      */
     QString toString( int precision = 16 ) const;
+
+    /**
+     * Returns a box offset from this one in the direction of the reversed vector.
+     * \since QGIS 3.34
+     */
+    QgsBox3d operator-( const QgsVector3D &v ) const;
+
+    /**
+     * Returns a box offset from this one in the direction of the vector.
+     * \since QGIS 3.34
+     */
+    QgsBox3d operator+( const QgsVector3D &v ) const;
+
+    /**
+     * Moves this box in the direction of the reversed vector.
+     * \since QGIS 3.34
+     */
+    QgsBox3d &operator-=( const QgsVector3D &v );
+
+    /**
+     * Moves this box in the direction of the vector.
+     * \since QGIS 3.34
+     */
+    QgsBox3d &operator+=( const QgsVector3D &v );
 
   private:
 

--- a/src/core/geometry/qgsorientedbox3d.cpp
+++ b/src/core/geometry/qgsorientedbox3d.cpp
@@ -134,9 +134,9 @@ QgsOrientedBox3D QgsOrientedBox3D::transformed( const QgsMatrix4x4 &transform ) 
 {
   const double *ptr = transform.constData();
   const QgsMatrix4x4 mm( ptr[0], ptr[4], ptr[8], 0,
-                   ptr[1], ptr[5], ptr[9], 0,
-                   ptr[2], ptr[6], ptr[10], 0,
-                   0, 0, 0, 1 );
+                         ptr[1], ptr[5], ptr[9], 0,
+                         ptr[2], ptr[6], ptr[10], 0,
+                         0, 0, 0, 1 );
 
   const QgsVector3D trCenter = transform.map( QgsVector3D( mCenter[0], mCenter[1], mCenter[2] ) );
 

--- a/src/core/geometry/qgsorientedbox3d.cpp
+++ b/src/core/geometry/qgsorientedbox3d.cpp
@@ -108,9 +108,10 @@ QgsVector3D QgsOrientedBox3D::size() const
 
 QgsBox3D QgsOrientedBox3D::reprojectedExtent( const QgsCoordinateTransform &ct ) const
 {
-  // reproject corners from ECEF to planar CRS
+  // reproject corners to destination CRS
   QVector<QgsVector3D> c = corners();
-  for ( int i = 0; i < c.count(); ++i )
+  Q_ASSERT( c.count() == 8 );
+  for ( int i = 0; i < 8; ++i )
   {
     c[i] = ct.transform( c[i] );
   }
@@ -129,19 +130,19 @@ QgsBox3D QgsOrientedBox3D::reprojectedExtent( const QgsCoordinateTransform &ct )
   return QgsBox3D( v0.x(), v0.y(), v0.z(), v1.x(), v1.y(), v1.z() );
 }
 
-QgsOrientedBox3D QgsOrientedBox3D::transformed( const QgsMatrix4x4 &tr ) const
+QgsOrientedBox3D QgsOrientedBox3D::transformed( const QgsMatrix4x4 &transform ) const
 {
-  const double *ptr = tr.constData();
-  QgsMatrix4x4 mm( ptr[0], ptr[4], ptr[8], 0,
+  const double *ptr = transform.constData();
+  const QgsMatrix4x4 mm( ptr[0], ptr[4], ptr[8], 0,
                    ptr[1], ptr[5], ptr[9], 0,
                    ptr[2], ptr[6], ptr[10], 0,
                    0, 0, 0, 1 );
 
-  QgsVector3D trCenter = tr.map( QgsVector3D( mCenter[0], mCenter[1], mCenter[2] ) );
+  const QgsVector3D trCenter = transform.map( QgsVector3D( mCenter[0], mCenter[1], mCenter[2] ) );
 
-  QgsVector3D col1 = mm.map( QgsVector3D( mHalfAxes[0], mHalfAxes[1], mHalfAxes[2] ) );
-  QgsVector3D col2 = mm.map( QgsVector3D( mHalfAxes[3], mHalfAxes[4], mHalfAxes[5] ) );
-  QgsVector3D col3 = mm.map( QgsVector3D( mHalfAxes[6], mHalfAxes[7], mHalfAxes[8] ) );
+  const QgsVector3D col1 = mm.map( QgsVector3D( mHalfAxes[0], mHalfAxes[1], mHalfAxes[2] ) );
+  const QgsVector3D col2 = mm.map( QgsVector3D( mHalfAxes[3], mHalfAxes[4], mHalfAxes[5] ) );
+  const QgsVector3D col3 = mm.map( QgsVector3D( mHalfAxes[6], mHalfAxes[7], mHalfAxes[8] ) );
 
   return QgsOrientedBox3D( QList<double>() << trCenter.x() << trCenter.y() << trCenter.z(),
                            QList<double>() << col1.x() << col1.y() << col1.z()

--- a/src/core/geometry/qgsorientedbox3d.h
+++ b/src/core/geometry/qgsorientedbox3d.h
@@ -27,6 +27,8 @@
 #include <limits>
 
 class QgsBox3D;
+class QgsCoordinateTransform;
+class QgsMatrix4x4;
 class QgsVector3D;
 
 /**
@@ -121,6 +123,22 @@ class CORE_EXPORT QgsOrientedBox3D
      * Returns an array of all corners as 3D vectors.
      */
     QVector< QgsVector3D > corners() const;
+
+    /**
+     * Returns size of sides of the box.
+     */
+    QgsVector3D size() const;
+
+    /**
+     * Reprojects corners of this box using the given coordinate transform
+     * and returns axis-aligned box containing reprojected corners.
+     */
+    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const;
+
+    /**
+     * Returns box transformed by a 4x4 matrix.
+     */
+    QgsOrientedBox3D transformed( const QgsMatrix4x4 &tr ) const;
 
   private:
 

--- a/src/core/geometry/qgsorientedbox3d.h
+++ b/src/core/geometry/qgsorientedbox3d.h
@@ -130,15 +130,16 @@ class CORE_EXPORT QgsOrientedBox3D
     QgsVector3D size() const;
 
     /**
-     * Reprojects corners of this box using the given coordinate transform
+     * Reprojects corners of this box using the given coordinate \a transform
      * and returns axis-aligned box containing reprojected corners.
+     * \throws QgsCsException
      */
-    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const;
+    QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const SIP_THROW( QgsCsException );
 
     /**
      * Returns box transformed by a 4x4 matrix.
      */
-    QgsOrientedBox3D transformed( const QgsMatrix4x4 &tr ) const;
+    QgsOrientedBox3D transformed( const QgsMatrix4x4 &transform ) const;
 
   private:
 

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -13,7 +13,7 @@ import sys
 
 import qgis  # NOQA
 
-from qgis.core import QgsBox3d, QgsPoint, QgsRectangle
+from qgis.core import QgsBox3d, QgsPoint, QgsRectangle, QgsVector3D
 from qgis.testing import unittest
 
 
@@ -401,6 +401,41 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(
             box3.toString(3),
             "1.452,2.854,3.349 : 4.655,5.548,6.457")
+
+    def testMove(self):
+        box1 = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)
+
+        box1a = box1 + QgsVector3D(1, 2, 3)
+        self.assertEqual(box1a.xMinimum(), 6.0)
+        self.assertEqual(box1a.yMinimum(), 8.0)
+        self.assertEqual(box1a.zMinimum(), 10.0)
+        self.assertEqual(box1a.xMaximum(), 12.0)
+        self.assertEqual(box1a.yMaximum(), 15.0)
+        self.assertEqual(box1a.zMaximum(), 18.0)
+
+        box1b = box1 - QgsVector3D(1, 2, 3)
+        self.assertEqual(box1b.xMinimum(), 4.0)
+        self.assertEqual(box1b.yMinimum(), 4.0)
+        self.assertEqual(box1b.zMinimum(), 4.0)
+        self.assertEqual(box1b.xMaximum(), 10.0)
+        self.assertEqual(box1b.yMaximum(), 11.0)
+        self.assertEqual(box1b.zMaximum(), 12.0)
+
+        box1a += QgsVector3D(10., 20., 30.)
+        self.assertEqual(box1a.xMinimum(), 16.0)
+        self.assertEqual(box1a.yMinimum(), 28.0)
+        self.assertEqual(box1a.zMinimum(), 40.0)
+        self.assertEqual(box1a.xMaximum(), 22.0)
+        self.assertEqual(box1a.yMaximum(), 35.0)
+        self.assertEqual(box1a.zMaximum(), 48.0)
+
+        box1a -= QgsVector3D(10., 20., 30.)
+        self.assertEqual(box1a.xMinimum(), 6.0)
+        self.assertEqual(box1a.yMinimum(), 8.0)
+        self.assertEqual(box1a.zMinimum(), 10.0)
+        self.assertEqual(box1a.xMaximum(), 12.0)
+        self.assertEqual(box1a.yMaximum(), 15.0)
+        self.assertEqual(box1a.zMaximum(), 18.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A couple of utility functions that will be useful when dealing with 3D Tiles:

- operators to move QgsBox3d by a QgsVector3D
- reproject QgsOrientedBox3D and get its axis-aligned bounding box
- get length of sides of QgsOrientedBox3D
- transform QgsOrientedBox3D with a QgsMatrix4x4
