### PR TITLE
Fix typo in qgscoordinatereferencesystemutils.cpp

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystemutils.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemutils.cpp
@@ -259,7 +259,7 @@ QString QgsCoordinateReferenceSystemUtils::translateProjection( const QString &p
   if ( projection == QLatin1String( "eck6" ) )
     return QObject::tr( "Eckert VI" );
   if ( projection == QLatin1String( "eqc" ) )
-    return QObject::tr( "Equidistant Cylindrical (Plate Caree)" );
+    return QObject::tr( "Equidistant Cylindrical (Plate Carrée)" );
   if ( projection == QLatin1String( "eqdc" ) )
     return QObject::tr( "Equidistant Conic" );
   if ( projection == QLatin1String( "eqearth" ) )


### PR DESCRIPTION
## Description

Name of projection "Plate carrée" was misspelled.