### PR TITLE
QGraphicsItem::setGraphicsEffect takes ownership, using a unique_ptr is not appropriate

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -81,7 +81,7 @@ QgsLayoutItem::QgsLayoutItem( QgsLayout *layout, bool manageZValue )
   }
 
   // Setup layout effect
-  mEffect.reset( new QgsLayoutEffect() );
+  mEffect = new QgsLayoutEffect();
   if ( mLayout )
   {
     mEffect->setEnabled( mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagUseAdvancedEffects );
@@ -90,7 +90,7 @@ QgsLayoutItem::QgsLayoutItem( QgsLayout *layout, bool manageZValue )
       mEffect->setEnabled( flags & QgsLayoutRenderContext::FlagUseAdvancedEffects );
     } );
   }
-  setGraphicsEffect( mEffect.get() );
+  setGraphicsEffect( mEffect.data() );
 }
 
 QgsLayoutItem::~QgsLayoutItem()
@@ -1558,6 +1558,7 @@ void QgsLayoutItem::refreshBlendMode()
   }
 
   // Update the item effect to use the new blend mode
-  mEffect->setCompositionMode( blendMode );
+  if ( mEffect )
+    mEffect->setCompositionMode( blendMode );
 }
 

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -1316,7 +1316,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
 
     //! Composition blend mode for item
     QPainter::CompositionMode mBlendMode = QPainter::CompositionMode_SourceOver;
-    std::unique_ptr< QgsLayoutEffect > mEffect;
+    QPointer< QgsLayoutEffect > mEffect;
 
     //! Item opacity, between 0 and 1
     double mOpacity = 1.0;


### PR DESCRIPTION
Refs #54012

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
