### PR TITLE
Include all nodes when rendering gltf content instead of just first node

### DIFF
--- a/src/3d/qgsgltf3dutils.cpp
+++ b/src/3d/qgsgltf3dutils.cpp
@@ -491,20 +491,15 @@ static Qt3DCore::QEntity *parseModel( tinygltf::Model &model, const QgsGltf3DUti
     return nullptr;
   }
 
-  if ( scene.nodes.size() > 1 )
-  {
-    // TODO: handle multiple root nodes
-    if ( errors )
-      *errors << "Scene contains multiple nodes: only loading the first one!";
-  }
-
   const QgsVector3D tileTranslationEcef = QgsGltfUtils::extractTileTranslation( model );
 
-  int rootNodeIndex = scene.nodes[0];
-  const QVector<Qt3DCore::QEntity *> entities = parseNode( model, rootNodeIndex, transform, tileTranslationEcef, baseUri, QMatrix4x4(), errors );
   Qt3DCore::QEntity *rootEntity = new Qt3DCore::QEntity;
-  for ( Qt3DCore::QEntity *e : entities )
-    e->setParent( rootEntity );
+  for ( const int nodeIndex : scene.nodes )
+  {
+    const QVector<Qt3DCore::QEntity *> entities = parseNode( model, nodeIndex, transform, tileTranslationEcef, baseUri, QMatrix4x4(), errors );
+    for ( Qt3DCore::QEntity *e : entities )
+      e->setParent( rootEntity );
+  }
   return rootEntity;
 }
 

--- a/src/analysis/processing/qgsalgorithmgltftovector.cpp
+++ b/src/analysis/processing/qgsalgorithmgltftovector.cpp
@@ -327,97 +327,99 @@ QVariantMap QgsGltfToVectorFeaturesAlgorithm::processAlgorithm( const QVariantMa
   QSet< int > warnedPrimitiveTypes;
   if ( !scene.nodes.empty() )
   {
-    const int nodeIndex = scene.nodes[0];
-    const tinygltf::Node &gltfNode = model.nodes[nodeIndex];
-    const QgsVector3D tileTranslationEcef = QgsGltfUtils::extractTileTranslation( model );
-    const std::unique_ptr< QMatrix4x4 > gltfLocalTransform = QgsGltfUtils::parseNodeTransform( gltfNode );
-
-    if ( gltfNode.mesh >= 0 )
+    for ( const int nodeIndex : scene.nodes )
     {
-      const tinygltf::Mesh &mesh = model.meshes[gltfNode.mesh];
-      feedback->pushDebugInfo( QObject::tr( "Found %1 primitives in default scene node [%2]" ).arg( mesh.primitives.size() ).arg( nodeIndex ) );
+      const tinygltf::Node &gltfNode = model.nodes[nodeIndex];
+      const QgsVector3D tileTranslationEcef = QgsGltfUtils::extractTileTranslation( model );
+      const std::unique_ptr< QMatrix4x4 > gltfLocalTransform = QgsGltfUtils::parseNodeTransform( gltfNode );
 
-      for ( const tinygltf::Primitive &primitive : mesh.primitives )
+      if ( gltfNode.mesh >= 0 )
       {
-        switch ( primitive.mode )
+        const tinygltf::Mesh &mesh = model.meshes[gltfNode.mesh];
+        feedback->pushDebugInfo( QObject::tr( "Found %1 primitives in default scene node [%2]" ).arg( mesh.primitives.size() ).arg( nodeIndex ) );
+
+        for ( const tinygltf::Primitive &primitive : mesh.primitives )
         {
-          case TINYGLTF_MODE_TRIANGLES:
+          switch ( primitive.mode )
           {
-            if ( polygonSink )
+            case TINYGLTF_MODE_TRIANGLES:
             {
-              std::unique_ptr< QgsAbstractGeometry > geometry = extractTriangles( model, primitive, ecefTransform, tileTranslationEcef, gltfLocalTransform.get(), feedback );
-              if ( geometry )
+              if ( polygonSink )
               {
-                QgsFeature f;
-                f.setGeometry( std::move( geometry ) );
-                polygonSink->addFeature( f, QgsFeatureSink::FastInsert );
+                std::unique_ptr< QgsAbstractGeometry > geometry = extractTriangles( model, primitive, ecefTransform, tileTranslationEcef, gltfLocalTransform.get(), feedback );
+                if ( geometry )
+                {
+                  QgsFeature f;
+                  f.setGeometry( std::move( geometry ) );
+                  polygonSink->addFeature( f, QgsFeatureSink::FastInsert );
+                }
               }
+              break;
             }
-            break;
-          }
 
-          case TINYGLTF_MODE_LINE:
-          {
-            if ( lineSink )
+            case TINYGLTF_MODE_LINE:
             {
-              std::unique_ptr< QgsAbstractGeometry > geometry = extractLines( model, primitive, ecefTransform, tileTranslationEcef, gltfLocalTransform.get(), feedback );
-              if ( geometry )
+              if ( lineSink )
               {
-                QgsFeature f;
-                f.setGeometry( std::move( geometry ) );
-                polygonSink->addFeature( f, QgsFeatureSink::FastInsert );
+                std::unique_ptr< QgsAbstractGeometry > geometry = extractLines( model, primitive, ecefTransform, tileTranslationEcef, gltfLocalTransform.get(), feedback );
+                if ( geometry )
+                {
+                  QgsFeature f;
+                  f.setGeometry( std::move( geometry ) );
+                  polygonSink->addFeature( f, QgsFeatureSink::FastInsert );
+                }
               }
+              break;
             }
-            break;
+
+            case TINYGLTF_MODE_POINTS:
+              if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_POINTS ) )
+              {
+                feedback->reportError( QObject::tr( "Point objects are not supported" ) );
+                warnedPrimitiveTypes.insert( TINYGLTF_MODE_POINTS );
+              }
+              break;
+
+            case TINYGLTF_MODE_LINE_LOOP:
+              if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_LINE_LOOP ) )
+              {
+                feedback->reportError( QObject::tr( "Line loops in are not supported" ) );
+                warnedPrimitiveTypes.insert( TINYGLTF_MODE_LINE_LOOP );
+              }
+              break;
+
+            case TINYGLTF_MODE_LINE_STRIP:
+              if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_LINE_STRIP ) )
+              {
+                feedback->reportError( QObject::tr( "Line strips in are not supported" ) );
+                warnedPrimitiveTypes.insert( TINYGLTF_MODE_LINE_STRIP );
+              }
+              break;
+
+            case TINYGLTF_MODE_TRIANGLE_STRIP:
+              if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_TRIANGLE_STRIP ) )
+              {
+                feedback->reportError( QObject::tr( "Triangular strips are not supported" ) );
+                warnedPrimitiveTypes.insert( TINYGLTF_MODE_TRIANGLE_STRIP );
+              }
+              break;
+
+            case TINYGLTF_MODE_TRIANGLE_FAN:
+              if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_TRIANGLE_FAN ) )
+              {
+                feedback->reportError( QObject::tr( "Triangular fans are not supported" ) );
+                warnedPrimitiveTypes.insert( TINYGLTF_MODE_TRIANGLE_FAN );
+              }
+              break;
+
+            default:
+              if ( !warnedPrimitiveTypes.contains( primitive.mode ) )
+              {
+                feedback->reportError( QObject::tr( "Primitive type %1 are not supported" ).arg( primitive.mode ) );
+                warnedPrimitiveTypes.insert( primitive.mode );
+              }
+              break;
           }
-
-          case TINYGLTF_MODE_POINTS:
-            if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_POINTS ) )
-            {
-              feedback->reportError( QObject::tr( "Point objects are not supported" ) );
-              warnedPrimitiveTypes.insert( TINYGLTF_MODE_POINTS );
-            }
-            break;
-
-          case TINYGLTF_MODE_LINE_LOOP:
-            if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_LINE_LOOP ) )
-            {
-              feedback->reportError( QObject::tr( "Line loops in are not supported" ) );
-              warnedPrimitiveTypes.insert( TINYGLTF_MODE_LINE_LOOP );
-            }
-            break;
-
-          case TINYGLTF_MODE_LINE_STRIP:
-            if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_LINE_STRIP ) )
-            {
-              feedback->reportError( QObject::tr( "Line strips in are not supported" ) );
-              warnedPrimitiveTypes.insert( TINYGLTF_MODE_LINE_STRIP );
-            }
-            break;
-
-          case TINYGLTF_MODE_TRIANGLE_STRIP:
-            if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_TRIANGLE_STRIP ) )
-            {
-              feedback->reportError( QObject::tr( "Triangular strips are not supported" ) );
-              warnedPrimitiveTypes.insert( TINYGLTF_MODE_TRIANGLE_STRIP );
-            }
-            break;
-
-          case TINYGLTF_MODE_TRIANGLE_FAN:
-            if ( !warnedPrimitiveTypes.contains( TINYGLTF_MODE_TRIANGLE_FAN ) )
-            {
-              feedback->reportError( QObject::tr( "Triangular fans are not supported" ) );
-              warnedPrimitiveTypes.insert( TINYGLTF_MODE_TRIANGLE_FAN );
-            }
-            break;
-
-          default:
-            if ( !warnedPrimitiveTypes.contains( primitive.mode ) )
-            {
-              feedback->reportError( QObject::tr( "Primitive type %1 are not supported" ).arg( primitive.mode ) );
-              warnedPrimitiveTypes.insert( primitive.mode );
-            }
-            break;
         }
       }
     }

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -358,20 +358,22 @@ bool QgsTiledSceneLayerRenderer::renderTileContent( const QgsTiledSceneTile &til
   {
     const QgsVector3D tileTranslationEcef = content.rtcCenter + QgsGltfUtils::extractTileTranslation( model );
     const tinygltf::Scene &scene = model.scenes[model.defaultScene];
-    const int nodeIndex = scene.nodes[0];
-    const tinygltf::Node &gltfNode = model.nodes[nodeIndex];
-    const std::unique_ptr< QMatrix4x4 > gltfLocalTransform = QgsGltfUtils::parseNodeTransform( gltfNode );
-
-    if ( gltfNode.mesh >= 0 )
+    for ( int nodeIndex : scene.nodes )
     {
-      const tinygltf::Mesh &mesh = model.meshes[gltfNode.mesh];
+      const tinygltf::Node &gltfNode = model.nodes[nodeIndex];
+      const std::unique_ptr< QMatrix4x4 > gltfLocalTransform = QgsGltfUtils::parseNodeTransform( gltfNode );
 
-      for ( const tinygltf::Primitive &primitive : mesh.primitives )
+      if ( gltfNode.mesh >= 0 )
       {
-        if ( context.renderContext().renderingStopped() )
-          break;
+        const tinygltf::Mesh &mesh = model.meshes[gltfNode.mesh];
 
-        renderPrimitive( model, primitive, tile, tileTranslationEcef, gltfLocalTransform.get(), contentUri, context );
+        for ( const tinygltf::Primitive &primitive : mesh.primitives )
+        {
+          if ( context.renderContext().renderingStopped() )
+            break;
+
+          renderPrimitive( model, primitive, tile, tileTranslationEcef, gltfLocalTransform.get(), contentUri, context );
+        }
       }
     }
   }


### PR DESCRIPTION
Partially fixes rendering of content from https://geoportal.trier.de/trier/mod_3d/index.php?service=trier3dmesh