### PR TITLE
More info about ISO 32000 in GeoPDF Exporter abstract class

### DIFF
--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        * TRUE if ISO32000 extension format georeferencing should be used.
        *
        * This is a recommended setting which results in Geospatial PDF files
-       * that uses PDF 2.0 Geospatial Features (ISO 32000-2:2017).
+       * that use PDF 2.0 Geospatial Features (ISO 32000-2:2017).
        * Compatible with the built-in Acrobat geospatial tools
        */
       bool useIso32000ExtensionFormatGeoreferencing = true;

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -228,10 +228,11 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
       QgsAbstractMetadataBase::KeywordMap keywords;
 
       /**
-       * TRUE if ISO3200 extension format georeferencing should be used.
+       * TRUE if ISO32000 extension format georeferencing should be used.
        *
-       * This is a recommended setting which results in Geospatial PDF files compatible
-       * with the built-in Acrobat geospatial tools.
+       * This is a recommended setting which results in Geospatial PDF files
+       * that uses PDF 2.0 Geospatial Features (ISO 32000-2:2017).
+       * Compatible with the built-in Acrobat geospatial tools
        */
       bool useIso32000ExtensionFormatGeoreferencing = true;
 


### PR DESCRIPTION
## Description

Fixing typo and adding more information in comment about ISO 32000 option, present in abstract base class for GeoPDF exporters.
