### PR TITLE
correctly handle composite file extensions like tar.gz or copc.laz in QgsFileUtils

### DIFF
--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -57,7 +57,7 @@ QString QgsFileUtils::representFileSize( qint64 bytes )
 
 QStringList QgsFileUtils::extensionsFromFilter( const QString &filter )
 {
-  const thread_local QRegularExpression rx( QStringLiteral( "\\*\\.([a-zA-Z0-9]+)" ) );
+  const thread_local QRegularExpression rx( QStringLiteral( "\\*\\.([a-zA-Z0-9\\.]+)" ) );
   QStringList extensions;
   QRegularExpressionMatchIterator matches = rx.globalMatch( filter );
 

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -33,6 +33,7 @@ class TestQgsFileUtils(unittest.TestCase):
         self.assertEqual(QgsFileUtils.extensionsFromFilter('PNG Files (*.png)'), ['png'])
         self.assertEqual(QgsFileUtils.extensionsFromFilter('PNG Files (*.PNG)'), ['PNG'])
         self.assertEqual(QgsFileUtils.extensionsFromFilter('Geotiff Files (*.tiff *.tif)'), ['tiff', 'tif'])
+        self.assertEqual(QgsFileUtils.extensionsFromFilter('TAR.GZ Files (*.tar.gz *.tgz)'), ['tar.gz', 'tgz'])
 
     def testWildcardsFromFilter(self):
         self.assertEqual(QgsFileUtils.wildcardsFromFilter(''), '')


### PR DESCRIPTION
## Description

If file filter has a composite extension like `*.tar.gz` or `*.copc.laz` the `extensionsFromFilter` method strips second part of the extension and returns incomplete/incorrect extension (refs #53476)