### PR TITLE
Clear recent projects

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -72,6 +72,7 @@ set(QGIS_APP_SRCS
   qgstemporalcontrollerdockwidget.cpp
   qgsversioninfo.cpp
   qgsrecentprojectsitemsmodel.cpp
+  qgsrecentprojectsmenueventfilter.cpp
   qgsvectorlayerdigitizingproperties.cpp
   qgswelcomepage.cpp
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5193,6 +5193,7 @@ void QgisApp::updateRecentProjectPaths()
   mRecentProjectsMenu->clear();
 
   const auto constMRecentProjects = mRecentProjects;
+  int projectIndex = 0;
   for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : constMRecentProjects )
   {
     QAction *action = mRecentProjectsMenu->addAction(
@@ -5223,7 +5224,7 @@ void QgisApp::updateRecentProjectPaths()
         action->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorBadLayer.svg" ) ) );
     }
 
-    action->setData( recentProject.path );
+    action->setData( projectIndex++ );
     if ( recentProject.pin )
     {
       action->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/pin.svg" ) ) );
@@ -6912,17 +6913,19 @@ void QgisApp::openTemplate( const QString &fileName )
 }
 
 // Open the project file corresponding to the
-// path at the given index in mRecentProjectPaths
+// path at the given index in mRecentProjects
 void QgisApp::openProject( QAction *action )
 {
-  // possibly save any pending work before opening a different project
   Q_ASSERT( action );
-  const QString project = action->data().toString().replace( "&&", "&" );
 
-  // If project is empty, it means that the clicked action is "Clear recent projects"
-  if ( project.isEmpty() )
+  bool ok;
+  const int projectIndex = action->data().toInt( &ok );
+  if ( !ok || projectIndex < 0 || projectIndex >= mRecentProjects.count() )
     return;
+  QString project =  mRecentProjects.at( projectIndex ).path;
+  project.replace( "&&", "&" );
 
+  // possibly save any pending work before opening a different project
   if ( checkTasksDependOnProject() )
     return;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1105,16 +1105,23 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
     saveRecentProjects();
     updateRecentProjectPaths();
   } );
-  connect( mWelcomePage, &QgsWelcomePage::projectsCleared, this, [ this ]()
+  connect( mWelcomePage, &QgsWelcomePage::projectsCleared, this, [ this ]( bool clearPinned )
   {
-    mRecentProjects.erase(
-      std::remove_if(
-        mRecentProjects.begin(),
-        mRecentProjects.end(),
-    []( const QgsRecentProjectItemsModel::RecentProjectData & recentProject ) { return !recentProject.pin; }
-      ),
-    mRecentProjects.end()
-    );
+    if ( clearPinned )
+    {
+      mRecentProjects.clear();
+    }
+    else
+    {
+      mRecentProjects.erase(
+        std::remove_if(
+          mRecentProjects.begin(),
+          mRecentProjects.end(),
+      []( const QgsRecentProjectItemsModel::RecentProjectData & recentProject ) { return !recentProject.pin; }
+        ),
+      mRecentProjects.end()
+      );
+    }
     saveRecentProjects();
     updateRecentProjectPaths();
   } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -410,6 +410,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsmessagelogviewer.h"
 #include "qgsmaplayeractionregistry.h"
 #include "qgswelcomepage.h"
+#include "qgsrecentprojectsmenueventfilter.h"
 #include "qgsversioninfo.h"
 #include "qgslegendfilterbutton.h"
 #include "qgsvirtuallayerdefinition.h"
@@ -3364,6 +3365,10 @@ void QgisApp::createMenus()
 
   // Connect once for the entire submenu.
   connect( mRecentProjectsMenu, &QMenu::triggered, this, static_cast < void ( QgisApp::* )( QAction *action ) >( &QgisApp::openProject ) );
+  QgsRecentProjectsMenuEventFilter *recentsProjectMenuEventFilter = new QgsRecentProjectsMenuEventFilter( mWelcomePage, mRecentProjectsMenu );
+  mRecentProjectsMenu->installEventFilter( recentsProjectMenuEventFilter );
+
+
   connect( mProjectFromTemplateMenu, &QMenu::triggered,
            this, &QgisApp::fileNewFromTemplateAction );
 

--- a/src/app/qgsrecentprojectsitemsmodel.cpp
+++ b/src/app/qgsrecentprojectsitemsmodel.cpp
@@ -146,6 +146,27 @@ void QgsRecentProjectItemsModel::removeProject( const QModelIndex &index )
   endRemoveRows();
 }
 
+void QgsRecentProjectItemsModel::clear( bool clearPinned )
+{
+  beginResetModel();
+  if ( clearPinned )
+  {
+    mRecentProjects.clear();
+  }
+  else
+  {
+    mRecentProjects.erase(
+      std::remove_if(
+        mRecentProjects.begin(),
+        mRecentProjects.end(),
+    []( const QgsRecentProjectItemsModel::RecentProjectData & recentProject ) { return !recentProject.pin; }
+      ),
+    mRecentProjects.end()
+    );
+  }
+  endResetModel();
+}
+
 void QgsRecentProjectItemsModel::recheckProject( const QModelIndex &index )
 {
   QString path;

--- a/src/app/qgsrecentprojectsitemsmodel.h
+++ b/src/app/qgsrecentprojectsitemsmodel.h
@@ -51,6 +51,7 @@ class QgsRecentProjectItemsModel : public QAbstractListModel
     void unpinProject( const QModelIndex &index );
     void removeProject( const QModelIndex &index );
     void recheckProject( const QModelIndex &index );
+    void clear( bool clearPinned = false );
 
   private:
     QList<RecentProjectData> mRecentProjects;

--- a/src/app/qgsrecentprojectsmenueventfilter.cpp
+++ b/src/app/qgsrecentprojectsmenueventfilter.cpp
@@ -33,30 +33,29 @@ bool QgsRecentProjectsMenuEventFilter::eventFilter( QObject *obj, QEvent *event 
 {
 
   if ( event->type() != QEvent::MouseButtonPress )
-    return false;
+    return QObject::eventFilter( obj, event );
 
   QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>( event );
   if ( !mouseEvent )
-    return false;
+    return QObject::eventFilter( obj, event );
 
   if ( mouseEvent->button() != Qt::RightButton )
-    return false;
+    return QObject::eventFilter( obj, event );
 
   QMenu *menu = qobject_cast<QMenu *>( obj );
   if ( !menu )
-    return false;
+    return QObject::eventFilter( obj, event );
 
   QAction *action = menu->actionAt( mouseEvent->pos() );
   if ( !action )
-    return false;
+    return QObject::eventFilter( obj, event );
 
-  int actionIndex = menu->actions().indexOf( action );
+  bool ok = false;
+  const int actionIndex = action->data().toInt( &ok );
+  if ( !ok )
+    return QObject::eventFilter( obj, event );
 
-  // The last action is the "Clear recent projects" action
-  if ( actionIndex == menu->actions().count() - 1 )
-    return false;
-
-  QModelIndex modelIndex = mWelcomePage->recentProjectsModel()->index( actionIndex, 0 );
+  const QModelIndex modelIndex = mWelcomePage->recentProjectsModel()->index( actionIndex, 0 );
   const bool pinned = mWelcomePage->recentProjectsModel()->data( modelIndex, QgsProjectListItemDelegate::PinRole ).toBool();
 
   QMenu subMenu;

--- a/src/app/qgsrecentprojectsmenueventfilter.cpp
+++ b/src/app/qgsrecentprojectsmenueventfilter.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+               qgsrecentprojectsmenueventfilter.cpp
+               ----------------------------------------------------
+    begin                : August 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrecentprojectsmenueventfilter.h"
+
+#include "qgswelcomepage.h"
+#include "qgsprojectlistitemdelegate.h"
+
+#include <QMenu>
+#include <QAction>
+#include <QEvent>
+#include <QMouseEvent>
+
+
+QgsRecentProjectsMenuEventFilter::QgsRecentProjectsMenuEventFilter( QgsWelcomePage *welcomePage, QObject *parent )
+  : QObject( parent ), mWelcomePage( welcomePage )
+{
+}
+
+bool QgsRecentProjectsMenuEventFilter::eventFilter( QObject *obj, QEvent *event )
+{
+
+  if ( event->type() != QEvent::MouseButtonPress )
+    return false;
+
+  QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>( event );
+  if ( !mouseEvent )
+    return false;
+
+  if ( mouseEvent->button() != Qt::RightButton )
+    return false;
+
+  QMenu *menu = qobject_cast<QMenu *>( obj );
+  if ( !menu )
+    return false;
+
+  QAction *action = menu->actionAt( mouseEvent->pos() );
+  if ( !action )
+    return false;
+
+  int actionIndex = menu->actions().indexOf( action );
+
+  // The last action is the "Clear recent projects" action
+  if ( actionIndex == menu->actions().count() - 1 )
+    return false;
+
+  QModelIndex modelIndex = mWelcomePage->recentProjectsModel()->index( actionIndex, 0 );
+  const bool pinned = mWelcomePage->recentProjectsModel()->data( modelIndex, QgsProjectListItemDelegate::PinRole ).toBool();
+
+  QMenu subMenu;
+  if ( pinned )
+  {
+    QAction *unpin = subMenu.addAction( tr( "Unpin" ) );
+    connect( unpin, &QAction::triggered, this, [this, actionIndex] { mWelcomePage->unpinProject( actionIndex ); } );
+  }
+  else
+  {
+    QAction *remove = subMenu.addAction( tr( "Remove" ) );
+    QAction *pin = subMenu.addAction( tr( "Pin" ) );
+    connect( remove, &QAction::triggered, this, [this, actionIndex] { mWelcomePage->removeProject( actionIndex ); } );
+    connect( pin, &QAction::triggered, this, [this, actionIndex] { mWelcomePage->pinProject( actionIndex ); } );
+  }
+  subMenu.exec( menu->mapToGlobal( mouseEvent->pos() ) );
+  return true;
+}

--- a/src/app/qgsrecentprojectsmenueventfilter.h
+++ b/src/app/qgsrecentprojectsmenueventfilter.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+               qgsrecentprojectsmenueventfilter.h
+               ----------------------------------------------------
+    begin                : August 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRECENTPROJECTSMENUEVENTFILTER_H
+#define QGSRECENTPROJECTSMENUEVENTFILTER_H
+
+#include <QObject>
+
+class QgsWelcomePage;
+
+class QgsRecentProjectsMenuEventFilter : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    QgsRecentProjectsMenuEventFilter( QgsWelcomePage *welcomePage = nullptr, QObject *parent = nullptr );
+
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+
+  private:
+    QgsWelcomePage *mWelcomePage;
+};
+
+#endif // QGSRECENTPROJECTSMENUEVENTFILTER_H

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -477,7 +477,20 @@ void QgsWelcomePage::unpinProject( int row )
 
 void QgsWelcomePage::clearRecentProjects( bool clearPinned )
 {
-  mRecentProjectsModel->clear( clearPinned );
-  emit projectsCleared();
+  QString message;
+  if ( clearPinned )
+  {
+    message = tr( "Are you sure you want to clear the list of recent projects, including pinned projects?" );
+  }
+  else
+  {
+    message = tr( "Are you sure you want to clear the list of recent projects?" );
+  }
+
+  if ( QMessageBox::question( this,  tr( "Recent Projects" ), message ) == QMessageBox::Yes )
+  {
+    mRecentProjectsModel->clear( clearPinned );
+    emit projectsCleared();
+  }
 }
 

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -255,7 +255,10 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
     const bool pin = mRecentProjectsModel->data( index, QgsProjectListItemDelegate::PinRole ).toBool();
     QString path = mRecentProjectsModel->data( index, QgsProjectListItemDelegate::PathRole ).toString();
     if ( path.isEmpty() )
+    {
+      delete menu;
       return;
+    }
 
     QgsProjectStorage *storage = QgsApplication::projectStorageRegistry()->projectStorageFromUri( path );
     const bool enabled = mRecentProjectsModel->flags( index ) & Qt::ItemIsEnabled;

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -200,6 +200,11 @@ QString QgsWelcomePage::newsFeedUrl()
   return QStringLiteral( FEED_URL );
 }
 
+QgsRecentProjectItemsModel *QgsWelcomePage::recentProjectsModel()
+{
+  return mRecentProjectsModel;
+}
+
 void QgsWelcomePage::recentProjectItemActivated( const QModelIndex &index )
 {
   QgisApp::instance()->openProject( mRecentProjectsModel->data( index, Qt::ToolTipRole ).toString() );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -259,8 +259,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
       QAction *pinAction = new QAction( tr( "Pin to List" ), menu );
       connect( pinAction, &QAction::triggered, this, [this, index]
       {
-        mRecentProjectsModel->pinProject( index );
-        emit projectPinned( index.row() );
+        pinProject( index.row() );
       } );
       menu->addAction( pinAction );
     }
@@ -269,8 +268,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
       QAction *pinAction = new QAction( tr( "Unpin from List" ), menu );
       connect( pinAction, &QAction::triggered, this, [this, index]
       {
-        mRecentProjectsModel->unpinProject( index );
-        emit projectUnpinned( index.row() );
+        unpinProject( index.row() );
       } );
       menu->addAction( pinAction );
     }
@@ -328,8 +326,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
   QAction *removeProjectAction = new QAction( tr( "Remove from List" ), menu );
   connect( removeProjectAction, &QAction::triggered, this, [this, index]
   {
-    mRecentProjectsModel->removeProject( index );
-    emit projectRemoved( index.row() );
+    removeProject( index.row() );
   } );
   menu->addAction( removeProjectAction );
 
@@ -453,5 +450,29 @@ bool QgsWelcomePage::eventFilter( QObject *obj, QEvent *event )
   }
 
   return QWidget::eventFilter( obj, event );
+}
+
+void QgsWelcomePage::removeProject( int row )
+{
+  mRecentProjectsModel->removeProject( mRecentProjectsModel->index( row ) );
+  emit projectRemoved( row );
+}
+
+void QgsWelcomePage::pinProject( int row )
+{
+  mRecentProjectsModel->pinProject( mRecentProjectsModel->index( row ) );
+  emit projectPinned( row );
+}
+
+void QgsWelcomePage::unpinProject( int row )
+{
+  mRecentProjectsModel->unpinProject( mRecentProjectsModel->index( row ) );
+  emit projectUnpinned( row );
+}
+
+void QgsWelcomePage::clearRecentProjects( bool clearPinned )
+{
+  mRecentProjectsModel->clear( clearPinned );
+  emit projectsCleared();
 }
 

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -47,6 +47,8 @@ class QgsWelcomePage : public QWidget
      */
     static QString newsFeedUrl();
 
+    QgsRecentProjectItemsModel *recentProjectsModel();
+
   public slots:
     void removeProject( int row );
     void pinProject( int row );

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -47,10 +47,17 @@ class QgsWelcomePage : public QWidget
      */
     static QString newsFeedUrl();
 
+  public slots:
+    void removeProject( int row );
+    void pinProject( int row );
+    void unpinProject( int row );
+    void clearRecentProjects( bool clearPinned = false );
+
   signals:
     void projectRemoved( int row );
     void projectPinned( int row );
     void projectUnpinned( int row );
+    void projectsCleared();
 
   protected:
     bool eventFilter( QObject *obj, QEvent *event ) override;

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -59,7 +59,7 @@ class QgsWelcomePage : public QWidget
     void projectRemoved( int row );
     void projectPinned( int row );
     void projectUnpinned( int row );
-    void projectsCleared();
+    void projectsCleared( bool clearPinned );
 
   protected:
     bool eventFilter( QObject *obj, QEvent *event ) override;


### PR DESCRIPTION
- Fixes #44478

## Description

Adds a "Clear Recently Opened" action in the recent projects menu, that removes every unpinned project from the menu.

Adds a context menu on individual entries, with the following actions
- "Remove" and "Pin" for unpinned projects
- "Unpin" for pinned projects

State is synchronized between the recent projects menu, and the QGIS Welcome Page.

![clear_recent](https://github.com/qgis/QGIS/assets/9693475/f9bbfa26-9d82-4c17-ba01-9bf7a20a3e00)

