### PR TITLE
[ui] Fix attribute row cache spinbox width (fixes #54201)

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1882,37 +1882,20 @@
                    </widget>
                   </item>
                   <item row="5" column="1">
-                   <layout class="QHBoxLayout" name="horizontalLayout_10">
-                    <item>
-                     <widget class="QgsSpinBox" name="spinBoxAttrTableRowCache">
-                      <property name="minimum">
-                       <number>0</number>
-                      </property>
-                      <property name="maximum">
-                       <number>10000000</number>
-                      </property>
-                      <property name="singleStep">
-                       <number>1000</number>
-                      </property>
-                      <property name="value">
-                       <number>10000</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_8">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
+                   <widget class="QgsSpinBox" name="spinBoxAttrTableRowCache">
+                    <property name="minimum">
+                     <number>0</number>
+                    </property>
+                    <property name="maximum">
+                     <number>10000000</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>1000</number>
+                    </property>
+                    <property name="value">
+                     <number>10000</number>
+                    </property>
+                   </widget>
                   </item>
                   <item row="2" column="1">
                    <widget class="QComboBox" name="mComboCopyFeatureFormat"/>


### PR DESCRIPTION
## Description

This PR fixes #54201 by expanding the spin box widget to occupy all available width. Looks much more harmonized to other widgets too:

![image](https://github.com/qgis/QGIS/assets/1728657/c79e7f1a-e850-431c-ade9-28486db9a93a)
