### PR TITLE
Tiled scene: improve handling of URLs

### DIFF
--- a/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsTiledSceneTile
 {
 %Docstring(signature="appended")
@@ -132,6 +133,22 @@ Sets the tile's geometric ``error``, which is the error, in scene CRS units, of 
 simplified representation of its source geometry.
 
 .. seealso:: :py:func:`geometricError`
+%End
+
+    QUrl baseUrl() const;
+%Docstring
+Returns the tile's base URL. If this tile's resources are relative paths, they would
+get resolved against this URL.
+
+.. seealso:: :py:func:`setBaseUrl`
+%End
+
+    void setBaseUrl( const QUrl &baseUrl );
+%Docstring
+Sets the tile's base URL. If this tile's resources are relative paths, they would
+get resolved against this URL.
+
+.. seealso:: :py:func:`baseUrl`
 %End
 
 };

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -77,7 +77,7 @@ class QgsTiledSceneChunkLoaderFactory : public QgsChunkLoaderFactory
 {
     Q_OBJECT
   public:
-    QgsTiledSceneChunkLoaderFactory( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index );
+    QgsTiledSceneChunkLoaderFactory( const Qgs3DMapSettings &map, const QgsTiledSceneIndex &index );
 
     virtual QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override;
     virtual QgsChunkNode *createRootNode() const override;
@@ -112,7 +112,7 @@ class QgsTiledSceneLayerChunkedEntity : public QgsChunkedEntity
 {
     Q_OBJECT
   public:
-    explicit QgsTiledSceneLayerChunkedEntity( const Qgs3DMapSettings &map, QString relativePathBase, const QgsTiledSceneIndex &index, double maximumScreenError, bool showBoundingBoxes );
+    explicit QgsTiledSceneLayerChunkedEntity( const Qgs3DMapSettings &map, const QgsTiledSceneIndex &index, double maximumScreenError, bool showBoundingBoxes );
 
     ~QgsTiledSceneLayerChunkedEntity();
 

--- a/src/3d/qgstiledscenelayer3drenderer.cpp
+++ b/src/3d/qgstiledscenelayer3drenderer.cpp
@@ -65,9 +65,7 @@ Qt3DCore::QEntity *QgsTiledSceneLayer3DRenderer::createEntity( const Qgs3DMapSet
 
   QgsTiledSceneIndex index = tsl->dataProvider()->index();
 
-  QString relativePathBase = QFileInfo( tsl->source() ).path() + "/";
-
-  return new QgsTiledSceneLayerChunkedEntity( map, relativePathBase, index, maximumScreenError(), showBoundingBoxes() );
+  return new QgsTiledSceneLayerChunkedEntity( map, index, maximumScreenError(), showBoundingBoxes() );
 }
 
 void QgsTiledSceneLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -467,8 +467,7 @@ void QgsTiledSceneLayerRenderer::renderTrianglePrimitive( const tinygltf::Model 
         case QgsGltfUtils::ResourceType::Linked:
         {
           const QString linkedPath = QgsGltfUtils::linkedImagePath( model, tex.source );
-          const QString base = contentUri.left( contentUri.lastIndexOf( '/' ) );
-          const QString textureUri = base + '/' + linkedPath;
+          const QString textureUri = QUrl( contentUri ).resolved( linkedPath ).toString();
           const QByteArray rep = mIndex.retrieveContent( textureUri, feedback() );
           if ( !rep.isEmpty() )
           {

--- a/src/core/tiledscene/qgstiledscenetile.cpp
+++ b/src/core/tiledscene/qgstiledscenetile.cpp
@@ -39,6 +39,7 @@ QgsTiledSceneTile::QgsTiledSceneTile( const QgsTiledSceneTile &other )
   , mBoundingVolume( other.mBoundingVolume )
   , mResources( other.mResources )
   , mGeometricError( other.mGeometricError )
+  , mBaseUrl( other.mBaseUrl )
 {
   mTransform.reset( other.mTransform ? new QgsMatrix4x4( *other.mTransform.get() ) : nullptr );
 }
@@ -51,6 +52,7 @@ QgsTiledSceneTile &QgsTiledSceneTile::operator=( const QgsTiledSceneTile &other 
   mResources = other.mResources;
   mGeometricError = other.mGeometricError;
   mBoundingVolume = other.mBoundingVolume;
+  mBaseUrl = other.mBaseUrl;
   return *this;
 }
 
@@ -92,3 +94,12 @@ void QgsTiledSceneTile::setGeometricError( double error )
   mGeometricError = error;
 }
 
+QUrl QgsTiledSceneTile::baseUrl() const
+{
+  return mBaseUrl;
+}
+
+void QgsTiledSceneTile::setBaseUrl( const QUrl &baseUrl )
+{
+  mBaseUrl = baseUrl;
+}

--- a/src/core/tiledscene/qgstiledscenetile.h
+++ b/src/core/tiledscene/qgstiledscenetile.h
@@ -24,6 +24,8 @@
 #include "qgsmatrix4x4.h"
 #include "qgstiledsceneboundingvolume.h"
 
+#include <QUrl>
+
 /**
  * \ingroup core
  * \brief Represents an individual tile from a tiled scene data source.
@@ -146,6 +148,22 @@ class CORE_EXPORT QgsTiledSceneTile
      */
     void setGeometricError( double error );
 
+    /**
+     * Returns the tile's base URL. If this tile's resources are relative paths, they would
+     * get resolved against this URL.
+     *
+     * \see setBaseUrl()
+     */
+    QUrl baseUrl() const;
+
+    /**
+     * Sets the tile's base URL. If this tile's resources are relative paths, they would
+     * get resolved against this URL.
+     *
+     * \see baseUrl()
+     */
+    void setBaseUrl( const QUrl &baseUrl );
+
   private:
     long long mId = -1;
     Qgis::TileRefinementProcess mRefinementProcess = Qgis::TileRefinementProcess::Replacement;
@@ -153,6 +171,7 @@ class CORE_EXPORT QgsTiledSceneTile
     std::unique_ptr< QgsMatrix4x4 > mTransform;
     QVariantMap mResources;
     double mGeometricError = 0;
+    QUrl mBaseUrl;
 
 };
 

--- a/tests/src/python/test_qgscesium3dtileslayer.py
+++ b/tests/src/python/test_qgscesium3dtileslayer.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 
 import qgis  # NOQA
+from qgis.PyQt.QtCore import QUrl
 from qgis.core import (
     Qgis,
     QgsTiledSceneLayer,
@@ -701,6 +702,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(root_tile.id()), -1)
             self.assertFalse(root_tile.resources())
             self.assertEqual(root_tile.geometricError(), 100.0)
+            self.assertEqual(root_tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 root_tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -728,9 +730,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             child_tile0 = index.getTile(children[0])
             self.assertEqual(
                 child_tile0.resources(),
-                {"content": temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"},
             )
             self.assertEqual(child_tile0.geometricError(), 9.1)
+            self.assertEqual(child_tile0.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile0.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -758,9 +761,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile00.id()), child_tile0.id())
             self.assertEqual(
                 child_tile00.resources(),
-                {"content": temp_dir + "/LOD-1/Mesh-XR-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-1/Mesh-XR-YR.b3dm"},
             )
             self.assertEqual(child_tile00.geometricError(), 3)
+            self.assertEqual(child_tile00.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile00.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -787,9 +791,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile000.id()), child_tile00.id())
             self.assertEqual(
                 child_tile000.resources(),
-                {"content": temp_dir + "/LOD-0/Mesh-XR-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-0/Mesh-XR-YR.b3dm"},
             )
             self.assertEqual(child_tile000.geometricError(), 0)
+            self.assertEqual(child_tile000.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile000.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -816,9 +821,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile1.id()), root_tile.id())
             self.assertEqual(
                 child_tile1.resources(),
-                {"content": temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"},
             )
             self.assertEqual(child_tile1.geometricError(), 9.1)
+            self.assertEqual(child_tile1.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile1.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -846,9 +852,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile10.id()), child_tile1.id())
             self.assertEqual(
                 child_tile10.resources(),
-                {"content": temp_dir + "/LOD-1/Mesh-XL-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-1/Mesh-XL-YR.b3dm"},
             )
             self.assertEqual(child_tile10.geometricError(), 3)
+            self.assertEqual(child_tile10.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile10.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -875,9 +882,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile100.id()), child_tile10.id())
             self.assertEqual(
                 child_tile100.resources(),
-                {"content": temp_dir + "/LOD-0/Mesh-XL-YR.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-0/Mesh-XL-YR.b3dm"},
             )
             self.assertEqual(child_tile100.geometricError(), 0)
+            self.assertEqual(child_tile100.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile100.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -904,9 +912,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile2.id()), root_tile.id())
             self.assertEqual(
                 child_tile2.resources(),
-                {"content": temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"},
             )
             self.assertEqual(child_tile2.geometricError(), 9.0)
+            self.assertEqual(child_tile2.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile2.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -933,9 +942,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile20.id()), child_tile2.id())
             self.assertEqual(
                 child_tile20.resources(),
-                {"content": temp_dir + "/LOD-1/Mesh-XR-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-1/Mesh-XR-YL.b3dm"},
             )
             self.assertEqual(child_tile20.geometricError(), 3)
+            self.assertEqual(child_tile20.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile20.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -962,9 +972,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile200.id()), child_tile20.id())
             self.assertEqual(
                 child_tile200.resources(),
-                {"content": temp_dir + "/LOD-0/Mesh-XR-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-0/Mesh-XR-YL.b3dm"},
             )
             self.assertEqual(child_tile200.geometricError(), 0)
+            self.assertEqual(child_tile200.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile200.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -991,9 +1002,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile3.id()), root_tile.id())
             self.assertEqual(
                 child_tile3.resources(),
-                {"content": temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"},
             )
             self.assertEqual(child_tile3.geometricError(), 9.1)
+            self.assertEqual(child_tile3.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile3.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1020,9 +1032,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile30.id()), child_tile3.id())
             self.assertEqual(
                 child_tile30.resources(),
-                {"content": temp_dir + "/LOD-1/Mesh-XL-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-1/Mesh-XL-YL.b3dm"},
             )
             self.assertEqual(child_tile30.geometricError(), 3)
+            self.assertEqual(child_tile30.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile30.refinementProcess(), Qgis.TileRefinementProcess.Replacement
             )
@@ -1049,9 +1062,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(index.parentTileId(child_tile300.id()), child_tile30.id())
             self.assertEqual(
                 child_tile300.resources(),
-                {"content": temp_dir + "/LOD-0/Mesh-XL-YL.b3dm"},
+                {"content": "file://" + temp_dir + "/LOD-0/Mesh-XL-YL.b3dm"},
             )
             self.assertEqual(child_tile300.geometricError(), 0)
+            self.assertEqual(child_tile300.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 child_tile300.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1080,6 +1094,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             tile = index.getTile(tile_ids[11])
             self.assertFalse(tile.resources())
             self.assertEqual(tile.geometricError(), 100.0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1103,9 +1118,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[2])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1129,9 +1145,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[1])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-1/Mesh-XR-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-1/Mesh-XR-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 3)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1155,9 +1172,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[0])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-0/Mesh-XR-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-0/Mesh-XR-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1181,9 +1199,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[5])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1207,9 +1226,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[4])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-1/Mesh-XL-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-1/Mesh-XL-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 3)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1233,9 +1253,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[3])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-0/Mesh-XL-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-0/Mesh-XL-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1259,9 +1280,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[8])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1285,9 +1307,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[7])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-1/Mesh-XR-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-1/Mesh-XR-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 3)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1311,9 +1334,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[6])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-0/Mesh-XR-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-0/Mesh-XR-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1337,9 +1361,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[10])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1365,9 +1390,10 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[9])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-0/Mesh-XL-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-0/Mesh-XL-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 0)
+            self.assertEqual(tile.baseUrl(), QUrl("file://" + tmp_file))
             self.assertEqual(
                 tile.refinementProcess(), Qgis.TileRefinementProcess.Additive
             )
@@ -1422,7 +1448,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             tile = index.getTile(tile_ids[0])
             parent_id = tile_ids[0]
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
             self.assertEqual(
@@ -1448,7 +1474,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[1])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YR.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
             self.assertEqual(
@@ -1474,7 +1500,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[2])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.0)
             self.assertEqual(
@@ -1500,7 +1526,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
 
             tile = index.getTile(tile_ids[3])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XL-YL.b3dm"}
             )
             self.assertEqual(tile.geometricError(), 9.1)
             self.assertEqual(
@@ -1530,7 +1556,7 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(len(tile_ids), 1)
             tile = index.getTile(tile_ids[0])
             self.assertEqual(
-                tile.resources(), {"content": temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
+                tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
             )
 
 

--- a/tests/src/python/test_qgstiledscenetile.py
+++ b/tests/src/python/test_qgstiledscenetile.py
@@ -14,6 +14,7 @@ __copyright__ = "Copyright 2023, The QGIS Project"
 import unittest
 
 import qgis  # NOQA
+from qgis.PyQt.QtCore import QUrl
 from qgis.core import (
     Qgis,
     QgsTiledSceneBoundingVolume,
@@ -65,6 +66,10 @@ class TestQgsTiledSceneTile(QgisTestCase):
         node.setGeometricError(1.2)
         self.assertEqual(node.geometricError(), 1.2)
 
+        node = QgsTiledSceneTile()
+        node.setBaseUrl(QUrl("http://example.com/foo.txt"))
+        self.assertEqual(node.baseUrl(), QUrl("http://example.com/foo.txt"))
+
     def test_copy(self):
         node = QgsTiledSceneTile(11)
         node.setRefinementProcess(Qgis.TileRefinementProcess.Additive)
@@ -74,6 +79,7 @@ class TestQgsTiledSceneTile(QgisTestCase):
         node.setTransform(QgsMatrix4x4(1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0))
         node.setResources({"content": "parent"})
         node.setGeometricError(1.2)
+        node.setBaseUrl(QUrl("http://example.com/hello.json"))
 
         copy = QgsTiledSceneTile(node)
         self.assertTrue(copy.isValid())
@@ -86,6 +92,7 @@ class TestQgsTiledSceneTile(QgisTestCase):
         )
         self.assertEqual(copy.resources(), {"content": "parent"})
         self.assertEqual(copy.geometricError(), 1.2)
+        self.assertEqual(copy.baseUrl(), QUrl("http://example.com/hello.json"))
 
     def test_set_transform(self):
         node = QgsTiledSceneTile()


### PR DESCRIPTION
- added QgsTiledSceneTile::baseUrl() to get URL that generated the tile and thus base URL for resolving relative paths of linked content
- resolution of relative URLs should work also when sub-tree JSON files are in a different path than the root tileset JSON
- all content URLs are now using scheme - URLs of local files start with file://
- removed duplicated code to resolve relative URLs in GLTF parsing and chunk loading
