### PR TITLE
[DXF] Don't write nan or inf in group codes for X and Y scale factors (Fix #54176)

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -965,7 +965,7 @@ void QgsDxfExport::writePoint( const QgsPoint &pt, const QString &layer, const Q
     writeGroup( 8, layer );
     writeGroup( 2, blockIt.value() ); // Block name
     writeGroup( 50, mPointSymbolBlockAngles.value( symbolLayer ) - angle );
-    if ( scale != 1.0 )
+    if ( std::isfinite( scale ) && scale != 1.0 )
     {
       writeGroup( 41, scale );
       writeGroup( 42, scale );


### PR DESCRIPTION
## Description

This PR ensures that group codes for X and Y scale factors are not written in exported DXF files if the calculated scale factor is not finite (i.e. `nan` or `inf`).

Fixes #54176.

The writing of group codes for scale factors in DXF files was introduced with https://github.com/qgis/QGIS/pull/53249 since QGIS 3.32.0.

@nirvn, what do you think?

I would also add a check in `QgsDxfExport::writeGroup` in order to globally avoid the writing of group codes if the value is not finite.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
