### PR TITLE
[maptools] Fix extra duplicated feature when using the copy+move map tool action

### DIFF
--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -244,7 +244,6 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       }
       case CopyMove:
         QgsFeatureRequest request;
-        qDebug() << mMovedFeatures;
         request.setFilterFids( mMovedFeatures );
         QString errorMsg;
         QString childrenInfoMsg;

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -244,6 +244,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       }
       case CopyMove:
         QgsFeatureRequest request;
+        qDebug() << mMovedFeatures;
         request.setFilterFids( mMovedFeatures );
         QString errorMsg;
         QString childrenInfoMsg;

--- a/src/core/vector/qgsvectorlayertools.cpp
+++ b/src/core/vector/qgsvectorlayertools.cpp
@@ -59,6 +59,15 @@ bool QgsVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureReq
     if ( mProject )
     {
       newFeature = QgsVectorLayerUtils::duplicateFeature( layer, f, mProject, duplicateFeatureContext );
+      if ( !newFeature.isValid() )
+      {
+        couldNotWriteCount++;
+        QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
+      }
+      else
+      {
+        fidList.insert( newFeature.id() );
+      }
 
       const auto duplicateFeatureContextLayers = duplicateFeatureContext.layers();
       for ( QgsVectorLayer *chl : duplicateFeatureContextLayers )
@@ -81,13 +90,16 @@ bool QgsVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureReq
         couldNotWriteCount++;
         QgsDebugError( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( f.id() ) );
       }
+      else
+      {
+        fidList.insert( newFeature.id() );
+      }
     }
 
     // translate
     if ( newFeature.hasGeometry() )
     {
       QgsGeometry geom = newFeature.geometry();
-      fidList.insert( newFeature.id() );
       if ( topologicalEditing )
       {
         if ( topologicalLayer )

--- a/tests/src/python/test_qgsvectorlayertools.py
+++ b/tests/src/python/test_qgsvectorlayertools.py
@@ -96,9 +96,11 @@ class TestQgsVectorLayerTools(QgisTestCase):
         """ Test copy and move features"""
         rqst = QgsFeatureRequest()
         rqst.setFilterFid(4)
+        features_count = self.vl.featureCount()
         self.vl.startEditing()
         (ok, rqst, msg) = self.vltools.copyMoveFeatures(self.vl, rqst, -0.1, 0.2)
         self.assertTrue(ok)
+        self.assertEqual(self.vl.featureCount(), features_count + 1)
         for f in self.vl.getFeatures(rqst):
             geom = f.geometry()
             self.assertAlmostEqual(geom.asPoint().x(), -65.42)


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/54607 , a regression which slipped into QGIS master through this PR (#53965). 

@agiudiceandrea , thanks for the ping, I wouldn't have caught the issue being filed otherwise. Cheers.