### PR TITLE
Fix label movement for lines when x/y placement is already active

### DIFF
--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -264,6 +264,8 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
       const bool isMovableUsingLineAnchor = labelAnchorPercentMovable( vlayer, mCurrentLabel.settings, lineAnchorPercentCol, lineAnchorClippingCol, lineAnchorTypeCol, lineAnchorTextPointCol );
 
       bool useLineAnchor = false;
+      // cloned branches are intentional here for improved readability
+      // NOLINTBEGIN(bugprone-branch-clone)
       if ( isCurvedOrLine )
       {
         if ( isMovableUsingLineAnchor )
@@ -273,6 +275,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
         else
           useLineAnchor = true;
       }
+      // NOLINTEND(bugprone-branch-clone)
 
       if ( useLineAnchor && !mCurrentLabel.pos.isDiagram && !isMovableUsingLineAnchor )
       {

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -260,8 +260,21 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
       }
 
       const bool isCurvedOrLine = mCurrentLabel.settings.placement == Qgis::LabelPlacement::Curved || mCurrentLabel.settings.placement == Qgis::LabelPlacement::PerimeterCurved || mCurrentLabel.settings.placement == Qgis::LabelPlacement::Line;
+      const bool isMovableUsingPoint = labelMoveable( vlayer, mCurrentLabel.settings, xCol, yCol, pointCol );
+      const bool isMovableUsingLineAnchor = labelAnchorPercentMovable( vlayer, mCurrentLabel.settings, lineAnchorPercentCol, lineAnchorClippingCol, lineAnchorTypeCol, lineAnchorTextPointCol );
 
-      if ( isCurvedOrLine && !mCurrentLabel.pos.isDiagram && ! labelAnchorPercentMovable( vlayer, mCurrentLabel.settings, lineAnchorPercentCol, lineAnchorClippingCol, lineAnchorTypeCol, lineAnchorTextPointCol ) )
+      bool useLineAnchor = false;
+      if ( isCurvedOrLine )
+      {
+        if ( isMovableUsingLineAnchor )
+          useLineAnchor = true;
+        else if ( isMovableUsingPoint )
+          useLineAnchor = false;
+        else
+          useLineAnchor = true;
+      }
+
+      if ( useLineAnchor && !mCurrentLabel.pos.isDiagram && !isMovableUsingLineAnchor )
       {
         QgsPalIndexes indexes;
         if ( createAuxiliaryFields( indexes ) )
@@ -303,7 +316,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
         //lineAnchorTextPointCol = indexes[ QgsPalLayerSettings::LineAnchorTextPoint];
 
       }
-      else if ( !mCurrentLabel.pos.isDiagram && !labelMoveable( vlayer, mCurrentLabel.settings, xCol, yCol, pointCol ) )
+      else if ( !mCurrentLabel.pos.isDiagram && !isMovableUsingPoint )
       {
         if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::PositionPoint ) )
         {


### PR DESCRIPTION
When interactive move label tools are used on a line layer, don't force the creation of columns for data defined anchor based placement if the layer has already been setup with columns for x/y placement
