### PR TITLE
Added new QgsProject signal willBeCleared

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1647,6 +1647,13 @@ just before a new project is read).
 .. versionadded:: 3.2
 %End
 
+    void willBeCleared();
+%Docstring
+Emitted when the project is about to be cleared.
+
+.. seealso:: :py:func:`clear`
+%End
+
     void readProject( const QDomDocument & );
 %Docstring
 Emitted when a project is being read.

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1652,6 +1652,8 @@ just before a new project is read).
 Emitted when the project is about to be cleared.
 
 .. seealso:: :py:func:`clear`
+
+.. versionadded:: 3.34
 %End
 
     void readProject( const QDomDocument & );

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1647,7 +1647,7 @@ just before a new project is read).
 .. versionadded:: 3.2
 %End
 
-    void willBeCleared();
+    void aboutToBeCleared();
 %Docstring
 Emitted when the project is about to be cleared.
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1024,7 +1024,7 @@ void QgsProject::clear()
 
   ScopedIntIncrementor snapSingleBlocker( &mBlockSnappingUpdates );
 
-  emit willBeCleared()
+  emit willBeCleared();
 
   mProjectScope.reset();
   mFile.setFileName( QString() );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1024,6 +1024,8 @@ void QgsProject::clear()
 
   ScopedIntIncrementor snapSingleBlocker( &mBlockSnappingUpdates );
 
+  emit willBeCleared()
+
   mProjectScope.reset();
   mFile.setFileName( QString() );
   mProperties.clearKeys();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1024,7 +1024,7 @@ void QgsProject::clear()
 
   ScopedIntIncrementor snapSingleBlocker( &mBlockSnappingUpdates );
 
-  emit willBeCleared();
+  emit aboutToBeCleared();
 
   mProjectScope.reset();
   mFile.setFileName( QString() );

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1691,7 +1691,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \see clear()
      * \since QGIS 3.34
      */
-    void willBeCleared();
+    void aboutToBeCleared();
 
     /**
      * Emitted when a project is being read.

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1689,6 +1689,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Emitted when the project is about to be cleared.
      *
      * \see clear()
+     * \since QGIS 3.34
      */
     void willBeCleared();
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1686,6 +1686,13 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void cleared();
 
     /**
+     * Emitted when the project is about to be cleared.
+     *
+     * \see clear()
+     */
+    void willBeCleared();
+
+    /**
      * Emitted when a project is being read.
      */
     void readProject( const QDomDocument & );


### PR DESCRIPTION
New signal emitted every time in the beginning of QgsProject::clear call

## Description

QgsProject::cleared signal is emitted every time project is cleared. However the process of clearing the project may emit signals, that are unwanted for python plugins that synchronise their behaviour with project. For example, removing layers can be misinterpreted as action requested by user. In order to explicitly inform plugin that following layer removals are performed by QGIS itself,  it is useful to emit signal BEFORE anything would actually be cleared from project.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
