### PR TITLE
Insure that copied features within the same layer respect project relationship(s) strength

### DIFF
--- a/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -41,7 +41,7 @@ This method calls the addFeature method of the backend :py:class:`QgsVectorLayer
 
     virtual bool saveEdits( QgsVectorLayer *layer ) const;
 
-    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double  dx = 0, double dy = 0, QString *errorMsg = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0 ) const;
+    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double  dx = 0, double dy = 0, QString *errorMsg = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0, QString *childrenInfoMsg = 0 ) const;
 
 
     void setVectorLayerTools( const QgsVectorLayerTools *tools );

--- a/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
@@ -78,7 +78,7 @@ Should be called, when the features should be committed but the editing session 
 %End
 
 
-    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request /In,Out/, double dx = 0, double dy = 0, QString *errorMsg /Out/ = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0, QString *childrenInfoMsg /Out/ = 0 ) const;
+    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request /In,Out/, double dx = 0, double dy = 0, QString *errorMsg /Out/ = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0, QString *childrenInfoMsg = 0 ) const;
 %Docstring
 Copy and move features with defined translation.
 
@@ -89,10 +89,10 @@ Copy and move features with defined translation.
 :param topologicalEditing: If ``True``, the function will perform topological
                            editing of the vertices of ``layer`` on ``layer`` and ``topologicalLayer``
 :param topologicalLayer: The layer where vertices from the moved features of ``layer`` will be added
+:param childrenInfoMsg: If given, it will contain messages related to the creation of child features
 
 :return: - ``True`` if all features could be copied.
          - errorMsg: If given, it will contain the error message
-         - childrenInfoMsg: If given, it will contain messages related to the creation of child features
 %End
 
     bool forceSuppressFormPopup() const;

--- a/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
@@ -78,7 +78,7 @@ Should be called, when the features should be committed but the editing session 
 %End
 
 
-    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request /In,Out/, double dx = 0, double dy = 0, QString *errorMsg /Out/ = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0 ) const;
+    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request /In,Out/, double dx = 0, double dy = 0, QString *errorMsg /Out/ = 0, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = 0, QString *childrenInfoMsg /Out/ = 0 ) const;
 %Docstring
 Copy and move features with defined translation.
 
@@ -92,6 +92,7 @@ Copy and move features with defined translation.
 
 :return: - ``True`` if all features could be copied.
          - errorMsg: If given, it will contain the error message
+         - childrenInfoMsg: If given, it will contain messages related to the creation of child features
 %End
 
     bool forceSuppressFormPopup() const;
@@ -111,6 +112,20 @@ This flag will override the layer and general settings regarding the automatic
 opening of the attribute form dialog when digitizing is completed.
 
 .. versionadded:: 3.14
+%End
+
+    void setProject( QgsProject *project );
+%Docstring
+Sets the project to be used by operations when needed.
+
+.. versionadded:: 3.34
+%End
+
+    QgsProject *project() const;
+%Docstring
+Returns the project to be used by operations when needed.
+
+.. versionadded:: 3.34
 %End
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1510,6 +1510,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   connect( QgsApplication::messageLog(), static_cast < void ( QgsMessageLog::* )( bool ) >( &QgsMessageLog::messageReceived ), this, &QgisApp::toggleLogMessageIcon );
   connect( mMessageButton, &QAbstractButton::toggled, this, &QgisApp::toggleLogMessageIcon );
   mVectorLayerTools = new QgsGuiVectorLayerTools();
+  mVectorLayerTools->setProject( QgsProject::instance() );
 
   // Init the editor widget types
   QgsGui::editorWidgetRegistry()->initEditors( mMapCanvas, mInfoBar );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2351,8 +2351,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     /**
      * Pastes the \a features to the \a pasteVectorLayer and gives feedback to the user
      * according to \a invalidGeometryCount and \a nTotalFeatures
+     * \note Setting the \a duplicateFeature to TRUE will handle the pasting of features as duplicates of pre-existing features
      */
-    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features );
+    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features, bool duplicateFeature = false );
 
     /**
      * starts/stops for a vector layer \a vlayer

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -59,6 +59,7 @@ void QgsClipboard::replaceWithCopyOf( QgsVectorLayer *src )
   mFeatureFields = src->fields();
   mFeatureClipboard = src->selectedFeatures();
   mCRS = src->crs();
+  mFeatureLayer = src;
   QgsDebugMsgLevel( QStringLiteral( "replaced QGIS clipboard." ), 2 );
 
   setSystemClipboard();
@@ -99,6 +100,7 @@ void QgsClipboard::replaceWithCopyOf( QgsVectorTileLayer *src )
   }
 
   mCRS = src->crs();
+  mFeatureLayer = src;
   QgsDebugMsgLevel( QStringLiteral( "replaced QGIS clipboard." ), 2 );
 
   setSystemClipboard();
@@ -112,6 +114,7 @@ void QgsClipboard::replaceWithCopyOf( QgsFeatureStore &featureStore )
   mFeatureFields = featureStore.fields();
   mFeatureClipboard = featureStore.features();
   mCRS = featureStore.crs();
+  mFeatureLayer.clear();
   setSystemClipboard();
   mUseSystemClipboard = false;
   emit changed();
@@ -526,6 +529,14 @@ QgsFields QgsClipboard::fields() const
     return mFeatureFields;
   else
     return retrieveFields();
+}
+
+QgsMapLayer *QgsClipboard::layer() const
+{
+  if ( !mUseSystemClipboard )
+    return mFeatureLayer.data();
+  else
+    return nullptr;
 }
 
 void QgsClipboard::systemClipboardChanged()

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -108,13 +108,13 @@ void QgsClipboard::replaceWithCopyOf( QgsVectorTileLayer *src )
   emit changed();
 }
 
-void QgsClipboard::replaceWithCopyOf( QgsFeatureStore &featureStore )
+void QgsClipboard::replaceWithCopyOf( QgsFeatureStore &featureStore, QgsVectorLayer *src )
 {
   QgsDebugMsgLevel( QStringLiteral( "features count = %1" ).arg( featureStore.features().size() ), 2 );
   mFeatureFields = featureStore.fields();
   mFeatureClipboard = featureStore.features();
   mCRS = featureStore.crs();
-  mFeatureLayer.clear();
+  mFeatureLayer = src;
   setSystemClipboard();
   mUseSystemClipboard = false;
   emit changed();

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -81,7 +81,7 @@ class APP_EXPORT QgsClipboard : public QObject
      * Place a copy of features on the internal clipboard,
      * destroying the previous contents.
      */
-    void replaceWithCopyOf( QgsFeatureStore &featureStore );
+    void replaceWithCopyOf( QgsFeatureStore &featureStore, QgsVectorLayer *src = nullptr );
 
     /**
      * Returns a copy of features on the internal clipboard.

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -26,6 +26,7 @@
 #include "qgsfields.h"
 #include "qgsfeature.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsmaplayer.h"
 #include "qgis_app.h"
 
 class QgsVectorLayer;
@@ -140,6 +141,8 @@ class APP_EXPORT QgsClipboard : public QObject
      */
     QgsFields fields() const;
 
+    QgsMapLayer *layer() const;
+
   private slots:
 
     void systemClipboardChanged();
@@ -184,6 +187,7 @@ class APP_EXPORT QgsClipboard : public QObject
     QgsFeatureList mFeatureClipboard;
     QgsFields mFeatureFields;
     QgsCoordinateReferenceSystem mCRS;
+    QPointer<QgsMapLayer> mFeatureLayer;
 
     //! True if next system clipboard change should be ignored
     bool mIgnoreNextSystemClipboardChange = false;

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -245,17 +245,17 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       case CopyMove:
         QgsFeatureRequest request;
         request.setFilterFids( mMovedFeatures );
-        QString *errorMsg = new QString();
-        QString *childrenInfoMsg = new QString();
-        if ( !QgisApp::instance()->vectorLayerTools()->copyMoveFeatures( vlayer, request, dx, dy, errorMsg, QgsProject::instance()->topologicalEditing(), mSnapIndicator->match().layer(), childrenInfoMsg ) )
+        QString errorMsg;
+        QString childrenInfoMsg;
+        if ( !QgisApp::instance()->vectorLayerTools()->copyMoveFeatures( vlayer, request, dx, dy, &errorMsg, QgsProject::instance()->topologicalEditing(), mSnapIndicator->match().layer(), &childrenInfoMsg ) )
         {
-          emit messageEmitted( *errorMsg, Qgis::MessageLevel::Critical );
+          emit messageEmitted( errorMsg, Qgis::MessageLevel::Critical );
           deleteRubberband();
           mSnapIndicator->setMatch( QgsPointLocator::Match() );
         }
-        if ( !childrenInfoMsg->isEmpty() )
+        if ( !childrenInfoMsg.isEmpty() )
         {
-          emit messageEmitted( *childrenInfoMsg, Qgis::MessageLevel::Info );
+          emit messageEmitted( childrenInfoMsg, Qgis::MessageLevel::Info );
         }
         break;
     }

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -246,11 +246,16 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         QgsFeatureRequest request;
         request.setFilterFids( mMovedFeatures );
         QString *errorMsg = new QString();
-        if ( !QgisApp::instance()->vectorLayerTools()->copyMoveFeatures( vlayer, request, dx, dy, errorMsg, QgsProject::instance()->topologicalEditing(), mSnapIndicator->match().layer() ) )
+        QString *childrenInfoMsg = new QString();
+        if ( !QgisApp::instance()->vectorLayerTools()->copyMoveFeatures( vlayer, request, dx, dy, errorMsg, QgsProject::instance()->topologicalEditing(), mSnapIndicator->match().layer(), childrenInfoMsg ) )
         {
           emit messageEmitted( *errorMsg, Qgis::MessageLevel::Critical );
           deleteRubberband();
           mSnapIndicator->setMatch( QgsPointLocator::Match() );
+        }
+        if ( !childrenInfoMsg->isEmpty() )
+        {
+          emit messageEmitted( *childrenInfoMsg, Qgis::MessageLevel::Info );
         }
         break;
     }

--- a/src/core/qgstrackedvectorlayertools.cpp
+++ b/src/core/qgstrackedvectorlayertools.cpp
@@ -55,9 +55,9 @@ bool QgsTrackedVectorLayerTools::saveEdits( QgsVectorLayer *layer ) const
   return mBackend->saveEdits( layer );
 }
 
-bool QgsTrackedVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double dx, double dy, QString *errorMsg, const bool topologicalEditing, QgsVectorLayer *topologicalLayer ) const
+bool QgsTrackedVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double dx, double dy, QString *errorMsg, const bool topologicalEditing, QgsVectorLayer *topologicalLayer, QString *childrenInfoMsg ) const
 {
-  return mBackend->copyMoveFeatures( layer, request, dx, dy, errorMsg, topologicalEditing, topologicalLayer );
+  return mBackend->copyMoveFeatures( layer, request, dx, dy, errorMsg, topologicalEditing, topologicalLayer, childrenInfoMsg );
 }
 
 void QgsTrackedVectorLayerTools::setVectorLayerTools( const QgsVectorLayerTools *tools )

--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -50,7 +50,7 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
     bool startEditing( QgsVectorLayer *layer ) const override;
     bool stopEditing( QgsVectorLayer *layer, bool allowCancel ) const override;
     bool saveEdits( QgsVectorLayer *layer ) const override;
-    bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double  dx = 0, double dy = 0, QString *errorMsg = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr ) const override;
+    bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request, double  dx = 0, double dy = 0, QString *errorMsg = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg = nullptr ) const override;
 
     /**
      * Set the vector layer tools that will be used to interact with the data

--- a/src/core/vector/qgsvectorlayertools.h
+++ b/src/core/vector/qgsvectorlayertools.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      * \returns TRUE if all features could be copied.
      *
      */
-    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg SIP_OUT = nullptr ) const;
+    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg = nullptr ) const;
 
     /**
      * Returns force suppress form popup status.

--- a/src/core/vector/qgsvectorlayertools.h
+++ b/src/core/vector/qgsvectorlayertools.h
@@ -25,6 +25,7 @@
 
 class QgsFeatureRequest;
 class QgsVectorLayer;
+class QgsProject;
 
 /**
  * \ingroup core
@@ -111,10 +112,11 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      * \param topologicalEditing If TRUE, the function will perform topological
      * editing of the vertices of \a layer on \a layer and \a topologicalLayer
      * \param topologicalLayer The layer where vertices from the moved features of \a layer will be added
+     * \param childrenInfoMsg If given, it will contain messages related to the creation of child features
      * \returns TRUE if all features could be copied.
      *
      */
-    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr ) const;
+    virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr, QString *childrenInfoMsg SIP_OUT = nullptr ) const;
 
     /**
      * Returns force suppress form popup status.
@@ -134,8 +136,23 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      */
     void setForceSuppressFormPopup( bool forceSuppressFormPopup );
 
+    /**
+     * Sets the project to be used by operations when needed.
+     *
+     * \since QGIS 3.34
+     */
+    void setProject( QgsProject *project ) { mProject = project; }
+
+    /**
+     * Returns the project to be used by operations when needed.
+     *
+     * \since QGIS 3.34
+     */
+    QgsProject *project() const { return mProject; }
+
   private:
 
+    QgsProject *mProject = nullptr;
     bool mForceSuppressFormPopup { false };
 
 

--- a/tests/src/python/test_qgsvectorlayertools.py
+++ b/tests/src/python/test_qgsvectorlayertools.py
@@ -13,10 +13,15 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 import os
 
 from qgis.core import (
+    QgsFeature,
     QgsFeatureRequest,
+    QgsPoint,
     QgsProject,
+    QgsRelation,
+    QgsRelationManager,
     QgsVectorLayer,
     QgsVectorLayerTools,
+    Qgis,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -54,12 +59,38 @@ class TestQgsVectorLayerTools(QgisTestCase):
         cls.dbconn = 'service=\'qgis_test\''
         if 'QGIS_PGTEST_DB' in os.environ:
             cls.dbconn = os.environ['QGIS_PGTEST_DB']
-        # Create test layer
+
+        # Create test layers
         cls.vl = QgsVectorLayer(cls.dbconn + ' sslmode=disable key=\'pk\' table="qgis_test"."someData" (geom) sql=', 'layer', 'postgres')
 
-        QgsProject.instance().addMapLayer(cls.vl)
+        cls.vl2 = QgsVectorLayer('Point?crs=EPSG:4326&field=id:integer(10,0)', 'points', 'memory')
+        f = QgsFeature(cls.vl2.fields())
+        f.setGeometry(QgsPoint(1, 1))
+        f.setAttributes([1])
+        cls.vl2.startEditing()
+        cls.vl2.addFeature(f)
+        cls.vl2.commitChanges()
+
+        cls.vl3 = QgsVectorLayer('NoGeometry?crs=EPSG:4326&field=point_id:integer(10,0)', 'details', 'memory')
+        f = QgsFeature(cls.vl3.fields())
+        f.setAttributes([1])
+        cls.vl3.startEditing()
+        cls.vl3.addFeature(f)
+        cls.vl3.addFeature(f)
+        cls.vl3.commitChanges()
+
+        QgsProject.instance().addMapLayers([cls.vl, cls.vl2, cls.vl3])
+
+        relation = QgsRelation()
+        relation.setName('test')
+        relation.setReferencedLayer(cls.vl2.id())
+        relation.setReferencingLayer(cls.vl3.id())
+        relation.setStrength(Qgis.RelationshipStrength.Composition)
+        relation.addFieldPair('point_id', 'id')
+        QgsProject.instance().relationManager().addRelation(relation)
 
         cls.vltools = SubQgsVectorLayerTools()
+        cls.vltools.setProject(QgsProject.instance())
 
     def testCopyMoveFeature(self):
         """ Test copy and move features"""
@@ -72,6 +103,15 @@ class TestQgsVectorLayerTools(QgisTestCase):
             geom = f.geometry()
             self.assertAlmostEqual(geom.asPoint().x(), -65.42)
             self.assertAlmostEqual(geom.asPoint().y(), 78.5)
+
+    def testCopyMoveFeatureRelationship(self):
+        """ Test copy and move features"""
+        rqst = QgsFeatureRequest()
+        rqst.setFilterFid(1)
+        self.vl2.startEditing()
+        (ok, rqst, msg) = self.vltools.copyMoveFeatures(self.vl2, rqst, -0.1, 0.2)
+        self.assertTrue(ok)
+        self.assertEqual(self.vl3.featureCount(), 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR insures that the two main ways to copy features within the same layer both respect relationship(s) strength. 

---

**Copy/pasting from and to the same vector layer**

When copy/pasting features from and to the same vector layer, QGIS now respects any relationship within the opened project. To achieve that, the QgsClipboard class keeps track of the vector layer from which features are copied. Upon pasting, if the layer used for pasting matches that recorded by the QgsClipboard, we use the QgsVectorLayerUtils::duplicateFeature() to insure that children of composition relations are also copied.

This works both through the main window and within the attribute table.

**Copy and move feature(s) map tool**

The other main way to copy a feature is through the copy and move feature map tool. With this PR, the map tool will now use the QgsVectorLayerUtils::duplicateFeature() when a project is detected. As with the copy/pasting above, this insures that children of composition relations are also copied.

---

With those functionalities added, the relationship strength shines through :)
