### PR TITLE
Ensure that we always call prepareGeometryChange BEFORE changing properties which effect the boundingRect of a layout item

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -232,12 +232,9 @@ Returns the label font color.
 
     virtual QRectF boundingRect() const;
 
-
     virtual void setFrameEnabled( bool drawFrame );
 
-
     virtual void setFrameStrokeWidth( QgsLayoutMeasurement strokeWidth );
-
 
 
     QgsTextFormat textFormat() const;

--- a/src/core/layout/qgslayoutitemlabel.cpp
+++ b/src/core/layout/qgslayoutitemlabel.cpp
@@ -20,7 +20,6 @@
 #include "qgslayoututils.h"
 #include "qgslayoutmodel.h"
 #include "qgsexpression.h"
-#include "qgsnetworkaccessmanager.h"
 #include "qgsvectorlayer.h"
 #include "qgsdistancearea.h"
 #include "qgsfontutils.h"
@@ -58,6 +57,11 @@ QgsLayoutItemLabel::QgsLayoutItemLabel( QgsLayout *layout )
   //default to a 10 point font size
   mFormat.setSize( 10 );
   mFormat.setSizeUnit( Qgis::RenderUnit::Points );
+
+  connect( this, &QgsLayoutItem::sizePositionChanged, this, [ = ]
+  {
+    updateBoundingRect();
+  } );
 
   //default to no background
   setBackgroundEnabled( false );
@@ -219,6 +223,29 @@ void QgsLayoutItemLabel::refreshExpressionContext()
   update();
 }
 
+void QgsLayoutItemLabel::updateBoundingRect()
+{
+  QRectF rectangle = rect();
+  const double frameExtension = frameEnabled() ? pen().widthF() / 2.0 : 0.0;
+  if ( frameExtension > 0 )
+    rectangle.adjust( -frameExtension, -frameExtension, frameExtension, frameExtension );
+
+  if ( mMarginX < 0 )
+  {
+    rectangle.adjust( mMarginX, 0, -mMarginX, 0 );
+  }
+  if ( mMarginY < 0 )
+  {
+    rectangle.adjust( 0, mMarginY, 0, -mMarginY );
+  }
+
+  if ( rectangle != mCurrentRectangle )
+  {
+    prepareGeometryChange();
+    mCurrentRectangle = rectangle;
+  }
+}
+
 QString QgsLayoutItemLabel::currentText() const
 {
   QString displayText = mText;
@@ -275,19 +302,19 @@ void QgsLayoutItemLabel::setMargin( const double m )
 {
   mMarginX = m;
   mMarginY = m;
-  prepareGeometryChange();
+  updateBoundingRect();
 }
 
 void QgsLayoutItemLabel::setMarginX( const double margin )
 {
   mMarginX = margin;
-  prepareGeometryChange();
+  updateBoundingRect();
 }
 
 void QgsLayoutItemLabel::setMarginY( const double margin )
 {
   mMarginY = margin;
-  prepareGeometryChange();
+  updateBoundingRect();
 }
 
 void QgsLayoutItemLabel::adjustSizeToText()
@@ -413,6 +440,8 @@ bool QgsLayoutItemLabel::readPropertiesFromElement( const QDomElement &itemElem,
     }
   }
 
+  updateBoundingRect();
+
   return true;
 }
 
@@ -452,32 +481,19 @@ QString QgsLayoutItemLabel::displayName() const
 
 QRectF QgsLayoutItemLabel::boundingRect() const
 {
-  QRectF rectangle = rect();
-  const double penWidth = frameEnabled() ? ( pen().widthF() / 2.0 ) : 0;
-  rectangle.adjust( -penWidth, -penWidth, penWidth, penWidth );
-
-  if ( mMarginX < 0 )
-  {
-    rectangle.adjust( mMarginX, 0, -mMarginX, 0 );
-  }
-  if ( mMarginY < 0 )
-  {
-    rectangle.adjust( 0, mMarginY, 0, -mMarginY );
-  }
-
-  return rectangle;
+  return mCurrentRectangle;
 }
 
-void QgsLayoutItemLabel::setFrameEnabled( const bool drawFrame )
+void QgsLayoutItemLabel::setFrameEnabled( bool drawFrame )
 {
   QgsLayoutItem::setFrameEnabled( drawFrame );
-  prepareGeometryChange();
+  updateBoundingRect();
 }
 
-void QgsLayoutItemLabel::setFrameStrokeWidth( const QgsLayoutMeasurement strokeWidth )
+void QgsLayoutItemLabel::setFrameStrokeWidth( QgsLayoutMeasurement strokeWidth )
 {
   QgsLayoutItem::setFrameStrokeWidth( strokeWidth );
-  prepareGeometryChange();
+  updateBoundingRect();
 }
 
 void QgsLayoutItemLabel::refresh()

--- a/src/core/layout/qgslayoutitemlabel.h
+++ b/src/core/layout/qgslayoutitemlabel.h
@@ -211,13 +211,8 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     // In case of negative margins, the bounding rect may be larger than the
     // label's frame
     QRectF boundingRect() const override;
-
-    // Reimplemented to call prepareGeometryChange after toggling frame
     void setFrameEnabled( bool drawFrame ) override;
-
-    // Reimplemented to call prepareGeometryChange after changing stroke width
     void setFrameStrokeWidth( QgsLayoutMeasurement strokeWidth ) override;
-
 
     /**
      * Returns the text format used for drawing text in the label.
@@ -253,6 +248,8 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
   private slots:
 
     void refreshExpressionContext();
+    //! Updates the bounding rect of this item
+    void updateBoundingRect();
 
   private:
     bool mFirstRender = true;
@@ -296,6 +293,8 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
     QString createStylesheet() const;
 
     std::unique_ptr< QgsDistanceArea > mDistanceArea;
+
+    QRectF mCurrentRectangle;
 
     friend class QgsLayoutItemHtml;
 };

--- a/src/core/layout/qgslayoutitemnodeitem.cpp
+++ b/src/core/layout/qgslayoutitemnodeitem.cpp
@@ -344,10 +344,10 @@ void QgsLayoutNodesItem::updateBoundingRect()
 {
   QRectF br = rect();
   br.adjust( -mMaxSymbolBleed, -mMaxSymbolBleed, mMaxSymbolBleed, mMaxSymbolBleed );
+  prepareGeometryChange();
   mCurrentRectangle = br;
 
   // update
-  prepareGeometryChange();
   update();
 }
 

--- a/src/core/layout/qgslayoutitempage.cpp
+++ b/src/core/layout/qgslayoutitempage.cpp
@@ -38,8 +38,8 @@ QgsLayoutItemPage::QgsLayoutItemPage( QgsLayout *layout )
 
   connect( this, &QgsLayoutItem::sizePositionChanged, this, [ = ]
   {
-    mBoundingRect = QRectF();
     prepareGeometryChange();
+    mBoundingRect = QRectF();
   } );
 
   const QFont font;

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -467,10 +467,10 @@ void QgsLayoutItemPolyline::updateBoundingRect()
     margin += 0.5 * mArrowHeadWidth;
   }
   br.adjust( -margin, -margin, margin, margin );
+  prepareGeometryChange();
   mCurrentRectangle = br;
 
   // update
-  prepareGeometryChange();
   update();
 }
 


### PR DESCRIPTION
Refs #52079, but does not fix that -- the underlying bug is also triggered by the graphicEffect set on QgsLayoutItem (see https://bugreports.qt.io/browse/QTBUG-58501)

Refs https://bugreports.qt.io/browse/QTBUG-18021
