### PR TITLE
sandbox 3d: use projected CRS if project's CRS is not projected

### DIFF
--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -42,6 +42,13 @@ void initCanvas3D( Qgs3DMapCanvas *canvas )
   QgsLayerTree *root = QgsProject::instance()->layerTreeRoot();
   const QList< QgsMapLayer * > visibleLayers = root->checkedLayers();
 
+  QgsCoordinateReferenceSystem crs = QgsProject::instance()->crs();
+  if ( crs.isGeographic() )
+  {
+    // we can't deal with non-projected CRS, so let's just pick something
+    QgsProject::instance()->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+  }
+
   QgsMapSettings ms;
   ms.setDestinationCrs( QgsProject::instance()->crs() );
   ms.setLayers( visibleLayers );


### PR DESCRIPTION
... because 3D map views simply don't work with lat/lon CRS

(QGIS app does a similar thing)