### PR TITLE
Layout Page number in page properties

### DIFF
--- a/src/gui/layout/qgslayoutpagepropertieswidget.cpp
+++ b/src/gui/layout/qgslayoutpagepropertieswidget.cpp
@@ -86,6 +86,18 @@ QgsLayoutPagePropertiesWidget::QgsLayoutPagePropertiesWidget( QWidget *parent, Q
   if ( mPage->layout() )
   {
     connect( &mPage->layout()->reportContext(), &QgsLayoutReportContext::layerChanged, mSymbolButton, &QgsSymbolButton::setLayer );
+
+    QgsLayoutPageCollection *pages = mPage->layout()->pageCollection();
+    if ( pages->pageCount() > 1 )
+    {
+      const int pageNumber = mPage->layout()->pageCollection()->pageNumber( mPage );
+      mTitleLabel->setText( tr( "Page (%1/%2)" ).arg( pageNumber + 1 ).arg( pages->pageCount() ) );
+    }
+    else
+    {
+      mTitleLabel->setText( tr( "Page" ) );
+    }
+
   }
 
   showCurrentPageSize();

--- a/src/ui/layout/qgslayoutpagepropertieswidget.ui
+++ b/src/ui/layout/qgslayoutpagepropertieswidget.ui
@@ -6,261 +6,298 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>717</width>
-    <height>473</height>
+    <width>385</width>
+    <height>405</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>New Item Properties</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-   <item row="4" column="1">
-    <widget class="QgsSymbolButton" name="mSymbolButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="mTitleLabel">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>0</height>
-      </size>
+     <property name="styleSheet">
+      <string notr="true">padding: 2px; font-weight: bold; background-color: rgb(200, 200, 200);</string>
      </property>
      <property name="text">
-      <string/>
+      <string>Page</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Background</string>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Page Size</string>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
      </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-      <item row="3" column="0">
-       <widget class="QLabel" name="mWidthLabel">
-        <property name="text">
-         <string>Width</string>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string/>
         </property>
+        <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+         <item row="3" column="0">
+          <widget class="QLabel" name="mWidthLabel">
+           <property name="text">
+            <string>Width</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1" rowspan="2">
+          <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0,0,0,0,0">
+           <item row="0" column="5" rowspan="2">
+            <widget class="QgsLayoutUnitsComboBox" name="mSizeUnitsComboBox"/>
+           </item>
+           <item row="1" column="0" colspan="3">
+            <widget class="QgsDoubleSpinBox" name="mHeightSpin">
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="maximum">
+              <double>9999999.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>100.000000000000000</double>
+             </property>
+             <property name="showClearButton">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0" colspan="3">
+            <widget class="QgsDoubleSpinBox" name="mWidthSpin">
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="maximum">
+              <double>9999999.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>100.000000000000000</double>
+             </property>
+             <property name="showClearButton">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4" rowspan="2">
+            <layout class="QHBoxLayout" name="_2">
+             <property name="leftMargin">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>2</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>2</number>
+             </property>
+             <item>
+              <widget class="QgsRatioLockButton" name="mLockAspectRatio">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Lock aspect ratio (including while drawing extent onto canvas)</string>
+               </property>
+               <property name="leftMargin" stdset="0">
+                <number>13</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="0" column="3">
+            <widget class="QgsPropertyOverrideButton" name="mWidthDDBtn">
+             <property name="text">
+              <string>…</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QgsPropertyOverrideButton" name="mHeightDDBtn">
+             <property name="text">
+              <string>…</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="mHeightLabel">
+           <property name="text">
+            <string>Height</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QComboBox" name="mPageSizeComboBox"/>
+           </item>
+           <item>
+            <widget class="QgsPropertyOverrideButton" name="mPaperSizeDDBtn">
+             <property name="text">
+              <string>…</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QComboBox" name="mPageOrientationComboBox"/>
+           </item>
+           <item>
+            <widget class="QgsPropertyOverrideButton" name="mOrientationDDBtn">
+             <property name="text">
+              <string>…</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Orientation</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
-      <item row="3" column="1" rowspan="2">
-       <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0,0,0,0,0">
-        <item row="0" column="5" rowspan="2">
-         <widget class="QgsLayoutUnitsComboBox" name="mSizeUnitsComboBox"/>
-        </item>
-        <item row="1" column="0" colspan="3">
-         <widget class="QgsDoubleSpinBox" name="mHeightSpin">
-          <property name="suffix">
-           <string/>
+      <item row="3" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="mExcludePageCheckBox">
+          <property name="toolTip">
+           <string>If checked, this page will not be included when exporting the layout</string>
           </property>
-          <property name="decimals">
-           <number>3</number>
+          <property name="text">
+           <string>Exclude page from exports</string>
           </property>
-          <property name="maximum">
-           <double>9999999.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="showClearButton" stdset="0">
+          <property name="checked">
            <bool>false</bool>
           </property>
          </widget>
         </item>
-        <item row="0" column="0" colspan="3">
-         <widget class="QgsDoubleSpinBox" name="mWidthSpin">
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="decimals">
-           <number>3</number>
-          </property>
-          <property name="maximum">
-           <double>9999999.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="showClearButton" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="4" rowspan="2">
-         <layout class="QHBoxLayout" name="_2">
-          <property name="leftMargin">
-           <number>2</number>
-          </property>
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>2</number>
-          </property>
-          <item>
-           <widget class="QgsRatioLockButton" name="mLockAspectRatio">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Lock aspect ratio (including while drawing extent onto canvas)</string>
-            </property>
-            <property name="leftMargin" stdset="0">
-             <number>13</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="3">
-         <widget class="QgsPropertyOverrideButton" name="mWidthDDBtn">
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="mExcludePageDDBtn">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
-         <widget class="QgsPropertyOverrideButton" name="mHeightDDBtn">
-          <property name="text">
-           <string>…</string>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-         </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="mHeightLabel">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Height</string>
+         <string>Background</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="topMargin">
-         <number>0</number>
+      <item row="2" column="1">
+       <widget class="QgsSymbolButton" name="mSymbolButton">
+        <property name="enabled">
+         <bool>true</bool>
         </property>
-        <item>
-         <widget class="QComboBox" name="mPageSizeComboBox"/>
-        </item>
-        <item>
-         <widget class="QgsPropertyOverrideButton" name="mPaperSizeDDBtn">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Size</string>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QComboBox" name="mPageOrientationComboBox"/>
-        </item>
-        <item>
-         <widget class="QgsPropertyOverrideButton" name="mOrientationDDBtn">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
-         <string>Orientation</string>
+         <string/>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="mExcludePageCheckBox">
-       <property name="toolTip">
-        <string>If checked, this page will not be included when exporting the layout</string>
-       </property>
-       <property name="text">
-        <string>Exclude page from exports</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsPropertyOverrideButton" name="mExcludePageDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsRatioLockButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsratiolockbutton.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
@@ -280,6 +317,12 @@
    <class>QgsLayoutUnitsComboBox</class>
    <extends>QComboBox</extends>
    <header>qgslayoutunitscombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsRatioLockButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsratiolockbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
- Fix #25694

## Description

- Harmonize the Page Properties widget with other items' widget (notably adds the grey header label)
- When the layout has more than one page, display the page_number/pagecount in the header

![Page Properties](https://github.com/qgis/QGIS/assets/9693475/4932b10e-4197-4170-b313-abded408da1d)
