### PR TITLE
Fix ci test for AWS S3

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -124,7 +124,7 @@ else
 fi
 
 # Create an empty minio folder with appropriate permissions so www user can write inside it
-mkdir -p /tmp/minio_tests/test_bucket && chmod -R 777 /tmp/minio_tests
+mkdir -p /tmp/minio_tests/test-bucket && chmod -R 777 /tmp/minio_tests
 
 # Create an empty webdav folder with appropriate permissions so www user can write inside it
 mkdir -p /tmp/webdav_tests && chmod 777 /tmp/webdav_tests

--- a/.ci/test_blocklist_qt5.txt
+++ b/.ci/test_blocklist_qt5.txt
@@ -24,6 +24,3 @@ test_core_layerdefinition
 PyQgsProviderConnectionMssql
 PyQgsStyleStorageMssql
 
-# CI setup is no longer working for this test
-PyQgsExternalStorageAwsS3
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -409,7 +409,7 @@ jobs:
           echo "TEST_BATCH=$TEST_BATCH"
           echo "DOCKERFILE=$DOCKERFILE"
           mkdir -p /tmp/webdav_tests && chmod 777 /tmp/webdav_tests
-          mkdir -p /tmp/minio_tests/test_bucket && chmod -R 777 /tmp/minio_tests
+          mkdir -p /tmp/minio_tests/test-bucket && chmod -R 777 /tmp/minio_tests
           docker-compose -f .docker/$DOCKERFILE run qgis-deps /root/QGIS/.docker/docker-qgis-test.sh $TEST_BATCH
 
       - name: Archive test results report

--- a/tests/src/python/test_qgsexternalstorage_awss3.py
+++ b/tests/src/python/test_qgsexternalstorage_awss3.py
@@ -34,7 +34,7 @@ class TestPyQgsExternalStorageAwsS3(TestPyQgsExternalStorageBase, unittest.TestC
         super().setUpClass()
         unittest.TestCase.setUpClass()
 
-        bucket_name = "test_bucket"
+        bucket_name = "test-bucket"
 
         cls.auth_config = QgsAuthMethodConfig("AWSS3")
         cls.auth_config.setConfig("username", "minioadmin")


### PR DESCRIPTION
## Description

AWS S3 external storage test, with Minio docker image, is broken.

This PR should fix it.

It seems that the test bucket name was containing a forbidden character (the underscore) that is now strictly forbidden since latest Minio releases (from https://github.com/minio/minio/pull/17742/files).