### PR TITLE
OAUTH2 Authorization Code PKCE

### DIFF
--- a/external/o2/src/o0baseauth.h
+++ b/external/o2/src/o0baseauth.h
@@ -116,6 +116,8 @@ protected:
     quint16 localPort_;
     O0AbstractStore *store_;
     QVariantMap extraTokens_;
+    QByteArray pkceCodeVerifier_;
+    QString pkceCodeChallenge_;
 };
 
 #endif // O0BASEAUTH

--- a/external/o2/src/o0globals.h
+++ b/external/o2/src/o0globals.h
@@ -59,4 +59,10 @@ const char O2_AUTHORIZATION_CODE[] = "authorization_code";
 // Standard HTTP headers
 const char O2_HTTP_AUTHORIZATION_HEADER[] = "Authorization";
 
+// PKCE parameters
+const char O2_OAUTH2_PKCE_CODE_VERIFIER_PARAM[] = "code_verifier";
+const char O2_OAUTH2_PKCE_CODE_CHALLENGE_PARAM[] = "code_challenge";
+const char O2_OAUTH2_PKCE_CODE_CHALLENGE_METHOD_S256[] = "S256";
+const char O2_OAUTH2_PKCE_CODE_CHALLENGE_METHOD_PARAM[] = "code_challenge_method";
+
 #endif // O0GLOBALS_H

--- a/external/o2/src/o2.h
+++ b/external/o2/src/o2.h
@@ -24,6 +24,7 @@ public:
         GrantFlowAuthorizationCode, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.1
         GrantFlowImplicit, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.2
         GrantFlowResourceOwnerPasswordCredentials,
+        GrantFlowPkce, ///< @see https://www.rfc-editor.org/rfc/rfc7636
     };
 
     /// Authorization flow.

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -308,12 +308,12 @@ void QgsAuthOAuth2Config::validateConfigId( bool needsId )
 {
   const bool oldvalid = mValid;
 
-  if ( mGrantFlow == AuthCode || mGrantFlow == Implicit )
+  if ( mGrantFlow == AuthCode || mGrantFlow == Implicit ||  mGrantFlow == Pkce )
   {
     mValid = ( !requestUrl().isEmpty()
                && !tokenUrl().isEmpty()
                && !clientId().isEmpty()
-               && ( mGrantFlow == AuthCode ? !clientSecret().isEmpty() : true )
+               && ( ( mGrantFlow == AuthCode || mGrantFlow == Pkce ) ? !clientSecret().isEmpty() : true )
                && redirectPort() > 0
                && ( needsId ? !id().isEmpty() : true ) );
   }
@@ -790,6 +790,8 @@ QString QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::GrantFlow flo
       return tr( "Authorization Code" );
     case QgsAuthOAuth2Config::Implicit:
       return tr( "Implicit" );
+    case QgsAuthOAuth2Config::Pkce:
+      return tr( "Authorization Code PKCE" );
     case QgsAuthOAuth2Config::ResourceOwner:
     default:
       return tr( "Resource Owner" );

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -308,12 +308,20 @@ void QgsAuthOAuth2Config::validateConfigId( bool needsId )
 {
   const bool oldvalid = mValid;
 
-  if ( mGrantFlow == AuthCode || mGrantFlow == Implicit ||  mGrantFlow == Pkce )
+  if ( mGrantFlow == AuthCode || mGrantFlow == Implicit )
   {
     mValid = ( !requestUrl().isEmpty()
                && !tokenUrl().isEmpty()
                && !clientId().isEmpty()
                && ( ( mGrantFlow == AuthCode || mGrantFlow == Pkce ) ? !clientSecret().isEmpty() : true )
+               && redirectPort() > 0
+               && ( needsId ? !id().isEmpty() : true ) );
+  }
+  else if ( mGrantFlow == Pkce )  // No client secret for PKCE
+  {
+    mValid = ( !requestUrl().isEmpty()
+               && !tokenUrl().isEmpty()
+               && !clientId().isEmpty()
                && redirectPort() > 0
                && ( needsId ? !id().isEmpty() : true ) );
   }

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -72,6 +72,7 @@ class QgsAuthOAuth2Config : public QObject
       AuthCode,      //!< See http://tools.ietf.org/html/rfc6749#section-4.1
       Implicit,      //!< See http://tools.ietf.org/html/rfc6749#section-4.2
       ResourceOwner, //!< See http://tools.ietf.org/html/rfc6749#section-4.3
+      Pkce,          //!< See https://www.rfc-editor.org/rfc/rfc7636
     };
 
     //! Configuration format for serialize/unserialize operations

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -29,6 +29,7 @@
 #include <QSettings>
 #include <QUrl>
 #include <QUrlQuery>
+#include <QCryptographicHash>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 #include <QRandomGenerator>
@@ -89,6 +90,13 @@ void QgsO2::initOAuthConfig()
 
   switch ( mOAuth2Config->grantFlow() )
   {
+    case QgsAuthOAuth2Config::Pkce:
+      setGrantFlow( O2::GrantFlowPkce );
+      setRequestUrl( mOAuth2Config->requestUrl() );
+      setClientId( mOAuth2Config->clientId() );
+      setClientSecret( mOAuth2Config->clientSecret() );
+
+      break;
     case QgsAuthOAuth2Config::AuthCode:
       setGrantFlow( O2::GrantFlowAuthorizationCode );
       setRequestUrl( mOAuth2Config->requestUrl() );
@@ -176,7 +184,7 @@ void QgsO2::link()
   setRefreshToken( QString() );
   setExpires( 0 );
 
-  if ( grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowImplicit )
+  if ( grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowImplicit || grantFlow_ == GrantFlowPkce )
   {
     if ( mIsLocalHost )
     {
@@ -188,11 +196,22 @@ void QgsO2::link()
     }
     // Assemble initial authentication URL
     QList<QPair<QString, QString> > parameters;
-    parameters.append( qMakePair( QString( O2_OAUTH2_RESPONSE_TYPE ), ( grantFlow_ == GrantFlowAuthorizationCode ) ?
+    parameters.append( qMakePair( QString( O2_OAUTH2_RESPONSE_TYPE ), ( grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowPkce ) ?
                                   QString( O2_OAUTH2_GRANT_TYPE_CODE ) :
                                   QString( O2_OAUTH2_GRANT_TYPE_TOKEN ) ) );
     parameters.append( qMakePair( QString( O2_OAUTH2_CLIENT_ID ), clientId_ ) );
     parameters.append( qMakePair( QString( O2_OAUTH2_REDIRECT_URI ), redirectUri_ ) );
+
+    if ( grantFlow_ == GrantFlowPkce )
+    {
+      pkceCodeVerifier_ = ( QUuid::createUuid().toString( QUuid::WithoutBraces ) +
+                            QUuid::createUuid().toString( QUuid::WithoutBraces ) ).toLatin1();
+      pkceCodeChallenge_ = QCryptographicHash::hash( pkceCodeVerifier_, QCryptographicHash::Sha256 ).toBase64(
+                             QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals );
+      parameters.append( qMakePair( QString( O2_OAUTH2_PKCE_CODE_CHALLENGE_PARAM ), pkceCodeChallenge_ ) );
+      parameters.append( qMakePair( QString( O2_OAUTH2_PKCE_CODE_CHALLENGE_METHOD_PARAM ), QString( O2_OAUTH2_PKCE_CODE_CHALLENGE_METHOD_S256 ) ) );
+    }
+
     if ( !scope_.isEmpty() )
       parameters.append( qMakePair( QString( O2_OAUTH2_SCOPE ), scope_ ) );
     if ( !state_.isEmpty() )
@@ -299,7 +318,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     setCode( response.value( QString( O2_OAUTH2_GRANT_TYPE_CODE ) ) );
   }
 
-  if ( grantFlow_ == GrantFlowAuthorizationCode )
+  if ( grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowPkce )
   {
 
     // Exchange access code for access/refresh tokens
@@ -315,6 +334,10 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
     parameters.insert( O2_OAUTH2_REDIRECT_URI, redirectUri_ );
     parameters.insert( O2_OAUTH2_GRANT_TYPE, O2_AUTHORIZATION_CODE );
+    if ( grantFlow() == GrantFlowPkce )
+    {
+      parameters.insert( O2_OAUTH2_PKCE_CODE_VERIFIER_PARAM, pkceCodeVerifier_ );
+    }
     const QByteArray data = buildRequestBody( parameters );
     QNetworkReply *tokenReply = getManager()->post( tokenRequest, data );
     timedReplies_.add( tokenReply );

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -94,7 +94,8 @@ void QgsO2::initOAuthConfig()
       setGrantFlow( O2::GrantFlowPkce );
       setRequestUrl( mOAuth2Config->requestUrl() );
       setClientId( mOAuth2Config->clientId() );
-      setClientSecret( mOAuth2Config->clientSecret() );
+      // No client secret with PKCE
+      //setClientSecret( mOAuth2Config->clientSecret() );
 
       break;
     case QgsAuthOAuth2Config::AuthCode:
@@ -331,7 +332,11 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     QMap<QString, QString> parameters;
     parameters.insert( O2_OAUTH2_GRANT_TYPE_CODE, code() );
     parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-    parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+    //No client secret with PKCE
+    if ( grantFlow_ != GrantFlowPkce )
+    {
+      parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+    }
     parameters.insert( O2_OAUTH2_REDIRECT_URI, redirectUri_ );
     parameters.insert( O2_OAUTH2_GRANT_TYPE, O2_AUTHORIZATION_CODE );
     if ( grantFlow() == GrantFlowPkce )
@@ -428,7 +433,11 @@ void QgsO2::refreshSynchronous()
   refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
   QMap<QString, QString> parameters;
   parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-  parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+  // No secret with PKCE
+  if ( grantFlow_ != GrantFlowPkce )
+  {
+    parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+  }
   parameters.insert( O2_OAUTH2_REFRESH_TOKEN, refreshToken() );
   parameters.insert( O2_OAUTH2_GRANT_TYPE, O2_OAUTH2_REFRESH_TOKEN );
 

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -738,8 +738,9 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   mOAuthConfigCustom->setGrantFlow( flow );
 
   // bool authcode = ( flow == QgsAuthOAuth2Config::AuthCode );
-  const bool implicit = ( flow == QgsAuthOAuth2Config::Implicit );
-  const bool resowner = ( flow == QgsAuthOAuth2Config::ResourceOwner );
+  const bool implicit = ( flow == QgsAuthOAuth2Config::GrantFlow::Implicit );
+  const bool resowner = ( flow == QgsAuthOAuth2Config::GrantFlow::ResourceOwner );
+  const bool pkce = ( flow == QgsAuthOAuth2Config::GrantFlow::Pkce );
 
   lblRequestUrl->setVisible( !resowner );
   leRequestUrl->setVisible( !resowner );
@@ -755,6 +756,10 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
     leClientSecret->setText( QString() );
 
   leClientId->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
+
+  // No client secret with PKCE
+  lblClientSecret->setVisible( !pkce );
+  leClientSecret->setVisible( !pkce );
   leClientSecret->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
 
 

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -500,6 +500,8 @@ void QgsAuthOAuth2Edit::populateGrantFlows()
                            static_cast<int>( QgsAuthOAuth2Config::Implicit ) );
   cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::ResourceOwner ),
                            static_cast<int>( QgsAuthOAuth2Config::ResourceOwner ) );
+  cmbbxGrantFlow->addItem( QgsAuthOAuth2Config::grantFlowString( QgsAuthOAuth2Config::Pkce ),
+                           static_cast<int>( QgsAuthOAuth2Config::Pkce ) );
 }
 
 

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -85,8 +85,8 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
   mUri.setParam( QStringLiteral( "url" ), url );
 
   // Check for credentials and prepend to the connection info
-  const QString username = settingsUsername->value( {mService, mConnName} );
-  const QString password = settingsPassword->value( {mService, mConnName} );
+  const QString username = settingsUsername->value( {mService.toLower(), mConnName} );
+  const QString password = settingsPassword->value( {mService.toLower(), mConnName} );
   if ( !username.isEmpty() )
   {
     // check for a password, if none prompt to get it
@@ -94,7 +94,7 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
     mUri.setPassword( password );
   }
 
-  const QString authcfg = settingsAuthCfg->value( {mService, mConnName} );
+  const QString authcfg = settingsAuthCfg->value( {mService.toLower(), mConnName} );
   if ( !authcfg.isEmpty() )
   {
     mUri.setAuthConfigId( authcfg );


### PR DESCRIPTION
Implementation of PKCE for OAUTH2 

PKCE ([RFC 7636](http://tools.ietf.org/html/rfc7636)) is an extension to the [Authorization Code flow](https://oauth.net/2/grant-types/authorization-code/) to prevent CSRF and authorization code injection attacks.

Fix #47760

Funded by: Comune di Roma