### PR TITLE
Fix #54683 - Map tips black scrollbars

### DIFF
--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -174,9 +174,9 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
     cursorOffset = static_cast< int >( std::ceil( scale * 32 ) );
   }
 
-  // Ensures the map tip is never larger than half the map canvas minus the cursor size + margin (cursorOffset)
-  const int MAX_WIDTH = pMapCanvas->width() / 2 - cursorOffset;
-  const int MAX_HEIGHT = pMapCanvas->height() / 2;
+  // Ensures the map tip is never larger than the available space
+  const int MAX_WIDTH = std::max( pixelPosition.x(), pMapCanvas->width() - pixelPosition.x() ) - cursorOffset - 5;
+  const int MAX_HEIGHT = std::max( pixelPosition.y(), pMapCanvas->height() - pixelPosition.y() ) - 5;
 
   mWebView->setMaximumSize( MAX_WIDTH, MAX_HEIGHT );
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -113,7 +113,12 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   {
     mWebView = new QgsWebView( pMapCanvas );
     // Make the webwiew transparent
-    mWebView->setStyleSheet( QStringLiteral( "background:transparent;" ) );
+
+    // Setting the background color to 'transparent' does not play nice
+    // with webkit scrollbars, that are rendered as black rectangles (#54683)
+    QColor transparentColor = mWebView->palette().color( QPalette::Window );
+    transparentColor.setAlpha( 0 );
+    mWebView->setStyleSheet( QString( "background:%1;" ).arg( transparentColor.name( QColor::HexArgb ) ) );
 
 
 #if WITH_QTWEBKIT


### PR DESCRIPTION
- Fix #54683

## Description

Setting the background to "transparent" in the QWebView stlyesheet does not play nice with the webkit scrollbars.

This PR work around the issue by setting the background color to the QPalette::Widow color, with its alpha set to 0. 


The rationale for having a transparent QWebView is to allow the user to use HTML to design semi transparent maptips.