### PR TITLE
OWS Fix unreported regression with credentials

### DIFF
--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -85,8 +85,8 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
   mUri.setParam( QStringLiteral( "url" ), url );
 
   // Check for credentials and prepend to the connection info
-  const QString username = settingsUsername->value( {mService, mConnName} );
-  const QString password = settingsPassword->value( {mService, mConnName} );
+  const QString username = settingsUsername->value( {mService.toLower(), mConnName} );
+  const QString password = settingsPassword->value( {mService.toLower(), mConnName} );
   if ( !username.isEmpty() )
   {
     // check for a password, if none prompt to get it
@@ -94,7 +94,7 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
     mUri.setPassword( password );
   }
 
-  const QString authcfg = settingsAuthCfg->value( {mService, mConnName} );
+  const QString authcfg = settingsAuthCfg->value( {mService.toLower(), mConnName} );
   if ( !authcfg.isEmpty() )
   {
     mUri.setAuthConfigId( authcfg );


### PR DESCRIPTION
authcfg/username/password were not correctly read from the settings.

