### PR TITLE
zip_get_num_files deprecated in libzip 1.10.0

### DIFF
--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -70,7 +70,7 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
 
   if ( rc == ZIP_ER_OK && z )
   {
-    const int count = zip_get_num_files( z );
+    const int count = zip_get_num_entries( z, ZIP_FL_UNCHANGED );
     if ( count != -1 )
     {
       struct zip_stat stat;
@@ -308,7 +308,7 @@ const QStringList QgsZipUtils::files( const QString &zip )
 
   if ( rc == ZIP_ER_OK && z )
   {
-    const int count = zip_get_num_files( z );
+    const int count = zip_get_num_entries( z, ZIP_FL_UNCHANGED );
     if ( count != -1 )
     {
       struct zip_stat stat;

--- a/src/core/vectortile/qgsvtpktiles.cpp
+++ b/src/core/vectortile/qgsvtpktiles.cpp
@@ -55,7 +55,7 @@ bool QgsVtpkTiles::open()
   mZip = zip_open( fileNamePtr.constData(), ZIP_CHECKCONS, &rc );
   if ( rc == ZIP_ER_OK && mZip )
   {
-    const int count = zip_get_num_files( mZip );
+    const int count = zip_get_num_entries( mZip, ZIP_FL_UNCHANGED );
     if ( count != -1 )
     {
       return true;


### PR DESCRIPTION
Warnings raised during compilation:

``` console
[1136/10852] Building CXX object src/core/CMakeFiles/qgis_core.dir/qgsziputils.cpp.o
/home/pblottiere/devel/qgis/QGIS/src/core/qgsziputils.cpp: In function ‘bool QgsZipUtils::unzip(const QString&, const QString&, QStringList&, bool)’:
/home/pblottiere/devel/qgis/QGIS/src/core/qgsziputils.cpp:73:40: warning: ‘int zip_get_num_files(zip_t*)’ is deprecated: use 'zip_get_num_entries' instead [-Wdeprecated-declarations]
   73 |     const int count = zip_get_num_files( z );
      |                       ~~~~~~~~~~~~~~~~~^~~~~
In file included from /home/pblottiere/devel/qgis/QGIS/src/core/qgsziputils.cpp:21:
/usr/include/zip.h:379:68: note: declared here
  379 | ZIP_DEPRECATED("use 'zip_get_num_entries' instead") ZIP_EXTERN int zip_get_num_files(zip_t *_Nonnull);
      |                                                                    ^~~~~~~~~~~~~~~~~
/home/pblottiere/devel/qgis/QGIS/src/core/qgsziputils.cpp: In function ‘const QStringList QgsZipUtils::files(const QString&)’:
/home/pblottiere/devel/qgis/QGIS/src/core/qgsziputils.cpp:311:40: warning: ‘int zip_get_num_files(zip_t*)’ is deprecated: use 'zip_get_num_entries' instead [-Wdeprecated-declarations]
  311 |     const int count = zip_get_num_files( z );
      |                       ~~~~~~~~~~~~~~~~~^~~~~
/usr/include/zip.h:379:68: note: declared here
  379 | ZIP_DEPRECATED("use 'zip_get_num_entries' instead") ZIP_EXTERN int zip_get_num_files(zip_t *_Nonnull);
```