### PR TITLE
Don't crash when changeAttributeValues is used with invalid field index

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -675,6 +675,10 @@ bool QgsMemoryProvider::changeAttributeValues( const QgsChangedAttributesMap &at
     // Break on errors
     for ( QgsAttributeMap::const_iterator it2 = attrs.constBegin(); it2 != attrs.constEnd(); ++it2 )
     {
+      const int fieldIndex = it2.key();
+      if ( fieldIndex < 0 || fieldIndex >= mFields.count() )
+        continue;
+
       QVariant attrValue = it2.value();
       // Check attribute conversion
       const bool conversionError { ! QgsVariantUtils::isNull( attrValue )

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -629,6 +629,22 @@ class TestPyQgsMemoryProvider(QgisTestCase, ProviderTestCase):
             self.assertEqual(layer.fields()[i].length(), fields[i].length())
             self.assertEqual(layer.fields()[i].precision(), fields[i].precision())
 
+    def testChangeAttributeValuesInvalidFieldIndex(self):
+        """
+        Test there's no crash when changeAttributeValues is called with a non existing field index  (https://github.com/qgis/QGIS/issues/54817)
+        """
+        layer = QgsVectorLayer(
+            'Point?crs=epsg:4326&index=yes&field=pk:integer', 'test', 'memory')
+        provider = layer.dataProvider()
+        f = QgsFeature()
+        f.setAttributes([0])
+        self.assertTrue(provider.addFeatures([f]))
+
+        saved_feature = next(provider.getFeatures())
+        self.assertTrue(provider.changeAttributeValues({saved_feature.id(): {-1: 42}}))
+        self.assertTrue(provider.changeAttributeValues({saved_feature.id(): {42: 42}}))
+        self.assertTrue(provider.changeAttributeValues({saved_feature.id(): {'fortytwo': 42}}))
+
     def testAddChangeFeatureConvertAttribute(self):
         """
         Test add features with attribute values which require conversion


### PR DESCRIPTION
## Description
fix #54817 

entries with invalid field index are now ignored (matches ogr provider behavior)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
