### PR TITLE
add object names to annotation actions, so they can be removed with interface customization (fix #54250)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -816,6 +816,7 @@ void QgisApp::annotationItemTypeAdded( int id )
   action->setCheckable( true );
   action->setData( id );
   action->setIcon( QgsGui::annotationItemGuiRegistry()->itemMetadata( id )->creationIcon() );
+  action->setObjectName( QStringLiteral( "mAction%1" ).arg( name.replace( " ", "" ) ) );
 
   mMapToolGroup->addAction( action );
 


### PR DESCRIPTION
## Description

Actions to create different types of annotations do no have `objectName` set. This makes impossible to hide them using interface customization functionality.

Fixes #54250.