### PR TITLE
qgsmesh3dmaterial: Ensure to create valid textures for the fragment shader

### DIFF
--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -122,7 +122,7 @@ QgsMesh3DMaterial::QgsMesh3DMaterial( QgsMeshLayer *layer,
   configure();
 
   // this method has to be called even if there isn't arrows (terrain) because it configures the parameter of shaders
-  // If al the parameters ("uniform" in shaders) are not defined in QGis, the shaders it happens the sahder doesn't work (depend on hardware?)
+  // If all the parameters ("uniform" in shaders) are not defined in QGIS, the shaders sometimes don't work (depends on hardware?)
   configureArrows( layer, timeRange );
 
   eff->addTechnique( mTechnique );

--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -132,10 +132,9 @@ QgsMesh3DMaterial::QgsMesh3DMaterial( QgsMeshLayer *layer,
 void QgsMesh3DMaterial::configure()
 {
   // Create the texture to pass the color ramp
-  Qt3DRender::QTexture1D *colorRampTexture = nullptr;
+  Qt3DRender::QTexture1D *colorRampTexture = new Qt3DRender::QTexture1D( this );
   if ( mSymbol->colorRampShader().colorRampItemList().count() > 0 )
   {
-    colorRampTexture = new Qt3DRender::QTexture1D( this );
     switch ( mMagnitudeType )
     {
       case QgsMesh3DMaterial::ZValue:
@@ -148,9 +147,15 @@ void QgsMesh3DMaterial::configure()
         break;
     }
 
-    colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
-    colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
   }
+  else
+  {
+    // create a simple texture to have a valid parameter in the shader and avoid undefined behaviors
+    colorRampTexture->addTextureImage( new QgsColorRampTexture( QgsColorRampShader(), 1 ) );
+  }
+
+  colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
+  colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
 
   // Create and configure technique
   mTechnique = new Qt3DRender::QTechnique();
@@ -184,8 +189,7 @@ void QgsMesh3DMaterial::configure()
   mTechnique->addParameter( new Qt3DRender::QParameter( "lineColor", QVector4D( wireframecolor.redF(), wireframecolor.greenF(), wireframecolor.blueF(), 1.0f ) ) );
   mTechnique->addParameter( new Qt3DRender::QParameter( "wireframeEnabled", mSymbol->wireframeEnabled() ) );
   mTechnique->addParameter( new Qt3DRender::QParameter( "textureType", int( mSymbol->renderingStyle() ) ) );
-  if ( colorRampTexture )
-    mTechnique->addParameter( new Qt3DRender::QParameter( "colorRampTexture", colorRampTexture ) ) ;
+  mTechnique->addParameter( new Qt3DRender::QParameter( "colorRampTexture", colorRampTexture ) ) ;
   mTechnique->addParameter( new Qt3DRender::QParameter( "colorRampCount", mSymbol->colorRampShader().colorRampItemList().count() ) );
   const int colorRampType = mSymbol->colorRampShader().colorRampType();
   mTechnique->addParameter( new Qt3DRender::QParameter( "colorRampType", colorRampType ) );
@@ -203,8 +207,8 @@ void QgsMesh3DMaterial::configureArrows( QgsMeshLayer *layer, const QgsDateTimeR
   if ( layer )
     datasetIndex = layer->activeVectorDatasetAtTime( timeRange );
 
-  QVector<QgsVector> vectors;
-  QSize gridSize;
+  QVector<QgsVector> vectors( 1 );
+  QSize gridSize( 1, 1 );
   QgsPointXY minCorner;
   std::unique_ptr< Qt3DRender::QParameter > arrowsEnabledParameter = std::make_unique< Qt3DRender::QParameter >( "arrowsEnabled", nullptr );
   if ( !layer || mMagnitudeType != MagnitudeType::ScalarDataSet || !mSymbol->arrowsEnabled() || meta.isScalar() || !datasetIndex.isValid() )


### PR DESCRIPTION
## Description

Sometimes, some meshes may not be visible on a 3d scene. This can be easily reproduced by creating a 3d scene with one mesh and clicking multiple times on the `apply` button of the configuration dialog. Sometimes, it is visible, sometimes it is not. See the video below: 

[mesh-missing.webm](https://github.com/qgis/QGIS/assets/497207/8db1c674-5c03-4264-bbc6-30f0e5140426)

It turns out that some shaders may be improperly set. This results in an undefined behavior. From the main commit message:

```
In the shader code, all the parameters need to be properly initialized
even if they are not used. Otherwise, this can create undefined
behaviors and some missing meshes in a 3d scene. In the current code,
there are two parameters which may not be properly initialized:
- "colorRampTexture" is not set if the color ramp mode is not set
- "arrowsGridTexture" texture image is invalid if the "display arrows"
  mode is disabled

The first issue ("colorRampTexture") is solved by creating a dummy
valid texture image if the color ramp mode is disabled and setting the
"colorRampTexture" parameter in all cases. This does not change
anything in the shader code. The parameter is not used. The shader
only needs a valid parameter.

The second issue ("arrowsGridTexture") is solved by setting proper
default values for the parameters which generate the arrows grid
texture. This ensure to generate a valid texture image . This also
does not change anything in the shader code. The parameter is not
used. The shader only needs a valid parameter.
```

cc @vcloarec @wonder-sk @benoitdm-oslandia 