### PR TITLE
[GUI] VectorLayerSaveAsDialog: allow to select an existing FileGeodatabase (fixes #54566)

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -235,7 +235,6 @@ QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( c
   for ( it = options.constBegin(); it != options.constEnd(); ++it )
   {
     QgsVectorFileWriter::Option *option = it.value();
-    QLabel *label = new QLabel( it.key() );
     QWidget *control = nullptr;
     switch ( option->type )
     {
@@ -294,6 +293,8 @@ QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( c
 
     if ( control )
     {
+      QLabel *label = new QLabel( it.key() );
+
       // Pack the tooltip in some html element, so it gets linebreaks.
       label->setToolTip( QStringLiteral( "<p>%1</p>" ).arg( option->docString.toHtmlEscaped() ) );
       control->setToolTip( QStringLiteral( "<p>%1</p>" ).arg( option->docString.toHtmlEscaped() ) );

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -337,6 +337,18 @@ void QgsFileWidget::openFileDialog()
         // make sure filename ends with filter. This isn't automatically done by
         // getSaveFileName on some platforms (e.g. gnome)
         fileName = QgsFileUtils::addExtensionFromFilter( fileName, mSelectedFilter );
+
+        // A bit of hack to solve https://github.com/qgis/QGIS/issues/54566
+        // to be able to select an existing File Geodatabase, we add in the filter
+        // the "gdb" file that is found in all File Geodatabase .gdb directory
+        // to allow the user to select it. We now need to remove this gdb file
+        // (which became gdb.gdb due to above logic) from the selected filename
+        if ( mFilter.contains( QLatin1String( "(*.gdb *.GDB gdb)" ) ) &&
+             ( fileName.endsWith( QLatin1String( "/gdb.gdb" ) ) ||
+               fileName.endsWith( QLatin1String( "\\gdb.gdb" ) ) ) )
+        {
+          fileName.chop( static_cast<int>( strlen( "/gdb.gdb" ) ) );
+        }
       }
       break;
     }


### PR DESCRIPTION
This fix isn't totally satisfactory, because AFAICS there's no way in Qt FileDialog to both be able select an existing directory (.gdb) without entering into it, or select the parent of a new directory to be created. We'd need something between the GetFile or GetDirectory storage modes, although it is not clear how that could be implemented, without 2 separate buttons in the QtFileDialog (like "Select directory" and "Enter directory")
The hack/fix here is to add to the (*.gdb *.GDB) filter an extra "gdb" file that matches the "gdb" file found in existing File Geodatabase. And remove it from the filename once it is selected.

Select the "gdb" file:

![image](https://github.com/qgis/QGIS/assets/1192433/7758a7fa-ac48-42bb-8ead-d5d119a2e8f6)

And get only the directory name after it has been removed:

![image](https://github.com/qgis/QGIS/assets/1192433/3f4e8384-46fe-4e0a-b478-f6acbc40d820)
