### PR TITLE
Case-insensitive plugin metadata.txt parsing

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -42,7 +42,7 @@ import configparser
 import qgis.utils
 from qgis.core import QgsNetworkAccessManager, QgsApplication
 from qgis.gui import QgsGui
-from qgis.utils import iface, plugin_paths
+from qgis.utils import iface, plugin_paths, parseMetadata
 from .version_compare import pyQgisVersion, compareVersions, normalizeVersion, isCompatible
 
 
@@ -538,11 +538,10 @@ class Plugins(QObject):
                 for better control of which module is examined
                 in case there is an installed plugin masking a core one """
             global errorDetails
-            cp = configparser.ConfigParser()
+            
             try:
-                with codecs.open(metadataFile, "r", "utf8") as f:
-                    cp.read_file(f)
-                return cp.get('general', fct)
+                cp = parseMetadata(metadataFile)
+                return cp.get(cp.default_section, fct)
             except Exception as e:
                 if not errorDetails:
                     errorDetails = e.args[0]  # set to the first problem

--- a/python/pyplugin_installer/plugindependencies.py
+++ b/python/pyplugin_installer/plugindependencies.py
@@ -52,8 +52,13 @@ def find_dependencies(plugin_id, plugin_data=None, plugin_deps=None, installed_p
 
     if installed_plugins is None:
         metadata_parser = metadataParser()
-        installed_plugins = {metadata_parser[k].get('general', 'name'): metadata_parser[k].get('general', 'version') for k, v in metadata_parser.items()}
-
+        installed_plugins = {
+            metadata_parser[k]
+            .get(metadata_parser[k].default_section, "name"): metadata_parser[k]
+            .get(metadata_parser[k].default_section, "version")
+            for k, v in metadata_parser.items()
+        }
+        
     if plugin_data is None:
         plugin_data = plugin_installer.plugins.all()
 


### PR DESCRIPTION
Python plugins metadata are parsed from the required metadata.txt file using [keys](https://docs.qgis.org/3.28/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#metadata-txt) under a section [general]. This file is parsed using [ConfigParser](https://docs.python.org/3/library/configparser.html) which mixes case-sensitive sections and case-insensitive key. So any changes in the name of the default general section would break QGIS integration. This is confusing for developpers since all keys are lowered by ConfigParser ...

This is also problematic when using a tool such as [Qt.QSettings](https://doc.qt.io/qt-5/qsettings.html) and INI format to read (actually write ... reading is straight forward) this file since it will always rename general into General (under windows).

Also we propose a simple patch that will look for the general default section in a case-insensitive manner at parsing.

It also prepare to allow empty keys, so people can use the [template](https://docs.qgis.org/3.28/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#metadata-txt), editing values and leaving blanks without the need for commenting the lines