### PR TITLE
qgsvirtualpointcloudprovider.cpp: add a missing variable initialization

### DIFF
--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
@@ -193,7 +193,7 @@ void QgsVirtualPointCloudProvider::parseFile()
     }
 
     QString uri;
-    qint64 count;
+    qint64 count = 0;
     QgsRectangle extent;
     QgsGeometry geometry;
     QgsDoubleRange zRange;


### PR DESCRIPTION
Fixes the following compiler warning:
```
In file included from /home/even/qgis/qgis/src/core/pointcloud/qgspointclouddataprovider.h:26,
                 from /home/even/qgis/qgis/src/core/providers/vpc/qgsvirtualpointcloudprovider.h:21,
                 from /home/even/qgis/qgis/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp:21:
/home/even/qgis/qgis/src/core/pointcloud/qgspointcloudsubindex.h: In member function 'void QgsVirtualPointCloudProvider::parseFile()':
/home/even/qgis/qgis/src/core/pointcloud/qgspointcloudsubindex.h:47:9: warning: 'count' may be used uninitialized in this function [-Wmaybe-uninitialized]
   47 |       , mPointCount( count )
      |         ^~~~~~~~~~~~~~~~~~~~
/home/even/qgis/qgis/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp:196:12: note: 'count' was declared here
  196 |     qint64 count;
      |            ^~~~~
```
