### PR TITLE
Possibility to apply default values for the processing gui from the s…

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -789,6 +789,13 @@ The ``variables`` list should contain the variable names only, without the usual
   protected:
 
 
+    QVariant defaultGuiValueFromSetting() const;
+%Docstring
+Default gui value for an algorithm parameter from settings
+
+:return: default value from settings or null QVariant if there is no default value defined in the settings
+%End
+
 
 
 

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -793,7 +793,9 @@ The ``variables`` list should contain the variable names only, without the usual
 %Docstring
 Default gui value for an algorithm parameter from settings
 
-:return: default value from settings or null QVariant if there is no default value defined in the settings
+:return: default value from settings or invalid QVariant if there is no default value defined in the settings
+
+.. versionadded:: 3.34
 %End
 
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2465,7 +2465,7 @@ QVariant QgsProcessingParameterDefinition::guiDefaultValueOverride() const
 QVariant QgsProcessingParameterDefinition::defaultValueForGui() const
 {
   QVariant defaultSettingsValue = defaultGuiValueFromSetting();
-  if ( !defaultSettingsValue.isNull() )
+  if ( defaultSettingsValue.isValid() )
   {
     return defaultSettingsValue;
   }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -33,6 +33,7 @@
 #include "qgsapplication.h"
 #include "qgslayoutmanager.h"
 #include "qgsprintlayout.h"
+#include "qgssettings.h"
 #include "qgssymbollayerutils.h"
 #include "qgsfileutils.h"
 #include "qgsproviderregistry.h"
@@ -2450,6 +2451,40 @@ QgsProcessingParameterDefinition::QgsProcessingParameterDefinition( const QStrin
   , mDefault( defaultValue )
   , mFlags( optional ? FlagOptional : 0 )
 {}
+
+QVariant QgsProcessingParameterDefinition::guiDefaultValueOverride() const
+{
+  QVariant defaultSettingsValue = defaultGuiValueFromSetting();
+  if ( !defaultSettingsValue.isNull() )
+  {
+    return defaultSettingsValue;
+  }
+  return mGuiDefault;
+}
+
+QVariant QgsProcessingParameterDefinition::defaultValueForGui() const
+{
+  QVariant defaultSettingsValue = defaultGuiValueFromSetting();
+  if ( !defaultSettingsValue.isNull() )
+  {
+    return defaultSettingsValue;
+  }
+  return mGuiDefault.isValid() ? mGuiDefault : mDefault;
+}
+
+QVariant QgsProcessingParameterDefinition::defaultGuiValueFromSetting() const
+{
+  if ( mAlgorithm )
+  {
+    QgsSettings s;
+    QVariant settingValue = s.value( QStringLiteral( "/Processing/DefaultGuiParam/%1/%2" ).arg( mAlgorithm->id() ).arg( mName ) );
+    if ( !settingValue.isNull() )
+    {
+      return settingValue;
+    }
+  }
+  return QVariant();
+}
 
 bool QgsProcessingParameterDefinition::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2478,7 +2478,7 @@ QVariant QgsProcessingParameterDefinition::defaultGuiValueFromSetting() const
   {
     QgsSettings s;
     QVariant settingValue = s.value( QStringLiteral( "/Processing/DefaultGuiParam/%1/%2" ).arg( mAlgorithm->id() ).arg( mName ) );
-    if ( !settingValue.isNull() )
+    if ( settingValue.isValid() )
     {
       return settingValue;
     }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2455,7 +2455,7 @@ QgsProcessingParameterDefinition::QgsProcessingParameterDefinition( const QStrin
 QVariant QgsProcessingParameterDefinition::guiDefaultValueOverride() const
 {
   QVariant defaultSettingsValue = defaultGuiValueFromSetting();
-  if ( !defaultSettingsValue.isNull() )
+  if ( defaultSettingsValue.isValid() )
   {
     return defaultSettingsValue;
   }

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -899,7 +899,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     /**
      * Default gui value for an algorithm parameter from settings
      *
-     * \return default value from settings or null QVariant if there is no default value defined in the settings
+     * \return default value from settings or invalid QVariant if there is no default value defined in the settings
      */
     QVariant defaultGuiValueFromSetting() const;
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -900,6 +900,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * Default gui value for an algorithm parameter from settings
      *
      * \return default value from settings or invalid QVariant if there is no default value defined in the settings
+     * \since QGIS 3.34
      */
     QVariant defaultGuiValueFromSetting() const;
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -577,7 +577,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      *
      * \since QGIS 3.18
      */
-    QVariant guiDefaultValueOverride() const { return mGuiDefault; }
+    QVariant guiDefaultValueOverride() const;
 
     /**
      * Sets the default \a value to use for the parameter in GUI widgets. Caller takes responsibility
@@ -604,7 +604,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      *
      * \since QGIS 3.18
      */
-    QVariant defaultValueForGui() const { return mGuiDefault.isValid() ? mGuiDefault : mDefault; }
+    QVariant defaultValueForGui() const;
 
     /**
      * Returns any flags associated with the parameter.
@@ -895,6 +895,13 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      */
     QVariant valueAsJsonObjectPrivate( const QVariant &value, QgsProcessingContext &context, ValueAsStringFlags flags ) const;
 #endif
+
+    /**
+     * Default gui value for an algorithm parameter from settings
+     *
+     * \return default value from settings or null QVariant if there is no default value defined in the settings
+     */
+    QVariant defaultGuiValueFromSetting() const;
 
     //! Parameter name
     QString mName;

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -809,6 +809,7 @@ class TestQgsProcessing: public QObject
     void sourceTypeToString();
     void formatHelp();
     void preprocessParameters();
+    void guiDefaultParameterValues();
 
   private:
 
@@ -12657,6 +12658,27 @@ void TestQgsProcessing::preprocessParameters()
 
   QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().propertyType(), QgsProperty::ExpressionBasedProperty );
   QCOMPARE( outputs.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >().expressionString(), QStringLiteral( "A_FIELD * 200" ) );
+}
+
+void TestQgsProcessing::guiDefaultParameterValues()
+{
+  DummyAlgorithm alg( "testAlgorithm" );
+  QgsProcessingParameterNumber *intTestParam = new QgsProcessingParameterNumber( QStringLiteral( "testIntegerParameter" ), QStringLiteral( "A test parameter" ), QgsProcessingParameterNumber::Integer, 10 );
+  alg.addParameter( intTestParam );
+  QgsProcessingParameterString *stringTestParam = new QgsProcessingParameterString( QStringLiteral( "testStringParameter" ), QStringLiteral( "A test parameter" ), QStringLiteral( "test, test, test" ) );
+  alg.addParameter( stringTestParam );
+
+  QgsSettings s;
+  s.setValue( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testIntegerParameter" ), 42 );
+  s.setValue( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testStringParameter" ), QStringLiteral( "defaultString" ) );
+
+  QCOMPARE( intTestParam->defaultValueForGui(), 42 );
+  QCOMPARE( intTestParam->guiDefaultValueOverride(), 42 );
+  QCOMPARE( stringTestParam->defaultValueForGui(), QStringLiteral( "defaultString" ) );
+  QCOMPARE( stringTestParam->guiDefaultValueOverride(), QStringLiteral( "defaultString" ) );
+
+  s.remove( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testIntegerParameter" ) );
+  s.remove( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testStringParameter" ) );
 }
 
 QGSTEST_MAIN( TestQgsProcessing )


### PR DESCRIPTION
This PR adds the possibility to configure GUI default values for processing in the QGIS.ini file. Use case is that sometimes we want to configure organization wide default values for some algorithms (e.g. precision (GRID_SIZE) for vector overlay). In such cases, it would be handy if the admin could configure it in the prepared ini-file for all users. If the users then open the toolbox to execute an algorithm, the default values will be there. To set the default value e.g. for GRID_SIZE for the intersection algorithm, the admin could write the following into the ini-file:

[Processing]
DefaultGuiParam\native%3Aintersection\GRID_SIZE=0.01

Do you think this is a usefull addition or is the use-case to special (or is there a better way to set default gui values that I did not see)? In case it is usefull, it would probably also be worth to have a gui in the options dialog to add default values.
