### PR TITLE
[ui] Fix visual glitches when resizing the overview panel

### DIFF
--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -48,6 +48,7 @@ QgsMapOverviewCanvas::QgsMapOverviewCanvas( QWidget *parent, QgsMapCanvas *mapCa
   connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsMapOverviewCanvas::drawExtentRect );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapOverviewCanvas::destinationCrsChanged );
   connect( mMapCanvas, &QgsMapCanvas::transformContextChanged, this, &QgsMapOverviewCanvas::transformContextChanged );
+  connect( mMapCanvas, &QgsMapCanvas::canvasColorChanged, this, &QgsMapOverviewCanvas::refresh );
 
   connect( QgsProject::instance()->viewSettings(), &QgsProjectViewSettings::presetFullExtentChanged, this, &QgsMapOverviewCanvas::refresh );
 }
@@ -73,10 +74,14 @@ void QgsMapOverviewCanvas::showEvent( QShowEvent *e )
 
 void QgsMapOverviewCanvas::paintEvent( QPaintEvent *pe )
 {
+  QPainter paint( this );
   if ( !mPixmap.isNull() )
   {
-    QPainter paint( this );
     paint.drawPixmap( pe->rect().topLeft(), mPixmap, pe->rect() );
+  }
+  else
+  {
+    paint.fillRect( pe->rect(), QBrush( mSettings.backgroundColor() ) );
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes visual glitches (acutely visible on dark themes) when resizing the overview panel.

Without fix:

[Screencast from 2023-08-02 10-01-39.webm](https://github.com/qgis/QGIS/assets/1728657/243fcbfd-a55d-41ed-bfd6-47d3080e7bfd)

With fix:

[Screencast from 2023-08-02 10-02-01.webm](https://github.com/qgis/QGIS/assets/1728657/079575bd-0e63-4988-a818-4ca412f49913)
