### PR TITLE
[ui][symbology] Fix customized graduated renderer label format and precision not restored

### DIFF
--- a/src/core/classification/qgsclassificationmethod.cpp
+++ b/src/core/classification/qgsclassificationmethod.cpp
@@ -75,7 +75,7 @@ QgsClassificationMethod *QgsClassificationMethod::create( const QDomElement &ele
   }
 
   // label format
-  QDomElement labelFormatElem = element.firstChildElement( QStringLiteral( "labelformat" ) );
+  QDomElement labelFormatElem = element.firstChildElement( QStringLiteral( "labelFormat" ) );
   if ( !labelFormatElem.isNull() )
   {
     QString format = labelFormatElem.attribute( QStringLiteral( "format" ), "%1" + QStringLiteral( " - " ) + "%2" );

--- a/tests/src/python/test_qgsgraduatedsymbolrenderer.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrenderer.py
@@ -356,6 +356,10 @@ class TestQgsGraduatedSymbolRenderer(QgisTestCase):
         range = QgsRendererRange(20.0, 25.5, symbol.clone(), 'Third range', False)
         renderer.addClassRange(range)
 
+        # Add classification method label and precision
+        renderer.classificationMethod().setLabelFormat("111")
+        renderer.classificationMethod().setLabelPrecision(1)
+
         # Add class by lower and upper
         renderer.addClassLowerUpper(25.5, 30.5)
         # (Update label for sorting tests)
@@ -389,6 +393,10 @@ class TestQgsGraduatedSymbolRenderer(QgisTestCase):
             dumpGraduatedRenderer(renderer2),
             "Save/create from DOM doesn't replicate renderer properly"
         )
+
+        # Check classification method label and precision properly created from DOM
+        self.assertEqual(renderer2.classificationMethod().labelFormat(), "111")
+        self.assertEqual(renderer2.classificationMethod().labelPrecision(), 1)
 
         # Check sorting
 


### PR DESCRIPTION
## Description

This PR fixes  #54255, whereas customized graduated renderer label format and precision was not restored properly when loading project or using the layer styling panel. 

![image](https://github.com/qgis/QGIS/assets/1728657/efe12cc3-55c6-407e-ba16-977d702c2d37)

A test was added to make sure we never regress on that front again.