### PR TITLE
[BSD][PDAL] Fix build using pthread

### DIFF
--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -190,6 +190,7 @@ if (PDAL_2_5_OR_HIGHER)
   target_link_libraries (pdal_wrench PRIVATE
     ${PDAL_LIBRARIES}
     ${GDAL_LIBRARY}
+    Threads::Threads
   )
 
   install(TARGETS pdal_wrench
@@ -256,12 +257,6 @@ if (WITH_GUI)
   )
   add_dependencies(provider_pdal_gui_a ui)
 endif()
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
-  set(CMAKE_THREAD_LIBS -pthread)
-  set(CMAKE_USE_PTHREADS ON)
-  set(CMAKE_EXE_LINKER_FLAGS -pthread)
-endif(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
 
 install(TARGETS provider_pdal
   RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -257,6 +257,12 @@ if (WITH_GUI)
   add_dependencies(provider_pdal_gui_a ui)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+  set(CMAKE_THREAD_LIBS -pthread)
+  set(CMAKE_USE_PTHREADS ON)
+  set(CMAKE_EXE_LINKER_FLAGS -pthread)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+
 install(TARGETS provider_pdal
   RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
   LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})


### PR DESCRIPTION
## Description

PDAL requires pthread to build, however is not linked nor defined for *BSD. One have to, at least, add CXXFLAGS+=-pthread to fix build.

This PR proposes to avoid a manual task and directly link pdal with pthread on BSD systems.

cc @rhurlin @landryb 