### PR TITLE
Fix #53776 - Annotation DPI

### DIFF
--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -97,7 +97,7 @@ void QgsMapCanvasAnnotationItem::updateBoundingRect()
   const double fillSymbolBleed = mAnnotation && mAnnotation->fillSymbol() ?
                                  QgsSymbolLayerUtils::estimateMaxSymbolBleed( mAnnotation->fillSymbol(), rc ) : 0;
 
-  const double mmToPixelScale = mMapCanvas->logicalDpiX() / 25.4;
+  const double mmToPixelScale = mMapCanvas->physicalDpiX() / 25.4;
 
   if ( mAnnotation && !mAnnotation->hasFixedMapPosition() )
   {


### PR DESCRIPTION
- Fix #53776

## Description

When the screen logicalDpi differs from the physicalDpi, annotation are not correctly sized.

Step to reproduce (Ubuntu)

- Run `xrandr --output HDMI --scale 1.3x1.3` on the terminal to set a custom screen scale (you may need to replace "HDMI" with the correct output device)
- Launch QGIS
- Create and move around a balloon annotation
- Behold the artifacts in their full glory!


PhysicalDPI : 102
![qgis-bin_tNScK6LzyL](https://github.com/qgis/QGIS/assets/9693475/3bbcc01f-7449-454c-b3f9-0096f4db3245)

PhysicalDPI : 142
![qgis-bin_UF5j7sWILp](https://github.com/qgis/QGIS/assets/9693475/a4ba727d-fedf-467f-9169-c6ac791b5c08)


This also occurs on e.g. labtop screens on Windows.


This seems linked to the recent work by @nyalldawson to consistently handle high-DPI screens.
This PR just replaces the call to `logicalDpiX` with `physicalDpiX`, but there are probably some side effects regarding print layout rendering for instance.


