### PR TITLE
[3D] hide the terrain shading opacity slider

### DIFF
--- a/src/app/3d/qgsphongmaterialwidget.h
+++ b/src/app/3d/qgsphongmaterialwidget.h
@@ -28,8 +28,10 @@ class QgsPhongMaterialSettings;
 class QgsPhongMaterialWidget : public QgsMaterialSettingsWidget, private Ui::PhongMaterialWidget
 {
     Q_OBJECT
+    Q_PROPERTY( bool hasOpacity READ hasOpacity WRITE setHasOpacity )
+
   public:
-    explicit QgsPhongMaterialWidget( QWidget *parent = nullptr );
+    explicit QgsPhongMaterialWidget( QWidget *parent = nullptr, bool hasOpacity = true );
 
     static QgsMaterialSettingsWidget *create();
 
@@ -37,6 +39,11 @@ class QgsPhongMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Pho
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
     QgsAbstractMaterialSettings *settings() override;
 
+    bool hasOpacity() const { return mHasOpacity; }
+    void setHasOpacity( const bool opacity );
+
+  private:
+    bool mHasOpacity; //! whether to display the opacity slider
 };
 
 #endif // QGSPHONGMATERIALWIDGET_H

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -447,7 +447,11 @@
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QgsPhongMaterialWidget" name="widgetTerrainMaterial" native="true"/>
+                   <widget class="QgsPhongMaterialWidget" name="widgetTerrainMaterial" native="true">
+                    <property name="hasOpacity">
+                     <bool>false</bool>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -124,7 +124,7 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="lblOpacity">
+    <widget class="QLabel" name="mLblOpacity">
      <property name="text">
       <string>Opacity</string>
      </property>


### PR DESCRIPTION
## Description

```
The terrain shading widget automatically got an opacity slider when
`QgsPhongMaterialWidget` was updated to get transparency support.
However, this parameter is not used by the terrain.

This issue is fixed by hiding this slider.
```
