### PR TITLE
We can't use a read/write lock for QCache, use QMutex instead

### DIFF
--- a/src/core/tiledscene/qgstiledsceneindex.cpp
+++ b/src/core/tiledscene/qgstiledsceneindex.cpp
@@ -18,7 +18,6 @@
 #include "qgstiledsceneindex.h"
 #include "qgsfeedback.h"
 #include "qgstiledscenetile.h"
-#include "qgsreadwritelocker.h"
 
 //
 // QgsAbstractTiledSceneIndex
@@ -33,7 +32,7 @@ QgsAbstractTiledSceneIndex::~QgsAbstractTiledSceneIndex() = default;
 
 QByteArray QgsAbstractTiledSceneIndex::retrieveContent( const QString &uri, QgsFeedback *feedback )
 {
-  QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Read );
+  QMutexLocker locker( &mCacheMutex );
   if ( QByteArray *cachedData = mContentCache.object( uri ) )
   {
     return *cachedData;
@@ -44,7 +43,7 @@ QByteArray QgsAbstractTiledSceneIndex::retrieveContent( const QString &uri, QgsF
   if ( feedback && feedback->isCanceled() )
     return QByteArray();
 
-  locker.changeMode( QgsReadWriteLocker::Write );
+  locker.relock();
   mContentCache.insert( uri, new QByteArray( res ) );
   return res;
 }

--- a/src/core/tiledscene/qgstiledsceneindex.h
+++ b/src/core/tiledscene/qgstiledsceneindex.h
@@ -23,7 +23,7 @@
 #include "qgis.h"
 
 #include <QCache>
-#include <QReadWriteLock>
+#include <QMutex>
 
 class QgsTiledSceneTile;
 class QgsFeedback;
@@ -125,7 +125,9 @@ class CORE_EXPORT QgsAbstractTiledSceneIndex
 
   private:
 
-    mutable QReadWriteLock mCacheLock;
+    // we have to use a mutex to protect a QCache, not a read/write lock
+    // see https://bugreports.qt.io/browse/QTBUG-19794
+    mutable QMutex mCacheMutex;
     QCache< QString, QByteArray > mContentCache;
 
 };

--- a/src/core/vectortile/qgsvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvectortiledataprovider.cpp
@@ -122,7 +122,7 @@ QgsVectorTileDataProviderSharedData::QgsVectorTileDataProviderSharedData()
 
 bool QgsVectorTileDataProviderSharedData::getCachedTileData( QgsVectorTileRawData &data, QgsTileXYZ tile )
 {
-  QgsReadWriteLocker locker( mMutex, QgsReadWriteLocker::Read );
+  QMutexLocker locker( &mMutex );
   if ( QgsVectorTileRawData *cachedData = mTileCache.object( tile ) )
   {
     data = *cachedData;
@@ -134,6 +134,6 @@ bool QgsVectorTileDataProviderSharedData::getCachedTileData( QgsVectorTileRawDat
 
 void QgsVectorTileDataProviderSharedData::storeCachedTileData( const QgsVectorTileRawData &data )
 {
-  QgsReadWriteLocker locker( mMutex, QgsReadWriteLocker::Write );
+  QMutexLocker locker( &mMutex );
   mTileCache.insert( data.id, new QgsVectorTileRawData( data ) );
 }

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -58,7 +58,8 @@ class QgsVectorTileDataProviderSharedData
 
     QCache< QgsTileXYZ, QgsVectorTileRawData > mTileCache;
 
-    QReadWriteLock mMutex; //!< Access to all data members is guarded by the mutex
+    // cannot use a read/write lock here -- see https://bugreports.qt.io/browse/QTBUG-19794
+    QMutex mMutex; //!< Access to all data members is guarded by the mutex
 
 };
 


### PR DESCRIPTION
Because of https://bugreports.qt.io/browse/QTBUG-19794

(I wonder how many times we'll keep getting hit by this issue and have to re-discover the solution...)
