### PR TITLE
[ui] Fix QgsExpressionLineEdit's display of valid expression for dark themes

### DIFF
--- a/src/gui/qgsexpressionlineedit.cpp
+++ b/src/gui/qgsexpressionlineedit.cpp
@@ -204,10 +204,11 @@ void QgsExpressionLineEdit::updateLineEditStyle( const QString &expression )
   if ( !mLineEdit )
     return;
 
+  QPalette appPalette = qApp->palette();
   QPalette palette = mLineEdit->palette();
   if ( !isEnabled() )
   {
-    palette.setColor( QPalette::Text, Qt::gray );
+    palette.setColor( QPalette::Text, appPalette.color( QPalette::Disabled, QPalette::Text ) );
   }
   else
   {
@@ -222,7 +223,7 @@ void QgsExpressionLineEdit::updateLineEditStyle( const QString &expression )
     }
     else
     {
-      palette.setColor( QPalette::Text, Qt::black );
+      palette.setColor( QPalette::Text, appPalette.color( QPalette::Text ) );
     }
   }
   mLineEdit->setPalette( palette );


### PR DESCRIPTION
## Description

Fixes this black text on dark background situation:
![image](https://github.com/qgis/QGIS/assets/1728657/4755318d-abf0-4e87-a918-7ef718c46adb)

