### PR TITLE
fix remove/rename Arcgis connections in browser

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -169,7 +169,7 @@ void QgsArcGisRestDataItemGuiProvider::deleteConnection( QgsDataItem *item )
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  QgsOwsConnection::deleteConnection( QStringLiteral( "arcgisfeatureserver" ), item->name() );
+  QgsArcGisConnectionSettings::sTreeConnectionArcgis->deleteItem( item->name() );
 
   // the parent should be updated
   if ( item->parent() )


### PR DESCRIPTION
fixes #54718
fixes #53321
