### PR TITLE
[symbology] Avoid large pattern QImage memory allocation for line and point pattern symbol layers

### DIFF
--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -1662,7 +1662,7 @@ class CORE_EXPORT QgsLinePatternFillSymbolLayer: public QgsImageFillSymbolLayer
 #endif
 
     //! Applies the svg pattern to the brush
-    void applyPattern( const QgsSymbolRenderContext &context, QBrush &brush, double lineAngle, double distance );
+    bool applyPattern( const QgsSymbolRenderContext &context, QBrush &brush, double lineAngle, double distance );
 
     //! Fill line
     std::unique_ptr< QgsLineSymbol > mFillLineSymbol;
@@ -2213,7 +2213,7 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer: public QgsImageFillSymbolLayer
     QgsPointPatternFillSymbolLayer( const QgsPointPatternFillSymbolLayer &other );
 #endif
 
-    void applyPattern( const QgsSymbolRenderContext &context, QBrush &brush, double distanceX, double distanceY,
+    bool applyPattern( const QgsSymbolRenderContext &context, QBrush &brush, double distanceX, double distanceY,
                        double displacementX, double displacementY, double offsetX, double offsetY );
 
     Qgis::MarkerClipMode mClipMode = Qgis::MarkerClipMode::Shape;


### PR DESCRIPTION
… instead rely on vector rendering.

While doing some memory usage analysis, I stumbled on some pretty inefficient memory allocation for line pattern fill and point pattern fill symbol layers. The long story short here is that if you are setting your line pattern to rely on map unit spacing in between lines, you can _rapidly_ end up with a very large rasterized pattern QImage. 

Since we now have the capability to render those patterns as vector, I propose that we allow for only max. rasterized pattern QImage having width or height <= 2,000 pixel. 

On machines/devices with limited memory, this can be the difference between a crash and a rendered map :)