### PR TITLE
[GPX provider] Add a 'time' attribute for the waypoint layer (fixes #54119)

### DIFF
--- a/src/providers/gpx/gpsdata.cpp
+++ b/src/providers/gpx/gpsdata.cpp
@@ -585,6 +585,17 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
     else
       parseModes.push( ParsingUnknown );
   }
+  else if ( !std::strcmp( qName, "time" ) )
+  {
+    if ( parseModes.top() == ParsingWaypoint )
+    {
+      mDateTime = &mWpt.time;
+      mCharBuffer.clear();
+      parseModes.push( ParsingDateTime );
+    }
+    else
+      parseModes.push( ParsingUnknown );
+  }
   else if ( !std::strcmp( qName, "sym" ) )
   {
     if ( parseModes.top() == ParsingWaypoint )
@@ -732,6 +743,11 @@ bool QgsGPXHandler::endElement( const std::string &qName )
   else if ( parseModes.top() == ParsingString )
   {
     *mString = mCharBuffer;
+    mCharBuffer.clear();
+  }
+  else if ( parseModes.top() == ParsingDateTime )
+  {
+    *mDateTime = QDateTime::fromString( mCharBuffer, Qt::ISODateWithMs );
     mCharBuffer.clear();
   }
   parseModes.pop();

--- a/src/providers/gpx/gpsdata.h
+++ b/src/providers/gpx/gpsdata.h
@@ -21,6 +21,7 @@
 #include <limits>
 
 #include <expat.h>
+#include <QDateTime>
 #include <QString>
 #include <QTextStream>
 #include <QStack>
@@ -92,6 +93,7 @@ class QgsWaypoint : public QgsGpsPoint
   public:
     void writeXml( QTextStream &stream ) override;
     QgsFeatureId id;
+    QDateTime time;
 };
 
 
@@ -344,6 +346,7 @@ class QgsGPXHandler
       ParsingDouble,
       ParsingInt,
       ParsingString,
+      ParsingDateTime,
       ParsingUnknown
     };
 
@@ -361,6 +364,7 @@ class QgsGPXHandler
     QString *mString = nullptr;
     double *mDouble = nullptr;
     int *mInt = nullptr;
+    QDateTime *mDateTime = nullptr;
     QString mCharBuffer;
 };
 

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -398,6 +398,9 @@ void QgsGPXFeatureIterator::readAttributes( QgsFeature &feature, const QgsWaypoi
       case QgsGPXProvider::URLNameAttr:
         feature.setAttribute( i, QVariant( wpt.urlname ) );
         break;
+      case QgsGPXProvider::TimeAttr:
+        feature.setAttribute( i, QVariant( wpt.time ) );
+        break;
     }
   }
 }

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -48,17 +48,17 @@
 
 const QStringList QgsGPXProvider::sAttributeNames = { "name", "elevation", "symbol", "number",
                                                       "comment", "description", "source",
-                                                      "url", "url name"
+                                                      "url", "url name", "time"
                                                     };
 const QList< QVariant::Type > QgsGPXProvider::sAttributeTypes = { QVariant::String, QVariant::Double, QVariant::String, QVariant::Int,
                                                                   QVariant::String, QVariant::String, QVariant::String,
-                                                                  QVariant::String, QVariant::String
+                                                                  QVariant::String, QVariant::String, QVariant::DateTime,
                                                                 };
 const QList< QgsGPXProvider::DataType > QgsGPXProvider::sAttributedUsedForLayerType =
 {
   QgsGPXProvider::AllType, QgsGPXProvider::WaypointType, QgsGPXProvider::TrkRteType, QgsGPXProvider::TrkRteType,
   QgsGPXProvider::AllType, QgsGPXProvider::AllType, QgsGPXProvider::AllType, QgsGPXProvider::AllType,
-  QgsGPXProvider::AllType, QgsGPXProvider::AllType
+  QgsGPXProvider::AllType, QgsGPXProvider::AllType, QgsGPXProvider::WaypointType,
 };
 
 const QString GPX_KEY = QStringLiteral( "gpx" );

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -92,7 +92,8 @@ class QgsGPXProvider final: public QgsVectorDataProvider
     };
 
     enum Attribute { NameAttr = 0, EleAttr, SymAttr, NumAttr,
-                     CmtAttr, DscAttr, SrcAttr, URLAttr, URLNameAttr
+                     CmtAttr, DscAttr, SrcAttr, URLAttr, URLNameAttr,
+                     TimeAttr
                    };
 
   private:

--- a/tests/src/python/test_provider_gpx.py
+++ b/tests/src/python/test_provider_gpx.py
@@ -11,6 +11,8 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 
 import os
 
+from qgis.PyQt.QtCore import Qt, QDateTime, QVariant
+
 from qgis.core import (
     QgsFeature,
     QgsPathResolver,
@@ -219,6 +221,13 @@ class TestPyQgsGpxProvider(QgisTestCase, ProviderTestCase):
 
         self.assertEqual(meta.absoluteToRelativeUri(absolute_uri, context), relative_uri)
         self.assertEqual(meta.relativeToAbsoluteUri(relative_uri, context), absolute_uri)
+
+    def test_waypoint_layer(self):
+        vl = QgsVectorLayer(f'{unitTestDataPath()}/gpx_test_suite.gpx' + "?type=waypoint", 'test2', 'gpx')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.fields().field("time").type(), QVariant.DateTime)
+        values = [f["time"] for f in vl.getFeatures()]
+        self.assertEqual(values[0], QDateTime(2023, 4, 25, 9, 52, 14, 0, Qt.TimeSpec(1)))
 
 
 if __name__ == '__main__':

--- a/tests/testdata/gpx_test_suite.gpx
+++ b/tests/testdata/gpx_test_suite.gpx
@@ -5,12 +5,14 @@
 <cmt>3</cmt>
 <urlname>Digitized in QGIS</urlname>
 <ele>0</ele>
+<time>2023-04-25T09:52:14Z</time>
 </wpt>
 <wpt lat="70.800000000000" lon="-68.200000000000">
 <name>Apple</name>
 <cmt>2</cmt>
 <urlname>Digitized in QGIS</urlname>
 <ele>0</ele>
+<time>invalid</time>
 </wpt>
 <wpt lat="66.330000000000" lon="-70.332000000000">
 <name>Orange</name>


### PR DESCRIPTION
It looks to me that this GPX provider could probably be replaced with OGR GPX driver which I believe is more capable

fixes #54119