### PR TITLE
[processing] replace illegal characters with underscore when splitting vector layer (fix #53856)

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -18,6 +18,7 @@
 #include "qgsalgorithmsplitvectorlayer.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsvariantutils.h"
+#include "qgsfileutils.h"
 
 ///@cond PRIVATE
 
@@ -139,9 +140,7 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
     }
     else
     {
-      QString value = ( *it ).toString();
-      value.replace( QRegularExpression( "<|>|\\:|\\\\|\\/|\\||\\?|\\*|\"" ), QStringLiteral( "_" ) );
-      fileName = QStringLiteral( "%1%2.%3" ).arg( baseName ).arg( value ).arg( outputFormat );
+      fileName = QStringLiteral( "%1%2.%3" ).arg( baseName ).arg( QgsFileUtils::stringToSafeFilename( ( *it ).toString() ) ).arg( outputFormat );
     }
     feedback->pushInfo( QObject::tr( "Creating layer: %1" ).arg( fileName ) );
 


### PR DESCRIPTION
## Description

Field values may contain characters which can not be safely used in the file names, as a result Split Vector Layer Processing algorithm fails to create output file. To fix this, algorithm will replace characters `< > : \ / | ? * "` with `_` (underscore) when generating output file name.

Also ignore invalid geometries, as we only want to split vector layer and does not care about geometry validity in this particular case.

Fixes #53856.