### PR TITLE
Data Source Manger: connect the Help button to the docs for some providers (Fix #54125)

### DIFF
--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -39,6 +39,7 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   connect( radioSrcOgcApi, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcOgcApi_toggled );
   connect( radioSrcProtocol, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcProtocol_toggled );
   connect( cmbProtocolTypes, &QComboBox::currentTextChanged, this, &QgsGdalSourceSelect::cmbProtocolTypes_currentIndexChanged );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGdalSourceSelect::showHelp );
 
   whileBlocking( radioSrcFile )->setChecked( true );
   protocolGroupBox->hide();
@@ -449,6 +450,11 @@ void QgsGdalSourceSelect::fillOpenOptions()
 
   mOpenOptionsGroupBox->setVisible( !mOpenOptionsWidgets.empty() );
 
+}
+
+void QgsGdalSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-layer-from-a-file" ) );
 }
 
 ///@endcond

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -26,6 +26,7 @@
 
 #include <gdal.h>
 #include <cpl_minixml.h>
+#include "qgshelp.h"
 
 QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QgsAbstractDataSourceWidget( parent, fl, widgetMode )

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -21,7 +21,6 @@
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
-#include "qgshelp.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -21,6 +21,7 @@
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
+#include "qgshelp.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -50,6 +51,9 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
     void radioSrcOgcApi_toggled( bool checked );
     void radioSrcProtocol_toggled( bool checked );
     void cmbProtocolTypes_currentIndexChanged( const QString &text );
+
+  private slots:
+    void showHelp();
 
   private:
 

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -20,6 +20,7 @@
 #include "qgspointcloudsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "qgsprovidermetadata.h"
+#include "qgshelp.h"
 
 ///@cond PRIVATE
 

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -32,6 +32,7 @@ QgsPointCloudSourceSelect::QgsPointCloudSourceSelect( QWidget *parent, Qt::Windo
   connect( mRadioSrcFile, &QRadioButton::toggled, this, &QgsPointCloudSourceSelect::radioSrcFile_toggled );
   connect( mRadioSrcProtocol, &QRadioButton::toggled, this, &QgsPointCloudSourceSelect::radioSrcProtocol_toggled );
   connect( cmbProtocolTypes, &QComboBox::currentTextChanged, this, &QgsPointCloudSourceSelect::cmbProtocolTypes_currentIndexChanged );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPointCloudSourceSelect::showHelp );
 
   radioSrcFile_toggled( true );
   setProtocolWidgetsVisibility();
@@ -181,6 +182,11 @@ void QgsPointCloudSourceSelect::setProtocolWidgetsVisibility()
   labelKey->hide();
   mKey->hide();
   mAuthWarning->hide();
+}
+
+void QgsPointCloudSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-layer-from-a-file" ) );
 }
 
 ///@endcond

--- a/src/gui/providers/qgspointcloudsourceselect.h
+++ b/src/gui/providers/qgspointcloudsourceselect.h
@@ -24,6 +24,7 @@
 #include "ui_qgspointcloudsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -51,6 +52,9 @@ class QgsPointCloudSourceSelect : public QgsAbstractDataSourceWidget, private Ui
 
     //! Sets protocol-related widget visibility
     void setProtocolWidgetsVisibility();
+
+    void showHelp();
+
   private:
     QString mPath;
     QString mDataSourceType;

--- a/src/gui/providers/qgspointcloudsourceselect.h
+++ b/src/gui/providers/qgspointcloudsourceselect.h
@@ -24,7 +24,6 @@
 #include "ui_qgspointcloudsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -151,6 +151,8 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
     updateExtentFilter( mExtentFilterComboBox->currentIndex() );
   } );
 
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayerMetadataSearchWidget::showHelp );
+
   // Start loading metadata in the model
   mSourceModel->reloadAsync();
   mIsLoading = true;
@@ -249,4 +251,9 @@ void QgsLayerMetadataSearchWidget::showEvent( QShowEvent *event )
 {
   QgsAbstractDataSourceWidget::showEvent( event );
   mSearchFilterLineEdit->setText( mProxyModel->filterString( ) );
+}
+
+void QgsLayerMetadataSearchWidget::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#the-layer-metadata-search-panel" ) );
 }

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsprojectviewsettings.h"
 #include "qgsiconutils.h"
+#include "qgshelp.h"
 
 
 QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )

--- a/src/gui/qgslayermetadatasearchwidget.h
+++ b/src/gui/qgslayermetadatasearchwidget.h
@@ -22,6 +22,7 @@
 #include "qgsfeedback.h"
 #include "qgsabstractlayermetadataprovider.h"
 #include "qgsabstractdatasourcewidget.h"
+#include "qgshelp.h"
 
 class QgsMapCanvas;
 class QgsLayerMetadataResultsProxyModel;
@@ -53,6 +54,9 @@ class GUI_EXPORT QgsLayerMetadataSearchWidget : public QgsAbstractDataSourceWidg
     void refresh() override;
     void addButtonClicked() override;
     void reset() override;
+
+  private slots:
+    void showHelp();
 
   private:
 

--- a/src/gui/qgslayermetadatasearchwidget.h
+++ b/src/gui/qgslayermetadatasearchwidget.h
@@ -22,7 +22,6 @@
 #include "qgsfeedback.h"
 #include "qgsabstractlayermetadataprovider.h"
 #include "qgsabstractdatasourcewidget.h"
-#include "qgshelp.h"
 
 class QgsMapCanvas;
 class QgsLayerMetadataResultsProxyModel;

--- a/src/gui/tiledscene/qgstiledscenesourceselect.cpp
+++ b/src/gui/tiledscene/qgstiledscenesourceselect.cpp
@@ -68,6 +68,7 @@ QgsTiledSceneSourceSelect::QgsTiledSceneSourceSelect( QWidget *parent, Qt::Windo
   connect( btnLoad, &QToolButton::clicked, this, &QgsTiledSceneSourceSelect::btnLoad_clicked );
   connect( cmbConnections, &QComboBox::currentTextChanged, this, &QgsTiledSceneSourceSelect::cmbConnections_currentTextChanged );
   setupButtons( buttonBox );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsTiledSceneSourceSelect::showHelp );
 
   populateConnectionList();
 
@@ -213,6 +214,11 @@ void QgsTiledSceneSourceSelect::cmbConnections_currentTextChanged( const QString
 {
   QgsTiledSceneProviderConnection::setSelectedConnection( text );
   emit enableButtons( !text.isEmpty() );
+}
+
+void QgsTiledSceneSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html" ) );
 }
 
 ///@endcond

--- a/src/gui/tiledscene/qgstiledscenesourceselect.cpp
+++ b/src/gui/tiledscene/qgstiledscenesourceselect.cpp
@@ -22,6 +22,7 @@
 #include "qgsproviderutils.h"
 #include "qgsmanageconnectionsdialog.h"
 #include "qgstiledsceneconnectiondialog.h"
+#include "qgshelp.h"
 
 #include <QMenu>
 #include <QMessageBox>

--- a/src/gui/tiledscene/qgstiledscenesourceselect.h
+++ b/src/gui/tiledscene/qgstiledscenesourceselect.h
@@ -23,6 +23,7 @@
 
 #include "qgsabstractdatasourcewidget.h"
 #include "ui_qgstiledscenesourceselectbase.h"
+#include "qgshelp.h"
 
 /*!
  * \brief Dialog to create connections to tiled scene servers.
@@ -58,6 +59,8 @@ class QgsTiledSceneSourceSelect : public QgsAbstractDataSourceWidget, private Ui
     void btnLoad_clicked();
     //! Stores the selected datasource whenerver it is changed
     void cmbConnections_currentTextChanged( const QString &text );
+
+    void showHelp();
 
   private:
     void populateConnectionList();

--- a/src/gui/tiledscene/qgstiledscenesourceselect.h
+++ b/src/gui/tiledscene/qgstiledscenesourceselect.h
@@ -23,7 +23,6 @@
 
 #include "qgsabstractdatasourcewidget.h"
 #include "ui_qgstiledscenesourceselectbase.h"
-#include "qgshelp.h"
 
 /*!
  * \brief Dialog to create connections to tiled scene servers.

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -39,6 +39,8 @@ QgsGpxSourceSelect::QgsGpxSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   connect( mFileWidget, &QgsFileWidget::fileChanged,
            this, &QgsGpxSourceSelect::enableRelevantControls );
+
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGpxSourceSelect::showHelp );
 }
 
 void QgsGpxSourceSelect::addButtonClicked()
@@ -98,4 +100,9 @@ void QgsGpxSourceSelect::enableRelevantControls()
   cbGPXWaypoints->setChecked( enabled );
   cbGPXRoutes->setChecked( enabled );
   cbGPXTracks->setChecked( enabled );
+}
+
+void QgsGpxSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#gps" ) );
 }

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -18,6 +18,7 @@
 #include "qgsgpxsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgshelp.h"
 
 #include <QMessageBox>
 

--- a/src/providers/gpx/qgsgpxsourceselect.h
+++ b/src/providers/gpx/qgsgpxsourceselect.h
@@ -20,6 +20,7 @@
 #include "ui_qgsgpxsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -41,6 +42,7 @@ class QgsGpxSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsGp
   private slots:
 
     void enableRelevantControls();
+    void showHelp();
 
   private:
     QString mGpxPath;

--- a/src/providers/gpx/qgsgpxsourceselect.h
+++ b/src/providers/gpx/qgsgpxsourceselect.h
@@ -20,7 +20,6 @@
 #include "ui_qgsgpxsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -20,6 +20,7 @@
 #include "qgsmdalsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgshelp.h"
 
 QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QgsAbstractDataSourceWidget( parent, fl, widgetMode )

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -35,6 +35,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
     mMeshPath = path;
     emit enableButtons( ! mMeshPath.isEmpty() );
   } );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMdalSourceSelect::showHelp );
 }
 
 void QgsMdalSourceSelect::addButtonClicked()
@@ -54,4 +55,9 @@ void QgsMdalSourceSelect::addButtonClicked()
     Q_NOWARN_DEPRECATED_POP
     emit addLayer( Qgis::LayerType::Mesh, path, QFileInfo( path ).completeBaseName(), QStringLiteral( "mdal" ) );
   }
+}
+
+void QgsMdalSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-mesh-layer" ) );
 }

--- a/src/providers/mdal/qgsmdalsourceselect.h
+++ b/src/providers/mdal/qgsmdalsourceselect.h
@@ -20,7 +20,6 @@
 #include "ui_qgsmdalsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/providers/mdal/qgsmdalsourceselect.h
+++ b/src/providers/mdal/qgsmdalsourceselect.h
@@ -20,6 +20,7 @@
 #include "ui_qgsmdalsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -37,6 +38,9 @@ class QgsMdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsM
   public slots:
     //! Determines the tables the user selected and closes the dialog
     void addButtonClicked() override;
+
+  private slots:
+    void showHelp();
 
   private:
     QString mMeshPath;


### PR DESCRIPTION
## Description

This PR connects the Help button of some items of the Data Source Manger dialog window to the docs:

Raster -> [managing_data_source/opening_data.html#loading-a-layer-from-a-file](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html#loading-a-layer-from-a-file)
Mesh -> [managing_data_source/opening_data.html#loading-a-mesh-layer](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html#loading-a-mesh-layer)
GPS -> [managing_data_source/opening_data.html#gps](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html#gps)
Metadata Search -> [managing_data_source/opening_data.html#the-layer-metadata-search-panel](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html#the-layer-metadata-search-panel)
Point Cloud -> [managing_data_source/opening_data.html#loading-a-layer-from-a-file](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html#loading-a-layer-from-a-file)
Scene -> [managing_data_source/opening_data.html](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/opening_data.html)

A specific paragraph for the Point Cloud provider is currently missing, anyway the paragraph at managing_data_source/opening_data.html#loading-a-layer-from-a-file should be OK since the Point Cloud dialog is very similar to the Raster one.

A specific paragraph for the Scene provider is currently missing: I've linked the Help button the generic Data Source Manager doc page managing_data_source/opening_data.html.

Fixes https://github.com/qgis/QGIS/issues/54125.

@DelazJ, could you please have a look at this?

Would it be better to not add the link for the Point Cloud and / or the Scene providers?

This would need a manual backport to release-3_32 branch (missing Scene in 3.32) and to release-3_28 (missing Scene, GeoNode present).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
