### PR TITLE
Fix segfault in coordinate transform

### DIFF
--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -666,14 +666,17 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
 
   // check if result bbox is geographic and is crossing 180/-180 line: ie. min X is before the 180° and max X is after the -180°
   bool doHandle180Crossover = false;
-  double xMin = std::fmod( x[0], 180.0 );
-  double xMax = std::fmod( x[nXPoints - 1], 180.0 );
-  if ( handle180Crossover
-       && ( ( direction == Qgis::TransformDirection::Forward && d->mDestCRS.isGeographic() ) ||
-            ( direction == Qgis::TransformDirection::Reverse && d->mSourceCRS.isGeographic() ) )
-       && xMin > 0.0 && xMin <= 180.0 && xMax < 0.0 && xMax >= -180.0 )
+  if ( nXPoints > 0 && x.size() >= nXPoints )
   {
-    doHandle180Crossover = true;
+    const double xMin = std::fmod( x[0], 180.0 );
+    const double xMax = std::fmod( x[nXPoints - 1], 180.0 );
+    if ( handle180Crossover
+         && ( ( direction == Qgis::TransformDirection::Forward && d->mDestCRS.isGeographic() ) ||
+              ( direction == Qgis::TransformDirection::Reverse && d->mSourceCRS.isGeographic() ) )
+         && xMin > 0.0 && xMin <= 180.0 && xMax < 0.0 && xMax >= -180.0 )
+    {
+      doHandle180Crossover = true;
+    }
   }
 
   // Calculate the bounding box and use that for the extent

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -666,7 +666,7 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
 
   // check if result bbox is geographic and is crossing 180/-180 line: ie. min X is before the 180° and max X is after the -180°
   bool doHandle180Crossover = false;
-  if ( nXPoints > 0 && x.size() >= nXPoints )
+  if ( nXPoints > 0 )
   {
     const double xMin = std::fmod( x[0], 180.0 );
     const double xMax = std::fmod( x[nXPoints - 1], 180.0 );


### PR DESCRIPTION
## Description

To reproduce the segfault:

1. for example open the `QGIS-Training-Data/exercise_data/qgis-server-tutorial-data/world.qgs` project
2. update the project CRS to EPSG:3857 (the CRS by default is EPSG:4326)

The segfault:

```
#12 0x00007f174896f274 in QVector<double>::operator[](int) (this=0x7fff8f8fb390, i=-2147483648) at /usr/include/qt/QtCore/qvector.h:457
#13 0x00007f17499d70de in QgsCoordinateTransform::transformBoundingBox(QgsRectangle const&, Qgis::TransformDirection, bool) const
    (this=0x7fff8f8fb580, rect=..., direction=Qgis::TransformDirection::Forward, handle180Crossover=false) at /home/pblottiere/devel/qgis/QGIS/src/core/proj/qgscoordinatetransform.cpp:670
#14 0x00007f17498bf253 in QgsMapRendererJob::reprojectToLayerExtent(QgsMapLayer const*, QgsCoordinateTransform const&, QgsRectangle&, QgsRectangle&) (ml=0x556b317a3630, ct=..., extent=..., r2=...)
    at /home/pblottiere/devel/qgis/QGIS/src/core/maprenderer/qgsmaprendererjob.cpp:322
#15 0x00007f17498c199c in QgsMapRendererJob::prepareJobs(QPainter*, QgsLabelingEngine*, bool) (this=0x556b34917620, painter=0x556b313a05d0, labelingEngine2=0x0, deferredPainterSet=false)
    at /home/pblottiere/devel/qgis/QGIS/src/core/maprenderer/qgsmaprendererjob.cpp:518
```

(it looks like a regression introduced in https://github.com/qgis/QGIS/pull/54483)
