### PR TITLE
Only set application font once at startup, and require restarts after user changes the font

### DIFF
--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -27,6 +27,8 @@
 #include "qgssettings.h"
 #include "qgsguiutils.h"
 
+bool QgisAppStyleSheet::sIsFirstRun = true;
+
 QgisAppStyleSheet::QgisAppStyleSheet( QObject *parent )
   : QObject( parent )
 {
@@ -84,12 +86,18 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
 
     if ( overriddenFontFamily || overriddenFontSize )
     {
-      QFont font = QApplication::font();
-      if ( overriddenFontFamily )
-        font.setFamily( currentFontFamily );
-      if ( overriddenFontSize )
-        font.setPointSizeF( currentFontSize );
-      QApplication::setFont( font );
+      // this seems only safe to do at startup, at least on Windows.
+      // see https://github.com/qgis/QGIS/issues/54402, https://github.com/qgis/QGIS/issues/54295
+      // Let's play it safe and require a restart to change the font.
+      if ( sIsFirstRun )
+      {
+        QFont font = QApplication::font();
+        if ( overriddenFontFamily )
+          font.setFamily( currentFontFamily );
+        if ( overriddenFontSize )
+          font.setPointSizeF( currentFontSize );
+        QApplication::setFont( font );
+      }
     }
   }
 
@@ -171,6 +179,8 @@ void QgisAppStyleSheet::applyStyleSheet( const QMap<QString, QVariant> &opts )
   }
 
   QgsDebugMsgLevel( QStringLiteral( "Stylesheet built: %1" ).arg( ss ), 2 );
+
+  sIsFirstRun = false;
 
   emit appStyleSheetChanged( ss );
 }

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -114,6 +114,8 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
     // platforms, specific
     bool mWinOS = false;
     bool mAndroidOS = false;
+
+    static bool sIsFirstRun;
 };
 
 #endif //QGISAPPSTYLESHEET_H

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -374,7 +374,7 @@
                     <item>
                      <widget class="QLabel" name="label_43">
                       <property name="text">
-                       <string>Font</string>
+                       <string>Font &lt;i&gt;(QGIS restart required)&lt;/i&gt;</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
Avoids a potential crash

Fixes #54402
Fixes #54295
Fixes #53466
Fixes #54130
