### PR TITLE
expose QgsField configuration flags in python bindings

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -34,6 +34,15 @@ length, and if applicable, precision.
 
   public:
 
+    enum class ConfigurationFlag
+    {
+      None,
+      NotSearchable,
+      HideFromWms,
+      HideFromWfs,
+    };
+    typedef QFlags<QgsField::ConfigurationFlag> ConfigurationFlags;
+
 
     QgsField( const QString &name = QString(),
               QVariant::Type type = QVariant::Invalid,
@@ -342,13 +351,31 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. versionadded:: 3.0
 %End
 
+    QgsField::ConfigurationFlags configurationFlags() const;
+%Docstring
+Returns the Flags for the field (searchable, …)
 
+.. versionadded:: 3.16
+%End
+
+    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags );
+%Docstring
+Sets the Flags for the field (searchable, …)
+
+.. versionadded:: 3.16
+%End
 
     QString displayString( const QVariant &v ) const;
 %Docstring
 Formats string for display
 %End
 
+    static QString readableConfigurationFlag( QgsField::ConfigurationFlag flag );
+%Docstring
+Returns the readable and translated value of the configuration flag
+
+.. versionadded:: 3.16
+%End
 
 
     bool convertCompatible( QVariant &v ) const;
@@ -475,6 +502,9 @@ be handled during a split operation.
 
 
 }; // class QgsField
+
+
+QFlags<QgsField::ConfigurationFlag> operator|(QgsField::ConfigurationFlag f1, QFlags<QgsField::ConfigurationFlag> f2);
 
 
 

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -69,8 +69,6 @@ class CORE_EXPORT QgsField
 
   public:
 
-#ifndef SIP_RUN
-
     /**
        * Configuration flags for fields
        * These flags are meant to be user-configurable
@@ -88,7 +86,6 @@ class CORE_EXPORT QgsField
     Q_ENUM( ConfigurationFlag )
     Q_DECLARE_FLAGS( ConfigurationFlags, ConfigurationFlag )
     Q_FLAG( ConfigurationFlags )
-#endif
 
     /**
      * Constructor. Constructs a new QgsField object.
@@ -378,13 +375,13 @@ class CORE_EXPORT QgsField
      * Returns the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    QgsField::ConfigurationFlags configurationFlags() const SIP_SKIP;
+    QgsField::ConfigurationFlags configurationFlags() const;
 
     /**
      * Sets the Flags for the field (searchable, …)
      * \since QGIS 3.16
      */
-    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags ) SIP_SKIP;
+    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags );
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;
@@ -393,7 +390,7 @@ class CORE_EXPORT QgsField
      * Returns the readable and translated value of the configuration flag
      * \since QGIS 3.16
      */
-    static QString readableConfigurationFlag( QgsField::ConfigurationFlag flag ) SIP_SKIP;
+    static QString readableConfigurationFlag( QgsField::ConfigurationFlag flag );
 
 #ifndef SIP_RUN
 
@@ -548,7 +545,7 @@ class CORE_EXPORT QgsField
 
 Q_DECLARE_METATYPE( QgsField )
 
-Q_DECLARE_OPERATORS_FOR_FLAGS( QgsField::ConfigurationFlags ) SIP_SKIP
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsField::ConfigurationFlags )
 
 //! Writes the field to stream out. QGIS version compatibility is not guaranteed.
 CORE_EXPORT QDataStream &operator<<( QDataStream &out, const QgsField &field );


### PR DESCRIPTION
these were not exposed when created due to some limitations in sip which should have been addressed since then.

following comment https://github.com/qgis/QGIS/pull/40602#issuecomment-1661856975 from @Gustry 