### PR TITLE
Mark node tile as NotJson when its hierarchy fetch fails

### DIFF
--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -83,7 +83,7 @@ struct QgsChunkNodeId
   //! Returns textual representation of the node ID in form of "Z/X/Y"
   QString text() const
   {
-    if ( uniqueId == -1 )
+    if ( uniqueId != -1 )
       return QString::number( uniqueId );
     else if ( z == -1 )
       return QStringLiteral( "%1/%2/%3" ).arg( d ).arg( x ).arg( y );   // quadtree

--- a/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
@@ -587,6 +587,9 @@ bool QgsCesiumTiledSceneIndex::fetchHierarchy( long long id, QgsFeedback *feedba
   }
   else
   {
+    // we got empty content, so the hierarchy content is probably missing,
+    // so let's mark it as not JSON so that we do not try to fetch it again
+    mTileContentFormats.insert( id, TileContentFormat::NotJson );
     return false;
   }
 }


### PR DESCRIPTION
When we fetch hierarchy and it leads to a bad URL, we get no content and then we try to get the hierarchy again and again (especially in 3D view this can trigger loads of requests). So when we failed to get content, let's mark it as NotJson so that we do not retry hierarchy fetch.

As a bonus, one tiny QgsChunkNodeId::text() fix...