### PR TITLE
RASTER: fix gh54702 crash on wcs bad layers

### DIFF
--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -622,7 +622,8 @@ QString QgsRasterInterface::generateBandName( int bandNumber ) const
   if ( mInput )
     return mInput->generateBandName( bandNumber );
 
-  return tr( "Band" ) + QStringLiteral( " %1" ) .arg( bandNumber, 1 + static_cast< int >( std::log10( static_cast< double >( bandCount() ) ) ), 10, QChar( '0' ) );
+  // For bad layers bandCount is 0, no log!
+  return tr( "Band" ) + QStringLiteral( " %1" ) .arg( bandNumber, 1 + ( bandCount() > 0 ? static_cast< int >( std::log10( static_cast< double >( bandCount() ) ) ) : 0 ), 10, QChar( '0' ) );
 }
 
 QString QgsRasterInterface::colorInterpretationName( int bandNo ) const

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -957,6 +957,10 @@ QList<QgsColorRampShader::ColorRampItem> QgsWcsProvider::colorTable( int bandNum
 
 Qgis::RasterColorInterpretation QgsWcsProvider::colorInterpretation( int bandNo ) const
 {
+  if ( !mCachedGdalDataset.get() )
+  {
+    return Qgis::RasterColorInterpretation::Undefined;
+  }
   GDALRasterBandH myGdalBand = GDALGetRasterBand( mCachedGdalDataset.get(), bandNo );
   return colorInterpretationFromGdal( GDALGetRasterColorInterpretation( myGdalBand ) );
 }

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -345,6 +345,16 @@ class PyQgsGdalProvider(QgisTestCase):
         rl = QgsRasterLayer(tmpfile)
         self.assertEqual(rl.dataProvider().bandDescription(1), 'my metadata description')
 
+    def testDisplayBandNameBadLayer(self):
+        """Test crash from issue GH #54702"""
+
+        rl = QgsRasterLayer("https://FAKESERVER/ImageServer/WCSServer", "BadWCS", "wcs")
+        self.assertFalse(rl.isValid())
+        # This was triggering a std::bad_alloc exception:
+        self.assertEqual(rl.dataProvider().displayBandName(1), 'Band 1')
+        # This was triggering another crash:
+        self.assertEqual(rl.dataProvider().colorInterpretationName(1), 'Undefined')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a crash on bad GDAL raster layers when the user chooses to keep it.

Fix #54702