### PR TITLE
Remove the password when a layer is not found from the log

### DIFF
--- a/src/core/project/qgsprojectbadlayerhandler.cpp
+++ b/src/core/project/qgsprojectbadlayerhandler.cpp
@@ -13,6 +13,7 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include "qgsdatasourceuri.h"
 #include "qgsprojectbadlayerhandler.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -27,7 +28,7 @@ void QgsProjectBadLayerHandler::handleBadLayers( const QList<QDomNode> &layers )
 
   for ( const QDomNode &layer : layers )
   {
-    QgsMessageLog::logMessage( QObject::tr( " * %1" ).arg( dataSource( layer ) ) );
+    QgsMessageLog::logMessage( QObject::tr( " * %1" ).arg( QgsDataSourceUri::removePassword( dataSource( layer ) ) ) );
   }
 }
 


### PR DESCRIPTION
It will avoid having the password displayed in the logs :

```
[WRN] (from QGIS) : 1 unavailable layer(s) found:
[WRN] (from QGIS) : * dbname='database' host=localhost port=5432 user='user' password='password' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table="schema"."table"
```
