### PR TITLE
[cesium] Add support for deprecated gltfUpAxis asset setting

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1651,6 +1651,13 @@ Qgis.CoordinateOrder.__doc__ = "Order of coordinates.\n\n.. versionadded:: 3.26\
 # --
 Qgis.CoordinateOrder.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.Axis.X.__doc__ = "X-axis"
+Qgis.Axis.Y.__doc__ = "Y-axis"
+Qgis.Axis.Z.__doc__ = "Z-axis"
+Qgis.Axis.__doc__ = "Cartesian axes.\n\n.. versionadded:: 3.34\n\n" + '* ``X``: ' + Qgis.Axis.X.__doc__ + '\n' + '* ``Y``: ' + Qgis.Axis.Y.__doc__ + '\n' + '* ``Z``: ' + Qgis.Axis.Z.__doc__
+# --
+Qgis.Axis.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.AnnotationItemFlag.ScaleDependentBoundingBox.__doc__ = "Item's bounding box will vary depending on map scale"
 Qgis.AnnotationItemFlag.__doc__ = "Flags for annotation items.\n\n.. versionadded:: 3.22\n\n" + '* ``ScaleDependentBoundingBox``: ' + Qgis.AnnotationItemFlag.ScaleDependentBoundingBox.__doc__
 # --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1037,6 +1037,13 @@ The development version
       YX,
     };
 
+    enum class Axis
+    {
+      X,
+      Y,
+      Z
+    };
+
     enum class AnnotationItemFlag
     {
       ScaleDependentBoundingBox,

--- a/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
@@ -151,6 +151,20 @@ get resolved against this URL.
 .. seealso:: :py:func:`baseUrl`
 %End
 
+    QVariantMap metadata() const;
+%Docstring
+Returns additional metadata attached to the tile.
+
+.. seealso:: :py:func:`setMetadata`
+%End
+
+    void setMetadata( const QVariantMap &metadata );
+%Docstring
+Sets additional ``metadata`` attached to the tile.
+
+.. seealso:: :py:func:`metadata`
+%End
+
 };
 
 /************************************************************************

--- a/src/3d/qgsgltf3dutils.cpp
+++ b/src/3d/qgsgltf3dutils.cpp
@@ -156,7 +156,7 @@ static Qt3DQAttribute *reprojectPositions( tinygltf::Model &model, int accessorI
   tinygltf::Accessor &accessor = model.accessors[accessorIndex];
 
   QVector<double> vx, vy, vz;
-  bool res = QgsGltfUtils::accessorToMapCoordinates( model, accessorIndex, transform.tileTransform, transform.ecefToTargetCrs, tileTranslationEcef, matrix, vx, vy, vz );
+  bool res = QgsGltfUtils::accessorToMapCoordinates( model, accessorIndex, transform.tileTransform, transform.ecefToTargetCrs, tileTranslationEcef, matrix, transform.gltfUpAxis, vx, vy, vz );
   if ( !res )
     return nullptr;
 

--- a/src/3d/qgsgltf3dutils.h
+++ b/src/3d/qgsgltf3dutils.h
@@ -61,6 +61,9 @@ class _3D_EXPORT QgsGltf3DUtils
       //! Transform from ECEF (normally EPSG:4978) to the target CRS
       const QgsCoordinateTransform *ecefToTargetCrs = nullptr;
 
+      //! Axis to treat as up axis in the GLTF model
+      Qgis::Axis gltfUpAxis = Qgis::Axis::Y;
+
       double zValueScale = 1;
       double zValueOffset = 0;
     };

--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -91,6 +91,7 @@ QgsTiledSceneChunkLoader::QgsTiledSceneChunkLoader( QgsChunkNode *node, const Qg
     entityTransform.ecefToTargetCrs = &mFactory.mBoundsTransform;
     entityTransform.zValueScale = zValueScale;
     entityTransform.zValueOffset = zValueOffset;
+    entityTransform.gltfUpAxis = static_cast< Qgis::Axis >( mTile.metadata().value( QStringLiteral( "gltfUpAxis" ), static_cast< int >( Qgis::Axis::Y ) ).toInt() );
 
     QStringList errors;
     mEntity = QgsGltf3DUtils::gltfToEntity( tileContent.gltf, entityTransform, uri, &errors );

--- a/src/analysis/processing/qgsalgorithmgltftovector.cpp
+++ b/src/analysis/processing/qgsalgorithmgltftovector.cpp
@@ -101,6 +101,7 @@ std::unique_ptr< QgsAbstractGeometry > extractTriangles(
     &ecefTransform,
     tileTranslationEcef,
     gltfLocalTransform,
+    Qgis::Axis::Y,
     x, y, z
   );
 
@@ -203,6 +204,7 @@ std::unique_ptr< QgsAbstractGeometry > extractLines(
     &ecefTransform,
     tileTranslationEcef,
     gltfLocalTransform,
+    Qgis::Axis::Y,
     x, y, z
   );
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1722,6 +1722,19 @@ class CORE_EXPORT Qgis
     Q_ENUM( CoordinateOrder )
 
     /**
+     * Cartesian axes.
+     *
+     * \since QGIS 3.34
+     */
+    enum class Axis : int
+    {
+      X, //!< X-axis
+      Y, //!< Y-axis
+      Z //!< Z-axis
+    };
+    Q_ENUM( Axis )
+
+    /**
      * Flags for annotation items.
      *
      * \since QGIS 3.22

--- a/src/core/tiledscene/qgsgltfutils.h
+++ b/src/core/tiledscene/qgsgltfutils.h
@@ -30,6 +30,7 @@
 #define SIP_NO_FILE
 
 #include "qgis_core.h"
+#include "qgis.h"
 
 #include <memory>
 #include <QVector>
@@ -81,6 +82,7 @@ class CORE_EXPORT QgsGltfUtils
                                           const QgsCoordinateTransform *ecefToTargetCrs,
                                           const QgsVector3D &tileTranslationEcef,
                                           const QMatrix4x4 *nodeTransform,
+                                          Qgis::Axis gltfUpAxis,
                                           QVector<double> &vx, QVector<double> &vy, QVector<double> &vz );
 
     /**
@@ -132,7 +134,7 @@ class CORE_EXPORT QgsGltfUtils
      * or by taking translation from the root node. The returned offset should be
      * in ECEF coordinates.
      */
-    static QgsVector3D extractTileTranslation( tinygltf::Model &model );
+    static QgsVector3D extractTileTranslation( tinygltf::Model &model, Qgis::Axis upAxis = Qgis::Axis::Y );
 
     /**
      * Helper function to allow tinygltf to read images, based on QImage readers.

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -356,7 +356,8 @@ bool QgsTiledSceneLayerRenderer::renderTileContent( const QgsTiledSceneTile &til
   const bool res = QgsGltfUtils::loadGltfModel( content.gltf, model, &gltfErrors, &gltfWarnings );
   if ( res )
   {
-    const QgsVector3D tileTranslationEcef = content.rtcCenter + QgsGltfUtils::extractTileTranslation( model );
+    const QgsVector3D tileTranslationEcef = content.rtcCenter + QgsGltfUtils::extractTileTranslation( model,
+                                            static_cast< Qgis::Axis >( tile.metadata().value( QStringLiteral( "gltfUpAxis" ), static_cast< int >( Qgis::Axis::Y ) ).toInt() ) );
     const tinygltf::Scene &scene = model.scenes[model.defaultScene];
     const int nodeIndex = scene.nodes[0];
     const tinygltf::Node &gltfNode = model.nodes[nodeIndex];
@@ -470,6 +471,7 @@ void QgsTiledSceneLayerRenderer::renderTrianglePrimitive( const tinygltf::Model 
     &mSceneToMapTransform,
     tileTranslationEcef,
     gltfLocalTransform,
+    static_cast< Qgis::Axis >( tile.metadata().value( QStringLiteral( "gltfUpAxis" ), static_cast< int >( Qgis::Axis::Y ) ).toInt() ),
     x, y, z
   );
 
@@ -716,6 +718,7 @@ void QgsTiledSceneLayerRenderer::renderLinePrimitive( const tinygltf::Model &mod
     &mSceneToMapTransform,
     tileTranslationEcef,
     gltfLocalTransform,
+    static_cast< Qgis::Axis >( tile.metadata().value( QStringLiteral( "gltfUpAxis" ), static_cast< int >( Qgis::Axis::Y ) ).toInt() ),
     x, y, z
   );
 

--- a/src/core/tiledscene/qgstiledscenetile.cpp
+++ b/src/core/tiledscene/qgstiledscenetile.cpp
@@ -40,6 +40,7 @@ QgsTiledSceneTile::QgsTiledSceneTile( const QgsTiledSceneTile &other )
   , mResources( other.mResources )
   , mGeometricError( other.mGeometricError )
   , mBaseUrl( other.mBaseUrl )
+  , mMetadata( other.mMetadata )
 {
   mTransform.reset( other.mTransform ? new QgsMatrix4x4( *other.mTransform.get() ) : nullptr );
 }
@@ -53,6 +54,7 @@ QgsTiledSceneTile &QgsTiledSceneTile::operator=( const QgsTiledSceneTile &other 
   mGeometricError = other.mGeometricError;
   mBoundingVolume = other.mBoundingVolume;
   mBaseUrl = other.mBaseUrl;
+  mMetadata = other.mMetadata;
   return *this;
 }
 
@@ -102,4 +104,14 @@ QUrl QgsTiledSceneTile::baseUrl() const
 void QgsTiledSceneTile::setBaseUrl( const QUrl &baseUrl )
 {
   mBaseUrl = baseUrl;
+}
+
+QVariantMap QgsTiledSceneTile::metadata() const
+{
+  return mMetadata;
+}
+
+void QgsTiledSceneTile::setMetadata( const QVariantMap &metadata )
+{
+  mMetadata = metadata;
 }

--- a/src/core/tiledscene/qgstiledscenetile.h
+++ b/src/core/tiledscene/qgstiledscenetile.h
@@ -164,6 +164,20 @@ class CORE_EXPORT QgsTiledSceneTile
      */
     void setBaseUrl( const QUrl &baseUrl );
 
+    /**
+     * Returns additional metadata attached to the tile.
+     *
+     * \see setMetadata()
+     */
+    QVariantMap metadata() const;
+
+    /**
+     * Sets additional \a metadata attached to the tile.
+     *
+     * \see metadata()
+     */
+    void setMetadata( const QVariantMap &metadata );
+
   private:
     long long mId = -1;
     Qgis::TileRefinementProcess mRefinementProcess = Qgis::TileRefinementProcess::Replacement;
@@ -172,6 +186,7 @@ class CORE_EXPORT QgsTiledSceneTile
     QVariantMap mResources;
     double mGeometricError = 0;
     QUrl mBaseUrl;
+    QVariantMap mMetadata;
 
 };
 

--- a/tests/src/python/test_qgscesium3dtileslayer.py
+++ b/tests/src/python/test_qgscesium3dtileslayer.py
@@ -685,6 +685,8 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertTrue(index.isValid())
 
             root_tile = index.rootTile()
+            self.assertEqual(root_tile.metadata(), {'gltfUpAxis': Qgis.Axis.Y})
+
             root_node_bounds = root_tile.boundingVolume()
             self.compare_boxes(
                 root_node_bounds.box(),
@@ -1564,6 +1566,52 @@ class TestQgsCesium3dTilesLayer(unittest.TestCase):
             self.assertEqual(
                 tile.resources(), {"content": "file://" + temp_dir + "/LOD-2/Mesh-XR-YR.b3dm"}
             )
+
+    def test_gltf_up_axis(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tmp_file = os.path.join(temp_dir, "tileset.json")
+            with open(tmp_file, "wt", encoding="utf-8") as f:
+                f.write(
+                    """
+        {
+  "asset": {
+    "version": "1.0",
+    "gltfUpAxis":"Z"
+  },
+  "geometricError": 100.0,
+  "root": {
+    "boundingVolume": {
+      "box": [
+        -1.45782,
+        0.265355,
+        7.44958,
+        94.1946,
+        0.0,
+        0.0,
+        0.0,
+        -14.9309,
+        0.0,
+        0.0,
+        0.0,
+        75.0565
+      ]
+    },
+    "geometricError": 100.0,
+    "refine": "ADD",
+    "content": null,
+    "children": [
+    ]
+  }
+}"""
+                )
+            layer = QgsTiledSceneLayer(tmp_file, "my layer", "cesiumtiles")
+            self.assertTrue(layer.dataProvider().isValid())
+
+            index = layer.dataProvider().index()
+            self.assertTrue(index.isValid())
+
+            root_tile = index.rootTile()
+            self.assertEqual(root_tile.metadata(), {'gltfUpAxis': Qgis.Axis.Z})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for Z up gltf content

Fixes reading content from https://geoportal.trier.de/trier/mod_3d/index.php?service=trier3dmesh (along with https://github.com/qgis/QGIS/pull/54502 )