### PR TITLE
Fix contributors.json commit date

### DIFF
--- a/resources/data/contributors.json
+++ b/resources/data/contributors.json
@@ -560,7 +560,7 @@
         "Name": "Luiz Motta",
         "Committer": "No",
         "GIT Nickname": "lmotta",
-        "First Commit Date": 2010
+        "First Commit Date": "2010"
       },
       "geometry": {
         "type": "Point",


### PR DESCRIPTION
## Description

Having mixed type in the `First Commit Date` field makes QGIS consider all commit dates as NULL

![image](https://github.com/qgis/QGIS/assets/9693475/f9b3fe59-56c2-472a-b13b-619dd9b75995)

![image](https://github.com/qgis/QGIS/assets/9693475/4b4728d4-01cc-414d-8ab0-c9f9c3e2ed01)
