### PR TITLE
fix deletion of project's temporary directory on windows

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1086,7 +1086,12 @@ void QgsProject::clear()
   releaseHandlesToProjectArchive();
 
   mAuxiliaryStorage.reset( new QgsAuxiliaryStorage() );
+
+  QgsArchive* oldArchive = mArchive.release();
+  
   mArchive.reset( new QgsArchive() );
+
+  connect(mStyleSettings->projectStyle(), &QObject::destroyed, [=]{ delete oldArchive; });
 
   // must happen AFTER archive reset, as it will populate a new style database within the new archive
   mStyleSettings->reset();


### PR DESCRIPTION
really ugly.  the project style lives in the archive's temporary directory and is kept open until replaced by a fresh project style database in a new archive, but the going archive cannot remove it's temporary directory on windows, while the going project style is not yet closed.  And the going project style is delete(d )Later