### PR TITLE
[Backport queued_ltr_backports] Data Source Manger: connect the Help button to the docs for some providers (Fix #54125)

### DIFF
--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -25,6 +25,7 @@
 
 #include <gdal.h>
 #include <cpl_minixml.h>
+#include "qgshelp.h"
 
 QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QgsAbstractDataSourceWidget( parent, fl, widgetMode )

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -35,6 +35,7 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   connect( radioSrcFile, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcFile_toggled );
   connect( radioSrcProtocol, &QRadioButton::toggled, this, &QgsGdalSourceSelect::radioSrcProtocol_toggled );
   connect( cmbProtocolTypes, &QComboBox::currentTextChanged, this, &QgsGdalSourceSelect::cmbProtocolTypes_currentIndexChanged );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGdalSourceSelect::showHelp );
 
   whileBlocking( radioSrcFile )->setChecked( true );
   protocolGroupBox->hide();
@@ -366,6 +367,11 @@ void QgsGdalSourceSelect::fillOpenOptions()
   }
 
   mOpenOptionsGroupBox->setVisible( !mOpenOptionsWidgets.empty() );
+}
+
+void QgsGdalSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-layer-from-a-file" ) );
 }
 
 ///@endcond

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -21,7 +21,6 @@
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
-#include "qgshelp.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -21,6 +21,7 @@
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
+#include "qgshelp.h"
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -49,6 +50,9 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
     void radioSrcFile_toggled( bool checked );
     void radioSrcProtocol_toggled( bool checked );
     void cmbProtocolTypes_currentIndexChanged( const QString &text );
+
+  private slots:
+    void showHelp();
 
   private:
 

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -20,6 +20,7 @@
 #include "qgspointcloudsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "qgsprovidermetadata.h"
+#include "qgshelp.h"
 
 ///@cond PRIVATE
 

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -32,6 +32,7 @@ QgsPointCloudSourceSelect::QgsPointCloudSourceSelect( QWidget *parent, Qt::Windo
   connect( mRadioSrcFile, &QRadioButton::toggled, this, &QgsPointCloudSourceSelect::radioSrcFile_toggled );
   connect( mRadioSrcProtocol, &QRadioButton::toggled, this, &QgsPointCloudSourceSelect::radioSrcProtocol_toggled );
   connect( cmbProtocolTypes, &QComboBox::currentTextChanged, this, &QgsPointCloudSourceSelect::cmbProtocolTypes_currentIndexChanged );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPointCloudSourceSelect::showHelp );
 
   radioSrcFile_toggled( true );
   setProtocolWidgetsVisibility();
@@ -174,6 +175,11 @@ void QgsPointCloudSourceSelect::setProtocolWidgetsVisibility()
   labelKey->hide();
   mKey->hide();
   mAuthWarning->hide();
+}
+
+void QgsPointCloudSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-layer-from-a-file" ) );
 }
 
 ///@endcond

--- a/src/gui/providers/qgspointcloudsourceselect.h
+++ b/src/gui/providers/qgspointcloudsourceselect.h
@@ -24,6 +24,7 @@
 #include "ui_qgspointcloudsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -51,6 +52,9 @@ class QgsPointCloudSourceSelect : public QgsAbstractDataSourceWidget, private Ui
 
     //! Sets protocol-related widget visibility
     void setProtocolWidgetsVisibility();
+
+    void showHelp();
+
   private:
     QString mPath;
     QString mDataSourceType;

--- a/src/gui/providers/qgspointcloudsourceselect.h
+++ b/src/gui/providers/qgspointcloudsourceselect.h
@@ -24,7 +24,6 @@
 #include "ui_qgspointcloudsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -151,6 +151,8 @@ QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt:
     updateExtentFilter( mExtentFilterComboBox->currentIndex() );
   } );
 
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayerMetadataSearchWidget::showHelp );
+
   // Start loading metadata in the model
   mSourceModel->reloadAsync();
   mIsLoading = true;
@@ -240,4 +242,9 @@ void QgsLayerMetadataSearchWidget::showEvent( QShowEvent *event )
 {
   QgsAbstractDataSourceWidget::showEvent( event );
   mSearchFilterLineEdit->setText( mProxyModel->filterString( ) );
+}
+
+void QgsLayerMetadataSearchWidget::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#the-layer-metadata-search-panel" ) );
 }

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsprojectviewsettings.h"
 #include "qgsiconutils.h"
+#include "qgshelp.h"
 
 
 QgsLayerMetadataSearchWidget::QgsLayerMetadataSearchWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )

--- a/src/gui/qgslayermetadatasearchwidget.h
+++ b/src/gui/qgslayermetadatasearchwidget.h
@@ -22,6 +22,7 @@
 #include "qgsfeedback.h"
 #include "qgsabstractlayermetadataprovider.h"
 #include "qgsabstractdatasourcewidget.h"
+#include "qgshelp.h"
 
 class QgsMapCanvas;
 class QgsLayerMetadataResultsProxyModel;
@@ -53,6 +54,9 @@ class GUI_EXPORT QgsLayerMetadataSearchWidget : public QgsAbstractDataSourceWidg
     void refresh() override;
     void addButtonClicked() override;
     void reset() override;
+
+  private slots:
+    void showHelp();
 
   private:
 

--- a/src/gui/qgslayermetadatasearchwidget.h
+++ b/src/gui/qgslayermetadatasearchwidget.h
@@ -22,7 +22,6 @@
 #include "qgsfeedback.h"
 #include "qgsabstractlayermetadataprovider.h"
 #include "qgsabstractdatasourcewidget.h"
-#include "qgshelp.h"
 
 class QgsMapCanvas;
 class QgsLayerMetadataResultsProxyModel;

--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -25,6 +25,7 @@
 
 #include "qgsgeonodenewconnection.h"
 #include "qgsmanageconnectionsdialog.h"
+#include "qgshelp.h"
 
 #include <QDomDocument>
 #include <QListWidgetItem>
@@ -57,6 +58,7 @@ QgsGeoNodeSourceSelect::QgsGeoNodeSourceSelect( QWidget *parent, Qt::WindowFlags
   connect( btnLoad, &QPushButton::clicked, this, &QgsGeoNodeSourceSelect::loadGeonodeConnection );
   connect( lineFilter, &QLineEdit::textChanged, this, &QgsGeoNodeSourceSelect::filterChanged );
   connect( treeView, &QTreeView::clicked, this, &QgsGeoNodeSourceSelect::treeViewSelectionChanged );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGeoNodeSourceSelect::showHelp );
 
   mItemDelegate = new QgsGeonodeItemDelegate( treeView );
   treeView->setItemDelegate( mItemDelegate );
@@ -150,8 +152,7 @@ void QgsGeoNodeSourceSelect::setConnectionListPosition( const QString &selectedC
 
 void QgsGeoNodeSourceSelect::showHelp()
 {
-  //TODO - correct URL
-  //QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#spatialite-layers" ) );
+  QgsHelp::openHelp( QStringLiteral( "working_with_ogc/ogc_client_support.html" ) );
 }
 
 void QgsGeoNodeSourceSelect::connectToGeonodeConnection()

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -18,6 +18,7 @@
 #include "qgsgpxsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgshelp.h"
 
 #include <QMessageBox>
 

--- a/src/providers/gpx/qgsgpxsourceselect.cpp
+++ b/src/providers/gpx/qgsgpxsourceselect.cpp
@@ -39,6 +39,8 @@ QgsGpxSourceSelect::QgsGpxSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   connect( mFileWidget, &QgsFileWidget::fileChanged,
            this, &QgsGpxSourceSelect::enableRelevantControls );
+
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGpxSourceSelect::showHelp );
 }
 
 void QgsGpxSourceSelect::addButtonClicked()
@@ -80,4 +82,9 @@ void QgsGpxSourceSelect::enableRelevantControls()
   cbGPXWaypoints->setChecked( enabled );
   cbGPXRoutes->setChecked( enabled );
   cbGPXTracks->setChecked( enabled );
+}
+
+void QgsGpxSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#gps" ) );
 }

--- a/src/providers/gpx/qgsgpxsourceselect.h
+++ b/src/providers/gpx/qgsgpxsourceselect.h
@@ -20,6 +20,7 @@
 #include "ui_qgsgpxsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -41,6 +42,7 @@ class QgsGpxSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsGp
   private slots:
 
     void enableRelevantControls();
+    void showHelp();
 
   private:
     QString mGpxPath;

--- a/src/providers/gpx/qgsgpxsourceselect.h
+++ b/src/providers/gpx/qgsgpxsourceselect.h
@@ -20,7 +20,6 @@
 #include "ui_qgsgpxsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -20,6 +20,7 @@
 #include "qgsmdalsourceselect.h"
 #include "qgsproviderregistry.h"
 #include "ogr/qgsogrhelperfunctions.h"
+#include "qgshelp.h"
 
 QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QgsAbstractDataSourceWidget( parent, fl, widgetMode )

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -35,6 +35,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
     mMeshPath = path;
     emit enableButtons( ! mMeshPath.isEmpty() );
   } );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMdalSourceSelect::showHelp );
 }
 
 void QgsMdalSourceSelect::addButtonClicked()
@@ -51,4 +52,9 @@ void QgsMdalSourceSelect::addButtonClicked()
   {
     emit addMeshLayer( path, QFileInfo( path ).completeBaseName(), QStringLiteral( "mdal" ) );
   }
+}
+
+void QgsMdalSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-mesh-layer" ) );
 }

--- a/src/providers/mdal/qgsmdalsourceselect.h
+++ b/src/providers/mdal/qgsmdalsourceselect.h
@@ -20,7 +20,6 @@
 #include "ui_qgsmdalsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
-#include "qgshelp.h"
 
 
 /**

--- a/src/providers/mdal/qgsmdalsourceselect.h
+++ b/src/providers/mdal/qgsmdalsourceselect.h
@@ -20,6 +20,7 @@
 #include "ui_qgsmdalsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
+#include "qgshelp.h"
 
 
 /**
@@ -37,6 +38,9 @@ class QgsMdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsM
   public slots:
     //! Determines the tables the user selected and closes the dialog
     void addButtonClicked() override;
+
+  private slots:
+    void showHelp();
 
   private:
     QString mMeshPath;


### PR DESCRIPTION
Manual backport of #54168.

I've linked the Help button for the GeoNode item (which is available in 3.28 only) to [working_with_ogc/ogc_client_support.html](https://docs.qgis.org/3.28/en/docs/user_manual/working_with_ogc/ogc_client_support.html) docs page (like for WMS/WMTS, WFS / OGC API - Features and WCS items) since I didn't find a GeoNode paragraph in the Data Source Manager docs.

In https://docs.qgis.org/3.28/en/docs/user_manual/introduction/browser.html#tiles-and-web-services, GeoNode is mentioned in the same group with WMS / WMTS, WCS, WFS / OGC API - Features.

What do you think @DelazJ?