### PR TITLE
Greatly speed up running qgis_process help usage/version commands

### DIFF
--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -77,7 +77,63 @@ int main( int argc, char *argv[] )
 #endif  // _MSC_VER
 #endif  // Q_OS_WIN
 
+  // a shortcut -- let's see if we are being called without any arguments, or just the usage argument.
+  // If so, let's skip the startup cost of a QCoreApplication/QgsApplication
+  bool hasHelpArgument = false;
+  for ( int i = 1; i < argc; ++i )
+  {
+    const QString arg( argv[i] );
+    if ( arg == QLatin1String( "--help" ) || arg == QLatin1String( "-h" ) )
+    {
+      hasHelpArgument = true;
+      break;
+    }
+  }
+  if ( argc == 1 || hasHelpArgument )
+  {
+    QgsProcessingExec::showUsage( QString( argv[ 0 ] ) );
+    return 0;
+  }
+
   QgsApplication app( argc, argv, false, QString(), QStringLiteral( "qgis_process" ) );
+
+  // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
+  // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.
+  QStringList args = QCoreApplication::arguments();
+
+  const int jsonIndex = args.indexOf( QLatin1String( "--json" ) );
+  bool useJson = false;
+  if ( jsonIndex >= 0 )
+  {
+    useJson = true;
+    args.removeAt( jsonIndex );
+  }
+
+  const int verboseIndex = args.indexOf( QLatin1String( "--verbose" ) );
+  QgsProcessingContext::LogLevel logLevel = QgsProcessingContext::DefaultLevel;
+  if ( verboseIndex >= 0 )
+  {
+    logLevel = QgsProcessingContext::Verbose;
+    args.removeAt( verboseIndex );
+  }
+
+  const int noPythonIndex = args.indexOf( QLatin1String( "--no-python" ) );
+  bool skipPython = false;
+  if ( noPythonIndex >= 0 )
+  {
+    skipPython = true;
+    args.removeAt( noPythonIndex );
+  }
+
+  const QString command = args.value( 1 );
+  if ( args.size() == 1 || command == QLatin1String( "--help" ) || command == QLatin1String( "-h" ) )
+  {
+    // a shortcut -- if we are showing usage information, we don't need to initialise
+    // QgsApplication at all!
+    QgsProcessingExec::showUsage( args.at( 0 ) );
+    return 0;
+  }
+
   QString myPrefixPath;
   if ( myPrefixPath.isEmpty() )
   {
@@ -99,15 +155,11 @@ int main( int argc, char *argv[] )
 
   ( void ) QgsApplication::resolvePkgPath(); // trigger storing of application path in QgsApplication
 
-  // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
-  // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.
-  const QStringList args = QCoreApplication::arguments();
-
   QgsProcessingExec exec;
   int res = 0;
-  QTimer::singleShot( 0, &app, [&exec, args, &res]
+  QTimer::singleShot( 0, &app, [&exec, args, useJson, logLevel, skipPython, &res]
   {
-    res = exec.run( args );
+    res = exec.run( args, useJson, logLevel, skipPython );
     QgsApplication::exitQgis();
     QCoreApplication::exit( res );
   } );

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -77,21 +77,41 @@ int main( int argc, char *argv[] )
 #endif  // _MSC_VER
 #endif  // Q_OS_WIN
 
-  // a shortcut -- let's see if we are being called without any arguments, or just the usage argument.
+  // a shortcut -- let's see if we are being called without any arguments, or just the usage/version argument.
   // If so, let's skip the startup cost of a QCoreApplication/QgsApplication
   bool hasHelpArgument = false;
+  bool hasVersionArgument = false;
   for ( int i = 1; i < argc; ++i )
   {
     const QString arg( argv[i] );
+    if ( arg == QLatin1String( "--json" )
+         || arg == QLatin1String( "--verbose" )
+         || arg == QLatin1String( "--no-python" ) )
+    {
+      // ignore these arguments
+      continue;
+    }
     if ( arg == QLatin1String( "--help" ) || arg == QLatin1String( "-h" ) )
     {
       hasHelpArgument = true;
       break;
     }
+    else if ( arg == QLatin1String( "--version" ) || arg == QLatin1String( "-v" ) )
+    {
+      hasVersionArgument = true;
+      break;
+    }
+    break;
   }
+
   if ( argc == 1 || hasHelpArgument )
   {
     QgsProcessingExec::showUsage( QString( argv[ 0 ] ) );
+    return 0;
+  }
+  else if ( hasVersionArgument )
+  {
+    QgsProcessingExec::showVersionInformation();
     return 0;
   }
 

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -148,7 +148,7 @@ int main( int argc, char *argv[] )
   const QString command = args.value( 1 );
   if ( args.size() == 1 || command == QLatin1String( "--help" ) || command == QLatin1String( "-h" ) )
   {
-    // a shortcut -- if we are showing usage information, we don't need to initialise
+    // a shortcut -- if we are showing usage information, we don't need to initialize
     // QgsApplication at all!
     QgsProcessingExec::showUsage( args.at( 0 ) );
     return 0;

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -297,11 +297,6 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
     listAlgorithms( useJson );
     return 0;
   }
-  else if ( command == QLatin1String( "--version" ) || command == QLatin1String( "-v" ) )
-  {
-    std::cout << QgsCommandLineUtils::allVersions().toStdString();
-    return 0;
-  }
   else if ( command == QLatin1String( "help" ) )
   {
     if ( args.size() < 3 )
@@ -526,6 +521,11 @@ void QgsProcessingExec::showUsage( const QString &appName )
       << "\t\t\tWhen passing parameters as a JSON object from STDIN, these extra arguments can be provided as an \"ellipsoid\" and a \"project_path\" key respectively.\n";
 
   std::cout << msg.join( QString() ).toLocal8Bit().constData();
+}
+
+void QgsProcessingExec::showVersionInformation()
+{
+  std::cout << QgsCommandLineUtils::allVersions().toStdString();
 }
 
 void QgsProcessingExec::loadPlugins()

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -69,11 +69,11 @@ class QgsProcessingExec
   public:
 
     QgsProcessingExec();
-    int run( const QStringList &args );
+    int run( const QStringList &args, bool useJson, QgsProcessingContext::LogLevel logLevel, bool skipPython );
+    static void showUsage( const QString &appName );
 
   private:
 
-    void showUsage( const QString &appName );
     void loadPlugins();
     void listAlgorithms( bool useJson );
     void listPlugins( bool useJson, bool showLoaded );

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -71,6 +71,7 @@ class QgsProcessingExec
     QgsProcessingExec();
     int run( const QStringList &args, bool useJson, QgsProcessingContext::LogLevel logLevel, bool skipPython );
     static void showUsage( const QString &appName );
+    static void showVersionInformation();
 
   private:
 


### PR DESCRIPTION
Add a shortcut so that if we're just showing the usage documentation or version information, avoid the whole startup costs of QgsApplication.

Drops execution time from a couple of seconds to ~100ms.

Refs https://github.com/qgis/QGIS/issues/54563