### PR TITLE
Fix Crash when saving layout after removing map

### DIFF
--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -239,7 +239,6 @@ void QgsLayoutItemAttributeTable::setMap( QgsLayoutItemMap *map )
     //listen out for extent changes in linked map
     connect( mMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutTable::refreshAttributes );
     connect( mMap, &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutTable::refreshAttributes );
-    connect( mMap, &QObject::destroyed, this, &QgsLayoutItemAttributeTable::disconnectCurrentMap );
   }
   refreshAttributes();
   emit changed();

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -20,10 +20,10 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgslayoutitemmap.h"
 #include "qgslayouttable.h"
 #include "qgsvectorlayerref.h"
 
-class QgsLayoutItemMap;
 class QgsVectorLayer;
 
 /**
@@ -331,7 +331,7 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     QgsVectorLayer *mCurrentAtlasLayer = nullptr;
 
     //! Associated map (used to display the visible features)
-    QgsLayoutItemMap *mMap = nullptr;
+    QPointer< QgsLayoutItemMap > mMap = nullptr;
     QString mMapUuid;
 
     //! Maximum number of features that is displayed


### PR DESCRIPTION
- Fix #53988

## Description

This PR ensure the layout map is always disconnected from the linked attribute table items when it is destroyed, by storing the map item as a `QPointer< QgsLayoutItemMap >`.