### PR TITLE
Avoid forcing an excessively large processing algorithm dialog width

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -235,6 +235,7 @@ QLabel *QgsAbstractProcessingParameterWidgetWrapper::createLabel()
         description = QObject::tr( "%1 [optional]" ).arg( description );
       std::unique_ptr< QLabel > label = std::make_unique< QLabel >( description );
       label->setToolTip( mParameterDefinition->toolTip() );
+      label->setWordWrap( true );
       return label.release();
     }
   }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2868,6 +2868,7 @@ QWidget *QgsProcessingEnumWidgetWrapper::createWidget()
         }
 
         mComboBox->setToolTip( parameterDefinition()->toolTip() );
+        mComboBox->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
         connect( mComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
         {
           emit widgetValueHasChanged( this );


### PR DESCRIPTION
## Description

By allowing for parameter description labels to wrap onto new lines and ensuring that enum parameter's combobox can have a width that's smaller than the length of individual items within the combobox, we unlock narrower processing algorithm dialog:

![image](https://github.com/qgis/QGIS/assets/1728657/641cf83e-3ec4-4820-a0cf-c80c96630c7d)
