### PR TITLE
Rename "Query Builder" dialog into "Provider Filter" and display layername in dialog title

### DIFF
--- a/python/gui/auto_generated/qgsquerybuilder.sip.in
+++ b/python/gui/auto_generated/qgsquerybuilder.sip.in
@@ -114,8 +114,6 @@ Load query from the XML file
 .. versionadded:: 3.16
 %End
 
-    void setDatasourceDescription( const QString &uri );
-
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/gui/qgspointcloudquerybuilder.cpp
+++ b/src/gui/qgspointcloudquerybuilder.cpp
@@ -74,7 +74,7 @@ QgsPointCloudQueryBuilder::QgsPointCloudQueryBuilder( QgsPointCloudLayer *layer,
 
   mOrigSubsetString = layer->subsetString();
 
-  lblDataUri->setText( tr( "Set provider filter on %1" ).arg( layer->name() ) );
+  setWindowTitle( tr( "Provider Filter - %1" ).arg( layer->name() ) );
   mTxtSql->setText( mOrigSubsetString );
 }
 

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -87,7 +87,7 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   connect( layer, &QgsVectorLayer::subsetStringChanged, this, &QgsQueryBuilder::layerSubsetStringChanged );
   layerSubsetStringChanged();
 
-  lblDataUri->setText( tr( "Set provider filter on %1" ).arg( layer->name() ) );
+  setWindowTitle( tr( "Provider Filter - %1" ).arg( layer->name() ) );
   mTxtSql->setText( mOrigSubsetString );
 
   mFilterLineEdit->setShowSearchIcon( true );
@@ -451,11 +451,6 @@ void QgsQueryBuilder::btnILike_clicked()
 {
   mTxtSql->insertText( QStringLiteral( " ILIKE " ) );
   mTxtSql->setFocus();
-}
-
-void QgsQueryBuilder::setDatasourceDescription( const QString &uri )
-{
-  lblDataUri->setText( uri );
 }
 
 void QgsQueryBuilder::showHelp()

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -131,8 +131,6 @@ class GUI_EXPORT QgsQueryBuilder : public QgsSubsetStringEditorInterface, privat
      */
     void loadQuery();
 
-    void setDatasourceDescription( const QString &uri );
-
   private slots:
     void btnEqual_clicked();
     void btnLessThan_clicked();

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -63,7 +63,8 @@ QgsSearchQueryBuilder::QgsSearchQueryBuilder( QgsVectorLayer *layer,
   setupListViews();
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsSearchQueryBuilder::showHelp );
 
-  setWindowTitle( tr( "Search Query Builder" ) );
+  if ( layer )
+    setWindowTitle( tr( "Search Query Builder - %1" ).arg( layer->name() ) );
 
   QPushButton *pbn = new QPushButton( tr( "&Test" ) );
   buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
@@ -83,8 +84,6 @@ QgsSearchQueryBuilder::QgsSearchQueryBuilder( QgsVectorLayer *layer,
   pbn->setToolTip( tr( "Load query from xml file" ) );
   connect( pbn, &QAbstractButton::clicked, this, &QgsSearchQueryBuilder::loadQuery );
 
-  if ( layer )
-    lblDataUri->setText( layer->name() );
   populateFields();
 }
 

--- a/src/ui/pointcloud/qgspointcloudquerybuilderbase.ui
+++ b/src/ui/pointcloud/qgspointcloudquerybuilderbase.ui
@@ -19,7 +19,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Query Builder</string>
+   <string>Provider Filter</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -30,13 +30,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="lblDataUri">
-     <property name="text">
-      <string>Datasource</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QSplitter" name="splitter_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -259,7 +252,7 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -268,7 +261,6 @@
    </item>
   </layout>
   <zorder>splitter_2</zorder>
-  <zorder>lblDataUri</zorder>
   <zorder>buttonBox</zorder>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/ui/qgsquerybuilderbase.ui
+++ b/src/ui/qgsquerybuilderbase.ui
@@ -19,7 +19,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Query Builder</string>
+   <string>Provider Filter</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -30,13 +30,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="lblDataUri">
-     <property name="text">
-      <string>Datasource</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QSplitter" name="splitter_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -332,7 +325,7 @@ p, li { white-space: pre-wrap; }
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
@@ -341,7 +334,6 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
   <zorder>splitter_2</zorder>
-  <zorder>lblDataUri</zorder>
   <zorder>buttonBox</zorder>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
Hopefully this makes the dialog purpose and scope more obvious. The new title is taken from an almost visible text in the top of the settings. Though TBH I feel like "provider" is a dev jargon and maybe "Filter at source" would be clearer for end users?
Before
![image](https://github.com/qgis/QGIS/assets/7983394/20f9c9c3-5532-4b1a-a09e-a07b8235d29e)
After
![image](https://github.com/qgis/QGIS/assets/7983394/b6586924-5000-4475-bbbb-728cdfdd4ad6)
