### PR TITLE
Just make 3d maps in 3857 instead of refusing to do anything when project is in geographic crs

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -138,6 +138,7 @@
 #include "qgs3danimationwidget.h"
 #include "qgs3dmapcanvas.h"
 #include "qgs3dmapsettings.h"
+#include "qgs3dutils.h"
 #include "qgscameracontroller.h"
 #include "qgsflatterraingenerator.h"
 #include "qgslayoutitem3dmap.h"
@@ -13291,12 +13292,6 @@ void QgisApp::new3DMapCanvas()
     return;
   }
 
-  if ( mMapCanvas->mapSettings().destinationCrs().isGeographic() )
-  {
-    QMessageBox::warning( this, tr( "New 3D Map View" ), tr( "3D view currently does not support unprojected coordinate reference systems (CRS).\nPlease switch project's CRS to a projected CRS." ) );
-    return;
-  }
-
   int i = 1;
   const QList< QString > usedCanvasNames = QgsProject::instance()->viewsManager()->get3DViewsNames();
   QString name = tr( "3D Map %1" ).arg( i );
@@ -13309,11 +13304,20 @@ void QgisApp::new3DMapCanvas()
   if ( canvasWidget )
   {
     QgsProject *prj = QgsProject::instance();
-    QgsRectangle fullExtent = mMapCanvas->projectExtent();
     QgsSettings settings;
 
     Qgs3DMapSettings *map = new Qgs3DMapSettings;
-    map->setCrs( prj->crs() );
+    if ( !prj->crs().isGeographic() )
+    {
+      map->setCrs( prj->crs() );
+    }
+    else
+    {
+      map->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+    }
+
+    const QgsReferencedRectangle projectExtent = prj->viewSettings()->fullExtent();
+    const QgsRectangle fullExtent = Qgs3DUtils::tryReprojectExtent2D( projectExtent, projectExtent.crs(), map->crs(), prj->transformContext() );
     map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
     map->setSelectionColor( mMapCanvas->selectionColor() );
     map->setBackgroundColor( mMapCanvas->canvasColor() );
@@ -13346,9 +13350,9 @@ void QgisApp::new3DMapCanvas()
 
     canvasWidget->setMapSettings( map );
 
-    QgsRectangle extent = mMapCanvas->extent();
-    float dist = static_cast< float >( std::max( extent.width(), extent.height() ) );
-    canvasWidget->mapCanvas3D()->setViewFromTop( mMapCanvas->extent().center(), dist, static_cast< float >( mMapCanvas->rotation() ) );
+    const QgsRectangle canvasExtent = Qgs3DUtils::tryReprojectExtent2D( mMapCanvas->extent(),  mMapCanvas->mapSettings().destinationCrs(), map->crs(), prj->transformContext() );
+    float dist = static_cast< float >( std::max( canvasExtent.width(), canvasExtent.height() ) );
+    canvasWidget->mapCanvas3D()->setViewFromTop( canvasExtent.center(), dist, static_cast< float >( mMapCanvas->rotation() ) );
 
     const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( QStringLiteral( "map3d/axisInversion" ), Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
     if ( canvasWidget->mapCanvas3D()->cameraController() )


### PR DESCRIPTION
When trying to create a 3d map for a project with a geographic crs, don't hassle the user and instead just make a 3d map in EPSG:3857

It might not be a perfect approach, but it's better then the annoying message!