### PR TITLE
Only build static libs when required

### DIFF
--- a/src/auth/apiheader/CMakeLists.txt
+++ b/src/auth/apiheader/CMakeLists.txt
@@ -25,26 +25,26 @@ endif()
 
 
 # static library
-add_library(authmethod_apiheader_a STATIC ${AUTH_APIHEADER_SRCS} ${AUTH_APIHEADER_HDRS} ${AUTH_APIHEADER_UIS_H})
-
-target_include_directories(authmethod_apiheader_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/apiheader/core)
-
-# require c++17
-target_compile_features(authmethod_apiheader_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_apiheader_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_apiheader_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/apiheader/gui
-    ${CMAKE_BINARY_DIR}/src/auth/apiheader
-  )
-  target_link_libraries (authmethod_apiheader_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_apiheader_a PRIVATE "-DQT_NO_FOREACH")
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_apiheader_a STATIC ${AUTH_APIHEADER_SRCS} ${AUTH_APIHEADER_HDRS} ${AUTH_APIHEADER_UIS_H})
+
+  target_include_directories(authmethod_apiheader_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/apiheader/core)
+
+  # require c++17
+  target_compile_features(authmethod_apiheader_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_apiheader_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_apiheader_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/apiheader/gui
+      ${CMAKE_BINARY_DIR}/src/auth/apiheader
+    )
+    target_link_libraries (authmethod_apiheader_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_apiheader_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_apiheader_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/awss3/CMakeLists.txt
+++ b/src/auth/awss3/CMakeLists.txt
@@ -25,29 +25,27 @@ endif()
 
 
 # static library
-add_library(authmethod_awss3_a STATIC ${AUTH_AWSS3_SRCS} ${AUTH_AWSS3_HDRS} ${AUTH_AWSS3_UIS_H})
-
-target_include_directories(authmethod_awss3_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/awss3/core)
-
-# require c++17
-target_compile_features(authmethod_awss3_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_awss3_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_awss3_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/awss3/gui
-    ${CMAKE_BINARY_DIR}/src/auth/awss3
-  )
-
-  target_link_libraries (authmethod_awss3_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_awss3_a PRIVATE "-DQT_NO_FOREACH")
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_awss3_a STATIC ${AUTH_AWSS3_SRCS} ${AUTH_AWSS3_HDRS} ${AUTH_AWSS3_UIS_H})
+
+  target_include_directories(authmethod_awss3_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/awss3/core)
+
+  # require c++17
+  target_compile_features(authmethod_awss3_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_awss3_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_awss3_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/awss3/gui
+      ${CMAKE_BINARY_DIR}/src/auth/awss3
+    )
+
+    target_link_libraries (authmethod_awss3_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_awss3_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_awss3_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/basic/CMakeLists.txt
+++ b/src/auth/basic/CMakeLists.txt
@@ -25,29 +25,27 @@ endif()
 
 
 # static library
-add_library(authmethod_basic_a STATIC ${AUTH_BASIC_SRCS} ${AUTH_BASIC_HDRS} ${AUTH_BASIC_UIS_H})
-
-target_include_directories(authmethod_basic_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/basic/core)
-
-# require c++17
-target_compile_features(authmethod_basic_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_basic_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_basic_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/basic/gui
-    ${CMAKE_BINARY_DIR}/src/auth/basic
-  )
-
-  target_link_libraries (authmethod_basic_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_basic_a PRIVATE "-DQT_NO_FOREACH")
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_basic_a STATIC ${AUTH_BASIC_SRCS} ${AUTH_BASIC_HDRS} ${AUTH_BASIC_UIS_H})
+
+  target_include_directories(authmethod_basic_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/basic/core)
+
+  # require c++17
+  target_compile_features(authmethod_basic_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_basic_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_basic_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/basic/gui
+      ${CMAKE_BINARY_DIR}/src/auth/basic
+    )
+
+    target_link_libraries (authmethod_basic_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_basic_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_basic_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/esritoken/CMakeLists.txt
+++ b/src/auth/esritoken/CMakeLists.txt
@@ -25,26 +25,26 @@ endif()
 
 
 # static library
-add_library(authmethod_esritoken_a STATIC ${AUTH_ESRITOKEN_SRCS} ${AUTH_ESRITOKEN_HDRS} ${AUTH_ESRITOKEN_UIS_H})
-
-target_include_directories(authmethod_esritoken_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/esritoken/core)
-
-# require c++17
-target_compile_features(authmethod_esritoken_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_esritoken_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_esritoken_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/esritoken/gui
-    ${CMAKE_BINARY_DIR}/src/auth/esritoken
-  )
-  target_link_libraries (authmethod_esritoken_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_esritoken_a PRIVATE "-DQT_NO_FOREACH")
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_esritoken_a STATIC ${AUTH_ESRITOKEN_SRCS} ${AUTH_ESRITOKEN_HDRS} ${AUTH_ESRITOKEN_UIS_H})
+
+  target_include_directories(authmethod_esritoken_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/esritoken/core)
+
+  # require c++17
+  target_compile_features(authmethod_esritoken_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_esritoken_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_esritoken_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/esritoken/gui
+      ${CMAKE_BINARY_DIR}/src/auth/esritoken
+    )
+    target_link_libraries (authmethod_esritoken_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_esritoken_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_esritoken_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/identcert/CMakeLists.txt
+++ b/src/auth/identcert/CMakeLists.txt
@@ -25,28 +25,26 @@ endif()
 
 
 # static library
-add_library(authmethod_identcert_a STATIC ${AUTH_IDENTCERT_SRCS} ${AUTH_IDENTCERT_HDRS} ${AUTH_IDENTCERT_UIS_H})
-
-target_include_directories(authmethod_identcert_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/identcert/core)
-
-# require c++17
-target_compile_features(authmethod_identcert_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_identcert_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_identcert_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/identcert/gui
-    ${CMAKE_BINARY_DIR}/src/auth/identcert
-  )
-  target_link_libraries (authmethod_identcert_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_identcert_a PRIVATE "-DQT_NO_FOREACH")
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_identcert_a STATIC ${AUTH_IDENTCERT_SRCS} ${AUTH_IDENTCERT_HDRS} ${AUTH_IDENTCERT_UIS_H})
+
+  target_include_directories(authmethod_identcert_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/identcert/core)
+
+  # require c++17
+  target_compile_features(authmethod_identcert_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_identcert_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_identcert_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/identcert/gui
+      ${CMAKE_BINARY_DIR}/src/auth/identcert
+    )
+    target_link_libraries (authmethod_identcert_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_identcert_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_identcert_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/maptiler_hmacsha256/CMakeLists.txt
+++ b/src/auth/maptiler_hmacsha256/CMakeLists.txt
@@ -25,26 +25,26 @@ endif()
 
 
 # static library
-add_library(authmethod_maptilerhmacsha256_a STATIC ${AUTH_MAPTILER_HMACSHA256_SRCS} ${AUTH_MAPTILER_HMACSHA256_HDRS} ${AUTH_MAPTILER_HMACSHA256_UIS_H})
-
-target_include_directories(authmethod_maptilerhmacsha256_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/hmacsha256/core)
-
-# require c++17
-target_compile_features(authmethod_maptilerhmacsha256_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_maptilerhmacsha256_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_maptilerhmacsha256_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/maptiler_hmacsha256/gui
-    ${CMAKE_BINARY_DIR}/src/auth/maptiler_hmacsha256
-  )
-  target_link_libraries (authmethod_maptilerhmacsha256_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_maptilerhmacsha256_a PRIVATE "-DQT_NO_FOREACH")
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_maptilerhmacsha256_a STATIC ${AUTH_MAPTILER_HMACSHA256_SRCS} ${AUTH_MAPTILER_HMACSHA256_HDRS} ${AUTH_MAPTILER_HMACSHA256_UIS_H})
+
+  target_include_directories(authmethod_maptilerhmacsha256_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/hmacsha256/core)
+
+  # require c++17
+  target_compile_features(authmethod_maptilerhmacsha256_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_maptilerhmacsha256_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_maptilerhmacsha256_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/maptiler_hmacsha256/gui
+      ${CMAKE_BINARY_DIR}/src/auth/maptiler_hmacsha256
+    )
+    target_link_libraries (authmethod_maptilerhmacsha256_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_maptilerhmacsha256_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_maptilerhmacsha256_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/oauth2/CMakeLists.txt
+++ b/src/auth/oauth2/CMakeLists.txt
@@ -85,7 +85,7 @@ if (WITH_GUI)
   else()
     QT5_WRAP_UI(AUTH_OAUTH2_UIS_H ${AUTH_OAUTH2_UIS})
   endif()
-  
+
 endif()
 
 ############################################################
@@ -101,41 +101,39 @@ if(WITH_INTERNAL_O2 AND CMAKE_GENERATOR MATCHES "Ninja")
 endif()
 
 # static library
-add_library(authmethod_oauth2_a STATIC ${AUTH_OAUTH2_SRCS} ${AUTH_OAUTH2_HDRS} ${AUTH_OAUTH2_RCCS} ${AUTH_OAUTH2_UIS_H})
-
-target_include_directories(authmethod_oauth2_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/oauth2/core)
-
-# require c++17
-target_compile_features(authmethod_oauth2_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_oauth2_a qgis_core)
-
-if(WITH_INTERNAL_O2)
-  target_include_directories(authmethod_oauth2_a SYSTEM PUBLIC ${O2_INCLUDE_DIR})
-else()
-  if(NOT "${O2_LIBRARY}" STREQUAL "")
-    # prefer dynamic linking
-    target_link_libraries(authmethod_oauth2_a ${O2_LIBRARY})
-  else()
-    target_link_libraries(authmethod_oauth2_a ${O2_LIBRARY_STATIC})
-  endif()
-endif()
-
-target_include_directories(authmethod_oauth2_a PRIVATE
-  ${CMAKE_SOURCE_DIR}/external/qjsonwrapper
-  ${CMAKE_SOURCE_DIR}/src/auth/oauth2/core
-)
-if (WITH_GUI)
-  target_include_directories(authmethod_oauth2_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/oauth2/gui
-    ${CMAKE_BINARY_DIR}/src/auth/oauth2
-  )
-  target_link_libraries (authmethod_oauth2_a qgis_gui)
-endif()
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_oauth2_a STATIC ${AUTH_OAUTH2_SRCS} ${AUTH_OAUTH2_HDRS} ${AUTH_OAUTH2_RCCS} ${AUTH_OAUTH2_UIS_H})
+
+  target_include_directories(authmethod_oauth2_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/oauth2/core)
+
+  # require c++17
+  target_compile_features(authmethod_oauth2_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_oauth2_a qgis_core)
+
+  if(WITH_INTERNAL_O2)
+    target_include_directories(authmethod_oauth2_a SYSTEM PUBLIC ${O2_INCLUDE_DIR})
+  else()
+    if(NOT "${O2_LIBRARY}" STREQUAL "")
+      # prefer dynamic linking
+      target_link_libraries(authmethod_oauth2_a ${O2_LIBRARY})
+    else()
+      target_link_libraries(authmethod_oauth2_a ${O2_LIBRARY_STATIC})
+    endif()
+  endif()
+
+  target_include_directories(authmethod_oauth2_a PRIVATE
+    ${CMAKE_SOURCE_DIR}/external/qjsonwrapper
+    ${CMAKE_SOURCE_DIR}/src/auth/oauth2/core
+  )
+  if (WITH_GUI)
+    target_include_directories(authmethod_oauth2_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/oauth2/gui
+      ${CMAKE_BINARY_DIR}/src/auth/oauth2
+    )
+    target_link_libraries (authmethod_oauth2_a qgis_gui)
+  endif()
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_oauth2_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/pkipaths/CMakeLists.txt
+++ b/src/auth/pkipaths/CMakeLists.txt
@@ -24,28 +24,26 @@ if (WITH_GUI)
 endif()
 
 # static library
-add_library(authmethod_pkipaths_a STATIC ${AUTH_PKIPATHS_SRCS} ${AUTH_PKIPATHS_HDRS} ${AUTH_PKIPATHS_UIS_H})
-
-target_include_directories(authmethod_pkipaths_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/pkipaths/core)
-
-# require c++17
-target_compile_features(authmethod_pkipaths_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_pkipaths_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_pkipaths_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/pkipaths/gui
-    ${CMAKE_BINARY_DIR}/src/auth/pkipaths
-  )
-  target_link_libraries (authmethod_pkipaths_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_pkipaths_a PRIVATE "-DQT_NO_FOREACH")
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_pkipaths_a STATIC ${AUTH_PKIPATHS_SRCS} ${AUTH_PKIPATHS_HDRS} ${AUTH_PKIPATHS_UIS_H})
+
+  target_include_directories(authmethod_pkipaths_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/pkipaths/core)
+
+  # require c++17
+  target_compile_features(authmethod_pkipaths_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_pkipaths_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_pkipaths_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/pkipaths/gui
+      ${CMAKE_BINARY_DIR}/src/auth/pkipaths
+    )
+    target_link_libraries (authmethod_pkipaths_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_pkipaths_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_pkipaths_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/auth/pkipkcs12/CMakeLists.txt
+++ b/src/auth/pkipkcs12/CMakeLists.txt
@@ -24,28 +24,26 @@ if (WITH_GUI)
 endif()
 
 # static library
-add_library(authmethod_pkcs12_a STATIC ${AUTH_PKCS12_SRCS} ${AUTH_PKCS12_HDRS} ${AUTH_PKCS12_UIS_H})
-
-target_include_directories(authmethod_pkcs12_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/pkipkcs12/core)
-
-# require c++17
-target_compile_features(authmethod_pkcs12_a PRIVATE cxx_std_17)
-
-target_link_libraries(authmethod_pkcs12_a qgis_core)
-
-if (WITH_GUI)
-  target_include_directories(authmethod_pkcs12_a PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/auth/pkipkcs12/gui
-    ${CMAKE_BINARY_DIR}/src/auth/pkipkcs12
-  )
-  target_link_libraries (authmethod_pkcs12_a qgis_gui)
-endif()
-
-target_compile_definitions(authmethod_pkcs12_a PRIVATE "-DQT_NO_FOREACH")
-
-
-
 if (FORCE_STATIC_LIBS)
+  add_library(authmethod_pkcs12_a STATIC ${AUTH_PKCS12_SRCS} ${AUTH_PKCS12_HDRS} ${AUTH_PKCS12_UIS_H})
+
+  target_include_directories(authmethod_pkcs12_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/pkipkcs12/core)
+
+  # require c++17
+  target_compile_features(authmethod_pkcs12_a PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_pkcs12_a qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_pkcs12_a PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/pkipkcs12/gui
+      ${CMAKE_BINARY_DIR}/src/auth/pkipkcs12
+    )
+    target_link_libraries (authmethod_pkcs12_a qgis_gui)
+  endif()
+
+  target_compile_definitions(authmethod_pkcs12_a PRIVATE "-DQT_NO_FOREACH")
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS authmethod_pkcs12_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -118,12 +118,11 @@ if (FORCE_STATIC_LIBS)
     ${QCA_LIBRARY}
   )
 
-target_link_libraries (provider_arcgismapserver_a
-  qgis_core
-  ${QCA_LIBRARY}
-)
+  target_link_libraries (provider_arcgismapserver_a
+    qgis_core
+    ${QCA_LIBRARY}
+  )
 
-if (FORCE_STATIC_LIBS)
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_arcgismapserver_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -14,7 +14,7 @@ if (WITH_GUI)
     qgsarcgisrestsourcewidget.cpp
     qgsnewarcgisrestconnection.cpp
   )
-  
+
   set(AFS_UIS
     ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisrestsourcewidgetbase.ui
     ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisservicesourceselectbase.ui
@@ -22,19 +22,21 @@ if (WITH_GUI)
   )
 endif()
 
-add_library (provider_arcgisfeatureserver_a STATIC ${AFS_SRCS})
+if (FORCE_STATIC_LIBS)
+  add_library (provider_arcgisfeatureserver_a STATIC ${AFS_SRCS})
 
-target_include_directories(provider_arcgisfeatureserver_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
-)
+  target_include_directories(provider_arcgisfeatureserver_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
+  )
 
-# require c++17
-target_compile_features(provider_arcgisfeatureserver_a PRIVATE cxx_std_17)
+  # require c++17
+  target_compile_features(provider_arcgisfeatureserver_a PRIVATE cxx_std_17)
 
-target_link_libraries (provider_arcgisfeatureserver_a
-  qgis_core
-  ${QCA_LIBRARY}
-)
+  target_link_libraries (provider_arcgisfeatureserver_a
+    qgis_core
+    ${QCA_LIBRARY}
+  )
+endif()
 
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
@@ -42,25 +44,27 @@ if (WITH_GUI)
   else()
     QT5_WRAP_UI(AFS_UIS_H ${AFS_UIS})
   endif()
-  
-  add_library(provider_arcgisfeatureserver_gui_a STATIC ${AFS_GUI_SRCS} ${AFS_UIS_H})
-
-  # require c++17
-  target_compile_features(provider_arcgisfeatureserver_gui_a PRIVATE cxx_std_17)
-  
-  target_link_libraries(provider_arcgisfeatureserver_a
-    qgis_gui
-  )
-  target_link_libraries(provider_arcgisfeatureserver_gui_a
-    qgis_gui
-  )
 
   include_directories(SYSTEM
     ${CMAKE_BINARY_DIR}/src/ui
     ${QSCINTILLA_INCLUDE_DIR}
   )
 
-  add_dependencies(provider_arcgisfeatureserver_gui_a ui)
+  if (FORCE_STATIC_LIBS)
+    add_library(provider_arcgisfeatureserver_gui_a STATIC ${AFS_GUI_SRCS} ${AFS_UIS_H})
+
+    # require c++17
+    target_compile_features(provider_arcgisfeatureserver_gui_a PRIVATE cxx_std_17)
+
+    target_link_libraries(provider_arcgisfeatureserver_a
+      qgis_gui
+    )
+    target_link_libraries(provider_arcgisfeatureserver_gui_a
+      qgis_gui
+    )
+
+    add_dependencies(provider_arcgisfeatureserver_gui_a ui)
+  endif()
 endif()
 
 if (FORCE_STATIC_LIBS)
@@ -71,22 +75,22 @@ if (FORCE_STATIC_LIBS)
   endif()
 else()
   add_library(provider_arcgisfeatureserver MODULE ${AFS_SRCS} ${AFS_GUI_SRCS} ${AFS_UIS_H})
-  
+
   target_link_libraries(provider_arcgisfeatureserver
     qgis_core
     ${QCA_LIBRARY}
   )
-  
+
   # require c++17
   target_compile_features(provider_arcgisfeatureserver PRIVATE cxx_std_17)
-  
+
   if (WITH_GUI)
     target_link_libraries(provider_arcgisfeatureserver
       qgis_gui
     )
     add_dependencies(provider_arcgisfeatureserver ui)
   endif()
-  
+
   install (TARGETS provider_arcgisfeatureserver
     RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
     LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
@@ -99,14 +103,20 @@ set (AMS_SRCS
   qgsamsprovider.cpp
 )
 
-add_library (provider_arcgismapserver_a STATIC ${AMS_SRCS})
+if (FORCE_STATIC_LIBS)
+  add_library (provider_arcgismapserver_a STATIC ${AMS_SRCS})
 
-target_include_directories(provider_arcgismapserver_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
-)
+  target_include_directories(provider_arcgismapserver_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
+  )
 
-# require c++17
-target_compile_features(provider_arcgismapserver_a PRIVATE cxx_std_17)
+  # require c++17
+  target_compile_features(provider_arcgismapserver_a PRIVATE cxx_std_17)
+
+  target_link_libraries (provider_arcgismapserver_a
+    qgis_core
+    ${QCA_LIBRARY}
+  )
 
 target_link_libraries (provider_arcgismapserver_a
   qgis_core
@@ -118,15 +128,15 @@ if (FORCE_STATIC_LIBS)
   install (TARGETS provider_arcgismapserver_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
 else()
   add_library(provider_arcgismapserver MODULE ${AMS_SRCS})
-  
+
   # require c++17
   target_compile_features(provider_arcgismapserver PRIVATE cxx_std_17)
-  
+
   target_link_libraries(provider_arcgismapserver
     qgis_core
     ${QCA_LIBRARY}
   )
-  
+
   install (TARGETS provider_arcgismapserver
     RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
     LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/delimitedtext/CMakeLists.txt
+++ b/src/providers/delimitedtext/CMakeLists.txt
@@ -13,21 +13,23 @@ if (WITH_GUI)
   set(DTEXT_UIS ${CMAKE_SOURCE_DIR}/src/ui/qgsdelimitedtextsourceselectbase.ui)
 endif()
 
-# static library
-add_library(provider_delimitedtext_a STATIC ${DTEXT_SRCS})
+if (FORCE_STATIC_LIBS)
+  # static library
+  add_library(provider_delimitedtext_a STATIC ${DTEXT_SRCS})
 
-target_include_directories(provider_delimitedtext_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/delimitedtext
-)
+  target_include_directories(provider_delimitedtext_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/delimitedtext
+  )
 
-target_link_libraries(provider_delimitedtext_a
-  qgis_core
-)
+  target_link_libraries(provider_delimitedtext_a
+    qgis_core
+  )
 
-# require c++17
-target_compile_features(provider_delimitedtext_a PRIVATE cxx_std_17)
+  # require c++17
+  target_compile_features(provider_delimitedtext_a PRIVATE cxx_std_17)
 
-target_compile_definitions(provider_delimitedtext_a PRIVATE "-DQT_NO_FOREACH")
+  target_compile_definitions(provider_delimitedtext_a PRIVATE "-DQT_NO_FOREACH")
+endif()
 
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
@@ -36,22 +38,24 @@ if (WITH_GUI)
     QT5_WRAP_UI(DTEXT_UIS_H ${DTEXT_UIS})
   endif()
 
-  add_library(provider_delimitedtext_gui_a STATIC ${DTEXT_GUI_SRCS} ${DTEXT_UIS_H})
+  if (FORCE_STATIC_LIBS)
+    add_library(provider_delimitedtext_gui_a STATIC ${DTEXT_GUI_SRCS} ${DTEXT_UIS_H})
 
-  target_include_directories(provider_delimitedtext_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/delimitedtext
-  )
+    target_include_directories(provider_delimitedtext_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/delimitedtext
+    )
 
-  target_link_libraries(provider_delimitedtext_gui_a
-    qgis_gui
-  )
+    target_link_libraries(provider_delimitedtext_gui_a
+      qgis_gui
+    )
 
-  # require c++17
-  target_compile_features(provider_delimitedtext_gui_a PRIVATE cxx_std_17)
+    # require c++17
+    target_compile_features(provider_delimitedtext_gui_a PRIVATE cxx_std_17)
 
-  target_compile_definitions(provider_delimitedtext_gui_a PRIVATE "-DQT_NO_FOREACH")
+    target_compile_definitions(provider_delimitedtext_gui_a PRIVATE "-DQT_NO_FOREACH")
 
-  add_dependencies(provider_delimitedtext_gui_a ui)
+    add_dependencies(provider_delimitedtext_gui_a ui)
+  endif()
 endif()
 
 if (FORCE_STATIC_LIBS)
@@ -62,10 +66,10 @@ if (FORCE_STATIC_LIBS)
   endif()
 else()
   add_library(provider_delimitedtext MODULE ${DTEXT_SRCS} ${DTEXT_GUI_SRCS})
-  
+
   # require c++17
   target_compile_features(provider_delimitedtext PRIVATE cxx_std_17)
-  
+
   target_link_libraries(provider_delimitedtext
     qgis_core
   )

--- a/src/providers/hana/CMakeLists.txt
+++ b/src/providers/hana/CMakeLists.txt
@@ -72,40 +72,38 @@ include_directories (SYSTEM
   ${QTKEYCHAIN_INCLUDE_DIR}
 )
 
-add_library(provider_hana MODULE ${HANA_SRCS} ${HANA_HDRS})
-add_library(provider_hana_a STATIC ${HANA_SRCS} ${HANA_HDRS})
-
-# require c++17
-target_compile_features(provider_hana PRIVATE cxx_std_17)
-target_compile_features(provider_hana_a PRIVATE cxx_std_17)
-
-target_compile_definitions(provider_hana
-    PRIVATE
-        $<TARGET_PROPERTY:odbccpp_static,INTERFACE_COMPILE_DEFINITIONS>)
-target_compile_definitions(provider_hana_a
-    PRIVATE
-        $<TARGET_PROPERTY:odbccpp_static,INTERFACE_COMPILE_DEFINITIONS>)
-
-target_link_libraries(provider_hana
-  qgis_core
-  odbccpp_static
-  ${ODBC_LIBRARIES}
-)
-
-target_link_libraries(provider_hana_a
-  qgis_core
-  odbccpp_static
-  ${ODBC_LIBRARIES}
-)
-
-if (WITH_GUI)
-  target_link_libraries (provider_hana_a
-    qgis_gui
+if (FORCE_STATIC_LIBS)
+  add_library(provider_hana_a STATIC ${HANA_SRCS} ${HANA_HDRS})
+  target_compile_features(provider_hana_a PRIVATE cxx_std_17)
+  target_compile_definitions(provider_hana_a
+      PRIVATE
+          $<TARGET_PROPERTY:odbccpp_static,INTERFACE_COMPILE_DEFINITIONS>)
+  target_link_libraries(provider_hana_a
+    qgis_core
+    odbccpp_static
+    ${ODBC_LIBRARIES}
   )
-
-  target_link_libraries (provider_hana
-    qgis_gui
+  if (WITH_GUI)
+    target_link_libraries (provider_hana_a
+      qgis_gui
+    )
+  endif()
+else()
+  add_library(provider_hana MODULE ${HANA_SRCS} ${HANA_HDRS})
+  target_compile_features(provider_hana PRIVATE cxx_std_17)
+  target_compile_definitions(provider_hana
+      PRIVATE
+          $<TARGET_PROPERTY:odbccpp_static,INTERFACE_COMPILE_DEFINITIONS>)
+  target_link_libraries(provider_hana
+    qgis_core
+    odbccpp_static
+    ${ODBC_LIBRARIES}
   )
+  if (WITH_GUI)
+    target_link_libraries (provider_hana
+      qgis_gui
+    )
+  endif()
 endif()
 
 # clang-tidy

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -222,29 +222,13 @@ if (WITH_GUI)
 endif()
 
 # static library
-add_library (provider_pdal_a STATIC ${PDAL_SRCS} ${PDAL_HDRS})
-
-# require c++17
-target_compile_features(provider_pdal_a PRIVATE cxx_std_17)
-
-target_link_libraries (provider_pdal_a
-  ${PDAL_LIBRARIES}
-  ${QT_VERSION_BASE}::Xml
-  ${QT_VERSION_BASE}::Core
-  ${QT_VERSION_BASE}::Svg
-  ${QT_VERSION_BASE}::Network
-  ${QT_VERSION_BASE}::Sql
-  ${QT_VERSION_BASE}::Concurrent
-  qgis_core
-)
-
-if (WITH_GUI)
-  add_library (provider_pdal_gui_a STATIC ${PDAL_GUI_SRCS} ${PDAL_GUI_HDRS})
+if (FORCE_STATIC_LIBS)
+  add_library (provider_pdal_a STATIC ${PDAL_SRCS} ${PDAL_HDRS})
 
   # require c++17
-  target_compile_features(provider_pdal_gui_a PRIVATE cxx_std_17)
+  target_compile_features(provider_pdal_a PRIVATE cxx_std_17)
 
-  target_link_libraries (provider_pdal_gui_a
+  target_link_libraries (provider_pdal_a
     ${PDAL_LIBRARIES}
     ${QT_VERSION_BASE}::Xml
     ${QT_VERSION_BASE}::Core
@@ -252,9 +236,27 @@ if (WITH_GUI)
     ${QT_VERSION_BASE}::Network
     ${QT_VERSION_BASE}::Sql
     ${QT_VERSION_BASE}::Concurrent
-    qgis_gui
+    qgis_core
   )
-  add_dependencies(provider_pdal_gui_a ui)
+
+  if (WITH_GUI)
+    add_library (provider_pdal_gui_a STATIC ${PDAL_GUI_SRCS} ${PDAL_GUI_HDRS})
+
+    # require c++17
+    target_compile_features(provider_pdal_gui_a PRIVATE cxx_std_17)
+
+    target_link_libraries (provider_pdal_gui_a
+      ${PDAL_LIBRARIES}
+      ${QT_VERSION_BASE}::Xml
+      ${QT_VERSION_BASE}::Core
+      ${QT_VERSION_BASE}::Svg
+      ${QT_VERSION_BASE}::Network
+      ${QT_VERSION_BASE}::Sql
+      ${QT_VERSION_BASE}::Concurrent
+      qgis_gui
+    )
+    add_dependencies(provider_pdal_gui_a ui)
+  endif()
 endif()
 
 install(TARGETS provider_pdal

--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -39,51 +39,55 @@ set(PG_HDRS
 ########################################################
 # Build
 
-# static library
-add_library (provider_postgres_a STATIC ${PG_SRCS} ${PG_HDRS})
-
-target_include_directories(provider_postgres_a SYSTEM PUBLIC
-  ${POSTGRES_INCLUDE_DIR}
-)
-
-target_include_directories(provider_postgres_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/postgres
-)
-
-# require c++17
-target_compile_features(provider_postgres_a PRIVATE cxx_std_17)
-
-target_link_libraries (provider_postgres_a
-  qgis_core
-  ${POSTGRES_LIBRARY}
-)
-
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
     QT6_WRAP_UI(PG_UIS_H ${PG_UIS})
   else()
     QT5_WRAP_UI(PG_UIS_H ${PG_UIS})
   endif()
+endif()
 
-  add_library(provider_postgres_gui_a STATIC ${PG_GUI_SRCS} ${PG_UIS_H})
+# static library
+if (FORCE_STATIC_LIBS)
+  add_library (provider_postgres_a STATIC ${PG_SRCS} ${PG_HDRS})
 
-  target_include_directories(provider_postgres_gui_a SYSTEM PRIVATE
+  target_include_directories(provider_postgres_a SYSTEM PUBLIC
     ${POSTGRES_INCLUDE_DIR}
   )
 
-  target_include_directories(provider_postgres_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/postgres
+  target_include_directories(provider_postgres_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/postgres
   )
 
   # require c++17
-  target_compile_features(provider_postgres_gui_a PRIVATE cxx_std_17)
+  target_compile_features(provider_postgres_a PRIVATE cxx_std_17)
 
-  target_link_libraries(provider_postgres_gui_a
-    qgis_gui
-    provider_postgres_a
+  target_link_libraries (provider_postgres_a
+    qgis_core
     ${POSTGRES_LIBRARY}
   )
-  add_dependencies(provider_postgres_gui_a ui)
+
+  if (WITH_GUI)
+    add_library(provider_postgres_gui_a STATIC ${PG_GUI_SRCS} ${PG_UIS_H})
+
+    target_include_directories(provider_postgres_gui_a SYSTEM PRIVATE
+      ${POSTGRES_INCLUDE_DIR}
+    )
+
+    target_include_directories(provider_postgres_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/postgres
+    )
+
+    # require c++17
+    target_compile_features(provider_postgres_gui_a PRIVATE cxx_std_17)
+
+    target_link_libraries(provider_postgres_gui_a
+      qgis_gui
+      provider_postgres_a
+      ${POSTGRES_LIBRARY}
+    )
+    add_dependencies(provider_postgres_gui_a ui)
+  endif()
 endif()
 
 #################################################################
@@ -99,34 +103,34 @@ set(PGRASTER_SRCS
 )
 
 # static library
-add_library (provider_postgresraster_a STATIC ${PGRASTER_SRCS} ${PG_HDRS})
-
-target_include_directories(provider_postgresraster_a SYSTEM PRIVATE
-  ${POSTGRES_INCLUDE_DIR}
-)
-target_include_directories(provider_postgresraster_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/postgres/raster
-)
-
-# require c++17
-target_compile_features(provider_postgresraster_a PRIVATE cxx_std_17)
-
-target_link_libraries (provider_postgresraster_a
-    qgis_core
-    provider_postgres_a
-    ${POSTGRES_LIBRARY}
-)
-
-if (WITH_GUI)
-  target_link_libraries (provider_postgresraster_a
-    qgis_gui
-  )
-  add_dependencies(provider_postgresraster_a ui)
-endif()
-
-#################################################################
-
 if (FORCE_STATIC_LIBS)
+  add_library (provider_postgresraster_a STATIC ${PGRASTER_SRCS} ${PG_HDRS})
+
+  target_include_directories(provider_postgresraster_a SYSTEM PRIVATE
+    ${POSTGRES_INCLUDE_DIR}
+  )
+  target_include_directories(provider_postgresraster_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/postgres/raster
+  )
+
+  # require c++17
+  target_compile_features(provider_postgresraster_a PRIVATE cxx_std_17)
+
+  target_link_libraries (provider_postgresraster_a
+      qgis_core
+      provider_postgres_a
+      ${POSTGRES_LIBRARY}
+  )
+
+  if (WITH_GUI)
+    target_link_libraries (provider_postgresraster_a
+      qgis_gui
+    )
+    add_dependencies(provider_postgresraster_a ui)
+  endif()
+
+  #################################################################
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_postgres_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   install (TARGETS provider_postgresraster_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})

--- a/src/providers/spatialite/CMakeLists.txt
+++ b/src/providers/spatialite/CMakeLists.txt
@@ -30,56 +30,56 @@ endif()
 
 ########################################################
 # Static
-add_library(provider_spatialite_a STATIC ${SPATIALITE_SRCS})
+if (FORCE_STATIC_LIBS)
+  add_library(provider_spatialite_a STATIC ${SPATIALITE_SRCS})
 
-target_include_directories(provider_spatialite_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/spatialite
-)
+  target_include_directories(provider_spatialite_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/spatialite
+  )
 
-target_link_libraries(provider_spatialite_a
-  qgis_core
-  spatialite::spatialite
-)
+  target_link_libraries(provider_spatialite_a
+    qgis_core
+    spatialite::spatialite
+  )
 
-# require c++17
-target_compile_features(provider_spatialite_a PRIVATE cxx_std_17)
+  # require c++17
+  target_compile_features(provider_spatialite_a PRIVATE cxx_std_17)
 
-target_compile_definitions(provider_spatialite_a PRIVATE "-DQT_NO_FOREACH")
+  target_compile_definitions(provider_spatialite_a PRIVATE "-DQT_NO_FOREACH")
 
-if (WITH_GUI)
   if (BUILD_WITH_QT6)
     QT6_WRAP_UI(SPATIALITE_UIS_H ${SPATIALITE_UIS})
   else()
     QT5_WRAP_UI(SPATIALITE_UIS_H ${SPATIALITE_UIS})
   endif()
 
-  add_library(provider_spatialite_gui_a STATIC ${SPATIALITE_GUI_SRCS} ${SPATIALITE_UIS_H})
-
-  target_include_directories(provider_spatialite_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/spatialite
-  )
-
-  target_link_libraries(provider_spatialite_a
-    qgis_gui
-  )
-  target_link_libraries(provider_spatialite_gui_a
-    qgis_gui
-  )
-
-  # require c++17
-  target_compile_features(provider_spatialite_gui_a PRIVATE cxx_std_17)
-
-  target_compile_definitions(provider_spatialite_gui_a PRIVATE "-DQT_NO_FOREACH")
-
-  add_dependencies(provider_spatialite_gui_a ui)
-
   include_directories(SYSTEM
     ${QSCINTILLA_INCLUDE_DIR}
     ${CMAKE_BINARY_DIR}/src/ui
   )
-endif()
 
-if (FORCE_STATIC_LIBS)
+  if (WITH_GUI)
+    add_library(provider_spatialite_gui_a STATIC ${SPATIALITE_GUI_SRCS} ${SPATIALITE_UIS_H})
+
+    target_include_directories(provider_spatialite_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/spatialite
+    )
+
+    target_link_libraries(provider_spatialite_a
+      qgis_gui
+    )
+    target_link_libraries(provider_spatialite_gui_a
+      qgis_gui
+    )
+
+    # require c++17
+    target_compile_features(provider_spatialite_gui_a PRIVATE cxx_std_17)
+
+    target_compile_definitions(provider_spatialite_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+    add_dependencies(provider_spatialite_gui_a ui)
+  endif()
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_spatialite_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   if (WITH_GUI)
@@ -92,7 +92,7 @@ else()
   target_compile_features(provider_spatialite PRIVATE cxx_std_17)
 
   target_compile_definitions(provider_spatialite PRIVATE "-DQT_NO_FOREACH")
-  
+
   target_link_libraries(provider_spatialite
     qgis_core
     spatialite::spatialite

--- a/src/providers/virtual/CMakeLists.txt
+++ b/src/providers/virtual/CMakeLists.txt
@@ -30,45 +30,12 @@ if (WITH_GUI)
   )
 endif()
 
-########################################################
-# Static
-add_library(provider_virtuallayer_a STATIC ${VLAYER_PROVIDER_SRCS} ${VLAYER_PROVIDER_HDRS} ${VLAYER_SQL_FUNCTIONS_RCCS})
-
-target_include_directories(provider_virtuallayer_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/virtual
-)
-
-target_link_libraries(provider_virtuallayer_a
-  qgis_core
-)
-
-# require c++17
-target_compile_features(provider_virtuallayer_a PRIVATE cxx_std_17)
-
-target_compile_definitions(provider_virtuallayer_a PRIVATE "-DQT_NO_FOREACH")
-
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
     QT6_WRAP_UI(VLAYER_PROVIDER_UIS_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
   else()
     QT5_WRAP_UI(VLAYER_PROVIDER_UIS_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
   endif()
-  add_library(provider_virtuallayer_gui_a STATIC ${VLAYER_PROVIDER_GUI_SRCS} ${VLAYER_PROVIDER_GUI_HDRS} ${VLAYER_PROVIDER_UIS_H})
-
-  target_include_directories(provider_virtuallayer_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/virtual
-  )
-
-  target_link_libraries(provider_virtuallayer_gui_a
-    qgis_gui
-  )
-
-  # require c++17
-  target_compile_features(provider_virtuallayer_gui_a PRIVATE cxx_std_17)
-
-  target_compile_definitions(provider_virtuallayer_gui_a PRIVATE "-DQT_NO_FOREACH")
-
-  add_dependencies(provider_virtuallayer_gui_a ui)
 
   include_directories(
     ${CMAKE_BINARY_DIR}/src/ui
@@ -76,11 +43,41 @@ if (WITH_GUI)
   )
 endif()
 
-
 if (FORCE_STATIC_LIBS)
-  # for (external) mobile apps to be able to pick up provider for linking
+  add_library(provider_virtuallayer_a STATIC ${VLAYER_PROVIDER_SRCS} ${VLAYER_PROVIDER_HDRS} ${VLAYER_SQL_FUNCTIONS_RCCS})
+
+  target_include_directories(provider_virtuallayer_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/virtual
+  )
+
+  target_link_libraries(provider_virtuallayer_a
+    qgis_core
+  )
+
+  # require c++17
+  target_compile_features(provider_virtuallayer_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_virtuallayer_a PRIVATE "-DQT_NO_FOREACH")
+
   install (TARGETS provider_virtuallayer_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+
   if (WITH_GUI)
+    add_library(provider_virtuallayer_gui_a STATIC ${VLAYER_PROVIDER_GUI_SRCS} ${VLAYER_PROVIDER_GUI_HDRS} ${VLAYER_PROVIDER_UIS_H})
+
+    target_include_directories(provider_virtuallayer_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/virtual
+    )
+
+    target_link_libraries(provider_virtuallayer_gui_a
+      qgis_gui
+    )
+
+    # require c++17
+    target_compile_features(provider_virtuallayer_gui_a PRIVATE cxx_std_17)
+
+    target_compile_definitions(provider_virtuallayer_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+    add_dependencies(provider_virtuallayer_gui_a ui)
     install (TARGETS provider_virtuallayer_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   endif()
 else()
@@ -90,7 +87,7 @@ else()
   target_compile_features(provider_virtuallayer PRIVATE cxx_std_17)
 
   target_compile_definitions(provider_virtuallayer PRIVATE "-DQT_NO_FOREACH")
-  
+
   target_link_libraries(provider_virtuallayer
     qgis_core
     ${QT_VERSION_BASE}::Core
@@ -104,7 +101,7 @@ else()
     )
     add_dependencies(provider_virtuallayer ui)
   endif()
-  
+
   install(TARGETS provider_virtuallayer
     RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
     LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/wcs/CMakeLists.txt
+++ b/src/providers/wcs/CMakeLists.txt
@@ -16,48 +16,48 @@ endif()
 
 ########################################################
 # Static
-add_library(provider_wcs_a STATIC ${WCS_SRCS})
+if (FORCE_STATIC_LIBS)
+  add_library(provider_wcs_a STATIC ${WCS_SRCS})
 
-target_include_directories(provider_wcs_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/wcs
-)
-
-target_link_libraries(provider_wcs_a
-  qgis_core
-)
-
-# require c++17
-target_compile_features(provider_wcs_a PRIVATE cxx_std_17)
-
-target_compile_definitions(provider_wcs_a PRIVATE "-DQT_NO_FOREACH")
-
-if (WITH_GUI)
-  add_library(provider_wcs_gui_a STATIC ${WCS_GUI_SRCS})
-
-  target_include_directories(provider_wcs_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/wcs
+  target_include_directories(provider_wcs_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/wcs
   )
 
   target_link_libraries(provider_wcs_a
-    qgis_gui
-  )
-  target_link_libraries(provider_wcs_gui_a
-    qgis_gui
+    qgis_core
   )
 
   # require c++17
-  target_compile_features(provider_wcs_gui_a PRIVATE cxx_std_17)
+  target_compile_features(provider_wcs_a PRIVATE cxx_std_17)
 
-  target_compile_definitions(provider_wcs_gui_a PRIVATE "-DQT_NO_FOREACH")
+  target_compile_definitions(provider_wcs_a PRIVATE "-DQT_NO_FOREACH")
 
-  add_dependencies(provider_wcs_gui_a ui)
+  if (WITH_GUI)
+    add_library(provider_wcs_gui_a STATIC ${WCS_GUI_SRCS})
 
-  include_directories(SYSTEM
-    ${CMAKE_BINARY_DIR}/src/ui
-  )
-endif()
+    target_include_directories(provider_wcs_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/wcs
+    )
 
-if (FORCE_STATIC_LIBS)
+    target_link_libraries(provider_wcs_a
+      qgis_gui
+    )
+    target_link_libraries(provider_wcs_gui_a
+      qgis_gui
+    )
+
+    # require c++17
+    target_compile_features(provider_wcs_gui_a PRIVATE cxx_std_17)
+
+    target_compile_definitions(provider_wcs_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+    add_dependencies(provider_wcs_gui_a ui)
+
+    include_directories(SYSTEM
+      ${CMAKE_BINARY_DIR}/src/ui
+    )
+  endif()
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_wcs_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   if (WITH_GUI)
@@ -65,20 +65,20 @@ if (FORCE_STATIC_LIBS)
   endif()
 else()
   add_library(provider_wcs MODULE ${WCS_SRCS} ${WCS_GUI_SRCS})
-  
+
   # require c++17
   target_compile_features(provider_wcs PRIVATE cxx_std_17)
-  
+
   target_link_libraries(provider_wcs
     qgis_core
   )
-  
+
   if (WITH_GUI)
     target_link_libraries (provider_wcs
       qgis_gui
     )
   endif()
-  
+
   install (TARGETS provider_wcs
     RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
     LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -52,24 +52,6 @@ if (WITH_GUI)
   set(WFS_UIS ${CMAKE_SOURCE_DIR}/src/ui/qgswfssourceselectbase.ui)
 endif()
 
-########################################################
-# Static
-add_library(provider_wfs_a STATIC ${WFS_SRCS})
-
-target_include_directories(provider_wfs_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/wfs
-  ${CMAKE_SOURCE_DIR}/src/providers/wfs/oapif
-)
-
-target_link_libraries(provider_wfs_a
-  qgis_core
-)
-
-# require c++17
-target_compile_features(provider_wfs_a PRIVATE cxx_std_17)
-
-target_compile_definitions(provider_wfs_a PRIVATE "-DQT_NO_FOREACH")
-
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
     QT6_WRAP_UI(WFS_UIS_H ${WFS_UIS})
@@ -77,34 +59,55 @@ if (WITH_GUI)
     QT5_WRAP_UI(WFS_UIS_H ${WFS_UIS})
   endif()
 
-  add_library(provider_wfs_gui_a STATIC ${WFS_GUI_SRCS} ${WFS_UIS_H})
-
-  target_include_directories(provider_wfs_gui_a PUBLIC
-    ${CMAKE_SOURCE_DIR}/src/providers/wfs
-    ${CMAKE_SOURCE_DIR}/src/providers/wfs/oapif
-  )
-
-  target_link_libraries(provider_wfs_a
-    qgis_gui
-  )
-  target_link_libraries(provider_wfs_gui_a
-    qgis_gui
-  )
-
-  # require c++17
-  target_compile_features(provider_wfs_gui_a PRIVATE cxx_std_17)
-
-  target_compile_definitions(provider_wfs_gui_a PRIVATE "-DQT_NO_FOREACH")
-
-  add_dependencies(provider_wfs_gui_a ui)
-
   include_directories(SYSTEM
     ${QSCINTILLA_INCLUDE_DIR}
     ${CMAKE_BINARY_DIR}/src/ui
   )
 endif()
 
+########################################################
+# Static
 if (FORCE_STATIC_LIBS)
+  add_library(provider_wfs_a STATIC ${WFS_SRCS})
+
+  target_include_directories(provider_wfs_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/wfs
+    ${CMAKE_SOURCE_DIR}/src/providers/wfs/oapif
+  )
+
+  target_link_libraries(provider_wfs_a
+    qgis_core
+  )
+
+  # require c++17
+  target_compile_features(provider_wfs_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_wfs_a PRIVATE "-DQT_NO_FOREACH")
+
+  if (WITH_GUI)
+    add_library(provider_wfs_gui_a STATIC ${WFS_GUI_SRCS} ${WFS_UIS_H})
+
+    target_include_directories(provider_wfs_gui_a PUBLIC
+      ${CMAKE_SOURCE_DIR}/src/providers/wfs
+      ${CMAKE_SOURCE_DIR}/src/providers/wfs/oapif
+    )
+
+    target_link_libraries(provider_wfs_a
+      qgis_gui
+    )
+    target_link_libraries(provider_wfs_gui_a
+      qgis_gui
+    )
+
+    # require c++17
+    target_compile_features(provider_wfs_gui_a PRIVATE cxx_std_17)
+
+    target_compile_definitions(provider_wfs_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+    add_dependencies(provider_wfs_gui_a ui)
+
+  endif()
+
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_wfs_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   if (WITH_GUI)

--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -22,53 +22,48 @@ if (WITH_GUI)
   set(WMS_UIS ${CMAKE_SOURCE_DIR}/src/ui/qgswmstsettingswidgetbase.ui)
 endif()
 
-# static library
-add_library(provider_wms_a STATIC ${WMS_SRCS})
-
-target_include_directories(provider_wms_a PUBLIC
-  ${CMAKE_SOURCE_DIR}/src/providers/wms
-)
-
-# require c++17
-target_compile_features(provider_wms_a PRIVATE cxx_std_17)
-
 if (WITH_GUI)
   if (BUILD_WITH_QT6)
     QT6_WRAP_UI(WMS_UIS_H ${WMS_UIS})
   else()
     QT5_WRAP_UI(WMS_UIS_H ${WMS_UIS})
   endif()
+endif()
+# static library
+if (FORCE_STATIC_LIBS)
+  add_library(provider_wms_a STATIC ${WMS_SRCS})
 
-  add_library(provider_wms_gui_a STATIC ${WMS_GUI_SRCS} ${WMS_UIS_H})
-
-  target_include_directories (provider_wms_gui_a PUBLIC
-    ${CMAKE_BINARY_DIR}/src/providers/wms
+  target_include_directories(provider_wms_a PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/providers/wms
   )
 
   # require c++17
-  target_compile_features(provider_wms_gui_a PRIVATE cxx_std_17)
+  target_compile_features(provider_wms_a PRIVATE cxx_std_17)
 
-  add_dependencies(provider_wms_a ui)
-  add_dependencies(provider_wms_gui_a ui)
-endif()
-
-target_link_libraries(provider_wms_a
-  qgis_core
-)
-target_compile_definitions(provider_wms_a PRIVATE "-DQT_NO_FOREACH")
-
-if (WITH_GUI)
-  target_link_libraries(provider_wms_gui_a
-    qgis_gui
-    provider_wms_a
+  target_link_libraries(provider_wms_a
+    qgis_core
   )
-  target_compile_definitions(provider_wms_gui_a PRIVATE "-DQT_NO_FOREACH")
-endif()
-
-if (FORCE_STATIC_LIBS)
-  # for (external) mobile apps to be able to pick up provider for linking
+  target_compile_definitions(provider_wms_a PRIVATE "-DQT_NO_FOREACH")
   install (TARGETS provider_wms_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+
   if (WITH_GUI)
+    add_library(provider_wms_gui_a STATIC ${WMS_GUI_SRCS} ${WMS_UIS_H})
+
+    target_include_directories (provider_wms_gui_a PUBLIC
+      ${CMAKE_BINARY_DIR}/src/providers/wms
+    )
+
+    # require c++17
+    target_compile_features(provider_wms_gui_a PRIVATE cxx_std_17)
+
+    add_dependencies(provider_wms_a ui)
+    add_dependencies(provider_wms_gui_a ui)
+
+    target_link_libraries(provider_wms_gui_a
+      qgis_gui
+      provider_wms_a
+    )
+    target_compile_definitions(provider_wms_gui_a PRIVATE "-DQT_NO_FOREACH")
     install (TARGETS provider_wms_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   endif()
 else()


### PR DESCRIPTION
Only build static libs when they are actually needed, shaves off a bit of build time (and fixes some limitations of newer mac build systems)