### PR TITLE
qgis_process: fix unreported deadlock

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -422,7 +422,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       QVariantMap results;
       try
       {
-        if ( childAlg->flags() & QgsProcessingAlgorithm::FlagNoThreading )
+        if ( ( childAlg->flags() & QgsProcessingAlgorithm::FlagNoThreading ) && ( QThread::currentThread() != qApp->thread() ) )
         {
           // child algorithm run step must be called on main thread
           auto runOnMainThread = [modelThread, &context, &modelFeedback, &results, &childAlg, &childParams]


### PR DESCRIPTION
Fix deadlock when running models with algorithms that need to run in main thread.

error is "QMetaObject::invokeMethod: Dead lock detected"
triggered by QMetaObject::invokeMethod( qApp, runOnMainThread, Qt::BlockingQueuedConnection );

Funded by: Gis3W
