### PR TITLE
QgsGeometryUtils: Fix wktReadBlock for EMPTY wkt string

### DIFF
--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1366,14 +1366,19 @@ QPair<Qgis::WkbType, QString> QgsGeometryUtils::wktReadBlock( const QString &wkt
 {
   QString wktParsed = wkt;
   QString contents;
-  if ( wkt.contains( QLatin1String( "EMPTY" ), Qt::CaseInsensitive ) )
+  const QString empty { "EMPTY" };
+  if ( wkt.contains( empty, Qt::CaseInsensitive ) )
   {
-    const thread_local QRegularExpression sWktRegEx( QStringLiteral( "^\\s*(\\w+)\\s+(\\w+)\\s*$" ), QRegularExpression::DotMatchesEverythingOption );
-    const QRegularExpressionMatch match = sWktRegEx.match( wkt );
-    if ( match.hasMatch() )
+    const thread_local QRegularExpression whiteSpaces( "\\s" );
+    wktParsed.remove( whiteSpaces );
+    const int index = wktParsed.indexOf( empty, 0, Qt::CaseInsensitive );
+
+    if ( /*index != -1 && */index == wktParsed.length() - empty.length() )
     {
-      wktParsed = match.captured( 1 );
-      contents = match.captured( 2 ).toUpper();
+      // "EMPTY" found at the end of the QString
+      // Extract the part of the QString to the left of "EMPTY"
+      wktParsed = wktParsed.left( index );
+      contents = empty;
     }
   }
   else

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1366,14 +1366,14 @@ QPair<Qgis::WkbType, QString> QgsGeometryUtils::wktReadBlock( const QString &wkt
 {
   QString wktParsed = wkt;
   QString contents;
-  const QString empty { "EMPTY" };
+  const QLatin1String empty { "EMPTY" };
   if ( wkt.contains( empty, Qt::CaseInsensitive ) )
   {
     const thread_local QRegularExpression whiteSpaces( "\\s" );
     wktParsed.remove( whiteSpaces );
     const int index = wktParsed.indexOf( empty, 0, Qt::CaseInsensitive );
 
-    if ( /*index != -1 && */index == wktParsed.length() - empty.length() )
+    if ( index == wktParsed.length() - empty.size() )
     {
       // "EMPTY" found at the end of the QString
       // Extract the part of the QString to the left of "EMPTY"

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -997,6 +997,7 @@ namespace
   inline void testCreateEmptyWithSameType()
   {
     std::unique_ptr<QgsAbstractGeometry> geom { new T() };
+    std::unique_ptr<QgsAbstractGeometry> geomResult { new T() };
     std::unique_ptr<QgsAbstractGeometry> created { TestQgsGeometry::createEmpty( geom.get() ) };
     QVERIFY( created->isEmpty() );
 #if defined(__clang__) || defined(__GNUG__)
@@ -1010,7 +1011,7 @@ namespace
 // remove Qgs prefix
     type = type.right( type.count() - 3 );
     QStringList extensionZM;
-    extensionZM << QString() << QString( "Z" ) << QString( "M" ) << QString( "ZM" );
+    extensionZM << QString() << QString( "Z" ) << QString( "M" ) << QString( "ZM" ) << QString( " Z" ) << QString( " M" ) << QString( " ZM" ) << QString( "Z M" ) << QString( " Z M" );
     for ( const QString &ext : extensionZM )
     {
       QString wkt = type + ext;
@@ -1028,10 +1029,10 @@ namespace
           QString generatedWkt = spacesBefore + wkt + spacesMiddle + emptyStringList.at( j ) + spacesAfter;
 
           QgsGeometry gWkt = QgsGeometry::fromWkt( generatedWkt );
-          QVERIFY( gWkt.asWkt().compare( result, Qt::CaseInsensitive ) == 0 );
 
           QVERIFY( geom->fromWkt( generatedWkt ) );
-          QVERIFY( geom->asWkt().compare( result, Qt::CaseInsensitive ) == 0 );
+          QVERIFY( geomResult->fromWkt( result ) );
+          QCOMPARE( geom->asWkt(), geomResult->asWkt() );
         }
       }
     }


### PR DESCRIPTION
## Description

Relaxed parser to allow more flexible input.
Previously, it accepted 'PointZ EMPTY' but not 'Point Z Empty.' Now, it also accepts 'Point Z M Empty' while still being permissive compared to other implementations like PostGIS.

IMHO, the correct rule should be:
'Type Extension Empty|Coordinates' or 'TypeExtension Empty|Coordinates', rather than 'Type Z M Empty|Coordinates'.

We maintain the principle that the parser should be lenient.
