### PR TITLE
Fix crash when certain symbol pages are open in style dock and QGIS is closed or a new project opened

### DIFF
--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -43,6 +43,8 @@ Symbol selector widget that can be used to select and build a symbol
    The ownership of the symbol is not transferred and must exist for the lifetime of the widget.
 %End
 
+
+
     QMenu *advancedMenu();
 %Docstring
 Returns menu for "advanced" button - create it if doesn't exist and show the advanced button

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -30,6 +30,7 @@ class QgsPanelWidget;
 class QgsMessageBar;
 class QMimeData;
 class QgsSymbol;
+class QgsSymbolSelectorWidget;
 
 /**
  * \ingroup gui
@@ -304,8 +305,7 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
   private slots:
 
     void showSettingsDialog();
-    void updateSymbolFromWidget();
-    void cleanUpSymbolSelector( QgsPanelWidget *container );
+    void updateSymbolFromWidget( QgsSymbolSelectorWidget *widget );
 
     /**
      * Creates the drop-down menu entries

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -25,6 +25,7 @@
 
 class QgsCategorizedSymbolRenderer;
 class QgsRendererCategory;
+class QgsSymbolSelectorWidget;
 
 #include "ui_qgscategorizedsymbolrendererwidget.h"
 #include "qgis_gui.h"
@@ -191,8 +192,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
   private slots:
 
-    void cleanUpSymbolSelector( QgsPanelWidget *container );
-    void updateSymbolsFromWidget();
+    void updateSymbolsFromWidget( QgsSymbolSelectorWidget *widget );
     void updateSymbolsFromButton();
     void dataDefinedSizeLegend();
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -31,6 +31,7 @@
 
 #include "qgis_gui.h"
 
+class QgsSymbolSelectorWidget;
 
 #ifndef SIP_RUN
 /// @cond PRIVATE
@@ -144,8 +145,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void mSizeUnitWidget_changed();
     void methodComboBox_currentIndexChanged( int );
     void updateMethodParameters();
-    void cleanUpSymbolSelector( QgsPanelWidget *container );
-    void updateSymbolsFromWidget();
+    void updateSymbolsFromWidget( QgsSymbolSelectorWidget *widget );
     void dataDefinedSizeLegend();
     void changeGraduatedSymbol();
     void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -386,6 +386,14 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QList<QgsMapLayer *>& layers ) > ( &QgsProject::layersWillBeRemoved ), this, &QgsSymbolSelectorWidget::layersAboutToBeRemoved );
 }
 
+QgsSymbolSelectorWidget *QgsSymbolSelectorWidget::createWidgetWithSymbolOwnership( std::unique_ptr<QgsSymbol> symbol, QgsStyle *style, QgsVectorLayer *vl, QWidget *parent )
+{
+  QgsSymbolSelectorWidget *widget = new QgsSymbolSelectorWidget( symbol.get(), style, vl, parent );
+  // transfer ownership of symbol to widget, so that we are guaranteed it will last for the duration of the widget
+  widget->mOwnedSymbol = std::move( symbol );
+  return widget;
+}
+
 QMenu *QgsSymbolSelectorWidget::advancedMenu()
 {
   if ( !mAdvancedMenu )

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -105,6 +105,16 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *style, QgsVectorLayer *vl, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    // TODO QGIS 4.0 -- remove when normal constructor takes ownership
+
+    /**
+     * Creates a QgsSymbolSelectorWidget which takes ownership of a symbol and maintains
+     * the ownership for the life of the widget.
+     *
+     * \note Not available in Python bindings.
+    */
+    static QgsSymbolSelectorWidget *createWidgetWithSymbolOwnership( std::unique_ptr< QgsSymbol > symbol, QgsStyle *style, QgsVectorLayer *vl, QWidget *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
+
     //! Returns menu for "advanced" button - create it if doesn't exist and show the advanced button
     QMenu *advancedMenu();
 
@@ -258,6 +268,7 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
 
     QgsStyle *mStyle = nullptr;
     QgsSymbol *mSymbol = nullptr;
+    std::unique_ptr< QgsSymbol > mOwnedSymbol;
     QMenu *mAdvancedMenu = nullptr;
     QAction *mLockColorAction = nullptr;
     QAction *mLockSelectionColorAction = nullptr;

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -33,6 +33,7 @@ class QgsVectorTileLayer;
 class QgsMapCanvas;
 class QgsMessageBar;
 class QgsVectorTileBasicRendererProxyModel;
+class QgsSymbolSelectorWidget;
 
 /**
  * \ingroup gui
@@ -59,8 +60,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     void editStyleAtIndex( const QModelIndex &index );
     void removeStyle();
 
-    void updateSymbolsFromWidget();
-    void cleanUpSymbolSelector( QgsPanelWidget *container );
+    void updateSymbolsFromWidget( QgsSymbolSelectorWidget *widget );
 
   private:
     QPointer< QgsVectorTileLayer > mVTLayer;


### PR DESCRIPTION
(eg categorized class symbol editors)

The symbol ownership of QgsSymbolSelectorWidget is very messy, and we can't fix till 4.0. Workaround this by introducing a temporary API to transfer symbol ownership to the widget.
