### PR TITLE
Load some basic provider metadata to tiled scene layer metadata

### DIFF
--- a/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
@@ -88,6 +88,8 @@ QgsTiledSceneLayer cannot be copied.
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;
 
+    virtual QString loadDefaultMetadata( bool &resultFlag /Out/ );
+
 
   private:
     QgsTiledSceneLayer( const QgsTiledSceneLayer &rhs );

--- a/src/core/tiledscene/qgscesiumtilesdataprovider.h
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsCesiumTilesDataProvider final: public QgsTiledSceneDataProv
     QgsCesiumTilesDataProvider &operator=( const QgsCesiumTilesDataProvider &other ) = delete;
 
     ~QgsCesiumTilesDataProvider() final;
-
+    Qgis::TiledSceneProviderCapabilities capabilities() const final;
     QgsCesiumTilesDataProvider *clone() const final;
     QgsCoordinateReferenceSystem crs() const final;
     QgsRectangle extent() const final;
@@ -54,6 +54,7 @@ class CORE_EXPORT QgsCesiumTilesDataProvider final: public QgsTiledSceneDataProv
     QString name() const final;
     QString description() const final;
     QString htmlMetadata() const final;
+    QgsLayerMetadata layerMetadata() const override;
     const QgsCoordinateReferenceSystem sceneCrs() const final;
     const QgsAbstractTiledSceneBoundingVolume *boundingVolume() const final;
     QgsTiledSceneIndex index() const final;

--- a/src/core/tiledscene/qgstiledscenelayer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayer.cpp
@@ -77,6 +77,26 @@ QgsRectangle QgsTiledSceneLayer::extent() const
   return mDataProvider->extent();
 }
 
+QString QgsTiledSceneLayer::loadDefaultMetadata( bool &resultFlag )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  resultFlag = false;
+  if ( !mDataProvider || !mDataProvider->isValid() )
+    return QString();
+
+  if ( qgis::down_cast< QgsTiledSceneDataProvider * >( mDataProvider.get() )->capabilities() & Qgis::TiledSceneProviderCapability::ReadLayerMetadata )
+  {
+    setMetadata( mDataProvider->layerMetadata() );
+  }
+  else
+  {
+    QgsMapLayer::loadDefaultMetadata( resultFlag );
+  }
+  resultFlag = true;
+  return QString();
+}
+
 QgsMapLayerRenderer *QgsTiledSceneLayer::createMapRenderer( QgsRenderContext &context )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/tiledscene/qgstiledscenelayer.h
+++ b/src/core/tiledscene/qgstiledscenelayer.h
@@ -111,6 +111,7 @@ class CORE_EXPORT QgsTiledSceneLayer : public QgsMapLayer
     QString loadDefaultStyle( bool &resultFlag SIP_OUT ) FINAL;
     QString htmlMetadata() const override;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
+    QString loadDefaultMetadata( bool &resultFlag SIP_OUT ) override;
 
   private slots:
     void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags ) override;

--- a/tests/src/python/test_qgscesium3dtileslayer.py
+++ b/tests/src/python/test_qgscesium3dtileslayer.py
@@ -15,15 +15,12 @@ import tempfile
 import qgis  # NOQA
 from qgis.core import (
     Qgis,
-    QgsBox3D,
     QgsTiledSceneLayer,
     QgsCoordinateReferenceSystem,
-    QgsMatrix4x4,
     QgsOrientedBox3D,
     QgsTiledSceneRequest,
 )
 from qgis.testing import start_app, unittest
-from utilities import unitTestDataPath
 
 start_app()
 
@@ -103,6 +100,31 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertIn("1.1", layer.dataProvider().htmlMetadata())
             self.assertIn("e575c6f1", layer.dataProvider().htmlMetadata())
             self.assertIn("1.2 - 67.01", layer.dataProvider().htmlMetadata())
+
+            # check metadata
+            layer.loadDefaultMetadata()
+            self.assertEqual(layer.metadata().type(), "dataset")
+            self.assertEqual(layer.metadata().identifier(), 'e575c6f1')
+            self.assertEqual(layer.metadata().crs().authid(), 'EPSG:4978')
+            self.assertEqual(layer.metadata().extent().spatialExtents()[0].extentCrs.authid(), "EPSG:4979")
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.xMinimum(), -75.61444, 3
+            )
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.xMaximum(), -75.609747, 3
+            )
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.yMinimum(), 40.040721, 3
+            )
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.yMaximum(), 40.0443399, 3
+            )
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.zMinimum(), 1.2, 3
+            )
+            self.assertAlmostEqual(
+                layer.metadata().extent().spatialExtents()[0].bounds.zMaximum(), 67.0099999, 3
+            )
 
     def test_source_bounding_volume_region_with_transform(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Unfortunately the cesium specifications don't have support for dataset level metadata (ie descriptions, credits, etc), so we can only populate very basic layer metadata automatically (crs, source link, extent).