### PR TITLE
Add PyQgsExternalStorageAwsS3 to ci blocklist

### DIFF
--- a/.ci/test_blocklist_qt5.txt
+++ b/.ci/test_blocklist_qt5.txt
@@ -24,3 +24,6 @@ test_core_layerdefinition
 PyQgsProviderConnectionMssql
 PyQgsStyleStorageMssql
 
+# CI setup is no longer working for this test
+PyQgsExternalStorageAwsS3
+


### PR DESCRIPTION
The CI setup is no longer working for this test, resulting in continuous false positives
