### PR TITLE
migrate build docker image from ubuntu 22.04 to 23.04

### DIFF
--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -31,7 +31,7 @@ RUN  apt-get update \
     libexiv2-27 \
     libfcgi0ldbl \
     libgsl27 \
-    'libprotobuf-lite17|libprotobuf-lite23' \
+    'libprotobuf-lite17|libprotobuf-lite23|libprotobuf-lite32' \
     libqca-qt5-2-plugins \
     libqt53dextras5 \
     libqt53drender5 \

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -14,8 +14,10 @@ LABEL Description="Docker container with QGIS dependencies" Vendor="QGIS.org" Ve
 
 RUN  apt-get update \
   && apt-get install -y software-properties-common \
-  && echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
-  && echo "deb-src http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
+  # && echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
+  # && echo "deb-src http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
+  # && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160 \
+  && echo "deb http://archive.ubuntu.com/ubuntu jammy main universe" >> /etc/apt/sources.list \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160 \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -30,7 +30,7 @@ RUN  apt-get update \
     gpsbabel \
     graphviz \
     libaio1 \
-    libdraco4 \
+    'libdraco4|libdraco7' \
     libexiv2-27 \
     libfcgi0ldbl \
     libgsl27 \

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -1,5 +1,5 @@
 
-ARG DISTRO_VERSION=22.04
+ARG DISTRO_VERSION=23.04
 
 # Oracle Docker image is too large, so we add as less dependencies as possible
 # so there is enough space on GitHub runner

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -170,7 +170,9 @@ ENV OTB_INSTALL_DIR=/opt/otb
 
 FROM binary-only
 
-RUN  apt-get update \
+RUN echo "deb http://archive.ubuntu.com/ubuntu jammy main universe" >> /etc/apt/sources.list \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160 \
+  && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bison \
     ccache \

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -14,6 +14,9 @@ LABEL Description="Docker container with QGIS dependencies" Vendor="QGIS.org" Ve
 
 RUN  apt-get update \
   && apt-get install -y software-properties-common \
+  && echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
+  && echo "deb-src http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu jammy main" >> /etc/apt/sources.list \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160 \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     apt-transport-https \

--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -94,21 +94,21 @@ RUN  apt-get update \
     xfonts-scalable \
     xvfb \
     ocl-icd-libopencl1 \
-  && pip3 install \
-    numpy \
-    nose2 \
+    python3-numpy \
+    python3-nose2 \
+    python3-mock \
+    python3-future \
+    python3-termcolor \
+    python3-oauthlib \
+    python3-pep8 \
+    python3-pexpect \
+    python3-sphinx \
+    python3-requests \
+    python3-six \
+  && pip3 install --break-system-packages \
     pyyaml \
-    mock \
-    future \
-    termcolor \
-    oauthlib \
     pyopenssl \
-    pep8 \
-    pexpect \
     capturer \
-    sphinx \
-    requests \
-    six \
     hdbcli \
   && apt-get clean
 
@@ -144,8 +144,7 @@ RUN  apt-get update \
     iproute2 \
     postgresql-client \
     spawn-fcgi \
-  && pip3 install \
-    psycopg2 \
+    python3-psycopg2 \
   && apt-get clean
 
 # HANA: client side

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - distro-version: '22.04'
+          - distro-version: '23.04'
             qt-version: 5
             run-tests: true
             docker-tag-suffix: ''
@@ -304,7 +304,7 @@ jobs:
 
         include:
           - qt-version: 5
-            distro-version: 22.04
+            distro-version: 23.04
             docker-target: binary-only
 
           - qt-version: 6
@@ -312,7 +312,7 @@ jobs:
             docker-target: single
 
           - qt-version: 5
-            distro-version: 22.04
+            distro-version: 23.04
             test-batch: ORACLE
             docker-target: binary-for-oracle
 
@@ -427,7 +427,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - distro-version: '22.04'
+          - distro-version: '23.04'
             qt-version: 5
 
     steps:


### PR DESCRIPTION
To test build + test execution against new dep versions.

cc @lbartoletti  @ptitjano 