### PR TITLE
Improve "avoid intersections" type awareness

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1384,6 +1384,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     bool saveDirty();
 
+    /**
+     * Pastes the \a features to the \a pasteVectorLayer and gives feedback to the user
+     * according to \a invalidGeometryCount and \a nTotalFeatures
+     * \note Setting the \a duplicateFeature to TRUE will handle the pasting of features as duplicates of pre-existing features
+     */
+    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features, bool duplicateFeature = false );
+
   public slots:
 
     /**
@@ -2347,13 +2354,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Create the option dialog
     QgsOptions *createOptionsDialog( QWidget *parent = nullptr );
-
-    /**
-     * Pastes the \a features to the \a pasteVectorLayer and gives feedback to the user
-     * according to \a invalidGeometryCount and \a nTotalFeatures
-     * \note Setting the \a duplicateFeature to TRUE will handle the pasting of features as duplicates of pre-existing features
-     */
-    void pasteFeatures( QgsVectorLayer *pasteVectorLayer, int invalidGeometriesCount, int nTotalFeatures, QgsFeatureList &features, bool duplicateFeature = false );
 
     /**
      * starts/stops for a vector layer \a vlayer

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2446,7 +2446,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
               for ( int i = 0; i < newGeoms.size(); ++i )
               {
                 QgsGeometry currentPart = newGeoms.at( i );
-                double currentPartSize = layer->geometryType() == Qgis::GeometryType::Polygon ? currentPart.area() : currentPart.length();
+                const double currentPartSize = layer->geometryType() == Qgis::GeometryType::Polygon ? currentPart.area() : currentPart.length();
 
                 QgsFeature partFeature( layer->fields() );
                 partFeature.setAttributes( originalFeature.attributes() );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2431,8 +2431,48 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
         switch ( avoidIntersectionsReturn )
         {
           case 2: // Geometry type was changed, let's try our best to make it compatible with the target layer
-            featGeom.coerceToType( layer->wkbType() );
+          {
+            const QVector<QgsGeometry> newGeoms = featGeom.coerceToType( layer->wkbType() );
+            if ( newGeoms.count() == 1 )
+            {
+              featGeom = newGeoms.at( 0 );
+            }
+            else // handle multi geometries
+            {
+              QgsFeatureList removedFeatures;
+              double largest = 0;
+              QgsFeature originalFeature = layer->getFeature( it2.key() );
+              int largestPartIndex = -1;
+              for ( int i = 0; i < newGeoms.size(); ++i )
+              {
+                QgsGeometry currentPart = newGeoms.at( i );
+                double currentPartSize = layer->geometryType() == Qgis::GeometryType::Polygon ? currentPart.area() : currentPart.length();
+
+                QgsFeature partFeature( layer->fields() );
+                partFeature.setAttributes( originalFeature.attributes() );
+                partFeature.setGeometry( currentPart );
+                removedFeatures.append( partFeature );
+                if ( currentPartSize > largest )
+                {
+                  featGeom = currentPart;
+                  largestPartIndex = i;
+                  largest = currentPartSize;
+                }
+              }
+              removedFeatures.removeAt( largestPartIndex );
+              QgsMessageBarItem *messageBarItem = QgisApp::instance()->messageBar()->createMessage( tr( "Avoid overlaps" ), tr( "Only the largest of multiple created geometries was preserved." ) );
+              QPushButton *restoreButton = new QPushButton( tr( "Restore others" ) );
+              connect( restoreButton, &QPushButton::clicked, restoreButton, [ = ]
+              {
+                layer->beginEditCommand( tr( "Restored geometry parts removed by avoid overlaps" ) );
+                QgsFeatureList unconstFeatures = removedFeatures;
+                QgisApp::instance()->pasteFeatures( layer, 0, removedFeatures.size(), unconstFeatures );
+              } );
+              messageBarItem->layout()->addWidget( restoreButton );
+              QgisApp::instance()->messageBar()->pushWidget( messageBarItem, Qgis::MessageLevel::Info, 5 );
+            }
             break;
+          }
 
           case 3:
             emit messageEmitted( tr( "At least one geometry intersected is invalid. These geometries must be manually repaired." ), Qgis::MessageLevel::Warning );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2469,7 +2469,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
                 QgisApp::instance()->pasteFeatures( layer, 0, removedFeatures.size(), unconstFeatures );
               } );
               messageBarItem->layout()->addWidget( restoreButton );
-              QgisApp::instance()->messageBar()->pushWidget( messageBarItem, Qgis::MessageLevel::Info, 5 );
+              QgisApp::instance()->messageBar()->pushWidget( messageBarItem, Qgis::MessageLevel::Info, 15 );
             }
             break;
           }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2462,11 +2462,14 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
               removedFeatures.removeAt( largestPartIndex );
               QgsMessageBarItem *messageBarItem = QgisApp::instance()->messageBar()->createMessage( tr( "Avoid overlaps" ), tr( "Only the largest of multiple created geometries was preserved." ) );
               QPushButton *restoreButton = new QPushButton( tr( "Restore others" ) );
+              QPointer<QgsVectorLayer> layerPtr( layer );
               connect( restoreButton, &QPushButton::clicked, restoreButton, [ = ]
               {
-                layer->beginEditCommand( tr( "Restored geometry parts removed by avoid overlaps" ) );
+                if ( !layerPtr )
+                  return;
+                layerPtr->beginEditCommand( tr( "Restored geometry parts removed by avoid overlaps" ) );
                 QgsFeatureList unconstFeatures = removedFeatures;
-                QgisApp::instance()->pasteFeatures( layer, 0, removedFeatures.size(), unconstFeatures );
+                QgisApp::instance()->pasteFeatures( layerPtr.data(), 0, removedFeatures.size(), unconstFeatures );
               } );
               messageBarItem->layout()->addWidget( restoreButton );
               QgisApp::instance()->messageBar()->pushWidget( messageBarItem, Qgis::MessageLevel::Info, 15 );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2427,10 +2427,11 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
         id.insert( it2.key() );
         ignoreFeatures.insert( layer, id );
         int avoidIntersectionsReturn = featGeom.avoidIntersections( avoidIntersectionsLayers, ignoreFeatures );
+
         switch ( avoidIntersectionsReturn )
         {
-          case 2:
-            emit messageEmitted( tr( "The operation would change the geometry type." ), Qgis::MessageLevel::Warning );
+          case 2: // Geometry type was changed, let's try our best to make it compatible with the target layer
+            featGeom.coerceToType( layer->wkbType() );
             break;
 
           case 3:

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -1248,6 +1248,19 @@ void TestQgsVertexTool::testAvoidIntersections()
   mLayerPolygon->undoStack()->undo(); // delete feature polygonF_topo1
   QCOMPARE( mLayerPolygon->featureCount(), ( long )1 );
 
+  // Make sure the largest part is preserved if multiple parts are created
+  polygonF2.setGeometry( QgsGeometry::fromWkt( "Polygon ((8 3, 9 3, 9 2, 8 2, 8 3))" ) );
+  mLayerPolygon->addFeature( polygonF2 );
+  const QgsFeatureId fidPoly2 = polygonF2.id();
+  mouseClick( 8, 2.75, Qt::LeftButton ); // moves the edge
+  mouseClick( 3, 2.75, Qt::LeftButton );
+
+  QCOMPARE( mLayerPolygon->getFeature( fidPoly2 ).geometry().asWkt( 1 ), "Polygon ((9 3, 9 2, 7 2, 7 3, 9 3))" );
+  mLayerPolygon->undoStack()->undo(); // undo edge move
+  mLayerPolygon->undoStack()->undo(); // undo feature addition
+
+  QCOMPARE( mLayerPolygon->featureCount(), ( long )1 );
+
   QgsProject::instance()->setTopologicalEditing( false );
   QgsProject::instance()->setAvoidIntersectionsMode( mode );
 }


### PR DESCRIPTION
## Description

When "avoid intersections" is enabled and the geometry type is changed (e.g. the last curve of a curvepolygon was removed), QGIS was giving a strange message "The operation would change the geometry type". This gives a) no helpful context for a user at all and b) is wrong because by saying it "would" it suggests that it attempted but did not change the geometry type, but it actually did change the geometry type.
In case of a single polygon being split into multiple polygons, the operation would actually create a multi geometry which cannot be saved.

With this change
1. the resulting geometry is coerced to the target geometry type.
2. in case of a single polygon being split into a multipolygon (or single line being split into multi line), it will now preserve only the biggest part (as often smaller parts are sliver polygons that better would be removed) and propose to restore the removed parts and insert them as new geometries for the cases where the user actually wants to preserve them.

![Peek 2023-09-04 09-35](https://github.com/qgis/QGIS/assets/588407/de2d6349-7fc1-4e98-9a4e-99dc5801ee17)
