### PR TITLE
Load tiled scene hierarchy in background in 3D views

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -389,7 +389,7 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneState &state )
     // ensure we have child nodes (at least skeletons) available, if any
     if ( !node->hasChildrenPopulated() )
     {
-      // Some chunked entities (e.g. tiled scene) may know the full node hierarchy in advance
+      // Some chunked entities (e.g. tiled scene) may not know the full node hierarchy in advance
       // and need to fetch it from a remote server. Having a blocking network request
       // in createChildren() is not wanted because this code runs on the main thread and thus
       // would cause GUI freezes. Here is a mechanism to first check whether there are any

--- a/src/3d/chunks/qgschunkloader_p.h
+++ b/src/3d/chunks/qgschunkloader_p.h
@@ -79,6 +79,35 @@ class QgsChunkLoaderFactory  : public QObject
     virtual QgsChunkNode *createRootNode() const = 0;
     //! Creates child nodes for the given node. Ownership of the returned objects is passed to the caller.
     virtual QVector<QgsChunkNode *> createChildren( QgsChunkNode *node ) const = 0;
+
+    /**
+     * Returns true if createChildren() is ready to return node's children (i.e. it has
+     * enough hierarchy information available). If not, createChildren() should not be called,
+     * but prepareChildren() should be called first, and only after childrenPrepared() gets
+     * emitted, it is safe to call createChildren().
+     *
+     * The default implementation returns true. This only needs to be implemented when the factory
+     * would otherwise need to do blocking network requests in createChildren() to avoid GUI freeze.
+     * \sa prepareChildren()
+     * \sa createChildren()
+     */
+    virtual bool canCreateChildren( QgsChunkNode *node ) { Q_UNUSED( node ); return true; }
+
+    /**
+     * Requests that node has enough hierarchy information to create children in createChildren().
+     * This function must not block, only start any requests in background. When the hierarchy
+     * information is ready, the signal childrenPrepared() must be emitted.
+     *
+     * The default implementation does nothing. This only needs to be implemented when the factory
+     * would otherwise need to do blocking network requests in createChildren() to avoid GUI freeze.
+     * \sa canCreateChildren()
+     * \sa createChildren()
+     */
+    virtual void prepareChildren( QgsChunkNode *node ) { Q_UNUSED( node ); }
+
+  signals:
+    //! Signal that gets emitted when a background job triggered from prepareChildren() has finished
+    void childrenPrepared( QgsChunkNode *node );
 };
 
 

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -81,12 +81,18 @@ class QgsTiledSceneChunkLoaderFactory : public QgsChunkLoaderFactory
     virtual QgsChunkNode *createRootNode() const override;
     virtual QVector<QgsChunkNode *> createChildren( QgsChunkNode *node ) const override;
 
+    virtual bool canCreateChildren( QgsChunkNode *node ) override;
+    virtual void prepareChildren( QgsChunkNode *node ) override;
+
     QgsChunkNode *nodeForTile( const QgsTiledSceneTile &t, const QgsChunkNodeId &nodeId ) const;
+    void fetchHierarchyForNode( long long nodeId, QgsChunkNode *origNode );
 
     const Qgs3DMapSettings &mMap;
     QString mRelativePathBase;
     mutable QgsTiledSceneIndex mIndex;
     QgsCoordinateTransform mBoundsTransform;
+    QSet<long long> mPendingHierarchyFetches;
+    QSet<long long> mFutureHierarchyFetches;
 };
 
 
@@ -107,6 +113,8 @@ class QgsTiledSceneLayerChunkedEntity : public QgsChunkedEntity
     explicit QgsTiledSceneLayerChunkedEntity( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index, double maximumScreenError, bool showBoundingBoxes );
 
     ~QgsTiledSceneLayerChunkedEntity();
+
+    int pendingJobsCount() const override;
 };
 
 /// @endcond


### PR DESCRIPTION
Additions in this PR:
- added API in chunked entity / chunk loader factory for hierarchy fetching in background
- added implementation for tiled scene

As a result, this avoids GUI freezes whenever chunked entity needs further information about hierarchy, resulting in a smooth 3D view operation.

Point cloud support could also benefit from this API, as it has the same issue with occasional GUI freezes when fetching hierarchy - but that's probably for some other time :slightly_smiling_face: 