### PR TITLE
mark project dirty after pasting a layer style (fix #53693)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10612,6 +10612,7 @@ void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCateg
 
       mLayerTreeView->refreshLayerSymbology( selectionLayer->id() );
       selectionLayer->triggerRepaint();
+      QgsProject::instance()->setDirty( true );
     }
   }
 }


### PR DESCRIPTION
## Description

Pasting a style should mark project as dirty, otherwise we can easily lost changes.

Fixes #53693.