### PR TITLE
[qml] Add a couple of useful Q_PROPERTY to QgsSnappingConfig

### DIFF
--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -702,9 +702,11 @@ QgsProject *QgsSnappingConfig::project() const
 
 void QgsSnappingConfig::setProject( QgsProject *project )
 {
-  if ( mProject != project )
-    mProject = project;
-
+  if ( mProject == project )
+  {
+    return;
+  }
+  mProject = project;
   reset();
 }
 

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -39,6 +39,8 @@ class CORE_EXPORT QgsSnappingConfig
     Q_GADGET
 
     Q_PROPERTY( QgsProject *project READ project WRITE setProject )
+    Q_PROPERTY( bool enabled READ enabled WRITE setEnabled )
+    Q_PROPERTY( Qgis::SnappingMode mode READ mode WRITE setMode )
 
   public:
 


### PR DESCRIPTION
## Description

Thee two properties are needed to allow for basic control of snapping functionality within a QML environment.