### PR TITLE
When drag and dropping a style xml onto qgis, handle in the same way as double-clicking the styling in the browser

### DIFF
--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -458,18 +458,14 @@ QString QgsStyleXmlDropHandler::customUriProviderKey() const
 
 void QgsStyleXmlDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const
 {
-  QgsStyleExportImportDialog dlg( QgsStyle::defaultStyle(), QgisApp::instance(), QgsStyleExportImportDialog::Import );
-  dlg.setImportFilePath( uri.uri );
-  dlg.exec();
+  QgsStyleXmlDataItem::browseStyle( uri.uri );
 }
 
 bool QgsStyleXmlDropHandler::handleFileDrop( const QString &file )
 {
   if ( QgsStyle::isXmlStyleFile( file ) )
   {
-    QgsStyleExportImportDialog dlg( QgsStyle::defaultStyle(), QgisApp::instance(), QgsStyleExportImportDialog::Import );
-    dlg.setImportFilePath( file );
-    dlg.exec();
+    QgsStyleXmlDataItem::browseStyle( file );
     return true;
   }
   return false;

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -169,8 +169,6 @@ class QgsStyleXmlDataItem : public QgsDataItem
     bool handleDoubleClick() override;
     QList< QAction * > actions( QWidget *parent ) override;
 
-  private:
-
     static void browseStyle( const QString &xmlPath );
 
 };


### PR DESCRIPTION
Open the interactive style manager dialog for that style instead of the functionality-limited style import dialog.
