### PR TITLE
Improve layout clipping test

### DIFF
--- a/tests/src/python/test_qgslayoutmapitemclippingsettings.py
+++ b/tests/src/python/test_qgslayoutmapitemclippingsettings.py
@@ -149,7 +149,7 @@ class TestQgsLayoutItemMapItemClipPathSettings(QgisTestCase):
     def testClippedMapExtent(self):
         # - we position a map and a triangle in a layout at specific layout/scene coordinates
         # - the map is zoomed to a specific extent, defined in map/crs coordinates
-        # - we use the triangle to clip the map in the layout 
+        # - we use the triangle to clip the map in the layout
         #   and test if the triangle is converted to the correct clipped extent in map/crs coordinates
         p = QgsProject()
         l = QgsPrintLayout(p)
@@ -172,7 +172,7 @@ class TestQgsLayoutItemMapItemClipPathSettings(QgisTestCase):
     def testToMapClippingRegion(self):
         # - we position a map and a triangle in a layout at specific layout/scene coordinates
         # - the map is zoomed to a specific extent, defined in map/crs coordinates
-        # - we use the triangle to clip the map in the layout 
+        # - we use the triangle to clip the map in the layout
         #   and test if the triangle is converted to the correct clipping shape in map/crs coordinates
         p = QgsProject()
         l = QgsPrintLayout(p)

--- a/tests/src/python/test_qgslayoutmapitemclippingsettings.py
+++ b/tests/src/python/test_qgslayoutmapitemclippingsettings.py
@@ -147,13 +147,17 @@ class TestQgsLayoutItemMapItemClipPathSettings(QgisTestCase):
         self.assertEqual(map2.itemClippingSettings().sourceItem(), shape2)
 
     def testClippedMapExtent(self):
+        # - we position a map and a triangle in a layout at specific layout/scene coordinates
+        # - the map is zoomed to a specific extent, defined in map/crs coordinates
+        # - we use the triangle to clip the map in the layout 
+        #   and test if the triangle is converted to the correct clipped extent in map/crs coordinates
         p = QgsProject()
         l = QgsPrintLayout(p)
         map = QgsLayoutItemMap(l)
         shape = QgsLayoutItemShape(l)
         l.addLayoutItem(map)
         map.attemptSetSceneRect(QRectF(10, 20, 100, 80))
-        map.zoomToExtent(QgsRectangle(100, 200, 50, 40))
+        map.zoomToExtent(QgsRectangle(50, 40, 100, 200))
         l.addLayoutItem(shape)
         shape.setShapeType(QgsLayoutItemShape.Triangle)
         shape.attemptSetSceneRect(QRectF(20, 30, 70, 50))
@@ -166,6 +170,10 @@ class TestQgsLayoutItemMapItemClipPathSettings(QgisTestCase):
         self.assertEqual(geom.asWkt(), 'Polygon ((-5 80, 135 80, 65 180, -5 80))')
 
     def testToMapClippingRegion(self):
+        # - we position a map and a triangle in a layout at specific layout/scene coordinates
+        # - the map is zoomed to a specific extent, defined in map/crs coordinates
+        # - we use the triangle to clip the map in the layout 
+        #   and test if the triangle is converted to the correct clipping shape in map/crs coordinates
         p = QgsProject()
         l = QgsPrintLayout(p)
         p.layoutManager().addLayout(l)
@@ -173,7 +181,7 @@ class TestQgsLayoutItemMapItemClipPathSettings(QgisTestCase):
         shape = QgsLayoutItemShape(l)
         l.addLayoutItem(map)
         map.attemptSetSceneRect(QRectF(10, 20, 100, 80))
-        map.zoomToExtent(QgsRectangle(100, 200, 50, 40))
+        map.zoomToExtent(QgsRectangle(50, 40, 100, 200))
         l.addLayoutItem(shape)
         shape.setShapeType(QgsLayoutItemShape.Triangle)
         shape.attemptSetSceneRect(QRectF(20, 30, 70, 50))


### PR DESCRIPTION
- Avoid QgsRectangle's normalisation (the min/max values were mismatched)
- Add helpful commentary to describe what the tests are testing and how

Found when trying to debug failing tests with @strk on https://github.com/qgis/QGIS/pull/54646

@nyalldawson could you take a look? You added this in https://github.com/qgis/QGIS/pull/37990