### PR TITLE
[themes] Fix black label on dark layout designer ruler issue

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1188,3 +1188,7 @@ QWidget#QgsRasterCalcDialogBase QWidget#mOperatorsGroupBox QPushButton {
 QFrame#mUserInputContainer { 
     background-color: @background;
 }
+
+QgsLayoutRuler {
+    color: @textlight;
+}


### PR DESCRIPTION
## Description

This PR fixes the layout designer ruler's annotation color.

Before:
![image](https://github.com/qgis/QGIS/assets/1728657/3ad8c1e3-c29d-4822-b07e-cf86c6b3dc92)

PR:
![image](https://github.com/qgis/QGIS/assets/1728657/2d4cdf8b-1612-4bd2-8f50-a69bc27628ba)
