### PR TITLE
enable Delete button if there is at least one user function (fix #51108)

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -444,6 +444,7 @@ void QgsExpressionBuilderWidget::btnNewFile_pressed()
   if ( ok && !text.isEmpty() )
   {
     newFunctionFile( text );
+    btnRemoveFile->setEnabled( cmbFileNames->count() > 0 );
   }
 }
 


### PR DESCRIPTION
## Description

When the last user defined function is removed "Delete" button in the function editor becomes disabled. But it is not enabled when a new function is added.

Fixes #51108.