### PR TITLE
CRS must be a property of tiled scene bounding volumes

### DIFF
--- a/python/core/auto_generated/tiledscene/qgstiledsceneboundingvolume.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledsceneboundingvolume.sip.in
@@ -48,12 +48,11 @@ Abstract base class for bounding volumes for tiled scene nodes.
 Returns the type of the volume;
 %End
 
-    virtual QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const = 0;
+    virtual QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0;
 %Docstring
 Returns the axis aligned bounding box of the volume.
 
-The optional ``transform`` and ``direction`` arguments should be used whenever the volume needs
-to be transformed into a specific destination CRS, in order to correctly handle 3D coordinate transforms.
+The ``crs`` and ``context`` arguments are used to specify the destination coordinate reference system for the bounding box.
 %End
 
     virtual QgsAbstractTiledSceneBoundingVolume *clone() const = 0 /Factory/;
@@ -61,14 +60,13 @@ to be transformed into a specific destination CRS, in order to correctly handle 
 Returns a clone of the volume.
 %End
 
-    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0 /Factory/;
 %Docstring
 Returns a new geometry representing the 2-dimensional X/Y center slice of the volume.
 
 Caller takes ownership of the returned geometry.
 
-The optional ``transform`` and ``direction`` arguments should be used whenever the volume needs
-to be transformed into a specific destination CRS, in order to correctly handle 3D coordinate transforms.
+The ``crs`` and ``context`` arguments are used to specify the destination coordinate reference system for the geometry.
 %End
 
     virtual void transform( const QgsMatrix4x4 &transform ) = 0;
@@ -81,10 +79,29 @@ The actual result of transforming a bounding volume depends on subclass specific
 - transforming a :py:class:`QgsTiledSceneBoundingVolumeSphere` causes the radius to be multiplied by the maximum length of the transform scales
 %End
 
-    virtual bool intersects( const QgsOrientedBox3D &box ) const = 0;
+    virtual bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0;
 %Docstring
 Returns ``True`` if this bounds intersects the specified ``box``.
+
+The ``crs`` argument specifies the coordinate reference system of the box.
 %End
+
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+Sets the ``crs`` associated with the volume.
+
+.. seealso:: :py:func:`crs`
+%End
+
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+Returns the coordinate reference system associated with the volume.
+
+.. seealso:: :py:func:`setCrs`
+%End
+
+  protected:
+
 
 };
 
@@ -110,13 +127,13 @@ Constructor for QgsTiledSceneBoundingVolumeRegion, with the specified ``region``
 
     virtual void transform( const QgsMatrix4x4 &transform ) ${SIP_FINAL};
 
-    virtual QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException );
+    virtual QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException );
 
     virtual QgsTiledSceneBoundingVolumeRegion *clone() const ${SIP_FINAL} /Factory/;
 
-    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
+    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
 
-    virtual bool intersects( const QgsOrientedBox3D &box ) const ${SIP_FINAL};
+    virtual bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL};
 
 
     QgsBox3D region() const;
@@ -148,13 +165,13 @@ Constructor for QgsTiledSceneBoundingVolumeBox, with the specified oriented ``bo
 
     virtual void transform( const QgsMatrix4x4 &transform ) ${SIP_FINAL};
 
-    virtual QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException );
+    virtual QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException );
 
     virtual QgsTiledSceneBoundingVolumeBox *clone() const ${SIP_FINAL} /Factory/;
 
-    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
+    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
 
-    virtual bool intersects( const QgsOrientedBox3D &box ) const ${SIP_FINAL};
+    virtual bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL};
 
 
     QgsOrientedBox3D box() const;
@@ -186,13 +203,13 @@ Constructor for QgsTiledSceneBoundingVolumeSphere, with the specified ``sphere``
 
     virtual void transform( const QgsMatrix4x4 &transform ) ${SIP_FINAL};
 
-    virtual QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException );
+    virtual QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException );
 
     virtual QgsTiledSceneBoundingVolumeSphere *clone() const ${SIP_FINAL} /Factory/;
 
-    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
+    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL} throw( QgsCsException ) /Factory/;
 
-    virtual bool intersects( const QgsOrientedBox3D &box ) const ${SIP_FINAL};
+    virtual bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const ${SIP_FINAL};
 
 
     QgsSphere sphere() const;

--- a/python/core/auto_generated/tiledscene/qgstiledscenerequest.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenerequest.sip.in
@@ -40,18 +40,36 @@ Returns the flags which affect how tiles are fetched.
 .. seealso:: :py:func:`setFlags`
 %End
 
+    QgsCoordinateTransformContext transformContext() const;
+%Docstring
+Returns the transform context which should be used when transforming :py:func:`~QgsTiledSceneRequest.filterBox` coordinates.
+%End
+
     QgsOrientedBox3D filterBox() const;
 %Docstring
-Returns the box from which data will be taken, in the layer's CRS.
+Returns the box from which data will be taken.
+
+The CRS for the box can be retrieved by :py:func:`~QgsTiledSceneRequest.filterBoxCrs`.
 
 If the returned box is null, then no filter box is set.
+
+.. seealso:: :py:func:`filterBoxCrs`
 
 .. seealso:: :py:func:`setFilterBox`
 %End
 
-    void setFilterBox( const QgsOrientedBox3D &box );
+    QgsCoordinateReferenceSystem filterBoxCrs() const;
 %Docstring
-Sets the ``box`` from which data will be taken, in the layer's CRS.
+Returns the coordinate reference system for the filter box.
+
+.. seealso:: :py:func:`filterBox`
+
+.. seealso:: :py:func:`setFilterBox`
+%End
+
+    void setFilterBox( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the ``box`` from which data will be taken.
 
 An null ``box`` removes the filter.
 

--- a/src/core/tiledscene/qgstiledsceneboundingvolume.h
+++ b/src/core/tiledscene/qgstiledsceneboundingvolume.h
@@ -70,10 +70,9 @@ class CORE_EXPORT QgsAbstractTiledSceneBoundingVolume
     /**
      * Returns the axis aligned bounding box of the volume.
      *
-     * The optional \a transform and \a direction arguments should be used whenever the volume needs
-     * to be transformed into a specific destination CRS, in order to correctly handle 3D coordinate transforms.
+     * The \a crs and \a context arguments are used to specify the destination coordinate reference system for the bounding box.
      */
-    virtual QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const = 0;
+    virtual QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0;
 
     /**
      * Returns a clone of the volume.
@@ -85,10 +84,9 @@ class CORE_EXPORT QgsAbstractTiledSceneBoundingVolume
      *
      * Caller takes ownership of the returned geometry.
      *
-     * The optional \a transform and \a direction arguments should be used whenever the volume needs
-     * to be transformed into a specific destination CRS, in order to correctly handle 3D coordinate transforms.
+     * The \a crs and \a context arguments are used to specify the destination coordinate reference system for the geometry.
      */
-    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0 SIP_FACTORY;
 
     /**
      * Applies a \a transform to the bounding volume.
@@ -102,8 +100,28 @@ class CORE_EXPORT QgsAbstractTiledSceneBoundingVolume
 
     /**
      * Returns TRUE if this bounds intersects the specified \a box.
+     *
+     * The \a crs argument specifies the coordinate reference system of the box.
      */
-    virtual bool intersects( const QgsOrientedBox3D &box ) const = 0;
+    virtual bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const = 0;
+
+    /**
+     * Sets the \a crs associated with the volume.
+     *
+     * \see crs()
+     */
+    void setCrs( const QgsCoordinateReferenceSystem &crs ) { mCrs = crs; }
+
+    /**
+     * Returns the coordinate reference system associated with the volume.
+     *
+     * \see setCrs()
+     */
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+
+  protected:
+
+    QgsCoordinateReferenceSystem mCrs;
 
 };
 
@@ -124,10 +142,10 @@ class CORE_EXPORT QgsTiledSceneBoundingVolumeRegion : public QgsAbstractTiledSce
 
     Qgis::TiledSceneBoundingVolumeType type() const FINAL;
     void transform( const QgsMatrix4x4 &transform ) FINAL;
-    QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException );
+    QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException );
     QgsTiledSceneBoundingVolumeRegion *clone() const FINAL SIP_FACTORY;
-    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
-    bool intersects( const QgsOrientedBox3D &box ) const FINAL;
+    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
+    bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL;
 
     /**
      * Returns the volume's region.
@@ -155,10 +173,10 @@ class CORE_EXPORT QgsTiledSceneBoundingVolumeBox : public QgsAbstractTiledSceneB
 
     Qgis::TiledSceneBoundingVolumeType type() const FINAL;
     void transform( const QgsMatrix4x4 &transform ) FINAL;
-    QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException );
+    QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException );
     QgsTiledSceneBoundingVolumeBox *clone() const FINAL SIP_FACTORY;
-    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
-    bool intersects( const QgsOrientedBox3D &box ) const FINAL;
+    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
+    bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL;
 
     /**
      * Returns the volume's oriented box.
@@ -188,10 +206,10 @@ class CORE_EXPORT QgsTiledSceneBoundingVolumeSphere: public QgsAbstractTiledScen
 
     Qgis::TiledSceneBoundingVolumeType type() const FINAL;
     void transform( const QgsMatrix4x4 &transform ) FINAL;
-    QgsBox3D bounds( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException );
+    QgsBox3D bounds( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException );
     QgsTiledSceneBoundingVolumeSphere *clone() const FINAL SIP_FACTORY;
-    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateTransform &transform = QgsCoordinateTransform(), Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
-    bool intersects( const QgsOrientedBox3D &box ) const FINAL;
+    QgsAbstractGeometry *as2DGeometry( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL SIP_THROW( QgsCsException ) SIP_FACTORY;
+    bool intersects( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context ) const FINAL;
 
     /**
      * Returns the volume's sphere.

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -81,10 +81,9 @@ bool QgsTiledSceneLayerRenderer::render()
 
   if ( mLayerBoundingVolume )
   {
-    const QgsCoordinateTransform transform = QgsCoordinateTransform( mSceneCrs, renderContext()->coordinateTransform().destinationCrs(), renderContext()->transformContext() );
     try
     {
-      std::unique_ptr< QgsAbstractGeometry > rootBoundsGeometry( mLayerBoundingVolume->as2DGeometry( transform ) );
+      std::unique_ptr< QgsAbstractGeometry > rootBoundsGeometry( mLayerBoundingVolume->as2DGeometry( renderContext()->coordinateTransform().destinationCrs(), renderContext()->transformContext() ) );
       if ( QgsCurvePolygon *polygon = qgsgeometry_cast< QgsCurvePolygon * >( rootBoundsGeometry.get() ) )
       {
         QPolygonF rootBoundsPoly = polygon->exteriorRing()->asQPolygonF();

--- a/src/core/tiledscene/qgstiledscenerequest.cpp
+++ b/src/core/tiledscene/qgstiledscenerequest.cpp
@@ -19,6 +19,13 @@
 
 QgsTiledSceneRequest::QgsTiledSceneRequest() = default;
 
+void QgsTiledSceneRequest::setFilterBox( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context )
+{
+  mFilterBox = box;
+  mFilterBoxCrs = crs;
+  mTransformContext = context;
+}
+
 void QgsTiledSceneRequest::setFeedback( QgsFeedback *feedback )
 {
   mFeedback = feedback;

--- a/src/core/tiledscene/qgstiledscenerequest.h
+++ b/src/core/tiledscene/qgstiledscenerequest.h
@@ -21,6 +21,8 @@
 
 #include "qgis_core.h"
 #include "qgis.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgsorientedbox3d.h"
 
 class QgsFeedback;
@@ -53,22 +55,38 @@ class CORE_EXPORT QgsTiledSceneRequest
     Qgis::TiledSceneRequestFlags flags() const { return mFlags; }
 
     /**
-    * Returns the box from which data will be taken, in the layer's CRS.
+     * Returns the transform context which should be used when transforming filterBox() coordinates.
+    */
+    QgsCoordinateTransformContext transformContext() const { return mTransformContext; }
+
+    /**
+    * Returns the box from which data will be taken.
+    *
+    * The CRS for the box can be retrieved by filterBoxCrs().
     *
     * If the returned box is null, then no filter box is set.
     *
+    * \see filterBoxCrs()
     * \see setFilterBox()
     */
     QgsOrientedBox3D filterBox() const { return mFilterBox; }
 
     /**
-     * Sets the \a box from which data will be taken, in the layer's CRS.
+     * Returns the coordinate reference system for the filter box.
+     *
+     * \see filterBox()
+     * \see setFilterBox()
+     */
+    QgsCoordinateReferenceSystem filterBoxCrs() const { return mFilterBoxCrs; }
+
+    /**
+     * Sets the \a box from which data will be taken.
      *
      * An null \a box removes the filter.
      *
      * \see filterBox()
      */
-    void setFilterBox( const QgsOrientedBox3D &box ) { mFilterBox = box; }
+    void setFilterBox( const QgsOrientedBox3D &box, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
 
     /**
      * Returns the required geometric error threshold for the returned tiles, in
@@ -127,6 +145,9 @@ class CORE_EXPORT QgsTiledSceneRequest
 
     Qgis::TiledSceneRequestFlags mFlags;
     QgsOrientedBox3D mFilterBox;
+    QgsCoordinateReferenceSystem mFilterBoxCrs;
+    QgsCoordinateTransformContext mTransformContext;
+
     QgsFeedback *mFeedback = nullptr;
     double mRequiredGeometricError = 0;
     QString mParentTileId;

--- a/tests/src/python/test_qgstiledsceneboundingvolume.py
+++ b/tests/src/python/test_qgstiledsceneboundingvolume.py
@@ -48,7 +48,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertEqual(cloned.region(), QgsBox3d(1, 2, 3, 10, 11, 12))
 
         # bounds
-        bounds = volume.bounds()
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(bounds.xMinimum(), 1)
         self.assertEqual(bounds.xMaximum(), 10)
         self.assertEqual(bounds.yMinimum(), 2)
@@ -56,7 +58,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertEqual(bounds.zMinimum(), 3)
         self.assertEqual(bounds.zMaximum(), 12)
 
-        geometry_2d = volume.as2DGeometry()
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(geometry_2d.asWkt(), "Polygon ((1 2, 10 2, 10 11, 1 11, 1 2))")
 
         # with coordinate transform
@@ -70,12 +74,10 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
                 -3493318 + 2000,
             )
         )
-        transform = QgsCoordinateTransform(
-            QgsCoordinateReferenceSystem("EPSG:4978"),
-            QgsCoordinateReferenceSystem("EPSG:4979"),
-            QgsCoordinateTransformContext(),
+        volume.setCrs(QgsCoordinateReferenceSystem("EPSG:4978"))
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
         )
-        bounds = volume.bounds(transform)
         self.assertAlmostEqual(bounds.xMinimum(), 149.5582617, 3)
         self.assertAlmostEqual(bounds.xMaximum(), 149.577611, 3)
         self.assertAlmostEqual(bounds.yMinimum(), -33.424296, 3)
@@ -83,7 +85,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertAlmostEqual(bounds.zMinimum(), -1122.81806, 3)
         self.assertAlmostEqual(bounds.zMaximum(), 1332.44347, 3)
 
-        geometry_2d = volume.as2DGeometry(transform)
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
+        )
         self.assertEqual(
             geometry_2d.asWkt(3),
             "Polygon ((149.572 -33.424, 149.558 -33.421, 149.558 -33.405, 149.564 -33.401, 149.578 -33.405, 149.578 -33.42, 149.572 -33.424))",
@@ -93,11 +97,17 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         volume = QgsTiledSceneBoundingVolumeRegion(QgsBox3d(1, 2, 3, 10, 11, 12))
         self.assertFalse(
             volume.intersects(
-                QgsOrientedBox3D.fromBox3D(QgsBox3d(11, 2, 3, 10, 11, 12))
+                QgsOrientedBox3D.fromBox3D(QgsBox3d(11, 2, 3, 10, 11, 12)),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
             )
         )
         self.assertTrue(
-            volume.intersects(QgsOrientedBox3D.fromBox3D(QgsBox3d(9, 2, 3, 10, 11, 12)))
+            volume.intersects(
+                QgsOrientedBox3D.fromBox3D(QgsBox3d(9, 2, 3, 10, 11, 12)),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
+            )
         )
 
     def test_box(self):
@@ -117,7 +127,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         )
 
         # bounds
-        bounds = volume.bounds()
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(bounds.xMinimum(), -13.5)
         self.assertEqual(bounds.xMaximum(), 16.5)
         self.assertEqual(bounds.yMinimum(), -36)
@@ -125,7 +137,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertEqual(bounds.zMinimum(), -81)
         self.assertEqual(bounds.zMaximum(), 99)
 
-        geometry_2d = volume.as2DGeometry()
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(
             geometry_2d.asWkt(),
             "Polygon ((-13.5 -36, -13.5 44, 16.5 44, 16.5 -36, -13.5 -36))",
@@ -137,12 +151,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
                 [-4595750, 2698725, -3493318], [1000, 0, 0, 0, 1500, 0, 0, 0, 2000]
             )
         )
-        transform = QgsCoordinateTransform(
-            QgsCoordinateReferenceSystem("EPSG:4978"),
-            QgsCoordinateReferenceSystem("EPSG:4979"),
-            QgsCoordinateTransformContext(),
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
         )
-        bounds = volume.bounds(transform)
         self.assertAlmostEqual(bounds.xMinimum(), 149.5582617, 3)
         self.assertAlmostEqual(bounds.xMaximum(), 149.5969605, 3)
         self.assertAlmostEqual(bounds.yMinimum(), -33.44311, 3)
@@ -150,7 +161,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertAlmostEqual(bounds.zMinimum(), -1756.82217, 3)
         self.assertAlmostEqual(bounds.zMaximum(), 3153.6759909, 3)
 
-        geometry_2d = volume.as2DGeometry(transform)
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
+        )
         self.assertEqual(
             geometry_2d.asWkt(5),
             "Polygon ((149.58608 -33.44312, 149.55826 -33.43557, 149.55826 -33.40547, 149.56915 -33.39692, 149.59696 -33.40445, 149.59696 -33.43455, 149.58608 -33.44312))",
@@ -178,7 +191,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
                 QgsOrientedBox3D(
                     [4, 4, 4],
                     [1, 0, 0, 0, 1, 0, 0, 0, 1],
-                )
+                ),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
             )
         )
 
@@ -191,7 +206,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
             volume.intersects(
                 QgsOrientedBox3D(
                     [4, 4, 4], [0.7071 * 2, 0.7071 * 2, 0, -0.7071, 0.7071, 0, 0, 0, 3]
-                )
+                ),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
             )
         )
 
@@ -206,7 +223,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertEqual(cloned.sphere(), QgsSphere(1.5, 4, 9, 30))
 
         # bounds
-        bounds = volume.bounds()
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(bounds.xMinimum(), -28.5)
         self.assertEqual(bounds.xMaximum(), 31.5)
         self.assertEqual(bounds.yMinimum(), -26.0)
@@ -214,7 +233,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertEqual(bounds.zMinimum(), -21.0)
         self.assertEqual(bounds.zMaximum(), 39)
 
-        geometry_2d = volume.as2DGeometry()
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext()
+        )
         self.assertEqual(
             geometry_2d.asWkt(),
             "CurvePolygon (CircularString (1.5 34, 31.5 4, 1.5 -26, -28.5 4, 1.5 34))",
@@ -224,12 +245,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         volume = QgsTiledSceneBoundingVolumeSphere(
             QgsSphere(-4595750, 2698725, -3493318, 1983)
         )
-        transform = QgsCoordinateTransform(
-            QgsCoordinateReferenceSystem("EPSG:4978"),
-            QgsCoordinateReferenceSystem("EPSG:4979"),
-            QgsCoordinateTransformContext(),
+        bounds = volume.bounds(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
         )
-        bounds = volume.bounds(transform)
         self.assertAlmostEqual(bounds.xMinimum(), 149.5484294320, 3)
         self.assertAlmostEqual(bounds.xMaximum(), 149.606785943, 3)
         self.assertAlmostEqual(bounds.yMinimum(), -33.448419, 3)
@@ -237,7 +255,9 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         self.assertAlmostEqual(bounds.zMinimum(), -2659.1526749, 3)
         self.assertAlmostEqual(bounds.zMaximum(), 4055.8967716, 3)
 
-        geometry_2d = volume.as2DGeometry(transform)
+        geometry_2d = volume.as2DGeometry(
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
+        )
         self.assertEqual(
             geometry_2d.asWkt(3),
             "Polygon ((149.592 -33.433, 149.594 -33.431, 149.596 -33.429, 149.597 -33.427, 149.598 -33.425, 149.599 -33.423, 149.599 -33.421, 149.599 -33.418, 149.598 -33.416, 149.598 -33.414, 149.596 -33.412, 149.595 -33.41, 149.593 -33.408, 149.591 -33.406, 149.589 -33.405, 149.586 -33.404, 149.584 -33.403, 149.581 -33.402, 149.578 -33.402, 149.576 -33.402, 149.573 -33.403, 149.57 -33.403, 149.568 -33.404, 149.565 -33.405, 149.563 -33.407, 149.561 -33.409, 149.56 -33.411, 149.558 -33.413, 149.557 -33.415, 149.557 -33.417, 149.556 -33.419, 149.556 -33.422, 149.557 -33.424, 149.558 -33.426, 149.559 -33.428, 149.56 -33.43, 149.562 -33.432, 149.564 -33.434, 149.566 -33.435, 149.569 -33.436, 149.571 -33.437, 149.574 -33.438, 149.577 -33.438, 149.58 -33.438, 149.582 -33.437, 149.585 -33.437, 149.588 -33.436, 149.59 -33.435, 149.592 -33.433))",
@@ -247,12 +267,16 @@ class TestQgsTiledSceneBoundingVolume(QgisTestCase):
         volume = QgsTiledSceneBoundingVolumeSphere(QgsSphere(1, 2, 3, 6))
         self.assertFalse(
             volume.intersects(
-                QgsOrientedBox3D.fromBox3D(QgsBox3d(11, 2, 3, 10, 11, 12))
+                QgsOrientedBox3D.fromBox3D(QgsBox3d(11, 2, 3, 10, 11, 12)),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
             )
         )
         self.assertTrue(
             volume.intersects(
-                QgsOrientedBox3D.fromBox3D(QgsBox3d(6.5, 2, 3, 10, 11, 12))
+                QgsOrientedBox3D.fromBox3D(QgsBox3d(6.5, 2, 3, 10, 11, 12)),
+                QgsCoordinateReferenceSystem(),
+                QgsCoordinateTransformContext(),
             )
         )
 

--- a/tests/src/python/test_qgstiledscenerequest.py
+++ b/tests/src/python/test_qgstiledscenerequest.py
@@ -18,7 +18,9 @@ from qgis.core import (
     Qgis,
     QgsTiledSceneRequest,
     QgsFeedback,
-    QgsOrientedBox3D
+    QgsOrientedBox3D,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransformContext
 )
 from qgis.testing import start_app, QgisTestCase
 
@@ -52,12 +54,15 @@ class TestQgsTiledSceneRequest(QgisTestCase):
         self.assertEqual(request.feedback(), feedback)
 
         request.setFilterBox(
-            QgsOrientedBox3D([1, 2, 3], [1, 0, 0, 0, 2, 0, 0, 0, 3])
+            QgsOrientedBox3D([1, 2, 3], [1, 0, 0, 0, 2, 0, 0, 0, 3]),
+            QgsCoordinateReferenceSystem("EPSG:4979"), QgsCoordinateTransformContext()
         )
         self.assertEqual(
             request.filterBox(),
             QgsOrientedBox3D([1, 2, 3], [1, 0, 0, 0, 2, 0, 0, 0, 3])
         )
+        self.assertEqual(request.filterBoxCrs(),
+                         QgsCoordinateReferenceSystem('EPSG:4979'))
 
         self.assertFalse(request.parentTileId())
         request.setParentTileId('parent')


### PR DESCRIPTION
Since a single dataset can mix region, obb and spherical bounds, and each of these can have a different associated crs (regions vs obb/spheres), then we can't just rely on creating one coordinate transform which works for ALL dataset bounding volumes.

Instead we need to use a single transform per bounding volume, to account for these differing bound crses...
