### PR TITLE
Fix/rectangle isnull

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -479,7 +479,7 @@ class CORE_EXPORT QgsRectangle
     bool isNull() const
     {
       // rectangle created QgsRectangle() or with rect.setMinimal() ?
-      return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmin ) ) ||
+      return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmax ) ) ||
              ( qgsDoubleNear( mXmin, 0.0 ) && qgsDoubleNear( mXmax, 0.0 ) && qgsDoubleNear( mYmin, 0.0 ) && qgsDoubleNear( mYmax, 0.0 ) ) ||
              ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
                qgsDoubleNear( mXmax, -std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmax, -std::numeric_limits<double>::max() ) );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -26,6 +26,7 @@ class TestQgsRectangle: public QObject
     Q_OBJECT
   private slots:
     void isEmpty();
+    void isNull();
     void fromWkt();
     void constructor();
     void constructorTwoPoints();
@@ -65,6 +66,16 @@ void TestQgsRectangle::isEmpty()
   r = QgsRectangle( 2, 2, 3, 4 );
   r.setYMaximum( 1 );
   QVERIFY( r.isEmpty() );
+}
+
+void TestQgsRectangle::isNull()
+{
+  QVERIFY( QgsRectangle().isNull() );
+  QVERIFY( QgsRectangle( std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN() ).isNull() );
+  QVERIFY( QgsRectangle( 0.0, 0.0, 0.0, 0.0 ).isNull() );
+  QVERIFY( !QgsRectangle( std::numeric_limits<double>::max(), -std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), -std::numeric_limits<double>::max() ).isNull() );
+  QVERIFY( !QgsRectangle( 1, 2, 2, 1 ).isNull() );
 }
 
 void TestQgsRectangle::fromWkt()


### PR DESCRIPTION
fix bug in qgsrectangle. See https://github.com/qgis/QGIS/pull/53741#issuecomment-1708225551:

> @ptitjano QgsRectangle::isNull() doesn't check whether std::isnan( mYmax ). Instead yMin is checked twice.

> QgsRectangle line 482:
> `return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmin ) ) ||`

cc @ptitjano