### PR TITLE
Tiled scene 3D renderer - fetch content in background

### DIFF
--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -34,6 +34,8 @@
 #include "qgstiledsceneindex.h"
 #include "qgstiledscenetile.h"
 
+#include <QFutureWatcher>
+
 class Qgs3DMapSettings;
 class QgsTiledSceneChunkLoaderFactory;
 
@@ -57,6 +59,8 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
   private:
     const QgsTiledSceneChunkLoaderFactory &mFactory;
     QgsTiledSceneTile mTile;
+    QFutureWatcher<void> *mFutureWatcher = nullptr;
+    Qt3DCore::QEntity *mEntity = nullptr;
 };
 
 


### PR DESCRIPTION
Previously the content was fetched and loaded in the main thread - which was fine for local files, but horrible for remote datasets. This moves content fetching to a worker thread (just like other chunk loaders do) and we also parse the model + transform coordinates in the worker thread.

This makes browsing of remotes sources much smoother. There is still an issue with hierarchy fetching, which is currently done as a blocking network request on the main thread, causing occasional GUI freezes.

The PR also fixes issues with missing tiles at the nodes where content was a link to hierarchy continuation - the chunk loader was trying to load tileset JSON before the node got "refined" with a link to true content.
