### PR TITLE
Improve appearance of some arrows in model designer

### DIFF
--- a/src/gui/processing/models/qgsmodelarrowitem.h
+++ b/src/gui/processing/models/qgsmodelarrowitem.h
@@ -94,7 +94,7 @@ class GUI_EXPORT QgsModelArrowItem : public QObject, public QGraphicsPathItem
 
   private:
 
-    QPointF bezierPointForCurve( const QPointF &point, Qt::Edge edge, bool incoming ) const;
+    QPointF bezierPointForCurve( const QPointF &point, Qt::Edge edge, bool incoming, bool hasSpecificDirectionalFlow ) const;
 
     void drawArrowHead( QPainter *painter, const QPointF &point, const QPointF &vector );
 


### PR DESCRIPTION
The arrows attached to some components (like comments or input parameters) don't have any concept of "flow of information", so we shouldn't restrict these arrows to facing in certain directions.

Avoids arrows being drawn behind the box for these item types.

Before:

![image](https://github.com/qgis/QGIS/assets/1829991/0794d89d-c569-46ac-aeb8-0d04e2c51fcb)

After:

![image](https://github.com/qgis/QGIS/assets/1829991/749ee597-e158-4ca5-96aa-240d2bd99592)
