### PR TITLE
add icons to Elevation and Notes style categories (fix #53680)

### DIFF
--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -284,7 +284,7 @@ QVariant QgsMapLayerStyleCategoriesModel::data( const QModelIndex &index, int ro
         case Qt::ToolTipRole:
           return tr( "Elevation properties" );
         case Qt::DecorationRole:
-          return QIcon(); // TODO
+          return QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/elevationscale.svg" ) );
       }
       break;
 


### PR DESCRIPTION
## Description

Add icons to Elevation and Notes style categories
![image](https://github.com/qgis/QGIS/assets/776954/40346e3a-d437-45e2-bfd7-fb306ffa7b7e)

Fixes #53680.