### PR TITLE
[decorations] Scale bar should follow the current project's distance unit type

### DIFF
--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -242,12 +242,7 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
   QPaintDevice *device = context.painter()->device();
   const int deviceHeight = device->height() / device->devicePixelRatioF();
   const int deviceWidth = device->width() / device->devicePixelRatioF();
-  const QgsSettings settings;
-  bool ok = false;
-  Qgis::DistanceUnit preferredUnits = QgsUnitTypes::decodeDistanceUnit( settings.value( QStringLiteral( "qgis/measure/displayunits" ) ).toString(), &ok );
-  if ( !ok )
-    preferredUnits = Qgis::DistanceUnit::Meters;
-
+  const Qgis::DistanceUnit preferredUnits = QgsProject::instance()->distanceUnits();
   Qgis::DistanceUnit scaleBarUnits = mapSettings.mapUnits();
 
   //Get map units per pixel


### PR DESCRIPTION
## Description

This PR improves the scale bar decorator by having it respect the currently open project's distance unit as defined by users in the project properties window. 

![sb](https://github.com/qgis/QGIS/assets/1728657/bb40ffd2-f22b-4f19-88ff-c5c41d10a65a)

Previously, the decorator would ignore that setting and instead use the QGIS-wide default measurement distance unit. IMHO, this creates confusion with users at best, and at worse obscures the fact that the scale bar decorator is _not_ hard-coded to meters/kilometers.