### PR TITLE
[measure tool] Fix mix up in area/distance units when reactivating the measure tool after changing the unit type

### DIFF
--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -155,11 +155,13 @@ void QgsMeasureDialog::updateSettings()
 
   mDecimalPlaces = settings.value( QStringLiteral( "qgis/measure/decimalplaces" ), 3 ).toInt();
   mCanvasUnits = mCanvas->mapUnits();
+
   // Configure QgsDistanceArea
   mDistanceUnits = QgsProject::instance()->distanceUnits();
   mMapDistanceUnits = QgsProject::instance()->crs().mapUnits();
   mAreaUnits = QgsProject::instance()->areaUnits();
   mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+  updateUnitsMembers();
 
   // Calling projChanged() will set the ellipsoid and clear then re-populate the table
   projChanged();
@@ -181,6 +183,20 @@ void QgsMeasureDialog::unitsChanged( int index )
   if ( mMeasureArea )
   {
     mAreaUnits = static_cast< Qgis::AreaUnit >( mUnitsCombo->itemData( index ).toInt() );
+  }
+  else
+  {
+    mDistanceUnits = static_cast< Qgis::DistanceUnit >( mUnitsCombo->itemData( index ).toInt() );
+  }
+
+  updateUnitsMembers();
+  updateUi();
+}
+
+void QgsMeasureDialog:: updateUnitsMembers()
+{
+  if ( mMeasureArea )
+  {
     if ( mAreaUnits == Qgis::AreaUnit::Unknown )
     {
       mUseMapUnits = true;
@@ -193,7 +209,6 @@ void QgsMeasureDialog::unitsChanged( int index )
   }
   else
   {
-    mDistanceUnits = static_cast< Qgis::DistanceUnit >( mUnitsCombo->itemData( index ).toInt() );
     if ( mDistanceUnits == Qgis::DistanceUnit::Unknown )
     {
       mUseMapUnits = true;
@@ -204,8 +219,6 @@ void QgsMeasureDialog::unitsChanged( int index )
       mUseMapUnits = false;
     }
   }
-
-  updateUi();
 }
 
 void QgsMeasureDialog::restart()

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -99,6 +99,9 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! formats area to most appropriate units
     QString formatArea( double area, bool convertUnits = true ) const;
 
+    //! update units-related members passed on selected area/distance unit type
+    void updateUnitsMembers();
+
     //! shows/hides table, shows correct units
     void updateUi();
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/43732 , whereas the measure tool dialog would not properly reset/refresh settings when reactivating the tool leading to mixup in area/distance unit type.