### PR TITLE
test_qgsrasterattributetable: Use np.float64 instead of deprecated np.float

### DIFF
--- a/tests/src/python/test_qgsrasterattributetable.py
+++ b/tests/src/python/test_qgsrasterattributetable.py
@@ -123,7 +123,7 @@ def createTestRasters(cls, path):
     image_size = (2, 2)
 
     #  Create Each Channel
-    r_pixels = np.zeros((image_size), dtype=np.float)
+    r_pixels = np.zeros((image_size), dtype=np.float64)
 
     r_pixels[0, 0] = -1E23
     r_pixels[0, 1] = 2.345


### PR DESCRIPTION
It has been deprecated since version 1.20 and removed in version 1.24.

