### PR TITLE
Block updates to layer tree view while loading projects

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6396,6 +6396,7 @@ void QgisApp::enableProjectMacros()
 bool QgisApp::addProject( const QString &projectFile )
 {
   QgsCanvasRefreshBlocker refreshBlocker;
+  QWidgetUpdateBlocker layerTreeViewUpdateBlocker( mLayerTreeView );
 
   bool returnCode = false;
   std::unique_ptr< QgsProjectDirtyBlocker > dirtyBlocker = std::make_unique< QgsProjectDirtyBlocker >( QgsProject::instance() );

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -382,3 +382,27 @@ void QgsTemporaryCursorRestoreOverride::restore()
   }
   mCursors.clear();
 }
+
+//
+// QWidgetUpdateBlocker
+//
+
+QWidgetUpdateBlocker::QWidgetUpdateBlocker( QWidget *widget )
+  : mWidget( widget )
+{
+  mWidget->setUpdatesEnabled( false );
+}
+
+void QWidgetUpdateBlocker::release()
+{
+  if ( !mWidget )
+    return;
+
+  mWidget->setUpdatesEnabled( true );
+  mWidget = nullptr;
+}
+
+QWidgetUpdateBlocker::~QWidgetUpdateBlocker()
+{
+  release();
+}

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -209,6 +209,42 @@ namespace QgsGuiUtils
 }
 
 /**
+ * Temporarily disables updates for a QWidget for the lifetime of the object.
+ *
+ * When the object is deleted, the updates are re-enabled.
+ *
+ * \ingroup gui
+ * \since QGIS 3.34
+ */
+class GUI_EXPORT QWidgetUpdateBlocker
+{
+  public:
+
+    /**
+     * Constructor for QWidgetUpdateBlocker. Blocks updates for the specified \a widget.
+     *
+     * The caller must ensure that \a widget exists for the lifetime of this object.
+     */
+    QWidgetUpdateBlocker( QWidget *widget );
+
+    //! QWidgetUpdateBlocker cannot be copied
+    QWidgetUpdateBlocker( const QWidgetUpdateBlocker &other ) = delete;
+    //! QWidgetUpdateBlocker cannot be copied
+    QWidgetUpdateBlocker &operator=( const QWidgetUpdateBlocker &other ) = delete;
+
+    ~QWidgetUpdateBlocker();
+
+    /**
+     * Releases the update block early (i.e. before this object is destroyed).
+     */
+    void release();
+
+  private:
+
+    QWidget *mWidget = nullptr;
+};
+
+/**
  * Temporarily sets a cursor override for the QApplication for the lifetime of the object.
  *
  * When the object is deleted, the cursor override is removed.


### PR DESCRIPTION
These can cause a lot of unnecessary work during project load, especially for projects with many layers. By temporarily blocking graphical updates to the layer tree view we can defer all this work to a one-time cost after all layers have been loaded.
