### PR TITLE
Improve attributes form with dark themes

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
@@ -125,6 +125,15 @@ to :py:func:`QgsApplication.nullRepresentation()`.
 .. versionadded:: 3.14
 %End
 
+    virtual bool event( QEvent *event );
+
+%Docstring
+Reimplemented to enable/disable the clear action
+depending on read-only status
+
+.. versionadded:: 3.34
+%End
+
   signals:
 
     void valueChanged( const QDateTime &date );

--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -74,6 +74,10 @@ QAbstractSpinBox {
     color: @text;
 }
 
+QAbstractSpinBox:no-frame {
+    border-color: transparent;
+}
+
 QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
@@ -238,6 +242,11 @@ QLineEdit, QTextEdit, QPlainTextEdit
     background-color:@itembackground;
     selection-background-color: @selection;
     selection-color: @itemdarkbackground;
+}
+
+QLineEdit:no-frame
+{
+    border-color: transparent;
 }
 
 QPushButton 
@@ -1062,6 +1071,10 @@ QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true]
 
 QComboBox:focus, QAbstractSpinBox:focus, QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus {
     border:1px solid @focus;
+}
+
+QComboBox:focus:read-only, QAbstractSpinBox:focus:read-only, QLineEdit:focus:read-only, QPlainTextEdit:focus:read-only, QTextEdit:focus:read-only {
+    border-color: transparent;
 }
 
 QToolButton[autoRaise=true]:focus:!pressed {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -70,6 +70,10 @@ QAbstractSpinBox {
     color: @textlight;
 }
 
+QAbstractSpinBox:no-frame {
+    border-color: transparent;
+}
+
 QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
@@ -224,6 +228,11 @@ QLineEdit
     background-color: @itembackground;
     selection-background-color: @selection;
     selection-color: @text;
+}
+
+QLineEdit:no-frame
+{
+    border-color: transparent;
 }
 
 QTextEdit, QPlainTextEdit
@@ -1089,6 +1098,10 @@ QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true]
 
 QComboBox:focus, QAbstractSpinBox:focus, QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus {
     border:1px solid @focusdark;
+}
+
+QComboBox:focus:read-only, QAbstractSpinBox:focus:read-only, QLineEdit:focus:read-only, QPlainTextEdit:focus:read-only, QTextEdit:focus:read-only {
+    border-color: transparent;
 }
 
 QToolButton[autoRaise=true]:focus:!pressed {

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -69,7 +69,7 @@ QgsDateTimeEdit::QgsDateTimeEdit( const QVariant & var, QMetaType::Type parserTy
 void QgsDateTimeEdit::setAllowNull( bool allowNull )
 {
   mAllowNull = allowNull;
-  mClearAction->setVisible( mAllowNull && ( !mIsNull || mIsEmpty ) );
+  mClearAction->setVisible( !isReadOnly() && mAllowNull && ( !mIsNull || mIsEmpty ) );
 }
 
 
@@ -100,6 +100,16 @@ void QgsDateTimeEdit::setEmpty()
 {
   mClearAction->setVisible( mAllowNull );
   mIsEmpty = true;
+}
+
+bool QgsDateTimeEdit::event( QEvent *event )
+{
+  if ( event->type() == QEvent::ReadOnlyChange || event->type() == QEvent::EnabledChange )
+  {
+    mClearAction->setVisible( !isReadOnly() && mAllowNull && ( !mIsNull || mIsEmpty ) );
+  }
+
+  return QDateTimeEdit::event( event );
 }
 
 void QgsDateTimeEdit::mousePressEvent( QMouseEvent *event )

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -115,6 +115,14 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
      */
     void setNullRepresentation( const QString &null );
 
+    /**
+     * Reimplemented to enable/disable the clear action
+     * depending on read-only status
+     *
+     * \since QGIS 3.34
+     */
+    bool event( QEvent *event ) override;
+
   signals:
 
     /**

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -284,5 +284,6 @@ void QgsDateTimeEditWrapper::setEnabled( bool enabled )
   if ( !mQDateTimeEdit )
     return;
 
-  mQDateTimeEdit->setEnabled( enabled );
+  mQDateTimeEdit->setReadOnly( !enabled );
+  mQDateTimeEdit->setFrame( enabled );
 }

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -314,3 +314,22 @@ void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QVariantL
     mSlider->setValue( value.toInt() );
   }
 }
+
+void QgsRangeWidgetWrapper::setEnabled( bool enabled )
+{
+  if ( mDoubleSpinBox )
+  {
+    mDoubleSpinBox->setReadOnly( !enabled );
+    mDoubleSpinBox->setFrame( enabled );
+  }
+  else if ( mIntSpinBox )
+  {
+    mIntSpinBox->setReadOnly( !enabled );
+    mIntSpinBox->setFrame( enabled );
+  }
+  else
+  {
+    QgsEditorWidgetWrapper::setEnabled( enabled );
+  }
+}
+

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -71,6 +71,9 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
+  public slots:
+    void setEnabled( bool enabled ) override;
+
   private slots:
     // NOTE - cannot be named "valueChanged", otherwise implicit conversion to QVariant results in
     // infinite recursion

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -189,9 +189,6 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
       emit valuesChanged( value );
     } );
     connect( mLineEdit, &QLineEdit::textChanged, this, &QgsTextEditWrapper::textChanged );
-
-    mWritablePalette = mLineEdit->palette();
-    mReadOnlyPalette = mLineEdit->palette();
   }
 }
 
@@ -258,15 +255,6 @@ void QgsTextEditWrapper::setEnabled( bool enabled )
   if ( mLineEdit )
   {
     mLineEdit->setReadOnly( !enabled );
-    if ( enabled )
-      mLineEdit->setPalette( mWritablePalette );
-    else
-    {
-      mLineEdit->setPalette( mReadOnlyPalette );
-      // removing frame + setting transparent background to distinguish the readonly lineEdit from a normal one
-      // did not get this working via the Palette:
-      mLineEdit->setStyleSheet( QStringLiteral( "QLineEdit { background-color: rgba(255, 255, 255, 75%); }" ) );
-    }
     mLineEdit->setFrame( enabled );
   }
 }

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -95,8 +95,6 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     QTextEdit *mTextEdit = nullptr;
     QPlainTextEdit *mPlainTextEdit = nullptr;
     QLineEdit *mLineEdit = nullptr;
-    QPalette mReadOnlyPalette;
-    QPalette mWritablePalette;
     QString mPlaceholderText;
     QString mPlaceholderTextBackup;
 

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -17,6 +17,7 @@
 #include "qgstest.h"
 #include <QPushButton>
 #include <QLineEdit>
+#include <QSignalSpy>
 
 #include <editorwidgets/core/qgseditorwidgetregistry.h>
 #include "qgsattributeform.h"
@@ -32,7 +33,7 @@
 #include "qgsmultiedittoolbutton.h"
 #include "qgsattributeeditorfield.h"
 #include "qgsattributeeditorcontainer.h"
-#include <QSignalSpy>
+#include "qgsspinbox.h"
 
 class TestQgsAttributeForm : public QObject
 {
@@ -601,15 +602,15 @@ void TestQgsAttributeForm::testEditableJoin()
 
   // test if widget is enabled for layerA
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[0] );
-  QCOMPARE( ww->widget()->isEnabled(), true );
+  QCOMPARE( qobject_cast<QgsSpinBox *>( ww->widget() )->isReadOnly(), false );
 
   // test if widget is enabled for layerB
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[1] );
-  QCOMPARE( ww->widget()->isEnabled(), true );
+  QCOMPARE( qobject_cast<QgsSpinBox *>( ww->widget() )->isReadOnly(), false );
 
   // test if widget is disabled for layerC
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[2] );
-  QCOMPARE( ww->widget()->isEnabled(), false );
+  QCOMPARE( qobject_cast<QgsSpinBox *>( ww->widget() )->isReadOnly(), true );
 
   // change attributes
   form.changeAttribute( QStringLiteral( "layerB_col0" ), QVariant( 333 ) );


### PR DESCRIPTION
## Description

This PR fixes the looks of text editor widget (as well as improves the spinbox editor widget) on dark themes. The text editor widget was pretty bad with a stylesheet hack that was not compatible with non-light theme.

Before:
![image](https://github.com/qgis/QGIS/assets/1728657/bc2fd83b-f8f4-424f-bce9-75fc578710f6)

Now:
![image](https://github.com/qgis/QGIS/assets/1728657/e089ac6e-7a79-46e6-ae4c-dcfa1e474caa)

Themes (blend of gray and nightmapping) were also fixed to respect the read-only and no-frame properties.