### PR TITLE
Add option to auto-open exported layouts

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -23,6 +23,8 @@ Handles rendering and exports of layouts to various formats.
 %End
   public:
 
+    static const QgsSettingsEntryBool *settingOpenAfterExportingPdf;
+
     struct PageExportDetails
     {
       QString directory;

--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -23,7 +23,8 @@ Handles rendering and exports of layouts to various formats.
 %End
   public:
 
-    static const QgsSettingsEntryBool *settingOpenAfterExportingPdf;
+
+
 
     struct PageExportDetails
     {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -98,6 +98,7 @@
 #include <QWindow>
 #include <QScreen>
 #include <QActionGroup>
+#include <QDesktopServices>
 
 #ifdef Q_OS_MACX
 #include <ApplicationServices/ApplicationServices.h>
@@ -2386,6 +2387,12 @@ void QgsLayoutDesignerDialog::exportToPdf()
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( outputFileName ).toString(), QDir::toNativeSeparators( outputFileName ) ),
                                 Qgis::MessageLevel::Success, 0 );
+
+      // Open exported file in the default viewer if enabled
+      if ( QgsLayoutExporter::settingOpenAfterExportingPdf->value() )
+      {
+        QDesktopServices::openUrl( QUrl::fromLocalFile( outputFileName ) );
+      }
       break;
     }
 
@@ -4519,6 +4526,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   dialog.setUseOgcBestPracticeFormat( useOgcBestPracticeFormat );
   dialog.setExportThemes( exportThemes );
   dialog.setLosslessImageExport( losslessImages );
+  dialog.setOpenAfterExporting( QgsLayoutExporter::settingOpenAfterExportingPdf->value() );
 
   if ( dialog.exec() != QDialog::Accepted )
     return false;
@@ -4534,6 +4542,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   exportThemes = dialog.exportThemes();
   geoPdfLayerOrder = dialog.geoPdfLayerOrder();
   losslessImages = dialog.losslessImageExport();
+  QgsLayoutExporter::settingOpenAfterExportingPdf->setValue( dialog.openAfterExporting() );
 
   if ( mLayout )
   {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2511,6 +2511,12 @@ void QgsLayoutDesignerDialog::exportToSvg()
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( outputFileName ).toString(), QDir::toNativeSeparators( outputFileName ) ),
                                 Qgis::MessageLevel::Success, 0 );
+
+      // Open exported file in the default viewer if enabled
+      if ( QgsLayoutExporter::settingOpenAfterExportingSvg->value() )
+      {
+        QDesktopServices::openUrl( QUrl::fromLocalFile( outputFileName ) );
+      }
       break;
     }
 
@@ -4391,7 +4397,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   Ui::QgsSvgExportOptionsDialog options;
   options.setupUi( &dialog );
 
-  connect( options.buttonBox, &QDialogButtonBox::helpRequested, this, [ & ]
+  connect( options.mHelpButtonBox, &QDialogButtonBox::helpRequested, this, [ & ]
   {
     QgsHelp::openHelp( QStringLiteral( "print_composer/create_output.html" ) );
   }
@@ -4411,6 +4417,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
   options.mDisableRasterTilingCheckBox->setChecked( disableRasterTiles );
   options.mSimplifyGeometriesCheckbox->setChecked( simplify );
+  options.mOpenAfterExportingCheckBox->setChecked( QgsLayoutExporter::settingOpenAfterExportingSvg->value() );
 
   if ( dialog.exec() != QDialog::Accepted )
     return false;
@@ -4426,6 +4433,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   disableRasterTiles = options.mDisableRasterTilingCheckBox->isChecked();
   simplify = options.mSimplifyGeometriesCheckbox->isChecked();
   Qgis::TextRenderFormat textRenderFormat = static_cast< Qgis::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
+  QgsLayoutExporter::settingOpenAfterExportingSvg->setValue( options.mOpenAfterExportingCheckBox->isChecked() );
 
   if ( mLayout )
   {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2272,6 +2272,12 @@ void QgsLayoutDesignerDialog::exportToRaster()
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileNExt.first ).toString(), QDir::toNativeSeparators( fileNExt.first ) ),
                                 Qgis::MessageLevel::Success, 0 );
+
+      // Open exported file in the default viewer if enabled
+      if ( QgsLayoutExporter::settingOpenAfterExportingImage->value() )
+      {
+        QDesktopServices::openUrl( QUrl::fromLocalFile( fileNExt.first ) );
+      }
       break;
 
     case QgsLayoutExporter::PrintError:
@@ -4301,6 +4307,7 @@ bool QgsLayoutDesignerDialog::getRasterExportSettings( QgsLayoutExporter::ImageE
   if ( mLayout )
     imageDlg.setGenerateWorldFile( mLayout->customProperty( QStringLiteral( "exportWorldFile" ), false ).toBool() );
   imageDlg.setAntialiasing( antialias );
+  imageDlg.setOpenAfterExporting( QgsLayoutExporter::settingOpenAfterExportingImage->value() );
 
   if ( !imageDlg.exec() )
     return false;
@@ -4308,6 +4315,8 @@ bool QgsLayoutDesignerDialog::getRasterExportSettings( QgsLayoutExporter::ImageE
   imageSize = QSize( imageDlg.imageWidth(), imageDlg.imageHeight() );
   cropToContents = imageDlg.cropToContents();
   imageDlg.getCropMargins( marginTop, marginRight, marginBottom, marginLeft );
+  QgsLayoutExporter::settingOpenAfterExportingImage->setValue( imageDlg.openAfterExporting() );
+
   if ( mLayout )
   {
     mLayout->setCustomProperty( QStringLiteral( "imageCropToContents" ), cropToContents );

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -148,6 +148,7 @@ class LayoutItemHider
 
 const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingImage = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-image" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported image file with the default viewer after exporting a print layout" ) );
 const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingPdf = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-pdf" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported PDF file with the default viewer after exporting a print layout" ) );
+const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingSvg = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-svg" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported SVG file with the default viewer after exporting a print layout" ) );
 
 QgsLayoutExporter::QgsLayoutExporter( QgsLayout *layout )
   : mLayout( layout )

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -27,6 +27,8 @@
 #include "qgslinestring.h"
 #include "qgsmessagelog.h"
 #include "qgslabelingresults.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingstree.h"
 
 #include <QImageWriter>
 #include <QSize>
@@ -143,6 +145,8 @@ class LayoutItemHider
 };
 
 ///@endcond PRIVATE
+
+const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingPdf = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-pdf" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported PDF file with the default viewer after exporting a print layout" ) );
 
 QgsLayoutExporter::QgsLayoutExporter( QgsLayout *layout )
   : mLayout( layout )

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -146,6 +146,7 @@ class LayoutItemHider
 
 ///@endcond PRIVATE
 
+const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingImage = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-image" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported image file with the default viewer after exporting a print layout" ) );
 const QgsSettingsEntryBool *QgsLayoutExporter::settingOpenAfterExportingPdf = new QgsSettingsEntryBool( QStringLiteral( "open-after-exporting-pdf" ), QgsSettingsTree::sTreeLayout, false, QObject::tr( "Whether to open the exported PDF file with the default viewer after exporting a print layout" ) );
 
 QgsLayoutExporter::QgsLayoutExporter( QgsLayout *layout )

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -39,6 +39,7 @@ class QgsLayoutItemMap;
 class QgsAbstractLayoutIterator;
 class QgsFeedback;
 class QgsLabelingResults;
+class QgsSettingsEntryBool;
 
 /**
  * \ingroup core
@@ -50,6 +51,9 @@ class CORE_EXPORT QgsLayoutExporter
 {
 
   public:
+
+    //! Settings entry - Whether to automatically open pdfs after exporting them \since QGIS 3.34
+    static const QgsSettingsEntryBool *settingOpenAfterExportingPdf;
 
     //! Contains details of a page being exported by the class
     struct PageExportDetails

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -58,6 +58,9 @@ class CORE_EXPORT QgsLayoutExporter
     //! Settings entry - Whether to automatically open pdfs after exporting them \since QGIS 3.34
     static const QgsSettingsEntryBool *settingOpenAfterExportingPdf SIP_SKIP;
 
+    //! Settings entry - Whether to automatically open svgs after exporting them \since QGIS 3.34
+    static const QgsSettingsEntryBool *settingOpenAfterExportingSvg SIP_SKIP;
+
     //! Contains details of a page being exported by the class
     struct PageExportDetails
     {

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsLayoutExporter
   public:
 
     //! Settings entry - Whether to automatically open pdfs after exporting them \since QGIS 3.34
-    static const QgsSettingsEntryBool *settingOpenAfterExportingPdf;
+    static const QgsSettingsEntryBool *settingOpenAfterExportingPdf SIP_SKIP;
 
     //! Contains details of a page being exported by the class
     struct PageExportDetails

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -52,6 +52,9 @@ class CORE_EXPORT QgsLayoutExporter
 
   public:
 
+    //! Settings entry - Whether to automatically open images after exporting them \since QGIS 3.34
+    static const QgsSettingsEntryBool *settingOpenAfterExportingImage SIP_SKIP;
+
     //! Settings entry - Whether to automatically open pdfs after exporting them \since QGIS 3.34
     static const QgsSettingsEntryBool *settingOpenAfterExportingPdf SIP_SKIP;
 

--- a/src/gui/layout/qgslayoutimageexportoptionsdialog.cpp
+++ b/src/gui/layout/qgslayoutimageexportoptionsdialog.cpp
@@ -33,7 +33,7 @@ QgsLayoutImageExportOptionsDialog::QgsLayoutImageExportOptionsDialog( QWidget *p
   connect( mResolutionSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsLayoutImageExportOptionsDialog::mResolutionSpinBox_valueChanged );
 
   connect( mClipToContentGroupBox, &QGroupBox::toggled, this, &QgsLayoutImageExportOptionsDialog::clipToContentsToggled );
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutImageExportOptionsDialog::showHelp );
+  connect( mHelpButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutImageExportOptionsDialog::showHelp );
   QgsGui::enableAutoGeometryRestore( this );
 }
 
@@ -130,6 +130,16 @@ void QgsLayoutImageExportOptionsDialog::setCropMargins( int topMargin, int right
   mRightMarginSpinBox->setValue( rightMargin );
   mBottomMarginSpinBox->setValue( bottomMargin );
   mLeftMarginSpinBox->setValue( leftMargin );
+}
+
+bool QgsLayoutImageExportOptionsDialog::openAfterExporting() const
+{
+  return mOpenAfterExportingCheckBox->isChecked();
+}
+
+void QgsLayoutImageExportOptionsDialog::setOpenAfterExporting( bool enabled )
+{
+  mOpenAfterExportingCheckBox->setChecked( enabled );
 }
 
 void QgsLayoutImageExportOptionsDialog::mWidthSpinBox_valueChanged( int value )

--- a/src/gui/layout/qgslayoutimageexportoptionsdialog.h
+++ b/src/gui/layout/qgslayoutimageexportoptionsdialog.h
@@ -134,6 +134,11 @@ class GUI_EXPORT QgsLayoutImageExportOptionsDialog: public QDialog, private Ui::
      */
     void setCropMargins( int topMargin, int rightMargin, int bottomMargin, int leftMargin );
 
+    //! Sets whether to open the pdf after exporting it
+    void setOpenAfterExporting( bool enabled );
+    //! Returns whether the pdf should be opened after exporting it
+    bool openAfterExporting() const;
+
   private slots:
 
     void mWidthSpinBox_valueChanged( int value );

--- a/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
+++ b/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
@@ -261,6 +261,16 @@ QStringList QgsLayoutPdfExportOptionsDialog::geoPdfLayerOrder() const
   return order;
 }
 
+void QgsLayoutPdfExportOptionsDialog::setOpenAfterExporting( bool enabled )
+{
+  mOpenAfterExportingCheckBox->setChecked( enabled );
+}
+
+bool QgsLayoutPdfExportOptionsDialog::openAfterExporting() const
+{
+  return mOpenAfterExportingCheckBox->isChecked();
+}
+
 void QgsLayoutPdfExportOptionsDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "print_composer/create_output.html" ) );

--- a/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
+++ b/src/gui/layout/qgslayoutpdfexportoptionsdialog.cpp
@@ -104,7 +104,7 @@ QgsLayoutPdfExportOptionsDialog::QgsLayoutPdfExportOptionsDialog( QWidget *paren
       showContextMenuForGeoPdfStructure( point, mGeoPdfStructureProxyModel->mapToSource( index ) );
   } );
 
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutPdfExportOptionsDialog::showHelp );
+  connect( mHelpButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutPdfExportOptionsDialog::showHelp );
   QgsGui::enableAutoGeometryRestore( this );
 }
 

--- a/src/gui/layout/qgslayoutpdfexportoptionsdialog.h
+++ b/src/gui/layout/qgslayoutpdfexportoptionsdialog.h
@@ -107,6 +107,11 @@ class GUI_EXPORT QgsLayoutPdfExportOptionsDialog: public QDialog, private Ui::Qg
     //! Returns a list of map layer IDs in the desired order they should appear in a generated GeoPDF file
     QStringList geoPdfLayerOrder() const;
 
+    //! Sets whether to open the pdf after exporting it
+    void setOpenAfterExporting( bool enabled );
+    //! Returns whether the pdf should be opened after exporting it
+    bool openAfterExporting() const;
+
   private slots:
 
     void showHelp();

--- a/src/ui/layout/qgslayoutimageexportoptions.ui
+++ b/src/ui/layout/qgslayoutimageexportoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>533</width>
-    <height>424</height>
+    <width>565</width>
+    <height>524</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,26 +27,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2" colspan="2">
-       <widget class="QgsSpinBox" name="mResolutionSpinBox">
-        <property name="suffix">
-         <string> dpi</string>
+      <item row="3" column="0" colspan="5">
+       <widget class="QCheckBox" name="mAntialiasingCheckBox">
+        <property name="toolTip">
+         <string>If unchecked, the generated images will not be antialiased</string>
         </property>
-        <property name="prefix">
-         <string/>
-        </property>
-        <property name="maximum">
-         <number>3000</number>
-        </property>
-        <property name="showClearButton" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Export resolution</string>
+         <string>Enable antialiasing</string>
         </property>
        </widget>
       </item>
@@ -67,7 +54,46 @@
         <property name="maximum">
          <number>99999999</number>
         </property>
-        <property name="showClearButton" stdset="0">
+        <property name="showClearButton">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="5">
+       <widget class="QCheckBox" name="mGenerateWorldFile">
+        <property name="toolTip">
+         <string>If checked, a separate world file which georeferences exported images will be created</string>
+        </property>
+        <property name="text">
+         <string>Generate world file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="2" colspan="2">
+       <widget class="QgsSpinBox" name="mResolutionSpinBox">
+        <property name="suffix">
+         <string> dpi</string>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="maximum">
+         <number>3000</number>
+        </property>
+        <property name="showClearButton">
          <bool>false</bool>
         </property>
        </widget>
@@ -96,41 +122,15 @@
         <property name="maximum">
          <number>99999999</number>
         </property>
-        <property name="showClearButton" stdset="0">
+        <property name="showClearButton">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="4">
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="4" column="0" colspan="5">
-       <widget class="QCheckBox" name="mGenerateWorldFile">
-        <property name="toolTip">
-         <string>If checked, a separate world file which georeferences exported images will be created</string>
-        </property>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Generate world file</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="5">
-       <widget class="QCheckBox" name="mAntialiasingCheckBox">
-        <property name="toolTip">
-         <string>If unchecked, the generated images will not be antialiased</string>
-        </property>
-        <property name="text">
-         <string>Enable antialiasing</string>
+         <string>Export resolution</string>
         </property>
        </widget>
       </item>
@@ -268,28 +268,62 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QDialogButtonBox" name="mHelpButtonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Help</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mOpenAfterExportingCheckBox">
+       <property name="text">
+        <string>Open file after exporting</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>730</height>
+    <height>696</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,7 @@
         <x>0</x>
         <y>0</y>
         <width>457</width>
-        <height>944</height>
+        <height>973</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -50,15 +50,18 @@
           <string>Export Options</string>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
             <property name="text">
-             <string>Text export</string>
+             <string>Export RDF metadata (title, author, etc.)</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="mComboImageCompression"/>
           </item>
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="mForceVectorCheckBox">
@@ -70,20 +73,20 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Text export</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+          </item>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="mAppendGeoreferenceCheckbox">
             <property name="text">
              <string>Append georeference information</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
-            <property name="text">
-             <string>Export RDF metadata (title, author, etc.)</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -97,8 +100,12 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QComboBox" name="mComboImageCompression"/>
+          <item row="6" column="0" colspan="2">
+           <widget class="QCheckBox" name="mOpenAfterExportingCheckBox">
+            <property name="text">
+             <string>Open file after exporting</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -324,13 +331,14 @@
   <tabstop>mIncludeMetadataCheckbox</tabstop>
   <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mComboImageCompression</tabstop>
+  <tabstop>mOpenAfterExportingCheckBox</tabstop>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
   <tabstop>mIncludeMapThemesCheck</tabstop>
   <tabstop>mThemesList</tabstop>
   <tabstop>mGeoPdfStructureTree</tabstop>
-  <tabstop>mDisableRasterTilingCheckBox</tabstop>
   <tabstop>mSimplifyGeometriesCheckbox</tabstop>
+  <tabstop>mDisableRasterTilingCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>489</width>
-    <height>696</height>
+    <width>565</width>
+    <height>773</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,8 +27,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>457</width>
-        <height>973</height>
+        <width>533</width>
+        <height>944</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -97,13 +97,6 @@
            <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Image compression</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="2">
-           <widget class="QCheckBox" name="mOpenAfterExportingCheckBox">
-            <property name="text">
-             <string>Open file after exporting</string>
             </property>
            </widget>
           </item>
@@ -299,14 +292,48 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QDialogButtonBox" name="mHelpButtonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Help</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mOpenAfterExportingCheckBox">
+       <property name="text">
+        <string>Open file after exporting</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -331,7 +358,6 @@
   <tabstop>mIncludeMetadataCheckbox</tabstop>
   <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mComboImageCompression</tabstop>
-  <tabstop>mOpenAfterExportingCheckBox</tabstop>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
   <tabstop>mIncludeMapThemesCheck</tabstop>

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>489</width>
-    <height>483</height>
+    <width>565</width>
+    <height>486</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,18 +20,15 @@
       <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkMapLayersAsGroup">
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
         <property name="text">
-         <string>Export map layers as SVG groups</string>
+         <string>Simplify geometries to reduce output file size</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
       </item>
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
@@ -40,6 +37,13 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Text export</string>
         </property>
        </widget>
       </item>
@@ -53,22 +57,18 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_6">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkMapLayersAsGroup">
         <property name="text">
-         <string>Text export</string>
+         <string>Export map layers as SVG groups</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
-        <property name="text">
-         <string>Simplify geometries to reduce output file size</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
       </item>
      </layout>
     </widget>
@@ -214,28 +214,62 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QDialogButtonBox" name="mHelpButtonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Help</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mOpenAfterExportingCheckBox">
+       <property name="text">
+        <string>Open file after exporting</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
- Fixes #54139

## Description

Add a checkbox in the Print Layout PDF, SVG and Image export dialogs to automatically open the exported file with the default PDF/SVG/Image viewer (`QDesktopServices::openUrl`)

![pdf_export_settings](https://github.com/qgis/QGIS/assets/9693475/6f58334c-ea58-4cba-8dc0-bd41f3099764)

![svg_export_settings](https://github.com/qgis/QGIS/assets/9693475/db1bed00-f06a-4491-b853-e97d1779588e)


![image_export_settings](https://github.com/qgis/QGIS/assets/9693475/dfb71acd-98ae-4490-a736-af21214de9fb)

This is a user setting, using the kinda new settings API (`QgsSettingsEntryBool` / `QgsSettingsTree`)