### PR TITLE
Keep snapped coordinates when using vertex tool on a curved geometries

### DIFF
--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -290,7 +290,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
               // when snapping to a curve we need to use real geometry in order to have correct location
               // of the snapped point, see https://github.com/qgis/QGIS/issues/53197.
               // In other cases it is ok to use only a segment to speedup calculations.
-              if ( QgsWkbTypes::isCurvedType( mLayer->wkbType() ) )
+              if ( QgsWkbTypes::isCurvedType( geom.wkbType() ) )
               {
                 point = QgsGeometryUtils::closestPoint( *geom.constGet(), QgsPoint( snappedPoint ) );
               }

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -287,12 +287,17 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
             if ( !( geom.isNull() || geom.isEmpty() ) )
             {
-              const QgsLineString line( geom.vertexAt( mVertexIndex ), geom.vertexAt( mVertexIndex + 1 ) );
-              point = QgsGeometryUtils::closestPoint( line, QgsPoint( snappedPoint ) );
+              // when snapping to a curve we need to use real geometry in order to have correct location
+              // of the snapped point, see https://github.com/qgis/QGIS/issues/53197.
+              // In other cases it is ok to use only a segment to speedup calculations.
               if ( QgsWkbTypes::isCurvedType( mLayer->wkbType() ) )
               {
-                point.setX( snappedPoint.x() );
-                point.setY( snappedPoint.y() );
+                point = QgsGeometryUtils::closestPoint( *geom.constGet(), QgsPoint( snappedPoint ) );
+              }
+              else
+              {
+                const QgsLineString line( geom.vertexAt( mVertexIndex ), geom.vertexAt( mVertexIndex + 1 ) );
+                point = QgsGeometryUtils::closestPoint( line, QgsPoint( snappedPoint ) );
               }
             }
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -289,8 +289,12 @@ class CORE_EXPORT QgsPointLocator : public QObject
             {
               const QgsLineString line( geom.vertexAt( mVertexIndex ), geom.vertexAt( mVertexIndex + 1 ) );
               point = QgsGeometryUtils::closestPoint( line, QgsPoint( snappedPoint ) );
+              if ( QgsWkbTypes::isCurvedType( mLayer->wkbType() ) )
+              {
+                point.setX( snappedPoint.x() );
+                point.setY( snappedPoint.y() );
+              }
             }
-
 
             if ( transform.isValid() )
             {


### PR DESCRIPTION
## Description

When using vertex tool to modify geometry and snap to a curve, the rubber band shows a correct snap but after "commiting" changes updated point jumps to a location on a segmentized curve.

This happens because `QgsPointLocator::Match::interpolatedPoint()` performs interpolation on a segment, even if curved geometry is used. Proposed fix keeps snapped X and Y coordinates while Z coordinate is interpolated from a segment.

Refs #53197.

Funded by NetPMD