### PR TITLE
Fix external tileset transform

### DIFF
--- a/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
@@ -323,11 +323,17 @@ QgsTiledSceneNode *QgsCesiumTiledSceneIndex::nodeFromJson( const json &json, con
 
 void QgsCesiumTiledSceneIndex::refineNodeFromJson( QgsTiledSceneNode *node, const QUrl &baseUrl, const json &json )
 {
-  std::unique_ptr< QgsTiledSceneTile > newTile = tileFromJson( json, baseUrl, node->parentNode() ? node->parentNode()->tile() : nullptr );
+  std::unique_ptr< QgsTiledSceneTile > newTile = tileFromJson( json, baseUrl, node->tile() );
   // copy just the resources from the retrieved tileset to the refined node. We assume all the rest of the tile content
   // should be the same between the node being refined and the root node of the fetched sub dataset!
   // (Ie the bounding volume, geometric error, etc).
   node->tile()->setResources( newTile->resources() );
+
+  // root tile of the sub dataset may have transform as well, we need to bring it back
+  // (actually even the referencing tile may have transform - if that's the case,
+  // that transform got combined with the root tile's transform in tileFromJson)
+  if ( newTile->transform() )
+    node->tile()->setTransform( *newTile->transform() );
 
   if ( json.contains( "children" ) )
   {

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -130,7 +130,7 @@ QgsTiledSceneRequest QgsTiledSceneLayerRenderer::createBaseRequest()
   request.setFeedback( feedback() );
 
   // TODO what z range makes sense here??
-  const QVector< QgsVector3D > corners = QgsBox3D( mapExtent, -1000, 1000 ).corners();
+  const QVector< QgsVector3D > corners = QgsBox3D( mapExtent, -10000, 10000 ).corners();
   QVector< double > x;
   x.reserve( 8 );
   QVector< double > y;


### PR DESCRIPTION
There were two issues when handling transforms while loading external datasets:
- root tile's transform was getting ignored (it was parsed but then not applied)
- root tile's transform would get combined with transform of referencing node's
  parent, although it should have been combined with referencing node's transform

Also use wider elevation range +/- 10km

This fixes reading of the Denver dataset and display in 2D (the station was not showing up at all).

For the record, this is the dataset structure:
```
tileset.json:
- root node (no content, ADD)
  - node (refs 5cm JSON, REPLACE)
  - node (refs 2cm JSON, REPLACE)
  - node (refs union station JSON, REPLACE)

union station json:
- root node (no content, REPLACE) + transform
  - node (b3dm content) + transform
    - 8 child nodes, each referencing other JSONs
```
