### PR TITLE
Fixes the wrong reference point for mode fill above and fill below. Fixes #54422

### DIFF
--- a/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
@@ -331,7 +331,7 @@ void QgsAbstractProfileSurfaceResults::renderResults( QgsProfileRenderContext &c
     }
     if ( currentLine.length() < 1 )
     {
-        currentPartStartDistance = pointIt.key();
+      currentPartStartDistance = pointIt.key();
     }
     currentLine.append( context.worldTransform().map( QPointF( pointIt.key(), pointIt.value() ) ) );
     prevDistance = pointIt.key();

--- a/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
@@ -302,10 +302,6 @@ void QgsAbstractProfileSurfaceResults::renderResults( QgsProfileRenderContext &c
   double currentPartStartDistance = 0;
   for ( auto pointIt = mDistanceToHeightMap.constBegin(); pointIt != mDistanceToHeightMap.constEnd(); ++pointIt )
   {
-    if ( std::isnan( prevDistance ) )
-    {
-      currentPartStartDistance = pointIt.key();
-    }
     if ( std::isnan( pointIt.value() ) )
     {
       if ( currentLine.length() > 1 )
@@ -333,7 +329,10 @@ void QgsAbstractProfileSurfaceResults::renderResults( QgsProfileRenderContext &c
       currentLine.clear();
       continue;
     }
-
+    if ( currentLine.length() < 1 )
+    {
+        currentPartStartDistance = pointIt.key();
+    }
     currentLine.append( context.worldTransform().map( QPointF( pointIt.key(), pointIt.value() ) ) );
     prevDistance = pointIt.key();
   }


### PR DESCRIPTION
## Description
Fixes the bug that in the "Fill above" and "Fill below" mode the area below NaN values is filled. It also fixes an unreported bug that pulls the fill to distance=0 when the profile line starts on NaN values (compare issue screenshot with the PR screenshot).

![grafik](https://github.com/qgis/QGIS/assets/18557959/ee2afe96-4ef8-4246-a4a6-64daf2106732)

Fixes #54422 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
