### PR TITLE
Use correct test when validating missing parameter inputs for model child algorithms

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -2261,7 +2261,7 @@ bool QgsProcessingModelAlgorithm::validateChildAlgorithm( const QString &childId
         if ( def->isDestination() )
           continue;
 
-        if ( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) )
+        if ( !def->checkValueIsAcceptable( QVariant() ) )
         {
           res = false;
           issues <<  QObject::tr( "Parameter <i>%1</i> is mandatory" ).arg( def->name() );

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -2010,14 +2010,12 @@ void TestQgsProcessingModelAlgorithm::modelValidate()
   m.addChildAlgorithm( alg2c1 );
 
   QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx1" ), errors ) );
-  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.size(), 1 );
   QCOMPARE( errors.at( 0 ), QStringLiteral( "Parameter <i>INPUT</i> is mandatory" ) );
-  QCOMPARE( errors.at( 1 ), QStringLiteral( "Parameter <i>ALL_PARTS</i> is mandatory" ) );
 
   QVERIFY( !m.validate( errors ) );
-  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.size(), 1 );
   QCOMPARE( errors.at( 0 ), QStringLiteral( "<b>centroids</b>: Parameter <i>INPUT</i> is mandatory" ) );
-  QCOMPARE( errors.at( 1 ), QStringLiteral( "<b>centroids</b>: Parameter <i>ALL_PARTS</i> is mandatory" ) );
 
   QgsProcessingModelChildParameterSource badSource;
   badSource.setSource( Qgis::ProcessingModelChildParameterSource::StaticValue );
@@ -2025,9 +2023,8 @@ void TestQgsProcessingModelAlgorithm::modelValidate()
   m.childAlgorithm( QStringLiteral( "cx1" ) ).addParameterSources( QStringLiteral( "INPUT" ), QList< QgsProcessingModelChildParameterSource >() << badSource );
 
   QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx1" ), errors ) );
-  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.size(), 1 );
   QCOMPARE( errors.at( 0 ), QStringLiteral( "Value for <i>INPUT</i> is not acceptable for this parameter" ) );
-  QCOMPARE( errors.at( 1 ), QStringLiteral( "Parameter <i>ALL_PARTS</i> is mandatory" ) );
 
   QgsProcessingModelChildParameterSource goodSource;
   goodSource.setSource( Qgis::ProcessingModelChildParameterSource::Expression );
@@ -2036,6 +2033,31 @@ void TestQgsProcessingModelAlgorithm::modelValidate()
   QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx1" ), errors ) );
   QCOMPARE( errors.size(), 1 );
   QCOMPARE( errors.at( 0 ), QStringLiteral( "Value for <i>INPUT</i> is not acceptable for this parameter" ) );
+
+  QgsProcessingModelChildAlgorithm alg3c1;
+  alg3c1.setChildId( QStringLiteral( "cx3" ) );
+  alg3c1.setAlgorithmId( "native:stringconcatenation" );
+  alg3c1.setDescription( QStringLiteral( "string concat" ) );
+  m.addChildAlgorithm( alg3c1 );
+  QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx3" ), errors ) );
+  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.at( 0 ), QStringLiteral( "Parameter <i>INPUT_1</i> is mandatory" ) );
+  QCOMPARE( errors.at( 1 ), QStringLiteral( "Parameter <i>INPUT_2</i> is mandatory" ) );
+  goodSource.setSource( Qgis::ProcessingModelChildParameterSource::StaticValue );
+  goodSource.setStaticValue( 56 );
+  m.childAlgorithm( QStringLiteral( "cx3" ) ).addParameterSources( QStringLiteral( "INPUT_1" ), QList< QgsProcessingModelChildParameterSource >() << goodSource );
+  QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx3" ), errors ) );
+  QCOMPARE( errors.size(), 1 );
+  QCOMPARE( errors.at( 0 ), QStringLiteral( "Parameter <i>INPUT_2</i> is mandatory" ) );
+  badSource.setSource( Qgis::ProcessingModelChildParameterSource::StaticValue );
+  badSource.setStaticValue( "" );
+  m.childAlgorithm( QStringLiteral( "cx3" ) ).addParameterSources( QStringLiteral( "INPUT_1" ), QList< QgsProcessingModelChildParameterSource >() << badSource );
+  QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx3" ), errors ) );
+  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.at( 0 ), QStringLiteral( "Value for <i>INPUT_1</i> is not acceptable for this parameter" ) );
+  QCOMPARE( errors.at( 1 ), QStringLiteral( "Parameter <i>INPUT_2</i> is mandatory" ) );
+
+  m.removeChildAlgorithm( QStringLiteral( "cx3" ) );
 
   badSource.setSource( Qgis::ProcessingModelChildParameterSource::ChildOutput );
   badSource.setOutputChildId( QStringLiteral( "cc" ) );


### PR DESCRIPTION
If a parameter is unspecified and mandatory, BUT has a non-null default value then we should consider the parameter as having a valid value and not fail the model validation.

Refs #37692
