### PR TITLE
When rendering tile borders for tiled scenes in 2d, also overlay the tile ids onto the tiles

### DIFF
--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -29,6 +29,7 @@
 #include "qgsgltfutils.h"
 #include "qgscesiumutils.h"
 #include "qgscurvepolygon.h"
+#include "qgstextrenderer.h"
 
 #include <QMatrix4x4>
 
@@ -261,6 +262,15 @@ bool QgsTiledSceneLayerRenderer::renderTiles( QgsTiledSceneRenderContext &contex
       painter->setPen( pen );
       painter->setBrush( brush );
       painter->drawPolygon( tile.boundary );
+#if 1
+      QgsTextFormat format;
+      format.setColor( QColor( 255, 0, 0 ) );
+      format.buffer().setEnabled( true );
+
+      QgsTextRenderer::drawText( QRectF( QPoint( 0, 0 ), renderContext()->outputSize() ).intersected( tile.boundary.boundingRect() ),
+                                 0, Qgis::TextHorizontalAlignment::Center, { tile.id },
+                                 *renderContext(), format, true, Qgis::TextVerticalAlignment::VerticalCenter );
+#endif
     }
   }
 
@@ -297,6 +307,7 @@ void QgsTiledSceneLayerRenderer::renderTile( const QgsTiledSceneTile &tile, QgsT
         TileDetails details;
         details.boundary = volumePolygon;
         details.hasContent = hasContent;
+        details.id = QString::number( tile.id() );
         mTileDetails.append( details );
       }
     }

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.h
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.h
@@ -129,6 +129,7 @@ class CORE_EXPORT QgsTiledSceneLayerRenderer: public QgsMapLayerRenderer
     {
       QPolygonF boundary;
       bool hasContent = false;
+      QString id;
     };
     QVector< TileDetails > mTileDetails;
 


### PR DESCRIPTION
This matches what we do for vector tiles, and makes it easier to debug what's happening with individual tile content