### PR TITLE
CI: stop accepting gitstatus checks failures from non-provider tests

### DIFF
--- a/.docker/docker-compose-testing.yml
+++ b/.docker/docker-compose-testing.yml
@@ -44,4 +44,3 @@ services:
       - LANG=C.UTF-8
       - LC_ALL=en_US.UTF-8
       - QGIS_HTTPBIN_HOST=httpbin
-      - QGIS_TEST_ACCEPT_GITSTATUS_CHECK_FAILURE=1


### PR DESCRIPTION
See also GH-48904
Continuation of GH-52510 as that one was closed by stale bot and I don't seem to have the possibility of reopening it
