### PR TITLE
Better expression insertion

### DIFF
--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -328,6 +328,45 @@ is in the QgsCodeEditor.Mode.CommandInput mode.
 .. versionadded:: 3.30
 %End
 
+    int linearPosition() const;
+%Docstring
+Convenience function to return the cursor position as a linear index
+
+.. versionadded:: 3.36
+%End
+
+    void setLinearPosition( int position );
+%Docstring
+Convenience function to set the cursor position as a linear index
+
+.. versionadded:: 3.36
+%End
+
+    int selectionStart() const;
+%Docstring
+Convenience function to return the start of the selection as a linear index
+Contrary to the getSelection method, this method returns the cursor position if
+no selection is made.
+
+.. versionadded:: 3.36
+%End
+
+    int selectionEnd() const;
+%Docstring
+Convenience function to return the end of the selection as a linear index
+Contrary to the getSelection method, this method returns the cursor position if
+no selection is made.
+
+.. versionadded:: 3.36
+%End
+
+    void setLinearSelection( int start, int end );
+%Docstring
+Convenience function to set the selection using linear indexes
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void runCommand( const QString &command, bool skipHistory = false );

--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -15,7 +15,7 @@
 class QgsFieldExpressionWidget : QWidget
 {
 %Docstring(signature="appended")
-The :py:class:`QgsFieldExpressionWidget` class reates a widget to choose fields and edit expressions
+The :py:class:`QgsFieldExpressionWidget` class creates a widget to choose fields and edit expressions
 It contains a combo box to display the fields and expression and a button to open the expression dialog.
 The combo box is editable, allowing expressions to be edited inline.
 The validity of the expression is checked live on key press, invalid expressions are displayed in red.
@@ -164,6 +164,24 @@ provide an expression context of which we are sure it's completely populated.
 .. versionadded:: 3.0
 %End
 
+    bool buttonVisible() const;
+%Docstring
+Returns the visibility of the button
+
+If button is hidden, the widget essentially becomes an editable combo box
+
+.. versionadded:: 3.36
+%End
+
+    void setButtonVisible( bool visible );
+%Docstring
+Set the visibility of the button
+
+If button is hidden, the widget essentially becomes an editable combo box
+
+.. versionadded:: 3.36
+%End
+
   signals:
     void fieldChanged( const QString &fieldName );
 %Docstring
@@ -181,6 +199,13 @@ Allow accepting expressions with evaluation errors. This can be useful when we a
 provide an expression context of which we are sure it's completely populated.
 
 .. versionadded:: 3.0
+%End
+
+    void buttonVisibleChanged();
+%Docstring
+Emitted when the button visibility changes
+
+.. versionadded:: 3.36
 %End
 
   public slots:

--- a/src/app/decorations/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/decorations/qgsdecorationcopyrightdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgshelp.h"
 #include "qgsmapcanvas.h"
 #include "qgsgui.h"
+#include "qgsexpressionfinder.h"
 
 //qt includes
 #include <QColorDialog>
@@ -99,18 +100,13 @@ void QgsDecorationCopyrightDialog::buttonBox_rejected()
 
 void QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked()
 {
-  QString selText = txtCopyrightText->textCursor().selectedText();
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
-
-  QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( txtCopyrightText );
+  QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
 
   exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    const QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText().trimmed();
     if ( !expression.isEmpty() )
     {
       txtCopyrightText->insertPlainText( "[%" + expression + "%]" );

--- a/src/app/decorations/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/decorations/qgsdecorationcopyrightdialog.cpp
@@ -100,7 +100,7 @@ void QgsDecorationCopyrightDialog::buttonBox_rejected()
 
 void QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked()
 {
-  QString expression = QgsExpressionFinder::findAndSelectExpression( txtCopyrightText );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( txtCopyrightText );
   QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
 
   exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );

--- a/src/app/decorations/qgsdecorationtitledialog.cpp
+++ b/src/app/decorations/qgsdecorationtitledialog.cpp
@@ -109,7 +109,7 @@ void QgsDecorationTitleDialog::buttonBox_rejected()
 
 void QgsDecorationTitleDialog::mInsertExpressionButton_clicked()
 {
-  QString expression = QgsExpressionFinder::findAndSelectExpression( txtTitleText );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( txtTitleText );
   QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
 
   exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );

--- a/src/app/decorations/qgsdecorationtitledialog.cpp
+++ b/src/app/decorations/qgsdecorationtitledialog.cpp
@@ -22,6 +22,7 @@
 #include "qgshelp.h"
 #include "qgsmapcanvas.h"
 #include "qgsgui.h"
+#include "qgsexpressionfinder.h"
 
 #include <QColorDialog>
 #include <QColor>
@@ -108,20 +109,13 @@ void QgsDecorationTitleDialog::buttonBox_rejected()
 
 void QgsDecorationTitleDialog::mInsertExpressionButton_clicked()
 {
-  QString selText = txtTitleText->textCursor().selectedText();
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
-
-  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
-
-  QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( txtTitleText );
+  QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
 
   exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    const QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText().trimmed();
     if ( !expression.isEmpty() )
     {
       txtTitleText->insertPlainText( "[%" + expression + "%]" );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -547,6 +547,7 @@ set(QGIS_GUI_SRCS
   qgserrordialog.cpp
   qgsexpressionbuilderdialog.cpp
   qgsexpressionbuilderwidget.cpp
+  qgsexpressionfinder.cpp
   qgsexpressionhighlighter.cpp
   qgsexpressionlineedit.cpp
   qgsexpressionpreviewwidget.cpp
@@ -823,6 +824,7 @@ set(QGIS_GUI_HDRS
   qgsexpressionbuilderdialog.h
   qgsexpressionstoredialog.h
   qgsexpressionbuilderwidget.h
+  qgsexpressionfinder.h
   qgsexpressionhighlighter.h
   qgsexpressionlineedit.h
   qgsexpressionpreviewwidget.h

--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -436,7 +436,7 @@ bool QgsAnnotationPointTextItemWidget::setNewItem( QgsAnnotationItem *item )
 
 void QgsAnnotationPointTextItemWidget::mInsertExpressionButton_clicked()
 {
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mTextEdit );
 
   QgsExpressionContext expressionContext;
   if ( context().expressionContext() )
@@ -585,7 +585,7 @@ bool QgsAnnotationLineTextItemWidget::setNewItem( QgsAnnotationItem *item )
 
 void QgsAnnotationLineTextItemWidget::mInsertExpressionButton_clicked()
 {
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mTextEdit );
 
   QgsExpressionContext expressionContext;
   if ( context().expressionContext() )

--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -28,6 +28,7 @@
 #include "qgstextformatwidget.h"
 #include "qgsapplication.h"
 #include "qgsrecentstylehandler.h"
+#include "qgsexpressionfinder.h"
 
 ///@cond PRIVATE
 
@@ -435,14 +436,7 @@ bool QgsAnnotationPointTextItemWidget::setNewItem( QgsAnnotationItem *item )
 
 void QgsAnnotationPointTextItemWidget::mInsertExpressionButton_clicked()
 {
-  QString selText = mTextEdit->textCursor().selectedText();
-
-  // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
-  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
 
   QgsExpressionContext expressionContext;
   if ( context().expressionContext() )
@@ -450,12 +444,12 @@ void QgsAnnotationPointTextItemWidget::mInsertExpressionButton_clicked()
   else
     expressionContext = QgsProject::instance()->createExpressionContext();
 
-  QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), expressionContext );
+  QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), expressionContext );
 
   exprDlg.setWindowTitle( tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText().trimmed();
     if ( !expression.isEmpty() )
     {
       mTextEdit->insertPlainText( "[%" + expression + "%]" );
@@ -591,14 +585,7 @@ bool QgsAnnotationLineTextItemWidget::setNewItem( QgsAnnotationItem *item )
 
 void QgsAnnotationLineTextItemWidget::mInsertExpressionButton_clicked()
 {
-  QString selText = mTextEdit->textCursor().selectedText();
-
-  // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
-  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
 
   QgsExpressionContext expressionContext;
   if ( context().expressionContext() )
@@ -606,12 +593,12 @@ void QgsAnnotationLineTextItemWidget::mInsertExpressionButton_clicked()
   else
     expressionContext = QgsProject::instance()->createExpressionContext();
 
-  QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), expressionContext );
+  QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), expressionContext );
 
   exprDlg.setWindowTitle( tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText().trimmed();
     if ( !expression.isEmpty() )
     {
       mTextEdit->insertPlainText( "[%" + expression + "%]" );

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -751,13 +751,8 @@ void QgsCodeEditor::reformatCode()
   if ( !( languageCapabilities() & Qgis::ScriptLanguageCapability::Reformat ) )
     return;
 
-  int line = 0;
-  int index = 0;
-  getCursorPosition( &line, &index );
-  const QString textBeforeCursor = text( 0, positionFromLineIndex( line, index ) );
-
+  const QString textBeforeCursor = text( 0, linearPosition() );
   const QString originalText = text();
-
   const QString newText = reformatCodeString( originalText );
 
   if ( originalText == newText )
@@ -765,14 +760,13 @@ void QgsCodeEditor::reformatCode()
 
   // try to preserve the cursor position and scroll position
   const int oldScrollValue = verticalScrollBar()->value();
-  const int linearPosition = findMinimalDistanceIndex( newText, textBeforeCursor );
+  const int linearIndex = findMinimalDistanceIndex( newText, textBeforeCursor );
 
   beginUndoAction();
   selectAll();
   removeSelectedText();
   insert( newText );
-  lineIndexFromPosition( linearPosition, &line, &index );
-  setCursorPosition( line, index );
+  setLinearPosition( linearIndex );
   verticalScrollBar()->setValue( oldScrollValue );
   endUndoAction();
 }
@@ -1118,6 +1112,50 @@ void QgsCodeEditor::moveCursorToEnd()
 
   if ( mMode == QgsCodeEditor::Mode::CommandInput )
     updatePrompt();
+}
+
+int QgsCodeEditor::linearPosition() const
+{
+  int line, index;
+  getCursorPosition( &line, &index );
+  return positionFromLineIndex( line, index );
+}
+
+void QgsCodeEditor::setLinearPosition( int linearIndex )
+{
+  int line, index;
+  lineIndexFromPosition( linearIndex, &line, &index );
+  setCursorPosition( line, index );
+}
+
+int QgsCodeEditor::selectionStart() const
+{
+  int startLine, startIndex, _;
+  getSelection( &startLine, &startIndex, &_, &_ );
+  if ( startLine == -1 )
+  {
+    return linearPosition();
+  }
+  return positionFromLineIndex( startLine, startIndex );
+}
+
+int QgsCodeEditor::selectionEnd() const
+{
+  int endLine, endIndex, _;
+  getSelection( &_, &_, &endLine, &endIndex );
+  if ( endLine == -1 )
+  {
+    return linearPosition();
+  }
+  return positionFromLineIndex( endLine, endIndex );
+}
+
+void QgsCodeEditor::setLinearSelection( int start, int end )
+{
+  int startLine, startIndex, endLine, endIndex;
+  lineIndexFromPosition( start, &startLine, &startIndex );
+  lineIndexFromPosition( end, &endLine, &endIndex );
+  setSelection( startLine, startIndex, endLine, endIndex );
 }
 
 QgsCodeInterpreter::~QgsCodeInterpreter() = default;

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -360,6 +360,45 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
      */
     void setInterpreter( QgsCodeInterpreter *newInterpreter );
 
+    /**
+     * Convenience function to return the cursor position as a linear index
+     *
+     * \since QGIS 3.36
+     */
+    int linearPosition() const;
+
+    /**
+     * Convenience function to set the cursor position as a linear index
+     *
+     * \since QGIS 3.36
+     */
+    void setLinearPosition( int position );
+
+    /**
+     * Convenience function to return the start of the selection as a linear index
+     * Contrary to the getSelection method, this method returns the cursor position if
+     * no selection is made.
+     *
+     * \since QGIS 3.36
+     */
+    int selectionStart() const;
+
+    /**
+     * Convenience function to return the end of the selection as a linear index
+     * Contrary to the getSelection method, this method returns the cursor position if
+     * no selection is made.
+     *
+     * \since QGIS 3.36
+     */
+    int selectionEnd() const;
+
+    /**
+     * Convenience function to set the selection using linear indexes
+     *
+     * \since QGIS 3.36
+     */
+    void setLinearSelection( int start, int end );
+
   public slots:
 
     /**

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -584,9 +584,7 @@ bool QgsCodeEditorPython::loadScript( const QString &script )
 
 bool QgsCodeEditorPython::isCursorInsideStringLiteralOrComment() const
 {
-  int line, index;
-  getCursorPosition( &line, &index );
-  int position = positionFromLineIndex( line, index );
+  int position = linearPosition();
 
   // Special case: cursor at the end of the document. Style will always be Default,
   // so  we have to  check the style of the previous character.
@@ -621,9 +619,7 @@ bool QgsCodeEditorPython::isCursorInsideStringLiteralOrComment() const
 
 QString QgsCodeEditorPython::characterBeforeCursor() const
 {
-  int line, index;
-  getCursorPosition( &line, &index );
-  int position = positionFromLineIndex( line, index );
+  int position = linearPosition();
   if ( position <= 0 )
   {
     return QString();
@@ -633,9 +629,7 @@ QString QgsCodeEditorPython::characterBeforeCursor() const
 
 QString QgsCodeEditorPython::characterAfterCursor() const
 {
-  int line, index;
-  getCursorPosition( &line, &index );
-  int position = positionFromLineIndex( line, index );
+  int position = linearPosition();
   if ( position >= length() )
   {
     return QString();

--- a/src/gui/layout/qgslayouthtmlwidget.cpp
+++ b/src/gui/layout/qgslayouthtmlwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgscodeeditorcss.h"
 #include "qgssettings.h"
 #include "qgslayoutundostack.h"
+#include "qgsexpressionfinder.h"
 
 #include <QFileDialog>
 #include <QUrl>
@@ -342,43 +343,22 @@ void QgsLayoutHtmlWidget::mInsertExpressionButton_clicked()
     return;
   }
 
-  int line = 0;
-  int index = 0;
-  QString selText;
-  if ( mHtmlEditor->hasSelectedText() )
-  {
-    selText = mHtmlEditor->selectedText();
-
-    // edit the selected expression if there's one
-    if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-      selText = selText.mid( 2, selText.size() - 4 );
-  }
-  else
-  {
-    mHtmlEditor->getCursorPosition( &line, &index );
-  }
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mHtmlEditor );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = coverageLayer();
 
   const QgsExpressionContext context = mHtml->createExpressionContext();
-  QgsExpressionBuilderDialog exprDlg( layer, selText, this, QStringLiteral( "generic" ), context );
+  QgsExpressionBuilderDialog exprDlg( layer, expression, this, QStringLiteral( "generic" ), context );
   exprDlg.setWindowTitle( tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    const QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText();
     if ( !expression.isEmpty() )
     {
       blockSignals( true );
       mHtml->beginCommand( tr( "Change HTML Source" ) );
-      if ( mHtmlEditor->hasSelectedText() )
-      {
-        mHtmlEditor->replaceSelectedText( "[%" + expression + "%]" );
-      }
-      else
-      {
-        mHtmlEditor->insertAt( "[%" + expression + "%]", line, index );
-      }
+      mHtmlEditor->insertText( "[%" + expression.trimmed() + "%]" );
       mHtml->setHtml( mHtmlEditor->text() );
       mHtml->endCommand();
       blockSignals( false );

--- a/src/gui/layout/qgslayouthtmlwidget.cpp
+++ b/src/gui/layout/qgslayouthtmlwidget.cpp
@@ -343,7 +343,7 @@ void QgsLayoutHtmlWidget::mInsertExpressionButton_clicked()
     return;
   }
 
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mHtmlEditor );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mHtmlEditor );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = coverageLayer();

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -345,7 +345,7 @@ void QgsLayoutLabelWidget::mInsertExpressionButton_clicked()
     return;
   }
 
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mTextEdit );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = coverageLayer();

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsprojoperation.h"
 #include "qgslayoutreportcontext.h"
+#include "qgsexpressionfinder.h"
 
 #include <QColorDialog>
 #include <QFontDialog>
@@ -79,7 +80,7 @@ QgsLayoutLabelWidget::QgsLayoutLabelWidget( QgsLayoutItemLabel *label )
       buildInsertDynamicTextMenu( mLabel->layout(), mDynamicTextMenu, [ = ]( const QString & expression )
       {
         mLabel->beginCommand( tr( "Insert dynamic text" ) );
-        mTextEdit->insertPlainText( "[%" + expression + "%]" );
+        mTextEdit->insertPlainText( "[%" + expression.trimmed() + "%]" );
         mLabel->endCommand();
       } );
     }
@@ -344,29 +345,22 @@ void QgsLayoutLabelWidget::mInsertExpressionButton_clicked()
     return;
   }
 
-  QString selText = mTextEdit->textCursor().selectedText();
-
-  // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
-  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mTextEdit );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = coverageLayer();
 
   QgsExpressionContext context = mLabel->createExpressionContext();
-  QgsExpressionBuilderDialog exprDlg( layer, selText, this, QStringLiteral( "generic" ), context );
+  QgsExpressionBuilderDialog exprDlg( layer, expression, this, QStringLiteral( "generic" ), context );
 
   exprDlg.setWindowTitle( tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText();
     if ( !expression.isEmpty() )
     {
       mLabel->beginCommand( tr( "Insert expression" ) );
-      mTextEdit->insertPlainText( "[%" + expression + "%]" );
+      mTextEdit->insertPlainText( "[%" + expression.trimmed() + "%]" );
       mLabel->endCommand();
     }
   }

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -41,6 +41,7 @@
 #include "qgscolorramplegendnodewidget.h"
 #include "qgssymbol.h"
 #include "qgslayoutundostack.h"
+#include "qgsexpressionfinder.h"
 
 #include <QMenu>
 #include <QMessageBox>
@@ -1747,14 +1748,7 @@ void QgsLayoutLegendNodeWidget::insertExpression()
   if ( !mLegend )
     return;
 
-  QString selText = mLabelEdit->textCursor().selectedText();
-
-  // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
-  selText = selText.replace( QChar( 0x2029 ), QChar( '\n' ) );
-
-  // edit the selected expression if there's one
-  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
-    selText = selText.mid( 2, selText.size() - 4 );
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mLabelEdit );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = mLegend->layout() ? mLegend->layout()->reportContext().layer() : nullptr;
@@ -1773,16 +1767,16 @@ void QgsLayoutLegendNodeWidget::insertExpression()
                                    << QStringLiteral( "legend_filter_by_map" )
                                    << QStringLiteral( "legend_filter_out_atlas" ) );
 
-  QgsExpressionBuilderDialog exprDlg( layer, selText, this, QStringLiteral( "generic" ), context );
+  QgsExpressionBuilderDialog exprDlg( layer, expression, this, QStringLiteral( "generic" ), context );
 
   exprDlg.setWindowTitle( tr( "Insert Expression" ) );
   if ( exprDlg.exec() == QDialog::Accepted )
   {
-    QString expression = exprDlg.expressionText();
+    expression = exprDlg.expressionText();
     if ( !expression.isEmpty() )
     {
       mLegend->beginCommand( tr( "Insert expression" ) );
-      mLabelEdit->insertPlainText( "[%" + expression + "%]" );
+      mLabelEdit->insertPlainText( "[%" + expression.trimmed() + "%]" );
       mLegend->endCommand();
     }
   }

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1748,7 +1748,7 @@ void QgsLayoutLegendNodeWidget::insertExpression()
   if ( !mLegend )
     return;
 
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mLabelEdit );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mLabelEdit );
 
   // use the atlas coverage layer, if any
   QgsVectorLayer *layer = mLegend->layout() ? mLegend->layout()->reportContext().layer() : nullptr;

--- a/src/gui/qgsexpressionfinder.cpp
+++ b/src/gui/qgsexpressionfinder.cpp
@@ -19,7 +19,11 @@
 #include "qgscodeeditor.h"
 #include "qgsexpressionfinder.h"
 
-void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression )
+
+static const QString EXPRESSION_PATTERN = QStringLiteral( "\\[%\\s*(.*?)\\s*%\\]" );
+
+
+void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression, const QString &pattern )
 {
   start = startSelectionPos;
   end = endSelectionPos;
@@ -34,7 +38,7 @@ void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSel
     endSelectionPos--;
   }
 
-  const QRegularExpression regex( QStringLiteral( "\\[%\\s*(.*?)\\s*%\\]" ) );
+  const QRegularExpression regex( pattern.isEmpty() ? EXPRESSION_PATTERN : pattern );
   QRegularExpressionMatchIterator result = regex.globalMatch( text );
 
   while ( result.hasNext() )
@@ -56,7 +60,7 @@ void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSel
   }
 }
 
-QString QgsExpressionFinder::findAndSelectActiveExpression( QgsCodeEditor *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QgsCodeEditor *editor, const QString &pattern )
 {
   QString res;
 
@@ -65,14 +69,14 @@ QString QgsExpressionFinder::findAndSelectActiveExpression( QgsCodeEditor *edito
 
   // Find the expression at the cursor position
   int newSelectionStart, newSelectionEnd;
-  findExpressionAtPos( editor->text(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+  findExpressionAtPos( editor->text(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res, pattern );
 
   editor->setLinearSelection( newSelectionStart,  newSelectionEnd );
 
   return res;
 }
 
-QString QgsExpressionFinder::findAndSelectActiveExpression( QTextEdit *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QTextEdit *editor, const QString &pattern )
 {
   QString res;
 
@@ -81,7 +85,7 @@ QString QgsExpressionFinder::findAndSelectActiveExpression( QTextEdit *editor )
 
   // Find the expression at the cursor position
   int newSelectionStart, newSelectionEnd;
-  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res, pattern );
 
   QTextCursor cursor = editor->textCursor();
   cursor.setPosition( newSelectionStart, QTextCursor::MoveAnchor );
@@ -91,7 +95,7 @@ QString QgsExpressionFinder::findAndSelectActiveExpression( QTextEdit *editor )
   return res;
 }
 
-QString QgsExpressionFinder::findAndSelectActiveExpression( QPlainTextEdit *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QPlainTextEdit *editor, const QString &pattern )
 {
   QString res;
 
@@ -100,7 +104,7 @@ QString QgsExpressionFinder::findAndSelectActiveExpression( QPlainTextEdit *edit
 
   // Find the expression at the cursor position
   int newSelectionStart, newSelectionEnd;
-  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res, pattern );
 
   QTextCursor cursor = editor->textCursor();
   cursor.setPosition( newSelectionStart, QTextCursor::MoveAnchor );

--- a/src/gui/qgsexpressionfinder.cpp
+++ b/src/gui/qgsexpressionfinder.cpp
@@ -56,7 +56,7 @@ void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSel
   }
 }
 
-QString QgsExpressionFinder::findAndSelectExpression( QgsCodeEditor *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QgsCodeEditor *editor )
 {
   QString res;
 
@@ -72,7 +72,7 @@ QString QgsExpressionFinder::findAndSelectExpression( QgsCodeEditor *editor )
   return res;
 }
 
-QString QgsExpressionFinder::findAndSelectExpression( QTextEdit *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QTextEdit *editor )
 {
   QString res;
 
@@ -91,7 +91,7 @@ QString QgsExpressionFinder::findAndSelectExpression( QTextEdit *editor )
   return res;
 }
 
-QString QgsExpressionFinder::findAndSelectExpression( QPlainTextEdit *editor )
+QString QgsExpressionFinder::findAndSelectActiveExpression( QPlainTextEdit *editor )
 {
   QString res;
 

--- a/src/gui/qgsexpressionfinder.cpp
+++ b/src/gui/qgsexpressionfinder.cpp
@@ -1,0 +1,111 @@
+/*********************************************************************************
+    qgsexpressionfinder.cpp - A helper class to locate expression in text editors
+     --------------------------------------
+    begin                : September 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+ *********************************************************************************
+ *                                                                               *
+ *   This program is free software; you can redistribute it and/or modify        *
+ *   it under the terms of the GNU General Public License as published by        *
+ *   the Free Software Foundation; either version 2 of the License, or           *
+ *   (at your option) any later version.                                         *
+ *                                                                               *
+ *********************************************************************************/
+#include <QRegularExpression>
+#include <QPlainTextEdit>
+#include <QTextEdit>
+
+#include "qgscodeeditor.h"
+#include "qgsexpressionfinder.h"
+
+void QgsExpressionFinder::findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression )
+{
+  start = startSelectionPos;
+  end = endSelectionPos;
+  // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
+  expression = text.mid( startSelectionPos, endSelectionPos - startSelectionPos ).replace( QChar( 0x2029 ), QChar( '\n' ) );
+
+  // When the expression is selected including the opening and closing brackets,
+  // we still want it to be matched
+  if ( startSelectionPos !=  endSelectionPos )
+  {
+    startSelectionPos++;
+    endSelectionPos--;
+  }
+
+  const QRegularExpression regex( QStringLiteral( "\\[%\\s*(.*?)\\s*%\\]" ) );
+  QRegularExpressionMatchIterator result = regex.globalMatch( text );
+
+  while ( result.hasNext() )
+  {
+    const QRegularExpressionMatch match = result.next();
+
+    // Check if the selection or cursor is inside the opening and closing brackets
+    if ( match.capturedStart() < startSelectionPos && match.capturedEnd() > endSelectionPos )
+    {
+      start = match.capturedStart();
+      end = match.capturedEnd();
+      // Set the expression builder text to the trimmed expression
+      expression = match.captured( 1 );
+      // html editor replaces newlines with Paragraph Separator characters - see https://github.com/qgis/QGIS/issues/27568
+      expression = expression.replace( QChar( 0x2029 ), QChar( '\n' ) );
+
+      break;
+    }
+  }
+}
+
+QString QgsExpressionFinder::findAndSelectExpression( QgsCodeEditor *editor )
+{
+  QString res;
+
+  int startPosition = editor->selectionStart();
+  int endPosition = editor->selectionEnd();
+
+  // Find the expression at the cursor position
+  int newSelectionStart, newSelectionEnd;
+  findExpressionAtPos( editor->text(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+
+  editor->setLinearSelection( newSelectionStart,  newSelectionEnd );
+
+  return res;
+}
+
+QString QgsExpressionFinder::findAndSelectExpression( QTextEdit *editor )
+{
+  QString res;
+
+  int startPosition = editor->textCursor().selectionStart();
+  int endPosition = editor->textCursor().selectionEnd();
+
+  // Find the expression at the cursor position
+  int newSelectionStart, newSelectionEnd;
+  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+
+  QTextCursor cursor = editor->textCursor();
+  cursor.setPosition( newSelectionStart, QTextCursor::MoveAnchor );
+  cursor.setPosition( newSelectionEnd, QTextCursor::KeepAnchor );
+  editor->setTextCursor( cursor );
+
+  return res;
+}
+
+QString QgsExpressionFinder::findAndSelectExpression( QPlainTextEdit *editor )
+{
+  QString res;
+
+  int startPosition = editor->textCursor().selectionStart();
+  int endPosition = editor->textCursor().selectionEnd();
+
+  // Find the expression at the cursor position
+  int newSelectionStart, newSelectionEnd;
+  findExpressionAtPos( editor->toPlainText(), startPosition, endPosition, newSelectionStart, newSelectionEnd, res );
+
+  QTextCursor cursor = editor->textCursor();
+  cursor.setPosition( newSelectionStart, QTextCursor::MoveAnchor );
+  cursor.setPosition( newSelectionEnd, QTextCursor::KeepAnchor );
+  editor->setTextCursor( cursor );
+
+  return res;
+}

--- a/src/gui/qgsexpressionfinder.h
+++ b/src/gui/qgsexpressionfinder.h
@@ -1,0 +1,46 @@
+/*********************************************************************************
+    qgsexpressionfinder.h - A helper class to locate expression in text editors
+     --------------------------------------
+    begin                : September 2023
+    copyright            : (C) 2023 by Yoann Quenach de Quivillic
+    email                : yoann dot quenach at gmail dot com
+ *********************************************************************************
+ *                                                                               *
+ *   This program is free software; you can redistribute it and/or modify        *
+ *   it under the terms of the GNU General Public License as published by        *
+ *   the Free Software Foundation; either version 2 of the License, or           *
+ *   (at your option) any later version.                                         *
+ *                                                                               *
+ *********************************************************************************/
+
+#ifndef QGSEXPRESSIONFINDER_H
+#define QGSEXPRESSIONFINDER_H
+
+#include <QString>
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+
+class QgsCodeEditor;
+class QTextEdit;
+class QPlainTextEdit;
+
+/**
+ * \ingroup gui
+ * \class QgsExpressionFinder
+ */
+class GUI_EXPORT QgsExpressionFinder SIP_SKIP
+{
+  public:
+    static void findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression );
+
+    static QString findAndSelectExpression( QgsCodeEditor *editor );
+
+    static QString findAndSelectExpression( QTextEdit *editor );
+
+    static QString findAndSelectExpression( QPlainTextEdit *editor );
+
+
+};
+
+#endif // QGSEXPRESSIONFINDER_H

--- a/src/gui/qgsexpressionfinder.h
+++ b/src/gui/qgsexpressionfinder.h
@@ -46,8 +46,12 @@ class GUI_EXPORT QgsExpressionFinder
      *
      * Otherwise, start and end are set to startSelectionPos and endSelectionPos
      * and expression is set to the selected text
+     *
+     * Optionally, a custom regex pattern can be used to find the expression.
+     * This pattern must contain a capture group to extract the expression from
+     * the match.
      */
-    static void findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression );
+    static void findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression, const QString &pattern = QString() );
 
     /**
      * Find the expression under the cursor in the given editor and select it
@@ -55,7 +59,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectActiveExpression( QgsCodeEditor *editor );
+    static QString findAndSelectActiveExpression( QgsCodeEditor *editor, const QString &pattern = QString() );
 
     /**
      * Find the expression under the cursor in the given editor and select it
@@ -63,7 +67,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectActiveExpression( QTextEdit *editor );
+    static QString findAndSelectActiveExpression( QTextEdit *editor, const QString &pattern = QString() );
 
     /**
      * Find the expression under the cursor in the given editor and select it
@@ -71,7 +75,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectActiveExpression( QPlainTextEdit *editor );
+    static QString findAndSelectActiveExpression( QPlainTextEdit *editor, const QString &pattern = QString() );
 
 
 };

--- a/src/gui/qgsexpressionfinder.h
+++ b/src/gui/qgsexpressionfinder.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectExpression( QgsCodeEditor *editor );
+    static QString findAndSelectActiveExpression( QgsCodeEditor *editor );
 
     /**
      * Find the expression under the cursor in the given editor and select it
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectExpression( QTextEdit *editor );
+    static QString findAndSelectActiveExpression( QTextEdit *editor );
 
     /**
      * Find the expression under the cursor in the given editor and select it
@@ -71,7 +71,7 @@ class GUI_EXPORT QgsExpressionFinder
      * If an expression is found, it is returned (excluding the surrounding [% %] characters)
      * Otherwise, the selection is kept unchanged and the selected text is returned
      */
-    static QString findAndSelectExpression( QPlainTextEdit *editor );
+    static QString findAndSelectActiveExpression( QPlainTextEdit *editor );
 
 
 };

--- a/src/gui/qgsexpressionfinder.h
+++ b/src/gui/qgsexpressionfinder.h
@@ -21,23 +21,56 @@
 #include "qgis_sip.h"
 #include "qgis_gui.h"
 
+#define SIP_NO_FILE
+
 class QgsCodeEditor;
 class QTextEdit;
 class QPlainTextEdit;
 
 /**
  * \ingroup gui
- * \class QgsExpressionFinder
+ * \brief Helper methods to locate expressions within text editors
+ * \note not available in Python bindings
+ * \since QGIS 3.36
  */
-class GUI_EXPORT QgsExpressionFinder SIP_SKIP
+class GUI_EXPORT QgsExpressionFinder
 {
   public:
+
+    /**
+     * Find an expression at the given position in the given text
+     *
+     * If an expression is found, start and end are set to the position of the
+     * opening and closing brakets of the expression, and expression is set to
+     * the trimmed expression (excluding the surrounding [% %] characters)
+     *
+     * Otherwise, start and end are set to startSelectionPos and endSelectionPos
+     * and expression is set to the selected text
+     */
     static void findExpressionAtPos( const QString &text, int startSelectionPos, int endSelectionPos, int &start, int &end, QString &expression );
 
+    /**
+     * Find the expression under the cursor in the given editor and select it
+     *
+     * If an expression is found, it is returned (excluding the surrounding [% %] characters)
+     * Otherwise, the selection is kept unchanged and the selected text is returned
+     */
     static QString findAndSelectExpression( QgsCodeEditor *editor );
 
+    /**
+     * Find the expression under the cursor in the given editor and select it
+     *
+     * If an expression is found, it is returned (excluding the surrounding [% %] characters)
+     * Otherwise, the selection is kept unchanged and the selected text is returned
+     */
     static QString findAndSelectExpression( QTextEdit *editor );
 
+    /**
+     * Find the expression under the cursor in the given editor and select it
+     *
+     * If an expression is found, it is returned (excluding the surrounding [% %] characters)
+     * Otherwise, the selection is kept unchanged and the selected text is returned
+     */
     static QString findAndSelectExpression( QPlainTextEdit *editor );
 
 

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -317,6 +317,21 @@ void QgsFieldExpressionWidget::setAllowEvalErrors( bool allowEvalErrors )
   emit allowEvalErrorsChanged();
 }
 
+
+bool QgsFieldExpressionWidget::buttonVisible() const
+{
+  return mButton->isVisibleTo( this );
+}
+
+void QgsFieldExpressionWidget::setButtonVisible( bool visible )
+{
+  if ( visible == buttonVisible() )
+    return;
+
+  mButton->setVisible( visible );
+  emit buttonVisibleChanged();
+}
+
 void QgsFieldExpressionWidget::currentFieldChanged()
 {
   updateLineEditStyle();

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -36,7 +36,7 @@ class QgsExpressionContextGenerator;
 
 /**
  * \ingroup gui
- * \brief The QgsFieldExpressionWidget class reates a widget to choose fields and edit expressions
+ * \brief The QgsFieldExpressionWidget class creates a widget to choose fields and edit expressions
  * It contains a combo box to display the fields and expression and a button to open the expression dialog.
  * The combo box is editable, allowing expressions to be edited inline.
  * The validity of the expression is checked live on key press, invalid expressions are displayed in red.
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     Q_PROPERTY( QgsFieldProxyModel::Filters filters READ filters WRITE setFilters )
     Q_PROPERTY( bool allowEmptyFieldName READ allowEmptyFieldName WRITE setAllowEmptyFieldName )
     Q_PROPERTY( bool allowEvalErrors READ allowEvalErrors WRITE setAllowEvalErrors NOTIFY allowEvalErrorsChanged )
+    Q_PROPERTY( bool buttonVisible READ buttonVisible WRITE setButtonVisible NOTIFY buttonVisibleChanged )
 
   public:
 
@@ -170,6 +171,24 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
      */
     void setAllowEvalErrors( bool allowEvalErrors );
 
+    /**
+     * Returns the visibility of the button
+     *
+     * If button is hidden, the widget essentially becomes an editable combo box
+     *
+     * \since QGIS 3.36
+     */
+    bool buttonVisible() const;
+
+    /**
+     * Set the visibility of the button
+     *
+     * If button is hidden, the widget essentially becomes an editable combo box
+     *
+     * \since QGIS 3.36
+     */
+    void setButtonVisible( bool visible );
+
   signals:
     //! Emitted when the currently selected field changes.
     void fieldChanged( const QString &fieldName );
@@ -184,6 +203,13 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
      * \since QGIS 3.0
      */
     void allowEvalErrorsChanged();
+
+    /**
+     * Emitted when the button visibility changes
+     *
+     * \since QGIS 3.36
+     */
+    void buttonVisibleChanged();
 
   public slots:
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -295,7 +295,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     // Get the linear indexes if the start and end of the selection
     int selectionStart = mMapTipWidget->selectionStart();
     int selectionEnd = mMapTipWidget->selectionEnd();
-    QString expression = QgsExpressionFinder::findAndSelectExpression( mMapTipWidget );
+    QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mMapTipWidget );
     QgsExpressionBuilderDialog exprDlg( nullptr, expression, this, QStringLiteral( "generic" ), mContext );
 
     exprDlg.setWindowTitle( tr( "Insert Expression" ) );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1599,7 +1599,7 @@ void QgsAttributesDnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int colum
 
       connect( addExpressionButton, &QAbstractButton::clicked, this, [ = ]
       {
-        text->insertText( expressionWidget->expression().prepend( QStringLiteral( "[% " ) ).append( QStringLiteral( " %]" ) ) );
+        text->insertText( expressionWidget->expression().prepend( QStringLiteral( "[%" ) ).append( QStringLiteral( "%]" ) ) );
       } );
 
       layout->addWidget( new QLabel( tr( "Title" ) ) );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -520,7 +520,7 @@ void QgsVectorLayerProperties::insertOrEditExpression()
   // Get the linear indexes if the start and end of the selection
   int selectionStart = mMapTipWidget->selectionStart();
   int selectionEnd = mMapTipWidget->selectionEnd();
-  QString expression = QgsExpressionFinder::findAndSelectExpression( mMapTipWidget );
+  QString expression = QgsExpressionFinder::findAndSelectActiveExpression( mMapTipWidget );
 
   QgsExpressionContext context = createExpressionContext();
   QgsExpressionBuilderDialog exprDlg( mLayer, expression, this, QStringLiteral( "generic" ), context );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -508,9 +508,9 @@ void QgsVectorLayerProperties::insertField()
   // insert it into the action at the cursor position
   if ( mMapTipFieldComboBox->currentField().isEmpty() )
     return;
-  QString expression = QStringLiteral( "[%" );
+  QString expression = QStringLiteral( "[%\"" );
   expression += mMapTipFieldComboBox->currentField();
-  expression += QLatin1String( "%]" );
+  expression += QLatin1String( "\"%]" );
 
   mMapTipWidget->insertText( expression );
 }

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -70,6 +70,7 @@
 #include "qgsprovidersourcewidgetproviderregistry.h"
 #include "qgswebview.h"
 #include "qgswebframe.h"
+#include "qgsexpressionfinder.h"
 #if WITH_QTWEBKIT
 #include <QWebElement>
 #endif
@@ -154,13 +155,13 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
            << QgsExpressionContextUtils::mapSettingsScope( mCanvas->mapSettings() )
            << QgsExpressionContextUtils::layerScope( mLayer );
 
-  mMapTipExpressionFieldWidget->setLayer( lyr );
-  mMapTipExpressionFieldWidget->registerExpressionContextGenerator( this );
+  mMapTipFieldComboBox->setLayer( lyr );
   mDisplayExpressionWidget->setLayer( lyr );
   mDisplayExpressionWidget->registerExpressionContextGenerator( this );
   initMapTipPreview();
 
-  connect( mInsertExpressionButton, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::insertFieldOrExpression );
+  connect( mMapTipInsertFieldButton, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::insertField );
+  connect( mMapTipInsertExpressionButton, &QAbstractButton::clicked, this, &QgsVectorLayerProperties::insertOrEditExpression );
 
   if ( !mLayer )
     return;
@@ -501,15 +502,34 @@ void QgsVectorLayerProperties::toggleEditing()
   setPbnQueryBuilderEnabled();
 }
 
-void QgsVectorLayerProperties::insertFieldOrExpression()
+void QgsVectorLayerProperties::insertField()
 {
   // Convert the selected field to an expression and
   // insert it into the action at the cursor position
-  QString expression = QStringLiteral( "[% " );
-  expression += mMapTipExpressionFieldWidget->asExpression();
-  expression += QLatin1String( " %]" );
+  if ( mMapTipFieldComboBox->currentField().isEmpty() )
+    return;
+  QString expression = QStringLiteral( "[%" );
+  expression += mMapTipFieldComboBox->currentField();
+  expression += QLatin1String( "%]" );
 
   mMapTipWidget->insertText( expression );
+}
+
+void QgsVectorLayerProperties::insertOrEditExpression()
+{
+  // Get the linear indexes if the start and end of the selection
+  int selectionStart = mMapTipWidget->selectionStart();
+  int selectionEnd = mMapTipWidget->selectionEnd();
+  QString expression = QgsExpressionFinder::findAndSelectExpression( mMapTipWidget );
+
+  QgsExpressionContext context = createExpressionContext();
+  QgsExpressionBuilderDialog exprDlg( mLayer, expression, this, QStringLiteral( "generic" ), context );
+
+  exprDlg.setWindowTitle( tr( "Insert Expression" ) );
+  if ( exprDlg.exec() == QDialog::Accepted && !exprDlg.expressionText().trimmed().isEmpty() )
+    mMapTipWidget->insertText( "[%" + exprDlg.expressionText().trimmed() + "%]" );
+  else // Restore the selection
+    mMapTipWidget->setLinearSelection( selectionStart, selectionEnd );
 }
 
 void QgsVectorLayerProperties::addMetadataUrl()

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -110,7 +110,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
 
   private slots:
 
-    void insertFieldOrExpression();
+    void insertField();
+    void insertOrEditExpression();
 
     //! Gets metadata about the layer in nice formatted html
     QString htmlMetadata();

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -275,7 +275,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>5</number>
+          <number>10</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -320,8 +320,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>680</height>
+                <width>354</width>
+                <height>457</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -350,7 +350,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -358,7 +358,7 @@
                    <number>6</number>
                   </property>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -443,8 +443,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>680</height>
+                <width>665</width>
+                <height>365</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -471,7 +471,7 @@
                  <property name="title">
                   <string>Band Rendering</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14">
@@ -516,13 +516,13 @@
                  <property name="title">
                   <string>Layer Rendering</string>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_2">
@@ -877,13 +877,13 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout">
@@ -1013,7 +1013,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>643</width>
-                <height>680</height>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1075,7 +1075,7 @@
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup" stdset="0">
+             <property name="syncGroup">
               <string notr="true">rastergeneral</string>
              </property>
              <layout class="QGridLayout" name="_5">
@@ -1095,7 +1095,7 @@
                <number>6</number>
               </property>
               <item row="0" column="0" colspan="2">
-               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                 <property name="toolTip">
                  <string/>
                 </property>
@@ -1191,8 +1191,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>504</width>
-                <height>187</height>
+                <width>543</width>
+                <height>184</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1259,13 +1259,10 @@
                       </property>
                       <property name="html">
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
                     </item>
@@ -1464,8 +1461,8 @@ li.checked::marker { content: &quot;\2612&quot;; }
                 <property name="title">
                  <string>HTML Map Tip</string>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_8">
-                 <item row="0" column="0" colspan="2">
+                <layout class="QVBoxLayout" name="verticalLayout_22">
+                 <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1503,7 +1500,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                    </widget>
                   </widget>
                  </item>
-                 <item row="1" column="1">
+                 <item>
                   <widget class="QPushButton" name="mInsertExpressionButton">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1511,31 +1508,22 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <verstretch>0</verstretch>
                     </sizepolicy>
                    </property>
-                   <property name="toolTip">
-                    <string>Inserts the selected field or expression into the map tip</string>
-                   </property>
                    <property name="text">
-                    <string>Insert</string>
+                    <string>Insert/Edit Expression</string>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../images/images.qrc">
+                     <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
                    </property>
                   </widget>
                  </item>
-                 <item row="2" column="0" colspan="2">
+                 <item>
                   <widget class="QLabel" name="labelMapTipInfo">
                    <property name="text">
                     <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QgsExpressionLineEdit" name="mMapTipExpressionWidget" native="true">
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="toolTip">
-                    <string>The valid attribute names for this layer</string>
                    </property>
                   </widget>
                  </item>
@@ -1637,8 +1625,8 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>629</width>
-                <height>709</height>
+                <width>374</width>
+                <height>694</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -1659,7 +1647,7 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                  <property name="title">
                   <string>Description</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rastermeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -1795,7 +1783,7 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                  <property name="title">
                   <string>Attribution</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -1841,7 +1829,7 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
                  <property name="title">
                   <string>Metadata URL</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -2051,6 +2039,12 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -2067,15 +2061,21 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
@@ -2089,18 +2089,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <header>qgscodeeditorhtml.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
@@ -2109,12 +2097,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
    <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
    <header>qgsfilecontentsourcelineedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsExpressionLineEdit</class>
-   <extends>QWidget</extends>
-   <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2181,7 +2163,6 @@ You can also import an existing raster attribute table from a VAT.DBF file and a
   <tabstop>mInvertColorsCheck</tabstop>
   <tabstop>mEnableMapTips</tabstop>
   <tabstop>mInsertExpressionButton</tabstop>
-  <tabstop>mMapTipExpressionWidget</tabstop>
   <tabstop>mCreateRasterAttributeTableButton</tabstop>
   <tabstop>mLoadRasterAttributeTableFromFileButton</tabstop>
   <tabstop>tableViewMetadataUrl</tabstop>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>825</width>
-    <height>730</height>
+    <width>849</width>
+    <height>765</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -363,7 +363,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>11</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -439,8 +439,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>680</height>
+                <width>336</width>
+                <height>577</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -543,7 +543,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -551,7 +551,7 @@
                    <number>6</number>
                   </property>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -598,7 +598,7 @@
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -733,8 +733,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>680</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>680</height>
+                <width>104</width>
+                <height>102</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1095,7 +1095,7 @@
                 <property name="checkable">
                  <bool>false</bool>
                 </property>
-                <property name="syncGroup" stdset="0">
+                <property name="syncGroup">
                  <string notr="true">vectormeta</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_11">
@@ -1345,8 +1345,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>680</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1429,7 +1429,7 @@
                 </property>
                 <layout class="QGridLayout" name="gridLayout_50">
                  <item row="0" column="0">
-                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget" native="true">
+                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
@@ -1472,8 +1472,8 @@
                 <property name="title">
                  <string>HTML Map Tip</string>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_8">
-                 <item row="0" column="0" colspan="2">
+                <layout class="QVBoxLayout" name="verticalLayout_35">
+                 <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1484,7 +1484,7 @@
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
-                   <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
+                   <widget class="QWidget" name="mMapTipWidgetContainer" native="true">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                       <horstretch>0</horstretch>
@@ -1497,6 +1497,94 @@
                       <height>100</height>
                      </size>
                     </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_36">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QgsCodeEditorHTML" name="mMapTipWidget" native="true">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_3">
+                       <property name="spacing">
+                        <number>2</number>
+                       </property>
+                       <item>
+                        <widget class="QgsFieldComboBox" name="mMapTipFieldComboBox">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="allowEmptyFieldName">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="mMapTipInsertFieldButton">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="toolTip">
+                          <string>Inserts the selected field into the map tip</string>
+                         </property>
+                         <property name="text">
+                          <string/>
+                         </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <spacer name="horizontalSpacer_4">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>40</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="mMapTipInsertExpressionButton">
+                         <property name="text">
+                          <string>Insert/Edit Expression</string>
+                         </property>
+                         <property name="icon">
+                          <iconset resource="../../images/images.qrc">
+                           <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
                    </widget>
                    <widget class="QGroupBox" name="mMapTipPreviewContainer">
                     <property name="minimumSize">
@@ -1511,39 +1599,13 @@
                    </widget>
                   </widget>
                  </item>
-                 <item row="1" column="1">
-                  <widget class="QPushButton" name="mInsertExpressionButton">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="toolTip">
-                    <string>Inserts the selected field or expression into the map tip</string>
-                   </property>
-                   <property name="text">
-                    <string>Insert</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0" colspan="2">
+                 <item>
                   <widget class="QLabel" name="labelMapTipInfo">
                    <property name="text">
                     <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget" native="true">
-                   <property name="focusPolicy">
-                    <enum>Qt::StrongFocus</enum>
-                   </property>
-                   <property name="toolTip">
-                    <string>The valid attribute names for this layer</string>
                    </property>
                   </widget>
                  </item>
@@ -1582,8 +1644,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>639</width>
-                <height>705</height>
+                <width>703</width>
+                <height>726</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1609,7 +1671,7 @@
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
                   <item row="0" column="0">
-                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -1746,7 +1808,7 @@
                  <property name="checkable">
                   <bool>true</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
@@ -1765,7 +1827,7 @@
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QgsScaleWidget" name="mReferenceScaleWidget" native="true">
+                   <widget class="QgsScaleWidget" name="mReferenceScaleWidget">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -2164,8 +2226,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>331</width>
-                <height>829</height>
+                <width>374</width>
+                <height>813</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2186,7 +2248,7 @@
                  <property name="title">
                   <string>Description</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -2328,7 +2390,7 @@
                  <property name="title">
                   <string>Attribution</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -2628,9 +2690,26 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
@@ -2644,15 +2723,25 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2673,11 +2762,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
    <extends>QWidget</extends>
    <header>qgslayertreeembeddedconfigwidget.h</header>
@@ -2692,23 +2776,6 @@
    <class>QgsVectorLayerLegendWidget</class>
    <extends>QWidget</extends>
    <header>qgsvectorlayerlegendwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2746,8 +2813,6 @@
   <tabstop>mAuxiliaryStorageActions</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>mDisplayExpressionWidget</tabstop>
-  <tabstop>mMapTipExpressionFieldWidget</tabstop>
-  <tabstop>mInsertExpressionButton</tabstop>
   <tabstop>mScaleVisibilityGroupBox</tabstop>
   <tabstop>scrollArea_19</tabstop>
   <tabstop>mScaleRangeWidget</tabstop>


### PR DESCRIPTION
- Fixes #54705 

## Description

- Add a bunch of methods in `QgsCodeEditor`, to handle selection and cursor position similarly to `QTextEdit`: `linearPosition`, `setLinearPosition`, `setLinearSelection`, `selectionStart` and `selectionEnd`
- Add a helper class `QgsExpressionFinder`, to locate expressions in a Q(Plain)TextEdit or QgsCodeEditor. Not available in Python bindings (SIP_SKIP)
- Use `QgsExpressionFinder` to change the Insert/Edit Expression behavior as follow:
  - If some text is selected and the selection is within an expression (between `"[%"` and `"%]"`), selects the whole expression
  - If no text is selected, and the cursor is inside an expression, selects the whole expression
  - Otherwise, keep selection as is.
- Add an Insert/Edit Expression button in the vector layer properties MapTip tab.

![vector_properties](https://github.com/qgis/QGIS/assets/9693475/46e429f9-aafd-4105-a825-d8a7d5df8a07)

![raster_properties](https://github.com/qgis/QGIS/assets/9693475/c5c90e45-699f-4578-b128-7e79ed72a583)


The new expression edit behavior also applies to Print Layout TextLabel and HtmlLabel, Title and Copyright decorations, and Annotation items.
