### PR TITLE
Allow GPU memory limit configuration + show a warning when limit got hit

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -169,6 +169,13 @@ Emitted when the viewed 2D extent seen by the 3D camera has changed
 .. versionadded:: 3.26
 %End
 
+    void gpuMemoryLimitReached();
+%Docstring
+Emitted when one of the entities reaches its GPU memory limit
+and it is not possible to lower the GPU memory use by unloading
+data that's not currently needed.
+%End
+
   public slots:
     void updateTemporal();
 %Docstring

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -94,20 +94,6 @@ class QgsChunkedEntity : public Qgs3DMapSceneEntity
     QgsChunkNode *rootNode() const { return mRootNode; }
 
     /**
-     * Sets the limit of the GPU memory used to render the entity
-     * \since QGIS 3.26
-     */
-    void setGpuMemoryLimit( double gpuMemoryLimit ) { mGpuMemoryLimit = gpuMemoryLimit; }
-
-    /**
-     * Returns the limit of the GPU memory used to render the entity in megabytes
-     * \since QGIS 3.26
-     */
-    double gpuMemoryLimit() const { return mGpuMemoryLimit; }
-
-    static double calculateEntityGpuMemorySize( Qt3DCore::QEntity *entity );
-
-    /**
      * Checks if \a ray intersects the entity by using the specified parameters in \a context and returns information about the hits.
      * This method is typically used by map tools that need to identify the exact location on a 3d entity that the mouse cursor points at,
      * as well as properties of the intersected entity (fid for vector layers, point cloud attributes for point cloud layers etc). The camera position
@@ -182,7 +168,6 @@ class QgsChunkedEntity : public Qgs3DMapSceneEntity
     bool mIsValid = true;
 
     int mPrimitivesBudget = std::numeric_limits<int>::max();
-    double mGpuMemoryLimit = 500.0; // in megabytes
 };
 
 /// @endcond

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -371,6 +371,8 @@ void Qgs3DMapScene::updateScene()
   for ( Qgs3DMapSceneEntity *entity : std::as_const( mSceneEntities ) )
   {
     entity->handleSceneUpdate( sceneState_( mEngine ) );
+    if ( entity->hasReachedGpuMemoryLimit() )
+      emit gpuMemoryLimitReached();
   }
 
   updateSceneState();
@@ -446,6 +448,8 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
     {
       QgsDebugMsgLevel( QStringLiteral( "need for update" ), 2 );
       entity->handleSceneUpdate( sceneState_( mEngine ) );
+      if ( entity->hasReachedGpuMemoryLimit() )
+        emit gpuMemoryLimitReached();
     }
   }
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -230,6 +230,13 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
      */
     void viewed2DExtentFrom3DChanged( QVector<QgsPointXY> extent );
 
+    /**
+     *  Emitted when one of the entities reaches its GPU memory limit
+     *  and it is not possible to lower the GPU memory use by unloading
+     *  data that's not currently needed.
+     */
+    void gpuMemoryLimitReached();
+
   public slots:
     //! Updates the temporale entities
     void updateTemporal();

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -74,6 +74,13 @@ class _3D_EXPORT Qgs3DUtils
     static QImage captureSceneDepthBuffer( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene );
 
     /**
+     * Calculates approximate usage of GPU memory by an entity
+     * \return GPU memory usage in megabytes
+     * \since QGIS 3.34
+     */
+    static double calculateEntityGpuMemorySize( Qt3DCore::QEntity *entity );
+
+    /**
      * Captures 3D animation frames to the selected folder
      *
      * \param animationSettings Settings for keyframes and camera

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -37,6 +37,7 @@ class Qgs3DMapToolIdentify;
 class Qgs3DMapToolMeasureLine;
 class QgsMapCanvas;
 class QgsDockableWidgetHelper;
+class QgsMessageBar;
 class QgsRubberBand;
 
 class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
@@ -92,6 +93,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void onViewed2DExtentFrom3DChanged( QVector<QgsPointXY> extent );
     void onViewFrustumVisualizationEnabledChanged();
     void onExtentChanged();
+    void onGpuMemoryLimitReached();
 
   private:
     QString mCanvasName;
@@ -121,6 +123,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QObjectUniquePtr< QgsRubberBand > mViewFrustumHighlight;
     QObjectUniquePtr< QgsRubberBand > mViewExtentHighlight;
     QPointer<QDialog> mConfigureDialog;
+    QgsMessageBar *mMessageBar = nullptr;
+    bool mGpuMemoryLimitReachedReported = false;
 };
 
 #endif // QGS3DMAPCANVASWIDGET_H

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -55,6 +55,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
 
   mCameraMovementSpeed->setValue( settings.value( QStringLiteral( "map3d/defaultMovementSpeed" ), 5, QgsSettings::App ).toDouble() );
   spinCameraFieldOfView->setValue( settings.value( QStringLiteral( "map3d/defaultFieldOfView" ), 45, QgsSettings::App ).toInt() );
+
+  mGpuMemoryLimit->setValue( settings.value( QStringLiteral( "map3d/gpuMemoryLimit" ), 500.0, QgsSettings::App ).toDouble() );
 }
 
 void Qgs3DOptionsWidget::apply()
@@ -65,6 +67,8 @@ void Qgs3DOptionsWidget::apply()
   settings.setValue( QStringLiteral( "map3d/defaultProjection" ), static_cast< Qt3DRender::QCameraLens::ProjectionType >( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultMovementSpeed" ), mCameraMovementSpeed->value(), QgsSettings::App );
   settings.setValue( QStringLiteral( "map3d/defaultFieldOfView" ), spinCameraFieldOfView->value(), QgsSettings::App );
+
+  settings.setValue( QStringLiteral( "map3d/gpuMemoryLimit" ), mGpuMemoryLimit->value(), QgsSettings::App );
 }
 
 

--- a/src/ui/3d/qgs3doptionsbase.ui
+++ b/src/ui/3d/qgs3doptionsbase.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>677</width>
-    <height>298</height>
+    <height>383</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,7 +47,7 @@
          <x>0</x>
          <y>0</y>
          <width>677</width>
-         <height>298</height>
+         <height>383</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
@@ -63,6 +63,19 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
+        <item row="2" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="0" column="0">
          <widget class="QGroupBox" name="cameraTerrain">
           <property name="title">
@@ -140,17 +153,39 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="title">
+           <string>Graphics Memory</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Allowed memory per map layer</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QgsDoubleSpinBox" name="mGpuMemoryLimit">
+             <property name="suffix">
+              <string> MB</string>
+             </property>
+             <property name="decimals">
+              <number>0</number>
+             </property>
+             <property name="minimum">
+              <double>10.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>100.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
This should help a bit when people are using massive 3D scenes and get to the limits (until now fixed to 500 MB per entity/layer).

There's now a one-time warning when the GPU memory limit got hit and it was not possible to unload data to get back under the limit:

![qgis-3d-memory-limit](https://github.com/qgis/QGIS/assets/193367/d0ed2262-6cb5-4221-b276-7d04dec9fb7a)

And there's a new setting in QGIS options dialog > 3D tab to adjust the memory limit:

![gpu-limit-options](https://github.com/qgis/QGIS/assets/193367/a95d32eb-f754-4594-8dfd-96c56cef9644)
