### PR TITLE
Fix delete curve vertex

### DIFF
--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4851,7 +4851,7 @@ class TestQgsGeometry(QgisTestCase):
         wkt = "CurvePolygon (CompoundCurve (CircularString(0 0,1 1,2 0,1.5 -0.5,1 -1),(1 -1,0 0)))"
         geom = QgsGeometry.fromWkt(wkt)
         assert geom.deleteVertex(1)
-        expected_wkt = "CurvePolygon (CompoundCurve (CircularString (0 0, 1.5 -0.5, 1 -1),(1 -1, 0 0)))"
+        expected_wkt = "CurvePolygon (CompoundCurve ((0 0, 2 0),CircularString (2 0, 1.5 -0.5, 1 -1),(1 -1, 0 0)))"
         self.assertEqual(geom.asWkt(), QgsGeometry.fromWkt(expected_wkt).asWkt())
 
         wkt = "CurvePolygon (CompoundCurve (CircularString(0 0,1 1,2 0,1.5 -0.5,1 -1),(1 -1,0 0)))"
@@ -4863,7 +4863,7 @@ class TestQgsGeometry(QgisTestCase):
         wkt = "CurvePolygon (CompoundCurve (CircularString(0 0,1 1,2 0,1.5 -0.5,1 -1),(1 -1,0 0)))"
         geom = QgsGeometry.fromWkt(wkt)
         assert geom.deleteVertex(3)
-        expected_wkt = "CurvePolygon (CompoundCurve (CircularString (0 0, 1 1, 1 -1),(1 -1, 0 0)))"
+        expected_wkt = "CurvePolygon (CompoundCurve (CircularString (0 0, 1 1, 2 0),(2 0, 1 -1),(1 -1, 0 0)))"
         self.assertEqual(geom.asWkt(), QgsGeometry.fromWkt(expected_wkt).asWkt())
 
         wkt = "CurvePolygon (CompoundCurve (CircularString(0 0,1 1,2 0,1.5 -0.5,1 -1),(1 -1,0 0)))"


### PR DESCRIPTION
## Description

Fixes a bug when deleting a middle curve vertex.

The deletion was not correctly handled, corrupting the geometry (see picture below, where using the vertex tool we can see a rubber band issue, persisting even after saving the layer), and creating an OGR error when exporting in GPKG (Non contiguous curves).

**Vertex to delete**

![image](https://github.com/qgis/QGIS/assets/34267385/61603f38-9ec8-485b-9847-eeb552978c52)

**After deletion**

![image](https://github.com/qgis/QGIS/assets/34267385/334dd335-4706-405a-8379-57a0bad68618)

## Fix

Test if the vertex to delete is a middle vertex of a curve, and if so, delete the curve and simply replace it with a linestring going from the first to the last vertex and skipping the middle one.

---

Funded by Métropole de Lille