### PR TITLE
[api][profiler] Add a function to export the current runtime profiler model content as text

### DIFF
--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -134,6 +134,15 @@ Returns the translated name of a standard profile ``group``.
     virtual QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const;
 
 
+    QString asText( const QString &group = QString() );
+%Docstring
+Returns the model as a multi-line text string.
+
+:param group: A group name to filter the model against.
+
+.. versionadded:: 3.34
+%End
+
 
     void groupAdded( const QString &group );
 %Docstring

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -270,6 +270,13 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
 
+    /**
+     * Returns the model as a multi-line text string.
+     * \param group A group name to filter the model against.
+     * \since QGIS 3.34
+     */
+    QString asText( const QString &group = QString() );
+
 #ifndef SIP_RUN
     ///@cond PRIVATE
   signals:
@@ -300,6 +307,7 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
     QgsRuntimeProfilerNode *pathToNode( const QString &group, const QStringList &path ) const;
     QModelIndex node2index( QgsRuntimeProfilerNode *node ) const;
     QModelIndex indexOfParentNode( QgsRuntimeProfilerNode *parentNode ) const;
+    void extractModelAsText( QStringList &lines, const QString &group, const QModelIndex &parent = QModelIndex(), int level = 0 );
 
     /**
      * Returns node for given index. Returns root node for invalid index.

--- a/tests/src/core/testqgsruntimeprofiler.cpp
+++ b/tests/src/core/testqgsruntimeprofiler.cpp
@@ -87,6 +87,17 @@ void TestQgsRuntimeProfiler::testGroups()
   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1" ) );
   QCOMPARE( profiler.childGroups( QStringLiteral( "task 1" ), QStringLiteral( "group 1" ) ), QStringList() << QStringLiteral( "task 1a" ) );
   QCOMPARE( profiler.childGroups( QString(), QStringLiteral( "group 2" ) ), QStringList() << QStringLiteral( "task 2" ) );
+
+  QString profilerAsText = profiler.asText();
+  // verify individual chunks as the ordering of individual model items can vary
+  QVERIFY( profilerAsText.contains( QStringLiteral( "group 2\r\n- task 2: 0" ) ) );
+  QVERIFY( profilerAsText.contains( QStringLiteral( "group 1\r\n" ) ) );
+  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n- task 1: 0" ) ) );
+  QVERIFY( profilerAsText.contains( QStringLiteral( "\r\n-- task 1a: 0" ) ) );
+
+  profilerAsText = profiler.asText( QStringLiteral( "group 2" ) );
+  // verify individual chunks as the ordering of individual model items can vary
+  QCOMPARE( profilerAsText, QStringLiteral( "group 2\r\n- task 2: 0" ) );
 }
 
 


### PR DESCRIPTION
## Description

This PR adds a simple function to the QgsRuntimeProfiler to export the model content to a multi-line text string. The practical need was to allow for profiling of startup, project load, and rendering within QField, but can definitively come in handy for other QGIS projects (server for e.g.).