### PR TITLE
[processing] B3DM to GLTF algorithm - handle broken files

### DIFF
--- a/src/analysis/processing/qgsalgorithmb3dmtogltf.cpp
+++ b/src/analysis/processing/qgsalgorithmb3dmtogltf.cpp
@@ -109,7 +109,7 @@ QVariantMap QgsB3DMToGltfAlgorithm::processAlgorithm( const QVariantMap &paramet
   }
   if ( !res )
   {
-    // if we can't read the GLTF, then just write the original B3DM content to the output file
+    // if we can't read the GLTF, then just write the original GLTF content to the output file
     QFile outputFile( outputPath );
     if ( !outputFile.open( QFile::WriteOnly ) )
     {


### PR DESCRIPTION
When GLTF content cannot be parsed from the B3DM, just extract the binary contents anyway to a file.

Allows these broken files to be tested in other applications to determine if it's just the GLTF reader library which doesn't handle them, or actually broken content.
