### PR TITLE
Fix Advanced Digitizing locked distance circle

### DIFF
--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -161,7 +161,12 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   {
     painter->setPen( mLockedPen );
     const double r = mAdvancedDigitizingDockWidget->constraintDistance()->value() / mupp;
-    painter->drawEllipse( prevPointPix, r, r );
+    QPainterPath ellipsePath;
+    ellipsePath.addEllipse( prevPointPix, r, r );
+    const double a = std::atan2( -( curPoint.y() - prevPoint.y() ), curPoint.x() - prevPoint.x() ) + canvasRotationRad;
+    const QTransform t = QTransform().translate( prevPointPix.x(), prevPointPix.y() ).rotateRadians( a ).translate( -prevPointPix.x(), -prevPointPix.y() );
+    const QPolygonF ellipsePoly = ellipsePath.toFillPolygon( t );
+    painter->drawPolygon( ellipsePoly );
   }
 
   // Draw x


### PR DESCRIPTION
## Description

Refs. https://github.com/qgis/QGIS/issues/54494.

Using the Advanced Digitizing tools, when the segment length (distance) value is locked, then a segment with such length (the distance line) and a circle with such length value as radius (the distance circle) are drawn on the map: at high level zooms, the distance circle is quite off from the end of the distance line except at angles 0°, 90°, .....

It seems to me this is due to an upstream [QT bug](https://bugreports.qt.io/browse/QTBUG-52312) issue in QPainter::drawEllipse which is used by the QgsAdvancedDigitizingCanvasItem::paint function to draw the circle.

To workaround the QPainter::drawEllipse issue, I propose to appropriately rotate the distance circle around its center in order to have its 0° degree point always aligned with the distance line end point.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
