### PR TITLE
qgschunkedentity: Use estimated gpu memory instead of hard coded limit

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -62,6 +62,16 @@ QgsChunkedEntity::QgsChunkedEntity( float tau, QgsChunkLoaderFactory *loaderFact
   mRootNode = loaderFactory->createRootNode();
   mChunkLoaderQueue = new QgsChunkList;
   mReplacementQueue = new QgsChunkList;
+
+  int memoryAvailableKB = Qgs3DUtils::estimateGpuMemoryAvailable();
+  if ( memoryAvailableKB == -1 )
+  {
+    mGpuMemoryLimit = 500.0;
+  }
+  else
+  {
+    mGpuMemoryLimit = 0.8 * static_cast<double>( memoryAvailableKB ) / 1024.0;
+  }
 }
 
 

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -274,6 +274,16 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.32
      */
     static float screenSpaceError( float epsilon, float distance, float screenSize, float fov );
+
+    /**
+     * This routine tries to estimate the GPU available memory in kb;
+     * It uses some vendor OpenGL extensions. It works for AMD and Nvidia
+     * but there is no available extension for an Intel card.
+     * It returns -1 in case of failure.
+     *
+     * \since QGIS 3.34
+     */
+    static int estimateGpuMemoryAvailable();
 };
 
 #endif // QGS3DUTILS_H


### PR DESCRIPTION
## Description

This adds a routine to estimate the GPU available memory in kb. It uses some vendor OpenGL extensions. It works for AMD and Nvidia but there is no available extension for an Intel card. 
This estimation is then used in `QgsChunkedEntity` instead of the hard code memory limit.
This should mitigate the infinite 3d scene loading issue.

cc @benoitdm-oslandia @wonder-sk @uclaros 