### PR TITLE
Also set 'evaluate default values on provider side' property when loading a layer

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -527,9 +527,8 @@ void QgsProject::setFlags( Qgis::ProjectFlags flags )
     for ( auto layerIt = layers.constBegin(); layerIt != layers.constEnd(); ++layerIt )
     {
       if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layerIt.value() ) )
-      {
-        vl->dataProvider()->setProviderProperty( QgsVectorDataProvider::EvaluateDefaultValues, newEvaluateDefaultValues );
-      }
+        if ( vl->dataProvider() )
+          vl->dataProvider()->setProviderProperty( QgsVectorDataProvider::EvaluateDefaultValues, newEvaluateDefaultValues );
     }
   }
 
@@ -2667,6 +2666,14 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer *> &layers )
   {
     if ( ! layer->isValid() )
       return;
+
+    if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer ) )
+    {
+      vlayer->setReadExtentFromXml( mFlags & Qgis::ProjectFlag::TrustStoredLayerStatistics );
+      if ( vlayer->dataProvider() )
+        vlayer->dataProvider()->setProviderProperty( QgsVectorDataProvider::EvaluateDefaultValues,
+            ( bool )( mFlags & Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide ) );
+    }
 
     connect( layer, &QgsMapLayer::configChanged, this, [ = ] { setDirty(); } );
 

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1585,13 +1585,17 @@ class TestQgsProject(QgisTestCase):
         project = QgsProject()
 
         layer = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
+        layer2 = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
 
         project.addMapLayers([layer])
 
-        self.assertEqual(layer.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), None)
+        self.assertEqual(layer.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), False)
         project.setFlags(project.flags() | Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
         self.assertTrue(project.flags() & Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
         self.assertEqual(layer.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
+
+        project.addMapLayers([layer2])
+        self.assertEqual(layer2.dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
 
         tmp_dir = QTemporaryDir()
         tmp_project_file = f"{tmp_dir.path()}/project.qgs"
@@ -1601,10 +1605,11 @@ class TestQgsProject(QgisTestCase):
         self.assertTrue(project2.read(tmp_project_file))
 
         layers = list(project2.mapLayers().values())
-        self.assertEqual(len(layers), 1)
+        self.assertEqual(len(layers), 2)
 
         self.assertTrue(project2.flags() & Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide)
         self.assertEqual(layers[0].dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
+        self.assertEqual(layers[1].dataProvider().providerProperty(QgsDataProvider.EvaluateDefaultValues, None), True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The property `evaluate default values on provider side` is effective
- on the layers when a saved project is loaded
- on the layers already loaded when the property is set upon validation of the project properties dialog

but not on layers that are loaded **after** the property was set in the project.

## Steps to reproduce the problem

1. check the property in the project properties dialog
2. load a layer containing a default field value (like a postgresql or oracle sequence)

---

Funded by Métropole de Bordeaux