### PR TITLE
Handle PJ_TYPE_COORDINATE_METADATA in switch

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1366,6 +1366,8 @@ Qgis::CrsType QgsCoordinateReferenceSystem::type() const
 #if PROJ_VERSION_MAJOR>9 || (PROJ_VERSION_MAJOR==9 && PROJ_VERSION_MINOR>=2)
     case PJ_TYPE_DERIVED_PROJECTED_CRS:
       return Qgis::CrsType::DerivedProjected;
+    case PJ_TYPE_COORDINATE_METADATA:
+      return Qgis::CrsType::Other;
 #endif
   }
   return Qgis::CrsType::Unknown;
@@ -2678,8 +2680,9 @@ int QgsCoordinateReferenceSystem::syncDatabase()
         case PJ_TYPE_DERIVED_PROJECTED_CRS:
           srsTypeString = qgsEnumValueToKey( Qgis::CrsType::DerivedProjected );
           break;
+        case PJ_TYPE_COORDINATE_METADATA:
+          continue;
 #endif
-
         case PJ_TYPE_OTHER_CRS:
           srsTypeString = qgsEnumValueToKey( Qgis::CrsType::Other );
           break;


### PR DESCRIPTION
Lastly on ArchLinux with Proj v9.2.1:

``` console
/home/pblottiere/devel/qgis/QGIS/src/core/proj/qgscoordinatereferencesystem.cpp:1318:10: warning: enumeration value ‘PJ_TYPE_COORDINATE_METADATA’ not handled in switch [-Wswitch]
 1318 |   switch ( d->mProjType )
      |          ^
/home/pblottiere/devel/qgis/QGIS/src/core/proj/qgscoordinatereferencesystem.cpp: In static member function ‘static int QgsCoordinateReferenceSystem::syncDatabase()’:
/home/pblottiere/devel/qgis/QGIS/src/core/proj/qgscoordinatereferencesystem.cpp:2613:14: warning: enumeration value ‘PJ_TYPE_COORDINATE_METADATA’ not handled in switch [-Wswitch]
 2613 |       switch ( pjType )
      |              ^
```

But I'm not sure it's  the preferable way to manage `PJ_TYPE_COORDINATE_METADATA`...