### PR TITLE
Add Qgis::SymbolLayerUserFlags for user-controlled flags which alter the handling of symbol layers

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -540,11 +540,18 @@ Qgis.SymbolPreviewFlags.baseClass = Qgis
 SymbolPreviewFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.SymbolLayerFlag.DisableFeatureClipping.__doc__ = "If present, indicates that features should never be clipped to the map extent during rendering"
-Qgis.SymbolLayerFlag.__doc__ = "Flags controlling behavior of symbol layers\n\n.. versionadded:: 3.22\n\n" + '* ``DisableFeatureClipping``: ' + Qgis.SymbolLayerFlag.DisableFeatureClipping.__doc__
+Qgis.SymbolLayerFlag.__doc__ = "Flags controlling behavior of symbol layers\n\n.. note::\n\n   These differ from Qgis.SymbolLayerUserFlag in that Qgis.SymbolLayerFlag flags are used to reflect the inbuilt properties\n   of a symbol layer type, whereas Qgis.SymbolLayerUserFlag are optional, user controlled flags which can be toggled\n   for a symbol layer.\n\n.. versionadded:: 3.22\n\n" + '* ``DisableFeatureClipping``: ' + Qgis.SymbolLayerFlag.DisableFeatureClipping.__doc__
 # --
 Qgis.SymbolLayerFlag.baseClass = Qgis
 Qgis.SymbolLayerFlags.baseClass = Qgis
 SymbolLayerFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.SymbolLayerUserFlag.DisableSelectionRecoloring.__doc__ = "If present, indicates that the symbol layer should not be recolored when rendering selected features"
+Qgis.SymbolLayerUserFlag.__doc__ = "User-specified flags controlling behavior of symbol layers.\n\n.. note::\n\n   These differ from Qgis.SymbolLayerFlag in that Qgis.SymbolLayerFlag flags are used to reflect the inbuilt properties\n   of a symbol layer type, whereas Qgis.SymbolLayerUserFlag are optional, user controlled flags which can be toggled\n   for a symbol layer.\n\n.. versionadded:: 3.34\n\n" + '* ``DisableSelectionRecoloring``: ' + Qgis.SymbolLayerUserFlag.DisableSelectionRecoloring.__doc__
+# --
+Qgis.SymbolLayerUserFlag.baseClass = Qgis
+Qgis.SymbolLayerUserFlags.baseClass = Qgis
+SymbolLayerUserFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsDataItem.Type = Qgis.BrowserItemType
 # monkey patching scoped based enum
 QgsDataItem.Collection = Qgis.BrowserItemType.Collection

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -341,6 +341,14 @@ The development version
     typedef QFlags<Qgis::SymbolLayerFlag> SymbolLayerFlags;
 
 
+    enum class SymbolLayerUserFlag
+    {
+      DisableSelectionRecoloring,
+    };
+
+    typedef QFlags<Qgis::SymbolLayerUserFlag> SymbolLayerUserFlags;
+
+
     enum class BrowserItemType
       {
       Collection,
@@ -2240,6 +2248,8 @@ QFlags<Qgis::SymbolFlag> operator|(Qgis::SymbolFlag f1, QFlags<Qgis::SymbolFlag>
 QFlags<Qgis::SymbolPreviewFlag> operator|(Qgis::SymbolPreviewFlag f1, QFlags<Qgis::SymbolPreviewFlag> f2);
 
 QFlags<Qgis::SymbolLayerFlag> operator|(Qgis::SymbolLayerFlag f1, QFlags<Qgis::SymbolLayerFlag> f2);
+
+QFlags<Qgis::SymbolLayerUserFlag> operator|(Qgis::SymbolLayerUserFlag f1, QFlags<Qgis::SymbolLayerUserFlag> f2);
 
 QFlags<Qgis::BrowserItemCapability> operator|(Qgis::BrowserItemCapability f1, QFlags<Qgis::BrowserItemCapability> f2);
 

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -206,6 +206,24 @@ when desired.
 .. versionadded:: 3.0
 %End
 
+    Qgis::SymbolLayerUserFlags userFlags() const;
+%Docstring
+Returns user-controlled flags which control the symbol layer's behavior.
+
+.. seealso:: :py:func:`setUserFlags`
+
+.. versionadded:: 3.34
+%End
+
+    void setUserFlags( Qgis::SymbolLayerUserFlags flags );
+%Docstring
+Sets user-controlled ``flags`` which control the symbol layer's behavior.
+
+.. seealso:: :py:func:`userFlags`
+
+.. versionadded:: 3.34
+%End
+
     virtual QColor color() const;
 %Docstring
 Returns the "representative" color of the symbol layer.
@@ -689,6 +707,7 @@ Constructor for QgsSymbolLayer.
 
 
 
+
     void restoreOldDataDefinedProperties( const QVariantMap &stringMap );
 %Docstring
 Restores older data defined properties from string map.
@@ -734,6 +753,14 @@ if ``recursive`` is ``True`` masks are removed recursively for all children symb
 .. seealso:: :py:func:`installMasks`
 
 .. versionadded:: 3.30
+%End
+
+    bool shouldRenderUsingSelectionColor( const QgsSymbolRenderContext &context ) const;
+%Docstring
+Returns ``True`` if the symbol layer should be rendered using the selection color
+from the render context.
+
+.. versionadded:: 3.34
 %End
 
   private:

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -532,6 +532,10 @@ class CORE_EXPORT Qgis
     /**
      * \brief Flags controlling behavior of symbol layers
      *
+     * \note These differ from Qgis::SymbolLayerUserFlag in that Qgis::SymbolLayerFlag flags are used to reflect the inbuilt properties
+     * of a symbol layer type, whereas Qgis::SymbolLayerUserFlag are optional, user controlled flags which can be toggled
+     * for a symbol layer.
+     *
      * \since QGIS 3.22
      */
     enum class SymbolLayerFlag : int
@@ -542,6 +546,29 @@ class CORE_EXPORT Qgis
     //! Symbol layer flags
     Q_DECLARE_FLAGS( SymbolLayerFlags, SymbolLayerFlag )
     Q_FLAG( SymbolLayerFlags )
+
+    /**
+     * \brief User-specified flags controlling behavior of symbol layers.
+     *
+     * \note These differ from Qgis::SymbolLayerFlag in that Qgis::SymbolLayerFlag flags are used to reflect the inbuilt properties
+     * of a symbol layer type, whereas Qgis::SymbolLayerUserFlag are optional, user controlled flags which can be toggled
+     * for a symbol layer.
+     *
+     * \since QGIS 3.34
+     */
+    enum class SymbolLayerUserFlag : int
+    {
+      DisableSelectionRecoloring = 1 << 0, //!< If present, indicates that the symbol layer should not be recolored when rendering selected features
+    };
+    Q_ENUM( SymbolLayerUserFlag )
+
+    /**
+     * Symbol layer user flags.
+     *
+     * \since QGIS 3.34
+     */
+    Q_DECLARE_FLAGS( SymbolLayerUserFlags, SymbolLayerUserFlag )
+    Q_FLAG( SymbolLayerUserFlags )
 
     /**
      * Browser item types.
@@ -3895,6 +3922,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolRenderHints )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolPreviewFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolLayerFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolLayerUserFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BrowserItemCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SublayerQueryFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SublayerFlags )

--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -747,6 +747,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
   const double prevOpacity = mSymbol->opacity();
   mSymbol->setOpacity( prevOpacity * context.opacity() );
 
+  const bool useSelectedColor = shouldRenderUsingSelectionColor( context );
   if ( isCurved() )
   {
     _resolveDataDefined( context );
@@ -763,7 +764,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
         const QPointF pd( points.back() );
 
         const QPolygonF poly = curvedArrow( po, pm, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
-        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
       }
       // straight arrow
       else if ( points.size() == 2 )
@@ -774,7 +775,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
         const QPointF pd( points.at( 1 ) );
 
         const QPolygonF poly = straightArrow( po, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
-        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
       }
     }
     else
@@ -797,7 +798,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
           const QPointF pd( points.at( pIdx + 2 ) );
 
           const QPolygonF poly = curvedArrow( po, pm, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
-          mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+          mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
         }
         // straight arrow
         else if ( points.size() - pIdx == 2 )
@@ -808,7 +809,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
           const QPointF pd( points.at( pIdx + 1 ) );
 
           const QPolygonF poly = straightArrow( po, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
-          mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+          mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
         }
       }
     }
@@ -827,7 +828,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
         const QPointF pd( points.back() );
 
         const QPolygonF poly = straightArrow( po, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
-        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
       }
     }
     else
@@ -848,7 +849,7 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
 
         const QPolygonF poly = straightArrow( po, pd, mScaledArrowStartWidth, mScaledArrowWidth, mScaledHeadLength, mScaledHeadThickness, mComputedHeadType, mComputedArrowType, mScaledOffset );
 
-        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, context.selected() );
+        mSymbol->renderPolygon( poly, /* rings */ nullptr, context.feature(), context.renderContext(), -1, useSelectedColor );
       }
     }
   }

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -279,14 +279,15 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
     transform.rotate( angle );
   }
 
+  const bool useSelectedColor = shouldRenderUsingSelectionColor( context );
   if ( shapeIsFilled( shape ) )
   {
-    p->setPen( context.selected() ? mSelPen : mPen );
-    p->setBrush( context.selected() ? mSelBrush : mBrush );
+    p->setPen( useSelectedColor ? mSelPen : mPen );
+    p->setBrush( useSelectedColor ? mSelBrush : mBrush );
   }
   else
   {
-    p->setPen( context.selected() ? mSelPen : mPen );
+    p->setPen( useSelectedColor ? mSelPen : mPen );
     p->setBrush( QBrush() );
   }
   p->drawPath( transform.map( mPainterPath ) );

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -2179,13 +2179,13 @@ void QgsSVGFillSymbolLayer::renderPolygon( const QPolygonF &points, const QVecto
 
   if ( mStroke )
   {
-    const bool useSelectedColor = shouldRenderUsingSelectionColor( context );
-    mStroke->renderPolyline( points, context.feature(), context.renderContext(), -1, SELECT_FILL_BORDER && useSelectedColor );
+    const bool useSelectedColor = SELECT_FILL_BORDER && shouldRenderUsingSelectionColor( context );
+    mStroke->renderPolyline( points, context.feature(), context.renderContext(), -1, useSelectedColor );
     if ( rings )
     {
       for ( auto ringIt = rings->constBegin(); ringIt != rings->constEnd(); ++ringIt )
       {
-        mStroke->renderPolyline( *ringIt, context.feature(), context.renderContext(), -1, SELECT_FILL_BORDER && useSelectedColor );
+        mStroke->renderPolyline( *ringIt, context.feature(), context.renderContext(), -1, useSelectedColor );
       }
     }
   }

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -503,7 +503,8 @@ void QgsGeometryGeneratorSymbolLayer::render( QgsSymbolRenderContext &context, Q
   const bool prevIsSubsymbol = context.renderContext().flags() & Qgis::RenderContextFlag::RenderingSubSymbol;
   context.renderContext().setFlag( Qgis::RenderContextFlag::RenderingSubSymbol );
 
-  mSymbol->renderFeature( f, context.renderContext(), -1, context.selected() );
+  const bool useSelectedColor = shouldRenderUsingSelectionColor( context );
+  mSymbol->renderFeature( f, context.renderContext(), -1, useSelectedColor );
 
   context.renderContext().setFlag( Qgis::RenderContextFlag::RenderingSubSymbol, prevIsSubsymbol );
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1170,6 +1170,7 @@ QgsSymbolLayerList QgsSymbol::cloneLayers() const
     layer->setRenderingPass( ( *it )->renderingPass() );
     layer->setEnabled( ( *it )->enabled() );
     layer->setId( ( *it )->id() );
+    layer->setUserFlags( ( *it )->userFlags() );
     lst.append( layer );
   }
   return lst;

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -240,6 +240,16 @@ Qgis::SymbolLayerFlags QgsSymbolLayer::flags() const
   return Qgis::SymbolLayerFlags();
 }
 
+Qgis::SymbolLayerUserFlags QgsSymbolLayer::userFlags() const
+{
+  return mUserFlags;
+}
+
+void QgsSymbolLayer::setUserFlags( Qgis::SymbolLayerUserFlags flags )
+{
+  mUserFlags = flags;
+}
+
 QColor QgsSymbolLayer::color() const
 {
   return mColor;
@@ -952,7 +962,7 @@ void QgsSymbolLayer::prepareMasks( const QgsSymbolRenderContext &context )
   {
     QPainterPath mergedPaths;
     mergedPaths.setFillRule( Qt::WindingFill );
-    for ( QPainterPath path : clipPaths )
+    for ( const QPainterPath &path : clipPaths )
     {
       mergedPaths.addPath( path );
     }
@@ -976,7 +986,8 @@ void QgsSymbolLayer::installMasks( QgsRenderContext &context, bool recursive )
 
   if ( QgsSymbol *lSubSymbol = recursive ? subSymbol() : nullptr )
   {
-    for ( QgsSymbolLayer *sl : lSubSymbol->symbolLayers() )
+    const QList<QgsSymbolLayer *> layers = lSubSymbol->symbolLayers();
+    for ( QgsSymbolLayer *sl : layers )
       sl->installMasks( context, true );
   }
 }
@@ -990,11 +1001,16 @@ void QgsSymbolLayer::removeMasks( QgsRenderContext &context, bool recursive )
 
   if ( QgsSymbol *lSubSymbol = recursive ? subSymbol() : nullptr )
   {
-    for ( QgsSymbolLayer *sl : lSubSymbol->symbolLayers() )
+    const QList<QgsSymbolLayer *> layers = lSubSymbol->symbolLayers();
+    for ( QgsSymbolLayer *sl : layers )
       sl->removeMasks( context, true );
   }
 }
 
+bool QgsSymbolLayer::shouldRenderUsingSelectionColor( const QgsSymbolRenderContext &context ) const
+{
+  return context.selected() && !( mUserFlags & Qgis::SymbolLayerUserFlag::DisableSelectionRecoloring );
+}
 
 void QgsSymbolLayer::setId( const QString &id )
 {

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -251,6 +251,22 @@ class CORE_EXPORT QgsSymbolLayer
     void setEnabled( bool enabled ) { mEnabled = enabled; }
 
     /**
+     * Returns user-controlled flags which control the symbol layer's behavior.
+     *
+     * \see setUserFlags()
+     * \since QGIS 3.34
+     */
+    Qgis::SymbolLayerUserFlags userFlags() const;
+
+    /**
+     * Sets user-controlled \a flags which control the symbol layer's behavior.
+     *
+     * \see userFlags()
+     * \since QGIS 3.34
+     */
+    void setUserFlags( Qgis::SymbolLayerUserFlags flags );
+
+    /**
      * Returns the "representative" color of the symbol layer.
      *
      * Depending on the symbol layer type, this will have different meaning. For instance, a line
@@ -663,6 +679,9 @@ class CORE_EXPORT QgsSymbolLayer
     //! True if layer is enabled and should be drawn
     bool mEnabled = true;
 
+    //! User controlled flags
+    Qgis::SymbolLayerUserFlags mUserFlags;
+
     bool mLocked = false;
     QColor mColor;
     int mRenderingPass = 0;
@@ -719,6 +738,14 @@ class CORE_EXPORT QgsSymbolLayer
      * \since QGIS 3.30
      */
     void removeMasks( QgsRenderContext &context, bool recursive );
+
+    /**
+     * Returns TRUE if the symbol layer should be rendered using the selection color
+     * from the render context.
+     *
+     * \since QGIS 3.34
+     */
+    bool shouldRenderUsingSelectionColor( const QgsSymbolRenderContext &context ) const;
 
   private:
     static void initPropertyDefinitions();

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1445,7 +1445,8 @@ QDomElement QgsSymbolLayerUtils::saveSymbol( const QString &name, const QgsSymbo
     layerEl.setAttribute( QStringLiteral( "locked" ), layer->isLocked() );
     layerEl.setAttribute( QStringLiteral( "pass" ), layer->renderingPass() );
     layerEl.setAttribute( QStringLiteral( "id" ), layer->id() );
-    layerEl.setAttribute( QStringLiteral( "userFlags" ), qgsFlagValueToKeys( layer->userFlags() ) );
+    if ( layer->userFlags() != Qgis::SymbolLayerUserFlags() )
+      layerEl.setAttribute( QStringLiteral( "userFlags" ), qgsFlagValueToKeys( layer->userFlags() ) );
 
     QVariantMap props = layer->properties();
 

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1341,6 +1341,7 @@ QgsSymbolLayer *QgsSymbolLayerUtils::loadSymbolLayer( QDomElement &element, cons
   const bool enabled = element.attribute( QStringLiteral( "enabled" ), QStringLiteral( "1" ) ).toInt();
   const int pass = element.attribute( QStringLiteral( "pass" ) ).toInt();
   const QString id = element.attribute( QStringLiteral( "id" ) );
+  const Qgis::SymbolLayerUserFlags userFlags = qgsFlagKeysToValue( element.attribute( QStringLiteral( "userFlags" ) ), Qgis::SymbolLayerUserFlags() );
 
   // parse properties
   QVariantMap props = parseProperties( element );
@@ -1357,6 +1358,7 @@ QgsSymbolLayer *QgsSymbolLayerUtils::loadSymbolLayer( QDomElement &element, cons
     layer->setLocked( locked );
     layer->setRenderingPass( pass );
     layer->setEnabled( enabled );
+    layer->setUserFlags( userFlags );
 
     // old project format, empty is missing, keep the actual layer one
     if ( !id.isEmpty() )
@@ -1443,6 +1445,7 @@ QDomElement QgsSymbolLayerUtils::saveSymbol( const QString &name, const QgsSymbo
     layerEl.setAttribute( QStringLiteral( "locked" ), layer->isLocked() );
     layerEl.setAttribute( QStringLiteral( "pass" ), layer->renderingPass() );
     layerEl.setAttribute( QStringLiteral( "id" ), layer->id() );
+    layerEl.setAttribute( QStringLiteral( "userFlags" ), qgsFlagValueToKeys( layer->userFlags() ) );
 
     QVariantMap props = layer->properties();
 

--- a/src/core/symbology/qgssymbolrendercontext.h
+++ b/src/core/symbology/qgssymbolrendercontext.h
@@ -20,7 +20,6 @@
 #include "qgis.h"
 #include "qgsmapunitscale.h"
 #include "qgsfields.h"
-#include "qgswkbtypes.h"
 
 class QgsRenderContext;
 class QgsFeature;

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -619,7 +619,7 @@ void QgsVectorLayerProperties::syncToLayer()
     }
 
     case Qgis::SelectionRenderingMode::CustomSymbol:
-      if ( QgsSymbol *symbol = selectionProperties->selectionSymbol() )
+      if ( selectionProperties->selectionSymbol() )
       {
         mRadioOverrideSelectionSymbol->setChecked( true );
       }


### PR DESCRIPTION
These differ from Qgis::SymbolLayerFlag in that Qgis::SymbolLayerFlag flags are used to reflect the inbuilt properties of a symbol layer type, whereas Qgis::SymbolLayerUserFlag are optional, user controlled flags which can be toggled for a 
symbol layer.

Add a flag `DisableSelectionRecoloring` which can be set for symbol layers which prevents the layer from being  recolored to the render context selection color even when the feature being rendered is selected

This provides a mechanism for an individual symbol layer to avoid the forced recolor of selected features.

**This is not currently exposed anywhere in the GUI for users to set -- it is API only.**