### PR TITLE
[ui] Fix hard-to-see connecting arrows and text within the  processing's model designer

### DIFF
--- a/src/gui/processing/models/qgsmodelarrowitem.cpp
+++ b/src/gui/processing/models/qgsmodelarrowitem.cpp
@@ -42,7 +42,7 @@ QgsModelArrowItem::QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Q
 {
   setCacheMode( QGraphicsItem::DeviceCoordinateCache );
   setFlag( QGraphicsItem::ItemIsSelectable, false );
-  mColor = QApplication::palette().color( QPalette::WindowText );
+  mColor = QApplication::palette().color( QPalette::Text );
   mColor.setAlpha( 150 );
   setPen( QPen( mColor, 8, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
   setZValue( QgsModelGraphicsScene::ArrowLink );

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -378,7 +378,7 @@ void QgsModelComponentGraphicItem::paint( QPainter *painter, const QStyleOptionG
     painter->drawText( labelRect, Qt::TextWordWrap | Qt::AlignVCenter, text );
   }
 
-  painter->setPen( QPen( QApplication::palette().color( QPalette::WindowText ) ) );
+  painter->setPen( QPen( QApplication::palette().color( QPalette::Text ) ) );
 
   if ( linkPointCount( Qt::TopEdge ) || linkPointCount( Qt::BottomEdge ) )
   {


### PR DESCRIPTION
## Description

Before:
![Screenshot from 2023-08-05 15-39-33](https://github.com/qgis/QGIS/assets/1728657/69fe8fe2-d795-4f22-9d69-7729928a4538)

PR:
![Screenshot from 2023-08-05 15-39-20](https://github.com/qgis/QGIS/assets/1728657/cf252863-2f3f-49b6-9482-54ac86303d1f)
