### PR TITLE
do not crash when user hits "Test" button in point cloud expression editor (fix #54648)

### DIFF
--- a/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
+++ b/src/gui/processing/qgsprocessingpointcloudexpressionlineedit.cpp
@@ -309,7 +309,7 @@ void QgsProcessingPointCloudExpressionDialog::test()
     int offset;
     for ( const auto &attribute : attributes )
     {
-      if ( mLayer->dataProvider() &&
+      if ( mLayer && mLayer->dataProvider() &&
            !mLayer->dataProvider()->attributes().find( attribute, offset ) )
       {
         QMessageBox::warning( this,


### PR DESCRIPTION
## Description

Check that layer pointer is valid before accessing class methods.

Fixes #54648.