### PR TITLE
[ui] Fix svg selector widget's parameters view not closing field expression when losing focus

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -55,11 +55,6 @@ QgsFieldExpressionWidget::QgsFieldExpressionWidget( QWidget *parent )
   layout->addWidget( mCombo );
   layout->addWidget( mButton );
 
-  // give focus to the combo
-  // hence if the widget is used as a delegate
-  // it will allow pressing on the expression dialog button
-  setFocusProxy( mCombo );
-
   connect( mCombo->lineEdit(), &QLineEdit::textEdited, this, &QgsFieldExpressionWidget::expressionEdited );
   connect( mCombo->lineEdit(), &QLineEdit::editingFinished, this, &QgsFieldExpressionWidget::expressionEditingFinished );
   connect( mCombo, static_cast < void ( QComboBox::* )( int ) > ( &QComboBox::activated ), this, &QgsFieldExpressionWidget::currentFieldChanged );

--- a/src/gui/symbology/qgssvgselectorwidget.h
+++ b/src/gui/symbology/qgssvgselectorwidget.h
@@ -32,7 +32,7 @@
 #include <QWidget>
 #include <QThread>
 #include <QElapsedTimer>
-#include <QStyledItemDelegate>
+#include <QItemDelegate>
 
 
 class QCheckBox;
@@ -124,13 +124,13 @@ class GUI_EXPORT QgsSvgParametersModel : public QAbstractTableModel
  * \brief A delegate which will show a field expression widget to set the value of the SVG parameter
  * \since QGIS 3.18
  */
-class GUI_EXPORT QgsSvgParameterValueDelegate : public QStyledItemDelegate
+class GUI_EXPORT QgsSvgParameterValueDelegate : public QItemDelegate
 {
     Q_OBJECT
 
   public:
     QgsSvgParameterValueDelegate( QObject *parent = nullptr )
-      : QStyledItemDelegate( parent )
+      : QItemDelegate( parent )
     {}
 
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/54336 , whereas modified expression strings for a given SVG parameter could be lost when closing the widget due to focus issue.

@3nids , the root of the issue is this 9-year-old commit of yours (https://github.com/qgis/QGIS/commit/b52299132e2abe1b24fbe820871d3f6e36828402), which I'm wondering if we could let go of now. Pressing on the expression dialog button worked when I tried. Maybe the hack is not necessary anymore in recent versions of Qt?
