### PR TITLE
add binary and boolean types to QgsFieldProxyModel (fix #53940)

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -3172,7 +3172,9 @@ A vector layer or feature source field parameter for processing algorithms.
       Any,
       Numeric,
       String,
-      DateTime
+      DateTime,
+      Binary,
+      Boolean,
     };
 
     QgsProcessingParameterField( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),

--- a/python/core/auto_generated/qgsfieldproxymodel.sip.in
+++ b/python/core/auto_generated/qgsfieldproxymodel.sip.in
@@ -35,6 +35,8 @@ The :py:class:`QgsFieldProxyModel` class provides an easy to use model to displa
       Time,
       HideReadOnly,
       DateTime,
+      Binary,
+      Boolean,
       AllTypes,
     };
     typedef QFlags<QgsFieldProxyModel::Filter> Filters;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -5878,6 +5878,14 @@ QString QgsProcessingParameterField::asScriptCode() const
       code += QLatin1String( "datetime " );
       break;
 
+    case Binary:
+      code += QLatin1String( "binary " );
+      break;
+
+    case Boolean:
+      code += QLatin1String( "boolean " );
+      break;
+
     case Any:
       break;
   }
@@ -5922,6 +5930,14 @@ QString QgsProcessingParameterField::asPythonString( const QgsProcessing::Python
 
         case DateTime:
           dataType = QStringLiteral( "QgsProcessingParameterField.DateTime" );
+          break;
+
+        case Binary:
+          dataType = QStringLiteral( "QgsProcessingParameterField.Binary" );
+          break;
+
+        case Boolean:
+          dataType = QStringLiteral( "QgsProcessingParameterField.Boolean" );
           break;
       }
       code += QStringLiteral( ", type=%1" ).arg( dataType );
@@ -6032,6 +6048,16 @@ QgsProcessingParameterField *QgsProcessingParameterField::fromScriptCode( const 
   {
     type = DateTime;
     def = def.mid( 9 );
+  }
+  else if ( def.startsWith( QLatin1String( "binary " ), Qt::CaseInsensitive ) )
+  {
+    type = Binary;
+    def = def.mid( 7 );
+  }
+  else if ( def.startsWith( QLatin1String( "boolean " ), Qt::CaseInsensitive ) )
+  {
+    type = Boolean;
+    def = def.mid( 8 );
   }
 
   if ( def.startsWith( QLatin1String( "multiple" ), Qt::CaseInsensitive ) )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -3065,7 +3065,9 @@ class CORE_EXPORT QgsProcessingParameterField : public QgsProcessingParameterDef
       Any = -1, //!< Accepts any field
       Numeric = 0, //!< Accepts numeric fields
       String = 1, //!< Accepts string fields
-      DateTime = 2 //!< Accepts datetime fields
+      DateTime = 2, //!< Accepts datetime fields
+      Binary = 3, //!< Accepts binary fields, since QGIS 3.34
+      Boolean = 4, //!< Accepts boolean fields, since QGIS 3.34
     };
 
     /**

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -106,7 +106,9 @@ bool QgsFieldProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
        ( mFilters.testFlag( Date ) && type == QVariant::Date ) ||
        ( mFilters.testFlag( Date ) && type == QVariant::DateTime ) ||
        ( mFilters.testFlag( DateTime ) && type == QVariant::DateTime ) ||
-       ( mFilters.testFlag( Time ) && type == QVariant::Time ) )
+       ( mFilters.testFlag( Time ) && type == QVariant::Time ) ||
+       ( mFilters.testFlag( Binary ) && type == QVariant::ByteArray ) ||
+       ( mFilters.testFlag( Boolean ) && type == QVariant::Bool ) )
     return true;
 
   return false;

--- a/src/core/qgsfieldproxymodel.h
+++ b/src/core/qgsfieldproxymodel.h
@@ -46,8 +46,10 @@ class CORE_EXPORT QgsFieldProxyModel : public QSortFilterProxyModel
       Date = 16, //!< Date or datetime fields
       Time = 32, //!< Time fields
       HideReadOnly = 64,  //!< Hide read-only fields
-      DateTime = 128, //!< Datetime fieldss
-      AllTypes = Numeric | Date | String | Time, //!< All field types
+      DateTime = 128, //!< Datetime fields
+      Binary = 256, //!< Binary fields, since QGIS 3.34
+      Boolean = 512, //!< Boolean fields, since QGIS 3.34
+      AllTypes = Numeric | Date | String | Time | DateTime | Binary | Boolean, //!< All field types
     };
     Q_DECLARE_FLAGS( Filters, Filter )
     Q_FLAG( Filters )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -4412,6 +4412,8 @@ QgsProcessingFieldParameterDefinitionWidget::QgsProcessingFieldParameterDefiniti
   mDataTypeComboBox->addItem( tr( "Number" ), QgsProcessingParameterField::Numeric );
   mDataTypeComboBox->addItem( tr( "String" ), QgsProcessingParameterField::String );
   mDataTypeComboBox->addItem( tr( "Date/time" ), QgsProcessingParameterField::DateTime );
+  mDataTypeComboBox->addItem( tr( "Binary" ), QgsProcessingParameterField::Binary );
+  mDataTypeComboBox->addItem( tr( "Boolean" ), QgsProcessingParameterField::Boolean );
   if ( const QgsProcessingParameterField *fieldParam = dynamic_cast<const QgsProcessingParameterField *>( definition ) )
     mDataTypeComboBox->setCurrentIndex( mDataTypeComboBox->findData( fieldParam->dataType() ) );
 
@@ -4498,6 +4500,10 @@ QWidget *QgsProcessingFieldWidgetWrapper::createWidget()
           mComboBox->setFilters( QgsFieldProxyModel::String );
         else if ( fieldParam->dataType() == QgsProcessingParameterField::DateTime )
           mComboBox->setFilters( QgsFieldProxyModel::Date | QgsFieldProxyModel::Time | QgsFieldProxyModel::DateTime );
+        else if ( fieldParam->dataType() == QgsProcessingParameterField::Binary )
+          mComboBox->setFilters( QgsFieldProxyModel::Binary );
+        else if ( fieldParam->dataType() == QgsProcessingParameterField::Boolean )
+          mComboBox->setFilters( QgsFieldProxyModel::Boolean );
 
         mComboBox->setToolTip( parameterDefinition()->toolTip() );
         connect( mComboBox, &QgsFieldComboBox::fieldChanged, this, [ = ]( const QString & )
@@ -4794,6 +4800,16 @@ QgsFields QgsProcessingFieldWidgetWrapper::filterFields( const QgsFields &fields
 
       case QgsProcessingParameterField::DateTime:
         if ( f.type() == QVariant::Date || f.type() == QVariant::Time || f.type() == QVariant::DateTime )
+          res.append( f );
+        break;
+
+      case QgsProcessingParameterField::Binary:
+        if ( f.type() == QVariant::ByteArray )
+          res.append( f );
+        break;
+
+      case QgsProcessingParameterField::Boolean:
+        if ( f.type() == QVariant::Bool )
           res.append( f );
         break;
     }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6861,6 +6861,21 @@ void TestQgsProcessing::parameterField()
   QCOMPARE( fromCode->allowMultiple(), def->allowMultiple() );
   QCOMPARE( fromCode->defaultToAllFields(), def->defaultToAllFields() );
 
+  def->setDataType( QgsProcessingParameterField::Binary );
+  pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterField('non_optional', '', type=QgsProcessingParameterField.Binary, parentLayerParameterName='my_parent', allowMultiple=False, defaultValue=None)" ) );
+  code = def->asScriptCode();
+  fromCode.reset( dynamic_cast< QgsProcessingParameterField * >( QgsProcessingParameters::parameterFromScriptCode( code ) ) );
+  QVERIFY( fromCode.get() );
+  QCOMPARE( fromCode->name(), def->name() );
+  QCOMPARE( fromCode->description(), QStringLiteral( "non optional" ) );
+  QCOMPARE( fromCode->flags(), def->flags() );
+  QCOMPARE( fromCode->defaultValue(), def->defaultValue() );
+  QCOMPARE( fromCode->parentLayerParameterName(), def->parentLayerParameterName() );
+  QCOMPARE( fromCode->dataType(), def->dataType() );
+  QCOMPARE( fromCode->allowMultiple(), def->allowMultiple() );
+  QCOMPARE( fromCode->defaultToAllFields(), def->defaultToAllFields() );
+
   // multiple
   def.reset( new QgsProcessingParameterField( "non_optional", QString(), QVariant(), QString(), QgsProcessingParameterField::Any, true, false ) );
   QVERIFY( def->checkValueIsAcceptable( 1 ) );

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -3326,6 +3326,8 @@ void TestProcessingGui::testFieldWrapper()
     f.append( QgsField( QStringLiteral( "date" ), QVariant::Date ) );
     f.append( QgsField( QStringLiteral( "time" ), QVariant::Time ) );
     f.append( QgsField( QStringLiteral( "datetime" ), QVariant::DateTime ) );
+    f.append( QgsField( QStringLiteral( "binary" ), QVariant::ByteArray ) );
+    f.append( QgsField( QStringLiteral( "boolean" ), QVariant::Bool ) );
 
     QgsFields f2 = wrapper3.filterFields( f );
     QCOMPARE( f2, f );
@@ -3426,18 +3428,55 @@ void TestProcessingGui::testFieldWrapper()
     QCOMPARE( f2.at( 1 ).name(), QStringLiteral( "time" ) );
     QCOMPARE( f2.at( 2 ).name(), QStringLiteral( "datetime" ) );
 
-
-    // default to all fields
-    param = QgsProcessingParameterField( QStringLiteral( "field" ), QStringLiteral( "field" ), QVariant(), QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true );
-    param.setDefaultToAllFields( true );
+    // binary fields
+    param = QgsProcessingParameterField( QStringLiteral( "field" ), QStringLiteral( "field" ), QVariant(), QStringLiteral( "INPUT" ), QgsProcessingParameterField::Binary, false, true );
     QgsProcessingFieldWidgetWrapper wrapper7( &param, type );
     w = wrapper7.createWrappedWidget( context );
-    wrapper7.setParentLayerWrapperValue( &layerWrapper );
     switch ( type )
     {
       case QgsProcessingGui::Standard:
       case QgsProcessingGui::Batch:
-        QCOMPARE( wrapper7.widgetValue().toList(), QVariantList() << QStringLiteral( "aaa" ) << QStringLiteral( "bbb" ) );
+        QCOMPARE( static_cast< QgsFieldComboBox * >( wrapper7.wrappedWidget() )->filters(), QgsFieldProxyModel::Binary );
+        break;
+
+      case QgsProcessingGui::Modeler:
+        break;
+    }
+    f2 = wrapper7.filterFields( f );
+    QCOMPARE( f2.size(), 1 );
+    QCOMPARE( f2.at( 0 ).name(), QStringLiteral( "binary" ) );
+    delete w;
+
+    // boolean fields
+    param = QgsProcessingParameterField( QStringLiteral( "field" ), QStringLiteral( "field" ), QVariant(), QStringLiteral( "INPUT" ), QgsProcessingParameterField::Boolean, false, true );
+    QgsProcessingFieldWidgetWrapper wrapper8( &param, type );
+    w = wrapper8.createWrappedWidget( context );
+    switch ( type )
+    {
+      case QgsProcessingGui::Standard:
+      case QgsProcessingGui::Batch:
+        QCOMPARE( static_cast< QgsFieldComboBox * >( wrapper8.wrappedWidget() )->filters(), QgsFieldProxyModel::Boolean );
+        break;
+
+      case QgsProcessingGui::Modeler:
+        break;
+    }
+    f2 = wrapper8.filterFields( f );
+    QCOMPARE( f2.size(), 1 );
+    QCOMPARE( f2.at( 0 ).name(), QStringLiteral( "boolean" ) );
+    delete w;
+
+    // default to all fields
+    param = QgsProcessingParameterField( QStringLiteral( "field" ), QStringLiteral( "field" ), QVariant(), QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true );
+    param.setDefaultToAllFields( true );
+    QgsProcessingFieldWidgetWrapper wrapper9( &param, type );
+    w = wrapper9.createWrappedWidget( context );
+    wrapper9.setParentLayerWrapperValue( &layerWrapper );
+    switch ( type )
+    {
+      case QgsProcessingGui::Standard:
+      case QgsProcessingGui::Batch:
+        QCOMPARE( wrapper9.widgetValue().toList(), QVariantList() << QStringLiteral( "aaa" ) << QStringLiteral( "bbb" ) );
         break;
 
       case QgsProcessingGui::Modeler:
@@ -3449,17 +3488,17 @@ void TestProcessingGui::testFieldWrapper()
     QgsVectorLayer *vl2 = new QgsVectorLayer( QStringLiteral( "LineString?field=bbb:string" ), QStringLiteral( "y" ), QStringLiteral( "memory" ) );
     p.addMapLayer( vl2 );
 
-    QgsProcessingFieldWidgetWrapper wrapper8( &param, type );
-    wrapper8.registerProcessingContextGenerator( &generator );
-    w = wrapper8.createWrappedWidget( context );
+    QgsProcessingFieldWidgetWrapper wrapper10( &param, type );
+    wrapper10.registerProcessingContextGenerator( &generator );
+    w = wrapper10.createWrappedWidget( context );
     layerWrapper.setWidgetValue( QVariantList() << vl->id() << vl2->id(), context );
-    wrapper8.setParentLayerWrapperValue( &layerWrapper );
+    wrapper10.setParentLayerWrapperValue( &layerWrapper );
 
     switch ( type )
     {
       case QgsProcessingGui::Standard:
       case QgsProcessingGui::Batch:
-        QCOMPARE( wrapper8.widgetValue().toList(), QVariantList() << QStringLiteral( "bbb" ) );
+        QCOMPARE( wrapper10.widgetValue().toList(), QVariantList() << QStringLiteral( "bbb" ) );
         break;
 
       case QgsProcessingGui::Modeler:

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -286,13 +286,13 @@ void TestQgsFieldExpressionWidget::testIsValid()
 
 void TestQgsFieldExpressionWidget::testFilters()
 {
-  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "point?field=intfld:int&field=stringfld:string&field=string2fld:string&field=longfld:long&field=doublefld:double&field=datefld:date&field=timefld:time&field=datetimefld:datetime" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "point?field=intfld:int&field=stringfld:string&field=string2fld:string&field=longfld:long&field=doublefld:double&field=datefld:date&field=timefld:time&field=datetimefld:datetime&field=binaryfld:binary&field=booleanfld:boolean" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
   QgsProject::instance()->addMapLayer( layer );
 
   std::unique_ptr< QgsFieldExpressionWidget > widget( new QgsFieldExpressionWidget() );
   widget->setLayer( layer );
 
-  QCOMPARE( widget->mCombo->count(), 8 );
+  QCOMPARE( widget->mCombo->count(), 10 );
   QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "intfld" ) );
   QCOMPARE( widget->mCombo->itemText( 1 ), QStringLiteral( "stringfld" ) );
   QCOMPARE( widget->mCombo->itemText( 2 ), QStringLiteral( "string2fld" ) );
@@ -301,6 +301,8 @@ void TestQgsFieldExpressionWidget::testFilters()
   QCOMPARE( widget->mCombo->itemText( 5 ), QStringLiteral( "datefld" ) );
   QCOMPARE( widget->mCombo->itemText( 6 ), QStringLiteral( "timefld" ) );
   QCOMPARE( widget->mCombo->itemText( 7 ), QStringLiteral( "datetimefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 8 ), QStringLiteral( "binaryfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 9 ), QStringLiteral( "booleanfld" ) );
 
   widget->setFilters( QgsFieldProxyModel::String );
   QCOMPARE( widget->mCombo->count(), 2 );
@@ -337,6 +339,14 @@ void TestQgsFieldExpressionWidget::testFilters()
   widget->setFilters( QgsFieldProxyModel::DateTime );
   QCOMPARE( widget->mCombo->count(), 1 );
   QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "datetimefld" ) );
+
+  widget->setFilters( QgsFieldProxyModel::Binary );
+  QCOMPARE( widget->mCombo->count(), 1 );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "binaryfld" ) );
+
+  widget->setFilters( QgsFieldProxyModel::Boolean );
+  QCOMPARE( widget->mCombo->count(), 1 );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "booleanfld" ) );
 
   QgsProject::instance()->removeMapLayer( layer );
 }


### PR DESCRIPTION
## Description

`QgsFieldProxyModel` does not allow to filter binary and boolean fields. Also those data types are not exposed in the Processing field parameter. This PR adds both types and makes them available in Processing too.

Fixes #53940.