### PR TITLE
Improvements to processing model logging

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -41,6 +41,7 @@ expression context.
     {
       DefaultLevel,
       Verbose,
+      ModelDebug,
     };
 
     QgsProcessingContext();

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -146,7 +146,7 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.setLastRunChildAlgorithmInputs(dlg.results().get('CHILD_INPUTS', {}))
 
         dlg = AlgorithmDialog(self.model().create(), parent=self)
-        dlg.setLogLevel(QgsProcessingContext.Verbose)
+        dlg.setLogLevel(QgsProcessingContext.ModelDebug)
         dlg.setParameters(self.model().designerParameterValues())
         dlg.algorithmFinished.connect(on_finished)
         dlg.exec_()

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -474,6 +474,19 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       if ( !ppRes.isEmpty() )
         results = ppRes;
 
+      if ( feedback && !skipGenericLogging )
+      {
+        const QVariantMap displayOutputs = QgsProcessingUtils::removePointerValuesFromMap( results );
+        QStringList formattedOutputs;
+        for ( auto displayOutputIt = displayOutputs.constBegin(); displayOutputIt != displayOutputs.constEnd(); ++displayOutputIt )
+        {
+          formattedOutputs << QStringLiteral( "%1: %2" ).arg( displayOutputIt.key(),
+                           QgsProcessingUtils::variantToPythonLiteral( displayOutputIt.value() ) );;
+        }
+        feedback->pushInfo( QObject::tr( "Results:" ) );
+        feedback->pushCommandInfo( QStringLiteral( "{ %1 }" ).arg( formattedOutputs.join( QLatin1String( ", " ) ) ) );
+      }
+
       childResults.insert( childId, results );
 
       // look through child alg's outputs to determine whether any of these should be copied

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -63,6 +63,7 @@ class CORE_EXPORT QgsProcessingContext
     {
       DefaultLevel = 0, //!< Default logging level
       Verbose, //!< Verbose logging
+      ModelDebug, //!< Model debug level logging. Includes verbose logging and other outputs useful for debugging models (since QGIS 3.34).
     };
 
     /**

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -151,6 +151,7 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
           {
             mContextOptionsWidget = new QgsProcessingContextOptionsWidget();
             mContextOptionsWidget->setFromContext( processingContext() );
+            mContextOptionsWidget->setLogLevel( mLogLevel );
             panel->openPanel( mContextOptionsWidget );
 
             connect( mContextOptionsWidget, &QgsPanelWidget::widgetChanged, this, [ = ]
@@ -161,6 +162,7 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
               mAreaUnits = mContextOptionsWidget->areaUnit();
               mTemporaryFolderOverride = mContextOptionsWidget->temporaryFolder();
               mMaximumThreads = mContextOptionsWidget->maximumThreads();
+              mLogLevel = mContextOptionsWidget->logLevel();
             } );
           }
         }
@@ -954,6 +956,10 @@ QgsProcessingContextOptionsWidget::QgsProcessingContextOptionsWidget( QWidget *p
   mTemporaryFolderWidget->setStorageMode( QgsFileWidget::GetDirectory );
   mTemporaryFolderWidget->lineEdit()->setPlaceholderText( tr( "Default" ) );
 
+  mLogLevelComboBox->addItem( tr( "Default" ), QgsProcessingContext::LogLevel::DefaultLevel );
+  mLogLevelComboBox->addItem( tr( "Verbose" ), QgsProcessingContext::LogLevel::Verbose );
+  mLogLevelComboBox->addItem( tr( "Verbose (Model Debugging)" ), QgsProcessingContext::LogLevel::ModelDebug );
+
   mDistanceUnitsCombo->addItem( tr( "Default" ), QVariant::fromValue( Qgis::DistanceUnit::Unknown ) );
   for ( Qgis::DistanceUnit unit :
         {
@@ -1014,6 +1020,7 @@ QgsProcessingContextOptionsWidget::QgsProcessingContextOptionsWidget( QWidget *p
 
   mThreadsSpinBox->setRange( 1, QThread::idealThreadCount() );
 
+  connect( mLogLevelComboBox, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
   connect( mComboInvalidFeatureFiltering, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
   connect( mDistanceUnitsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
   connect( mAreaUnitsCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
@@ -1028,6 +1035,7 @@ void QgsProcessingContextOptionsWidget::setFromContext( const QgsProcessingConte
   whileBlocking( mAreaUnitsCombo )->setCurrentIndex( mAreaUnitsCombo->findData( QVariant::fromValue( context->areaUnit() ) ) );
   whileBlocking( mTemporaryFolderWidget )->setFilePath( context->temporaryFolder() );
   whileBlocking( mThreadsSpinBox )->setValue( context->maximumThreads() );
+  whileBlocking( mLogLevelComboBox )->setCurrentIndex( mLogLevelComboBox->findData( static_cast< int >( context->logLevel() ) ) );
 }
 
 QgsFeatureRequest::InvalidGeometryCheck QgsProcessingContextOptionsWidget::invalidGeometryCheck() const
@@ -1053,6 +1061,16 @@ QString QgsProcessingContextOptionsWidget::temporaryFolder()
 int QgsProcessingContextOptionsWidget::maximumThreads() const
 {
   return mThreadsSpinBox->value();
+}
+
+void QgsProcessingContextOptionsWidget::setLogLevel( QgsProcessingContext::LogLevel level )
+{
+  whileBlocking( mLogLevelComboBox )->setCurrentIndex( mLogLevelComboBox->findData( static_cast< int >( level ) ) );
+}
+
+QgsProcessingContext::LogLevel QgsProcessingContextOptionsWidget::logLevel() const
+{
+  return static_cast< QgsProcessingContext::LogLevel >( mLogLevelComboBox->currentData().toInt() );
 }
 
 ///@endcond

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -571,6 +571,20 @@ class GUI_EXPORT QgsProcessingContextOptionsWidget : public QgsPanelWidget, priv
      * Returns the number of threads to use selected in the widget.
      */
     int maximumThreads() const;
+
+    /**
+     * Sets the log \a level to shown in the widget.
+     *
+     * \since QGIS 3.34
+     */
+    void setLogLevel( QgsProcessingContext::LogLevel level );
+
+    /**
+     * Returns the logging level selected in the widget.
+     *
+     * \since QGIS 3.34
+     */
+    QgsProcessingContext::LogLevel logLevel() const;
 };
 
 #endif

--- a/src/ui/processing/qgsprocessingcontextoptionsbase.ui
+++ b/src/ui/processing/qgsprocessingcontextoptionsbase.ui
@@ -60,8 +60,12 @@
           <string>Environment Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="1">
-           <widget class="QgsFileWidget" name="mTemporaryFolderWidget" native="true"/>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Number of threads to use</string>
+            </property>
+           </widget>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_4">
@@ -70,15 +74,21 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
+          <item row="1" column="1">
+           <widget class="QgsSpinBox" name="mThreadsSpinBox"/>
+          </item>
+          <item row="0" column="1">
+           <widget class="QgsFileWidget" name="mTemporaryFolderWidget" native="true"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Number of threads to use</string>
+             <string>Logging level</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QgsSpinBox" name="mThreadsSpinBox"/>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="mLogLevelComboBox"/>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
- Log results from each child algorithm step in models when verbose output is enabled (lets model designers see the actual output values from each step in their models)
- Add a new processing log level for debugging models. At model debug log level we'll show all the generic logs for step preparation, inputs and outputs for every child algorithm, including those which we normally skip (eg raise warnings/outputs, string concatenation, etc). This gives model designers more useful information to debug their models. 
Use this new log level when running models through the model designer window.
- Add choice of log level to algorithm settings panel. Allows users to run algorithms with verbose logging through the
GUI (previously only available via qgis_process or model designer)

All together these should make model designing easier and less opaque!