### PR TITLE
use "@id" instead of deprecated "$id" in geometry checker (fix #52658)

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -459,7 +459,7 @@ void QgsGeometryCheckerResultTab::openAttributeTable()
     QStringList expr;
     for ( QgsFeatureId id : it.value() )
     {
-      expr.append( QStringLiteral( "$id = %1 " ).arg( id ) );
+      expr.append( QStringLiteral( "@id = %1 " ).arg( id ) );
     }
     if ( mAttribTableDialogs[layerId] )
     {


### PR DESCRIPTION
## Description

Replace deprecated `$id` with new `@id` in Geometry Checker.

Fixes #52658.