### PR TITLE
[3d] qgsmesh3dmaterial: Allow to change culling mode

### DIFF
--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -35,6 +35,7 @@
 #include <QByteArray>
 
 #include "qgsmeshlayer.h"
+#include "qgs3dutils.h"
 #include "qgsmeshlayerutils.h"
 #include "qgstriangularmesh.h"
 
@@ -170,6 +171,10 @@ void QgsMesh3DMaterial::configure()
 
   Qt3DRender::QRenderPass *renderPass = new Qt3DRender::QRenderPass();
   Qt3DRender::QShaderProgram *shaderProgram = new Qt3DRender::QShaderProgram();
+
+  Qt3DRender::QCullFace *cullingFace = new Qt3DRender::QCullFace();
+  cullingFace->setMode( Qgs3DUtils::qt3DcullingMode( mSymbol->cullingMode() ) );
+  renderPass->addRenderState( cullingFace );
 
   //Load shader programs
   const QUrl urlVert( QStringLiteral( "qrc:/shaders/mesh/mesh.vert" ) );

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -890,3 +890,15 @@ void Qgs3DUtils::computeBoundingBoxNearFarPlanes( const QgsAABB &bbox, const QMa
     ffar = std::max( ffar, dst );
   }
 }
+
+Qt3DRender::QCullFace::CullingMode Qgs3DUtils::qt3DcullingMode( Qgs3DTypes::CullingMode mode )
+{
+  switch ( mode )
+  {
+    case Qgs3DTypes::NoCulling:    return Qt3DRender::QCullFace::NoCulling;
+    case Qgs3DTypes::Front:        return Qt3DRender::QCullFace::Front;
+    case Qgs3DTypes::Back:         return Qt3DRender::QCullFace::Back;
+    case Qgs3DTypes::FrontAndBack: return Qt3DRender::QCullFace::FrontAndBack;
+  }
+  return Qt3DRender::QCullFace::NoCulling;
+}

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -40,6 +40,7 @@ namespace Qt3DExtras
 
 #include <QSize>
 #include <Qt3DRender/QCamera>
+#include <Qt3DRender/QCullFace>
 
 #include <memory>
 
@@ -295,6 +296,15 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.34
      */
     static void computeBoundingBoxNearFarPlanes( const QgsAABB &bbox, const QMatrix4x4 &viewMatrix, float &fnear, float &ffar );
+
+    /**
+     * Converts Qgs3DTypes::CullingMode \a mode into its Qt3D equivalent.
+     *
+     * \param mode culling mode
+     *
+     * \since QGIS 3.34
+     */
+    static Qt3DRender::QCullFace::CullingMode qt3DcullingMode( Qgs3DTypes::CullingMode mode );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/symbols/qgsmesh3dsymbol.cpp
+++ b/src/3d/symbols/qgsmesh3dsymbol.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsmesh3dsymbol.h"
+#include "qgs3dtypes.h"
 #include "qgssymbollayerutils.h"
 #include "qgs3dutils.h"
 #include "qgsphongmaterialsettings.h"
@@ -34,6 +35,7 @@ QgsMesh3DSymbol *QgsMesh3DSymbol::clone() const
   result->mHeight = mHeight;
   result->mMaterialSettings.reset( mMaterialSettings->clone() );
   result->mAddBackFaces = mAddBackFaces;
+  result->mCullingMode = mCullingMode;
   result->mEnabled = mEnabled;
   result->mSmoothedTriangles = mSmoothedTriangles;
   result->mWireframeEnabled = mWireframeEnabled;
@@ -73,6 +75,7 @@ void QgsMesh3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &co
   //Advanced symbol
   QDomElement elemAdvancedSettings = doc.createElement( QStringLiteral( "advanced-settings" ) );
   elemAdvancedSettings.setAttribute( QStringLiteral( "renderer-3d-enabled" ), mEnabled ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  elemAdvancedSettings.setAttribute( QStringLiteral( "culling-mode" ), Qgs3DUtils::cullingModeToString( mCullingMode ) );
   elemAdvancedSettings.setAttribute( QStringLiteral( "smoothed-triangle" ), mSmoothedTriangles ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   elemAdvancedSettings.setAttribute( QStringLiteral( "wireframe-enabled" ), mWireframeEnabled ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   elemAdvancedSettings.setAttribute( QStringLiteral( "wireframe-line-width" ), mWireframeLineWidth );
@@ -110,6 +113,7 @@ void QgsMesh3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   //Advanced symbol
   const QDomElement elemAdvancedSettings = elem.firstChildElement( QStringLiteral( "advanced-settings" ) );
   mEnabled = elemAdvancedSettings.attribute( QStringLiteral( "renderer-3d-enabled" ) ).toInt();
+  mCullingMode = Qgs3DUtils::cullingModeFromString( elemAdvancedSettings.attribute( QStringLiteral( "culling-mode" ), QStringLiteral( "back" ) ) );
   mSmoothedTriangles = elemAdvancedSettings.attribute( QStringLiteral( "smoothed-triangle" ) ).toInt();
   mWireframeEnabled = elemAdvancedSettings.attribute( QStringLiteral( "wireframe-enabled" ) ).toInt();
   mWireframeLineWidth = elemAdvancedSettings.attribute( QStringLiteral( "wireframe-line-width" ) ).toDouble();
@@ -292,6 +296,15 @@ void QgsMesh3DSymbol::setEnabled( bool enabled )
   mEnabled = enabled;
 }
 
+Qgs3DTypes::CullingMode QgsMesh3DSymbol::cullingMode() const
+{
+  return mCullingMode;
+}
+
+void QgsMesh3DSymbol::setCullingMode( const Qgs3DTypes::CullingMode &mode )
+{
+  mCullingMode = mode;
+}
 
 QgsAbstractMaterialSettings *QgsMesh3DSymbol::materialSettings() const
 {

--- a/src/3d/symbols/qgsmesh3dsymbol.h
+++ b/src/3d/symbols/qgsmesh3dsymbol.h
@@ -96,6 +96,20 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
      */
     void setEnabled( bool enabled );
 
+    /**
+     * Returns culling mode
+     *
+     * \since QGIS 3.34
+     */
+    Qgs3DTypes::CullingMode cullingMode() const;
+
+    /**
+     * Sets culling mode
+     *
+     * \since QGIS 3.34
+     */
+    void setCullingMode( const Qgs3DTypes::CullingMode &mode );
+
     //! Returns method that determines altitude (whether to clamp to feature to terrain)
     Qgis::AltitudeClamping altitudeClamping() const { return mAltClamping; }
     //! Sets method that determines altitude (whether to clamp to feature to terrain)
@@ -351,6 +365,8 @@ class _3D_EXPORT QgsMesh3DSymbol : public QgsAbstract3DSymbol
     bool mAddBackFaces = false;
 
     bool mEnabled = true;
+
+    Qgs3DTypes::CullingMode mCullingMode = Qgs3DTypes::NoCulling;
 
     //! Triangles settings
     bool mSmoothedTriangles = false;

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -286,19 +286,6 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
 // cppcheck-suppress memleak
 }
 
-
-static Qt3DRender::QCullFace::CullingMode _qt3DcullingMode( Qgs3DTypes::CullingMode mode )
-{
-  switch ( mode )
-  {
-    case Qgs3DTypes::NoCulling:    return Qt3DRender::QCullFace::NoCulling;
-    case Qgs3DTypes::Front:        return Qt3DRender::QCullFace::Front;
-    case Qgs3DTypes::Back:         return Qt3DRender::QCullFace::Back;
-    case Qgs3DTypes::FrontAndBack: return Qt3DRender::QCullFace::FrontAndBack;
-  }
-  return Qt3DRender::QCullFace::NoCulling;
-}
-
 // front/back side culling
 static void applyCullingMode( Qgs3DTypes::CullingMode cullingMode, Qt3DRender::QMaterial *material )
 {
@@ -309,7 +296,7 @@ static void applyCullingMode( Qgs3DTypes::CullingMode cullingMode, Qt3DRender::Q
     for ( auto rpit = renderPasses.begin(); rpit != renderPasses.end(); ++rpit )
     {
       Qt3DRender::QCullFace *cullFace = new Qt3DRender::QCullFace;
-      cullFace->setMode( _qt3DcullingMode( cullingMode ) );
+      cullFace->setMode( Qgs3DUtils::qt3DcullingMode( cullingMode ) );
       ( *rpit )->addRenderState( cullFace );
     }
   }

--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsmesh3dsymbolwidget.h"
+#include "qgs3dtypes.h"
 #include "qgsmeshlayer.h"
 #include "qgstriangularmesh.h"
 #include "qgsmeshdataprovider.h"
@@ -32,9 +33,19 @@ QgsMesh3DSymbolWidget::QgsMesh3DSymbolWidget( QgsMeshLayer *meshLayer, QWidget *
   mComboBoxTextureType->addItem( tr( "Single Color" ), QgsMesh3DSymbol::SingleColor );
   mComboBoxTextureType->setCurrentIndex( 0 );
 
+  mCullingMode->addItem( tr( "No Culling" ), Qgs3DTypes::NoCulling );
+  mCullingMode->addItem( tr( "Front" ), Qgs3DTypes::Front );
+  mCullingMode->addItem( tr( "Back" ), Qgs3DTypes::Back );
+
+  mCullingMode->setItemData( 0, tr( "Both sides of the mesh are visible" ), Qt::ToolTipRole );
+  mCullingMode->setItemData( 1, tr( "Only the back of the mesh is visible" ), Qt::ToolTipRole );
+  mCullingMode->setItemData( 2, tr( "Only the front of the mesh is visible" ), Qt::ToolTipRole );
+
   mDatasetGroupListModel = new QgsMeshDatasetGroupListModel( this );
   mComboBoxDatasetVertical->setModel( mDatasetGroupListModel );
   setLayer( meshLayer );
+
+  connect( mCullingMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsMesh3DSymbolWidget::changed );
 
   connect( mChkSmoothTriangles, &QCheckBox::clicked, this, &QgsMesh3DSymbolWidget::changed );
   connect( mGroupBoxWireframe, &QGroupBox::toggled, this, &QgsMesh3DSymbolWidget::changed );
@@ -77,6 +88,7 @@ QgsMesh3DSymbolWidget::QgsMesh3DSymbolWidget( QgsMeshLayer *meshLayer, QWidget *
 void QgsMesh3DSymbolWidget::setSymbol( const QgsMesh3DSymbol *symbol )
 {
   mSymbol.reset( symbol->clone() );
+  mCullingMode->setCurrentIndex( mCullingMode->findData( symbol->cullingMode() ) );
   mChkSmoothTriangles->setChecked( symbol->smoothedTriangles() );
   mGroupBoxWireframe->setChecked( symbol->wireframeEnabled() );
   mColorButtonWireframe->setColor( symbol->wireframeLineColor() );
@@ -179,6 +191,7 @@ std::unique_ptr<QgsMesh3DSymbol> QgsMesh3DSymbolWidget::symbol() const
 {
   std::unique_ptr< QgsMesh3DSymbol > sym( mSymbol->clone() );
 
+  sym->setCullingMode( static_cast<Qgs3DTypes::CullingMode>( mCullingMode->currentData().toInt() ) );
   sym->setSmoothedTriangles( mChkSmoothTriangles->isChecked() );
   sym->setWireframeEnabled( mGroupBoxWireframe->isChecked() );
   sym->setWireframeLineColor( mColorButtonWireframe->color() );

--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -266,5 +266,3 @@ void QgsMesh3DSymbolWidget::enableArrowSettings( bool isEnable )
 {
   mGroupBoxArrowsSettings->setVisible( isEnable );
 }
-
-

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -15,6 +15,7 @@
 
 #include "qgspolygon3dsymbolwidget.h"
 
+#include "qgs3dtypes.h"
 #include "qgspolygon3dsymbol.h"
 #include "qgsphongmaterialsettings.h"
 
@@ -25,6 +26,10 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   spinHeight->setClearValue( 0.0 );
   spinExtrusion->setClearValue( 0.0 );
   spinEdgeWidth->setClearValue( 1.0 );
+
+  cboCullingMode->addItem( tr( "No Culling" ), Qgs3DTypes::NoCulling );
+  cboCullingMode->addItem( tr( "Front" ), Qgs3DTypes::Front );
+  cboCullingMode->addItem( tr( "Back" ), Qgs3DTypes::Back );
 
   QgsPolygon3DSymbol defaultSymbol;
   setSymbol( &defaultSymbol, nullptr );
@@ -62,7 +67,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
   spinExtrusion->setValue( polygonSymbol->extrusionHeight() );
   cboAltClamping->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeClamping() ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeBinding() ) );
-  cboCullingMode->setCurrentIndex( static_cast<int>( polygonSymbol->cullingMode() ) );
+  cboCullingMode->setCurrentIndex( cboCullingMode->findData( polygonSymbol->cullingMode() ) );
   cboRenderedFacade->setCurrentIndex( polygonSymbol->renderedFacade() );
 
   chkAddBackFaces->setChecked( polygonSymbol->addBackFaces() );
@@ -85,7 +90,7 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
   sym->setExtrusionHeight( spinExtrusion->value() );
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );
-  sym->setCullingMode( static_cast<Qgs3DTypes::CullingMode>( cboCullingMode->currentIndex() ) );
+  sym->setCullingMode( static_cast<Qgs3DTypes::CullingMode>( cboCullingMode->currentData().toInt() ) );
   sym->setRenderedFacade( cboRenderedFacade->currentIndex() );
   sym->setAddBackFaces( chkAddBackFaces->isChecked() );
   sym->setInvertNormals( chkInvertNormals->isChecked() );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -31,6 +31,10 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   cboCullingMode->addItem( tr( "Front" ), Qgs3DTypes::Front );
   cboCullingMode->addItem( tr( "Back" ), Qgs3DTypes::Back );
 
+  cboCullingMode->setItemData( 0, tr( "Both sides of the shapes are visible" ), Qt::ToolTipRole );
+  cboCullingMode->setItemData( 1, tr( "Only the back of the shapes is visible" ), Qt::ToolTipRole );
+  cboCullingMode->setItemData( 2, tr( "Only the front of the shapes is visible" ), Qt::ToolTipRole );
+
   QgsPolygon3DSymbol defaultSymbol;
   setSymbol( &defaultSymbol, nullptr );
 

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -112,23 +112,7 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QComboBox" name="cboCullingMode">
-     <item>
-      <property name="text">
-       <string>No Culling</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Front</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Back</string>
-      </property>
-     </item>
-    </widget>
+    <widget class="QComboBox" name="cboCullingMode"/>
    </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="cboAltBinding">

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -27,6 +27,20 @@
     <number>0</number>
    </property>
    <item>
+    <layout class="QFormLayout" name="cullingModeFormLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="mCullingModeLabel">
+       <property name="text">
+        <string>Culling mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="mCullingMode"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QgsCollapsibleGroupBox" name="mGroupBoxTrianglesSettings">
      <property name="title">
       <string>Triangles Settings</string>
@@ -449,6 +463,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mCullingMode</tabstop>
   <tabstop>mChkSmoothTriangles</tabstop>
   <tabstop>mGroupBoxWireframe</tabstop>
   <tabstop>mSpinBoxWireframeLineWidth</tabstop>


### PR DESCRIPTION
This allows to see the meshes from behind for example. 

### Back culling

[mesh-culling-before.webm](https://github.com/qgis/QGIS/assets/497207/53f16ef3-d2d5-4614-8b96-6cfc4a8cf7be)

### No culling 

[mesh-culling-after.webm](https://github.com/qgis/QGIS/assets/497207/5da07e9a-73a7-49a3-98c0-dc81944d4c96)

cc @benoitdm-oslandia @wonder-sk @vcloarec 

### Update: added an option to choose culling mode

![Capture d’écran du 2023-09-06 11-29-28](https://github.com/qgis/QGIS/assets/497207/2a6feb8d-e829-4559-bdc4-bcac14511581)
