### PR TITLE
Fix widget z range restrictions for layer metadata

### DIFF
--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -41,6 +41,9 @@ QgsMetadataWidget::QgsMetadataWidget( QWidget *parent, QgsMapLayer *layer )
   // Disable the encoding
   encodingFrame->setHidden( true );
 
+  spinBoxZMinimum->setClearValue( 0 );
+  spinBoxZMaximum->setClearValue( 0 );
+
   // Default categories, we want them translated, so we are not using a CSV.
   mDefaultCategories << tr( "Farming" ) << tr( "Climatology Meteorology Atmosphere" ) << tr( "Location" ) << tr( "Intelligence Military" ) << tr( "Transportation" ) << tr( "Structure" ) << tr( "Boundaries" );
   mDefaultCategories << tr( "Inland Waters" ) << tr( "Planning Cadastre" ) << tr( "Geoscientific Information" ) << tr( "Elevation" ) << tr( "Health" ) << tr( "Biota" ) << tr( "Oceans" ) << tr( "Environment" );

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -976,7 +976,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QgsSpinBox" name="spinBoxZMaximum"/>
+          <widget class="QgsDoubleSpinBox" name="spinBoxZMaximum">
+           <property name="minimum">
+            <double>-9999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>9999999999.000000000000000</double>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -990,7 +997,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QgsSpinBox" name="spinBoxZMinimum"/>
+          <widget class="QgsDoubleSpinBox" name="spinBoxZMinimum">
+           <property name="minimum">
+            <double>-9999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>9999999999.000000000000000</double>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -1575,15 +1589,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>


### PR DESCRIPTION
Expand the range to allow negative values, set max to >99
