### PR TITLE
Add ray intersection to tiled scene in 3D

### DIFF
--- a/src/3d/qgsraycastingutils_p.cpp
+++ b/src/3d/qgsraycastingutils_p.cpp
@@ -391,7 +391,7 @@ namespace QgsRayCastingUtils
 
     for ( int i = 0; i < vertexCount; i += 3 )
     {
-      int v0index, v1index, v2index;
+      int v0index = 0, v1index = 0, v2index = 0;
       if ( !indexAttr )
       {
         v0index = i;

--- a/src/3d/qgsraycastingutils_p.cpp
+++ b/src/3d/qgsraycastingutils_p.cpp
@@ -17,8 +17,26 @@
 
 #include "qgis.h"
 #include "qgsaabb.h"
+#include "qgslogger.h"
 
 #include <Qt3DRender/QCamera>
+#include <Qt3DRender/QGeometryRenderer>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DRender/QGeometry>
+typedef Qt3DRender::QAttribute Qt3DQAttribute;
+typedef Qt3DRender::QBuffer Qt3DQBuffer;
+typedef Qt3DRender::QGeometry Qt3DQGeometry;
+#else
+#include <Qt3DCore/QAttribute>
+#include <Qt3DCore/QBuffer>
+#include <Qt3DCore/QGeometry>
+typedef Qt3DCore::QAttribute Qt3DQAttribute;
+typedef Qt3DCore::QBuffer Qt3DQBuffer;
+typedef Qt3DCore::QGeometry Qt3DQGeometry;
+#endif
 
 ///@cond PRIVATE
 
@@ -277,6 +295,175 @@ namespace QgsRayCastingUtils
     return true;
   }
 
+  bool rayMeshIntersection( Qt3DRender::QGeometryRenderer *geometryRenderer,
+                            const QgsRayCastingUtils::Ray3D &r,
+                            const QMatrix4x4 &worldTransform,
+                            QVector3D &intPt,
+                            int &triangleIndex )
+  {
+    if ( geometryRenderer->primitiveType() != Qt3DRender::QGeometryRenderer::Triangles )
+    {
+      QgsDebugError( QString( "Unsupported primitive type for intersection: " ).arg( geometryRenderer->primitiveType() ) );
+      return false;
+    }
+    if ( geometryRenderer->instanceCount() != 1 || geometryRenderer->indexOffset() != 0 || geometryRenderer->indexBufferByteOffset() != 0 || geometryRenderer->firstVertex() != 0 || geometryRenderer->firstInstance() != 0 )
+    {
+      QgsDebugError( QString( "Unsupported geometry renderer for intersection." ) );
+      return false;
+    }
+
+    Qt3DQGeometry *geometry = geometryRenderer->geometry();
+
+    Qt3DQAttribute *positionAttr = nullptr;
+    Qt3DQAttribute *indexAttr = nullptr;
+    for ( Qt3DQAttribute *attr : geometry->attributes() )
+    {
+      if ( attr->name() == Qt3DQAttribute::defaultPositionAttributeName() )
+      {
+        positionAttr = attr;
+      }
+      else if ( attr->attributeType() == Qt3DQAttribute::IndexAttribute )
+      {
+        indexAttr = attr;
+      }
+    }
+
+    if ( !positionAttr )
+    {
+      QgsDebugError( "Could not find position attribute!" );
+      return false;
+    }
+
+    if ( positionAttr->vertexBaseType() != Qt3DQAttribute::Float || positionAttr->vertexSize() != 3 )
+    {
+      QgsDebugError( QString( "Unsupported position attribute: base type %1, vertex size %2" ). arg( positionAttr->vertexBaseType() ).arg( positionAttr->vertexSize() ) );
+      return false;
+    }
+
+    const QByteArray vertexBuf = positionAttr->buffer()->data();
+    const char *vertexPtr = vertexBuf.constData();
+    vertexPtr += positionAttr->byteOffset();
+    int vertexByteStride = positionAttr->byteStride() == 0 ? 3 * sizeof( float ) : positionAttr->byteStride();
+
+    const uchar *indexPtrUChar = nullptr;
+    const ushort *indexPtrUShort = nullptr;
+    const uint *indexPtrUInt = nullptr;
+    if ( indexAttr )
+    {
+      if ( indexAttr->byteStride() != 0 || indexAttr->vertexSize() != 1 )
+      {
+        QgsDebugError( QString( "Unsupported index attribute: stride %1, vertex size %2" ).arg( indexAttr->byteStride() ).arg( indexAttr->vertexSize() ) );
+        return false;
+      }
+
+      const QByteArray indexBuf = indexAttr->buffer()->data();
+      if ( indexAttr->vertexBaseType() == Qt3DQAttribute::UnsignedByte )
+      {
+        indexPtrUChar = reinterpret_cast<const uchar *>( indexBuf.constData() );
+      }
+      else if ( indexAttr->vertexBaseType() == Qt3DQAttribute::UnsignedShort )
+      {
+        indexPtrUShort = reinterpret_cast<const ushort *>( indexBuf.constData() );
+      }
+      else if ( indexAttr->vertexBaseType() == Qt3DQAttribute::UnsignedInt )
+      {
+        indexPtrUInt = reinterpret_cast<const uint *>( indexBuf.constData() );
+      }
+      else
+      {
+        QgsDebugError( QString( "Unsupported index attribute: base type %1" ).arg( indexAttr->vertexBaseType() ) );
+        return false;
+      }
+    }
+
+    int vertexCount = geometryRenderer->vertexCount();
+    if ( vertexCount == 0 && indexAttr )
+    {
+      vertexCount = indexAttr->count();
+    }
+    if ( vertexCount == 0 )
+    {
+      vertexCount = positionAttr->count();
+    }
+
+    QVector3D intersectionPt, minIntersectionPt;
+    float minDistance = -1;
+
+    for ( int i = 0; i < vertexCount; i += 3 )
+    {
+      int v0index, v1index, v2index;
+      if ( !indexAttr )
+      {
+        v0index = i;
+        v1index = i + 1;
+        v2index = i + 2;
+      }
+      else if ( indexPtrUShort )
+      {
+        v0index = indexPtrUShort[i];
+        v1index = indexPtrUShort[i + 1];
+        v2index = indexPtrUShort[i + 2];
+      }
+      else if ( indexPtrUChar )
+      {
+        v0index = indexPtrUChar[i];
+        v1index = indexPtrUChar[i + 1];
+        v2index = indexPtrUChar[i + 2];
+      }
+      else if ( indexPtrUInt )
+      {
+        v0index = indexPtrUInt[i];
+        v1index = indexPtrUInt[i + 1];
+        v2index = indexPtrUInt[i + 2];
+      }
+      else
+        Q_ASSERT( false );
+
+      const float *v0ptr = reinterpret_cast<const float *>( vertexPtr + v0index * vertexByteStride );
+      const float *v1ptr = reinterpret_cast<const float *>( vertexPtr + v1index * vertexByteStride );
+      const float *v2ptr = reinterpret_cast<const float *>( vertexPtr + v2index * vertexByteStride );
+
+      const QVector3D a( v0ptr[0], v0ptr[1], v0ptr[2] );
+      const QVector3D b( v1ptr[0], v1ptr[1], v1ptr[2] );
+      const QVector3D c( v2ptr[0], v2ptr[1], v2ptr[2] );
+
+      // Currently the worldTransform only has vertical offset, so this could be optimized by applying the transform
+      // to the ray and the resulting intersecting point instead of all triangles
+      // Need to check for potential performance gains.
+      const QVector3D tA = worldTransform * a;
+      const QVector3D tB = worldTransform * b;
+      const QVector3D tC = worldTransform * c;
+
+      QVector3D uvw;
+      float t = 0;
+
+      // We're testing both triangle orientations here and ignoring the culling mode.
+      // We should probably respect the culling mode used for the entity and perform a
+      // single test using the properly oriented triangle.
+      if ( QgsRayCastingUtils::rayTriangleIntersection( r, tA, tB, tC, uvw, t ) ||
+           QgsRayCastingUtils::rayTriangleIntersection( r, tA, tC, tB, uvw, t ) )
+      {
+        intersectionPt = r.point( t * r.distance() );
+        const float distance = r.projectedDistance( intersectionPt );
+
+        // we only want the first intersection of the ray with the mesh (closest to the ray origin)
+        if ( minDistance == -1 || distance < minDistance )
+        {
+          triangleIndex = static_cast<int>( i / 3 );
+          minDistance = distance;
+          minIntersectionPt = intersectionPt;
+        }
+      }
+    }
+
+    if ( minDistance != -1 )
+    {
+      intPt = minIntersectionPt;
+      return true;
+    }
+    else
+      return false;
+  }
 }
 
 

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -39,6 +39,7 @@ class QgsAABB;
 namespace Qt3DRender
 {
   class QCamera;
+  class QGeometryRenderer;
 }
 
 
@@ -107,6 +108,18 @@ namespace QgsRayCastingUtils
                                 QVector3D c,
                                 QVector3D &uvw,
                                 float &t );
+
+  /**
+   * Tests whether a triangular mesh is intersected by a ray. Returns whether an intersection
+   * was found. If found, it outputs the point at which the intersection happened and index
+   * of the intersecting triangle.
+   * \since QGIS 3.34
+   */
+  bool rayMeshIntersection( Qt3DRender::QGeometryRenderer *geometryRenderer,
+                            const QgsRayCastingUtils::Ray3D &r,
+                            const QMatrix4x4 &worldTransform,
+                            QVector3D &intPt,
+                            int &triangleIndex );
 
   /**
    * Helper struct to store ray casting results.

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -80,64 +80,6 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   }
 }
 
-static bool intersectionTriangles( const QByteArray &vertexBuf, const int &stride, const QgsRayCastingUtils::Ray3D &r, const QMatrix4x4 &worldTransform, QVector3D &intPt, int &triangleIndex )
-{
-  const float *vertices = reinterpret_cast<const float *>( vertexBuf.constData() );
-
-  const int vertexCount = vertexBuf.size() / stride;
-  const int triangleCount = vertexCount / 3;
-
-  QVector3D intersectionPt, minIntersectionPt;
-  float minDistance = -1;
-
-  const int vertexSize = stride / sizeof( float );
-  const int triangleSize = 3 * vertexSize;
-  for ( int i = 0; i < triangleCount; ++i )
-  {
-    const int v0 = i * triangleSize, v1 = i * triangleSize + vertexSize, v2 = i * triangleSize + vertexSize + vertexSize;
-
-    const QVector3D a( vertices[v0], vertices[v0 + 1], vertices[v0 + 2] );
-    const QVector3D b( vertices[v1], vertices[v1 + 1], vertices[v1 + 2] );
-    const QVector3D c( vertices[v2], vertices[v2 + 1], vertices[v2 + 2] );
-
-    // Currently the worldTransform only has vertical offset, so this could be optimized by applying the transform
-    // to the ray and the resulting intersecting point instead of all triangles
-    // Need to check for potential performance gains.
-    const QVector3D tA = worldTransform * a;
-    const QVector3D tB = worldTransform * b;
-    const QVector3D tC = worldTransform * c;
-
-    QVector3D uvw;
-    float t = 0;
-
-    // We're testing both triangle orientations here and ignoring the culling mode.
-    // We should probably respect the culling mode used for the entity and perform a
-    // single test using the properly oriented triangle.
-    if ( QgsRayCastingUtils::rayTriangleIntersection( r, tA, tB, tC, uvw, t ) ||
-         QgsRayCastingUtils::rayTriangleIntersection( r, tA, tC, tB, uvw, t ) )
-    {
-      intersectionPt = r.point( t * r.distance() );
-      const float distance = r.projectedDistance( intersectionPt );
-
-      // we only want the first intersection of the ray with the mesh (closest to the ray origin)
-      if ( minDistance == -1 || distance < minDistance )
-      {
-        triangleIndex = static_cast<int>( i );
-        minDistance = distance;
-        minIntersectionPt = intersectionPt;
-      }
-    }
-  }
-
-  if ( minDistance != -1 )
-  {
-    intPt = minIntersectionPt;
-    return true;
-  }
-  else
-    return false;
-}
-
 void QgsTessellatedPolygonGeometry::setPolygons( const QList<QgsPolygon *> &polygons, const QList<QgsFeatureId> &featureIds, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon )
 {
   Q_ASSERT( polygons.count() == featureIds.count() );
@@ -181,17 +123,6 @@ void QgsTessellatedPolygonGeometry::setData( const QByteArray &vertexBufferData,
     mNormalAttribute->setCount( vertexCount );
   if ( mTextureCoordsAttribute )
     mTextureCoordsAttribute->setCount( vertexCount );
-}
-
-bool QgsTessellatedPolygonGeometry::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QMatrix4x4 &worldTransform, QVector3D &intersectionPoint, QgsFeatureId &fid )
-{
-  int triangleIndex = -1;
-  const int stride = static_cast<int>( mPositionAttribute->byteStride() );
-  bool success = intersectionTriangles( mVertexBuffer->data(), stride, ray, worldTransform, intersectionPoint, triangleIndex );
-
-  fid = success ? triangleIndexToFeatureId( triangleIndex ) : FID_NULL;
-
-  return success;
 }
 
 // run binary search on a sorted array, return index i where data[i] <= v < data[i+1]

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -108,12 +108,6 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
      */
     QgsFeatureId triangleIndexToFeatureId( uint triangleIndex ) const;
 
-    /**
-     * Tests whether the geometry is intersected by \a ray.
-     * In case of success, the \a intersectionPoint and the corresponding \a fid are updated.
-     */
-    bool rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QMatrix4x4 &worldTransform, QVector3D &intersectionPoint, QgsFeatureId &fid );
-
     friend class Qgs3DSceneExporter;
   private:
 

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -122,7 +122,12 @@ class QgsTiledSceneLayerChunkedEntity : public QgsChunkedEntity
 
     ~QgsTiledSceneLayerChunkedEntity();
 
+    QVector<QgsRayCastingUtils::RayHit> rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QgsRayCastingUtils::RayCastContext &context ) const override;
+
     int pendingJobsCount() const override;
+
+  private:
+    mutable QgsTiledSceneIndex mIndex;
 };
 
 /// @endcond

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -249,8 +249,9 @@ QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection
         }
 
         QVector3D nodeIntPoint;
-        QgsFeatureId fid = FID_NULL;
-        if ( polygonGeom->rayIntersection( ray, transformMatrix, nodeIntPoint, fid ) )
+        int triangleIndex = -1;
+
+        if ( QgsRayCastingUtils::rayMeshIntersection( rend, ray, transformMatrix, nodeIntPoint, triangleIndex ) )
         {
 #ifdef QGISDEBUG
           hits++;
@@ -260,7 +261,7 @@ QVector<QgsRayCastingUtils::RayHit> QgsVectorLayerChunkedEntity::rayIntersection
           {
             minDist = dist;
             intersectionPoint = nodeIntPoint;
-            nearestFid = fid;
+            nearestFid = polygonGeom->triangleIndexToFeatureId( triangleIndex );
           }
         }
       }

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -51,6 +51,7 @@ class QgsDockWidget;
 class QgsMapLayerAction;
 class QgsEditorWidgetSetup;
 class QgsSettingsEntryBool;
+class QgsTiledSceneLayer;
 
 class QwtPlotCurve;
 
@@ -177,6 +178,15 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     void addFeature( QgsPointCloudLayer *layer,
                      const QString &label,
                      const QMap< QString, QString > &attributes );
+
+    /**
+     * Adds results from tiled scene layer
+     * \since QGIS 3.34
+     */
+    void addFeature( QgsTiledSceneLayer *layer,
+                     const QString &label,
+                     const QMap< QString, QString > &attributes,
+                     const QMap< QString, QString > &derivedAttributes );
 
     //! Adds feature from identify results
     void addFeature( const QgsMapToolIdentify::IdentifyResult &result );
@@ -309,6 +319,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QgsMeshLayer *meshLayer( QTreeWidgetItem *item );
     QgsVectorTileLayer *vectorTileLayer( QTreeWidgetItem *item );
     QgsPointCloudLayer *pointCloudLayer( QTreeWidgetItem *item );
+    QgsTiledSceneLayer *tiledSceneLayer( QTreeWidgetItem *item );
     QTreeWidgetItem *featureItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QObject *layer );


### PR DESCRIPTION
This allows measuring on tiled scene data in 3D views, as well as very basic identify tool support (in 3D), mainly useful for debugging (returns tile ID, geometry error, content URL).

Also cleans up ray intersection code for tesselated polygon geometry, which is now using common code in QgsRayCastingUtils.