### PR TITLE
[processing] "Rectangles, ovals, diamonds" algorithm: set SEGMENTS default value to 36

### DIFF
--- a/src/analysis/processing/qgsalgorithmrectanglesovalsdiamonds.cpp
+++ b/src/analysis/processing/qgsalgorithmrectanglesovalsdiamonds.cpp
@@ -121,7 +121,7 @@ void QgsRectanglesOvalsDiamondsAlgorithm::initParameters( const QVariantMap & )
   rotationParam->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
   addParameter( rotationParam.release() );
 
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "SEGMENTS" ), QObject::tr( "Segments" ), QgsProcessingParameterNumber::Integer, 5, false, 1 ) );
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "SEGMENTS" ), QObject::tr( "Segments" ), QgsProcessingParameterNumber::Integer, 36, false, 1 ) );
 }
 
 bool QgsRectanglesOvalsDiamondsAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )


### PR DESCRIPTION
## Description

Sets the default value of the "Rectangles, ovals, diamonds" (native:rectanglesovalsdiamonds) processing algorithm's SEGMENTS parameter to 36.

The current default value is 5, which is too small.
Previously, the default value was 36:
https://github.com/qgis/QGIS/blob/cf36172e3322f18e75679d0c226eeafd679fb27d/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsFixed.py#L75-L78
and such value is also declared in the docs:
https://docs.qgis.org/3.28/en/docs/user_manual/processing_algs/qgis/vectorgeometry.html#id169

The change from 36 to 5 has been probably due to an oversight in PR #33794.

I would also raise the minimum value for such parameter at least to 3 or maybe to a larger value (since using the value 1 or the value 2 creates degenerate polygons).

@alexbruy, could you please have a look at this?



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
