### PR TITLE
QgsGeometry: Add `fromPoint` and `fromBox3D` constructors

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -275,6 +275,15 @@ Creates a new geometry from a :py:class:`QgsMultiPolygonXY`.
 %Docstring
 Creates a new geometry from a :py:class:`QgsRectangle`
 %End
+
+    static QgsGeometry fromBox3D( const QgsBox3D &box ) /HoldGIL/;
+%Docstring
+Creates a new geometry from a :py:class:`QgsBox3D` object
+
+.. versionadded:: 3.34
+%End
+
+
     static QgsGeometry collectGeometry( const QVector<QgsGeometry> &geometries );
 %Docstring
 Creates a new multipart geometry from a list of QgsGeometry objects

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -200,6 +200,14 @@ Creates a new geometry from a WKT string
 %Docstring
 Creates a new geometry from a :py:class:`QgsPointXY` object
 %End
+
+    static QgsGeometry fromPoint( const QgsPoint &point ) /HoldGIL/;
+%Docstring
+Creates a new geometry from a :py:class:`QgsPoint` object.
+
+.. versionadded:: 3.34
+%End
+
     static QgsGeometry fromMultiPointXY( const QgsMultiPointXY &multipoint );
 %Docstring
 Creates a new geometry from a :py:class:`QgsMultiPointXY` object

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -4076,4 +4076,3 @@ bool QgsGeometry::Error::hasWhere() const
 {
   return mHasLocation;
 }
-

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -171,6 +171,11 @@ QgsGeometry QgsGeometry::fromPointXY( const QgsPointXY &point )
   return QgsGeometry();
 }
 
+QgsGeometry QgsGeometry::fromPoint( const QgsPoint &point )
+{
+  return QgsGeometry( point.clone() );
+}
+
 QgsGeometry QgsGeometry::fromPolylineXY( const QgsPolylineXY &polyline )
 {
   std::unique_ptr< QgsAbstractGeometry > geom = QgsGeometryFactory::fromPolylineXY( polyline );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -249,6 +249,132 @@ QgsGeometry QgsGeometry::fromRect( const QgsRectangle &rect )
   return QgsGeometry( std::move( polygon ) );
 }
 
+QgsGeometry QgsGeometry::fromBox3D( const QgsBox3D &box )
+{
+  if ( box.is2d() )
+  {
+    return fromRect( box.toRectangle() );
+  }
+
+  std::unique_ptr< QgsMultiPolygon > multiPolygon = std::make_unique< QgsMultiPolygon >();
+
+  std::unique_ptr< QgsLineString > ext1 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMinimum()
+      << box.xMinimum()
+      << box.xMaximum()
+      << box.xMaximum()
+      << box.xMinimum(),
+      QVector< double >() << box.yMinimum()
+      << box.yMaximum()
+      << box.yMaximum()
+      << box.yMinimum()
+      << box.yMinimum(),
+      QVector< double >() << box.zMinimum()
+      << box.zMinimum()
+      << box.zMinimum()
+      << box.zMinimum()
+      << box.zMinimum() );
+  std::unique_ptr< QgsPolygon > polygon1 = std::make_unique< QgsPolygon >( ext1.release() );
+  multiPolygon->addGeometry( polygon1.release() );
+
+  std::unique_ptr< QgsLineString > ext2 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMinimum()
+      << box.xMinimum()
+      << box.xMinimum()
+      << box.xMinimum()
+      << box.xMinimum(),
+      QVector< double >() << box.yMinimum()
+      << box.yMaximum()
+      << box.yMaximum()
+      << box.yMinimum()
+      << box.yMinimum(),
+      QVector< double >() << box.zMinimum()
+      << box.zMinimum()
+      << box.zMaximum()
+      << box.zMaximum()
+      << box.zMinimum() );
+  std::unique_ptr< QgsPolygon > polygon2 = std::make_unique< QgsPolygon >( ext2.release() );
+  multiPolygon->addGeometry( polygon2.release() );
+
+  std::unique_ptr< QgsLineString > ext3 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMinimum()
+      << box.xMaximum()
+      << box.xMaximum()
+      << box.xMinimum()
+      << box.xMinimum(),
+      QVector< double >() << box.yMinimum()
+      << box.yMinimum()
+      << box.yMinimum()
+      << box.yMinimum()
+      << box.yMinimum(),
+      QVector< double >() << box.zMinimum()
+      << box.zMinimum()
+      << box.zMaximum()
+      << box.zMaximum()
+      << box.zMinimum() );
+  std::unique_ptr< QgsPolygon > polygon3 = std::make_unique< QgsPolygon >( ext3.release() );
+  multiPolygon->addGeometry( polygon3.release() );
+
+  std::unique_ptr< QgsLineString > ext4 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMaximum()
+      << box.xMaximum()
+      << box.xMinimum()
+      << box.xMinimum()
+      << box.xMaximum(),
+      QVector< double >() << box.yMaximum()
+      << box.yMinimum()
+      << box.yMinimum()
+      << box.yMaximum()
+      << box.yMaximum(),
+      QVector< double >() << box.zMaximum()
+      << box.zMaximum()
+      << box.zMaximum()
+      << box.zMaximum()
+      << box.zMaximum() );
+  std::unique_ptr< QgsPolygon > polygon4 = std::make_unique< QgsPolygon >( ext4.release() );
+  multiPolygon->addGeometry( polygon4.release() );
+
+  std::unique_ptr< QgsLineString > ext5 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMaximum()
+      << box.xMaximum()
+      << box.xMaximum()
+      << box.xMaximum()
+      << box.xMaximum(),
+      QVector< double >() << box.yMaximum()
+      << box.yMinimum()
+      << box.yMinimum()
+      << box.yMaximum()
+      << box.yMaximum(),
+      QVector< double >() << box.zMaximum()
+      << box.zMaximum()
+      << box.zMinimum()
+      << box.zMinimum()
+      << box.zMaximum() );
+  std::unique_ptr< QgsPolygon > polygon5 = std::make_unique< QgsPolygon >( ext5.release() );
+  multiPolygon->addGeometry( polygon5.release() );
+
+  std::unique_ptr< QgsLineString > ext6 = std::make_unique< QgsLineString >(
+      QVector< double >() << box.xMaximum()
+      << box.xMaximum()
+      << box.xMinimum()
+      << box.xMinimum()
+      << box.xMaximum(),
+      QVector< double >() << box.yMaximum()
+      << box.yMaximum()
+      << box.yMaximum()
+      << box.yMaximum()
+      << box.yMaximum(),
+      QVector< double >() << box.zMaximum()
+      << box.zMinimum()
+      << box.zMinimum()
+      << box.zMaximum()
+      << box.zMaximum() );
+  std::unique_ptr< QgsPolygon > polygon6 = std::make_unique< QgsPolygon >( ext6.release() );
+  multiPolygon->addGeometry( polygon6.release() );
+
+  return QgsGeometry( std::move( multiPolygon ) );
+}
+
 QgsGeometry QgsGeometry::collectGeometry( const QVector< QgsGeometry > &geometries )
 {
   QgsGeometry collected;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -251,6 +251,14 @@ class CORE_EXPORT QgsGeometry
     static QgsGeometry fromWkt( const QString &wkt );
     //! Creates a new geometry from a QgsPointXY object
     static QgsGeometry fromPointXY( const QgsPointXY &point ) SIP_HOLDGIL;
+
+    /**
+     * Creates a new geometry from a QgsPoint object.
+     *
+     * \since QGIS 3.34
+     */
+    static QgsGeometry fromPoint( const QgsPoint &point ) SIP_HOLDGIL;
+
     //! Creates a new geometry from a QgsMultiPointXY object
     static QgsGeometry fromMultiPointXY( const QgsMultiPointXY &multipoint );
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -325,6 +325,15 @@ class CORE_EXPORT QgsGeometry
 
     //! Creates a new geometry from a QgsRectangle
     static QgsGeometry fromRect( const QgsRectangle &rect ) SIP_HOLDGIL;
+
+    /**
+     * Creates a new geometry from a QgsBox3D object
+     *
+     * \since QGIS 3.34
+     */
+    static QgsGeometry fromBox3D( const QgsBox3D &box ) SIP_HOLDGIL;
+
+
     //! Creates a new multipart geometry from a list of QgsGeometry objects
     static QgsGeometry collectGeometry( const QVector<QgsGeometry> &geometries );
 

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -90,6 +90,7 @@ class TestQgsGeometry : public QgsTest
     void splitCurve_data();
     void splitCurve();
 
+    void fromPoint();
     void fromQgsPointXY();
     void fromQPoint();
     void fromQPolygonF();
@@ -742,6 +743,15 @@ void TestQgsGeometry::splitCurve()
   auto [p1, p2] = qgsgeometry_cast< const QgsCurve * >( curve.constGet() )->splitCurveAtVertex( vertex );
   QCOMPARE( p1->asWkt(), curve1 );
   QCOMPARE( p2->asWkt(), curve2 );
+}
+
+void TestQgsGeometry::fromPoint()
+{
+  QgsPoint point( 1.0, 2.0, 3.0 );
+  QgsGeometry result( QgsGeometry::fromPoint( point ) );
+  QCOMPARE( result.wkbType(), Qgis::WkbType::PointZ );
+  QgsPoint resultPoint = result.vertexAt( 0 );
+  QCOMPARE( resultPoint, point );
 }
 
 void TestQgsGeometry::fromQgsPointXY()

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -90,6 +90,7 @@ class TestQgsGeometry : public QgsTest
     void splitCurve_data();
     void splitCurve();
 
+    void fromBox3d();
     void fromPoint();
     void fromQgsPointXY();
     void fromQPoint();
@@ -743,6 +744,13 @@ void TestQgsGeometry::splitCurve()
   auto [p1, p2] = qgsgeometry_cast< const QgsCurve * >( curve.constGet() )->splitCurveAtVertex( vertex );
   QCOMPARE( p1->asWkt(), curve1 );
   QCOMPARE( p2->asWkt(), curve2 );
+}
+
+void TestQgsGeometry::fromBox3d()
+{
+  QgsBox3D box3d( 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 );
+  QgsGeometry result( QgsGeometry::fromBox3D( box3d ) );
+  QCOMPARE( result.asWkt(), "MultiPolygonZ (((1 2 3, 1 5 3, 4 5 3, 4 2 3, 1 2 3)),((1 2 3, 1 5 3, 1 5 6, 1 2 6, 1 2 3)),((1 2 3, 4 2 3, 4 2 6, 1 2 6, 1 2 3)),((4 5 6, 4 2 6, 1 2 6, 1 5 6, 4 5 6)),((4 5 6, 4 2 6, 4 2 3, 4 5 3, 4 5 6)),((4 5 6, 4 5 3, 1 5 3, 1 5 6, 4 5 6)))" );
 }
 
 void TestQgsGeometry::fromPoint()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -230,9 +230,16 @@ class TestQgsGeometry(QgisTestCase):
         self.assertEqual(geom.constGet().geometryN(1).x(), 21)
         self.assertEqual(geom.constGet().geometryN(1).y(), 31)
 
-    def testFromPoint(self):
+    def testFromPointXY(self):
         myPoint = QgsGeometry.fromPointXY(QgsPointXY(10, 10))
         self.assertEqual(myPoint.wkbType(), QgsWkbTypes.Point)
+
+    def testFromPoint(self):
+        myPoint = QgsGeometry.fromPoint(QgsPoint(10, 3, 5))
+        self.assertEqual(myPoint.wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(myPoint.constGet().x(), 10)
+        self.assertEqual(myPoint.constGet().y(), 3)
+        self.assertEqual(myPoint.constGet().z(), 5)
 
     def testFromMultiPoint(self):
         myMultiPoint = QgsGeometry.fromMultiPointXY([

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtGui import (
 from qgis.core import (
     Qgis,
     QgsAbstractGeometryTransformer,
+    QgsBox3D,
     QgsCircle,
     QgsCircularString,
     QgsCompoundCurve,
@@ -272,6 +273,10 @@ class TestQgsGeometry(QgisTestCase):
               QgsPointXY(2, 2)]]
         ])
         self.assertEqual(myMultiPolygon.wkbType(), QgsWkbTypes.MultiPolygon)
+
+    def testFromBox3D(self):
+        myBox3D = QgsGeometry.fromBox3D(QgsBox3D(1, 2, 3, 4, 5, 6))
+        self.assertEqual(myBox3D.asWkt(), "MultiPolygonZ (((1 2 3, 1 5 3, 4 5 3, 4 2 3, 1 2 3)),((1 2 3, 1 5 3, 1 5 6, 1 2 6, 1 2 3)),((1 2 3, 4 2 3, 4 2 6, 1 2 6, 1 2 3)),((4 5 6, 4 2 6, 1 2 6, 1 5 6, 4 5 6)),((4 5 6, 4 2 6, 4 2 3, 4 5 3, 4 5 6)),((4 5 6, 4 5 3, 1 5 3, 1 5 6, 4 5 6)))")
 
     def testLineStringPythonAdditions(self):
         """


### PR DESCRIPTION
## Description

This adds two new methods to `QgsGeometry`:
- `fromPoint` to generate a `QgsGeometry` from a `QgsPoint`
- `fromBox3D` to generate a `QgsGeometry` from a `QgsBox3D`

cc @lbartoletti @benoitdm-oslandia 