### PR TITLE
fix(3DSceneExporter): add entity sorting to have idempotent scene export

### DIFF
--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -544,6 +544,9 @@ Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeo
   if ( tessGeom )
   {
     QVector<QgsFeatureId> featureIds = tessGeom->featureIds();
+    // sort feature by their id in order to always export them in the same way:
+    std::sort( featureIds.begin(), featureIds.end() );
+
     QVector<uint> triangleIndex = tessGeom->triangleIndexStartingIndices();
     for ( int idx = 0; idx < featureIds.size(); idx++ )
     {

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -24,6 +24,7 @@
 #include "qgs3dsceneexporter.h"
 #include "qgsvectorlayerelevationproperties.h"
 #include "qgsvectorlayer.h"
+#include "qgstessellatedpolygongeometry.h"
 
 QgsPolygon3DSymbol::QgsPolygon3DSymbol()
   : mMaterialSettings( std::make_unique< QgsPhongMaterialSettings >() )
@@ -170,7 +171,13 @@ void QgsPolygon3DSymbol::setMaterialSettings( QgsAbstractMaterialSettings *mater
 
 bool QgsPolygon3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const
 {
-  const QList<Qt3DCore::QEntity *> subEntities = entity->findChildren<Qt3DCore::QEntity *>( QString(), Qt::FindDirectChildrenOnly );
+  QList<Qt3DCore::QEntity *> subEntities = entity->findChildren<Qt3DCore::QEntity *>( QString(), Qt::FindDirectChildrenOnly );
+  // sort geometries by their name in order to always export them in the same way:
+  std::sort( subEntities.begin(), subEntities.end(), []( const Qt3DCore::QEntity * a, const Qt3DCore::QEntity * b )
+  {
+    return a->objectName() < b->objectName();
+  } );
+
   if ( subEntities.isEmpty() )
   {
     const QList<Qt3DRender::QGeometryRenderer *> renderers = entity->findChildren<Qt3DRender::QGeometryRenderer *>();

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -1750,7 +1750,7 @@ void TestQgs3DRendering::do3DSceneExport( int zoomLevelsCount, int expectedObjec
     QVERIFY( o->indexes().size() * 3 <= o->vertexPosition().size() );
     sum += o->indexes().size();
   }
-  QCOMPARE( maxFaceCount, sum );
+  QCOMPARE( sum, maxFaceCount );
   exporter.save( QString( "test3DSceneExporter-%1" ).arg( zoomLevelsCount ), "/tmp/" );
 
   QCOMPARE( exporter.mExportedFeatureIds.size(), 3 );
@@ -1803,8 +1803,12 @@ void TestQgs3DRendering::test3DSceneExporter()
 
   // =========== check with 1 big tile ==> 1 exported object
   do3DSceneExport( 1, 1, 165, scene, symbol3d, layerPoly, &engine );
+  // =========== check with 4 tiles ==> 3 exported objects
+  do3DSceneExport( 2, 1, 165, scene, symbol3d, layerPoly, &engine );
   // =========== check with 9 tiles ==> 3 exported objects
-  do3DSceneExport( 3, 3, 165, scene, symbol3d, layerPoly, &engine );
+  do3DSceneExport( 3, 3, 216, scene, symbol3d, layerPoly, &engine );
+  // =========== check with 16 tiles ==> 3 exported objects
+  do3DSceneExport( 4, 3, 132, scene, symbol3d, layerPoly, &engine );
   // =========== check with 25 tiles ==> 3 exported objects
   do3DSceneExport( 5, 3, 165, scene, symbol3d, layerPoly, &engine );
 


### PR DESCRIPTION
follow https://github.com/qgis/QGIS/pull/52064#issuecomment-1718767179

Fix the way entities are handle during the export by sorting the scene entities by name. The TestQgs3DRendering::test3DSceneExporter test is now stable.

cc @ptitjano @lbartoletti @nyalldawson 