### PR TITLE
geometry: Add support for boundingbox3d

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -116,9 +116,16 @@ Comparator for sorting of geometry.
 Clears the geometry, ie reset it to a null geometry
 %End
 
-    virtual QgsRectangle boundingBox() const = 0;
+    virtual QgsRectangle boundingBox() const;
 %Docstring
 Returns the minimal bounding box for the geometry
+%End
+
+    virtual QgsBox3D boundingBox3D() const = 0;
+%Docstring
+Returns the 3D bounding box for the geometry.
+
+.. versionadded:: 3.34
 %End
 
 
@@ -929,6 +936,15 @@ Updates the geometry type based on whether sub geometries contain z or m values.
 %Docstring
 Default calculator for the minimal bounding box for the geometry. Derived classes should override this method
 if a more efficient bounding box calculation is available.
+%End
+
+    virtual QgsBox3D calculateBoundingBox3D() const;
+%Docstring
+Calculates the minimal 3D bounding box for the geometry.
+
+.. seealso:: :py:func:`calculateBoundingBox`
+
+.. versionadded:: 3.34
 %End
 
     virtual void clearCache() const;

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -559,6 +559,16 @@ calculate and handles invalid geometries.
 .. versionadded:: 3.20
 %End
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
+%Docstring
+Returns ``True`` if the bounding box of this geometry intersects with a ``box3d``.
+
+Since this test only considers the bounding box of the geometry, is is very fast to
+calculate and handles invalid geometries.
+
+.. versionadded:: 3.34
+%End
+
     virtual QgsAbstractGeometry *segmentize( double tolerance = M_PI / 180., SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;
 %Docstring
 Returns a version of the geometry without curves. Caller takes ownership of

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -225,8 +225,6 @@ Appends the contents of another circular ``string`` to the end of this circular 
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    virtual QgsRectangle calculateBoundingBox() const;
-
     virtual QgsBox3D calculateBoundingBox3D() const;
 
 

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -227,6 +227,8 @@ Appends the contents of another circular ``string`` to the end of this circular 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
+    virtual QgsBox3D calculateBoundingBox3D() const;
+
 
 };
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -85,6 +85,8 @@ of the curve.
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &rectangle ) const /HoldGIL/;
+
     virtual const QgsAbstractGeometry *simplifiedTypeRef() const /HoldGIL/;
 
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -83,9 +83,7 @@ of the curve.
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 
-    virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
-
-    virtual bool boundingBoxIntersects( const QgsBox3D &rectangle ) const /HoldGIL/;
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
 
     virtual const QgsAbstractGeometry *simplifiedTypeRef() const /HoldGIL/;
 
@@ -224,8 +222,6 @@ Appends first point if not already closed.
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    virtual QgsRectangle calculateBoundingBox() const;
-
     virtual QgsBox3D calculateBoundingBox3D() const;
 
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -224,6 +224,8 @@ Appends first point if not already closed.
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
+    virtual QgsBox3D calculateBoundingBox3D() const;
+
 
 };
 

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -206,7 +206,7 @@ Returns a geometry without curves. Caller takes ownership
 
     void normalize() final /HoldGIL/;
 
-    virtual QgsRectangle boundingBox() const;
+    virtual QgsBox3D boundingBox3D() const;
 
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -72,8 +72,6 @@ Curve polygon geometry type
 
     virtual bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false );
 
-    virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
-
     virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
 
 
@@ -343,8 +341,6 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
 
   protected:
 
-
-    virtual QgsRectangle calculateBoundingBox() const;
 
     virtual QgsBox3D calculateBoundingBox3D() const;
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -74,6 +74,8 @@ Curve polygon geometry type
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
+
 
     double roundness() const;
 %Docstring

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -344,6 +344,8 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
 
     virtual QgsRectangle calculateBoundingBox() const;
 
+    virtual QgsBox3D calculateBoundingBox3D() const;
+
 };
 
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1105,6 +1105,13 @@ Returns the bounding box of the geometry.
 .. seealso:: :py:func:`orientedMinimumBoundingBox`
 %End
 
+    QgsBox3D boundingBox3D() const;
+%Docstring
+Returns the 3D bounding box of the geometry.
+
+.. versionadded:: 3.34
+%End
+
     QgsGeometry orientedMinimumBoundingBox( double &area /Out/, double &angle /Out/, double &width /Out/, double &height /Out/ ) const;
 %Docstring
 Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -181,7 +181,7 @@ Removes a geometry from the collection by index.
     virtual QString asKml( int precision = 17 ) const;
 
 
-    virtual QgsRectangle boundingBox() const;
+    virtual QgsBox3D boundingBox3D() const;
 
 
     virtual QgsCoordinateSequence coordinateSequence() const;
@@ -343,6 +343,8 @@ Reads a collection from a WKT string.
 %End
 
     virtual QgsRectangle calculateBoundingBox() const;
+
+    virtual QgsBox3D calculateBoundingBox3D() const;
 
     virtual void clearCache() const;
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -104,8 +104,6 @@ Returns a geometry from within the collection.
 
     virtual int vertexNumberFromVertexId( QgsVertexId id ) const;
 
-    virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
-
     virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
 
 
@@ -343,8 +341,6 @@ Returns whether child type names are omitted from Wkt representations of the col
 %Docstring
 Reads a collection from a WKT string.
 %End
-
-    virtual QgsRectangle calculateBoundingBox() const;
 
     virtual QgsBox3D calculateBoundingBox3D() const;
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -106,6 +106,8 @@ Returns a geometry from within the collection.
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
+
 
     void reserve( int size ) /HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -867,8 +867,6 @@ Calculates the minimal 3D bounding box for the geometry.
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    virtual QgsRectangle calculateBoundingBox() const;
-
 
 };
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -605,6 +605,8 @@ segment in the line.
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
+
 
     QVector< QgsVertexId > collectDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) const;
 %Docstring

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -840,13 +840,26 @@ corresponds to the last point in the line.
 %End
 
 
-    QgsBox3D calculateBoundingBox3d() const;
+ QgsBox3D calculateBoundingBox3d() const /Deprecated/;
+%Docstring
+Calculates the minimal 3D bounding box for the geometry.
+Deprecated: use calculateBoundingBox3D instead
+
+.. seealso:: :py:func:`calculateBoundingBox`
+
+.. versionadded:: 3.26
+
+.. deprecated:: QGIS 3.34
+%End
+
+    virtual QgsBox3D calculateBoundingBox3D() const;
+
 %Docstring
 Calculates the minimal 3D bounding box for the geometry.
 
 .. seealso:: :py:func:`calculateBoundingBox`
 
-.. versionadded:: 3.26
+.. versionadded:: 3.34
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -454,6 +454,8 @@ Angle undefined. Always returns 0.0
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const /HoldGIL/;
+
 
     virtual bool addZValue( double zValue = 0 );
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -367,7 +367,7 @@ Example
     void normalize() final /HoldGIL/;
     virtual bool isEmpty() const /HoldGIL/;
 
-    virtual QgsRectangle boundingBox() const /HoldGIL/;
+    virtual QgsBox3D boundingBox3D() const /HoldGIL/;
 
     virtual QString geometryType() const /HoldGIL/;
 

--- a/python/core/auto_generated/geometry/qgssurface.sip.in
+++ b/python/core/auto_generated/geometry/qgssurface.sip.in
@@ -27,7 +27,7 @@ Gets a polygon representation of this surface.
 Ownership is transferred to the caller.
 %End
 
-    virtual QgsRectangle boundingBox() const;
+    virtual QgsBox3D boundingBox3D() const;
 
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -18,6 +18,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsgeometrycollection.h"
 #include "qgsvertexid.h"
 #include "qgscurve.h"
+#include "qgsbox3d.h"
 
 #include <nlohmann/json.hpp>
 #include <limits>
@@ -113,31 +114,63 @@ void QgsAbstractGeometry::setZMTypeFromSubGeometry( const QgsAbstractGeometry *s
   }
 }
 
+QgsRectangle QgsAbstractGeometry::boundingBox() const
+{
+  return boundingBox3D().toRectangle();
+}
+
 QgsRectangle QgsAbstractGeometry::calculateBoundingBox() const
+{
+  return calculateBoundingBox3D().toRectangle();
+}
+
+QgsBox3D QgsAbstractGeometry::calculateBoundingBox3D() const
 {
   double xmin = std::numeric_limits<double>::max();
   double ymin = std::numeric_limits<double>::max();
+  double zmin = std::numeric_limits<double>::max();
   double xmax = -std::numeric_limits<double>::max();
   double ymax = -std::numeric_limits<double>::max();
+  double zmax = -std::numeric_limits<double>::max();
 
   QgsVertexId id;
   QgsPoint vertex;
-  double x, y;
-  while ( nextVertex( id, vertex ) )
+  double x, y, z;
+  if ( is3D() )
   {
-    x = vertex.x();
-    y = vertex.y();
-    if ( x < xmin )
-      xmin = x;
-    if ( x > xmax )
-      xmax = x;
-    if ( y < ymin )
-      ymin = y;
-    if ( y > ymax )
-      ymax = y;
+    while ( nextVertex( id, vertex ) )
+    {
+      x = vertex.x();
+      y = vertex.y();
+      z = vertex.z();
+
+      xmin = std::min( xmin, x );
+      xmax = std::max( xmax, x );
+
+      ymin = std::min( ymin, y );
+      ymax = std::max( ymax, y );
+
+      zmin = std::min( zmin, z );
+      zmax = std::max( zmax, z );
+    }
+  }
+  else
+  {
+    while ( nextVertex( id, vertex ) )
+    {
+      x = vertex.x();
+      y = vertex.y();
+      xmin = std::min( xmin, x );
+      xmax = std::max( xmax, x );
+
+      ymin = std::min( ymin, y );
+      ymax = std::max( ymax, y );
+    }
+    zmin = std::numeric_limits<double>::quiet_NaN();
+    zmax = std::numeric_limits<double>::quiet_NaN();
   }
 
-  return QgsRectangle( xmin, ymin, xmax, ymax );
+  return QgsBox3D( xmin, ymin, zmin, xmax, ymax, zmax );
 }
 
 void QgsAbstractGeometry::clearCache() const

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -422,6 +422,11 @@ bool QgsAbstractGeometry::boundingBoxIntersects( const QgsRectangle &rectangle )
   return boundingBox().intersects( rectangle );
 }
 
+bool QgsAbstractGeometry::boundingBoxIntersects( const QgsBox3D &box3d ) const
+{
+  return boundingBox3D().intersects( box3d );
+}
+
 QgsAbstractGeometry *QgsAbstractGeometry::segmentize( double tolerance, SegmentationToleranceType toleranceType ) const
 {
   Q_UNUSED( tolerance )

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -578,6 +578,16 @@ class CORE_EXPORT QgsAbstractGeometry
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const SIP_HOLDGIL;
 
     /**
+     * Returns TRUE if the bounding box of this geometry intersects with a \a box3d.
+     *
+     * Since this test only considers the bounding box of the geometry, is is very fast to
+     * calculate and handles invalid geometries.
+     *
+     * \since QGIS 3.34
+     */
+    virtual bool boundingBoxIntersects( const QgsBox3D &box3d ) const SIP_HOLDGIL;
+
+    /**
      * Returns a version of the geometry without curves. Caller takes ownership of
      * the returned geometry.
      * \param tolerance segmentation tolerance

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -50,6 +50,7 @@ class QgsFeedback;
 class QgsCoordinateTransform;
 class QgsPoint;
 class QgsRectangle;
+class QgsBox3D;
 
 typedef QVector< QgsPoint > QgsPointSequence;
 #ifndef SIP_RUN
@@ -181,7 +182,14 @@ class CORE_EXPORT QgsAbstractGeometry
     /**
      * Returns the minimal bounding box for the geometry
      */
-    virtual QgsRectangle boundingBox() const = 0;
+    virtual QgsRectangle boundingBox() const;
+
+    /**
+     * Returns the 3D bounding box for the geometry.
+     *
+     * \since QGIS 3.34
+     */
+    virtual QgsBox3D boundingBox3D() const = 0;
 
     //mm-sql interface
 
@@ -1129,6 +1137,14 @@ class CORE_EXPORT QgsAbstractGeometry
      * if a more efficient bounding box calculation is available.
      */
     virtual QgsRectangle calculateBoundingBox() const;
+
+    /**
+     * Calculates the minimal 3D bounding box for the geometry.
+     * \see calculateBoundingBox()
+     *
+     * \since QGIS 3.34
+     */
+    virtual QgsBox3D calculateBoundingBox3D() const;
 
     /**
      * Clears any cached parameters associated with the geometry, e.g., bounding boxes

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -269,48 +269,20 @@ void QgsCircularString::clear()
   clearCache();
 }
 
-QgsRectangle QgsCircularString::calculateBoundingBox() const
-{
-  QgsRectangle bbox;
-  int nPoints = numPoints();
-  for ( int i = 0; i < ( nPoints - 2 ) ; i += 2 )
-  {
-    if ( i == 0 )
-    {
-      bbox = segmentBoundingBox( QgsPoint( mX[i], mY[i] ), QgsPoint( mX[i + 1], mY[i + 1] ), QgsPoint( mX[i + 2], mY[i + 2] ) );
-    }
-    else
-    {
-      QgsRectangle segmentBox = segmentBoundingBox( QgsPoint( mX[i], mY[i] ), QgsPoint( mX[i + 1], mY[i + 1] ), QgsPoint( mX[i + 2], mY[i + 2] ) );
-      bbox.combineExtentWith( segmentBox );
-    }
-  }
-
-  if ( nPoints > 0 && nPoints % 2 == 0 )
-  {
-    if ( nPoints == 2 )
-    {
-      bbox.combineExtentWith( mX[ 0 ], mY[ 0 ] );
-    }
-    bbox.combineExtentWith( mX[ nPoints - 1 ], mY[ nPoints - 1 ] );
-  }
-  return bbox;
-}
-
 QgsBox3D QgsCircularString::calculateBoundingBox3D() const
 {
-  if ( !is3D() )
-  {
-    return QgsBox3D( calculateBoundingBox() );
-  }
-
   QgsBox3D bbox;
   int nPoints = numPoints();
   for ( int i = 0; i < ( nPoints - 2 ) ; i += 2 )
   {
     QgsRectangle box2d = segmentBoundingBox( QgsPoint( mX[i], mY[i] ), QgsPoint( mX[i + 1], mY[i + 1] ), QgsPoint( mX[i + 2], mY[i + 2] ) );
-    double zMin = *std::min_element( mZ.begin() + i, mZ.begin() + i + 3 );
-    double zMax = *std::max_element( mZ.begin() + i, mZ.begin() + i + 3 );
+    double zMin = std::numeric_limits<double>::quiet_NaN();
+    double zMax = std::numeric_limits<double>::quiet_NaN();
+    if ( is3D() )
+    {
+      zMin = *std::min_element( mZ.begin() + i, mZ.begin() + i + 3 );
+      zMax = *std::max_element( mZ.begin() + i, mZ.begin() + i + 3 );
+    }
     if ( i == 0 )
     {
       bbox = QgsBox3D( box2d, zMin, zMax );
@@ -323,11 +295,20 @@ QgsBox3D QgsCircularString::calculateBoundingBox3D() const
 
   if ( nPoints > 0 && nPoints % 2 == 0 )
   {
+    double z = std::numeric_limits<double>::quiet_NaN();
     if ( nPoints == 2 )
     {
-      bbox.combineWith( mX[ 0 ], mY[ 0 ], mZ[ 0 ] );
+      if ( is3D() )
+      {
+        z = mZ[ 0 ];
+      }
+      bbox.combineWith( mX[ 0 ], mY[ 0 ], z );
     }
-    bbox.combineWith( mX[ nPoints - 1 ], mY[ nPoints - 1 ], mZ[nPoints - 1] );
+    if ( is3D() )
+    {
+      z = mZ[ nPoints - 1 ];
+    }
+    bbox.combineWith( mX[ nPoints - 1 ], mY[ nPoints - 1 ], z );
   }
   return bbox;
 }

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -204,6 +204,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
+    QgsBox3D calculateBoundingBox3D() const override;
 
   private:
     QVector<double> mX;

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -203,7 +203,6 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    QgsRectangle calculateBoundingBox() const override;
     QgsBox3D calculateBoundingBox3D() const override;
 
   private:

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -162,6 +162,22 @@ QgsRectangle QgsCompoundCurve::calculateBoundingBox() const
   return bbox;
 }
 
+QgsBox3D QgsCompoundCurve::calculateBoundingBox3D() const
+{
+  if ( mCurves.empty() )
+  {
+    return QgsBox3D();
+  }
+
+  QgsBox3D bbox = mCurves.at( 0 )->boundingBox3D();
+  for ( int i = 1; i < mCurves.size(); ++i )
+  {
+    QgsBox3D curveBox = mCurves.at( i )->boundingBox3D();
+    bbox.combineWith( curveBox );
+  }
+  return bbox;
+}
+
 void QgsCompoundCurve::scroll( int index )
 {
   const int size = numPoints();

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -146,22 +146,6 @@ void QgsCompoundCurve::clear()
   clearCache();
 }
 
-QgsRectangle QgsCompoundCurve::calculateBoundingBox() const
-{
-  if ( mCurves.empty() )
-  {
-    return QgsRectangle();
-  }
-
-  QgsRectangle bbox = mCurves.at( 0 )->boundingBox();
-  for ( int i = 1; i < mCurves.size(); ++i )
-  {
-    QgsRectangle curveBox = mCurves.at( i )->boundingBox();
-    bbox.combineExtentWith( curveBox );
-  }
-  return bbox;
-}
-
 QgsBox3D QgsCompoundCurve::calculateBoundingBox3D() const
 {
   if ( mCurves.empty() )
@@ -548,35 +532,6 @@ bool QgsCompoundCurve::removeDuplicateNodes( double epsilon, bool useZValues )
     i++;
   }
   return result;
-}
-
-bool QgsCompoundCurve::boundingBoxIntersects( const QgsRectangle &rectangle ) const
-{
-  if ( mCurves.empty() )
-    return false;
-
-  // if we already have the bounding box calculated, then this check is trivial!
-  if ( !mBoundingBox.isNull() )
-  {
-    return mBoundingBox.intersects( rectangle );
-  }
-
-  // otherwise loop through each member curve and test the bounding box intersection.
-  // This gives us a chance to use optimisations which may be present on the individual
-  // curve subclasses, and at worst it will cause a calculation of the bounding box
-  // of each individual member curve which we would have to do anyway... (and these
-  // bounding boxes are cached, so would be reused without additional expense)
-  for ( const QgsCurve *curve : mCurves )
-  {
-    if ( curve->boundingBoxIntersects( rectangle ) )
-      return true;
-  }
-
-  // even if we don't intersect the bounding box of any member curves, we may still intersect the
-  // bounding box of the overall compound curve.
-  // so here we fall back to the non-optimised base class check which has to first calculate
-  // the overall bounding box of the compound curve..
-  return QgsAbstractGeometry::boundingBoxIntersects( rectangle );
 }
 
 bool QgsCompoundCurve::boundingBoxIntersects( const QgsBox3D &box3d ) const

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -200,6 +200,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
+    QgsBox3D calculateBoundingBox3D() const override;
 
   private:
     QVector< QgsCurve * > mCurves;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -74,6 +74,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &rectangle ) const override SIP_HOLDGIL;
     const QgsAbstractGeometry *simplifiedTypeRef() const override SIP_HOLDGIL;
 
     /**

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -73,8 +73,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
     QgsCompoundCurve *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
-    bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
-    bool boundingBoxIntersects( const QgsBox3D &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
     const QgsAbstractGeometry *simplifiedTypeRef() const override SIP_HOLDGIL;
 
     /**
@@ -200,7 +199,6 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    QgsRectangle calculateBoundingBox() const override;
     QgsBox3D calculateBoundingBox3D() const override;
 
   private:

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -235,11 +235,11 @@ void QgsCurve::normalize()
   scroll( minCoordinateIndex );
 }
 
-QgsRectangle QgsCurve::boundingBox() const
+QgsBox3D QgsCurve::boundingBox3D() const
 {
   if ( mBoundingBox.isNull() )
   {
-    mBoundingBox = calculateBoundingBox();
+    mBoundingBox = calculateBoundingBox3D();
   }
   return mBoundingBox;
 }
@@ -292,7 +292,7 @@ Qgis::AngularDirection QgsCurve::orientation() const
 
 void QgsCurve::clearCache() const
 {
-  mBoundingBox = QgsRectangle();
+  mBoundingBox = QgsBox3D();
   mHasCachedValidity = false;
   mValidityFailureReason.clear();
   mHasCachedSummedUpArea = false;

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -21,7 +21,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
-#include "qgsrectangle.h"
+#include "qgsbox3d.h"
 #include <QPainterPath>
 
 class QgsLineString;
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     QgsCurve *toCurveType() const override SIP_FACTORY;
     void normalize() final SIP_HOLDGIL;
 
-    QgsRectangle boundingBox() const override;
+    QgsBox3D boundingBox3D() const override;
     bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
 
     /**
@@ -355,7 +355,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     /**
      * Cached bounding box.
      */
-    mutable QgsRectangle mBoundingBox;
+    mutable QgsBox3D mBoundingBox;
 
     mutable bool mHasCachedSummedUpArea = false;
     mutable double mSummedUpArea = 0;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -293,6 +293,15 @@ QgsRectangle QgsCurvePolygon::calculateBoundingBox() const
   return QgsRectangle();
 }
 
+QgsBox3D QgsCurvePolygon::calculateBoundingBox3D() const
+{
+  if ( mExteriorRing )
+  {
+    return mExteriorRing->boundingBox3D();
+  }
+  return QgsBox3D();
+}
+
 int QgsCurvePolygon::wkbSize( QgsAbstractGeometry::WkbFlags flags ) const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -688,6 +688,39 @@ bool QgsCurvePolygon::boundingBoxIntersects( const QgsRectangle &rectangle ) con
   return QgsSurface::boundingBoxIntersects( rectangle );
 }
 
+bool QgsCurvePolygon::boundingBoxIntersects( const QgsBox3D &box3d ) const
+{
+  if ( !mExteriorRing && mInteriorRings.empty() )
+    return false;
+
+  // if we already have the bounding box calculated, then this check is trivial!
+  if ( !mBoundingBox.isNull() )
+  {
+    return mBoundingBox.intersects( box3d );
+  }
+
+  // loop through each ring and test the bounding box intersection.
+  // This gives us a chance to use optimisations which may be present on the individual
+  // ring geometry subclasses, and at worst it will cause a calculation of the bounding box
+  // of each individual ring geometry which we would have to do anyway... (and these
+  // bounding boxes are cached, so would be reused without additional expense)
+  if ( mExteriorRing && mExteriorRing->boundingBoxIntersects( box3d ) )
+    return true;
+
+  for ( const QgsCurve *ring : mInteriorRings )
+  {
+    if ( ring->boundingBoxIntersects( box3d ) )
+      return true;
+  }
+
+  // even if we don't intersect the bounding box of any rings, we may still intersect the
+  // bounding box of the overall polygon (we are considering worst case scenario here and
+  // the polygon is invalid, with rings outside the exterior ring!)
+  // so here we fall back to the non-optimised base class check which has to first calculate
+  // the overall bounding box of the polygon..
+  return QgsSurface::boundingBoxIntersects( box3d );
+}
+
 QgsPolygon *QgsCurvePolygon::toPolygon( double tolerance, SegmentationToleranceType toleranceType ) const
 {
   std::unique_ptr< QgsPolygon > poly( new QgsPolygon() );

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -284,15 +284,6 @@ bool QgsCurvePolygon::fromWkt( const QString &wkt )
   return true;
 }
 
-QgsRectangle QgsCurvePolygon::calculateBoundingBox() const
-{
-  if ( mExteriorRing )
-  {
-    return mExteriorRing->boundingBox();
-  }
-  return QgsRectangle();
-}
-
 QgsBox3D QgsCurvePolygon::calculateBoundingBox3D() const
 {
   if ( mExteriorRing )
@@ -653,39 +644,6 @@ bool QgsCurvePolygon::removeDuplicateNodes( double epsilon, bool useZValues )
     if ( cleanRing( ring ) ) result = true;
   }
   return result;
-}
-
-bool QgsCurvePolygon::boundingBoxIntersects( const QgsRectangle &rectangle ) const
-{
-  if ( !mExteriorRing && mInteriorRings.empty() )
-    return false;
-
-  // if we already have the bounding box calculated, then this check is trivial!
-  if ( !mBoundingBox.isNull() )
-  {
-    return mBoundingBox.intersects( rectangle );
-  }
-
-  // loop through each ring and test the bounding box intersection.
-  // This gives us a chance to use optimisations which may be present on the individual
-  // ring geometry subclasses, and at worst it will cause a calculation of the bounding box
-  // of each individual ring geometry which we would have to do anyway... (and these
-  // bounding boxes are cached, so would be reused without additional expense)
-  if ( mExteriorRing && mExteriorRing->boundingBoxIntersects( rectangle ) )
-    return true;
-
-  for ( const QgsCurve *ring : mInteriorRings )
-  {
-    if ( ring->boundingBoxIntersects( rectangle ) )
-      return true;
-  }
-
-  // even if we don't intersect the bounding box of any rings, we may still intersect the
-  // bounding box of the overall polygon (we are considering worst case scenario here and
-  // the polygon is invalid, with rings outside the exterior ring!)
-  // so here we fall back to the non-optimised base class check which has to first calculate
-  // the overall bounding box of the polygon..
-  return QgsSurface::boundingBoxIntersects( rectangle );
 }
 
 bool QgsCurvePolygon::boundingBoxIntersects( const QgsBox3D &box3d ) const

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -377,6 +377,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     QVector<QgsCurve *> mInteriorRings;
 
     QgsRectangle calculateBoundingBox() const override;
+    QgsBox3D calculateBoundingBox3D() const override;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -68,6 +68,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     /**
      * Returns the roundness of the curve polygon.

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -67,7 +67,6 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
     QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
-    bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
     bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     /**
@@ -377,7 +376,6 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     std::unique_ptr< QgsCurve > mExteriorRing;
     QVector<QgsCurve *> mInteriorRings;
 
-    QgsRectangle calculateBoundingBox() const override;
     QgsBox3D calculateBoundingBox3D() const override;
 };
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1204,6 +1204,16 @@ QgsRectangle QgsGeometry::boundingBox() const
   return QgsRectangle();
 }
 
+QgsBox3D QgsGeometry::boundingBox3D() const
+{
+  if ( d->geometry )
+  {
+    return d->geometry->boundingBox3D();
+  }
+  return QgsBox3D();
+}
+
+
 QgsGeometry QgsGeometry::orientedMinimumBoundingBox( double &area, double &angle, double &width, double &height ) const
 {
   mLastError.clear();

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1177,6 +1177,13 @@ class CORE_EXPORT QgsGeometry
     QgsRectangle boundingBox() const;
 
     /**
+     * Returns the 3D bounding box of the geometry.
+     *
+     * \since QGIS 3.34
+     */
+    QgsBox3D boundingBox3D() const;
+
+    /**
      * Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
      * rotated rectangle which fully encompasses the geometry. The area, angle (clockwise in degrees from North),
      * width and height of the rotated bounding box will also be returned.

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -530,11 +530,11 @@ QString QgsGeometryCollection::asKml( int precision ) const
   return kml;
 }
 
-QgsRectangle QgsGeometryCollection::boundingBox() const
+QgsBox3D QgsGeometryCollection::boundingBox3D() const
 {
   if ( mBoundingBox.isNull() )
   {
-    mBoundingBox = calculateBoundingBox();
+    mBoundingBox = calculateBoundingBox3D();
   }
   return mBoundingBox;
 }
@@ -575,9 +575,28 @@ QgsRectangle QgsGeometryCollection::calculateBoundingBox() const
   return bbox;
 }
 
+QgsBox3D QgsGeometryCollection::calculateBoundingBox3D() const
+{
+  if ( mGeometries.empty() )
+  {
+    return QgsBox3D();
+  }
+
+  QgsBox3D bbox = mGeometries.at( 0 )->boundingBox3D();
+  for ( int i = 1; i < mGeometries.size(); ++i )
+  {
+    if ( mGeometries.at( i )->isEmpty() )
+      continue;
+
+    QgsBox3D geomBox = mGeometries.at( i )->boundingBox3D();
+    bbox.combineWith( geomBox );
+  }
+  return bbox;
+}
+
 void QgsGeometryCollection::clearCache() const
 {
-  mBoundingBox = QgsRectangle();
+  mBoundingBox = QgsBox3D();
   mHasCachedValidity = false;
   mValidityFailureReason.clear();
   QgsAbstractGeometry::clearCache();

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -129,6 +129,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     void adjacentVertices( QgsVertexId vertex, QgsVertexId &previousVertex SIP_OUT, QgsVertexId &nextVertex SIP_OUT ) const override;
     int vertexNumberFromVertexId( QgsVertexId id ) const override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     /**
      * Attempts to allocate memory for at least \a size geometries.

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -128,7 +128,6 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
     void adjacentVertices( QgsVertexId vertex, QgsVertexId &previousVertex SIP_OUT, QgsVertexId &nextVertex SIP_OUT ) const override;
     int vertexNumberFromVertexId( QgsVertexId id ) const override;
-    bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
     bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     /**
@@ -350,7 +349,6 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
      */
     bool fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType = QString() );
 
-    QgsRectangle calculateBoundingBox() const override;
     QgsBox3D calculateBoundingBox3D() const override;
     void clearCache() const override;
 

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -23,6 +23,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 #include "qgsrectangle.h"
+#include "qgsbox3d.h"
 
 class QgsPoint;
 
@@ -198,7 +199,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     json asJsonObject( int precision = 17 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
 
-    QgsRectangle boundingBox() const override;
+    QgsBox3D boundingBox3D() const override;
 
     QgsCoordinateSequence coordinateSequence() const override;
     int nCoordinates() const override;
@@ -349,11 +350,12 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     bool fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType = QString() );
 
     QgsRectangle calculateBoundingBox() const override;
+    QgsBox3D calculateBoundingBox3D() const override;
     void clearCache() const override;
 
   private:
 
-    mutable QgsRectangle mBoundingBox;
+    mutable QgsBox3D mBoundingBox;
     mutable bool mHasCachedValidity = false;
     mutable QString mValidityFailureReason;
 };

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -588,7 +588,7 @@ QgsRectangle QgsLineString::calculateBoundingBox() const
   return QgsRectangle( xmin, ymin, xmax, ymax, false );
 }
 
-QgsBox3D QgsLineString::calculateBoundingBox3d() const
+QgsBox3D QgsLineString::calculateBoundingBox3D() const
 {
 
   if ( mX.empty() )
@@ -614,6 +614,11 @@ QgsBox3D QgsLineString::calculateBoundingBox3d() const
     out = QgsBox3D( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), std::numeric_limits< double >::quiet_NaN(), mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), std::numeric_limits< double >::quiet_NaN() );
   }
   return out;
+}
+
+QgsBox3D QgsLineString::calculateBoundingBox3d() const
+{
+  return calculateBoundingBox3D();
 }
 
 void QgsLineString::scroll( int index )

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -424,6 +424,8 @@ bool QgsLineString::isClosed() const
   return closed;
 }
 
+// As `bool boundingBoxIntersects( const QgsBox3D &box3d )` and `bool boundingBoxIntersects( const QgsRectangle &rectangle )` are nearly
+// the same: if one of these functions is changed then remember to also update the other accordingly
 bool QgsLineString::boundingBoxIntersects( const QgsRectangle &rectangle ) const
 {
   if ( mX.empty() )
@@ -500,6 +502,95 @@ bool QgsLineString::boundingBoxIntersects( const QgsRectangle &rectangle ) const
   // the rectangle... and this will be very cheap now that we've already calculated and cached
   // the linestring's bounding box!
   return QgsCurve::boundingBoxIntersects( rectangle );
+}
+
+// As `bool boundingBoxIntersects( const QgsBox3D &box3d )` and `bool boundingBoxIntersects( const QgsRectangle &rectangle )` are nearly
+// the same: if one of these functions is changed then remember to also update the other accordingly
+bool QgsLineString::boundingBoxIntersects( const QgsBox3D &box3d ) const
+{
+  if ( mX.empty() )
+    return false;
+
+  if ( mZ.empty() )
+    return boundingBoxIntersects( box3d.toRectangle() );
+
+  if ( !mBoundingBox.isNull() )
+  {
+    return mBoundingBox.intersects( box3d );
+  }
+  const int nb = mX.size();
+
+  // We are a little fancy here!
+  if ( nb > 40 )
+  {
+    // if a large number of vertices, take some sample vertices at 1/5th increments through the linestring
+    // and test whether any are inside the rectangle. Maybe we can shortcut a lot of iterations by doing this!
+    // (why 1/5th? it's picked so that it works nicely for polygon rings which are almost rectangles, so the vertex extremities
+    // will fall on approximately these vertex indices)
+    if ( box3d.contains( mX.at( 0 ), mY.at( 0 ), mZ.at( 0 ) ) ||
+         box3d.contains( mX.at( static_cast< int >( nb * 0.2 ) ), mY.at( static_cast< int >( nb * 0.2 ) ), mZ.at( static_cast< int >( nb * 0.2 ) ) ) ||
+         box3d.contains( mX.at( static_cast< int >( nb * 0.4 ) ), mY.at( static_cast< int >( nb * 0.4 ) ), mZ.at( static_cast< int >( nb * 0.4 ) ) ) ||
+         box3d.contains( mX.at( static_cast< int >( nb * 0.6 ) ), mY.at( static_cast< int >( nb * 0.6 ) ), mZ.at( static_cast< int >( nb * 0.6 ) ) ) ||
+         box3d.contains( mX.at( static_cast< int >( nb * 0.8 ) ), mY.at( static_cast< int >( nb * 0.8 ) ), mZ.at( static_cast< int >( nb * 0.8 ) ) ) ||
+         box3d.contains( mX.at( nb - 1 ), mY.at( nb - 1 ), mZ.at( nb - 1 ) ) )
+      return true;
+  }
+
+  // Be even MORE fancy! Given that bounding box calculation is non-free, cached, and we don't
+  // already have it, we start performing the bounding box calculation while we are testing whether
+  // each point falls inside the rectangle. That way if we end up testing the majority of the points
+  // anyway, we can update the cached bounding box with the results we've calculated along the way
+  // and save future calls to calculate the bounding box!
+  double xmin = std::numeric_limits<double>::max();
+  double ymin = std::numeric_limits<double>::max();
+  double zmin = std::numeric_limits<double>::max();
+  double xmax = -std::numeric_limits<double>::max();
+  double ymax = -std::numeric_limits<double>::max();
+  double zmax = -std::numeric_limits<double>::max();
+
+  const double *x = mX.constData();
+  const double *y = mY.constData();
+  const double *z = mZ.constData();
+  bool foundPointInBox = false;
+  for ( int i = 0; i < nb; ++i )
+  {
+    const double px = *x++;
+    xmin = std::min( xmin, px );
+    xmax = std::max( xmax, px );
+    const double py = *y++;
+    ymin = std::min( ymin, py );
+    ymax = std::max( ymax, py );
+    const double pz = *z++;
+    zmin = std::min( zmin, pz );
+    zmax = std::max( zmax, pz );
+
+    if ( !foundPointInBox && box3d.contains( px, py, pz ) )
+    {
+      foundPointInBox = true;
+
+      // now... we have a choice to make. If we've already looped through the majority of the points
+      // in this linestring then let's just continue to iterate through the remainder so that we can
+      // complete the overall bounding box calculation we've already mostly done. If however we're only
+      // just at the start of iterating the vertices, we shortcut out early and leave the bounding box
+      // uncalculated
+      if ( i < nb * 0.5 )
+        return true;
+    }
+  }
+
+  // at this stage we now know the overall bounding box of the linestring, so let's cache
+  // it so we don't ever have to calculate this again. We've done all the hard work anyway!
+  mBoundingBox = QgsBox3D( xmin, ymin, zmin, xmax, ymax, zmax, false );
+
+  if ( foundPointInBox )
+    return true;
+
+  // NOTE: if none of the points in the line actually fell inside the rectangle, it doesn't
+  // exclude that the OVERALL bounding box of the linestring itself intersects the rectangle!!
+  // So we fall back to the parent class method which compares the overall bounding box against
+  // the rectangle... and this will be very cheap now that we've already calculated and cached
+  // the linestring's bounding box!
+  return QgsCurve::boundingBoxIntersects( box3d );
 }
 
 QVector< QgsVertexId > QgsLineString::collectDuplicateNodes( double epsilon, bool useZValues ) const
@@ -590,7 +681,6 @@ QgsRectangle QgsLineString::calculateBoundingBox() const
 
 QgsBox3D QgsLineString::calculateBoundingBox3D() const
 {
-
   if ( mX.empty() )
   {
     return QgsBox3D();

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -664,21 +664,6 @@ bool QgsLineString::fromWkb( QgsConstWkbPtr &wkbPtr )
   return true;
 }
 
-// duplicated code from calculateBoundingBox3d to avoid useless z computation
-QgsRectangle QgsLineString::calculateBoundingBox() const
-{
-  if ( mX.empty() )
-    return QgsRectangle();
-
-  auto result = std::minmax_element( mX.begin(), mX.end() );
-  const double xmin = *result.first;
-  const double xmax = *result.second;
-  result = std::minmax_element( mY.begin(), mY.end() );
-  const double ymin = *result.first;
-  const double ymax = *result.second;
-  return QgsRectangle( xmin, ymin, xmax, ymax, false );
-}
-
 QgsBox3D QgsLineString::calculateBoundingBox3D() const
 {
   if ( mX.empty() )
@@ -686,24 +671,24 @@ QgsBox3D QgsLineString::calculateBoundingBox3D() const
     return QgsBox3D();
   }
 
-  if ( mBoundingBox.isNull() )
-  {
-    mBoundingBox = calculateBoundingBox();
-  }
+  auto result2D = std::minmax_element( mX.begin(), mX.end() );
+  const double xmin = *result2D.first;
+  const double xmax = *result2D.second;
+  result2D = std::minmax_element( mY.begin(), mY.end() );
+  const double ymin = *result2D.first;
+  const double ymax = *result2D.second;
 
-  QgsBox3D out;
+  double zmin = std::numeric_limits< double >::quiet_NaN();
+  double zmax = std::numeric_limits< double >::quiet_NaN();
+
   if ( is3D() )
   {
-    auto result = std::minmax_element( mZ.begin(), mZ.end() );
-    const double zmin = *result.first;
-    const double zmax = *result.second;
-    out = QgsBox3D( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), zmin, mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), zmax );
+    auto resultZ = std::minmax_element( mZ.begin(), mZ.end() );
+    zmin = *resultZ.first;
+    zmax = *resultZ.second;
   }
-  else
-  {
-    out = QgsBox3D( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), std::numeric_limits< double >::quiet_NaN(), mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), std::numeric_limits< double >::quiet_NaN() );
-  }
-  return out;
+
+  return QgsBox3D( xmin, ymin, zmin, xmax, ymax, zmax );
 }
 
 QgsBox3D QgsLineString::calculateBoundingBox3d() const

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -1070,7 +1070,6 @@ class CORE_EXPORT QgsLineString: public QgsCurve
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
-    QgsRectangle calculateBoundingBox() const override;
 
   private:
     QVector<double> mX;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -1052,10 +1052,19 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     /**
      * Calculates the minimal 3D bounding box for the geometry.
+     * Deprecated: use calculateBoundingBox3D instead
      * \see calculateBoundingBox()
      * \since QGIS 3.26
+     * \deprecated since QGIS 3.34
      */
-    QgsBox3D calculateBoundingBox3d() const;
+    Q_DECL_DEPRECATED QgsBox3D calculateBoundingBox3d() const SIP_DEPRECATED;
+
+    /**
+     * Calculates the minimal 3D bounding box for the geometry.
+     * \see calculateBoundingBox()
+     * \since QGIS 3.34
+     */
+    QgsBox3D calculateBoundingBox3D() const override;
 
   protected:
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -838,6 +838,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool isClosed() const override SIP_HOLDGIL;
     bool isClosed2D() const override SIP_HOLDGIL;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     /**
      * Returns a list of any duplicate nodes contained in the geometry, within the specified tolerance.

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -23,6 +23,7 @@
 #include "qgsmaptopixel.h"
 #include "qgswkbptr.h"
 #include "qgsgeometrytransformer.h"
+#include "qgsbox3d.h"
 
 #include <cmath>
 #include <QPainter>
@@ -769,9 +770,9 @@ bool QgsPoint::isEmpty() const
   return std::isnan( mX ) || std::isnan( mY );
 }
 
-QgsRectangle QgsPoint::boundingBox() const
+QgsBox3D QgsPoint::boundingBox3D() const
 {
-  return QgsRectangle( mX, mY, mX, mY );
+  return QgsBox3D( mX, mY, mZ, mX, mY, mZ );
 }
 
 QString QgsPoint::geometryType() const

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -543,6 +543,11 @@ bool QgsPoint::boundingBoxIntersects( const QgsRectangle &rectangle ) const
   return rectangle.contains( mX, mY );
 }
 
+bool QgsPoint::boundingBoxIntersects( const QgsBox3D &box3d ) const
+{
+  return box3d.contains( mX, mY, mZ );
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -544,6 +544,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     QgsPoint *toCurveType() const override SIP_FACTORY;
     double segmentLength( QgsVertexId startVertex ) const override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+    bool boundingBoxIntersects( const QgsBox3D &box3d ) const override SIP_HOLDGIL;
 
     bool addZValue( double zValue = 0 ) override;
     bool addMValue( double mValue = 0 ) override;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -495,7 +495,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     //implementation of inherited methods
     void normalize() final SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;
-    QgsRectangle boundingBox() const override SIP_HOLDGIL;
+    QgsBox3D boundingBox3D() const override SIP_HOLDGIL;
     QString geometryType() const override SIP_HOLDGIL;
     int dimension() const override SIP_HOLDGIL;
     QgsPoint *clone() const override SIP_FACTORY;

--- a/src/core/geometry/qgssurface.cpp
+++ b/src/core/geometry/qgssurface.cpp
@@ -42,7 +42,7 @@ bool QgsSurface::isValid( QString &error, Qgis::GeometryValidityFlags flags ) co
 
 void QgsSurface::clearCache() const
 {
-  mBoundingBox = QgsRectangle();
+  mBoundingBox = QgsBox3D();
   mHasCachedValidity = false;
   mValidityFailureReason.clear();
   QgsAbstractGeometry::clearCache();

--- a/src/core/geometry/qgssurface.h
+++ b/src/core/geometry/qgssurface.h
@@ -21,7 +21,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
-#include "qgsrectangle.h"
+#include "qgsbox3d.h"
 
 class QgsPolygon;
 
@@ -40,11 +40,11 @@ class CORE_EXPORT QgsSurface: public QgsAbstractGeometry
      */
     virtual QgsPolygon *surfaceToPolygon() const = 0 SIP_FACTORY;
 
-    QgsRectangle boundingBox() const override
+    QgsBox3D boundingBox3D() const override
     {
       if ( mBoundingBox.isNull() )
       {
-        mBoundingBox = calculateBoundingBox();
+        mBoundingBox = calculateBoundingBox3D();
       }
       return mBoundingBox;
     }
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsSurface: public QgsAbstractGeometry
 
     void clearCache() const override;
 
-    mutable QgsRectangle mBoundingBox;
+    mutable QgsBox3D mBoundingBox;
     mutable bool mHasCachedValidity = false;
     mutable QString mValidityFailureReason;
 };

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -1278,16 +1278,29 @@ void TestQgsCurvePolygon::testBoundingBox3D()
 
 void TestQgsCurvePolygon::testBoundingBoxIntersects()
 {
-  QgsCurvePolygon poly;
-  QVERIFY( !poly.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  // 2d
+  QgsCurvePolygon poly1;
+  QVERIFY( !poly1.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
 
-  QgsCircularString *ext = new QgsCircularString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0, 1 ) << QgsPoint( 1, 10, 2 )
-                  << QgsPoint( 0, 18, 3 ) << QgsPoint( -1, 4, 4 ) << QgsPoint( 0, 0, 1 ) );
-  poly.setExteriorRing( ext );
+  std::unique_ptr< QgsCircularString > ext1( new QgsCircularString() );
+  ext1->setPoints( QgsPointSequence() << QgsPoint( 0, 0, 1 ) << QgsPoint( 1, 10, 2 )
+                   << QgsPoint( 0, 18, 3 ) << QgsPoint( -1, 4, 4 ) << QgsPoint( 0, 0, 1 ) );
+  poly1.setExteriorRing( ext1.release() );
 
-  QVERIFY( poly.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( !poly.boundingBoxIntersects( QgsRectangle( 1.1, -5, 6, -2 ) ) );
+  QVERIFY( poly1.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !poly1.boundingBoxIntersects( QgsRectangle( 1.1, -5, 6, -2 ) ) );
+
+  // 3d
+  QgsCurvePolygon poly2;
+  QVERIFY( !poly2.boundingBoxIntersects( QgsBox3D( 1, 3, 1, 6, 9, 2 ) ) );
+
+  std::unique_ptr< QgsCircularString > ext2( new QgsCircularString() );
+  ext2->setPoints( QgsPointSequence() << QgsPoint( 0, 0, 1 ) << QgsPoint( 1, 10, 2 )
+                   << QgsPoint( 0, 18, 3 ) << QgsPoint( -1, 4, 4 ) << QgsPoint( 0, 0, 1 ) );
+  poly2.setExteriorRing( ext2.release() );
+
+  QVERIFY( poly2.boundingBoxIntersects( QgsBox3D( 1, 3, 1, 6, 9, 2 ) ) );
+  QVERIFY( !poly2.boundingBoxIntersects( QgsBox3D( 1, 3, 4.1, 6, 9, 6 ) ) );
 }
 
 void TestQgsCurvePolygon::testRoundness()

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -55,6 +55,7 @@ class TestQgsCurvePolygon: public QObject
     void testClosestSegment();
     void testBoundary();
     void testBoundingBox();
+    void testBoundingBox3D();
     void testBoundingBoxIntersects();
     void testRoundness();
     void testDropZValue();
@@ -1254,6 +1255,25 @@ void TestQgsCurvePolygon::testBoundingBox()
   QGSCOMPARENEAR( bBox.xMaximum(), 1.012344, 0.001 );
   QGSCOMPARENEAR( bBox.yMinimum(), 0.000000, 0.001 );
   QGSCOMPARENEAR( bBox.yMaximum(), 18, 0.001 );
+}
+
+void TestQgsCurvePolygon::testBoundingBox3D()
+{
+  QgsCurvePolygon poly;
+  QgsBox3D bBox = poly.boundingBox3D();
+
+  QgsCircularString *ext = new QgsCircularString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0, 1 ) << QgsPoint( 1, 10, 2 )
+                  << QgsPoint( 0, 18, 3 ) << QgsPoint( -1, 4, 4 ) << QgsPoint( 0, 0, 1 ) );
+  poly.setExteriorRing( ext );
+
+  bBox = poly.boundingBox3D();
+  QGSCOMPARENEAR( bBox.xMinimum(), -1.435273, 0.001 );
+  QGSCOMPARENEAR( bBox.xMaximum(), 1.012344, 0.001 );
+  QGSCOMPARENEAR( bBox.yMinimum(), 0.000000, 0.001 );
+  QGSCOMPARENEAR( bBox.yMaximum(), 18, 0.001 );
+  QGSCOMPARENEAR( bBox.zMinimum(), 1., 0.001 );
+  QGSCOMPARENEAR( bBox.zMaximum(), 4., 0.001 );
 }
 
 void TestQgsCurvePolygon::testBoundingBoxIntersects()

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -155,6 +155,7 @@ class TestQgsGeometry : public QgsTest
     void createCollectionOfType();
 
     void orientedMinimumBoundingBox( );
+    void boundingBox3D();
     void minimalEnclosingCircle( );
     void splitGeometry();
     void snappedToGrid();
@@ -2173,6 +2174,21 @@ void TestQgsGeometry::orientedMinimumBoundingBox()
   QCOMPARE( result.asWkt( 2 ), resultTestWKT );
 
 }
+
+void TestQgsGeometry::boundingBox3D()
+{
+  QgsGeometry geomTest;
+  QCOMPARE( geomTest.boundingBox3D(), QgsBox3D() );
+
+  QgsGeometry geomTest2D = QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0, 5 5, -2.07106781186547462 12.07106781186547551, -7.07106781186547462 7.07106781186547551))" ) );
+  QgsBox3D expectedResult2D = QgsBox3D( -7.07106781186547462, 0, std::numeric_limits< double >::quiet_NaN(), 5, 12.07106781186547551, std::numeric_limits< double >::quiet_NaN() );
+  QCOMPARE( geomTest2D.boundingBox3D(), expectedResult2D );
+
+  QgsGeometry geomTest3D = QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0 0, 5 5 3, -2.07106781186547462 12.07106781186547551 4.3489, -7.07106781186547462 7.07106781186547551 -7.8909))" ) );
+  QgsBox3D expectedResult3D = QgsBox3D( -7.07106781186547462, 0, -7.8909, 5, 12.07106781186547551, 4.3489 );
+  QCOMPARE( geomTest3D.boundingBox3D(), expectedResult3D );
+}
+
 void TestQgsGeometry::minimalEnclosingCircle()
 {
   QgsGeometry geomTest;

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -1468,7 +1468,7 @@ void TestQgsGeometryCollection::geometryCollection()
   TestFailTransformer failTransformer;
   QVERIFY( !transformCollect2.transform( &failTransformer ) );
 
-  // bounding box intersects test
+  // bounding box intersects 2d test
   QgsGeometryCollection b1;
   QVERIFY( !b1.boundingBoxIntersects( QgsRectangle( 0, 0, 0, 0 ) ) );
   transformLine.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4, Qgis::WkbType::PointZM ) << QgsPoint( 11, 12, 13, 14, Qgis::WkbType::PointZM ) << QgsPoint( 111, 12, 23, 24, Qgis::WkbType::PointZM ) );
@@ -1482,9 +1482,27 @@ void TestQgsGeometryCollection::geometryCollection()
   QVERIFY( b1.boundingBox().isNull() );
   transformLine.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 10, 17, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 12, 17, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 12, 15, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) );
   b1.addGeometry( transformLine.clone() );
-  QgsPolygon polygon;
-  QVERIFY( polygon.fromWkt( "Polygon( (5 10 0, 5 15 0, 10 15 0, 10 10 0, 5 10 0) )" ) );
-  QVERIFY( b1.boundingBoxIntersects( polygon.boundingBox() ) );
+  QgsPolygon polygon1;
+  QVERIFY( polygon1.fromWkt( "Polygon( (5 10 0, 5 15 0, 10 15 0, 10 10 0, 5 10 0) )" ) );
+  QVERIFY( b1.boundingBoxIntersects( polygon1.boundingBox() ) );
+
+  // bounding box intersects 3d test
+  QgsGeometryCollection b2;
+  QVERIFY( !b2.boundingBoxIntersects( QgsBox3D( 0, 0, 0, 0, 0, 0 ) ) );
+  transformLine.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4, Qgis::WkbType::PointZM ) << QgsPoint( 11, 12, 13, 14, Qgis::WkbType::PointZM ) << QgsPoint( 111, 12, 23, 24, Qgis::WkbType::PointZM ) );
+  b2.addGeometry( transformLine.clone() );
+  QVERIFY( !b2.boundingBoxIntersects( QgsBox3D( -5, -2, 4, 0.5, 1.5, 5 ) ) );
+  QVERIFY( b2.boundingBoxIntersects( QgsBox3D( -5, -2, 2, 1.5, 2.5, 8 ) ) );
+  QVERIFY( b2.boundingBoxIntersects( QgsBox3D( 3, 7, 12, 5, 8, 26 ) ) );
+  QCOMPARE( b2.boundingBox3D(), QgsBox3D( 1, 2, 3, 111, 12, 23 ) );
+
+  b2.clear();
+  QVERIFY( b2.boundingBox().isNull() );
+  transformLine.setPoints( QgsPointSequence() << QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 10, 17, 1 ) << QgsPoint( Qgis::WkbType::PointZ, 12, 17, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 12, 15, 1 ) <<  QgsPoint( Qgis::WkbType::PointZ, 10, 15, 1 ) );
+  b2.addGeometry( transformLine.clone() );
+  QgsPolygon polygon2;
+  QVERIFY( polygon2.fromWkt( "Polygon( (5 10 0, 5 15 5, 10 15 5, 10 10 5, 5 10 0) )" ) );
+  QVERIFY( b2.boundingBoxIntersects( polygon2.boundingBox3D() ) );
 }
 
 

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -556,6 +556,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( extR->boundingBox().yMinimum(), -39.724, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().xMaximum(), 176.959, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMinimum(), std::numeric_limits<double>::quiet_NaN(), 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMaximum(), std::numeric_limits<double>::quiet_NaN(), 0.001 );
   const QgsLineString *intR = static_cast< const QgsLineString * >( pTransform.geometryN( 1 ) );
   QGSCOMPARENEAR( intR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -569,6 +575,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->boundingBox().yMinimum(), -39.724, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 176.959, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMinimum(), std::numeric_limits<double>::quiet_NaN(), 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMaximum(), std::numeric_limits<double>::quiet_NaN(), 0.001 );
 
   //3d CRS transform
   QgsLineString l22;
@@ -601,6 +613,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( extR->boundingBox().yMinimum(), -39.724, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().xMaximum(), 176.959, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMinimum(), 1.0, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMaximum(), 5.0, 0.001 );
   intR = static_cast< const QgsLineString * >( pTransform.geometryN( 1 ) );
   QGSCOMPARENEAR( intR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -622,6 +640,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->boundingBox().yMinimum(), -39.724, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 176.959, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMinimum(), 1.0, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMaximum(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMaximum(), 5.0, 0.001 );
 
   //reverse transform
   pTransform.transform( tr, Qgis::TransformDirection::Reverse );
@@ -646,6 +670,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( extR->boundingBox().yMinimum(), -3626584, 100 );
   QGSCOMPARENEAR( extR->boundingBox().xMaximum(), 6474984, 100 );
   QGSCOMPARENEAR( extR->boundingBox().yMaximum(), -3526584, 100 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMinimum(), 1.0, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMaximum(), -3526584, 100 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMaximum(), 5.0, 0.001 );
   intR = static_cast< const QgsLineString * >( pTransform.geometryN( 1 ) );
   QGSCOMPARENEAR( intR->pointN( 0 ).x(), 6374984, 100 );
   QGSCOMPARENEAR( intR->pointN( 0 ).y(), -3626584, 100 );
@@ -667,6 +697,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->boundingBox().yMinimum(), -3626584, 100 );
   QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 6474984, 100 );
   QGSCOMPARENEAR( intR->boundingBox().yMaximum(), -3526584, 100 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMinimum(), 1.0, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMaximum(), -3526584, 100 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMaximum(), 5.0, 0.001 );
 
 #if 0 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
@@ -727,6 +763,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( extR->boundingBox().yMinimum(), 6, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().xMaximum(), 22, 0.001 );
   QGSCOMPARENEAR( extR->boundingBox().yMaximum(), 36, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMinimum(), 9, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().yMaximum(), 36, 0.001 );
+  QGSCOMPARENEAR( extR->boundingBox3D().zMaximum(), 49, 0.001 );
   intR = static_cast< const QgsLineString * >( pTransform2.geometryN( 1 ) );
   QGSCOMPARENEAR( intR->pointN( 0 ).x(), 2, 100 );
   QGSCOMPARENEAR( intR->pointN( 0 ).y(), 6, 100 );
@@ -748,6 +790,12 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->boundingBox().yMinimum(), 6, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 22, 0.001 );
   QGSCOMPARENEAR( intR->boundingBox().yMaximum(), 36, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMinimum(), 9, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().yMaximum(), 36, 0.001 );
+  QGSCOMPARENEAR( intR->boundingBox3D().zMaximum(), 49, 0.001 );
 
 
   // closestSegment

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2331,16 +2331,16 @@ void TestQgsLineString::boundingBox3D()
                   << QgsPoint( -2.0, -1.0, -1.0 )
                   << QgsPoint( 1.0, 2.0, -1.0 )
                   << QgsPoint( 1.0, 2.0, 2.0 ) );
-  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3D( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
+  QCOMPARE( bb3d.calculateBoundingBox3D(), QgsBox3D( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
   // retrieve again, should use cached values
-  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3D( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
+  QCOMPARE( bb3d.calculateBoundingBox3D(), QgsBox3D( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
 
   // linestring with z
   bb3d.setPoints( QgsPointSequence() << QgsPoint( -1.0, -1.0 )
                   << QgsPoint( -2.0, -1.0 )
                   << QgsPoint( 1.0, 2.0 )
                   << QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3D( QgsPoint( -2.0, -1, std::numeric_limits< double >::quiet_NaN() ), QgsPoint( 1.0, 2.0, std::numeric_limits< double >::quiet_NaN() ) ) );
+  QCOMPARE( bb3d.calculateBoundingBox3D(), QgsBox3D( QgsPoint( -2.0, -1, std::numeric_limits< double >::quiet_NaN() ), QgsPoint( 1.0, 2.0, std::numeric_limits< double >::quiet_NaN() ) ) );
 }
 
 void TestQgsLineString::angle()

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2972,6 +2972,7 @@ void TestQgsLineString::orientation()
 
 void TestQgsLineString::boundingBoxIntersects()
 {
+  // 2d
   QgsLineString ls;
   QVERIFY( !ls.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
 
@@ -2994,6 +2995,30 @@ void TestQgsLineString::boundingBoxIntersects()
   QVERIFY( !ls.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( 11, -10, 13, 12 ) );
   QVERIFY( ls.boundingBoxIntersects( QgsRectangle( 12, 3, 16, 9 ) ) );
+
+  // 3d
+  QgsLineString ls3d;
+  QVERIFY( !ls3d.boundingBoxIntersects( QgsBox3D( 1, 3, 5, 6, 9, 11 ) ) );
+
+  ls3d.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                  << QgsPoint( 11, 12 ) << QgsPoint( 13, -10 ) );
+
+  QVERIFY( ls3d.boundingBoxIntersects( QgsRectangle( 12, 3, 16, 9 ) ) );
+
+  // double test because of cache
+  QVERIFY( ls3d.boundingBoxIntersects( QgsRectangle( 12, 3, 16, 9 ) ) );
+  QVERIFY( !ls3d.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !ls3d.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QCOMPARE( ls3d.boundingBox(), QgsRectangle( 11, -10, 13, 12 ) );
+
+  // clear cache
+  ls3d.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                  << QgsPoint( 11, 12 ) << QgsPoint( 13, -10 ) );
+
+  QVERIFY( !ls3d.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !ls3d.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QCOMPARE( ls3d.boundingBox(), QgsRectangle( 11, -10, 13, 12 ) );
+  QVERIFY( ls3d.boundingBoxIntersects( QgsRectangle( 12, 3, 16, 9 ) ) );
 }
 
 

--- a/tests/src/core/geometry/testqgsmultipoint.cpp
+++ b/tests/src/core/geometry/testqgsmultipoint.cpp
@@ -1015,7 +1015,7 @@ void TestQgsMultiPoint::boundingBox()
   QCOMPARE( mp.boundingBox(), QgsRectangle( 0, 0, 1, 2 ) );
 
   mp.clear();
-  QCOMPARE( mp.boundingBox(), QgsRectangle( 0, 0, 0, 0 ) );
+  QCOMPARE( mp.boundingBox(), QgsRectangle( std::numeric_limits< double >::quiet_NaN(), std::numeric_limits< double >::quiet_NaN(), std::numeric_limits< double >::quiet_NaN(), std::numeric_limits< double >::quiet_NaN() ) );
 
   mp.addGeometry( new QgsPoint( 1, 2 ) );
   QCOMPARE( mp.boundingBox(), QgsRectangle( 1, 2, 1, 2 ) );

--- a/tests/src/core/geometry/testqgspoint.cpp
+++ b/tests/src/core/geometry/testqgspoint.cpp
@@ -1212,7 +1212,3 @@ void TestQgsPoint::exportImport()
 
 QGSTEST_MAIN( TestQgsPoint )
 #include "testqgspoint.moc"
-
-
-
-

--- a/tests/src/core/geometry/testqgspoint.cpp
+++ b/tests/src/core/geometry/testqgspoint.cpp
@@ -944,12 +944,21 @@ void TestQgsPoint::boundingBox3D()
 
 void TestQgsPoint::boundingBoxIntersects()
 {
+  // 2d
   QVERIFY( QgsPoint( 1, 2 ).boundingBoxIntersects(
              QgsRectangle( 0, 0.5, 1.5, 3 ) ) );
   QVERIFY( !QgsPoint( 1, 2 ).boundingBoxIntersects(
              QgsRectangle( 3, 0.5, 3.5, 3 ) ) );
   QVERIFY( !QgsPoint().boundingBoxIntersects(
              QgsRectangle( 0, 0.5, 3.5, 3 ) ) );
+
+  // 3d
+  QVERIFY( QgsPoint( 1, 2, 3 ).boundingBoxIntersects(
+             QgsBox3D( 0, 0.5, 1.5, 3, 2.5, 4.2 ) ) );
+  QVERIFY( !QgsPoint( 1, 2, 3 ).boundingBoxIntersects(
+             QgsBox3D( 3, 0.5, 1.5, 3.5, 2.5, 4.5 ) ) );
+  QVERIFY( !QgsPoint().boundingBoxIntersects(
+             QgsBox3D( 0, 0.5, 1.5, 3.5, 2.5, 4.5 ) ) );
 }
 
 void TestQgsPoint::filterVertices()

--- a/tests/src/core/geometry/testqgspoint.cpp
+++ b/tests/src/core/geometry/testqgspoint.cpp
@@ -63,6 +63,7 @@ class TestQgsPoint: public QObject
     void inclination();
     void boundary();
     void boundingBox();
+    void boundingBox3D();
     void boundingBoxIntersects();
     void filterVertices();
     void transformVertices();
@@ -907,6 +908,38 @@ void TestQgsPoint::boundingBox()
 
   pt = QgsPoint( 21.0, 23.0 );
   QCOMPARE( pt.boundingBox(), QgsRectangle( 21.0, 23.0, 21.0, 23.0 ) );
+}
+
+void TestQgsPoint::boundingBox3D()
+{
+  QgsPoint pt( 1.0, 2.0, 3.0 );
+
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 1.0, 2.0, 3.0, 1.0, 2.0, 3.0 ) );
+
+  //modify points and test that bounding box is updated accordingly
+  pt.setX( 4.0 );
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 2.0, 3.0, 4.0, 2.0, 3.0 ) );
+
+  pt.setY( 6.0 );
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 6.0, 3.0, 4.0, 6.0, 3.0 ) );
+
+  pt.setZ( -2.0 );
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 6.0, -2.0, 4.0, 6.0, -2.0 ) );
+
+  pt.rx() = 4.0;
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 6.0, -2.0, 4.0, 6.0, -2.0 ) );
+
+  pt.ry() = 9.0;
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 9.0, -2.0, 4.0, 9.0, -2.0 ) );
+
+  pt.rz() = 7.0;
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 4.0, 9.0, 7.0, 4.0, 9.0, 7.0 ) );
+
+  pt.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 11.0, 13.0, 15.0 ) );
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 11.0, 13.0, 15.0, 11.0, 13.0, 15.0 ) );
+
+  pt = QgsPoint( 21.0, 23.0, 25.0 );
+  QCOMPARE( pt.boundingBox3D(), QgsBox3D( 21.0, 23.0, 25.0, 21.0, 23.0, 25.0 ) );
 }
 
 void TestQgsPoint::boundingBoxIntersects()

--- a/tests/src/core/testqgsclipper.cpp
+++ b/tests/src/core/testqgsclipper.cpp
@@ -181,7 +181,7 @@ void TestQgsClipper::basic()
 
 bool TestQgsClipper::checkBoundingBox( const QgsLineString &polygon, const QgsBox3D &clipRect )
 {
-  return clipRect.contains( polygon.calculateBoundingBox3d() );
+  return clipRect.contains( polygon.calculateBoundingBox3D() );
 }
 
 bool TestQgsClipper::checkBoundingBox( const QPolygonF &polygon, const QgsRectangle &clipRect )

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -2343,6 +2343,37 @@ class TestQgsGeometry(QgisTestCase):
         line = QgsGeometry.fromPolylineXY(points)
         assert line.boundingBox().isNull()
 
+    def testBoundingBox3D(self):
+        # null
+        points = []
+        geom = QgsGeometry.fromPolylineXY(points)
+        assert geom.boundingBox3D().isNull()
+
+        # fromBox3D
+        box3D = QgsBox3D(1, 2, 3, 4, 5, 6)
+        box3D_geom = QgsGeometry.fromBox3D(box3D)
+        result = box3D_geom.boundingBox3D()
+        self.assertEqual(
+            box3D, result,
+            f"Expected:\n{box3D.toString()}\nGot:\n{result.toString()}\n")
+
+        # 2D polyline
+        points = [QgsPointXY(5, 0), QgsPointXY(0, 0), QgsPointXY(0, 4), QgsPointXY(5, 4), QgsPointXY(5, 1),
+                  QgsPointXY(1, 1), QgsPointXY(1, 3), QgsPointXY(4, 3), QgsPointXY(4, 2), QgsPointXY(2, 2)]
+        polyline2D = QgsGeometry.fromPolylineXY(points)
+        expbb2D = QgsBox3D(0, 0, float("nan"), 5, 4, float("nan"))
+        bb2D = polyline2D.boundingBox3D()
+        self.assertEqual(
+            expbb2D, bb2D, f"Expected:\n{expbb2D.toString()}\nGot:\n{bb2D.toString()}\n")
+
+        # 3D polyline
+        points = [QgsPoint(5, 0, -3), QgsPoint(0, 0, 5), QgsPoint(0, 4, -3), QgsPoint(5, 4, 0), QgsPoint(5, 1, 1),
+                  QgsPoint(1, 1, 2), QgsPoint(1, 3, 5), QgsPoint(4, 3, 9), QgsPoint(4, 2, -6), QgsPoint(2, 2, 8)]
+        polyline3D = QgsGeometry.fromPolyline(points)
+        expbb3D = QgsBox3D(0, 0, -6, 5, 4, 9)
+        bb3D = polyline3D.boundingBox3D()
+        self.assertEqual(expbb3D, bb3D, f"Expected:\n{expbb3D.toString()}\nGot:\n{bb3D.toString()}\n")
+
     def testCollectGeometry(self):
         # collect points
         geometries = [QgsGeometry.fromPointXY(QgsPointXY(0, 0)), QgsGeometry.fromPointXY(QgsPointXY(1, 1))]


### PR DESCRIPTION
## Description

This mostly adds for the relevant geometry classes: 
- boundingBox3D()
- calculateBoundingBox3D()
- boundingBoxIntersects( const QgsBox3D &box3d )


cc @benoitdm-oslandia @lbartoletti 