### PR TITLE
Fix glitch in layout scalebar config widget

### DIFF
--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -330,16 +330,16 @@ void QgsLayoutScaleBarWidget::setGuiElements()
   if ( mScalebar->segmentSizeMode() == QgsScaleBarSettings::SegmentSizeFixed )
   {
     mFixedSizeRadio->setChecked( true );
-    mSegmentSizeSpinBox->setEnabled( true );
-    mMinWidthSpinBox->setEnabled( false );
-    mMaxWidthSpinBox->setEnabled( false );
+    mSegmentSizeWidget->setEnabled( true );
+    mMinWidthWidget->setEnabled( false );
+    mMaxWidthWidget->setEnabled( false );
   }
   else /*if(mComposerScaleBar->segmentSizeMode() == QgsComposerScaleBar::SegmentSizeFitWidth)*/
   {
     mFitWidthRadio->setChecked( true );
-    mSegmentSizeSpinBox->setEnabled( false );
-    mMinWidthSpinBox->setEnabled( true );
-    mMaxWidthSpinBox->setEnabled( true );
+    mSegmentSizeWidget->setEnabled( false );
+    mMinWidthWidget->setEnabled( true );
+    mMaxWidthWidget->setEnabled( true );
   }
   mMinWidthSpinBox->setValue( mScalebar->minimumBarWidth() );
   mMaxWidthSpinBox->setValue( mScalebar->maximumBarWidth() );
@@ -730,9 +730,9 @@ void QgsLayoutScaleBarWidget::disconnectUpdateSignal()
 void QgsLayoutScaleBarWidget::segmentSizeRadioChanged( QAbstractButton *radio )
 {
   const bool fixedSizeMode = radio == mFixedSizeRadio;
-  mMinWidthSpinBox->setEnabled( !fixedSizeMode );
-  mMaxWidthSpinBox->setEnabled( !fixedSizeMode );
-  mSegmentSizeSpinBox->setEnabled( fixedSizeMode );
+  mMinWidthWidget->setEnabled( !fixedSizeMode );
+  mMaxWidthWidget->setEnabled( !fixedSizeMode );
+  mSegmentSizeWidget->setEnabled( fixedSizeMode );
 
   if ( !mScalebar )
   {

--- a/src/ui/layout/qgslayoutscalebarwidgetbase.ui
+++ b/src/ui/layout/qgslayoutscalebarwidgetbase.ui
@@ -60,9 +60,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-287</y>
+        <y>0</y>
         <width>566</width>
-        <height>1061</height>
+        <height>1018</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -171,7 +171,7 @@
             <property name="maximum">
              <double>9999999999999.000000000000000</double>
             </property>
-            <property name="showClearButton" stdset="0">
+            <property name="showClearButton">
              <bool>false</bool>
             </property>
            </widget>
@@ -276,36 +276,6 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="2">
-           <layout class="QHBoxLayout" name="horizontalLayout3">
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mSegmentSizeSpinBox">
-              <property name="toolTip">
-               <string>Number of scalebar units per scalebar segment</string>
-              </property>
-              <property name="suffix">
-               <string> units</string>
-              </property>
-              <property name="decimals">
-               <number>6</number>
-              </property>
-              <property name="maximum">
-               <double>9999999999999.000000000000000</double>
-              </property>
-              <property name="showClearButton" stdset="0">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsPropertyOverrideButton" name="mSegmentSizeDDBtn">
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
           <item row="0" column="2">
            <layout class="QHBoxLayout" name="horizontalLayout1">
             <item>
@@ -351,54 +321,6 @@
             </item>
             <item>
              <widget class="QgsPropertyOverrideButton" name="mHeightDDBtn">
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="4" column="2">
-           <layout class="QHBoxLayout" name="horizontalLayout5">
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="suffix">
-               <string> mm</string>
-              </property>
-              <property name="maximum">
-               <double>999.990000000000009</double>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsPropertyOverrideButton" name="mMaxWidthDDBtn">
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="3" column="2">
-           <layout class="QHBoxLayout" name="horizontalLayout4">
-            <item>
-             <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="suffix">
-               <string> mm</string>
-              </property>
-              <property name="maximum">
-               <double>999.990000000000009</double>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsPropertyOverrideButton" name="mMinWidthDDBtn">
               <property name="text">
                <string>…</string>
               </property>
@@ -476,6 +398,126 @@
             <property name="text">
              <string>Subdivisions height</string>
             </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QWidget" name="mMinWidthWidget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout4">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="suffix">
+                <string> mm</string>
+               </property>
+               <property name="maximum">
+                <double>999.990000000000009</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsPropertyOverrideButton" name="mMinWidthDDBtn">
+               <property name="text">
+                <string>…</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QWidget" name="mMaxWidthWidget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout5">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="suffix">
+                <string> mm</string>
+               </property>
+               <property name="maximum">
+                <double>999.990000000000009</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsPropertyOverrideButton" name="mMaxWidthDDBtn">
+               <property name="text">
+                <string>…</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QWidget" name="mSegmentSizeWidget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout3">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QgsDoubleSpinBox" name="mSegmentSizeSpinBox">
+               <property name="toolTip">
+                <string>Number of scalebar units per scalebar segment</string>
+               </property>
+               <property name="suffix">
+                <string> units</string>
+               </property>
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="maximum">
+                <double>9999999999999.000000000000000</double>
+               </property>
+               <property name="showClearButton">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsPropertyOverrideButton" name="mSegmentSizeDDBtn">
+               <property name="text">
+                <string>…</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -692,11 +734,6 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -710,6 +747,16 @@
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>
@@ -733,11 +780,6 @@
    <class>QgsAlignmentComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsalignmentcombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
- Fix #53990

## Description

Spinboxes are registered as "enabled widget", which makes the data defined buttons re-enable them when the config widget is displayed

https://github.com/qgis/QGIS/blob/6bf819a5d9e2dc40be4ca14fc1fdab24bd87b3be/src/gui/layout/qgslayoutscalebarwidget.cpp#L71-L73

This PR wraps each spinboxes and their linked data-defined button in a QWidget. The radio buttons enable/disable these widgets instead of the spinboxes.

![scalebar_config](https://github.com/qgis/QGIS/assets/9693475/6f92fa4f-8bd6-4a75-8c31-65c714add56a)
