### PR TITLE
processing: Fix some gdal vector tests for GEOS 3.11 and above

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/gdal/geos311/clip_lines_by_multipolygon.gml
+++ b/python/plugins/processing/tests/testdata/expected/gdal/geos311/clip_lines_by_multipolygon.gml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ clip_lines_by_multipolygon.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>2</gml:X><gml:Y>-1</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+
+  <gml:featureMember>
+    <ogr:lines fid="lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,2 8,2</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:lines fid="lines.2">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>3,2 3,3</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>2,1 2,2</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>2,2 3,2</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+    </ogr:lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:lines fid="lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>4,1 3,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:lines fid="lines.6">
+    </ogr:lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/gdal/geos311/clip_lines_by_multipolygon.xsd
+++ b/python/plugins/processing/tests/testdata/expected/gdal/geos311/clip_lines_by_multipolygon.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="lines" type="ogr:lines_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="lines_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/gdal/geos311/offset_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/gdal/geos311/offset_lines.gml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ offset_lines.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-3.5 -1</gml:lowerCorner><gml:upperCorner>4.64644660940673 11.3535533905933</gml:upperCorner></gml:Envelope></gml:boundedBy>
+
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1.5 6.0</gml:lowerCorner><gml:upperCorner>4.64644660940673 11.3535533905933</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.0"><gml:posList>1.5 6.0 1.5 9.0 1.5024076366639 9.04900857016478 1.50960735979838 9.09754516100806 1.5215298321339 9.14514233862723 1.53806023374436 9.19134171618255 1.55903936782582 9.235698368413 1.58426519384873 9.2777851165098 1.61349477331863 9.31719664208182 1.64644660940673 9.35355339059327 1.68280335791818 9.38650522668137 1.7222148834902 9.41573480615127 1.764301631587 9.44096063217418 1.80865828381746 9.46193976625564 1.85485766137277 9.4784701678661 1.90245483899194 9.49039264020162 1.95099142983522 9.4975923633361 2.0 9.5 2.79289321881345 9.5 4.64644660940673 11.3535533905933</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.0</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1.5 -1</gml:lowerCorner><gml:upperCorner>-1.5 1.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.1"><gml:posList>-1.5 -1 -1.5 1.0</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.1</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0.0 2.5</gml:lowerCorner><gml:upperCorner>3.0 3.5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.2"><gml:posList>0.0 2.5 1.5 2.5 1.5 3.0 1.5024076366639 3.04900857016478 1.50960735979838 3.09754516100806 1.5215298321339 3.14514233862723 1.53806023374436 3.19134171618254 1.55903936782582 3.235698368413 1.58426519384873 3.2777851165098 1.61349477331863 3.31719664208182 1.64644660940673 3.35355339059327 1.68280335791818 3.38650522668137 1.7222148834902 3.41573480615127 1.764301631587 3.44096063217418 1.80865828381746 3.46193976625564 1.85485766137277 3.4784701678661 1.90245483899194 3.49039264020162 1.95099142983522 3.4975923633361 2.0 3.5 3.0 3.5</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.2</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0.5 3.0</gml:lowerCorner><gml:upperCorner>0.5 5.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.3"><gml:posList>0.5 3.0 0.5 5.0</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.3</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-3.5 7.0</gml:lowerCorner><gml:upperCorner>-3.5 10.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.4"><gml:posList>-3.5 7.0 -3.5 10.0</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.4</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:SELECT gml:id="SELECT.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-3.35355339059327 6.35355339059327</gml:lowerCorner><gml:upperCorner>0.64644660940673 10.3535533905933</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" gml:id="SELECT.geom.5"><gml:posList>-3.35355339059327 6.35355339059327 0.64644660940673 10.3535533905933</gml:posList></gml:LineString></ogr:geometryProperty>
+      <ogr:fid>lines.5</ogr:fid>
+    </ogr:SELECT>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/gdal/geos311/offset_lines.xsd
+++ b/python/plugins/processing/tests/testdata/expected/gdal/geos311/offset_lines.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="SELECT" type="ogr:SELECT_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="SELECT_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:CurvePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to LineString --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
@@ -156,7 +156,28 @@ tests:
 #        type: vector
 
   - algorithm: gdal:clipvectorbypolygon
-    name: Clip lines by multipolygons
+    name: Clip lines by multipolygons (GEOS >= 3.11)
+    condition:
+      geos:
+        at_least: 31100
+    params:
+      INPUT:
+        name: lines.gml
+        type: vector
+      MASK:
+        name: multipolys.gml
+        type: vector
+      OPTIONS: ''
+    results:
+      OUTPUT:
+        name: expected/gdal/geos311/clip_lines_by_multipolygon.gml
+        type: vector
+
+  - algorithm: gdal:clipvectorbypolygon
+    name: Clip lines by multipolygons (GEOS < 3.11)
+    condition:
+      geos:
+        less_than: 31100
     params:
       INPUT:
         name: lines.gml
@@ -185,7 +206,31 @@ tests:
         type: vector
 
   - algorithm: gdal:offsetcurve
-    name: Offset curve (right-sided)
+    name: Offset curve (right-sided) (GEOS >= 3.11)
+    condition:
+      geos:
+        at_least: 31100
+    params:
+      DISTANCE: -0.5
+      GEOMETRY: geometry
+      INPUT:
+        name: lines.gml
+        type: vector
+      OPTIONS: ''
+    results:
+      OUTPUT:
+        name: expected/gdal/geos311/offset_lines.gml
+        type: vector
+        compare:
+          ignore_crs_check: true
+          geometry:
+            explode_collections: true
+
+  - algorithm: gdal:offsetcurve
+    name: Offset curve (right-sided) (GEOS < 3.11)
+    condition:
+      geos:
+        less_than: 31100
     params:
       DISTANCE: -0.5
       GEOMETRY: geometry

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_vector_tests.yaml
@@ -313,4 +313,3 @@ tests:
         compare:
           fields:
             fid: skip
-


### PR DESCRIPTION
This has been tested with GEOS 3.10, 3.11 and 3.12.

cc @lbartoletti 