### PR TITLE
pointcloud: Allow to load csv and txt files as point clouds

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -452,6 +452,17 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       {
         pointCloudLayer = std::make_unique< QgsPointCloudLayer >( uri, name, preferredProviders.at( 0 ).metadata()->key(), pointCloudOptions );
       }
+      else
+      {
+        // pdal provider can read ascii files but it is not exposed by the provider to
+        // prevent automatic loading of tabular ascii files.
+        // Try to open the file with pdal provider.
+        QgsProviderMetadata *pdalProvider = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
+        if ( pdalProvider )
+        {
+          pointCloudLayer = std::make_unique< QgsPointCloudLayer >( uri, name, QStringLiteral( "pdal" ), pointCloudOptions );
+        }
+      }
     }
     if ( pointCloudLayer && pointCloudLayer->isValid() )
     {

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -77,17 +77,14 @@ void QgsPointCloudSourceSelect::addButtonClicked()
 
     for ( const QString &path : QgsFileWidget::splitFilePaths( mPath ) )
     {
-      // auto determine preferred provider for each path
-
-      const QList< QgsProviderRegistry::ProviderCandidateDetails > preferredProviders = QgsProviderRegistry::instance()->preferredProvidersForUri( path );
       // maybe we should raise an assert if preferredProviders size is 0 or >1? Play it safe for now...
-      if ( preferredProviders.empty() )
-        continue;
-
+      const QList< QgsProviderRegistry::ProviderCandidateDetails > preferredProviders = QgsProviderRegistry::instance()->preferredProvidersForUri( path );
+      // if no preferred providers we can still give pdal a try
+      const QString providerKey = preferredProviders.empty() ? QStringLiteral( "pdal" ) : preferredProviders.first().metadata()->key();
       Q_NOWARN_DEPRECATED_PUSH
-      emit addPointCloudLayer( path, QFileInfo( path ).baseName(), preferredProviders.at( 0 ).metadata()->key() ) ;
+      emit addPointCloudLayer( path, QFileInfo( path ).baseName(), providerKey ) ;
       Q_NOWARN_DEPRECATED_POP
-      emit addLayer( Qgis::LayerType::PointCloud, path, QFileInfo( path ).baseName(), preferredProviders.at( 0 ).metadata()->key() );
+      emit addLayer( Qgis::LayerType::PointCloud, path, QFileInfo( path ).baseName(), providerKey );
     }
   }
   else if ( mDataSourceType == QLatin1String( "remote" ) )

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -474,19 +474,35 @@ void QgsPdalProviderMetadata::buildSupportedPointCloudFileFilterAndExtensions()
       QStringLiteral( "readers.las" ),
       QStringLiteral( "readers.e57" ),
       QStringLiteral( "readers.bpf" ) };
+
+    // the readers.text exposes extensions (csv, txt) which are generally not
+    // point cloud files. Add these extensions to the filters but do not expose
+    // them to the list of supported extensions to prevent unexpected behaviors
+    // such as trying to load a  tabular csv file being from a drag and
+    // drop action. The windows which want to handle the "readers.text" reader
+    // need to explicitly call the provider.
+    // see for example qgspointcloudsourceselect.cpp.
+    const QStringList specificReaders {QStringLiteral( "readers.text" ) };
+
+    const QStringList readers = allowedReaders + specificReaders;
+    QStringList filterExtensions;
     for ( const auto &stage : stages )
     {
-      if ( ! allowedReaders.contains( QString::fromStdString( stage ) ) )
+      if ( !readers.contains( QString::fromStdString( stage ) ) )
         continue;
 
       const pdal::StringList readerExtensions = extensions.extensions( stage );
       for ( const auto &extension : readerExtensions )
       {
-        sExtensions.append( QString::fromStdString( extension ) );
+        if ( allowedReaders.contains( QString::fromStdString( stage ) ) )
+          sExtensions.append( QString::fromStdString( extension ) );
+
+        filterExtensions.append( QString::fromStdString( extension ) );
       }
     }
+    filterExtensions.sort();
     sExtensions.sort();
-    const QString extensionsString = QStringLiteral( "*." ).append( sExtensions.join( QLatin1String( " *." ) ) );
+    const QString extensionsString = QStringLiteral( "*." ).append( filterExtensions.join( QLatin1String( " *." ) ) );
     sFilterString = tr( "PDAL Point Clouds" ) + QString( " (%1 %2)" ).arg( extensionsString, extensionsString.toUpper() );
   } );
 }


### PR DESCRIPTION
pdal has a "readers.text" driver which allows to load csv and txt files. However, most of of csv and txt files contain tabular data and not point cloud. Therefore, the "readers.text" cannot be always exposed.

First, the "csv" and "txt" extensions are handles to the filters handled by `QgsPdalProviderMetadata` but not to the extensions handled by this provider. This allows to select a "csv" or "txt" file from a `QFileDialog` and it prevents `QgsPdalProviderMetadata` from being selected among the provider which can load "csv" or "txt" files.

Then, `QgsPointCloudSourceSelect` and `QgsProcessingUtils` are modified to specifically handle "csv" and "txt" files.

Closes: https://github.com/qgis/QGIS/issues/52593

