### PR TITLE
Fix QgsGeometryUtils::circleCircleIntersections for circles intersecting at only 1 point (Fix #54322)

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4216,7 +4216,7 @@ inline bool qgsDoubleNear( double a, double b, double epsilon = 4 * std::numeric
     return aIsNan && bIsNan;
 
   const double diff = a - b;
-  return diff > -epsilon && diff <= epsilon;
+  return diff >= -epsilon && diff <= epsilon;
 }
 
 /**
@@ -4233,7 +4233,7 @@ inline bool qgsFloatNear( float a, float b, float epsilon = 4 * FLT_EPSILON )
     return aIsNan && bIsNan;
 
   const float diff = a - b;
-  return diff > -epsilon && diff <= epsilon;
+  return diff >= -epsilon && diff <= epsilon;
 }
 
 //! Compare two doubles using specified number of significant digits

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -1077,6 +1077,25 @@ void TestQgsGeometryUtils::testCircleCircleIntersection()
   QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 0, 0 ), 1, QgsPointXY( 3, 0 ), 2, int1, int2 ), 1 );
   QCOMPARE( int1, QgsPointXY( 1, 0 ) );
   QCOMPARE( int2, QgsPointXY( 1, 0 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 5.17140812687688189, 0.57209787912912891 ), 2.2602305137548804, QgsPointXY( 11.33315669032675643, -2.99891549287022841 ), 4.8615165936742235, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( 7.12696368243243938, -0.56123545420420506 ) );
+  QCOMPARE( int2, QgsPointXY( 7.12696368243243938, -0.56123545420420506 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( -1.33611111111111125, -0.08333333333333348 ), 0.8101402103918971, QgsPointXY( -0.19561185568356954, -0.68452673929513763 ), 2.0993927314298557, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( -2.052777777777778, 0.2944444444444439 ) );
+  QCOMPARE( int2, QgsPointXY( -2.052777777777778, 0.2944444444444439 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 0, 0 ), 3.1, QgsPointXY( 10, 0 ), 6.9, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( 3.1, 0 ) );
+  QCOMPARE( int2, QgsPointXY( 3.1, 0 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 0, 0 ), 3.1, QgsPointXY( 6.9, 0 ), 10, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( -3.1, 0 ) );
+  QCOMPARE( int2, QgsPointXY( -3.1, 0 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 0, 0 ), 6.9, QgsPointXY( 3.1, 0 ), 10, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( -6.9, 0 ) );
+  QCOMPARE( int2, QgsPointXY( -6.9, 0 ) );
+  QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 0, 0 ), 7.111, QgsPointXY( -3, 0 ), 10.111, int1, int2 ), 1 );
+  QCOMPARE( int1, QgsPointXY( 7.111, 0 ) );
+  QCOMPARE( int2, QgsPointXY( 7.111, 0 ) );
+
   // two intersections
   QCOMPARE( QgsGeometryUtils::circleCircleIntersections( QgsPointXY( 5, 3 ), 2, QgsPointXY( 7, -1 ), 4, int1, int2 ), 2 );
   QGSCOMPARENEAR( int1.x(), 3.8, 0.001 );


### PR DESCRIPTION
## Description

Fixes an issue (affecting master, 3.32 and 3.28) in the `QgsGeometryUtils::circleCircleIntersections` function, which occurs in some cases when the two circles intersect at a single point.
The issue is due to floating point rounding errors in the calculation of the const `a`
https://github.com/qgis/QGIS/blob/eba2cb8598878c6cf76fb886a3d27030bd2b9478/src/core/geometry/qgsgeometryutils.cpp#L423
When the two circles intersect each other at a single point, i.e. when the distance between the two centers is equal to the sum of the two radii ("external intersection": `d == r1 + r1` ) or when it is equal to the absolute value of the difference of the two radii ("internal intersection" `d == r1 - r2` or `d == r2 - r1`), such expression should return the value of `r1` or the value of `-r1`, instead it returns a value of `a` very slightly bigger then `r1` or very slightly lower then `-r1` (due to floating point rounding errors) and thus the const 'h' https://github.com/qgis/QGIS/blob/366686e1b6254e12688b7665d63f3363fcf7e17e/src/core/geometry/qgsgeometryutils.cpp#L438-L438
becames a `NaN` value (since: if `r1 < a` or `-r1 > a` then `r1^2 < a^2` then `sqrt ( r1^2 - a^2)` = square root of a negative number = `NaN`)

In such cases, the expression could be simplified to `const double a = r1` (when `d == r1 + r1` or `d == r1 - r2`) or `const double a = -r1` (when `d == r2 - r1`), avoiding most of the floating point rounding errors.

Moreover, the `qgsDoubleNear` function (and also the `qgsFloatNear` for consistency) had to be fixed, since it incorrectly returned `false` when the difference between the two values is equal to` -epsilon`, while it returns `true` when it is equal to `epsilon`
https://github.com/qgis/QGIS/blob/366686e1b6254e12688b7665d63f3363fcf7e17e/src/core/qgis.h#L4219
In fact, e.g. `qgsDoubleNear( 3.0, 10.111 - 7.111 )` incorrectly returned `false` while it should clearly return `true`.
That line was changed to:
```c++
  return diff >= -epsilon && diff <= epsilon;
```

Various tests have been added:
- the two examples of circles given by the issue reporter for which the function returned the incorrect value of
`(1, <QgsPointXY: POINT(nan nan)>, <QgsPointXY: POINT(nan nan)>)`, while, with the fix, it returns the correct values of
`(1, <QgsPointXY: POINT(7.12696368243243938 -0.56123545420420506)>, <QgsPointXY: POINT(7.12696368243243938 -0.56123545420420506)>)` and `(1, <QgsPointXY: POINT(-2.05277777777777803 0.2944444444444439)>, <QgsPointXY: POINT(-2.05277777777777803 0.2944444444444439)>)`
- some very simple circles:
  - e.g. `QgsGeometryUtils.circleCircleIntersections( QgsPointXY( 0, 0 ), 3.1, QgsPointXY( 10, 0 ), 6.9)` for which the correct result is clearly the point at (3.1, 0), right on the abscissa axis, while the function incorrectly returned: `(1, <QgsPointXY: POINT(3.09999999999999964 -0.00000005960464478)>, <QgsPointXY: POINT(3.09999999999999964 0.00000005960464478)>)` (note that it says there is 1 point, while the two returned point are different from each other and they are above and below the abscissa axis). With the fix, the function correctly returns: `(1, <QgsPointXY: POINT(3.10000000000000009 0)>, <QgsPointXY: POINT(3.10000000000000009 0)>)` (`3.10000000000000009` is the same as `3.1` and it is the 17 decimal digits representation of `3.1` IEEE754 double precision)
  - or e.g. `QgsGeometryUtils.circleCircleIntersections( QgsPointXY( 0, 0 ), 7.111, QgsPointXY( -3, 0 ), 10.111)`, for which the correct result is clearly the point at (7.111, 0), while the function incorrectly returned `(0, <QgsPointXY: POINT EMPTY>, <QgsPointXY: POINT EMPTY>)`. With the fix (to both `QgsGeometryUtils.circleCircleIntersections` and `qgsDoubleNear`), the function correctly returns: `(1, <QgsPointXY: POINT(7.11099999999999977 0)>, <QgsPointXY: POINT(7.11099999999999977 0)>)` (`7.11099999999999977` is the same as `7.111` and it is the 17 decimal digits representation of `7.111` IEEE754 double precision).

Fixes #54322.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
