### PR TITLE
Fix MingW64 build

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -37,10 +37,10 @@ jobs:
         run: printf '[main]\ngpgcheck=True\ninstallonly_limit=3\nclean_requirements_on_remove=True\nbest=False\nskip_if_unavailable=True\ntsflags=nodocs' > /etc/dnf/dnf.conf
 
       - name: Update system
-        run: dnf5 -y update
+        run: dnf -y update
 
       - name: Install core dependencies
-        run: dnf5 -y install zip
+        run: dnf -y install zip
 
       - name: Install build dependencies
         run: ./ms-windows/mingw/mingwdeps.sh

--- a/ms-windows/mingw/build.sh
+++ b/ms-windows/mingw/build.sh
@@ -76,10 +76,7 @@ mkdir -p "$BUILDDIR"
 (
   CRSSYNC_BIN=$(readlink -f "$SRCDIR")/build/output/bin/crssync
   cd "$BUILDDIR"
-  rpm --eval "%{mingw64_cmake}" > mingw64-cmake.sh
-  sed -i -e 's/%__cmake/cmake/' mingw64-cmake.sh
-  chmod +x mingw64-cmake.sh
-  ./mingw$bits-cmake.sh \
+  mingw$bits-cmake \
     -DCMAKE_CROSS_COMPILING=1 \
     -DUSE_CCACHE=ON \
     -DCMAKE_BUILD_TYPE=$buildtype \

--- a/ms-windows/mingw/mingwdeps.sh
+++ b/ms-windows/mingw/mingwdeps.sh
@@ -5,7 +5,7 @@
 # just the "tsflags=nodocs" line
 printf '[main]\ngpgcheck=True\ninstallonly_limit=3\nclean_requirements_on_remove=True\nbest=False\nskip_if_unavailable=True\ntsflags=nodocs' > /etc/dnf/dnf.conf
 
-dnf5 install -y --nogpgcheck \
+dnf install -y --nogpgcheck \
   mingw64-dlfcn \
   mingw64-exiv2 \
   mingw64-fcgi \


### PR DESCRIPTION
## Description

Fixes the MingW64 build by reverting f3661ed.
It also removes the workaround introduced with 5703f03 since it is not needed anymore.

See https://lists.osgeo.org/pipermail/qgis-developer/2023-September/066079.html.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
