### PR TITLE
Treat very large region bounding boxes as global

### DIFF
--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -38,6 +38,9 @@ static bool hasLargeBounds( const QgsTiledSceneTile &t )
   if ( t.geometricError() > 1e6 )
     return true;
 
+  if ( t.boundingVolume().box().isNull() )
+    return true;
+
   const QgsVector3D size = t.boundingVolume().box().size();
   return size.x() > 1e5 || size.y() > 1e5 || size.z() > 1e5;
 }


### PR DESCRIPTION
Otherwise, the transformation from large geographic regions to EPSG:4978 coordinates fails and the tile is treated as always being out of view

Partially fixes rendering of Cesium ion OSM buildings dataset (some content missing because of errors raised in tinygltf)
