### PR TITLE
Crash expression attachment

### DIFF
--- a/src/core/network/qgsnetworkcontentfetcherregistry.cpp
+++ b/src/core/network/qgsnetworkcontentfetcherregistry.cpp
@@ -146,11 +146,7 @@ void QgsFetchedContent::cancel()
   if ( mFetchingTask && mFetchingTask->canCancel() )
   {
     mFetchingTask->cancel();
-  }
-  if ( mFile )
-  {
-    mFile->deleteLater();
-    mFilePath = QString();
+    mStatus = ContentStatus::NotStarted;
   }
 }
 

--- a/src/core/network/qgsnetworkcontentfetcherregistry.h
+++ b/src/core/network/qgsnetworkcontentfetcherregistry.h
@@ -25,6 +25,7 @@
 #include <QNetworkReply>
 #include <QFile>
 #include <QTemporaryFile>
+#include <QPointer>
 
 #include "qgis_core.h"
 #include "qgstaskmanager.h"
@@ -117,7 +118,7 @@ class CORE_EXPORT QgsFetchedContent : public QObject
     QString mUrl;
     QTemporaryFile *mFile = nullptr;
     QString mFilePath;
-    QgsNetworkContentFetcherTask *mFetchingTask = nullptr;
+    QPointer< QgsNetworkContentFetcherTask > mFetchingTask;
     ContentStatus mStatus = NotStarted;
     QNetworkReply::NetworkError mError = QNetworkReply::NoError;
     QString mAuthConfig;

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -314,7 +314,7 @@ void QgsExternalResourceWidget::updateDocumentContent( const QString &filePath )
     case Web:
     {
 #ifdef WITH_QTWEBKIT
-      mWebView->load( QUrl::fromEncoded( filePath.toUtf8() ) );
+      mWebView->load( QUrl::fromUserInput( filePath.toUtf8() ) );
       mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
 #endif
       break;


### PR DESCRIPTION
## Description

Fixes #53832 

The `cancel()` method on a QgsFetchedContent should not delete the associated file if it has already been downloaded, and the `mFetchingTask` is now a `QPointer` to avoid calling cancel on it when it does not exist any more.

Also, minor fix for the web viewer which was not working in "existing file" or "simple copy" attachment mode.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
