### PR TITLE
Handle sql='' or sql="" as empty sql strings instead of '' / "" literals

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -71,6 +71,12 @@ QgsDataSourceUri::QgsDataSourceUri( const QString &u )
       // rest of line is a sql where clause
       skipBlanks( uri, i );
       mSql = uri.mid( i );
+
+      // handle empty sql specified by a empty '' or "" encapsulated value
+      // possibly we should be calling getValue here, but there's a very high risk of regressions
+      // if we change that now...
+      if ( mSql == QLatin1String( "''" ) || mSql == QLatin1String( "\"\"" ) )
+        mSql.clear();
       break;
     }
     else

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -201,6 +201,75 @@ void TestQgsDataSourceUri::checkparser_data()
       << "" // myparam
       << "public" // schema
       ;
+
+  QTest::newRow( "arcgis rest sql" )
+      << "crs='EPSG:2154' filter='' url='https://carto.isogeo.net/server/rest/services/scan_services_1/EMS_EFS_WMS_WFS/FeatureServer/2' table='' sql=abc='def'"
+      << "" // table
+      << "" // geometrycolumn
+      << "" // key
+      << false // estimatedmetadata
+      << "" // srid
+      << Qgis::WkbType::Unknown // type
+      << false // selectatid
+      << "" // service
+      << "" // user
+      << "" // password
+      << "" // authcfg
+      << "" // dbname
+      << "" // host
+      << "" // port
+      << "" // driver
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "abc='def'" // sql
+      << "" // myparam
+      << "public" // schema
+      ;
+
+  QTest::newRow( "arcgis rest empty sql" )
+      << "crs='EPSG:2154' filter='' url='https://carto.isogeo.net/server/rest/services/scan_services_1/EMS_EFS_WMS_WFS/FeatureServer/2' table='' sql=''"
+      << "" // table
+      << "" // geometrycolumn
+      << "" // key
+      << false // estimatedmetadata
+      << "" // srid
+      << Qgis::WkbType::Unknown // type
+      << false // selectatid
+      << "" // service
+      << "" // user
+      << "" // password
+      << "" // authcfg
+      << "" // dbname
+      << "" // host
+      << "" // port
+      << "" // driver
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "" // sql
+      << "" // myparam
+      << "public" // schema
+      ;
+
+  QTest::newRow( "arcgis rest empty sql 2" )
+      << "crs='EPSG:2154' filter='' url='https://carto.isogeo.net/server/rest/services/scan_services_1/EMS_EFS_WMS_WFS/FeatureServer/2' table='' sql=\"\""
+      << "" // table
+      << "" // geometrycolumn
+      << "" // key
+      << false // estimatedmetadata
+      << "" // srid
+      << Qgis::WkbType::Unknown // type
+      << false // selectatid
+      << "" // service
+      << "" // user
+      << "" // password
+      << "" // authcfg
+      << "" // dbname
+      << "" // host
+      << "" // port
+      << "" // driver
+      << QgsDataSourceUri::SslPrefer // sslmode
+      << "" // sql
+      << "" // myparam
+      << "public" // schema
+      ;
 }
 
 void TestQgsDataSourceUri::checkparser()


### PR DESCRIPTION
Fixes #53736
