### PR TITLE
Handle the situation where a stored component type is incorrect

### DIFF
--- a/external/tinygltf/tiny_gltf.h
+++ b/external/tinygltf/tiny_gltf.h
@@ -4740,6 +4740,25 @@ static bool ParseDracoExtension(Primitive *primitive, Model *model,
 
   // create new bufferView for indices
   if (primitive->indices >= 0) {
+    const draco::PointIndex::ValueType numPoint = mesh->num_points();
+    // handle the situation where the stored component type does not match the
+    // required type for the actual number of stored points
+    int supposedComponentType = TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE;
+    if (numPoint < static_cast<draco::PointIndex::ValueType>(
+            std::numeric_limits<uint8_t>::max())) {
+      supposedComponentType = TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE;
+    } else if (
+        numPoint < static_cast<draco::PointIndex::ValueType>(
+            std::numeric_limits<uint16_t>::max())) {
+      supposedComponentType = TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT;
+    } else {
+      supposedComponentType = TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT;
+    }
+
+    if (supposedComponentType > model->accessors[primitive->indices].componentType) {
+      model->accessors[primitive->indices].componentType = supposedComponentType;
+    }
+
     int32_t componentSize = GetComponentSizeInBytes(
         model->accessors[primitive->indices].componentType);
     Buffer decodedIndexBuffer;


### PR DESCRIPTION
...and not sufficient to store the actual number of stored points

Ports the workaround from https://github.com/CesiumGS/cesium-native/blob/d9172461e2d53f19d050ebc39f24a4f4ef5b9224/CesiumGltfReader/src/decodeDraco.cpp#L101

Fixes decoding of tiles from Google Earth (and likely other sources)