### PR TITLE
Map theme preset's graduated & categorized renderers' legend key improvement

### DIFF
--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -47,6 +47,11 @@ Copy constructor.
     ~QgsRendererCategory();
 
     QString uuid() const;
+%Docstring
+Returns a unique identifier for this category.
+
+.. versionadded:: 3.34
+%End
 
     QVariant value() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -37,7 +37,7 @@ The ``label`` argument specifies the label used for this category in legends and
 
 The ``render`` argument indicates whether the category should initially be rendered and appear checked in the layer tree.
 
-The optional ``uuid`` argument manuallys set the UUID key identifier for the category (since QGIS 3.34).
+The optional ``uuid`` argument manually set the UUID key identifier for the category (since QGIS 3.34).
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
@@ -48,7 +48,7 @@ Copy constructor.
 
     QString uuid() const;
 %Docstring
-Returns a unique identifier for this category.
+Returns the unique identifier for this category.
 
 .. versionadded:: 3.34
 %End

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -25,7 +25,7 @@ Represents an individual category (class) from a :py:class:`QgsCategorizedSymbol
 Constructor for QgsRendererCategory.
 %End
 
-    QgsRendererCategory( const QVariant &value, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true );
+    QgsRendererCategory( const QVariant &value, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true, const QString &uuid = QString() );
 %Docstring
 Constructor for a new QgsRendererCategory, with the specified ``value`` and ``symbol``.
 
@@ -36,6 +36,8 @@ The ownership of ``symbol`` is transferred to the category.
 The ``label`` argument specifies the label used for this category in legends and the layer tree.
 
 The ``render`` argument indicates whether the category should initially be rendered and appear checked in the layer tree.
+
+The optional ``uuid`` argument manuallys set the UUID key identifier for the category (since QGIS 3.34).
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
@@ -43,6 +45,8 @@ The ``render`` argument indicates whether the category should initially be rende
 Copy constructor.
 %End
     ~QgsRendererCategory();
+
+    QString uuid() const;
 
     QVariant value() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -26,21 +26,38 @@ Constructor for QgsRendererRange.
 %End
     ~QgsRendererRange();
 
-    QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol /Transfer/, bool render = true );
+    QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol /Transfer/, bool render = true, const QString &uuid = QString() );
 %Docstring
 Creates a renderer symbol range
 
 :param range: The classification range
 :param symbol: The symbol for this renderer range
 :param render: If ``True``, it will be renderered
+:param uuid: Optional parameter to manually set the UUID key identifier for the this range (since QGIS 3.34).
 %End
+
     QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true, const QString &uuid = QString() );
+%Docstring
+Creates a renderer symbol range
+
+:param lowerValue: The lower bound of the range
+:param upperValue: The upper bound of the range
+:param symbol: The symbol for this renderer range
+:param label: The label used for the range
+:param render: If ``True``, it will be renderered
+:param uuid: Optional parameter to manually set the UUID key identifier for the this range (since QGIS 3.34).
+%End
     QgsRendererRange( const QgsRendererRange &range );
 
 
     bool operator<( const QgsRendererRange &other ) const;
 
     QString uuid() const;
+%Docstring
+Returns a unique identifier for this range.
+
+.. versionadded:: 3.34
+%End
 
     double lowerValue() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -54,7 +54,7 @@ Creates a renderer symbol range
 
     QString uuid() const;
 %Docstring
-Returns a unique identifier for this range.
+Returns the unique identifier for this range.
 
 .. versionadded:: 3.34
 %End

--- a/python/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -34,11 +34,13 @@ Creates a renderer symbol range
 :param symbol: The symbol for this renderer range
 :param render: If ``True``, it will be renderered
 %End
-    QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true );
+    QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true, const QString &uuid = QString() );
     QgsRendererRange( const QgsRendererRange &range );
 
 
     bool operator<( const QgsRendererRange &other ) const;
+
+    QString uuid() const;
 
     double lowerValue() const;
 %Docstring

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -44,13 +44,15 @@
 #include <QDomElement>
 #include <QSettings> // for legend
 #include <QRegularExpression>
+#include <QUuid>
 
-QgsRendererCategory::QgsRendererCategory( const QVariant &value, QgsSymbol *symbol, const QString &label, bool render )
+QgsRendererCategory::QgsRendererCategory( const QVariant &value, QgsSymbol *symbol, const QString &label, bool render, const QString &uuid )
   : mValue( value )
   , mSymbol( symbol )
   , mLabel( label )
   , mRender( render )
 {
+  mUuid = !uuid.isEmpty() ? uuid : QUuid::createUuid().toString();
 }
 
 QgsRendererCategory::QgsRendererCategory( const QgsRendererCategory &cat )
@@ -58,6 +60,7 @@ QgsRendererCategory::QgsRendererCategory( const QgsRendererCategory &cat )
   , mSymbol( cat.mSymbol ? cat.mSymbol->clone() : nullptr )
   , mLabel( cat.mLabel )
   , mRender( cat.mRender )
+  , mUuid( cat.mUuid )
 {
 }
 
@@ -75,6 +78,12 @@ void QgsRendererCategory::swap( QgsRendererCategory &cat )
   std::swap( mValue, cat.mValue );
   std::swap( mSymbol, cat.mSymbol );
   std::swap( mLabel, cat.mLabel );
+  std::swap( mUuid, cat.mUuid );
+}
+
+QString QgsRendererCategory::uuid() const
+{
+  return mUuid;
 }
 
 QVariant QgsRendererCategory::value() const
@@ -701,6 +710,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
   };
 
   QDomElement catElem = catsElem.firstChildElement();
+  int i = 0;
   while ( !catElem.isNull() )
   {
     if ( catElem.tagName() == QLatin1String( "category" ) )
@@ -729,10 +739,11 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
       QString symbolName = catElem.attribute( QStringLiteral( "symbol" ) );
       QString label = catElem.attribute( QStringLiteral( "label" ) );
       bool render = catElem.attribute( QStringLiteral( "render" ) ) != QLatin1String( "false" );
+      QString uuid = catElem.attribute( QStringLiteral( "uuid" ), QString::number( i++ ) );
       if ( symbolMap.contains( symbolName ) )
       {
         QgsSymbol *symbol = symbolMap.take( symbolName );
-        cats.append( QgsRendererCategory( value, symbol, label, render ) );
+        cats.append( QgsRendererCategory( value, symbol, label, render, uuid ) );
       }
     }
     catElem = catElem.nextSiblingElement();
@@ -866,6 +877,7 @@ QDomElement QgsCategorizedSymbolRenderer::save( QDomDocument &doc, const QgsRead
       catElem.setAttribute( QStringLiteral( "symbol" ), symbolName );
       catElem.setAttribute( QStringLiteral( "label" ), cat.label() );
       catElem.setAttribute( QStringLiteral( "render" ), cat.renderState() ? "true" : "false" );
+      catElem.setAttribute( QStringLiteral( "uuid" ), cat.uuid() );
       catsElem.appendChild( catElem );
       i++;
     }
@@ -914,10 +926,9 @@ QDomElement QgsCategorizedSymbolRenderer::save( QDomDocument &doc, const QgsRead
 QgsLegendSymbolList QgsCategorizedSymbolRenderer::baseLegendSymbolItems() const
 {
   QgsLegendSymbolList lst;
-  int i = 0;
   for ( const QgsRendererCategory &cat : mCategories )
   {
-    lst << QgsLegendSymbolItem( cat.symbol(), cat.label(), QString::number( i++ ), true );
+    lst << QgsLegendSymbolItem( cat.symbol(), cat.label(), cat.uuid(), true );
   }
   return lst;
 }
@@ -1085,7 +1096,6 @@ QgsLegendSymbolList QgsCategorizedSymbolRenderer::legendSymbolItems() const
 QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const
 {
   const QVariant value = valueForFeature( feature, context );
-  int i = 0;
 
   for ( const QgsRendererCategory &cat : mCategories )
   {
@@ -1120,11 +1130,10 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
     if ( match )
     {
       if ( cat.renderState() || mCounting )
-        return QSet< QString >() << QString::number( i );
+        return QSet< QString >() << cat.uuid();
       else
         return QSet< QString >();
     }
-    i++;
   }
 
   return QSet< QString >();
@@ -1133,8 +1142,17 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
 QString QgsCategorizedSymbolRenderer::legendKeyToExpression( const QString &key, QgsVectorLayer *layer, bool &ok ) const
 {
   ok = false;
-  int ruleIndex = key.toInt( &ok );
-  if ( !ok || ruleIndex < 0 || ruleIndex >= mCategories.size() )
+  int i = 0;
+  for ( i = 0; i < mCategories.size(); i++ )
+  {
+    if ( mCategories[i].uuid() == key )
+    {
+      ok = true;
+      break;
+    }
+  }
+
+  if ( !ok )
   {
     ok = false;
     return QString();
@@ -1146,7 +1164,7 @@ QString QgsCategorizedSymbolRenderer::legendKeyToExpression( const QString &key,
   const QString attributeComponent = QgsExpression::quoteFieldExpression( mAttrName, layer );
 
   ok = true;
-  const QgsRendererCategory &cat = mCategories[ ruleIndex ];
+  const QgsRendererCategory &cat = mCategories[i];
   if ( cat.value().type() == QVariant::List )
   {
     const QVariantList list = cat.value().toList();
@@ -1249,30 +1267,46 @@ bool QgsCategorizedSymbolRenderer::legendSymbolItemsCheckable() const
 
 bool QgsCategorizedSymbolRenderer::legendSymbolItemChecked( const QString &key )
 {
-  bool ok;
-  int index = key.toInt( &ok );
-  if ( ok && index >= 0 && index < mCategories.size() )
-    return mCategories.at( index ).renderState();
-  else
-    return true;
+  for ( auto category : std::as_const( mCategories ) )
+  {
+    if ( category.uuid() == key )
+    {
+      return category.renderState();
+    }
+  }
+
+  return true;
 }
 
 void QgsCategorizedSymbolRenderer::setLegendSymbolItem( const QString &key, QgsSymbol *symbol )
 {
-  bool ok;
-  int index = key.toInt( &ok );
+  bool ok = false;
+  int i = 0;
+  for ( i = 0; i < mCategories.size(); i++ )
+  {
+    if ( mCategories[i].uuid() == key )
+    {
+      ok = true;
+      break;
+    }
+  }
+
   if ( ok )
-    updateCategorySymbol( index, symbol );
+    updateCategorySymbol( i, symbol );
   else
     delete symbol;
 }
 
 void QgsCategorizedSymbolRenderer::checkLegendSymbolItem( const QString &key, bool state )
 {
-  bool ok;
-  int index = key.toInt( &ok );
-  if ( ok )
-    updateCategoryRenderState( index, state );
+  for ( int i = 0; i < mCategories.size(); i++ )
+  {
+    if ( mCategories[i].uuid() == key )
+    {
+      updateCategoryRenderState( i, state );
+      break;
+    }
+  }
 }
 
 QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -1267,7 +1267,7 @@ bool QgsCategorizedSymbolRenderer::legendSymbolItemsCheckable() const
 
 bool QgsCategorizedSymbolRenderer::legendSymbolItemChecked( const QString &key )
 {
-  for ( auto category : std::as_const( mCategories ) )
+  for ( const QgsRendererCategory &category : std::as_const( mCategories ) )
   {
     if ( category.uuid() == key )
     {

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -51,8 +51,10 @@ class CORE_EXPORT QgsRendererCategory
     * The \a label argument specifies the label used for this category in legends and the layer tree.
     *
     * The \a render argument indicates whether the category should initially be rendered and appear checked in the layer tree.
+    *
+    * The optional \a uuid argument manuallys set the UUID key identifier for the category (since QGIS 3.34).
     */
-    QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true );
+    QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true, const QString &uuid = QString() );
 
     /**
      * Copy constructor.
@@ -60,6 +62,8 @@ class CORE_EXPORT QgsRendererCategory
     QgsRendererCategory( const QgsRendererCategory &cat );
     QgsRendererCategory &operator=( QgsRendererCategory cat );
     ~QgsRendererCategory();
+
+    QString uuid() const;
 
     /**
      * Returns the value corresponding to this category.
@@ -151,6 +155,7 @@ class CORE_EXPORT QgsRendererCategory
     std::unique_ptr<QgsSymbol> mSymbol;
     QString mLabel;
     bool mRender = true;
+    QString mUuid;
 
     void swap( QgsRendererCategory &other );
 };

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -63,6 +63,10 @@ class CORE_EXPORT QgsRendererCategory
     QgsRendererCategory &operator=( QgsRendererCategory cat );
     ~QgsRendererCategory();
 
+    /**
+     * Returns a unique identifier for this category.
+     * \since QGIS 3.34
+     */
     QString uuid() const;
 
     /**

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsRendererCategory
     *
     * The \a render argument indicates whether the category should initially be rendered and appear checked in the layer tree.
     *
-    * The optional \a uuid argument manuallys set the UUID key identifier for the category (since QGIS 3.34).
+    * The optional \a uuid argument manually set the UUID key identifier for the category (since QGIS 3.34).
     */
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true, const QString &uuid = QString() );
 
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsRendererCategory
     ~QgsRendererCategory();
 
     /**
-     * Returns a unique identifier for this category.
+     * Returns the unique identifier for this category.
      * \since QGIS 3.34
      */
     QString uuid() const;

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -973,7 +973,7 @@ bool QgsGraduatedSymbolRenderer::legendSymbolItemsCheckable() const
 
 bool QgsGraduatedSymbolRenderer::legendSymbolItemChecked( const QString &key )
 {
-  for ( auto &range : std::as_const( mRanges ) )
+  for ( const QgsRendererRange &range : std::as_const( mRanges ) )
   {
     if ( range.uuid() == key )
     {

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -115,12 +115,10 @@ QString QgsGraduatedSymbolRenderer::legendKeyForValue( double value ) const
 {
   if ( const QgsRendererRange *matchingRange = rangeForValue( value ) )
   {
-    int i = 0;
     for ( const QgsRendererRange &range : mRanges )
     {
       if ( matchingRange == &range )
-        return QString::number( i );
-      i++;
+        return range.uuid();
     }
   }
   return QString();
@@ -474,6 +472,7 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
   QgsRangeList ranges;
 
   QDomElement rangeElem = rangesElem.firstChildElement();
+  int i = 0;
   while ( !rangeElem.isNull() )
   {
     if ( rangeElem.tagName() == QLatin1String( "range" ) )
@@ -483,10 +482,11 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
       QString symbolName = rangeElem.attribute( QStringLiteral( "symbol" ) );
       QString label = rangeElem.attribute( QStringLiteral( "label" ) );
       bool render = rangeElem.attribute( QStringLiteral( "render" ), QStringLiteral( "true" ) ) != QLatin1String( "false" );
+      QString uuid = rangeElem.attribute( QStringLiteral( "uuid" ), QString::number( i++ ) );
       if ( symbolMap.contains( symbolName ) )
       {
         QgsSymbol *symbol = symbolMap.take( symbolName );
-        ranges.append( QgsRendererRange( lowerValue, upperValue, symbol, label, render ) );
+        ranges.append( QgsRendererRange( lowerValue, upperValue, symbol, label, render, uuid ) );
       }
     }
     rangeElem = rangeElem.nextSiblingElement();
@@ -648,6 +648,7 @@ QDomElement QgsGraduatedSymbolRenderer::save( QDomDocument &doc, const QgsReadWr
     rangeElem.setAttribute( QStringLiteral( "symbol" ), symbolName );
     rangeElem.setAttribute( QStringLiteral( "label" ), range.label() );
     rangeElem.setAttribute( QStringLiteral( "render" ), range.renderState() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+    rangeElem.setAttribute( QStringLiteral( "uuid" ), range.uuid() );
     rangesElem.appendChild( rangeElem );
     i++;
   }
@@ -699,11 +700,10 @@ QDomElement QgsGraduatedSymbolRenderer::save( QDomDocument &doc, const QgsReadWr
 QgsLegendSymbolList QgsGraduatedSymbolRenderer::baseLegendSymbolItems() const
 {
   QgsLegendSymbolList lst;
-  int i = 0;
   lst.reserve( mRanges.size() );
   for ( const QgsRendererRange &range : mRanges )
   {
-    lst << QgsLegendSymbolItem( range.symbol(), range.label(), QString::number( i++ ), true );
+    lst << QgsLegendSymbolItem( range.symbol(), range.label(), range.uuid(), true );
   }
   return lst;
 }
@@ -805,17 +805,24 @@ QSet< QString > QgsGraduatedSymbolRenderer::legendKeysForFeature( const QgsFeatu
 QString QgsGraduatedSymbolRenderer::legendKeyToExpression( const QString &key, QgsVectorLayer *layer, bool &ok ) const
 {
   ok = false;
-  int ruleIndex = key.toInt( &ok );
-  if ( !ok || ruleIndex < 0 || ruleIndex >= mRanges.size() )
+  int i = 0;
+  for ( i = 0; i < mRanges.size(); i++ )
+  {
+    if ( mRanges[i].uuid() == key )
+    {
+      ok = true;
+      break;
+    }
+  }
+
+  if ( !ok )
   {
     ok = false;
     return QString();
   }
 
   const QString attributeComponent = QgsExpression::quoteFieldExpression( mAttrName, layer );
-
-  ok = true;
-  const QgsRendererRange &range = mRanges[ ruleIndex ];
+  const QgsRendererRange &range = mRanges[i];
 
   return QStringLiteral( "(%1 >= %2) AND (%1 <= %3)" ).arg( attributeComponent, QgsExpression::quotedValue( range.lowerValue(), QVariant::Double ),
          QgsExpression::quotedValue( range.upperValue(), QVariant::Double ) );
@@ -966,28 +973,43 @@ bool QgsGraduatedSymbolRenderer::legendSymbolItemsCheckable() const
 
 bool QgsGraduatedSymbolRenderer::legendSymbolItemChecked( const QString &key )
 {
-  bool ok;
-  int index = key.toInt( &ok );
-  if ( ok && index >= 0 && index < mRanges.size() )
-    return mRanges.at( index ).renderState();
-  else
-    return true;
+  for ( auto &range : std::as_const( mRanges ) )
+  {
+    if ( range.uuid() == key )
+    {
+      return range.renderState();
+    }
+  }
+  return true;
 }
 
 void QgsGraduatedSymbolRenderer::checkLegendSymbolItem( const QString &key, bool state )
 {
-  bool ok;
-  int index = key.toInt( &ok );
-  if ( ok )
-    updateRangeRenderState( index, state );
+  for ( int i = 0; i < mRanges.size(); i++ )
+  {
+    if ( mRanges[i].uuid() == key )
+    {
+      updateRangeRenderState( i, state );
+      break;
+    }
+  }
 }
 
 void QgsGraduatedSymbolRenderer::setLegendSymbolItem( const QString &key, QgsSymbol *symbol )
 {
-  bool ok;
-  int index = key.toInt( &ok );
+  bool ok = false;
+  int i = 0;
+  for ( i = 0; i < mRanges.size(); i++ )
+  {
+    if ( mRanges[i].uuid() == key )
+    {
+      ok = true;
+      break;
+    }
+  }
+
   if ( ok )
-    updateRangeSymbol( index, symbol );
+    updateRangeSymbol( i, symbol );
   else
     delete symbol;
 }

--- a/src/core/symbology/qgsrendererrange.cpp
+++ b/src/core/symbology/qgsrendererrange.cpp
@@ -21,14 +21,14 @@
 #include <QUuid>
 
 
-QgsRendererRange::QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol, bool render )
+QgsRendererRange::QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol, bool render, const QString &uuid )
   : mLowerValue( range.lowerBound() )
   , mUpperValue( range.upperBound() )
   , mSymbol( symbol )
   , mLabel( range.label() )
   , mRender( render )
-  , mUuid( QUuid::createUuid().toString() )
 {
+  mUuid = !uuid.isEmpty() ? uuid : QUuid::createUuid().toString();
 }
 
 QgsRendererRange::QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol, const QString &label, bool render, const QString &uuid )

--- a/src/core/symbology/qgsrendererrange.cpp
+++ b/src/core/symbology/qgsrendererrange.cpp
@@ -18,6 +18,7 @@
 #include "qgssymbol.h"
 
 #include <QLocale>
+#include <QUuid>
 
 
 QgsRendererRange::QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol, bool render )
@@ -26,16 +27,19 @@ QgsRendererRange::QgsRendererRange( const QgsClassificationRange &range, QgsSymb
   , mSymbol( symbol )
   , mLabel( range.label() )
   , mRender( render )
+  , mUuid( QUuid::createUuid().toString() )
 {
 }
 
-QgsRendererRange::QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol, const QString &label, bool render )
+QgsRendererRange::QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol, const QString &label, bool render, const QString &uuid )
   : mLowerValue( lowerValue )
   , mUpperValue( upperValue )
   , mSymbol( symbol )
   , mLabel( label )
   , mRender( render )
-{}
+{
+  mUuid = !uuid.isEmpty() ? uuid : QUuid::createUuid().toString();
+}
 
 QgsRendererRange::QgsRendererRange( const QgsRendererRange &range )
   : mLowerValue( range.mLowerValue )
@@ -43,6 +47,7 @@ QgsRendererRange::QgsRendererRange( const QgsRendererRange &range )
   , mSymbol( range.mSymbol ? range.mSymbol->clone() : nullptr )
   , mLabel( range.mLabel )
   , mRender( range.mRender )
+  , mUuid( range.mUuid )
 {}
 
 QgsRendererRange::~QgsRendererRange() = default;
@@ -69,6 +74,12 @@ void QgsRendererRange::swap( QgsRendererRange &other )
   std::swap( mUpperValue, other.mUpperValue );
   std::swap( mSymbol, other.mSymbol );
   std::swap( mLabel, other.mLabel );
+  std::swap( mUuid, other.mUuid );
+}
+
+QString QgsRendererRange::uuid() const
+{
+  return mUuid;
 }
 
 double QgsRendererRange::lowerValue() const

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -48,8 +48,19 @@ class CORE_EXPORT QgsRendererRange
      * \param range The classification range
      * \param symbol The symbol for this renderer range
      * \param render If TRUE, it will be renderered
+     * \param uuid Optional parameter to manually set the UUID key identifier for the this range (since QGIS 3.34).
      */
-    QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol SIP_TRANSFER, bool render = true );
+    QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol SIP_TRANSFER, bool render = true, const QString &uuid = QString() );
+
+    /**
+     * Creates a renderer symbol range
+     * \param lowerValue The lower bound of the range
+     * \param upperValue The upper bound of the range
+     * \param symbol The symbol for this renderer range
+     * \param label The label used for the range
+     * \param render If TRUE, it will be renderered
+     * \param uuid Optional parameter to manually set the UUID key identifier for the this range (since QGIS 3.34).
+     */
     QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true, const QString &uuid = QString() );
     QgsRendererRange( const QgsRendererRange &range );
 
@@ -58,6 +69,10 @@ class CORE_EXPORT QgsRendererRange
 
     bool operator<( const QgsRendererRange &other ) const;
 
+    /**
+     * Returns a unique identifier for this range.
+     * \since QGIS 3.34
+     */
     QString uuid() const;
 
     /**

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -50,13 +50,15 @@ class CORE_EXPORT QgsRendererRange
      * \param render If TRUE, it will be renderered
      */
     QgsRendererRange( const QgsClassificationRange &range, QgsSymbol *symbol SIP_TRANSFER, bool render = true );
-    QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true );
+    QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true, const QString &uuid = QString() );
     QgsRendererRange( const QgsRendererRange &range );
 
     // default dtor is OK
     QgsRendererRange &operator=( QgsRendererRange range );
 
     bool operator<( const QgsRendererRange &other ) const;
+
+    QString uuid() const;
 
     /**
      * Returns the lower bound of the range.
@@ -183,6 +185,7 @@ class CORE_EXPORT QgsRendererRange
     std::unique_ptr<QgsSymbol> mSymbol;
     QString mLabel;
     bool mRender = true;
+    QString mUuid;
 
     // for cpy+swap idiom
     void swap( QgsRendererRange &other );

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsRendererRange
     bool operator<( const QgsRendererRange &other ) const;
 
     /**
-     * Returns a unique identifier for this range.
+     * Returns the unique identifier for this range.
      * \since QGIS 3.34
      */
     QString uuid() const;

--- a/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
+++ b/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
@@ -243,7 +243,7 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   QVERIFY( !renderer.symbolForValue( 1 ) );
   QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
   QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
-  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), r1.uuid() );
 
   ms.setColor( QColor( 255, 255, 0 ) );
   const QgsRendererRange r2( 3.2, 3.3, ms.clone(), QStringLiteral( "r2" ) );
@@ -261,8 +261,8 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
   QCOMPARE( renderer.symbolForValue( 3.25 )->color().name(), QStringLiteral( "#ffff00" ) );
   QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
-  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
-  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), r1.uuid() );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), r2.uuid() );
 
   // disabled range
   ms.setColor( QColor( 255, 0, 255 ) );
@@ -282,8 +282,8 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   QCOMPARE( renderer.symbolForValue( 3.25 )->color().name(), QStringLiteral( "#ffff00" ) );
   QVERIFY( !renderer.symbolForValue( 3.5 ) );
   QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
-  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
-  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), r1.uuid() );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), r2.uuid() );
   QVERIFY( renderer.legendKeyForValue( 3.5 ).isEmpty() );
 
   // zero width range
@@ -306,9 +306,9 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   QCOMPARE( renderer.symbolForValue( 3.7 )->color().name(), QStringLiteral( "#00ffff" ) );
   QVERIFY( !renderer.symbolForValue( 3.5 ) );
   QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
-  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
-  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
-  QCOMPARE( renderer.legendKeyForValue( 3.7 ), QStringLiteral( "3" ) );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), r1.uuid() );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), r2.uuid() );
+  QCOMPARE( renderer.legendKeyForValue( 3.7 ), r4.uuid() );
   QVERIFY( renderer.legendKeyForValue( 3.5 ).isEmpty() );
 
   // test values which fall just outside ranges, e.g. due to double precision (refs https://github.com/qgis/QGIS/issues/27420)

--- a/tests/src/core/testqgslegendrenderer.cpp
+++ b/tests/src/core/testqgslegendrenderer.cpp
@@ -1564,8 +1564,8 @@ void TestQgsLegendRenderer::testTextOnSymbol()
   QgsDefaultVectorLayerLegend *legend = new QgsDefaultVectorLayerLegend( vl );
   legend->setTextOnSymbolEnabled( true );
   QHash<QString, QString> content;
-  content["0"] = "Rd";
-  content["2"] = "Bl";
+  content[cats[0].uuid()] = "Rd";
+  content[cats[2].uuid()] = "Bl";
   legend->setTextOnSymbolContent( content );
   QgsTextFormat textFormat;
   textFormat.setFont( QgsFontUtils::getStandardTestFont( QStringLiteral( "Roman" ) ) );

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -1147,9 +1147,9 @@ class TestQgsRuleBasedRenderer: public QgsTest
       QgsVectorLayerFeatureCounter *counter = layer->countSymbolFeatures();
       counter->waitForFinished();
 
-      QCOMPARE( counter->featureCount( "0" ), 1LL );
-      QCOMPARE( counter->featureCount( "1" ), 1LL );
-      QCOMPARE( counter->featureCount( "2" ), 1LL );
+      QCOMPARE( counter->featureCount( cats[0].uuid() ), 1LL );
+      QCOMPARE( counter->featureCount( cats[1].uuid() ), 1LL );
+      QCOMPARE( counter->featureCount( cats[2].uuid() ), 1LL );
     }
 
     void testLegendKeys()

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -398,20 +398,20 @@ class TestQgsCategorizedSymbolRenderer(QgisTestCase):
 
         symbol_a = createMarkerSymbol()
         symbol_a.setColor(QColor(255, 0, 0))
-        renderer.addCategory(QgsRendererCategory('a', symbol_a, 'a'))
+        renderer.addCategory(QgsRendererCategory('a', symbol_a, 'a', True, '0'))
         symbol_b = createMarkerSymbol()
         symbol_b.setColor(QColor(0, 255, 0))
-        renderer.addCategory(QgsRendererCategory('b', symbol_b, 'b'))
+        renderer.addCategory(QgsRendererCategory('b', symbol_b, 'b', True, '1'))
         symbol_c = createMarkerSymbol()
         symbol_c.setColor(QColor(0, 0, 255))
-        renderer.addCategory(QgsRendererCategory('c', symbol_c, 'c', False))
+        renderer.addCategory(QgsRendererCategory('c', symbol_c, 'c', False, '2'))
         symbol_d = createMarkerSymbol()
         symbol_d.setColor(QColor(255, 0, 255))
-        renderer.addCategory(QgsRendererCategory(['d', 'e'], symbol_d, 'de'))
+        renderer.addCategory(QgsRendererCategory(['d', 'e'], symbol_d, 'de', True, '3'))
         # add default category
         default_symbol = createMarkerSymbol()
         default_symbol.setColor(QColor(255, 255, 255))
-        renderer.addCategory(QgsRendererCategory('', default_symbol, 'default'))
+        renderer.addCategory(QgsRendererCategory('', default_symbol, 'default', True, '4'))
 
         self.assertEqual(renderer.legendKeys(), {'0', '1', '2', '3', '4'})
 
@@ -838,13 +838,13 @@ class TestQgsCategorizedSymbolRenderer(QgisTestCase):
         self.assertFalse(ok)
 
         symbol_a = createMarkerSymbol()
-        renderer.addCategory(QgsRendererCategory('a', symbol_a, 'a'))
+        renderer.addCategory(QgsRendererCategory('a', symbol_a, 'a', True, '0'))
         symbol_b = createMarkerSymbol()
-        renderer.addCategory(QgsRendererCategory(5, symbol_b, 'b'))
+        renderer.addCategory(QgsRendererCategory(5, symbol_b, 'b', True, '1'))
         symbol_c = createMarkerSymbol()
-        renderer.addCategory(QgsRendererCategory(5.5, symbol_c, 'c', False))
+        renderer.addCategory(QgsRendererCategory(5.5, symbol_c, 'c', False, '2'))
         symbol_d = createMarkerSymbol()
-        renderer.addCategory(QgsRendererCategory(['d', 'e'], symbol_d, 'de'))
+        renderer.addCategory(QgsRendererCategory(['d', 'e'], symbol_d, 'de', True, '3'))
 
         exp, ok = renderer.legendKeyToExpression('0', None)
         self.assertTrue(ok)

--- a/tests/src/python/test_qgsgraduatedsymbolrenderer.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrenderer.py
@@ -498,11 +498,11 @@ class TestQgsGraduatedSymbolRenderer(QgisTestCase):
         self.assertFalse(renderer.legendKeys())
 
         symbol_a = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(1, 2, symbol_a, 'a'))
+        renderer.addClassRange(QgsRendererRange(1, 2, symbol_a, 'a', True, '0'))
         symbol_b = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(5, 6, symbol_b, 'b'))
+        renderer.addClassRange(QgsRendererRange(5, 6, symbol_b, 'b', True, '1'))
         symbol_c = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(15.5, 16.5, symbol_c, 'c', False))
+        renderer.addClassRange(QgsRendererRange(15.5, 16.5, symbol_c, 'c', False, '2'))
 
         self.assertEqual(renderer.legendKeys(), {'0', '1', '2'})
 
@@ -518,11 +518,11 @@ class TestQgsGraduatedSymbolRenderer(QgisTestCase):
         self.assertFalse(ok)
 
         symbol_a = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(1, 2, symbol_a, 'a'))
+        renderer.addClassRange(QgsRendererRange(1, 2, symbol_a, 'a', True, '0'))
         symbol_b = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(5, 6, symbol_b, 'b'))
+        renderer.addClassRange(QgsRendererRange(5, 6, symbol_b, 'b', True, '1'))
         symbol_c = createMarkerSymbol()
-        renderer.addClassRange(QgsRendererRange(15.5, 16.5, symbol_c, 'c', False))
+        renderer.addClassRange(QgsRendererRange(15.5, 16.5, symbol_c, 'c', False, '2'))
 
         exp, ok = renderer.legendKeyToExpression('0', None)
         self.assertTrue(ok)

--- a/tests/src/python/test_qgsmergedfeaturerenderer.py
+++ b/tests/src/python/test_qgsmergedfeaturerenderer.py
@@ -50,8 +50,8 @@ class TestQgsMergedFeatureRenderer(unittest.TestCase):
     def test_legend_keys(self):
         symbol1 = QgsFillSymbol()
         symbol2 = QgsFillSymbol()
-        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
-                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1', True, '0'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2', True, '1')
                                                             ])
 
         renderer = QgsMergedFeatureRenderer(sub_renderer)

--- a/tests/src/python/test_qgspointclusterrenderer.py
+++ b/tests/src/python/test_qgspointclusterrenderer.py
@@ -128,8 +128,8 @@ class TestQgsPointClusterRenderer(QgisTestCase):
     def test_legend_keys(self):
         symbol1 = QgsMarkerSymbol()
         symbol2 = QgsMarkerSymbol()
-        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
-                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1', True, '0'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2', True, '1')
                                                             ])
 
         renderer = QgsPointClusterRenderer()

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -489,8 +489,8 @@ class TestQgsPointDisplacementRenderer(QgisTestCase):
     def test_legend_keys(self):
         symbol1 = QgsMarkerSymbol()
         symbol2 = QgsMarkerSymbol()
-        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1'),
-                                                            QgsRendererCategory('cat2', symbol2, 'cat2')
+        sub_renderer = QgsCategorizedSymbolRenderer('cat', [QgsRendererCategory('cat1', symbol1, 'cat1', True, '0'),
+                                                            QgsRendererCategory('cat2', symbol2, 'cat2', True, '1')
                                                             ])
 
         renderer = QgsPointDisplacementRenderer()


### PR DESCRIPTION
## Description

This PR dissociates the categorized and graduated renderers' list of categories/ranges from their symbol legend key so that map theme presets can properly apply visibility status of a given item irrespective of their position within the list.

The PR fixes https://github.com/qgis/QGIS/issues/52772 .

In addition, this fixes a pretty serious issue with the text on symbols functionality, whereas setting a text on a given category symbol would stick to the _category index_ instead of the actual category, meaning that a shuffling of categories would end up with text on the wrong legend symbols.