### PR TITLE
Fix QgsField::ConfigurationFlag::None causes syntax error when starting PyQGIS

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1214,6 +1214,16 @@ Qgis.SublayerPromptMode.__doc__ = "Specifies how to handle layer sources with mu
 # --
 Qgis.SublayerPromptMode.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.FieldConfigurationFlag.NoFlag.__doc__ = "No flag is defined"
+Qgis.FieldConfigurationFlag.NotSearchable.__doc__ = "Defines if the field is searchable (used in the locator search for instance)"
+Qgis.FieldConfigurationFlag.HideFromWms.__doc__ = "Field is not available if layer is served as WMS from QGIS server"
+Qgis.FieldConfigurationFlag.HideFromWfs.__doc__ = "Field is not available if layer is served as WFS from QGIS server"
+Qgis.FieldConfigurationFlag.__doc__ = "Configuration flags for fields\nThese flags are meant to be user-configurable\nand are not describing any information from the data provider.\n\n.. note::\n\n   FieldConfigurationFlag are expressed in the negative forms so that default flags is NoFlag.\n\n.. versionadded:: 3.34\n\n" + '* ``NoFlag``: ' + Qgis.FieldConfigurationFlag.NoFlag.__doc__ + '\n' + '* ``NotSearchable``: ' + Qgis.FieldConfigurationFlag.NotSearchable.__doc__ + '\n' + '* ``HideFromWms``: ' + Qgis.FieldConfigurationFlag.HideFromWms.__doc__ + '\n' + '* ``HideFromWfs``: ' + Qgis.FieldConfigurationFlag.HideFromWfs.__doc__
+# --
+Qgis.FieldConfigurationFlag.baseClass = Qgis
+Qgis.FieldConfigurationFlags.baseClass = Qgis
+FieldConfigurationFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.FieldMetadataProperty.GeometryCrs.__doc__ = "Available for geometry field types with a specific associated coordinate reference system (as a QgsCoordinateReferenceSystem value)"
 Qgis.FieldMetadataProperty.GeometryWkbType.__doc__ = "Available for geometry field types which accept geometries of a specific WKB type only (as a QgsWkbTypes.Type value)"
 Qgis.FieldMetadataProperty.CustomProperty.__doc__ = "Starting point for custom user set properties"

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -706,6 +706,17 @@ The development version
       NeverAskLoadAll,
     };
 
+    enum class FieldConfigurationFlag
+    {
+      NoFlag,
+      NotSearchable,
+      HideFromWms,
+      HideFromWfs,
+    };
+
+    typedef QFlags<Qgis::FieldConfigurationFlag> FieldConfigurationFlags;
+
+
     enum class FieldMetadataProperty
     {
       GeometryCrs,
@@ -2427,6 +2438,8 @@ QFlags<Qgis::TiledSceneProviderCapability> operator|(Qgis::TiledSceneProviderCap
 QFlags<Qgis::TiledSceneRequestFlag> operator|(Qgis::TiledSceneRequestFlag f1, QFlags<Qgis::TiledSceneRequestFlag> f2);
 
 QFlags<Qgis::TiledSceneRendererFlag> operator|(Qgis::TiledSceneRendererFlag f1, QFlags<Qgis::TiledSceneRendererFlag> f2);
+
+QFlags<Qgis::FieldConfigurationFlag> operator|(Qgis::FieldConfigurationFlag f1, QFlags<Qgis::FieldConfigurationFlag> f2);
 
 
 

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -34,16 +34,6 @@ length, and if applicable, precision.
 
   public:
 
-    enum class ConfigurationFlag
-    {
-      None,
-      NotSearchable,
-      HideFromWms,
-      HideFromWfs,
-    };
-    typedef QFlags<QgsField::ConfigurationFlag> ConfigurationFlags;
-
-
     QgsField( const QString &name = QString(),
               QVariant::Type type = QVariant::Invalid,
               const QString &typeName = QString(),
@@ -351,18 +341,22 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. versionadded:: 3.0
 %End
 
-    QgsField::ConfigurationFlags configurationFlags() const;
+    Qgis::FieldConfigurationFlags configurationFlags() const;
 %Docstring
-Returns the Flags for the field (searchable, …)
+Returns the Flags for the field (searchable, …).
 
-.. versionadded:: 3.16
+.. seealso:: :py:func:`setConfigurationFlags`
+
+.. versionadded:: 3.34
 %End
 
-    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags );
+    void setConfigurationFlags( Qgis::FieldConfigurationFlags flags );
 %Docstring
-Sets the Flags for the field (searchable, …)
+Sets the Flags for the field (searchable, …).
 
-.. versionadded:: 3.16
+.. seealso:: :py:func:`configurationFlags`
+
+.. versionadded:: 3.34
 %End
 
     QString displayString( const QVariant &v ) const;
@@ -370,7 +364,7 @@ Sets the Flags for the field (searchable, …)
 Formats string for display
 %End
 
-    static QString readableConfigurationFlag( QgsField::ConfigurationFlag flag );
+    static QString readableConfigurationFlag( Qgis::FieldConfigurationFlag flag );
 %Docstring
 Returns the readable and translated value of the configuration flag
 
@@ -502,9 +496,6 @@ be handled during a split operation.
 
 
 }; // class QgsField
-
-
-QFlags<QgsField::ConfigurationFlag> operator|(QgsField::ConfigurationFlag f1, QFlags<QgsField::ConfigurationFlag> f2);
 
 
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -2391,8 +2391,30 @@ can also be set. Setting an empty expression will clear any existing expression 
 .. versionadded:: 3.0
 %End
 
+    void setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags );
+%Docstring
+Sets the configuration flags of the field at given index
 
+.. seealso:: :py:func:`QgsField.configurationFlags`
 
+.. versionadded:: 3.16
+%End
+
+    void setFieldConfigurationFlag( int index, Qgis::FieldConfigurationFlag flag, bool active );
+%Docstring
+Sets the given configuration ``flag`` for the field at given ``index`` to be ``active`` or not.
+
+.. versionadded:: 3.16
+%End
+
+    Qgis::FieldConfigurationFlags fieldConfigurationFlags( int index ) const;
+%Docstring
+Returns the configuration flags of the field at given index
+
+.. seealso:: :py:func:`QgsField.setConfigurationFlags`
+
+.. versionadded:: 3.16
+%End
 
     void setEditorWidgetSetup( int index, const QgsEditorWidgetSetup &setup );
 %Docstring

--- a/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
+++ b/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
@@ -105,7 +105,7 @@ QStringList QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string,
   QgsAttributeList subsetOfAttributes = qgis::setToList( mDispExpression.referencedAttributeIndexes( layer->fields() ) );
   for ( const QgsField &field : fields )
   {
-    if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::NotSearchable ) )
+    if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::NotSearchable ) )
       continue;
 
     if ( isRestricting && !field.name().startsWith( _fieldRestriction ) )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1176,6 +1176,32 @@ class CORE_EXPORT Qgis
     Q_ENUM( SublayerPromptMode )
 
     /**
+     * Configuration flags for fields
+     * These flags are meant to be user-configurable
+     * and are not describing any information from the data provider.
+     * \note FieldConfigurationFlag are expressed in the negative forms so that default flags is NoFlag.
+     * \since QGIS 3.34
+     */
+    enum class FieldConfigurationFlag : int
+    {
+      NoFlag = 0, //!< No flag is defined
+      NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
+      HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
+      HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
+    };
+    Q_ENUM( FieldConfigurationFlag )
+
+    /**
+     * Configuration flags for fields
+     * These flags are meant to be user-configurable
+     * and are not describing any information from the data provider.
+     * \note FieldConfigurationFlag are expressed in the negative forms so that default flags is NoFlag.
+     * \since QGIS 3.34
+     */
+    Q_DECLARE_FLAGS( FieldConfigurationFlags, FieldConfigurationFlag )
+    Q_FLAG( FieldConfigurationFlags )
+
+    /**
      * Standard field metadata values.
      *
      * \since QGIS 3.30
@@ -4126,6 +4152,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorTileProviderCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::TiledSceneProviderCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::TiledSceneRequestFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::TiledSceneRendererFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FieldConfigurationFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -277,12 +277,12 @@ void QgsField::setAlias( const QString &alias )
   d->alias = alias;
 }
 
-QgsField::ConfigurationFlags QgsField::configurationFlags() const
+Qgis::FieldConfigurationFlags QgsField::configurationFlags() const
 {
   return d->flags;
 }
 
-void QgsField::setConfigurationFlags( QgsField::ConfigurationFlags flags )
+void QgsField::setConfigurationFlags( Qgis::FieldConfigurationFlags flags )
 {
   d->flags = flags;
 }
@@ -427,17 +427,17 @@ QString QgsField::displayString( const QVariant &v ) const
   return v.toString();
 }
 
-QString QgsField::readableConfigurationFlag( QgsField::ConfigurationFlag flag )
+QString QgsField::readableConfigurationFlag( Qgis::FieldConfigurationFlag flag )
 {
   switch ( flag )
   {
-    case ConfigurationFlag::None:
+    case Qgis::FieldConfigurationFlag::NoFlag:
       return QObject::tr( "None" );
-    case ConfigurationFlag::NotSearchable:
+    case Qgis::FieldConfigurationFlag::NotSearchable:
       return QObject::tr( "Not searchable" );
-    case ConfigurationFlag::HideFromWms:
+    case Qgis::FieldConfigurationFlag::HideFromWms:
       return QObject::tr( "Do not expose via WMS" );
-    case ConfigurationFlag::HideFromWfs:
+    case Qgis::FieldConfigurationFlag::HideFromWfs:
       return QObject::tr( "Do not expose via WFS" );
   }
   return QString();

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -63,29 +63,10 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( QString alias READ alias WRITE setAlias )
     Q_PROPERTY( QgsDefaultValue defaultValueDefinition READ defaultValueDefinition WRITE setDefaultValueDefinition )
     Q_PROPERTY( QgsFieldConstraints constraints READ constraints WRITE setConstraints )
-    Q_PROPERTY( ConfigurationFlags configurationFlags READ configurationFlags WRITE setConfigurationFlags )
+    Q_PROPERTY( Qgis::FieldConfigurationFlags configurationFlags READ configurationFlags WRITE setConfigurationFlags )
     Q_PROPERTY( bool isReadOnly READ isReadOnly WRITE setReadOnly )
 
-
   public:
-
-    /**
-       * Configuration flags for fields
-       * These flags are meant to be user-configurable
-       * and are not describing any information from the data provider.
-       * \note Flags are expressed in the negative forms so that default flags is None.
-       * \since QGIS 3.16
-       */
-    enum class ConfigurationFlag : int
-    {
-      None = 0, //!< No flag is defined
-      NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
-      HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
-      HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
-    };
-    Q_ENUM( ConfigurationFlag )
-    Q_DECLARE_FLAGS( ConfigurationFlags, ConfigurationFlag )
-    Q_FLAG( ConfigurationFlags )
 
     /**
      * Constructor. Constructs a new QgsField object.
@@ -372,16 +353,18 @@ class CORE_EXPORT QgsField
     void setAlias( const QString &alias );
 
     /**
-     * Returns the Flags for the field (searchable, …)
-     * \since QGIS 3.16
+     * Returns the Flags for the field (searchable, …).
+     * \see setConfigurationFlags()
+     * \since QGIS 3.34
      */
-    QgsField::ConfigurationFlags configurationFlags() const;
+    Qgis::FieldConfigurationFlags configurationFlags() const;
 
     /**
-     * Sets the Flags for the field (searchable, …)
-     * \since QGIS 3.16
+     * Sets the Flags for the field (searchable, …).
+     * \see configurationFlags()
+     * \since QGIS 3.34
      */
-    void setConfigurationFlags( QgsField::ConfigurationFlags configurationFlags );
+    void setConfigurationFlags( Qgis::FieldConfigurationFlags flags );
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;
@@ -390,7 +373,7 @@ class CORE_EXPORT QgsField
      * Returns the readable and translated value of the configuration flag
      * \since QGIS 3.16
      */
-    static QString readableConfigurationFlag( QgsField::ConfigurationFlag flag );
+    static QString readableConfigurationFlag( Qgis::FieldConfigurationFlag flag );
 
 #ifndef SIP_RUN
 
@@ -544,8 +527,6 @@ class CORE_EXPORT QgsField
 }; // class QgsField
 
 Q_DECLARE_METATYPE( QgsField )
-
-Q_DECLARE_OPERATORS_FOR_FLAGS( QgsField::ConfigurationFlags )
 
 //! Writes the field to stream out. QGIS version compatibility is not guaranteed.
 CORE_EXPORT QDataStream &operator<<( QDataStream &out, const QgsField &field );

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -129,7 +129,7 @@ class QgsFieldPrivate : public QSharedData
     QString alias;
 
     //! Flags for the field (searchable, …)
-    QgsField::ConfigurationFlags flags = QgsField::ConfigurationFlag::None;
+    Qgis::FieldConfigurationFlags flags = Qgis::FieldConfigurationFlag::NoFlag;
 
     //! Default value
     QgsDefaultValue defaultValueDefinition;

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2504,7 +2504,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
       QString fieldName = fieldConfigElement.attribute( QStringLiteral( "name" ) );
 
       if ( categories.testFlag( Fields ) )
-        mFieldConfigurationFlags[fieldName] = qgsFlagKeysToValue( fieldConfigElement.attribute( QStringLiteral( "configurationFlags" ) ), QgsField::ConfigurationFlag::None );
+        mFieldConfigurationFlags[fieldName] = qgsFlagKeysToValue( fieldConfigElement.attribute( QStringLiteral( "configurationFlags" ) ), Qgis::FieldConfigurationFlag::NoFlag );
 
       // Load editor widget configuration
       if ( categories.testFlag( Forms ) )
@@ -2527,10 +2527,10 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
   // Attributes excluded from WMS and WFS
   if ( categories.testFlag( Fields ) )
   {
-    const QList<QPair<QString, QgsField::ConfigurationFlag>> legacyConfig
+    const QList<QPair<QString, Qgis::FieldConfigurationFlag>> legacyConfig
     {
-      qMakePair( QStringLiteral( "excludeAttributesWMS" ), QgsField::ConfigurationFlag::HideFromWms ),
-      qMakePair( QStringLiteral( "excludeAttributesWFS" ), QgsField::ConfigurationFlag::HideFromWfs )
+      qMakePair( QStringLiteral( "excludeAttributesWMS" ), Qgis::FieldConfigurationFlag::HideFromWms ),
+      qMakePair( QStringLiteral( "excludeAttributesWFS" ), Qgis::FieldConfigurationFlag::HideFromWfs )
     };
     for ( const auto &config : legacyConfig )
     {
@@ -3440,10 +3440,10 @@ QSet<QString> QgsVectorLayer::excludeAttributesWms() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   QSet<QString> excludeList;
-  QMap< QString, QgsField::ConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
+  QMap< QString, Qgis::FieldConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
   for ( ; flagsIt != mFieldConfigurationFlags.constEnd(); ++flagsIt )
   {
-    if ( flagsIt->testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
+    if ( flagsIt->testFlag( Qgis::FieldConfigurationFlag::HideFromWms ) )
     {
       excludeList << flagsIt.key();
     }
@@ -3455,10 +3455,10 @@ void QgsVectorLayer::setExcludeAttributesWms( const QSet<QString> &att )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  QMap< QString, QgsField::ConfigurationFlags >::iterator flagsIt = mFieldConfigurationFlags.begin();
+  QMap< QString, Qgis::FieldConfigurationFlags >::iterator flagsIt = mFieldConfigurationFlags.begin();
   for ( ; flagsIt != mFieldConfigurationFlags.end(); ++flagsIt )
   {
-    flagsIt->setFlag( QgsField::ConfigurationFlag::HideFromWms, att.contains( flagsIt.key() ) );
+    flagsIt->setFlag( Qgis::FieldConfigurationFlag::HideFromWms, att.contains( flagsIt.key() ) );
   }
   updateFields();
 }
@@ -3468,10 +3468,10 @@ QSet<QString> QgsVectorLayer::excludeAttributesWfs() const
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   QSet<QString> excludeList;
-  QMap< QString, QgsField::ConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
+  QMap< QString, Qgis::FieldConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
   for ( ; flagsIt != mFieldConfigurationFlags.constEnd(); ++flagsIt )
   {
-    if ( flagsIt->testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+    if ( flagsIt->testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
     {
       excludeList << flagsIt.key();
     }
@@ -3483,10 +3483,10 @@ void QgsVectorLayer::setExcludeAttributesWfs( const QSet<QString> &att )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  QMap< QString, QgsField::ConfigurationFlags >::iterator flagsIt = mFieldConfigurationFlags.begin();
+  QMap< QString, Qgis::FieldConfigurationFlags >::iterator flagsIt = mFieldConfigurationFlags.begin();
   for ( ; flagsIt != mFieldConfigurationFlags.end(); ++flagsIt )
   {
-    flagsIt->setFlag( QgsField::ConfigurationFlag::HideFromWfs, att.contains( flagsIt.key() ) );
+    flagsIt->setFlag( Qgis::FieldConfigurationFlag::HideFromWfs, att.contains( flagsIt.key() ) );
   }
   updateFields();
 }
@@ -4308,7 +4308,7 @@ void QgsVectorLayer::updateFields()
   }
 
   // Update configuration flags
-  QMap< QString, QgsField::ConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
+  QMap< QString, Qgis::FieldConfigurationFlags >::const_iterator flagsIt = mFieldConfigurationFlags.constBegin();
   for ( ; flagsIt != mFieldConfigurationFlags.constEnd(); ++flagsIt )
   {
     int index = mFields.lookupField( flagsIt.key() );
@@ -6160,7 +6160,7 @@ void QgsVectorLayer::setConstraintExpression( int index, const QString &expressi
   updateFields();
 }
 
-void QgsVectorLayer::setFieldConfigurationFlags( int index, QgsField::ConfigurationFlags flags )
+void QgsVectorLayer::setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
@@ -6171,23 +6171,23 @@ void QgsVectorLayer::setFieldConfigurationFlags( int index, QgsField::Configurat
   updateFields();
 }
 
-void QgsVectorLayer::setFieldConfigurationFlag( int index, QgsField::ConfigurationFlag flag, bool active )
+void QgsVectorLayer::setFieldConfigurationFlag( int index, Qgis::FieldConfigurationFlag flag, bool active )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   if ( index < 0 || index >= mFields.count() )
     return;
-  QgsField::ConfigurationFlags flags = mFields.at( index ).configurationFlags();
+  Qgis::FieldConfigurationFlags flags = mFields.at( index ).configurationFlags();
   flags.setFlag( flag, active );
   setFieldConfigurationFlags( index, flags );
 }
 
-QgsField::ConfigurationFlags QgsVectorLayer::fieldConfigurationFlags( int index ) const
+Qgis::FieldConfigurationFlags QgsVectorLayer::fieldConfigurationFlags( int index ) const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   if ( index < 0 || index >= mFields.count() )
-    return QgsField::ConfigurationFlag::None;
+    return Qgis::FieldConfigurationFlag::NoFlag;
 
   return mFields.at( index ).configurationFlags();
 }

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2242,7 +2242,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Sets the configuration flags of the field at given index
-     * \see QgsField::ConfigurationFlag
+     * \see QgsField::configurationFlags()
      * \since QGIS 3.16
      */
     void setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags ) SIP_SKIP;
@@ -2255,7 +2255,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Returns the configuration flags of the field at given index
-     * \see QgsField::ConfigurationFlag
+     * \see QgsField::setConfigurationFlags()
      * \since QGIS 3.16
      */
     Qgis::FieldConfigurationFlags fieldConfigurationFlags( int index ) const SIP_SKIP;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2245,20 +2245,20 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see QgsField::ConfigurationFlag
      * \since QGIS 3.16
      */
-    void setFieldConfigurationFlags( int index, QgsField::ConfigurationFlags flags ) SIP_SKIP;
+    void setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags ) SIP_SKIP;
 
     /**
      * Sets the given configuration \a flag for the field at given \a index to be \a active or not.
      * \since QGIS 3.16
      */
-    void setFieldConfigurationFlag( int index, QgsField::ConfigurationFlag flag, bool active ) SIP_SKIP;
+    void setFieldConfigurationFlag( int index, Qgis::FieldConfigurationFlag flag, bool active ) SIP_SKIP;
 
     /**
      * Returns the configuration flags of the field at given index
      * \see QgsField::ConfigurationFlag
      * \since QGIS 3.16
      */
-    QgsField::ConfigurationFlags fieldConfigurationFlags( int index ) const SIP_SKIP;
+    Qgis::FieldConfigurationFlags fieldConfigurationFlags( int index ) const SIP_SKIP;
 
     /**
      * \copydoc editorWidgetSetup
@@ -2993,7 +2993,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Map which stores expression constraints for fields. Value is a pair of expression/description.
     QMap< QString, QPair< QString, QString > > mFieldConstraintExpressions;
 
-    QMap< QString, QgsField::ConfigurationFlags > mFieldConfigurationFlags;
+    QMap< QString, Qgis::FieldConfigurationFlags > mFieldConfigurationFlags;
     QMap< QString, QgsEditorWidgetSetup > mFieldWidgetSetups;
 
     //! Holds the configuration for the edit form

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2245,20 +2245,20 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see QgsField::configurationFlags()
      * \since QGIS 3.16
      */
-    void setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags ) SIP_SKIP;
+    void setFieldConfigurationFlags( int index, Qgis::FieldConfigurationFlags flags );
 
     /**
      * Sets the given configuration \a flag for the field at given \a index to be \a active or not.
      * \since QGIS 3.16
      */
-    void setFieldConfigurationFlag( int index, Qgis::FieldConfigurationFlag flag, bool active ) SIP_SKIP;
+    void setFieldConfigurationFlag( int index, Qgis::FieldConfigurationFlag flag, bool active );
 
     /**
      * Returns the configuration flags of the field at given index
      * \see QgsField::setConfigurationFlags()
      * \since QGIS 3.16
      */
-    Qgis::FieldConfigurationFlags fieldConfigurationFlags( int index ) const SIP_SKIP;
+    Qgis::FieldConfigurationFlags fieldConfigurationFlags( int index ) const;
 
     /**
      * \copydoc editorWidgetSetup

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -258,10 +258,10 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
 
   // Flags
   QgsCheckableComboBox *cb = new QgsCheckableComboBox( mFieldsList );
-  const QList<QgsField::ConfigurationFlag> flagList = qgsEnumList<QgsField::ConfigurationFlag>();
-  for ( const QgsField::ConfigurationFlag flag : flagList )
+  const QList<Qgis::FieldConfigurationFlag> flagList = qgsEnumList<Qgis::FieldConfigurationFlag>();
+  for ( const Qgis::FieldConfigurationFlag flag : flagList )
   {
-    if ( flag == QgsField::ConfigurationFlag::None )
+    if ( flag == Qgis::FieldConfigurationFlag::NoFlag )
       continue;
 
     cb->addItemWithCheckState( QgsField::readableConfigurationFlag( flag ),
@@ -293,7 +293,7 @@ void QgsSourceFieldsProperties::apply()
   for ( int i = 0; i < mFieldsList->rowCount(); i++ )
   {
     const int idx = mFieldsList->item( i, AttrIdCol )->data( Qt::DisplayRole ).toInt();
-    QgsField::ConfigurationFlags flags = mLayer->fieldConfigurationFlags( idx );
+    Qgis::FieldConfigurationFlags flags = mLayer->fieldConfigurationFlags( idx );
 
     QgsCheckableComboBox *cb = qobject_cast<QgsCheckableComboBox *>( mFieldsList->cellWidget( i, AttrConfigurationFlagsCol ) );
     if ( cb )
@@ -302,7 +302,7 @@ void QgsSourceFieldsProperties::apply()
       for ( int r = 0; r < model->rowCount(); ++r )
       {
         const QModelIndex index = model->index( r, 0 );
-        const QgsField::ConfigurationFlag flag = model->data( index, Qt::UserRole ).value<QgsField::ConfigurationFlag>();
+        const Qgis::FieldConfigurationFlag flag = model->data( index, Qt::UserRole ).value<Qgis::FieldConfigurationFlag>();
         const bool active = model->data( index, Qt::CheckStateRole ).value<Qt::CheckState>() == Qt::Checked ? true : false;
         flags.setFlag( flag, active );
       }

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -464,7 +464,7 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
           const QgsFields &cFields { vl->fields() };
           for ( const QgsField &field : cFields )
           {
-            if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+            if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
             {
               ++fieldIdx;
               continue;

--- a/src/server/services/wfs/qgswfsdescribefeaturetypegml.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetypegml.cpp
@@ -197,7 +197,7 @@ void QgsWfsDescribeFeatureTypeGml::setSchemaLayer( QDomElement &parentElement, Q
   {
     const QgsField field = fields.at( idx );
     //skip attribute if excluded from WFS publication
-    if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+    if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
     {
       continue;
     }

--- a/src/server/services/wfs/qgswfsdescribefeaturetypejson.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetypejson.cpp
@@ -142,7 +142,7 @@ QJsonObject QgsWfsDescribeFeatureTypeJson::schemaLayerToJson( const QgsVectorLay
   {
     const QgsField field = fields.at( idx );
     //skip attribute if excluded from WFS publication
-    if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+    if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
     {
       continue;
     }

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -306,7 +306,7 @@ namespace QgsWfs
       {
         for ( const QgsField &field : fields )
         {
-          if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+          if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
           {
             int fieldNameIdx = fields.indexOf( field.name() );
             if ( fieldNameIdx > -1 && attrIndexes.contains( fieldNameIdx ) )

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -249,7 +249,7 @@ QgsFields QgsWfs3AbstractItemsHandler::publishedFields( const QgsVectorLayer *vL
   const QgsFields &fields = vLayer->fields();
   for ( const QgsField &field : fields )
   {
-    if ( !field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWfs ) )
+    if ( !field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWfs ) )
     {
       publishedAttributes.push_back( field.name() );
     }

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1692,7 +1692,7 @@ namespace QgsWms
           for ( int idx = 0; idx < layerFields.count(); ++idx )
           {
             QgsField field = layerFields.at( idx );
-            if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
+            if ( field.configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWms ) )
             {
               continue;
             }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2033,7 +2033,7 @@ namespace QgsWms
     }
 
     //skip attribute if it is explicitly excluded from WMS publication
-    if ( fields.at( attributeIndex ).configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
+    if ( fields.at( attributeIndex ).configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWms ) )
     {
       return;
     }
@@ -2863,7 +2863,7 @@ namespace QgsWms
     {
       QString attributeName = fields.at( i ).name();
       //skip attribute if it is explicitly excluded from WMS publication
-      if ( fields.at( i ).configurationFlags().testFlag( QgsField::ConfigurationFlag::HideFromWms ) )
+      if ( fields.at( i ).configurationFlags().testFlag( Qgis::FieldConfigurationFlag::HideFromWms ) )
       {
         continue;
       }

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -417,12 +417,12 @@ void TestQgsVectorLayer::testCopyPasteFieldConfiguration()
   QgsVectorLayer layer1( QStringLiteral( "Point?field=name:string" ), QStringLiteral( "layer1" ), QStringLiteral( "memory" ) );
   QVERIFY( layer1.isValid() );
   QVERIFY( layer1.editorWidgetSetup( 0 ).type().isEmpty() );
-  QCOMPARE( layer1.fieldConfigurationFlags( 0 ), QgsField::ConfigurationFlags() );
+  QCOMPARE( layer1.fieldConfigurationFlags( 0 ), Qgis::FieldConfigurationFlags() );
 
   layer1.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( "ValueMap", QVariantMap() ) );
   QCOMPARE( layer1.editorWidgetSetup( 0 ).type(), QStringLiteral( "ValueMap" ) );
-  layer1.setFieldConfigurationFlags( 0, QgsField::ConfigurationFlag::NotSearchable );
-  QCOMPARE( layer1.fieldConfigurationFlags( 0 ), QgsField::ConfigurationFlag::NotSearchable );
+  layer1.setFieldConfigurationFlags( 0, Qgis::FieldConfigurationFlag::NotSearchable );
+  QCOMPARE( layer1.fieldConfigurationFlags( 0 ), Qgis::FieldConfigurationFlag::NotSearchable );
 
   // export given categories, import all
   QString errorMsg;
@@ -434,11 +434,11 @@ void TestQgsVectorLayer::testCopyPasteFieldConfiguration()
   QgsVectorLayer layer2( QStringLiteral( "Point?field=name:string" ), QStringLiteral( "layer2" ), QStringLiteral( "memory" ) );
   QVERIFY( layer2.isValid() );
   QVERIFY( layer2.editorWidgetSetup( 0 ).type().isEmpty() );
-  QCOMPARE( layer2.fieldConfigurationFlags( 0 ), QgsField::ConfigurationFlags() );
+  QCOMPARE( layer2.fieldConfigurationFlags( 0 ), Qgis::FieldConfigurationFlags() );
 
   QVERIFY( layer2.importNamedStyle( doc, errorMsg ) );
   QCOMPARE( layer2.editorWidgetSetup( 0 ).type(), categories.testFlag( QgsMapLayer::Forms ) ? QStringLiteral( "ValueMap" ) : QString( "" ) );
-  QCOMPARE( layer2.fieldConfigurationFlags( 0 ), categories.testFlag( QgsMapLayer::Fields ) ? QgsField::ConfigurationFlag::NotSearchable : QgsField::ConfigurationFlags() );
+  QCOMPARE( layer2.fieldConfigurationFlags( 0 ), categories.testFlag( QgsMapLayer::Fields ) ? Qgis::FieldConfigurationFlag::NotSearchable : Qgis::FieldConfigurationFlags() );
 
   // export all, import given categories
   QDomDocument doc2( QStringLiteral( "qgis" ) );
@@ -448,11 +448,11 @@ void TestQgsVectorLayer::testCopyPasteFieldConfiguration()
   QgsVectorLayer layer3( QStringLiteral( "Point?field=name:string" ), QStringLiteral( "layer3" ), QStringLiteral( "memory" ) );
   QVERIFY( layer3.isValid() );
   QVERIFY( layer3.editorWidgetSetup( 0 ).type().isEmpty() );
-  QCOMPARE( layer3.fieldConfigurationFlags( 0 ), QgsField::ConfigurationFlags() );
+  QCOMPARE( layer3.fieldConfigurationFlags( 0 ), Qgis::FieldConfigurationFlags() );
 
   QVERIFY( layer3.importNamedStyle( doc2, errorMsg, categories ) );
   QCOMPARE( layer3.editorWidgetSetup( 0 ).type(), categories.testFlag( QgsMapLayer::Forms ) ? QStringLiteral( "ValueMap" ) : QString( "" ) );
-  QCOMPARE( layer3.fieldConfigurationFlags( 0 ), categories.testFlag( QgsMapLayer::Fields ) ? QgsField::ConfigurationFlag::NotSearchable : QgsField::ConfigurationFlags() );
+  QCOMPARE( layer3.fieldConfigurationFlags( 0 ), categories.testFlag( QgsMapLayer::Fields ) ? Qgis::FieldConfigurationFlag::NotSearchable : Qgis::FieldConfigurationFlags() );
 }
 
 void TestQgsVectorLayer::testFieldExpression()


### PR DESCRIPTION
We can't use `None` as a keyword exposed to python, it's reserved. Also move the enum to Qgis before making it part of public stable API.
