### PR TITLE
"Sticky" Decorations

### DIFF
--- a/python/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/core/auto_generated/qgsmapdecoration.sip.in
@@ -42,6 +42,14 @@ Returns the map decoration display name.
 .. versionadded:: 3.14
 %End
 
+    virtual bool hasFixedMapPosition() const;
+%Docstring
+Returns ``True`` if the decoration is attached to a fixed map position (e.g title, north arrow), or
+``False`` if the annotation uses a position relative to the current map extent (e.g. grid, layout extent)
+
+.. versionadded:: 3.34
+%End
+
   protected:
 
     void setDisplayName( const QString &name );

--- a/python/core/auto_generated/qgsmapdecoration.sip.in
+++ b/python/core/auto_generated/qgsmapdecoration.sip.in
@@ -44,8 +44,8 @@ Returns the map decoration display name.
 
     virtual bool hasFixedMapPosition() const;
 %Docstring
-Returns ``True`` if the decoration is attached to a fixed map position (e.g title, north arrow), or
-``False`` if the annotation uses a position relative to the current map extent (e.g. grid, layout extent)
+Returns ``True`` if the decoration is attached to a fixed map position (e.g grid, layout extent), or
+``False`` if the annotation uses a position relative to the map canvas (e.g. title, copyright...)
 
 .. versionadded:: 3.34
 %End

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -127,6 +127,7 @@ set(QGIS_APP_SRCS
   decorations/qgsdecorationscalebardialog.cpp
   decorations/qgsdecorationgrid.cpp
   decorations/qgsdecorationgriddialog.cpp
+  decorations/qgsdecorationoverlay.cpp
 
   pointcloud/qgspointcloudelevationpropertieswidget.cpp
   pointcloud/qgspointcloudlayerproperties.cpp

--- a/src/app/decorations/qgsdecorationgrid.cpp
+++ b/src/app/decorations/qgsdecorationgrid.cpp
@@ -421,10 +421,10 @@ int QgsDecorationGrid::xGridLines( const QgsMapSettings &mapSettings, QList< QPa
 
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
 
-  // draw nothing if the distance between grid lines would be less than 1px
+  // draw nothing if the distance between grid lines would be less than 5px
   // otherwise the grid lines would completely cover the whole map
   //if ( mapBoundingRect.height() / mGridIntervalY >= p->device()->height() )
-  if ( mGridIntervalY / mapSettings.mapUnitsPerPixel() < 1 )
+  if ( mGridIntervalY / mapSettings.mapUnitsPerPixel() < 5 )
     return 1;
 
   const QPolygonF canvasPoly = mapSettings.visiblePolygon();
@@ -466,10 +466,10 @@ int QgsDecorationGrid::yGridLines( const QgsMapSettings &mapSettings, QList< QPa
 
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
 
-  // draw nothing if the distance between grid lines would be less than 1px
-  // otherwise the grid lines would completely cover the whole map
+  // draw nothing if the distance between grid lines would be less than 5px
+  // otherwise the grid lines would render the whole map illegible
   //if ( mapBoundingRect.height() / mGridIntervalY >= p->device()->height() )
-  if ( mGridIntervalX / mapSettings.mapUnitsPerPixel() < 1 )
+  if ( mGridIntervalX / mapSettings.mapUnitsPerPixel() < 5 )
     return 1;
 
   const QPolygonF canvasPoly = mapSettings.visiblePolygon();

--- a/src/app/decorations/qgsdecorationgrid.h
+++ b/src/app/decorations/qgsdecorationgrid.h
@@ -137,6 +137,8 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     //! Computes interval from current raster layer
     bool getIntervalFromCurrentLayer( double *values ) const;
 
+    bool hasFixedMapPosition() const override { return false; }
+
   public slots:
     //! Sets values on the gui when a project is read or the gui first loaded
     void projectRead() override;

--- a/src/app/decorations/qgsdecorationgrid.h
+++ b/src/app/decorations/qgsdecorationgrid.h
@@ -137,7 +137,7 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     //! Computes interval from current raster layer
     bool getIntervalFromCurrentLayer( double *values ) const;
 
-    bool hasFixedMapPosition() const override { return false; }
+    bool hasFixedMapPosition() const override { return true; }
 
   public slots:
     //! Sets values on the gui when a project is read or the gui first loaded

--- a/src/app/decorations/qgsdecorationlayoutextent.h
+++ b/src/app/decorations/qgsdecorationlayoutextent.h
@@ -82,6 +82,8 @@ class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
      */
     void setLabelExtents( bool labelExtents );
 
+    bool hasFixedMapPosition() const override { return false; }
+
   public slots:
     void projectRead() override;
     void saveToProject() override;

--- a/src/app/decorations/qgsdecorationlayoutextent.h
+++ b/src/app/decorations/qgsdecorationlayoutextent.h
@@ -82,7 +82,7 @@ class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
      */
     void setLabelExtents( bool labelExtents );
 
-    bool hasFixedMapPosition() const override { return false; }
+    bool hasFixedMapPosition() const override { return true; }
 
   public slots:
     void projectRead() override;

--- a/src/app/decorations/qgsdecorationoverlay.cpp
+++ b/src/app/decorations/qgsdecorationoverlay.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+                         qgsdecorationoverlay.cpp
+                         ----------------------
+    begin                : July 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationoverlay.h"
+#include "qgsmapdecoration.h"
+#include "qgsmapcanvas.h"
+#include "qgisapp.h"
+
+#include <QPainter>
+
+QgsDecorationOverlay::QgsDecorationOverlay( QWidget *parent )
+  : QWidget( parent )
+{
+  // Make the overlay transparent
+  setAttribute( Qt::WA_NoSystemBackground );
+
+  // Make the overlay transparent for mouse events
+  setAttribute( Qt::WA_TransparentForMouseEvents );
+
+  // Install the event filter to catch resize events
+  parent->installEventFilter( this );
+}
+
+
+void QgsDecorationOverlay::paintEvent( QPaintEvent * )
+{
+  QPainter p( this );
+
+  QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
+  context.setPainter( &p );
+
+  for ( QgsMapDecoration *item : QgisApp::instance()->activeDecorations() )
+  {
+    // Render only decorations with fixed map position
+    // other items are rendered directly on the map canvas
+    if ( !item->hasFixedMapPosition() )
+      continue;
+    item->render( QgisApp::instance()->mapCanvas()->mapSettings(), context );
+  }
+}
+
+bool QgsDecorationOverlay::eventFilter( QObject *obj, QEvent *event )
+{
+  // Resize the overlay to match the parent widget
+  if ( event->type() == QEvent::Resize )
+  {
+    resize( parentWidget()->size() );
+  }
+  return QWidget::eventFilter( obj, event );
+}

--- a/src/app/decorations/qgsdecorationoverlay.cpp
+++ b/src/app/decorations/qgsdecorationoverlay.cpp
@@ -46,9 +46,8 @@ void QgsDecorationOverlay::paintEvent( QPaintEvent * )
 
   for ( QgsMapDecoration *item : QgisApp::instance()->activeDecorations() )
   {
-    // Render only decorations with fixed map position
-    // other items are rendered directly on the map canvas
-    if ( !item->hasFixedMapPosition() )
+    // Do not render decorations with fixed map positionn they are rendered directly on the map canvas
+    if ( item->hasFixedMapPosition() )
       continue;
     item->render( QgisApp::instance()->mapCanvas()->mapSettings(), context );
   }

--- a/src/app/decorations/qgsdecorationoverlay.cpp
+++ b/src/app/decorations/qgsdecorationoverlay.cpp
@@ -39,12 +39,16 @@ QgsDecorationOverlay::QgsDecorationOverlay( QWidget *parent )
 
 void QgsDecorationOverlay::paintEvent( QPaintEvent * )
 {
+  const QList< QgsMapDecoration * > decorations = QgisApp::instance()->activeDecorations();
+  if ( decorations.empty() )
+    return;
+
   QPainter p( this );
 
   QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
   context.setPainter( &p );
 
-  for ( QgsMapDecoration *item : QgisApp::instance()->activeDecorations() )
+  for ( QgsMapDecoration *item : decorations )
   {
     // Do not render decorations with fixed map positionn they are rendered directly on the map canvas
     if ( item->hasFixedMapPosition() )

--- a/src/app/decorations/qgsdecorationoverlay.h
+++ b/src/app/decorations/qgsdecorationoverlay.h
@@ -1,0 +1,34 @@
+/***************************************************************************
+                         qgsdecorationoverlay.h
+                         ----------------------
+    begin                : July 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONOVERLAY_H
+#define QGSDECORATIONOVERLAY_H
+
+
+#include <QWidget>
+
+class QgsDecorationOverlay : public QWidget
+{
+    Q_OBJECT
+  public:
+    QgsDecorationOverlay( QWidget *parent );
+    void paintEvent( QPaintEvent *e ) override;
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+};
+
+
+#endif

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -244,6 +244,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsdecorationscalebar.h"
 #include "qgsdecorationgrid.h"
 #include "qgsdecorationlayoutextent.h"
+#include "qgsdecorationoverlay.h"
 #include "qgserror.h"
 #include "qgseventtracing.h"
 #include "qgsexception.h"
@@ -5123,6 +5124,10 @@ void QgisApp::createDecorations()
   addDecorationItem( decorationNorthArrow );
   addDecorationItem( decorationScaleBar );
   addDecorationItem( decorationLayoutExtent );
+
+  // Add buffer on which decorations are rendered
+  QgsDecorationOverlay *bufferWidget = new QgsDecorationOverlay( mMapCanvas->viewport() );
+
   connect( mMapCanvas, &QgsMapCanvas::renderComplete, this, &QgisApp::renderDecorationItems );
   connect( this, &QgisApp::newProject, this, &QgisApp::projectReadDecorationItems );
   connect( this, &QgisApp::projectRead, this, &QgisApp::projectReadDecorationItems );
@@ -5136,8 +5141,14 @@ void QgisApp::renderDecorationItems( QPainter *p )
   const auto constMDecorationItems = mDecorationItems;
   for ( QgsDecorationItem *item : constMDecorationItems )
   {
+    // Items with fixed map position are rendered on the overlay
+    if ( item->hasFixedMapPosition() )
+      continue;
     item->render( mMapCanvas->mapSettings(), context );
   }
+
+  // Update the decoration overlay
+  findChild<QgsDecorationOverlay *>()->update();
 }
 
 void QgisApp::projectReadDecorationItems()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5142,7 +5142,7 @@ void QgisApp::renderDecorationItems( QPainter *p )
   for ( QgsDecorationItem *item : constMDecorationItems )
   {
     // Items with fixed map position are rendered on the overlay
-    if ( item->hasFixedMapPosition() )
+    if ( !item->hasFixedMapPosition() )
       continue;
     item->render( mMapCanvas->mapSettings(), context );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5095,6 +5095,9 @@ void QgisApp::setMapTipsDelay( int timerInterval )
 
 void QgisApp::createDecorations()
 {
+  // Add buffer on which decorations are rendered
+  mDecorationOverlay = new QgsDecorationOverlay( mMapCanvas->viewport() );
+
   QgsDecorationTitle *decorationTitle = new QgsDecorationTitle( this );
   connect( mActionDecorationTitle, &QAction::triggered, decorationTitle, &QgsDecorationTitle::run );
 
@@ -5125,9 +5128,6 @@ void QgisApp::createDecorations()
   addDecorationItem( decorationScaleBar );
   addDecorationItem( decorationLayoutExtent );
 
-  // Add buffer on which decorations are rendered
-  QgsDecorationOverlay *bufferWidget = new QgsDecorationOverlay( mMapCanvas->viewport() );
-
   connect( mMapCanvas, &QgsMapCanvas::renderComplete, this, &QgisApp::renderDecorationItems );
   connect( this, &QgisApp::newProject, this, &QgisApp::projectReadDecorationItems );
   connect( this, &QgisApp::projectRead, this, &QgisApp::projectReadDecorationItems );
@@ -5148,7 +5148,7 @@ void QgisApp::renderDecorationItems( QPainter *p )
   }
 
   // Update the decoration overlay
-  findChild<QgsDecorationOverlay *>()->update();
+  mDecorationOverlay->update();
 }
 
 void QgisApp::projectReadDecorationItems()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -130,6 +130,7 @@ class QgsTemporalControllerDockWidget;
 
 class QgsMapDecoration;
 class QgsDecorationItem;
+class QgsDecorationOverlay;
 class QgsMessageLogViewer;
 class QgsMessageBar;
 class QgsMessageBarItem;
@@ -2593,6 +2594,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsTileScaleWidget *mpTileScaleWidget = nullptr;
 
     QList<QgsDecorationItem *> mDecorationItems;
+    QgsDecorationOverlay *mDecorationOverlay = nullptr;
 
     //! Persistent GPS toolbox
     QgsAppGpsConnection *mGpsConnection = nullptr;

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -55,11 +55,11 @@ class CORE_EXPORT QgsMapDecoration
     const QString displayName() const { return mDisplayName; }
 
     /**
-     * Returns TRUE if the decoration is attached to a fixed map position (e.g title, north arrow), or
-     * FALSE if the annotation uses a position relative to the current map extent (e.g. grid, layout extent)
+     * Returns TRUE if the decoration is attached to a fixed map position (e.g grid, layout extent), or
+     * FALSE if the annotation uses a position relative to the map canvas (e.g. title, copyright...)
      * \since QGIS 3.34
      */
-    virtual bool hasFixedMapPosition() const { return true; }
+    virtual bool hasFixedMapPosition() const { return false; }
 
   protected:
 

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -54,6 +54,13 @@ class CORE_EXPORT QgsMapDecoration
      */
     const QString displayName() const { return mDisplayName; }
 
+    /**
+     * Returns TRUE if the decoration is attached to a fixed map position (e.g title, north arrow), or
+     * FALSE if the annotation uses a position relative to the current map extent (e.g. grid, layout extent)
+     * \since QGIS 3.34
+     */
+    virtual bool hasFixedMapPosition() const { return true; }
+
   protected:
 
     /**


### PR DESCRIPTION
- Fixes #48518

## Description

- Add a `hasFixedMapPosition` member function to `QgsMapDecoration`
- "Non Fixed" decorations are no longer rendered directly on the map canvas, but are instead rendered on a transparent overlay

### Demonstration

![decorations](https://github.com/qgis/QGIS/assets/9693475/836c72f7-2fc5-4d03-a15f-155906998db4)


_Note: A similar approach could be applied to #25290_
