### PR TITLE
qgscameracontroller: Ensure to keep sane values for camera speed

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -90,7 +90,9 @@ void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
   if ( movementSpeed == mCameraMovementSpeed )
     return;
 
-  mCameraMovementSpeed = movementSpeed;
+  // If the speed becomes 0, navigation does not work anymore
+  // If the speed becomes too important, only one walk can move the view far from the scene.
+  mCameraMovementSpeed = std::clamp( movementSpeed, 0.05, 150.0 );
   emit cameraMovementSpeedChanged( mCameraMovementSpeed );
 }
 


### PR DESCRIPTION
## Description

With the current logic in `QgsCameraController::onWheel`, once the speed becomes null, it cannot increase anymore and navigation stops working. On the other hand, there is no upper limit for the speed. This means, that it can become very (too) important, even infinite.

These issues are fixed by limiting the values of
`mCameraMovementSpeed` in its setter.


