### PR TITLE
Fix plugin voting from within plugin manager 

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -564,14 +564,17 @@ class QgsPluginInstaller(QObject):
 
         if not plugin_id or not vote:
             return False
-        url = "http://plugins.qgis.org/plugins/RPC2/"
+        url = "https://plugins.qgis.org/plugins/RPC2/"
         params = {"id": "djangorpc", "method": "plugin.vote", "params": [str(plugin_id), str(vote)]}
         req = QNetworkRequest(QUrl(url))
         req.setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "QgsPluginInstaller")
         req.setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorRequestId), "sendVote")
         req.setRawHeader(b"Content-Type", b"application/json")
-        QgsNetworkAccessManager.instance().post(req, bytes(json.dumps(params), "utf-8"))
-        return True
+        reply = QgsNetworkAccessManager.instance().blockingPost(req, bytes(json.dumps(params), "utf-8"))
+        if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute) == 200:
+            return True
+        else:
+            return False
 
     def installFromZipFile(self, filePath):
         if not os.path.isfile(filePath):

--- a/src/app/pluginmanager/qgspluginmanager_texts.cpp
+++ b/src/app/pluginmanager/qgspluginmanager_texts.cpp
@@ -101,7 +101,7 @@ Click on an individual plugin; if possible QGIS shows you more information.\
 \
 <p>\
 The main reasons to have invalid plugins is that this plugin is not build \
-for this version of QGIS. Maybe you can download another version from <a href=\"http://plugins.qgis.org\">plugins.qgis.org</a>.\
+for this version of QGIS. Maybe you can download another version from <a href=\"https://plugins.qgis.org\">plugins.qgis.org</a>.\
 </p>\
 \
 <p>\


### PR DESCRIPTION
Plugin voting was broken but the message "Vote sent successfully" was shown.

The issue was that the vote was submitted to http://plugins.qgis.org/plugins/RPC2/ (`http`), which returns a 301 but this redirect to `https` never happened so the vote was lost and not count (ref https://github.com/qgis/QGIS/pull/6129#issuecomment-359478607).

This PR updates the URL to avoid the redirect, checks the reply status code to show the correct message and uses `blockingPost` to be able to handle redirects if there will be any in the future.


