### PR TITLE
Fix a couple of dark theme issues in various parts of QGIS

### DIFF
--- a/src/core/layertree/qgscolorramplegendnode.cpp
+++ b/src/core/layertree/qgscolorramplegendnode.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsapplication.h"
 #include "qgscolorramplegendnode.h"
 #include "qgscolorrampimpl.h"
 #include "qgslegendsettings.h"
@@ -22,6 +23,8 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgstextrenderer.h"
 #include "qgsnumericformat.h"
+
+#include <QPalette>
 
 QgsColorRampLegendNode::QgsColorRampLegendNode( QgsLayerTreeLayer *nodeLayer, QgsColorRamp *ramp, const QString &minimumLabel, const QString &maximumLabel, QObject *parent )
   : QgsLayerTreeModelLegendNode( nodeLayer, parent )
@@ -151,6 +154,7 @@ QVariant QgsColorRampLegendNode::data( int role ) const
       QPainter p( &mPixmap );
       p.drawPixmap( 0, 0, pix );
       p.setFont( font );
+      p.setPen( qApp->palette().color( QPalette::Text ) );
 
       switch ( mSettings.orientation() )
       {

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -16,6 +16,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsapplication.h"
 #include "qgselevationprofilecanvas.h"
 #include "qgsmaplayerlistutils_p.h"
 #include "qgsplotcanvasitem.h"
@@ -37,6 +38,7 @@
 
 #include <QWheelEvent>
 #include <QTimer>
+#include <QPalette>
 
 ///@cond PRIVATE
 class QgsElevationProfilePlotItem : public Qgs2DPlot, public QgsPlotCanvasItem
@@ -372,6 +374,11 @@ QgsElevationProfileCanvas::QgsElevationProfileCanvas( QWidget *parent )
   mScreenHelper = new QgsScreenHelper( this );
 
   mPlotItem = new QgsElevationProfilePlotItem( this );
+  QgsTextFormat textFormat = mPlotItem->xAxis().textFormat();
+  textFormat.setColor( qApp->palette().color( QPalette::Text ) );
+  mPlotItem->xAxis().setTextFormat( textFormat );
+  mPlotItem->yAxis().setTextFormat( textFormat );
+
   mCrossHairsItem = new QgsElevationProfileCrossHairsItem( this, mPlotItem );
   mCrossHairsItem->setZValue( 100 );
   mCrossHairsItem->hide();

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -224,7 +224,7 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
     expressionWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
     expressionWidget->layout()->addWidget( editExpressionButton );
     expressionWidget->layout()->addWidget( new QLabel( mLayer->expressionField( idx ) ) );
-    expressionWidget->setStyleSheet( "background-color: rgb( 200, 200, 255 )" );
+    expressionWidget->setStyleSheet( "*[class~=\"QWidget\"] { background-color: rgba( 103, 0, 243, 0.12 ); } QToolButton { background-color: rgba( 203, 100, 243, 0.6 ); }" );
     mFieldsList->setCellWidget( row, AttrCommentCol, expressionWidget );
   }
   else


### PR DESCRIPTION
## Description

This PR improves dark theme compatibility fixes.

#### Source fields' virtual field comment widget

Before (note the light text on light background expression label):
![image](https://github.com/qgis/QGIS/assets/1728657/483ae728-34f3-47a6-b87a-b1e20f5ff773)

PR:
![image](https://github.com/qgis/QGIS/assets/1728657/3de74f32-5ce6-480b-9ef8-0ceebceb3cfa)

#### Layers tree color ramp legend item

#### Elevation profile canvas axis labels

Before
![Screenshot from 2023-08-05 12-03-30](https://github.com/qgis/QGIS/assets/1728657/b1b862bf-5605-49b6-ace1-1b83b71e8ac8)

PR:
![Screenshot from 2023-08-05 12-03-34](https://github.com/qgis/QGIS/assets/1728657/d5f9e1f4-06fb-4869-999c-9460918cdefa)

@AlisterH , FYI, the last two fixes were raised by you a while back. 