### PR TITLE
Fix "Metadata Search" tab toolTip in Data Source Manager dialog

### DIFF
--- a/python/core/auto_generated/qgsiconutils.sip.in
+++ b/python/core/auto_generated/qgsiconutils.sip.in
@@ -30,7 +30,8 @@ Returns the icon for a vector layer whose geometry ``type`` is provided.
     static QIcon iconForGeometryType( Qgis::GeometryType typeGroup );
 %Docstring
 Returns the icon for a vector layer whose geometry ``typeGroup`` is provided.
-1since QGIS 3.28
+
+.. versionadded:: 3.28
 %End
 
     static QIcon iconPoint();

--- a/src/core/qgsiconutils.h
+++ b/src/core/qgsiconutils.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsIconUtils
 
     /**
      * Returns the icon for a vector layer whose geometry \a typeGroup is provided.
-     * 1since QGIS 3.28
+     * \since QGIS 3.28
      */
     static QIcon iconForGeometryType( Qgis::GeometryType typeGroup );
 

--- a/src/gui/qgslayermetadatasourceselectprovider.cpp
+++ b/src/gui/qgslayermetadatasourceselectprovider.cpp
@@ -34,6 +34,11 @@ QString QgsLayerMetadataSourceSelectProvider::text() const
   return QObject::tr( "Metadata Search" );
 }
 
+QString QgsLayerMetadataSourceSelectProvider::toolTip() const
+{
+  return QObject::tr( "Search and add layer metadata" );
+}
+
 QIcon QgsLayerMetadataSourceSelectProvider::icon() const
 {
   return QgsApplication::getThemeIcon( QStringLiteral( "search.svg" ) );

--- a/src/gui/qgslayermetadatasourceselectprovider.cpp
+++ b/src/gui/qgslayermetadatasourceselectprovider.cpp
@@ -36,7 +36,7 @@ QString QgsLayerMetadataSourceSelectProvider::text() const
 
 QString QgsLayerMetadataSourceSelectProvider::toolTip() const
 {
-  return QObject::tr( "Search and add layer metadata" );
+  return QObject::tr( "Find layers by metadata" );
 }
 
 QIcon QgsLayerMetadataSourceSelectProvider::icon() const

--- a/src/gui/qgslayermetadatasourceselectprovider.h
+++ b/src/gui/qgslayermetadatasourceselectprovider.h
@@ -39,6 +39,7 @@ class GUI_EXPORT QgsLayerMetadataSourceSelectProvider : public QgsSourceSelectPr
   public:
     QString providerKey() const override;
     QString text() const override;
+    QString toolTip() const override;
     QIcon icon() const override;
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ) const override;
     int ordering() const override;


### PR DESCRIPTION
i.e. "Search and add layer metadata" instead of "Add Metadata Search layer"
