### PR TITLE
SQLite layer export: do not set SRID= layer creation options that is …

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -4452,7 +4452,7 @@ QStringList QgsVectorFileWriter::concatenateOptions( const QMap<QString, QgsVect
 
       case QgsVectorFileWriter::Hidden:
         QgsVectorFileWriter::HiddenOption *opt = dynamic_cast<QgsVectorFileWriter::HiddenOption *>( option );
-        if ( opt )
+        if ( opt && !opt->mValue.isEmpty() )
         {
           list.append( QStringLiteral( "%1=%2" ).arg( it.key(), opt->mValue ) );
         }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -948,7 +948,8 @@ QStringList QgsVectorLayerSaveAsDialog::datasourceOptions() const
         {
           QgsVectorFileWriter::HiddenOption *opt =
             dynamic_cast<QgsVectorFileWriter::HiddenOption *>( it.value() );
-          options << QStringLiteral( "%1=%2" ).arg( it.key(), opt->mValue );
+          if ( !opt->mValue.isEmpty() )
+            options << QStringLiteral( "%1=%2" ).arg( it.key(), opt->mValue );
           break;
         }
       }
@@ -1007,7 +1008,8 @@ QStringList QgsVectorLayerSaveAsDialog::layerOptions() const
         {
           QgsVectorFileWriter::HiddenOption *opt =
             dynamic_cast<QgsVectorFileWriter::HiddenOption *>( it.value() );
-          options << QStringLiteral( "%1=%2" ).arg( it.key(), opt->mValue );
+          if ( !opt->mValue.isEmpty() )
+            options << QStringLiteral( "%1=%2" ).arg( it.key(), opt->mValue );
           break;
         }
       }


### PR DESCRIPTION
…interpreted by the OGR SQLite driver as meaning SRID=0 (fixes #54560)

Also fixed in GDAL per https://github.com/OSGeo/gdal/commit/9ff8ba649cc72dbca246963230ad161e9bab239d