### PR TITLE
display more verbose and less cryptic error if user selects unsupported output format

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalassignprojection.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalassignprojection.cpp
@@ -72,7 +72,9 @@ QStringList QgsPdalAssignProjectionAlgorithm::createArgumentLists( const QVarian
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -81,6 +81,7 @@ QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parame
 
   const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args =  { QStringLiteral( "clip" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
@@ -71,7 +71,9 @@ QStringList QgsPdalConvertFormatAlgorithm::createArgumentLists( const QVariantMa
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = { QStringLiteral( "translate" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -76,6 +76,7 @@ QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &para
 
   const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = { QStringLiteral( "translate" ),

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -75,6 +75,18 @@ QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &param
   }
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  if ( outputFile.endsWith( QStringLiteral( ".copc.laz" ), Qt::CaseInsensitive ) )
+    throw QgsProcessingException(
+      QObject::tr( "This algorithm does not support output to COPC. Please use LAS or LAZ as the output format. "
+                   "LAS/LAZ files get automatically converted to COPC when loaded in QGIS, alternatively you can use "
+                   "\"Create COPC\" algorithm." ) );
+
+  if ( outputFile.endsWith( QStringLiteral( ".vpc" ), Qt::CaseInsensitive ) )
+    throw QgsProcessingException(
+      QObject::tr( "This algorithm does not support output to VPC. Please use LAS or LAZ as the output format. "
+                   "To create a VPC please use \"Build virtual point cloud (VPC)\" algorithm." ) );
+
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args;

--- a/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
@@ -78,7 +78,9 @@ QStringList QgsPdalReprojectAlgorithm::createArgumentLists( const QVariantMap &p
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
@@ -75,6 +75,7 @@ QStringList QgsPdalThinByDecimateAlgorithm::createArgumentLists( const QVariantM
 
   const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   int step = parameterAsInt( parameters, QStringLiteral( "POINTS_NUMBER" ), context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthinbyradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthinbyradius.cpp
@@ -75,6 +75,7 @@ QStringList QgsPdalThinByRadiusAlgorithm::createArgumentLists( const QVariantMap
 
   const QString outputName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   QString outputFile = fixOutputFileName( layer->source(), outputName, context );
+  checkOutputFormat( layer->source(), outputFile );
   setOutputValue( QStringLiteral( "OUTPUT" ), outputFile );
 
   double step = parameterAsDouble( parameters, QStringLiteral( "SAMPLING_RADIUS" ), context );

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -130,6 +130,22 @@ QString QgsPdalAlgorithmBase::fixOutputFileName( const QString &inputFileName, c
   return outputFileName;
 }
 
+void QgsPdalAlgorithmBase::checkOutputFormat( const QString &inputFileName, const QString &outputFileName )
+{
+  if ( outputFileName.endsWith( QStringLiteral( ".copc.laz" ), Qt::CaseInsensitive ) )
+    throw QgsProcessingException(
+      QObject::tr( "This algorithm does not support output to COPC. Please use LAS or LAZ as the output format. "
+                   "LAS/LAZ files get automatically converted to COPC when loaded in QGIS, alternatively you can use "
+                   "\"Create COPC\" algorithm." ) );
+
+  bool inputIsVpc = inputFileName.endsWith( QStringLiteral( ".vpc" ), Qt::CaseInsensitive );
+  bool outputIsVpc = outputFileName.endsWith( QStringLiteral( ".vpc" ), Qt::CaseInsensitive );
+  if ( !inputIsVpc && outputIsVpc )
+    throw QgsProcessingException(
+      QObject::tr( "This algorithm does not support output to VPC if input is not a VPC. Please use LAS or LAZ as the output format. "
+                   "To create a VPC please use \"Build virtual point cloud (VPC)\" algorithm." ) );
+}
+
 QStringList QgsPdalAlgorithmBase::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   Q_UNUSED( parameters );

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.h
@@ -66,9 +66,20 @@ class QgsPdalAlgorithmBase : public QgsProcessingAlgorithm
      * This is necessary as pdal_wrench at the moment can create only VPC
      * output if input file is a VPC. We automatically adjust output file
      * extension for temporary outputs to provide better UX. For normal outputs
-     * user will see a error if output files is not a VPC.
+     * user will see a error if output file is not a VPC.
      */
     QString fixOutputFileName( const QString &inputFileName, const QString &outputFileName, QgsProcessingContext &context );
+
+    /**
+     * Checks that output file has correct format (LAS/LAZ) throws an exception
+     * if this is not the case.
+     *
+     * This check is needed because most of the pdal_wrench tools don't support
+     * writing COPC as they are being run in the streaming mode.
+     *
+     * Also checks that output file is not a VPC file when input is not a VPC.
+     */
+    void checkOutputFormat( const QString &inputFileName, const QString &outputFileName );
 
     /**
      * Returns path to the pdal_wrench executable binary.


### PR DESCRIPTION
## Description

Most of the `pdal_wrench` tools does not support COPC as output because they being run in the streaming mode. To make it more clear for end user, check output format and display verbose message. Also (when applicable) warn when VPC output is selected and input is not a VPC.

Fixes #53476.