### PR TITLE
use center of the upper left pixel when writing world file (fix #41795)

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1730,13 +1730,15 @@ bool QgsGeoreferencerMainWindow::writeWorldFile( const QgsPointXY &origin, doubl
     pixelYSize *= std::cos( rotation );
   }
 
+  // in world files we need to use center of the upper left pixel, not the corner
+  // see https://github.com/qgis/QGIS/issues/41795
   QTextStream stream( &file );
   stream << qgsDoubleToString( pixelXSize ) << Qt::endl
          << rotationX << Qt::endl
          << rotationY << Qt::endl
          << qgsDoubleToString( -pixelYSize ) << Qt::endl
-         << qgsDoubleToString( origin.x() ) << Qt::endl
-         << qgsDoubleToString( origin.y() ) << Qt::endl;
+         << qgsDoubleToString( origin.x() + pixelXSize / 2.0 ) << Qt::endl
+         << qgsDoubleToString( origin.y() - pixelYSize / 2.0 ) << Qt::endl;
   return true;
 }
 

--- a/tests/src/app/testqgsgeoreferencer.cpp
+++ b/tests/src/app/testqgsgeoreferencer.cpp
@@ -51,6 +51,7 @@ class TestQgsGeoreferencer : public QObject
     void testListModel();
     void testListModelCrs();
     void testGdalCommands();
+    void testWorldFile();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -874,6 +875,35 @@ void TestQgsGeoreferencer::testGdalCommands()
   QgsDebugMsgLevel( command, 1 );
   QCOMPARE( command, QStringLiteral( "ogr2ogr -gcp 783414 3350122 783414.00123457 3350122.00234568 -gcp 791344 3349795 791344 33497952 -gcp 783077 334093 783077 334093 -gcp 791134 3341401 791134 3341401 -tps -t_srs EPSG:4326 \"\" \"%1\"" ).arg(
               QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ) ) );
+}
+
+void TestQgsGeoreferencer::testWorldFile()
+{
+  QgsGeoreferencerMainWindow window;
+  window.openLayer( Qgis::LayerType::Raster, QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.tif" ) );
+  QString worldFileName = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/landsat.wld" );
+
+  QVERIFY( window.writeWorldFile( QgsPointXY( 0, 0 ), 1.0, 1.0, 0 ) );
+
+  QFile file( worldFileName );
+  QVERIFY( file.open( QIODevice::ReadOnly | QIODevice::Text ) );
+
+  QTextStream stream( &file );
+  QVector<double> values;
+  values.reserve( 6 );
+  while ( !stream.atEnd() )
+  {
+    values << stream.readLine().toDouble();
+  }
+  file.close();
+  QFile::remove( worldFileName );
+
+  QCOMPARE( values.at( 0 ), 1.0 );
+  QCOMPARE( values.at( 1 ), 0 );
+  QCOMPARE( values.at( 2 ), 0 );
+  QCOMPARE( values.at( 3 ), -1.0 );
+  QCOMPARE( values.at( 4 ), 0.5 ); // center of the origin pixel
+  QCOMPARE( values.at( 5 ), -0.5 );
 }
 
 QGSTEST_MAIN( TestQgsGeoreferencer )


### PR DESCRIPTION
## Description

In world files last two lines should contain X and Y coordinates of the center of the upper left pixel. In georeferencer we incorrectly write coordinates of the pixel corner, so to avoid half-pixel shift in the georeferenced raster we need to adjust calculated coordinates.

Fixes #41795.