### PR TITLE
Add generic API to allow map layer renderers to show temporary in-progress preview render results

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1910,6 +1910,14 @@ QgsRenderContext.Flags = Qgis.RenderContextFlags
 Qgis.RenderContextFlag.baseClass = Qgis
 Qgis.RenderContextFlags.baseClass = Qgis
 RenderContextFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.MapLayerRendererFlag.RenderPartialOutputs.__doc__ = "The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents."
+Qgis.MapLayerRendererFlag.RenderPartialOutputOverPreviousCachedImage.__doc__ = "When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image."
+Qgis.MapLayerRendererFlag.__doc__ = "Flags which control how map layer renderers behave.\n\n.. versionadded:: 3.34\n\n" + '* ``RenderPartialOutputs``: ' + Qgis.MapLayerRendererFlag.RenderPartialOutputs.__doc__ + '\n' + '* ``RenderPartialOutputOverPreviousCachedImage``: ' + Qgis.MapLayerRendererFlag.RenderPartialOutputOverPreviousCachedImage.__doc__
+# --
+Qgis.MapLayerRendererFlag.baseClass = Qgis
+Qgis.MapLayerRendererFlags.baseClass = Qgis
+MapLayerRendererFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsRenderContext.TextRenderFormat = Qgis.TextRenderFormat
 # monkey patching scoped based enum
 QgsRenderContext.TextFormatAlwaysOutlines = Qgis.TextRenderFormat.AlwaysOutlines

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1166,6 +1166,15 @@ The development version
     typedef QFlags<Qgis::RenderContextFlag> RenderContextFlags;
 
 
+    enum class MapLayerRendererFlag
+    {
+      RenderPartialOutputs,
+      RenderPartialOutputOverPreviousCachedImage,
+    };
+
+    typedef QFlags<Qgis::MapLayerRendererFlag> MapLayerRendererFlags;
+
+
 
     enum class TextRenderFormat
       {
@@ -2303,6 +2312,8 @@ QFlags<Qgis::AnnotationItemFlag> operator|(Qgis::AnnotationItemFlag f1, QFlags<Q
 QFlags<Qgis::AnnotationItemGuiFlag> operator|(Qgis::AnnotationItemGuiFlag f1, QFlags<Qgis::AnnotationItemGuiFlag> f2);
 
 QFlags<Qgis::MapSettingsFlag> operator|(Qgis::MapSettingsFlag f1, QFlags<Qgis::MapSettingsFlag> f2);
+
+QFlags<Qgis::MapLayerRendererFlag> operator|(Qgis::MapLayerRendererFlag f1, QFlags<Qgis::MapLayerRendererFlag> f2);
 
 QFlags<Qgis::RenderContextFlag> operator|(Qgis::RenderContextFlag f1, QFlags<Qgis::RenderContextFlag> f2);
 

--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -73,6 +73,13 @@ layer to always be rendered using a raster paint device.
 .. versionadded:: 3.18
 %End
 
+    virtual Qgis::MapLayerRendererFlags flags() const;
+%Docstring
+Returns flags which control how the map layer rendering behaves.
+
+.. versionadded:: 3.34
+%End
+
     virtual QgsFeedback *feedback() const;
 %Docstring
 Access to feedback object of the layer renderer (may be ``None``)

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -84,6 +84,18 @@ Returns the destination QPainter for the render operation.
 %End
 
 
+    QPainter *previewRenderPainter();
+%Docstring
+Returns the const destination QPainter for temporary in-progress preview renders.
+
+May be ``None`` if temporary in-progress preview renders are not required.
+
+.. seealso:: :py:func:`setPreviewRenderPainter`
+
+.. versionadded:: 3.34
+%End
+
+
     void setPainterFlagsUsingContext( QPainter *painter = 0 ) const;
 %Docstring
 Sets relevant flags on a destination ``painter``, using the flags and settings
@@ -554,6 +566,19 @@ is not transferred and the QPainter destination must stay alive for the duration
 of any rendering operations.
 
 .. seealso:: :py:func:`painter`
+%End
+
+    void setPreviewRenderPainter( QPainter *painter );
+%Docstring
+Sets the destination ``painter`` for temporary in-progress preview renders.
+Ownership of ``painter`` is not transferred and the QPainter destination must
+stay alive for the duration of any rendering operations.
+
+``painter`` may be ``None`` if temporary in-progress preview renders are not required.
+
+.. seealso:: :py:func:`previewRenderPainter`
+
+.. versionadded:: 3.34
 %End
 
     void setMaskPainter( QPainter *p, int id = 0 );

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -325,6 +325,12 @@ void QgsMapRendererCustomPainterJob::doRender()
       QElapsedTimer layerTime;
       layerTime.start();
 
+      if ( job.previewRenderImage && !job.previewRenderImageInitialized )
+      {
+        job.previewRenderImage->fill( 0 );
+        job.previewRenderImageInitialized = true;
+      }
+
       if ( job.img )
       {
         job.img->fill( 0 );
@@ -431,6 +437,12 @@ void QgsMapRendererCustomPainterJob::doRender()
       {
         QElapsedTimer layerTime;
         layerTime.start();
+
+        if ( job.previewRenderImage && !job.previewRenderImageInitialized )
+        {
+          job.previewRenderImage->fill( 0 );
+          job.previewRenderImageInitialized = true;
+        }
 
         if ( job.img )
         {

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -641,12 +641,16 @@ std::vector<LayerRenderJob> QgsMapRendererJob::prepareJobs( QPainter *painter, Q
     {
       if ( mCache && ( job.renderer->flags() & Qgis::MapLayerRendererFlag::RenderPartialOutputOverPreviousCachedImage ) && mCache->hasAnyCacheImage( job.layerId + QStringLiteral( "_preview" ) ) )
       {
-        job.previewRenderImage = new QImage( mCache->transformedCacheImage( job.layerId + QStringLiteral( "_preview" ), mSettings.mapToPixel() ) );
-        job.previewRenderImageInitialized = true;
-        job.context()->setPreviewRenderPainter( new QPainter( job.previewRenderImage ) );
-        job.context()->setPainterFlagsUsingContext( painter );
+        const QImage cachedImage = mCache->transformedCacheImage( job.layerId + QStringLiteral( "_preview" ), mSettings.mapToPixel() );
+        if ( !cachedImage.isNull() )
+        {
+          job.previewRenderImage = new QImage( cachedImage );
+          job.previewRenderImageInitialized = true;
+          job.context()->setPreviewRenderPainter( new QPainter( job.previewRenderImage ) );
+          job.context()->setPainterFlagsUsingContext( painter );
+        }
       }
-      else
+      if ( !job.previewRenderImage )
       {
         job.context()->setPreviewRenderPainter( allocateImageAndPainter( ml->id(), job.previewRenderImage, job.context() ) );
         job.previewRenderImageInitialized = false;

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -65,7 +65,12 @@ LayerRenderJob &LayerRenderJob::operator=( LayerRenderJob &&other )
   renderer = other.renderer;
   other.renderer = nullptr;
 
+  previewRenderImage = other.previewRenderImage;
+  other.previewRenderImage = nullptr;
+
   imageInitialized = other.imageInitialized;
+  previewRenderImageInitialized = other.previewRenderImageInitialized;
+
   blendMode = other.blendMode;
   opacity = other.opacity;
   cached = other.cached;
@@ -96,6 +101,7 @@ LayerRenderJob &LayerRenderJob::operator=( LayerRenderJob &&other )
 
 LayerRenderJob::LayerRenderJob( LayerRenderJob &&other )
   : imageInitialized( other.imageInitialized )
+  , previewRenderImageInitialized( other.previewRenderImageInitialized )
   , blendMode( other.blendMode )
   , opacity( other.opacity )
   , cached( other.cached )
@@ -114,6 +120,9 @@ LayerRenderJob::LayerRenderJob( LayerRenderJob &&other )
 
   img = other.img;
   other.img = nullptr;
+
+  previewRenderImage = other.previewRenderImage;
+  other.previewRenderImage = nullptr;
 
   renderer = other.renderer;
   other.renderer = nullptr;
@@ -628,6 +637,28 @@ std::vector<LayerRenderJob> QgsMapRendererJob::prepareJobs( QPainter *painter, Q
       job.context()->setElevationMap( job.elevationMap );
     }
 
+    if ( ( job.renderer->flags() & Qgis::MapLayerRendererFlag::RenderPartialOutputs ) && ( mSettings.flags() & Qgis::MapSettingsFlag::RenderPartialOutput ) )
+    {
+      if ( mCache && ( job.renderer->flags() & Qgis::MapLayerRendererFlag::RenderPartialOutputOverPreviousCachedImage ) && mCache->hasAnyCacheImage( job.layerId + QStringLiteral( "_preview" ) ) )
+      {
+        job.previewRenderImage = new QImage( mCache->transformedCacheImage( job.layerId + QStringLiteral( "_preview" ), mSettings.mapToPixel() ) );
+        job.previewRenderImageInitialized = true;
+        job.context()->setPreviewRenderPainter( new QPainter( job.previewRenderImage ) );
+        job.context()->setPainterFlagsUsingContext( painter );
+      }
+      else
+      {
+        job.context()->setPreviewRenderPainter( allocateImageAndPainter( ml->id(), job.previewRenderImage, job.context() ) );
+        job.previewRenderImageInitialized = false;
+      }
+
+      if ( !job.previewRenderImage )
+      {
+        delete job.context()->previewRenderPainter();
+        job.context()->setPreviewRenderPainter( nullptr );
+      }
+    }
+
     job.renderingTime = layerTime.elapsed(); // include job preparation time in layer rendering time
   }
 
@@ -1017,6 +1048,14 @@ void QgsMapRendererJob::cleanupJobs( std::vector<LayerRenderJob> &jobs )
       job.img = nullptr;
     }
 
+    if ( job.previewRenderImage )
+    {
+      delete job.context()->previewRenderPainter();
+      job.context()->setPreviewRenderPainter( nullptr );
+      delete job.previewRenderImage;
+      job.previewRenderImage = nullptr;
+    }
+
     if ( job.elevationMap )
     {
       job.context()->setElevationMap( nullptr );
@@ -1081,6 +1120,14 @@ void QgsMapRendererJob::cleanupSecondPassJobs( std::vector< LayerRenderJob > &jo
 
       delete job.img;
       job.img = nullptr;
+    }
+
+    if ( job.previewRenderImage )
+    {
+      delete job.context()->previewRenderPainter();
+      job.context()->setPreviewRenderPainter( nullptr );
+      delete job.previewRenderImage;
+      job.previewRenderImage = nullptr;
     }
 
     if ( job.picture )
@@ -1231,6 +1278,9 @@ QImage QgsMapRendererJob::layerImageToBeComposed(
 {
   if ( job.imageCanBeComposed() )
   {
+    if ( job.previewRenderImage && !job.completed )
+      return *job.previewRenderImage;
+
     Q_ASSERT( job.img );
     return *job.img;
   }

--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -95,8 +95,24 @@ class LayerRenderJob
      */
     QgsElevationMap *elevationMap = nullptr;
 
+    /**
+     * Pointer to destination image for in-progress preview renders.
+     *
+     * May be NULLPTR if it is not necessary to draw in-progress preview renders.
+     *
+     * \since QGIS 3.34
+     */
+    QImage *previewRenderImage = nullptr;
+
     //! TRUE when img has been initialized (filled with transparent pixels)
     bool imageInitialized = false;
+
+    /**
+     * TRUE when previewRenderImage has been initialized (filled with transparent pixels).
+     *
+     * \since QGIS 3.34
+     */
+    bool previewRenderImageInitialized = false;
 
     bool imageCanBeComposed() const;
 

--- a/src/core/maprenderer/qgsmaprendererparalleljob.cpp
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.cpp
@@ -356,6 +356,12 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
   if ( job.cached )
     return;
 
+  if ( job.previewRenderImage && !job.previewRenderImageInitialized )
+  {
+    job.previewRenderImage->fill( 0 );
+    job.previewRenderImageInitialized = true;
+  }
+
   if ( job.img )
   {
     job.img->fill( 0 );

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
@@ -113,6 +113,12 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
       painter->setCompositionMode( job.blendMode );
     }
 
+    if ( job.previewRenderImage && !job.previewRenderImageInitialized )
+    {
+      job.previewRenderImage->fill( 0 );
+      job.previewRenderImageInitialized = true;
+    }
+
     if ( job.img )
     {
       job.img->fill( 0 );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1942,6 +1942,26 @@ class CORE_EXPORT Qgis
     Q_ENUM( RenderContextFlag )
     Q_FLAG( RenderContextFlags )
 
+    /**
+     * Flags which control how map layer renderers behave.
+     *
+     * \since QGIS 3.34
+     */
+    enum class MapLayerRendererFlag : int
+    {
+      RenderPartialOutputs = 1 << 0,  //!< The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents.
+      RenderPartialOutputOverPreviousCachedImage = 1 << 1,//!< When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image.
+    };
+    Q_ENUM( MapLayerRendererFlag )
+
+    /**
+     * Flags which control how map layer renderers behave.
+     *
+     * \since QGIS 3.34
+     */
+    Q_DECLARE_FLAGS( MapLayerRendererFlags, MapLayerRendererFlag )
+    Q_FLAG( MapLayerRendererFlags )
+
     // refs for below dox: https://github.com/qgis/QGIS/pull/1286#issuecomment-39806854
     // https://github.com/qgis/QGIS/pull/8573#issuecomment-445585826
 
@@ -4002,6 +4022,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FileOperationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::AnnotationItemFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::AnnotationItemGuiFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapSettingsFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapLayerRendererFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::RenderContextFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorLayerTypeFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MarkerLinePlacements )

--- a/src/core/qgsmaplayerrenderer.cpp
+++ b/src/core/qgsmaplayerrenderer.cpp
@@ -19,6 +19,21 @@
 QgsMapLayerRenderer::~QgsMapLayerRenderer() = default;
 
 
+bool QgsMapLayerRenderer::forceRasterRender() const
+{
+  return false;
+}
+
+Qgis::MapLayerRendererFlags QgsMapLayerRenderer::flags() const
+{
+  return Qgis::MapLayerRendererFlags();
+}
+
+QgsFeedback *QgsMapLayerRenderer::feedback() const
+{
+  return nullptr;
+}
+
 QList<QgsRenderedItemDetails *> QgsMapLayerRenderer::takeRenderedItemDetails()
 {
   return std::move( mRenderedItemDetails );

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgis.h"
 
 class QgsFeedback;
 class QgsRenderContext;
@@ -86,13 +87,20 @@ class CORE_EXPORT QgsMapLayerRenderer
      *
      * \since QGIS 3.18
      */
-    virtual bool forceRasterRender() const { return false; }
+    virtual bool forceRasterRender() const;
+
+    /**
+     * Returns flags which control how the map layer rendering behaves.
+     *
+     * \since QGIS 3.34
+     */
+    virtual Qgis::MapLayerRendererFlags flags() const;
 
     /**
      * Access to feedback object of the layer renderer (may be NULLPTR)
      * \since QGIS 3.0
      */
-    virtual QgsFeedback *feedback() const { return nullptr; }
+    virtual QgsFeedback *feedback() const;
 
     //! Returns list of errors (problems) that happened during the rendering
     QStringList errors() const { return mErrors; }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -43,6 +43,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   : QgsTemporalRangeObject( rh )
   , mFlags( rh.mFlags )
   , mPainter( rh.mPainter )
+  , mPreviewRenderPainter( rh.mPreviewRenderPainter )
   , mMaskPainter( rh.mMaskPainter )
   , mCoordTransform( rh.mCoordTransform )
   , mDistanceArea( rh.mDistanceArea )
@@ -93,6 +94,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
 {
   mFlags = rh.mFlags;
   mPainter = rh.mPainter;
+  mPreviewRenderPainter = rh.mPreviewRenderPainter;
   mMaskPainter = rh.mMaskPainter;
   mCoordTransform = rh.mCoordTransform;
   mExtent = rh.mExtent;

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -123,6 +123,29 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
 #endif
 
     /**
+     * Returns the const destination QPainter for temporary in-progress preview renders.
+     *
+     * May be NULLPTR if temporary in-progress preview renders are not required.
+     *
+     * \see setPreviewRenderPainter()
+     * \since QGIS 3.34
+    */
+    QPainter *previewRenderPainter() {return mPreviewRenderPainter;}
+
+#ifndef SIP_RUN
+
+    /**
+     * Returns the const destination QPainter for temporary in-progress preview renders.
+     *
+     * May be NULLPTR if temporary in-progress preview renders are not required.
+     *
+     * \see setPreviewRenderPainter()
+     * \since QGIS 3.34
+    */
+    const QPainter *previewRenderPainter() const { return mPreviewRenderPainter; }
+#endif
+
+    /**
      * Sets relevant flags on a destination \a painter, using the flags and settings
      * currently defined for the render context.
      *
@@ -548,6 +571,18 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * \see painter()
      */
     void setPainter( QPainter *p ) {mPainter = p;}
+
+    /**
+     * Sets the destination \a painter for temporary in-progress preview renders.
+     * Ownership of \a painter is not transferred and the QPainter destination must
+     * stay alive for the duration of any rendering operations.
+     *
+     * \a painter may be NULLPTR if temporary in-progress preview renders are not required.
+     *
+     * \see previewRenderPainter()
+     * \since QGIS 3.34
+    */
+    void setPreviewRenderPainter( QPainter *painter ) { mPreviewRenderPainter = painter; }
 
     /**
      * Sets a mask QPainter for the render operation. Ownership of the painter
@@ -1098,6 +1133,9 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
 
     //! Painter for rendering operations
     QPainter *mPainter = nullptr;
+
+    //! Painter for in-progress rendering operations
+    QPainter *mPreviewRenderPainter = nullptr;
 
     /**
      * Mask painters for selective masking.

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.h
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsTiledSceneLayerRenderer: public QgsMapLayerRenderer
     ~QgsTiledSceneLayerRenderer();
 
     bool render() override;
-    void setLayerRenderingTimeHint( int time ) override;
+    Qgis::MapLayerRendererFlags flags() const override;
     bool forceRasterRender() const override;
     QgsFeedback *feedback() const override { return mFeedback.get(); }
 
@@ -107,10 +107,6 @@ class CORE_EXPORT QgsTiledSceneLayerRenderer: public QgsMapLayerRenderer
 
     QList< QgsMapClippingRegion > mClippingRegions;
 
-    int mRenderTimeHint = 0;
-    bool mBlockRenderUpdates = false;
-    QElapsedTimer mElapsedTimer;
-
     QgsCoordinateReferenceSystem mSceneCrs;
     QgsTiledSceneBoundingVolume mLayerBoundingVolume;
     QgsTiledSceneIndex mIndex;
@@ -138,6 +134,8 @@ class CORE_EXPORT QgsTiledSceneLayerRenderer: public QgsMapLayerRenderer
 
     std::unique_ptr<QgsFeedback> mFeedback;
     QSet< int > mWarnedPrimitiveTypes;
+
+    QElapsedTimer mElapsedTimer;
 };
 
 #endif // QGSTILEDSCENELAYERRENDERER_H


### PR DESCRIPTION
Add generic API to allow map layer renderers to show temporary in-progress preview render results while drawing the layer, which differ from the final layer render

The immediate use case here is for rendering tiled scene layers. In order to generate the actual final render for these layers, we need to first fetch ALL content for the render and then sort the primitives by z value. But this means that the layer renders can be extremely slow, with no visible changes on the map until all the content fetching is complete. Not great user experience!

Instead, here we add the infrastructure so that a layer renderer can get a temporary image to paint to for any partial renders. This image gets used during map composition up until the layer finally finishes rendering, at which time the layer's actual destination image will be used for the composition.

This means that tiled scene renderers can now draw all tiles (with unsorted primitives, and the artifacts which come with
that) as soon as we fetch each tile. This gives the user an immediate visual reflection that the tiles are being fetched
and that how quickly (or slowly) that is happening. As soon as we've got all tiles, the layer render will be immediately
switched to the version in which all content is rendered in the correct z order.

As a bonus, we draw these temporary in progress renders over any previously transformed cache version of the layer
available. So eg when you zoom in, you'll get a zoomed in pixelated version of the last render which gets progressively drawn over with each tile as it is fetched.

This same API could be used in future eg with point cloud rendering when points are being sorted by z value to give
timely visual feedback.

Here's how it looks in action now:


https://github.com/qgis/QGIS/assets/1829991/9fa6048c-f353-42cc-a02f-0fbaa8804a0d


