### PR TITLE
Synchronously fetch legend graphics when exporting layouts to PDF

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -210,7 +210,6 @@ Constructor for PdfExportSettings
       QStringList exportThemes;
 
       QVector<qreal> predefinedMapScales;
-
     };
 
     ExportResult exportToPdf( const QString &filePath, const QgsLayoutExporter::PdfExportSettings &settings );

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -33,6 +33,7 @@ Stores information relating to the current rendering settings for a layout.
       FlagDisableTiledRasterLayerRenders,
       FlagRenderLabelsByMapLayer,
       FlagLosslessImageRendering,
+      FlagSynchronousLegendGraphics
     };
     typedef QFlags<QgsLayoutRenderContext::Flag> Flags;
 

--- a/python/core/auto_generated/qgslegendsettings.sip.in
+++ b/python/core/auto_generated/qgslegendsettings.sip.in
@@ -395,6 +395,24 @@ Sets the desired size (in millimeters) of WMS legend graphics shown in the legen
 .. seealso:: :py:func:`wmsLegendSize`
 %End
 
+    void setSynchronousLegendRequests( bool b );
+%Docstring
+Sets whether to request legend graphics synchronously.
+
+.. seealso:: :py:func:`synchronousLegendRequests`
+
+.. versionadded:: 3.34
+%End
+
+    bool synchronousLegendRequests() const;
+%Docstring
+Returns whether to request legend graphics synchronously.
+
+.. seealso:: :py:func:`setSynchronousLegendRequests`
+
+.. versionadded:: 3.34
+%End
+
  double lineSpacing() const /Deprecated/;
 %Docstring
 Returns the line spacing to use between lines of legend text.

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -763,7 +763,7 @@ class CORE_EXPORT QgsWmsLegendNode : public QgsLayerTreeModelLegendNode
   private:
 
     // Lazily initializes mImage
-    QImage getLegendGraphic() const;
+    QImage getLegendGraphic( bool synchronous = false ) const;
 
     QImage renderMessage( const QString &msg ) const;
 

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -558,6 +558,11 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   // in items missing from the output
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagUseAdvancedEffects, !settings.forceVectorOutput );
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
+
+  // Force synchronous legend graphics requests. Necessary for WMS GetPrint,
+  // as otherwise processing the request ends before remote graphics are downloaded.
+  mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagSynchronousLegendGraphics, true );
+
   mLayout->renderContext().setTextRenderFormat( settings.textRenderFormat );
   mLayout->renderContext().setExportThemes( settings.exportThemes );
 

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -387,7 +387,6 @@ class CORE_EXPORT QgsLayoutExporter
        * \since QGIS 3.10
        */
       QVector<qreal> predefinedMapScales;
-
     };
 
     /**

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -128,6 +128,7 @@ void QgsLayoutItemLegend::paint( QPainter *painter, const QStyleOptionGraphicsIt
     // no longer required, but left set for api stability
     mSettings.setUseAdvancedEffects( mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagUseAdvancedEffects );
     mSettings.setDpi( dpi );
+    mSettings.setSynchronousLegendRequests( mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagSynchronousLegendGraphics );
     Q_NOWARN_DEPRECATED_POP
   }
   if ( mMap && mLayout )

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -53,6 +53,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
       FlagDisableTiledRasterLayerRenders = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
       FlagRenderLabelsByMapLayer = 1 << 9, //!< When rendering map items to multi-layered exports, render labels belonging to different layers into separate export layers
       FlagLosslessImageRendering = 1 << 10, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF).
+      FlagSynchronousLegendGraphics = 1 << 11 //!< Query legend graphics synchronously.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/qgslegendsettings.h
+++ b/src/core/qgslegendsettings.h
@@ -368,6 +368,24 @@ class CORE_EXPORT QgsLegendSettings
     void setWmsLegendSize( QSizeF s ) {mWmsLegendSize = s;}
 
     /**
+     * Sets whether to request legend graphics synchronously.
+     *
+     * \see synchronousLegendRequests()
+     *
+     * \since QGIS 3.34
+     */
+    void setSynchronousLegendRequests( bool b ) {mSynchronousLegendRequests = b;}
+
+    /**
+     * Returns whether to request legend graphics synchronously.
+     *
+     * \see setSynchronousLegendRequests()
+     *
+     * \since QGIS 3.34
+     */
+    bool synchronousLegendRequests() const {return mSynchronousLegendRequests;}
+
+    /**
      * Returns the line spacing to use between lines of legend text.
      *
      * \see setLineSpacing()
@@ -525,6 +543,9 @@ class CORE_EXPORT QgsLegendSettings
 
     //! Width and height of WMS legendGraphic pixmap
     QSizeF mWmsLegendSize;
+
+    //! Whether to request legend graphics synchronously
+    bool mSynchronousLegendRequests = false;
 
     //! Spacing between lines when wrapped
     double mLineSpacing = 1;


### PR DESCRIPTION
When printing a layout with a legend item via GetPrint, any WMS legends will currently appear without legend image, because the legend image is fetched asynchronously, and by the time the images have been downloaded, the GetPrint request has already finished.

This PR introduces a `synchronousLegendGraphics` flag which makes `QgsWmsLegendNode::getLegendGraphic` wait until the image has been fetched.