### PR TITLE
Recent menu's right-click menu and welcome page's right-click menu harmony

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5235,8 +5235,10 @@ void QgisApp::updateRecentProjectPaths()
   if ( !mRecentProjects.isEmpty() )
   {
     mRecentProjectsMenu->addSeparator();
-    QAction *clearRecentProjectsAction = mRecentProjectsMenu->addAction( tr( "Clear Recently Opened" ) );
-    connect( clearRecentProjectsAction, &QAction::triggered, mWelcomePage, &QgsWelcomePage::clearRecentProjects );
+    QAction *clearRecentProjectsAction = mRecentProjectsMenu->addAction( tr( "Clear List" ) );
+    connect( clearRecentProjectsAction, &QAction::triggered, mWelcomePage, [ = ]() { mWelcomePage->clearRecentProjects( false ); } );
+    QAction *clearAllRecentProjectsAction = mRecentProjectsMenu->addAction( tr( "Clear List (Including Pinned Projects)" ) );
+    connect( clearAllRecentProjectsAction, &QAction::triggered, mWelcomePage, [ = ]() { mWelcomePage->clearRecentProjects( true ); } );
   }
 
   std::vector< QgsNative::RecentProjectProperties > recentProjects;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5236,9 +5236,7 @@ void QgisApp::updateRecentProjectPaths()
   {
     mRecentProjectsMenu->addSeparator();
     QAction *clearRecentProjectsAction = mRecentProjectsMenu->addAction( tr( "Clear List" ) );
-    connect( clearRecentProjectsAction, &QAction::triggered, mWelcomePage, [ = ]() { mWelcomePage->clearRecentProjects( false ); } );
-    QAction *clearAllRecentProjectsAction = mRecentProjectsMenu->addAction( tr( "Clear List (Including Pinned Projects)" ) );
-    connect( clearAllRecentProjectsAction, &QAction::triggered, mWelcomePage, [ = ]() { mWelcomePage->clearRecentProjects( true ); } );
+    connect( clearRecentProjectsAction, &QAction::triggered, mWelcomePage, [ = ]() { mWelcomePage->clearRecentProjects(); } );
   }
 
   std::vector< QgsNative::RecentProjectProperties > recentProjects;

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -344,18 +344,8 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
   }
 
   QAction *clearAction = new QAction( tr( "Clear List" ), menu );
-  connect( clearAction, &QAction::triggered, this, [this]
-  {
-    clearRecentProjects( false );
-  } );
+  connect( clearAction, &QAction::triggered, this, [this] { clearRecentProjects(); } );
   menu->addAction( clearAction );
-  QAction *clearPinnedAction = new QAction( tr( "Clear List (Including Pinned Projects)" ), menu );
-  connect( clearPinnedAction, &QAction::triggered, this, [this]
-  {
-    clearRecentProjects( true );
-  } );
-  menu->addAction( clearPinnedAction );
-
 
   menu->popup( mapToGlobal( point ) );
   connect( menu, &QMenu::aboutToHide, menu, &QMenu::deleteLater );
@@ -497,20 +487,18 @@ void QgsWelcomePage::unpinProject( int row )
   emit projectUnpinned( row );
 }
 
-void QgsWelcomePage::clearRecentProjects( bool clearPinned )
+void QgsWelcomePage::clearRecentProjects()
 {
-  QString message;
-  if ( clearPinned )
+  QMessageBox messageBox( QMessageBox::Question,
+                          tr( "Recent Projects" ),
+                          tr( "Are you sure you want to clear the list of recent projects?" ),
+                          QMessageBox::No | QMessageBox::Yes | QMessageBox::YesToAll,
+                          this );
+  messageBox.button( QMessageBox::YesToAll )->setText( tr( "Yes, including pinned projects" ) );
+  int answer = messageBox.exec();
+  if ( answer != QMessageBox::No )
   {
-    message = tr( "Are you sure you want to clear the list of recent projects, including pinned projects?" );
-  }
-  else
-  {
-    message = tr( "Are you sure you want to clear the list of recent projects?" );
-  }
-
-  if ( QMessageBox::question( this,  tr( "Recent Projects" ), message ) == QMessageBox::Yes )
-  {
+    const bool clearPinned = ( answer == QMessageBox::YesToAll );
     mRecentProjectsModel->clear( clearPinned );
     emit projectsCleared( clearPinned );
   }

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -349,7 +349,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
     clearRecentProjects( false );
   } );
   menu->addAction( clearAction );
-  QAction *clearPinnedAction = new QAction( tr( "Clear List (including pinned projects)" ), menu );
+  QAction *clearPinnedAction = new QAction( tr( "Clear List (Including Pinned Projects)" ), menu );
   connect( clearPinnedAction, &QAction::triggered, this, [this]
   {
     clearRecentProjects( true );

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -53,7 +53,7 @@ class QgsWelcomePage : public QWidget
     void removeProject( int row );
     void pinProject( int row );
     void unpinProject( int row );
-    void clearRecentProjects( bool clearPinned = false );
+    void clearRecentProjects();
 
   signals:
     void projectRemoved( int row );


### PR DESCRIPTION
## Description

This PR harmonizes the right click menu for the project menu recent projects' sub menu and the welcome page recent project list by tweaking the following:
- An 'Open Directory...' action was added to the recent project sub-menu;
- The 'Unpin' and 'Pin' action labels have been renamed to 'Pin to List' and 'Unpin from List' to match preexisting label in the welcome page;
- Show the  'Remove from List' action for pinned items to match preexisting behavior in the welcome page;
- Merge 'Clear List' and 'Clear List (Including Pinned Projects)' actions into a single action with a message box asking whether the pinned projects should also be removed.

![image](https://github.com/qgis/QGIS/assets/1728657/3cb3d973-e70b-4971-bdf8-84e1a54f088f)

