### PR TITLE
Tiled scene: 3D renderer implementation

### DIFF
--- a/python/core/auto_generated/tiledscene/qgscesiumutils.sip.in
+++ b/python/core/auto_generated/tiledscene/qgscesiumutils.sip.in
@@ -42,10 +42,20 @@ Parses a ``box`` object from a Cesium JSON document to an oriented bounding box.
 Parses a ``sphere`` object from a Cesium JSON document.
 %End
 
-    static QByteArray extractGltfFromB3dm( QIODevice &file );
+    static QByteArray extractGltfFromB3dm( const QByteArray &tileContent );
 %Docstring
 Extracts GLTF binary data from the legacy b3dm (Batched 3D Model) tile format.
 Returns empty byte array on error.
+%End
+
+    static QByteArray extractGltfFromTileContent( const QByteArray &tileContent );
+%Docstring
+Extracts GLTF binary data from tile content.
+Returns empty byte array on error.
+
+.. note::
+
+   cmpt, pnts, i3dm tile types are currently not supported
 %End
 
 };

--- a/python/core/auto_generated/tiledscene/qgscesiumutils.sip.in
+++ b/python/core/auto_generated/tiledscene/qgscesiumutils.sip.in
@@ -41,6 +41,13 @@ Parses a ``box`` object from a Cesium JSON document to an oriented bounding box.
 %Docstring
 Parses a ``sphere`` object from a Cesium JSON document.
 %End
+
+    static QByteArray extractGltfFromB3dm( QIODevice &file );
+%Docstring
+Extracts GLTF binary data from the legacy b3dm (Batched 3D Model) tile format.
+Returns empty byte array on error.
+%End
+
 };
 
 /************************************************************************

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -26,6 +26,8 @@ set(QGIS_3D_SRCS
   qgsrulebased3drenderer.cpp
   qgsrulebasedchunkloader_p.cpp
   qgstessellatedpolygongeometry.cpp
+  qgstiledscenechunkloader_p.cpp
+  qgstiledscenelayer3drenderer.cpp
   qgstilingscheme.cpp
   qgsvectorlayer3drenderer.cpp
   qgsvectorlayerchunkloader_p.cpp
@@ -125,6 +127,8 @@ set(QGIS_3D_HDRS
   qgsoffscreen3dengine.h
   qgsrulebased3drenderer.h
   qgstessellatedpolygongeometry.h
+  qgstiledscenechunkloader_p.h
+  qgstiledscenelayer3drenderer.h
   qgstilingscheme.h
   qgsvectorlayer3drenderer.h
   qgswindow3dengine.h

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -380,7 +380,7 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneState &state )
     }
 
     // ensure we have child nodes (at least skeletons) available, if any
-    if ( node->childCount() == -1 )
+    if ( !node->hasChildrenPopulated() )
       node->populateChildren( mChunkLoaderFactory->createChildren( node ) );
 
     // make sure all nodes leading to children are always loaded

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -141,9 +141,9 @@ class QgsChunkNode
     //! Returns pointer to the parent node. Parent is NULLPTR in the root node
     QgsChunkNode *parent() const { return mParent; }
     //! Returns number of children of the node (returns -1 if the node has not yet been populated with populateChildren())
-    int childCount() const { return mChildCount; }
+    int childCount() const { return mChildren.count(); }
     //! Returns array of the four children. Children may be NULLPTR if they were not created yet
-    QgsChunkNode *const *children() const { return mChildren; }
+    QgsChunkNode *const *children() const { return mChildren.constData(); }
     //! Returns current state of the node
     State state() const { return mState; }
 
@@ -160,6 +160,9 @@ class QgsChunkNode
 
     //! Returns TRUE if all child chunks are available and thus this node could be swapped to the child nodes
     bool allChildChunksResident( QTime currentTime ) const;
+
+    //! Returns whether the child nodes have been populated already
+    bool hasChildrenPopulated() const { return mChildrenPopulated; }
 
     //! Sets child nodes of this node. Takes ownership of all objects. Must be only called once.
     void populateChildren( const QVector<QgsChunkNode *> &children );
@@ -231,8 +234,8 @@ class QgsChunkNode
     QgsChunkNodeId mNodeId;  //!< Chunk coordinates (for use with a tiling scheme)
 
     QgsChunkNode *mParent;        //!< TODO: should be shared pointer
-    QgsChunkNode *mChildren[8];   //!< TODO: should be weak pointers. May be nullptr if not created yet or removed already
-    int mChildCount = -1;         //! Number of children (-1 == not yet populated)
+    QVector<QgsChunkNode *> mChildren;   //!< Child nodes of this node. Initially children are not be populated
+    bool mChildrenPopulated = false;     //!< Whether the child nodes (if any) have been already created
 
     State mState;  //!< State of the node
 

--- a/src/3d/qgs3d.cpp
+++ b/src/3d/qgs3d.cpp
@@ -26,6 +26,7 @@
 #include "qgsvectorlayer3drenderer.h"
 #include "qgsmeshlayer3drenderer.h"
 #include "qgspointcloudlayer3drenderer.h"
+#include "qgstiledscenelayer3drenderer.h"
 #include "qgs3dsymbolregistry.h"
 #include "qgspoint3dsymbol.h"
 #include "qgsline3dsymbol.h"
@@ -63,6 +64,7 @@ void Qgs3D::initialize()
   QgsApplication::renderer3DRegistry()->addRenderer( new QgsRuleBased3DRendererMetadata );
   QgsApplication::renderer3DRegistry()->addRenderer( new QgsMeshLayer3DRendererMetadata );
   QgsApplication::renderer3DRegistry()->addRenderer( new QgsPointCloudLayer3DRendererMetadata );
+  QgsApplication::renderer3DRegistry()->addRenderer( new QgsTiledSceneLayer3DRendererMetadata );
 
   QgsApplication::symbol3DRegistry()->addSymbolType( new Qgs3DSymbolMetadata( QStringLiteral( "point" ), QObject::tr( "Point" ),
       &QgsPoint3DSymbol::create, nullptr, Qgs3DSymbolImpl::handlerForPoint3DSymbol ) );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -60,6 +60,8 @@
 #include "qgssourcecache.h"
 #include "qgsterrainentity_p.h"
 #include "qgsterraingenerator.h"
+#include "qgstiledscenelayer.h"
+#include "qgstiledscenelayer3drenderer.h"
 #include "qgsdirectionallightsettings.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3drenderer.h"
@@ -665,6 +667,11 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     {
       QgsPointCloudLayer3DRenderer *pointCloudRenderer = static_cast<QgsPointCloudLayer3DRenderer *>( renderer );
       pointCloudRenderer->setLayer( static_cast<QgsPointCloudLayer *>( layer ) );
+    }
+    else if ( layer->type() == Qgis::LayerType::TiledScene && renderer->type() == QLatin1String( "tiledscene" ) )
+    {
+      QgsTiledSceneLayer3DRenderer *tiledSceneRenderer = static_cast<QgsTiledSceneLayer3DRenderer *>( renderer );
+      tiledSceneRenderer->setLayer( static_cast<QgsTiledSceneLayer *>( layer ) );
     }
 
     Qt3DCore::QEntity *newEntity = renderer->createEntity( mMap );

--- a/src/3d/qgsgltf3dutils.h
+++ b/src/3d/qgsgltf3dutils.h
@@ -59,7 +59,7 @@ class _3D_EXPORT QgsGltf3DUtils
       //! Tile's matrix to transform GLTF model coordinates to ECEF (normally EPSG:4978)
       QgsMatrix4x4 tileTransform;
       //! Transform from ECEF (normally EPSG:4978) to the target CRS
-      QgsCoordinateTransform *ecefToTargetCrs = nullptr;
+      const QgsCoordinateTransform *ecefToTargetCrs = nullptr;
     };
 
     /**

--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -62,13 +62,26 @@ static bool hasLargeBounds( const QgsTiledSceneTile &t )
 // TODO: move elsewhere
 static QString resolveUri( QString uri, const QString &baseUri )
 {
-  if ( uri.startsWith( "./" ) )
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( baseUri );
+
+  const QString tileSetUri = dsUri.param( QStringLiteral( "url" ) );
+  if ( !tileSetUri.isEmpty() )
   {
-    uri.replace( "./", baseUri );
+    QUrl base( tileSetUri );
+    uri = base.resolved( uri ).toString();
   }
-  else if ( QFileInfo( uri ).isRelative() )
+  else
   {
-    uri = baseUri + uri;
+    // local files
+    if ( uri.startsWith( "./" ) )
+    {
+      uri.replace( "./", baseUri );
+    }
+    else if ( QFileInfo( uri ).isRelative() )
+    {
+      uri = baseUri + uri;
+    }
   }
   return uri;
 }

--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -21,7 +21,7 @@
 #include "qgstiledsceneboundingvolume.h"
 #include "qgstiledscenetile.h"
 
-#include <QBuffer>
+#include <QtCore/QBuffer>
 
 ///@cond PRIVATE
 

--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -1,0 +1,312 @@
+/***************************************************************************
+  qgstiledscenechunkloader_p.cpp
+  --------------------------------------
+  Date                 : July 2023
+  Copyright            : (C) 2023 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledscenechunkloader_p.h"
+
+#include "qgs3dmapsettings.h"
+#include "qgscesiumutils.h"
+#include "qgsgltf3dutils.h"
+#include "qgstiledsceneboundingvolume.h"
+#include "qgstiledscenetile.h"
+
+#include <QBuffer>
+
+///@cond PRIVATE
+
+size_t qHash( const QgsChunkNodeId &n )
+{
+  return n.d ^ n.x ^ n.y ^ n.z;
+}
+
+static bool hasLargeBounds( const QgsTiledSceneTile &t )
+{
+  if ( t.geometricError() > 1e6 )
+    return true;
+
+  switch ( t.boundingVolume()->type() )
+  {
+    case Qgis::TiledSceneBoundingVolumeType::Region:
+    {
+      // TODO: is region always lat/lon in degrees?
+      QgsBox3D region = static_cast<const QgsTiledSceneBoundingVolumeRegion *>( t.boundingVolume() )->region();
+      return region.width() > 15 || region.height() > 15;
+    }
+
+    case Qgis::TiledSceneBoundingVolumeType::OrientedBox:
+    {
+      QgsOrientedBox3D box = static_cast<const QgsTiledSceneBoundingVolumeBox *>( t.boundingVolume() )->box();
+      QgsVector3D size = box.size();
+      return size.x() > 1e5 || size.y() > 1e5 || size.z() > 1e5;
+    }
+
+    case Qgis::TiledSceneBoundingVolumeType::Sphere:
+      return static_cast<const QgsTiledSceneBoundingVolumeSphere *>( t.boundingVolume() )->sphere().diameter() > 1e5;
+  }
+
+  return false;
+}
+
+
+// TODO: move elsewhere
+static QString resolveUri( QString uri, const QString &baseUri )
+{
+  if ( uri.startsWith( "./" ) )
+  {
+    uri.replace( "./", baseUri );
+  }
+  else if ( QFileInfo( uri ).isRelative() )
+  {
+    uri = baseUri + uri;
+  }
+  return uri;
+}
+
+static QgsChunkNodeId nodeIdFromUuid( const QString &uuid )
+{
+  QgsChunkNodeId nodeId;
+  QUuid nodeUuid = QUuid::fromString( uuid );
+  Q_ASSERT( !nodeUuid.isNull() );
+  Q_ASSERT( sizeof( QUuid ) == 16 && sizeof( QgsChunkNodeId ) == 16 );
+  memcpy( reinterpret_cast<char *>( &nodeId ), reinterpret_cast<const char *>( &nodeUuid ), 16 );
+  return nodeId;
+}
+
+static QString uuidFromNodeId( const QgsChunkNodeId &nodeId )
+{
+  QUuid nodeUuid;
+  Q_ASSERT( sizeof( QUuid ) == 16 && sizeof( QgsChunkNodeId ) == 16 );
+  memcpy( reinterpret_cast<char *>( &nodeUuid ), reinterpret_cast<const char *>( &nodeId ), 16 );
+  return nodeUuid.toString();
+}
+
+///
+
+QgsTiledSceneChunkLoader::QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneChunkLoaderFactory *factory, const QgsTiledSceneTile &t )
+  : QgsChunkLoader( node ), mFactory( factory ), mTile( t )
+{
+  qDebug() << "chunk loader " << node->tileId().text();
+
+  // start async (actually just do deferred finish()!)
+  // TODO: loading in background thread
+  QMetaObject::invokeMethod( this, "finished", Qt::QueuedConnection );
+}
+
+Qt3DCore::QEntity *QgsTiledSceneChunkLoader::createEntity( Qt3DCore::QEntity *parent )
+{
+  qDebug() << "create entity!" << mNode->tileId().text();
+
+  // we do not load tiles that are too big - at least for the time being
+  // the problem is that their 3D bounding boxes with ECEF coordinates are huge
+  // and we are unable to turn them into planar bounding boxes
+  if ( hasLargeBounds( mTile ) )
+  {
+    return new Qt3DCore::QEntity( parent );
+  }
+
+  QString uri = mTile.resources().value( QStringLiteral( "content" ) ).toString();
+  if ( uri.isEmpty() )
+  {
+    // nothing to show for this tile
+    // TODO: can we skip loading it at all?
+    return new Qt3DCore::QEntity( parent );
+  }
+
+  uri = resolveUri( uri, mFactory->mRelativePathBase );
+
+  qDebug() << "loading: " << uri;
+  QByteArray content = mFactory->mIndex.retrieveContent( uri );
+
+  if ( content.isEmpty() )
+  {
+    // the request probably failed
+    // TODO: how can we report it?
+    qDebug() << "retrieveContent returned no content";
+    return new Qt3DCore::QEntity( parent );
+  }
+
+  QByteArray gltfData;
+  if ( content.startsWith( QByteArray( "b3dm" ) ) )
+  {
+    QBuffer buffer( &content );
+    buffer.open( QIODevice::ReadOnly );
+    gltfData = QgsCesiumUtils::extractGltfFromB3dm( buffer );
+  }
+  else if ( content.startsWith( QByteArray( "glTF" ) ) )
+  {
+    gltfData = content;
+  }
+  else
+  {
+    // unsupported tile content type
+    // TODO: we could extract "b3dm" data from a composite tile ("cmpt")
+    qDebug() << "unsupported content";
+    return new Qt3DCore::QEntity( parent );
+  }
+
+  QgsGltf3DUtils::EntityTransform entityTransform;
+  entityTransform.tileTransform = mTile.transform() ? *mTile.transform() : QgsMatrix4x4();
+  entityTransform.sceneOriginTargetCrs = mFactory->mMap.origin();
+  entityTransform.ecefToTargetCrs = mFactory->mBoundsTransform.get();
+
+  QStringList errors;
+  Qt3DCore::QEntity *gltfEntity = QgsGltf3DUtils::gltfToEntity( gltfData, entityTransform, uri, &errors );
+
+  // TODO: report errors somewhere?
+  if ( !errors.isEmpty() )
+    qDebug() << "gltf load errors: " << errors;
+
+  gltfEntity->setParent( parent );
+  return gltfEntity;
+}
+
+///
+
+QgsTiledSceneChunkLoaderFactory::QgsTiledSceneChunkLoaderFactory( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index )
+  : mMap( map ), mRelativePathBase( relativePathBase ), mIndex( index )
+{
+  mBoundsTransform.reset( new QgsCoordinateTransform( QgsCoordinateReferenceSystem( "EPSG:4978" ), mMap.crs(), mMap.transformContext() ) );
+  mRegionTransform.reset( new QgsCoordinateTransform( QgsCoordinateReferenceSystem( "EPSG:4979" ), mMap.crs(), mMap.transformContext() ) );
+}
+
+
+QgsChunkLoader *QgsTiledSceneChunkLoaderFactory::createChunkLoader( QgsChunkNode *node ) const
+{
+  QString id = uuidFromNodeId( node->tileId() );
+  QgsTiledSceneTile t = mIndex.getTile( id );
+
+  return new QgsTiledSceneChunkLoader( node, this, t );
+}
+
+
+// converts box from map coordinates to world coords (also flips [X,Y] to [X,-Z])
+static QgsAABB aabbConvert( const QgsBox3D &b0, const QgsVector3D &sceneOriginTargetCrs )
+{
+  QgsBox3D b = b0 - sceneOriginTargetCrs;
+  return QgsAABB( b.xMinimum(), b.zMinimum(), -b.yMaximum(), b.xMaximum(), b.zMaximum(), -b.yMinimum() );
+}
+
+
+QgsChunkNode *QgsTiledSceneChunkLoaderFactory::nodeForTile( const QgsTiledSceneTile &t, const QgsChunkNodeId &nodeId ) const
+{
+  if ( hasLargeBounds( t ) )
+  {
+    // use the full extent of the scene
+    QgsVector3D v0 = mMap.mapToWorldCoordinates( QgsVector3D( mMap.extent().xMinimum(), mMap.extent().yMinimum(), -100 ) );
+    QgsVector3D v1 = mMap.mapToWorldCoordinates( QgsVector3D( mMap.extent().xMaximum(), mMap.extent().yMaximum(), +100 ) );
+    QgsAABB aabb( v0.x(), v0.y(), v0.z(), v1.x(), v1.y(), v1.z() );
+    float err = std::min( 1e6, t.geometricError() );
+    //qDebug() << "child" << nodeId.text() << aabb.toString() << err;
+    return new QgsChunkNode( nodeId, aabb, err );
+  }
+  else
+  {
+    bool isRegion = t.boundingVolume()->type() == Qgis::TiledSceneBoundingVolumeType::Region;
+    QgsBox3D box = t.boundingVolume()->bounds( isRegion ? *mRegionTransform.get() : *mBoundsTransform.get() );
+    QgsAABB aabb = aabbConvert( box, mMap.origin() );
+    //qDebug() << "child" << nodeId.text() << aabb.toString() << t.geometricError();
+    return new QgsChunkNode( nodeId, aabb, t.geometricError() );
+  }
+}
+
+
+QgsChunkNode *QgsTiledSceneChunkLoaderFactory::createRootNode() const
+{
+  QgsTiledSceneTile t = mIndex.rootTile();
+  QgsChunkNodeId nodeId = nodeIdFromUuid( t.id() );
+  return nodeForTile( t, nodeId );
+}
+
+
+QVector<QgsChunkNode *> QgsTiledSceneChunkLoaderFactory::createChildren( QgsChunkNode *node ) const
+{
+  qDebug() << "create children" << node->tileId().text();
+  QVector<QgsChunkNode *> children;
+  QString indexTileId = uuidFromNodeId( node->tileId() );
+
+  switch ( mIndex.childAvailability( indexTileId ) )
+  {
+    case Qgis::TileChildrenAvailability::NoChildren:
+      return children;
+    case Qgis::TileChildrenAvailability::Available:
+      break;
+    case Qgis::TileChildrenAvailability::NeedFetching:
+      qDebug() << "going to fetch hierarchy!";
+      if ( !mIndex.fetchHierarchy( indexTileId ) )
+        return children;
+      break;
+  }
+
+  const QStringList childIds = mIndex.childTileIds( indexTileId );
+  for ( const QString &childId : childIds )
+  {
+    QgsChunkNodeId chId = nodeIdFromUuid( childId );
+    QgsTiledSceneTile t = mIndex.getTile( childId );
+
+    // first check if this node should be even considered
+    if ( hasLargeBounds( t ) )
+    {
+      // if the tile is huge, let's try to see if our scene is actually inside
+      // (if not, let' skip this child altogether!)
+      // TODO: make OBB of our scene in ECEF rather than just using center of the scene?
+      if ( t.boundingVolume()->type() == Qgis::TiledSceneBoundingVolumeType::OrientedBox )
+      {
+        QgsOrientedBox3D obb = static_cast<const QgsTiledSceneBoundingVolumeBox *>( t.boundingVolume() )->box();
+
+        QgsPointXY c = mMap.extent().center();
+        QgsVector3D cEcef = mBoundsTransform->transform( QgsVector3D( c.x(), c.y(), 0 ), Qgis::TransformDirection::Reverse );
+        QgsVector3D ecef2 = cEcef - obb.center();
+
+        const double *half = obb.halfAxes();
+
+        // this is an approximate check anyway, no need for double precision matrix/vector
+        QMatrix4x4 rot(
+          half[0], half[3], half[6], 0,
+          half[1], half[4], half[7], 0,
+          half[2], half[5], half[8], 0,
+          0, 0, 0, 1 );
+        QVector3D aaa = rot.inverted().map( ecef2.toVector3D() );
+
+        if ( aaa.x() > 1 || aaa.y() > 1 || aaa.z() > 1 ||
+             aaa.x() < -1 || aaa.y() < -1 || aaa.z() < -1 )
+        {
+          qDebug() << "skipping child because our scene is not in it" << chId.text();
+          continue;
+        }
+      }
+    }
+
+    QgsChunkNode *nChild = nodeForTile( t, chId );
+    children.append( nChild );
+  }
+  return children;
+}
+
+///
+
+QgsTiledSceneLayerChunkedEntity::QgsTiledSceneLayerChunkedEntity( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index, double maximumScreenError, bool showBoundingBoxes )
+  : QgsChunkedEntity( maximumScreenError, new QgsTiledSceneChunkLoaderFactory( map, relativePathBase, index ), true )
+{
+  if ( index.rootTile().refinementProcess() == Qgis::TileRefinementProcess::Additive )
+    setUsingAdditiveStrategy( true );
+  setShowBoundingBoxes( showBoundingBoxes );
+}
+
+QgsTiledSceneLayerChunkedEntity::~QgsTiledSceneLayerChunkedEntity()
+{
+  // cancel / wait for jobs
+  cancelActiveJobs();
+}
+
+/// @endcond

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -1,0 +1,112 @@
+/***************************************************************************
+  qgstiledscenechunkloader_p.h
+  --------------------------------------
+  Date                 : July 2023
+  Copyright            : (C) 2023 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDSCENECHUNKLOADER_P_H
+#define QGSTILEDSCENECHUNKLOADER_P_H
+
+///@cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include "qgschunkedentity_p.h"
+#include "qgschunkloader_p.h"
+#include "qgschunknode_p.h"
+#include "qgstiledsceneindex.h"
+#include "qgstiledscenetile.h"
+
+class Qgs3DMapSettings;
+class QgsCoordinateTransform;
+class QgsTiledSceneChunkLoaderFactory;
+
+
+/**
+ * \ingroup 3d
+ * \brief This loader class is responsible for async loading of data for a single tile
+ * of tiled scene chunk entity and creation of final 3D entity from the data
+ * previously prepared in a worker thread.
+ *
+ * \since QGIS 3.34
+ */
+class QgsTiledSceneChunkLoader : public QgsChunkLoader
+{
+    Q_OBJECT
+  public:
+    QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneChunkLoaderFactory *factory, const QgsTiledSceneTile &t );
+
+    virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
+
+  private:
+    const QgsTiledSceneChunkLoaderFactory *mFactory;
+    QgsTiledSceneTile mTile;
+};
+
+
+/**
+ * \ingroup 3d
+ * \brief This loader factory is responsible for creation of loaders for individual tiles
+ * of tiled scene chunk entity whenever a new tile is requested by the entity.
+ *
+ * \since QGIS 3.34
+ */
+class QgsTiledSceneChunkLoaderFactory : public QgsChunkLoaderFactory
+{
+    Q_OBJECT
+  public:
+    QgsTiledSceneChunkLoaderFactory( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index );
+
+    virtual QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override;
+    virtual QgsChunkNode *createRootNode() const override;
+    virtual QVector<QgsChunkNode *> createChildren( QgsChunkNode *node ) const override;
+
+    QgsChunkNode *nodeForTile( const QgsTiledSceneTile &t, const QgsChunkNodeId &nodeId ) const;
+
+    const Qgs3DMapSettings &mMap;
+    QString mRelativePathBase;
+    mutable QgsTiledSceneIndex mIndex;
+    std::unique_ptr<QgsCoordinateTransform> mBoundsTransform;
+    std::unique_ptr<QgsCoordinateTransform> mRegionTransform;
+    mutable QHash<QgsChunkNodeId, QString> mNodeIdToIndexId;
+};
+
+
+/**
+ * \ingroup 3d
+ * \brief 3D entity used for rendering of tiled scene layers.
+ *
+ * It is implemented using tiling approach with QgsChunkedEntity. Internally it uses
+ * QgsTiledSceneChunkLoaderFactory and QgsTiledSceneChunkLoader to do the actual work
+ * of loading and creating 3D sub-entities for each tile.
+ *
+ * \since QGIS 3.34
+ */
+class QgsTiledSceneLayerChunkedEntity : public QgsChunkedEntity
+{
+    Q_OBJECT
+  public:
+    explicit QgsTiledSceneLayerChunkedEntity( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index, double maximumScreenError, bool showBoundingBoxes );
+
+    ~QgsTiledSceneLayerChunkedEntity();
+};
+
+/// @endcond
+
+#endif // QGSTILEDSCENECHUNKLOADER_P_H

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -27,6 +27,7 @@
 // version without notice, or even be removed.
 //
 
+#include "qgscoordinatetransform.h"
 #include "qgschunkedentity_p.h"
 #include "qgschunkloader_p.h"
 #include "qgschunknode_p.h"
@@ -34,7 +35,6 @@
 #include "qgstiledscenetile.h"
 
 class Qgs3DMapSettings;
-class QgsCoordinateTransform;
 class QgsTiledSceneChunkLoaderFactory;
 
 
@@ -50,12 +50,12 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
 {
     Q_OBJECT
   public:
-    QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneChunkLoaderFactory *factory, const QgsTiledSceneTile &t );
+    QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneChunkLoaderFactory &factory, const QgsTiledSceneTile &t );
 
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
 
   private:
-    const QgsTiledSceneChunkLoaderFactory *mFactory;
+    const QgsTiledSceneChunkLoaderFactory &mFactory;
     QgsTiledSceneTile mTile;
 };
 
@@ -82,8 +82,8 @@ class QgsTiledSceneChunkLoaderFactory : public QgsChunkLoaderFactory
     const Qgs3DMapSettings &mMap;
     QString mRelativePathBase;
     mutable QgsTiledSceneIndex mIndex;
-    std::unique_ptr<QgsCoordinateTransform> mBoundsTransform;
-    std::unique_ptr<QgsCoordinateTransform> mRegionTransform;
+    QgsCoordinateTransform mBoundsTransform;
+    QgsCoordinateTransform mRegionTransform;
 };
 
 

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -84,7 +84,6 @@ class QgsTiledSceneChunkLoaderFactory : public QgsChunkLoaderFactory
     mutable QgsTiledSceneIndex mIndex;
     std::unique_ptr<QgsCoordinateTransform> mBoundsTransform;
     std::unique_ptr<QgsCoordinateTransform> mRegionTransform;
-    mutable QHash<QgsChunkNodeId, QString> mNodeIdToIndexId;
 };
 
 

--- a/src/3d/qgstiledscenelayer3drenderer.cpp
+++ b/src/3d/qgstiledscenelayer3drenderer.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+  qgstiledscenelayer3drenderer.cpp
+  --------------------------------------
+  Date                 : July 2023
+  Copyright            : (C) 2023 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstiledscenelayer3drenderer.h"
+
+#include "qgstiledsceneindex.h"
+#include "qgstiledscenelayer.h"
+#include "qgstiledscenechunkloader_p.h"
+
+#include "qgs3dmapsettings.h"
+
+
+QgsTiledSceneLayer3DRendererMetadata::QgsTiledSceneLayer3DRendererMetadata()
+  : Qgs3DRendererAbstractMetadata( QStringLiteral( "tiledscene" ) )
+{
+}
+
+QgsAbstract3DRenderer *QgsTiledSceneLayer3DRendererMetadata::createRenderer( QDomElement &elem, const QgsReadWriteContext &context )
+{
+  QgsTiledSceneLayer3DRenderer *r = new QgsTiledSceneLayer3DRenderer;
+  r->readXml( elem, context );
+  return r;
+}
+
+///
+
+QgsTiledSceneLayer3DRenderer::QgsTiledSceneLayer3DRenderer()
+{
+}
+
+void QgsTiledSceneLayer3DRenderer::setLayer( QgsTiledSceneLayer *layer )
+{
+  mLayerRef = QgsMapLayerRef( layer );
+}
+
+QgsTiledSceneLayer *QgsTiledSceneLayer3DRenderer::layer() const
+{
+  return qobject_cast<QgsTiledSceneLayer *>( mLayerRef.layer );
+}
+
+QgsAbstract3DRenderer *QgsTiledSceneLayer3DRenderer::clone() const
+{
+  QgsTiledSceneLayer3DRenderer *r = new QgsTiledSceneLayer3DRenderer;
+  r->setLayer( layer() );
+  return r;
+}
+
+Qt3DCore::QEntity *QgsTiledSceneLayer3DRenderer::createEntity( const Qgs3DMapSettings &map ) const
+{
+  QgsTiledSceneLayer *tsl = layer();
+  if ( !tsl || !tsl->dataProvider() )
+    return nullptr;
+
+  QgsTiledSceneIndex index = tsl->dataProvider()->index();
+
+  QString relativePathBase = QFileInfo( tsl->source() ).path() + "/";
+
+  return new QgsTiledSceneLayerChunkedEntity( map, relativePathBase, index, maximumScreenError(), showBoundingBoxes() );
+}
+
+void QgsTiledSceneLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const
+{
+  Q_UNUSED( context )
+
+  QDomDocument doc = elem.ownerDocument();
+
+  elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  elem.setAttribute( QStringLiteral( "max-screen-error" ), maximumScreenError() );
+  elem.setAttribute( QStringLiteral( "show-bounding-boxes" ), showBoundingBoxes() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+}
+
+void QgsTiledSceneLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
+{
+  Q_UNUSED( context )
+
+  mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+
+  mShowBoundingBoxes = elem.attribute( QStringLiteral( "show-bounding-boxes" ), QStringLiteral( "0" ) ).toInt();
+  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "50.0" ) ).toDouble();
+}
+
+void QgsTiledSceneLayer3DRenderer::resolveReferences( const QgsProject &project )
+{
+  mLayerRef.setLayer( project.mapLayer( mLayerRef.layerId ) );
+}
+
+double QgsTiledSceneLayer3DRenderer::maximumScreenError() const
+{
+  return mMaximumScreenError;
+}
+
+void QgsTiledSceneLayer3DRenderer::setMaximumScreenError( double error )
+{
+  mMaximumScreenError = error;
+}
+
+bool QgsTiledSceneLayer3DRenderer::showBoundingBoxes() const
+{
+  return mShowBoundingBoxes;
+}
+
+void QgsTiledSceneLayer3DRenderer::setShowBoundingBoxes( bool showBoundingBoxes )
+{
+  mShowBoundingBoxes = showBoundingBoxes;
+}

--- a/src/3d/qgstiledscenelayer3drenderer.h
+++ b/src/3d/qgstiledscenelayer3drenderer.h
@@ -1,0 +1,107 @@
+/***************************************************************************
+  qgstiledscenelayer3drenderer.h
+  --------------------------------------
+  Date                 : July 2023
+  Copyright            : (C) 2023 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILEDSCENELAYER3DRENDERER_H
+#define QGSTILEDSCENELAYER3DRENDERER_H
+
+#include "qgis_3d.h"
+
+#include "qgs3drendererregistry.h"
+#include "qgsabstract3drenderer.h"
+#include "qgsmaplayerref.h"
+
+class QgsTiledSceneLayer;
+
+
+/**
+ * \ingroup 3d
+ * \brief Metadata for tiled scene layer 3D renderer to allow creation of its instances from XML
+ *
+ * \note Not available in Python bindings
+ *
+ * \since QGIS 3.34
+ */
+class _3D_EXPORT QgsTiledSceneLayer3DRendererMetadata : public Qgs3DRendererAbstractMetadata SIP_SKIP
+{
+  public:
+    QgsTiledSceneLayer3DRendererMetadata();
+
+    //! Creates an instance of a 3D renderer based on a DOM element with renderer configuration
+    QgsAbstract3DRenderer *createRenderer( QDomElement &elem, const QgsReadWriteContext &context ) override SIP_FACTORY;
+};
+
+
+/**
+ * \ingroup 3d
+ * \brief 3D renderer that renders content of a tiled scene layer
+ *
+ * \since QGIS 3.34
+ */
+class _3D_EXPORT QgsTiledSceneLayer3DRenderer : public QgsAbstract3DRenderer
+{
+  public:
+    QgsTiledSceneLayer3DRenderer();
+
+    //! Sets tiled scene layer associated with the renderer
+    void setLayer( QgsTiledSceneLayer *layer );
+    //! Returns tiled scene layer associated with the renderer
+    QgsTiledSceneLayer *layer() const;
+
+    /**
+     * Returns the maximum screen error allowed when rendering the tiled scene.
+     *
+     * Larger values result in a faster render with less content rendered.
+     *
+     * \see setMaximumScreenError()
+     */
+    double maximumScreenError() const;
+
+    /**
+     * Sets the maximum screen \a error allowed when rendering the tiled scene.
+     *
+     * Larger values result in a faster render with less content rendered.
+     *
+     * \see maximumScreenError()
+     */
+    void setMaximumScreenError( double error );
+
+    /**
+     * Returns whether bounding boxes will be visible when rendering the tiled scene.
+     *
+     * \see setShowBoundingBoxes()
+     */
+    bool showBoundingBoxes() const;
+
+    /**
+     * Sets whether bounding boxes will be visible when rendering the tiled scene.
+     *
+     * \see showBoundingBoxes()
+     */
+    void setShowBoundingBoxes( bool showBoundingBoxes );
+
+    virtual QString type() const override { return "tiledscene"; }
+    virtual QgsAbstract3DRenderer *clone() const override;
+    virtual Qt3DCore::QEntity *createEntity( const Qgs3DMapSettings &map ) const override;
+    virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
+    virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
+    virtual void resolveReferences( const QgsProject &project ) override;
+
+  private:
+    QgsMapLayerRef mLayerRef; //!< Layer used to extract mesh data from
+    double mMaximumScreenError = 50.0;
+    bool mShowBoundingBoxes = true;
+};
+
+#endif

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -29,6 +29,7 @@
 #include "qgsterrainprovider.h"
 #ifdef HAVE_3D
 #include "qgspointcloudlayer3drenderer.h"
+#include "qgstiledscenelayer3drenderer.h"
 #endif
 #include "canvas/qgscanvasrefreshblocker.h"
 #include "qgsproviderutils.h"
@@ -160,6 +161,14 @@ void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
       QString error = layer->loadDefaultMetadata( ok );
       if ( !ok )
         QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Error loading layer metadata" ), error, Qgis::MessageLevel::Warning );
+
+#ifdef HAVE_3D
+      if ( !layer->renderer3D() )
+      {
+        std::unique_ptr< QgsTiledSceneLayer3DRenderer > renderer3D = std::make_unique< QgsTiledSceneLayer3DRenderer >();
+        layer->setRenderer3D( renderer3D.release() );
+      }
+#endif
 
       break;
     }

--- a/src/core/tiledscene/qgscesiumutils.cpp
+++ b/src/core/tiledscene/qgscesiumutils.cpp
@@ -22,6 +22,8 @@
 #include "qgssphere.h"
 #include "qgsorientedbox3d.h"
 
+#include <QIODevice>
+
 QgsBox3D QgsCesiumUtils::parseRegion( const json &region )
 {
   try

--- a/src/core/tiledscene/qgscesiumutils.cpp
+++ b/src/core/tiledscene/qgscesiumutils.cpp
@@ -110,3 +110,29 @@ QgsSphere QgsCesiumUtils::parseSphere( const QVariantList &sphere )
 
   return parseSphere( QgsJsonUtils::jsonFromVariant( sphere ) );
 }
+
+
+QByteArray QgsCesiumUtils::extractGltfFromB3dm( QIODevice &file )
+{
+  struct b3dmHeader
+  {
+    unsigned char magic[4];
+    quint32 version;
+    quint32 byteLength;
+    quint32 featureTableJsonByteLength;
+    quint32 featureTableBinaryByteLength;
+    quint32 batchTableJsonByteLength;
+    quint32 batchTableBinaryByteLength;
+  };
+
+  b3dmHeader hdr;
+  if ( !file.read( ( char * )&hdr, sizeof( b3dmHeader ) ) )
+    return QByteArray();
+
+  if ( !file.seek( sizeof( b3dmHeader ) +
+                   hdr.featureTableJsonByteLength + hdr.featureTableBinaryByteLength +
+                   hdr.batchTableJsonByteLength + hdr.batchTableBinaryByteLength ) )
+    return QByteArray();
+
+  return file.readAll();
+}

--- a/src/core/tiledscene/qgscesiumutils.h
+++ b/src/core/tiledscene/qgscesiumutils.h
@@ -86,6 +86,13 @@ class CORE_EXPORT QgsCesiumUtils
     * Parses a \a sphere object from a Cesium JSON document.
     */
     static QgsSphere parseSphere( const QVariantList &sphere );
+
+    /**
+     * Extracts GLTF binary data from the legacy b3dm (Batched 3D Model) tile format.
+     * Returns empty byte array on error.
+     */
+    static QByteArray extractGltfFromB3dm( QIODevice &file );
+
 };
 
 #endif // QGSCESIUMUTILS_H

--- a/src/core/tiledscene/qgscesiumutils.h
+++ b/src/core/tiledscene/qgscesiumutils.h
@@ -91,7 +91,15 @@ class CORE_EXPORT QgsCesiumUtils
      * Extracts GLTF binary data from the legacy b3dm (Batched 3D Model) tile format.
      * Returns empty byte array on error.
      */
-    static QByteArray extractGltfFromB3dm( QIODevice &file );
+    static QByteArray extractGltfFromB3dm( const QByteArray &tileContent );
+
+    /**
+     * Extracts GLTF binary data from tile content.
+     * Returns empty byte array on error.
+     *
+     * \note cmpt, pnts, i3dm tile types are currently not supported
+     */
+    static QByteArray extractGltfFromTileContent( const QByteArray &tileContent );
 
 };
 

--- a/tests/src/3d/sandbox/CMakeLists.txt
+++ b/tests/src/3d/sandbox/CMakeLists.txt
@@ -11,6 +11,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/src/native
   ${CMAKE_CURRENT_BINARY_DIR}
 
+  ${CMAKE_SOURCE_DIR}/src/3d/3dtiles
+
   ${CMAKE_SOURCE_DIR}/src/app/3d
   ${CMAKE_BINARY_DIR}/src/app
   ${QWT_INCLUDE_DIR}

--- a/tests/src/3d/sandbox/CMakeLists.txt
+++ b/tests/src/3d/sandbox/CMakeLists.txt
@@ -11,8 +11,6 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/src/native
   ${CMAKE_CURRENT_BINARY_DIR}
 
-  ${CMAKE_SOURCE_DIR}/src/3d/3dtiles
-
   ${CMAKE_SOURCE_DIR}/src/app/3d
   ${CMAKE_BINARY_DIR}/src/app
   ${QWT_INCLUDE_DIR}

--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -28,8 +28,12 @@
 #include "qgs3dmapscene.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dmapcanvas.h"
+#include "qgsprojectelevationproperties.h"
 #include "qgsprojectviewsettings.h"
 #include "qgspointlightsettings.h"
+#include "qgsterrainprovider.h"
+#include "qgstiledscenelayer.h"
+#include "qgstiledscenelayer3drenderer.h"
 
 #include <QScreen>
 
@@ -65,6 +69,7 @@ void initCanvas3D( Qgs3DMapCanvas *canvas )
   QgsFlatTerrainGenerator *flatTerrain = new QgsFlatTerrainGenerator;
   flatTerrain->setCrs( map->crs() );
   map->setTerrainGenerator( flatTerrain );
+  map->setTerrainElevationOffset( QgsProject::instance()->elevationProperties()->terrainProvider()->offset() );
 
   QgsPointLightSettings defaultPointLight;
   defaultPointLight.setPosition( QgsVector3D( 0, 1000, 0 ) );
@@ -96,7 +101,7 @@ void initCanvas3D( Qgs3DMapCanvas *canvas )
 
 int main( int argc, char *argv[] )
 {
-  const QApplication app( argc, argv );
+  QgsApplication myApp( argc, argv, true, QString(), QStringLiteral( "desktop" ) );
 
   // init QGIS's paths - true means that all path will be inited from prefix
   QgsApplication::init();
@@ -127,6 +132,14 @@ int main( int argc, char *argv[] )
       r->resolveReferences( *QgsProject::instance() );
       pcLayer->setRenderer3D( r );
     }
+
+    if ( QgsTiledSceneLayer *tsLayer = qobject_cast<QgsTiledSceneLayer *>( layer ) )
+    {
+      QgsTiledSceneLayer3DRenderer *r = new QgsTiledSceneLayer3DRenderer();
+      r->setLayer( tsLayer );
+      r->resolveReferences( *QgsProject::instance() );
+      tsLayer->setRenderer3D( r );
+    }
   }
 
   Qgs3DMapCanvas *canvas = new Qgs3DMapCanvas;
@@ -134,5 +147,5 @@ int main( int argc, char *argv[] )
   canvas->resize( 800, 600 );
   canvas->show();
 
-  return QApplication::exec();
+  return myApp.exec();
 }


### PR DESCRIPTION
This PR adds 3D renderer for tiled scenes with its 3D chunked entity implementation:
 - QgsTiledSceneLayer3DRenderer
 - QgsTiledSceneLayerChunkedEntity
 - QgsTiledSceneChunkLoader, QgsTiledSceneChunkLoaderFactory

The new 3D renderer gets automatically set for tiled scene layers when they get loaded.

This also fixed QgsChunkNode implementation when there are more than 8 children for a node.

With remote datasets the performance is currently quite bad as it is doing blocking requests in the main thread.

There are a couple of to-dos still, but it would be good to get the bulk of this merged first and focus on resolving them afterwards.

We will need to have a look at how to properly handle relative paths, and how to best fetch content if needed while parsing GLTF models...