### PR TITLE
Don't segmentize digitized feature if the layer supports curves

### DIFF
--- a/src/gui/maptools/qgsmaptoolcapturelayergeometry.cpp
+++ b/src/gui/maptools/qgsmaptoolcapturelayergeometry.cpp
@@ -37,11 +37,9 @@ void QgsMapToolCaptureLayerGeometry::geometryCaptured( const QgsGeometry &geomet
       break;
     case QgsMapToolCapture::CaptureLine:
     case QgsMapToolCapture::CapturePolygon:
-      //does compoundcurve contain circular strings?
       //does provider support circular strings?
-      const bool hasCurvedSegments = captureCurve()->hasCurvedSegments();
       const bool providerSupportsCurvedSegments = vlayer && ( vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::CircularGeometries );
-      if ( !hasCurvedSegments || !providerSupportsCurvedSegments )
+      if ( !providerSupportsCurvedSegments )
         g = QgsGeometry( g.constGet()->segmentize() );
 
       QList<QgsVectorLayer *>  avoidIntersectionsLayers;

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -271,7 +271,7 @@ void TestQgsMapToolAddFeatureLine::testNoTracing()
   QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( "LineString ((1 1, 3 2))" ) );
+  QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( "CompoundCurve ((1 1, 3 2))" ) );
 
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
@@ -333,7 +333,7 @@ void TestQgsMapToolAddFeatureLine::testTracing()
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( "LineString(1 1, 2 1, 3 2)" ) );
+  QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( "CompoundCurve ((1 1, 2 1, 3 2))" ) );
 
   mLayerLine->undoStack()->undo();
 
@@ -351,7 +351,7 @@ void TestQgsMapToolAddFeatureLine::testTracing()
   const QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
-  QCOMPARE( mLayerLine->getFeature( newFid2 ).geometry(), QgsGeometry::fromWkt( "LineString(0 2, 1 1, 2 1, 3 2, 4 1)" ) );
+  QCOMPARE( mLayerLine->getFeature( newFid2 ).geometry(), QgsGeometry::fromWkt( "CompoundCurve ((0 2, 1 1, 2 1, 3 2, 4 1))" ) );
 
   mLayerLine->undoStack()->undo();
 
@@ -391,7 +391,7 @@ void TestQgsMapToolAddFeatureLine::testTracingWithTransform()
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
   QCOMPARE( lineLayer3857->undoStack()->index(), 1 );
-  QCOMPARE( lineLayer3857->getFeature( newFid ).geometry().asWkt( -3 ), QStringLiteral( "LineString (-841000 6406000, -841000 6406000, -841000 6406000)" ) );
+  QCOMPARE( lineLayer3857->getFeature( newFid ).geometry().asWkt( -3 ), QStringLiteral( "CompoundCurve ((-841000 6406000, -841000 6406000, -841000 6406000))" ) );
 
   lineLayer3857->undoStack()->undo();
 
@@ -409,7 +409,7 @@ void TestQgsMapToolAddFeatureLine::testTracingWithTransform()
   const QgsFeatureId newFid2 = utils.newFeatureId( oldFids );
 
   QCOMPARE( lineLayer3857->undoStack()->index(), 1 );
-  QCOMPARE( lineLayer3857->getFeature( newFid2 ).geometry().asWkt( -3 ), QStringLiteral( "LineString (-841000 6406000, -841000 6406000, -841000 6406000, -841000 6406000, -841000 6406000, -841000 6406000)" ) );
+  QCOMPARE( lineLayer3857->getFeature( newFid2 ).geometry().asWkt( -3 ), QStringLiteral( "CompoundCurve ((-841000 6406000, -841000 6406000),(-841000 6406000, -841000 6406000, -841000 6406000),(-841000 6406000, -841000 6406000))" ) );
 
   mEnableTracingAction->setChecked( false );
   mCanvas->setCurrentLayer( mLayerLine );
@@ -703,7 +703,7 @@ void TestQgsMapToolAddFeatureLine::testLineString()
 
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  const QString wkt = "LineString(5 6.5, 6.25 6.5, 6.75 6.5, 7.25 6.5, 7.5 6.5)";
+  const QString wkt = "CompoundCurve ((5 6.5, 6.25 6.5, 6.75 6.5, 7.25 6.5, 7.5 6.5))";
   QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();
@@ -788,7 +788,7 @@ void TestQgsMapToolAddFeatureLine::testStream()
 
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  const QString wkt = "LineString (5 6.5, 6.25 6.5, 6.75 6.5, 7 6.59375, 7.09375 6.703125, 7.203125 6.59375, 7.296875 6.5, 7.5 6.90625, 7.59375 6.296875, 7.5 5, 7.40625 5, 7.296875 5.09375, 7.203125 5, 7.09375 4.90625)";
+  const QString wkt = "CompoundCurve ((5 6.5, 6.25 6.5, 6.75 6.5),(6.75 6.5, 7 6.59375, 7.09375 6.703125, 7.203125 6.59375, 7.296875 6.5, 7.5 6.90625, 7.59375 6.296875),(7.59375 6.296875, 7.5 5),(7.5 5, 7.40625 5, 7.296875 5.09375, 7.203125 5, 7.09375 4.90625))";
   QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();
@@ -922,7 +922,7 @@ void TestQgsMapToolAddFeatureLine::testStreamTolerance()
 
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  const QString wkt = "LineString(5 6.5, 6.25 6.5, 6.75 6.5, 7 6.59375, 7.203125 6.59375, 7.5 6.90625, 7.59375 6.296875, 7.5 5, 7.296875 5.09375, 7.09375 4.90625)";
+  const QString wkt = "CompoundCurve ((5 6.5, 6.25 6.5, 6.75 6.5),(6.75 6.5, 7 6.59375, 7.203125 6.59375, 7.5 6.90625, 7.59375 6.296875),(7.59375 6.296875, 7.5 5),(7.5 5, 7.296875 5.09375, 7.09375 4.90625))";
   QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();


### PR DESCRIPTION
## Description

Fixes #53818 

This fixes a behavior that happens after finishing digitizing a polygon feature (after right click), but before the feature is saved in the layer (save button, to commit the change).

At that moment, on a CurvePolygon Layer, using the vertex tool to convert a vertex into a curve vertex always results in a segmentized curve.

![image](https://github.com/qgis/QGIS/assets/34267385/9b13b5ce-8115-463b-b325-759bf724103d)

![image](https://github.com/qgis/QGIS/assets/34267385/afe7f4b1-6c14-474c-ad16-b985f7215b3b)

Now, the digitized polygon, if no curve is part of it, is only segmentized if the layer type does not support curves.

---

Funded by Métropole de Lille