### PR TITLE
[3D] crash - Fix terrain reloading

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -714,6 +714,7 @@ void QgsChunkedEntity::cancelActiveJob( QgsChunkQueueJob *job )
   Q_ASSERT( job );
 
   QgsChunkNode *node = job->chunk();
+  disconnect( job, &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
 
   if ( qobject_cast<QgsChunkLoader *>( job ) )
   {

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -670,11 +670,8 @@ void QgsChunkedEntity::onActiveJobFinished()
 
 void QgsChunkedEntity::startJobs()
 {
-  while ( mActiveJobs.count() < 4 )
+  while ( mActiveJobs.count() < 4 && !mChunkLoaderQueue->isEmpty() )
   {
-    if ( mChunkLoaderQueue->isEmpty() )
-      return;
-
     QgsChunkListEntry *entry = mChunkLoaderQueue->takeFirst();
     Q_ASSERT( entry );
     QgsChunkNode *node = entry->chunk;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -473,7 +473,7 @@ void Qgs3DMapScene::createTerrain()
   {
     mSceneEntities.removeOne( mTerrain );
 
-    mTerrain->deleteLater();
+    delete mTerrain;
     mTerrain = nullptr;
   }
 


### PR DESCRIPTION
## Description

This PR fixes a crash which occurs when a new terrain is loaded while the current terrain is still loading. This can easily be reproduced by quickly clicking 2 times on the `Apply` button of the 3d configuration dialog.

`QgsChunkedEntity` does not properly handle the cancellation and there is no mechanism to stop the `QgsChunkedEntity` jobs from the terrain generator. This PR tries to fix those issues.

From the main commit message: 

When a terrain (a `QgsTerrainEntity`) is replaced by a new one (in
`Qgs3DMapSettings::setTerrainGenerator()`),
`Qgs3DMapScene::createTerrain()` is called. This method removes the
existing `QgsTerrainEntity` and creates a new one. However, if some
jobs are still running on the existing terrain, this results in a
crash because the existing jobs then try to delete objects which have
already been freed by the deletion of the terrain.

This issue is fixed by stopping all the existing jobs and by
preventing the creation of new jobs when a terrain is removed before
the creation of the new one. This is achieved by adding a new public
method `stopAllJobs` to `QgsChunkedEntity`.

cc @wonder-sk @benoitdm-oslandia 