### PR TITLE
qgs3dmapscene: Ensure to compute a non empty elevationRange

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1098,7 +1098,7 @@ QgsDoubleRange Qgs3DMapScene::elevationRange() const
   }
   const QgsDoubleRange yRange( std::min( yMin, std::numeric_limits<double>::max() ),
                                std::max( yMax, std::numeric_limits<double>::lowest() ) );
-  return yRange;
+  return yRange.isEmpty() ? QgsDoubleRange() : yRange;
 }
 
 QMap< QString, Qgs3DMapScene * > Qgs3DMapScene::openScenes()


### PR DESCRIPTION
If the elevation range has not been computed,
`Qgs3DMapScene::elevationRange()` will return
`QgsDoubleRange(std::numeric_limits< double >::max(), std::numeric_limits< double >::lowest())`.
This may result in weird behaviors in the function which use `Qgs3DMapScene::elevationRange()`.

This issue is fixed by returning the default range if the range is empty.

