### PR TITLE
Add a fallback fill symbol to the 2d tiled scene texture renderer

### DIFF
--- a/python/core/auto_generated/tiledscene/qgstiledscenetexturerenderer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenetexturerenderer.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsTiledSceneTextureRenderer : QgsTiledSceneRenderer
 {
 %Docstring(signature="appended")
@@ -26,6 +27,7 @@ Renders tiled scene layers using textures.
 %Docstring
 Constructor for QgsTiledSceneTextureRenderer.
 %End
+    ~QgsTiledSceneTextureRenderer();
 
     virtual QString type() const;
 
@@ -39,10 +41,37 @@ Constructor for QgsTiledSceneTextureRenderer.
 
     virtual void renderLine( QgsTiledSceneRenderContext &context, const QPolygonF &line );
 
+    virtual void startRender( QgsTiledSceneRenderContext &context );
+
+    virtual void stopRender( QgsTiledSceneRenderContext &context );
+
 
     static QgsTiledSceneRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
 %Docstring
 Creates a textured renderer from an XML ``element``.
+%End
+
+    static QgsFillSymbol *createDefaultFillSymbol() /Factory/;
+%Docstring
+Returns a copy of the default fill symbol used to render triangles without textures.
+
+.. seealso:: :py:func:`setFillSymbol`
+%End
+
+    QgsFillSymbol *fillSymbol() const;
+%Docstring
+Returns the fill symbol used to render triangles without textures.
+
+.. seealso:: :py:func:`setFillSymbol`
+%End
+
+    void setFillSymbol( QgsFillSymbol *symbol /Transfer/ );
+%Docstring
+Sets the fill ``symbol`` used to render triangles without textures.
+
+Ownership of ``symbol`` is transferred.
+
+.. seealso:: :py:func:`fillSymbol`
 %End
 
 };

--- a/src/core/tiledscene/qgstiledscenetexturerenderer.h
+++ b/src/core/tiledscene/qgstiledscenetexturerenderer.h
@@ -22,6 +22,8 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 
+class QgsFillSymbol;
+
 /**
  * \ingroup core
  * \brief Renders tiled scene layers using textures.
@@ -36,6 +38,7 @@ class CORE_EXPORT QgsTiledSceneTextureRenderer : public QgsTiledSceneRenderer
      * Constructor for QgsTiledSceneTextureRenderer.
      */
     QgsTiledSceneTextureRenderer();
+    ~QgsTiledSceneTextureRenderer();
 
     QString type() const override;
     QgsTiledSceneRenderer *clone() const override;
@@ -43,14 +46,39 @@ class CORE_EXPORT QgsTiledSceneTextureRenderer : public QgsTiledSceneRenderer
     Qgis::TiledSceneRendererFlags flags() const override;
     void renderTriangle( QgsTiledSceneRenderContext &context, const QPolygonF &triangle ) override;
     void renderLine( QgsTiledSceneRenderContext &context, const QPolygonF &line ) override;
+    void startRender( QgsTiledSceneRenderContext &context ) override;
+    void stopRender( QgsTiledSceneRenderContext &context ) override;
 
     /**
      * Creates a textured renderer from an XML \a element.
      */
     static QgsTiledSceneRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
 
-  private:
+    /**
+     * Returns a copy of the default fill symbol used to render triangles without textures.
+     *
+     * \see setFillSymbol()
+     */
+    static QgsFillSymbol *createDefaultFillSymbol() SIP_FACTORY;
 
+    /**
+     * Returns the fill symbol used to render triangles without textures.
+     *
+     * \see setFillSymbol()
+     */
+    QgsFillSymbol *fillSymbol() const;
+
+    /**
+     * Sets the fill \a symbol used to render triangles without textures.
+     *
+     * Ownership of \a symbol is transferred.
+     *
+     * \see fillSymbol()
+     */
+    void setFillSymbol( QgsFillSymbol *symbol SIP_TRANSFER );
+
+  private:
+    std::unique_ptr< QgsFillSymbol> mFillSymbol;
 };
 
 #endif // QGSTILEDSCENETEXTURERENDERER_H

--- a/src/core/tiledscene/qgstiledscenewireframerenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenewireframerenderer.cpp
@@ -196,6 +196,8 @@ void QgsTiledSceneWireframeRenderer::renderLine( QgsTiledSceneRenderContext &con
 
 void QgsTiledSceneWireframeRenderer::startRender( QgsTiledSceneRenderContext &context )
 {
+  QgsTiledSceneRenderer::startRender( context );
+
   if ( !mUseTextureColors )
     mFillSymbol->startRender( context.renderContext() );
 
@@ -208,6 +210,8 @@ void QgsTiledSceneWireframeRenderer::stopRender( QgsTiledSceneRenderContext &con
     mFillSymbol->stopRender( context.renderContext() );
 
   mLineSymbol->stopRender( context.renderContext() );
+
+  QgsTiledSceneRenderer::stopRender( context );
 }
 
 Qgis::TiledSceneRendererFlags QgsTiledSceneWireframeRenderer::flags() const

--- a/src/gui/tiledscene/qgstiledscenetexturerendererwidget.cpp
+++ b/src/gui/tiledscene/qgstiledscenetexturerendererwidget.cpp
@@ -18,6 +18,7 @@
 #include "qgstiledscenetexturerendererwidget.h"
 #include "qgstiledscenelayer.h"
 #include "qgstiledscenetexturerenderer.h"
+#include "qgsfillsymbol.h"
 
 ///@cond PRIVATE
 
@@ -26,14 +27,15 @@ QgsTiledSceneTextureRendererWidget::QgsTiledSceneTextureRendererWidget( QgsTiled
 {
   setupUi( this );
 
+  mFillSymbolButton->setSymbolType( Qgis::SymbolType::Fill );
+  mFillSymbolButton->setSymbol( QgsTiledSceneTextureRenderer::createDefaultFillSymbol() );
+
   if ( layer )
   {
     setFromRenderer( layer->renderer() );
   }
-  else
-  {
 
-  }
+  connect( mFillSymbolButton, &QgsSymbolButton::changed, this, &QgsTiledSceneTextureRendererWidget::emitWidgetChanged );
 }
 
 QgsTiledSceneRendererWidget *QgsTiledSceneTextureRendererWidget::create( QgsTiledSceneLayer *layer, QgsStyle *style, QgsTiledSceneRenderer * )
@@ -43,12 +45,8 @@ QgsTiledSceneRendererWidget *QgsTiledSceneTextureRendererWidget::create( QgsTile
 
 QgsTiledSceneRenderer *QgsTiledSceneTextureRendererWidget::renderer()
 {
-  if ( !mLayer )
-  {
-    return nullptr;
-  }
-
   std::unique_ptr< QgsTiledSceneTextureRenderer > renderer = std::make_unique< QgsTiledSceneTextureRenderer >();
+  renderer->setFillSymbol( mFillSymbolButton->clonedSymbol< QgsFillSymbol >() );
 
   return renderer.release();
 }
@@ -59,11 +57,14 @@ void QgsTiledSceneTextureRendererWidget::emitWidgetChanged()
     emit widgetChanged();
 }
 
-void QgsTiledSceneTextureRendererWidget::setFromRenderer( const QgsTiledSceneRenderer * )
+void QgsTiledSceneTextureRendererWidget::setFromRenderer( const QgsTiledSceneRenderer *renderer )
 {
   mBlockChangedSignal = true;
 
-  // TODO
+  if ( const QgsTiledSceneTextureRenderer *textureRenderer = dynamic_cast< const QgsTiledSceneTextureRenderer * >( renderer ) )
+  {
+    mFillSymbolButton->setSymbol( textureRenderer->fillSymbol()->clone() );
+  }
 
   mBlockChangedSignal = false;
 }

--- a/src/ui/tiledscene/qgstiledscenetexturerendererwidgetbase.ui
+++ b/src/ui/tiledscene/qgstiledscenetexturerendererwidgetbase.ui
@@ -13,8 +13,20 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -28,14 +40,37 @@
     </spacer>
    </item>
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Textured scene</string>
+      <string>FiIl symbol</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsSymbolButton" name="mFillSymbolButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Fill symbol to use when scene content has no textures available</string>
+     </property>
+     <property name="text">
+      <string>Change…</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
to use when scenes have no textures available for some primitives

Since there's no way to determine in advance whether or not a scene will actually have textures, this prevents the non-ideal situation arising where no content is shown on the map because we default to the texture renderer and don't have any textures to draw.
