### PR TITLE
FEATURE: Source select configure from uri

### DIFF
--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -143,6 +143,13 @@ Set the data source specification.
 .. versionadded:: 3.0
 %End
 
+    void setUri( const QString &uri );
+%Docstring
+Set the data source specification.
+
+.. versionadded:: 3.38
+%End
+
     QgsDataSourceUri uri() const;
 %Docstring
 Gets the data source specification.

--- a/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -55,6 +55,7 @@ of feature and attribute information from a spatial datasource.
       CreateLabeling,
       ReloadData,
       FeatureSymbology,
+      ConfigureSourceSelectFromUri,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;

--- a/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -55,7 +55,6 @@ of feature and attribute information from a spatial datasource.
       CreateLabeling,
       ReloadData,
       FeatureSymbology,
-      ConfigureSourceSelectFromUri,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;

--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -86,11 +86,11 @@ Configure the widget from a layer ``uri`` by selecting the layer path or connect
 The base implementation does nothing and returns ``False``: providers with ConfigureSourceSelectFromUri capability
 must override to implement this functionality.
 
+:return: ``True`` on success.
+
 .. note::
 
    Not all data providers may be able to configure the widget from the provided uri, in that case this method returns ``False``.
-
-:return: ``True`` on success.
 
 .. versionadded:: 3.38
 %End

--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -80,6 +80,21 @@ This should clear any selection that has previously been done.
 .. versionadded:: 3.10
 %End
 
+    virtual bool configureFromUri( const QString &uri );
+%Docstring
+Configure the widget from a layer ``uri`` by selecting the layer path or connection options.
+The base implementation does nothing and returns ``False``: providers with ConfigureSourceSelectFromUri capability
+must override to implement this functionality.
+
+.. note::
+
+   Not all data providers may be able to configure the widget from the provided uri, in that case this method returns ``False``.
+
+:return: ``True`` on success.
+
+.. versionadded:: 3.38
+%End
+
   signals:
 
     void connectionsChanged();

--- a/python/gui/auto_generated/qgssourceselectprovider.sip.in
+++ b/python/gui/auto_generated/qgssourceselectprovider.sip.in
@@ -97,6 +97,8 @@ The default implementation returns no capabilites.
 
 };
 
+QFlags<QgsSourceSelectProvider::Capability> operator|(QgsSourceSelectProvider::Capability f1, QFlags<QgsSourceSelectProvider::Capability> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/qgssourceselectprovider.sip.in
+++ b/python/gui/auto_generated/qgssourceselectprovider.sip.in
@@ -21,6 +21,9 @@ This is the interface for those who want to add entries to the :py:class:`QgsDat
 #include "qgssourceselectprovider.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     enum Ordering
     {
@@ -30,6 +33,14 @@ This is the interface for those who want to add entries to the :py:class:`QgsDat
       OrderSearchProvider,
       OrderOtherProvider,
     };
+
+    enum class Capability
+    {
+      NoCapabilities,
+      ConfigureFromUri
+    };
+    typedef QFlags<QgsSourceSelectProvider::Capability> Capabilities;
+
 
     virtual ~QgsSourceSelectProvider();
 
@@ -75,6 +86,15 @@ the source selects (ascending) using this integer value
 Create a new instance of :py:class:`QgsAbstractDataSourceWidget` (or ``None``).
 Caller takes responsibility of deleting created.
 %End
+
+    virtual Capabilities capabilities();
+%Docstring
+Returns the source select provider capabilities.
+The default implementation returns no capabilites.
+
+.. versionadded:: 3.38
+%End
+
 };
 
 

--- a/python/gui/auto_generated/qgssourceselectprovider.sip.in
+++ b/python/gui/auto_generated/qgssourceselectprovider.sip.in
@@ -90,7 +90,7 @@ Caller takes responsibility of deleting created.
     virtual Capabilities capabilities();
 %Docstring
 Returns the source select provider capabilities.
-The default implementation returns no capabilites.
+The default implementation returns no capabilities.
 
 .. versionadded:: 3.38
 %End

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -526,291 +526,299 @@ QString QgsAppFileItemGuiProvider::name()
 
 void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context )
 {
-  if ( !( item->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile ) )
-    return;
 
-  // Check for certain file items
-  const QString filename = item->path();
-  const QFileInfo fi( filename );
-  if ( !filename.isEmpty() )
+  if ( const auto layerItem = qobject_cast< QgsLayerItem * >( item ) )
   {
-    const static QList< std::pair< QString, QString > > sStandardFileTypes =
+    const QList<QgsSourceSelectProvider *> sourceSelectProviders { QgsGui::sourceSelectProviderRegistry()->providersByKey( layerItem->providerKey() ) };
+    if ( ! sourceSelectProviders.isEmpty() && sourceSelectProviders.first()->capabilities().testFlag( QgsSourceSelectProvider::Capability::ConfigureFromUri ) )
     {
-      { QStringLiteral( "pdf" ), QObject::tr( "Document" )},
-      { QStringLiteral( "xls" ), QObject::tr( "Spreadsheet" )},
-      { QStringLiteral( "xlsx" ), QObject::tr( "Spreadsheet" )},
-      { QStringLiteral( "ods" ), QObject::tr( "Spreadsheet" )},
-      { QStringLiteral( "csv" ), QObject::tr( "CSV File" )},
-      { QStringLiteral( "txt" ), QObject::tr( "Text File" )},
-      { QStringLiteral( "png" ), QObject::tr( "PNG Image" )},
-      { QStringLiteral( "jpg" ), QObject::tr( "JPEG Image" )},
-      { QStringLiteral( "jpeg" ), QObject::tr( "JPEG Image" )},
-      { QStringLiteral( "tif" ), QObject::tr( "TIFF Image" )},
-      { QStringLiteral( "tiff" ), QObject::tr( "TIFF Image" )},
-      { QStringLiteral( "svg" ), QObject::tr( "SVG File" )}
-    };
-    for ( const auto &it : sStandardFileTypes )
-    {
-      const QString ext = it.first;
-      const QString name = it.second;
-      if ( fi.suffix().compare( ext, Qt::CaseInsensitive ) == 0 )
+      QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
+      connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
       {
-        QAction *viewAction = new QAction( tr( "Open %1 Externally…" ).arg( name ), menu );
-        connect( viewAction, &QAction::triggered, this, [ = ]
+        QString pageName { layerItem->providerKey() };
+        // GPKG special handling
+        if ( qobject_cast<QgsGeoPackageVectorLayerItem *>( layerItem ) )
         {
-          QDesktopServices::openUrl( QUrl::fromLocalFile( filename ) );
-        } );
+          pageName = QStringLiteral( "GeoPackage" );
+        }
+        QgisApp::instance()->dataSourceManager( pageName, layerItem->uri() );
+      } );
+      menu->addAction( openDataSourceManagerAction );
+      menu->addSeparator();
+    }
+  }
 
-        // we want this action to be at the top
-        QAction *beforeAction = menu->actions().value( 0 );
-        if ( beforeAction )
+  if ( item->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile )
+  {
+
+    // Check for certain file items
+    const QString filename = item->path();
+    const QFileInfo fi( filename );
+    if ( !filename.isEmpty() )
+    {
+      const static QList< std::pair< QString, QString > > sStandardFileTypes =
+      {
+        { QStringLiteral( "pdf" ), QObject::tr( "Document" )},
+        { QStringLiteral( "xls" ), QObject::tr( "Spreadsheet" )},
+        { QStringLiteral( "xlsx" ), QObject::tr( "Spreadsheet" )},
+        { QStringLiteral( "ods" ), QObject::tr( "Spreadsheet" )},
+        { QStringLiteral( "csv" ), QObject::tr( "CSV File" )},
+        { QStringLiteral( "txt" ), QObject::tr( "Text File" )},
+        { QStringLiteral( "png" ), QObject::tr( "PNG Image" )},
+        { QStringLiteral( "jpg" ), QObject::tr( "JPEG Image" )},
+        { QStringLiteral( "jpeg" ), QObject::tr( "JPEG Image" )},
+        { QStringLiteral( "tif" ), QObject::tr( "TIFF Image" )},
+        { QStringLiteral( "tiff" ), QObject::tr( "TIFF Image" )},
+        { QStringLiteral( "svg" ), QObject::tr( "SVG File" )}
+      };
+      for ( const auto &it : sStandardFileTypes )
+      {
+        const QString ext = it.first;
+        const QString name = it.second;
+        if ( fi.suffix().compare( ext, Qt::CaseInsensitive ) == 0 )
         {
-          menu->insertAction( beforeAction, viewAction );
-          menu->insertSeparator( beforeAction );
+          QAction *viewAction = new QAction( tr( "Open %1 Externally…" ).arg( name ), menu );
+          connect( viewAction, &QAction::triggered, this, [ = ]
+          {
+            QDesktopServices::openUrl( QUrl::fromLocalFile( filename ) );
+          } );
+
+          // we want this action to be at the top
+          QAction *beforeAction = menu->actions().value( 0 );
+          if ( beforeAction )
+          {
+            menu->insertAction( beforeAction, viewAction );
+            menu->insertSeparator( beforeAction );
+          }
+          else
+          {
+            menu->addAction( viewAction );
+            menu->addSeparator();
+          }
+          // will only find one!
+          break;
+        }
+      }
+    }
+
+    if ( qobject_cast< QgsDataCollectionItem * >( item ) )
+    {
+      QAction *actionRefresh = new QAction( QObject::tr( "Refresh" ), menu );
+      connect( actionRefresh, &QAction::triggered, item, [item] { item->refresh(); } );
+      QAction *separatorAction = new QAction( menu );
+      separatorAction->setSeparator( true );
+      if ( !menu->actions().empty() )
+      {
+        menu->insertAction( menu->actions().constFirst(), separatorAction );
+        menu->insertAction( menu->actions().constFirst(), actionRefresh );
+      }
+      else
+      {
+        menu->addAction( actionRefresh );
+        menu->addAction( separatorAction );
+      }
+    }
+
+    QMenu *manageFileMenu = new QMenu( tr( "Manage" ), menu );
+
+    QStringList selectedFiles;
+    QList< QPointer< QgsDataItem > > selectedParents;
+    for ( QgsDataItem *selectedItem : selectedItems )
+    {
+      if ( selectedItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile )
+      {
+        selectedFiles.append( selectedItem->path() );
+        selectedParents << selectedItem->parent();
+      }
+    }
+
+    if ( selectedFiles.size() == 1 )
+    {
+      const QString renameText = tr( "Rename “%1”…" ).arg( fi.fileName() );
+      QAction *renameAction = new QAction( renameText, menu );
+      connect( renameAction, &QAction::triggered, this, [ = ]
+      {
+        const QString oldPath = selectedFiles.value( 0 );
+        const QStringList existingNames = QFileInfo( oldPath ).dir().entryList();
+
+        QgsNewNameDialog dlg( tr( "file" ), QFileInfo( oldPath ).fileName(), QStringList(), existingNames, Qt::CaseInsensitive, menu );
+        dlg.setWindowTitle( tr( "Rename %1" ).arg( QFileInfo( oldPath ).fileName() ) );
+        dlg.setHintString( tr( "Rename “%1” to" ).arg( QFileInfo( oldPath ).fileName() ) );
+        dlg.setOverwriteEnabled( false );
+        dlg.setConflictingNameWarning( tr( "A file with this name already exists." ) );
+        if ( dlg.exec() != QDialog::Accepted || dlg.name().isEmpty() )
+          return;
+
+        QString newName = dlg.name();
+        if ( QFileInfo( newName ).suffix().isEmpty() )
+          newName = newName + '.' + QFileInfo( oldPath ).suffix();
+
+        rename( oldPath, newName, context, selectedParents );
+      } );
+      manageFileMenu->addAction( renameAction );
+    }
+
+    const QString deleteText = selectedFiles.count() == 1 ? tr( "Delete “%1”…" ).arg( fi.fileName() )
+                               : tr( "Delete Selected Files…" );
+    QAction *deleteAction = new QAction( deleteText, menu );
+    connect( deleteAction, &QAction::triggered, this, [ = ]
+    {
+      // Check if the files correspond to paths in the project
+      QList<QgsMapLayer *> layersList;
+      for ( const QString &path : std::as_const( selectedFiles ) )
+      {
+        layersList << QgsProjectUtils::layersMatchingPath( QgsProject::instance(), path );
+      }
+
+      // now expand out the list of files to include all sidecar files (e.g. .aux.xml files)
+      QSet< QString > allFilesWithSidecars;
+      for ( const QString &file : std::as_const( selectedFiles ) )
+      {
+        allFilesWithSidecars.insert( file );
+        allFilesWithSidecars.unite( QgsFileUtils::sidecarFilesForPath( file ) );
+      }
+      QStringList sortedAllFilesWithSidecars( qgis::setToList( allFilesWithSidecars ) );
+      std::sort( sortedAllFilesWithSidecars.begin(), sortedAllFilesWithSidecars.end(), []( const QString & a, const QString & b )
+      {
+        return a.compare( b, Qt::CaseInsensitive ) < 0;
+      } );
+
+      bool removeLayers = false;
+      if ( layersList.empty() )
+      {
+        // generic warning
+        QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
+                             sortedAllFilesWithSidecars.size() > 1 ? tr( "Permanently delete %n file(s)?", nullptr, sortedAllFilesWithSidecars.size() )
+                             : tr( "Permanently delete “%1”?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
+                             QMessageBox::Yes | QMessageBox::No );
+        message.setDefaultButton( QMessageBox::No );
+
+        if ( sortedAllFilesWithSidecars.size() > 1 )
+        {
+          QStringList fileNames;
+          fileNames.reserve( sortedAllFilesWithSidecars.size() );
+          for ( const QString &file : std::as_const( sortedAllFilesWithSidecars ) )
+          {
+            fileNames << QFileInfo( file ).fileName();
+          }
+          message.setDetailedText( tr( "The following files will be deleted:" ) + QStringLiteral( "\n\n• %1" ).arg( fileNames.join( QStringLiteral( "\n• " ) ) ) );
+        }
+
+        int res = message.exec();
+        if ( res == QMessageBox::No )
+          return;
+      }
+      else
+      {
+        QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
+                             sortedAllFilesWithSidecars.size() > 1 ? tr( "One or more selected files exist in the current project. Are you sure you want to delete these files?" )
+                             : tr( "The file %1 exists in the current project. Are you sure you want to delete it?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
+                             QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel );
+        message.setDefaultButton( QMessageBox::Cancel );
+        message.setButtonText( QMessageBox::Yes, tr( "Delete and Remove Layers" ) );
+        message.setButtonText( QMessageBox::No, tr( "Delete and Retain Layers" ) );
+
+        QStringList layerNames;
+        layerNames.reserve( layersList.size() );
+        for ( const QgsMapLayer *layer : std::as_const( layersList ) )
+        {
+          layerNames << layer->name();
+        }
+        QString detailedText = tr( "The following layers will be affected:" ) + QStringLiteral( "\n\n• %1" ).arg( layerNames.join( QStringLiteral( "\n• " ) ) );
+
+        if ( sortedAllFilesWithSidecars.size() > 1 )
+        {
+          QStringList fileNames;
+          fileNames.reserve( sortedAllFilesWithSidecars.size() );
+          for ( const QString &file : std::as_const( sortedAllFilesWithSidecars ) )
+          {
+            fileNames << QFileInfo( file ).fileName();
+          }
+          detailedText += QStringLiteral( "\n\n" ) + tr( "The following files will be deleted:" ) + QStringLiteral( "\n\n• %1" ).arg( fileNames.join( QStringLiteral( "\n• " ) ) );
+        }
+        message.setDetailedText( detailedText );
+
+        int res = message.exec();
+        if ( res == QMessageBox::Cancel )
+          return;
+
+        if ( res == QMessageBox::Yes )
+          removeLayers = true;
+      }
+
+      QStringList errors;
+      errors.reserve( allFilesWithSidecars.size() );
+      for ( const QString &path : std::as_const( allFilesWithSidecars ) )
+      {
+        // delete file
+        const QFileInfo fi( path );
+        if ( fi.isFile() )
+        {
+          if ( !QFile::remove( path ) )
+            errors << path;
+        }
+        else if ( fi.isDir() )
+        {
+          QDir dir( path );
+          if ( !dir.removeRecursively() )
+            errors << path;
+        }
+      }
+
+      for ( const QPointer< QgsDataItem > &parent : selectedParents )
+      {
+        if ( parent )
+          parent->refresh();
+      }
+
+      if ( !layersList.empty() )
+      {
+        if ( removeLayers )
+        {
+          QgsProject::instance()->removeMapLayers( layersList );
+          QgsProject::instance()->setDirty( true );
         }
         else
         {
-          menu->addAction( viewAction );
+          // we just update the layer source to get it to recognize that it's now broken in the UI
+          for ( QgsMapLayer *layer : std::as_const( layersList ) )
+          {
+            layer->setDataSource( layer->source(), layer->name(), layer->providerType() );
+          }
+        }
+      }
+
+      if ( !errors.empty() )
+      {
+        if ( errors.size() == 1 )
+          notify( QString(), tr( "Could not delete %1" ).arg( QFileInfo( errors.at( 0 ) ).fileName() ), context, Qgis::MessageLevel::Critical );
+        else
+          notify( QString(), tr( "Could not delete %n file(s)", nullptr, errors.size() ), context, Qgis::MessageLevel::Critical );
+      }
+    } );
+    manageFileMenu->addAction( deleteAction );
+
+    menu->addMenu( manageFileMenu );
+
+    if ( QgsGui::nativePlatformInterface()->capabilities() & QgsNative::NativeFilePropertiesDialog )
+    {
+      if ( QFileInfo::exists( item->path() ) )
+      {
+        if ( !menu->isEmpty() )
           menu->addSeparator();
-        }
-        // will only find one!
-        break;
-      }
-    }
 
-    if ( const auto layerItem = qobject_cast< QgsLayerItem * >( item ) )
-    {
-      const QList<QgsSourceSelectProvider *> sourceSelectProviders { QgsGui::sourceSelectProviderRegistry()->providersByKey( layerItem->providerKey() ) };
-      if ( ! sourceSelectProviders.isEmpty() && sourceSelectProviders.first()->capabilities().testFlag( QgsSourceSelectProvider::Capability::ConfigureFromUri ) )
-      {
-        QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
-        connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
+        QAction *showInFilesAction = menu->addAction( tr( "Show in Files" ) );
+        connect( showInFilesAction, &QAction::triggered, this, [ = ]
         {
-          QgisApp::instance()->dataSourceManager( layerItem->providerKey(), layerItem->uri() );
+          QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( item->path() );
         } );
-        menu->addAction( openDataSourceManagerAction );
-        menu->addSeparator();
-      }
-    }
-  }
 
-  if ( qobject_cast< QgsDataCollectionItem * >( item ) )
-  {
-    QAction *actionRefresh = new QAction( QObject::tr( "Refresh" ), menu );
-    connect( actionRefresh, &QAction::triggered, item, [item] { item->refresh(); } );
-    QAction *separatorAction = new QAction( menu );
-    separatorAction->setSeparator( true );
-    if ( !menu->actions().empty() )
-    {
-      menu->insertAction( menu->actions().constFirst(), separatorAction );
-      menu->insertAction( menu->actions().constFirst(), actionRefresh );
-    }
-    else
-    {
-      menu->addAction( actionRefresh );
-      menu->addAction( separatorAction );
-    }
-  }
-
-  QMenu *manageFileMenu = new QMenu( tr( "Manage" ), menu );
-
-  QStringList selectedFiles;
-  QList< QPointer< QgsDataItem > > selectedParents;
-  for ( QgsDataItem *selectedItem : selectedItems )
-  {
-    if ( selectedItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile )
-    {
-      selectedFiles.append( selectedItem->path() );
-      selectedParents << selectedItem->parent();
-    }
-  }
-
-  if ( selectedFiles.size() == 1 )
-  {
-    const QString renameText = tr( "Rename “%1”…" ).arg( fi.fileName() );
-    QAction *renameAction = new QAction( renameText, menu );
-    connect( renameAction, &QAction::triggered, this, [ = ]
-    {
-      const QString oldPath = selectedFiles.value( 0 );
-      const QStringList existingNames = QFileInfo( oldPath ).dir().entryList();
-
-      QgsNewNameDialog dlg( tr( "file" ), QFileInfo( oldPath ).fileName(), QStringList(), existingNames, Qt::CaseInsensitive, menu );
-      dlg.setWindowTitle( tr( "Rename %1" ).arg( QFileInfo( oldPath ).fileName() ) );
-      dlg.setHintString( tr( "Rename “%1” to" ).arg( QFileInfo( oldPath ).fileName() ) );
-      dlg.setOverwriteEnabled( false );
-      dlg.setConflictingNameWarning( tr( "A file with this name already exists." ) );
-      if ( dlg.exec() != QDialog::Accepted || dlg.name().isEmpty() )
-        return;
-
-      QString newName = dlg.name();
-      if ( QFileInfo( newName ).suffix().isEmpty() )
-        newName = newName + '.' + QFileInfo( oldPath ).suffix();
-
-      rename( oldPath, newName, context, selectedParents );
-    } );
-    manageFileMenu->addAction( renameAction );
-  }
-
-  const QString deleteText = selectedFiles.count() == 1 ? tr( "Delete “%1”…" ).arg( fi.fileName() )
-                             : tr( "Delete Selected Files…" );
-  QAction *deleteAction = new QAction( deleteText, menu );
-  connect( deleteAction, &QAction::triggered, this, [ = ]
-  {
-    // Check if the files correspond to paths in the project
-    QList<QgsMapLayer *> layersList;
-    for ( const QString &path : std::as_const( selectedFiles ) )
-    {
-      layersList << QgsProjectUtils::layersMatchingPath( QgsProject::instance(), path );
-    }
-
-    // now expand out the list of files to include all sidecar files (e.g. .aux.xml files)
-    QSet< QString > allFilesWithSidecars;
-    for ( const QString &file : std::as_const( selectedFiles ) )
-    {
-      allFilesWithSidecars.insert( file );
-      allFilesWithSidecars.unite( QgsFileUtils::sidecarFilesForPath( file ) );
-    }
-    QStringList sortedAllFilesWithSidecars( qgis::setToList( allFilesWithSidecars ) );
-    std::sort( sortedAllFilesWithSidecars.begin(), sortedAllFilesWithSidecars.end(), []( const QString & a, const QString & b )
-    {
-      return a.compare( b, Qt::CaseInsensitive ) < 0;
-    } );
-
-    bool removeLayers = false;
-    if ( layersList.empty() )
-    {
-      // generic warning
-      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
-                           sortedAllFilesWithSidecars.size() > 1 ? tr( "Permanently delete %n file(s)?", nullptr, sortedAllFilesWithSidecars.size() )
-                           : tr( "Permanently delete “%1”?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
-                           QMessageBox::Yes | QMessageBox::No );
-      message.setDefaultButton( QMessageBox::No );
-
-      if ( sortedAllFilesWithSidecars.size() > 1 )
-      {
-        QStringList fileNames;
-        fileNames.reserve( sortedAllFilesWithSidecars.size() );
-        for ( const QString &file : std::as_const( sortedAllFilesWithSidecars ) )
+        QAction *filePropertiesAction = menu->addAction( tr( "File Properties…" ) );
+        connect( filePropertiesAction, &QAction::triggered, this, [ = ]
         {
-          fileNames << QFileInfo( file ).fileName();
-        }
-        message.setDetailedText( tr( "The following files will be deleted:" ) + QStringLiteral( "\n\n• %1" ).arg( fileNames.join( QStringLiteral( "\n• " ) ) ) );
+          QgsGui::nativePlatformInterface()->showFileProperties( item->path() );
+        } );
       }
-
-      int res = message.exec();
-      if ( res == QMessageBox::No )
-        return;
-    }
-    else
-    {
-      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
-                           sortedAllFilesWithSidecars.size() > 1 ? tr( "One or more selected files exist in the current project. Are you sure you want to delete these files?" )
-                           : tr( "The file %1 exists in the current project. Are you sure you want to delete it?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
-                           QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel );
-      message.setDefaultButton( QMessageBox::Cancel );
-      message.setButtonText( QMessageBox::Yes, tr( "Delete and Remove Layers" ) );
-      message.setButtonText( QMessageBox::No, tr( "Delete and Retain Layers" ) );
-
-      QStringList layerNames;
-      layerNames.reserve( layersList.size() );
-      for ( const QgsMapLayer *layer : std::as_const( layersList ) )
-      {
-        layerNames << layer->name();
-      }
-      QString detailedText = tr( "The following layers will be affected:" ) + QStringLiteral( "\n\n• %1" ).arg( layerNames.join( QStringLiteral( "\n• " ) ) );
-
-      if ( sortedAllFilesWithSidecars.size() > 1 )
-      {
-        QStringList fileNames;
-        fileNames.reserve( sortedAllFilesWithSidecars.size() );
-        for ( const QString &file : std::as_const( sortedAllFilesWithSidecars ) )
-        {
-          fileNames << QFileInfo( file ).fileName();
-        }
-        detailedText += QStringLiteral( "\n\n" ) + tr( "The following files will be deleted:" ) + QStringLiteral( "\n\n• %1" ).arg( fileNames.join( QStringLiteral( "\n• " ) ) );
-      }
-      message.setDetailedText( detailedText );
-
-      int res = message.exec();
-      if ( res == QMessageBox::Cancel )
-        return;
-
-      if ( res == QMessageBox::Yes )
-        removeLayers = true;
-    }
-
-    QStringList errors;
-    errors.reserve( allFilesWithSidecars.size() );
-    for ( const QString &path : std::as_const( allFilesWithSidecars ) )
-    {
-      // delete file
-      const QFileInfo fi( path );
-      if ( fi.isFile() )
-      {
-        if ( !QFile::remove( path ) )
-          errors << path;
-      }
-      else if ( fi.isDir() )
-      {
-        QDir dir( path );
-        if ( !dir.removeRecursively() )
-          errors << path;
-      }
-    }
-
-    for ( const QPointer< QgsDataItem > &parent : selectedParents )
-    {
-      if ( parent )
-        parent->refresh();
-    }
-
-    if ( !layersList.empty() )
-    {
-      if ( removeLayers )
-      {
-        QgsProject::instance()->removeMapLayers( layersList );
-        QgsProject::instance()->setDirty( true );
-      }
-      else
-      {
-        // we just update the layer source to get it to recognize that it's now broken in the UI
-        for ( QgsMapLayer *layer : std::as_const( layersList ) )
-        {
-          layer->setDataSource( layer->source(), layer->name(), layer->providerType() );
-        }
-      }
-    }
-
-    if ( !errors.empty() )
-    {
-      if ( errors.size() == 1 )
-        notify( QString(), tr( "Could not delete %1" ).arg( QFileInfo( errors.at( 0 ) ).fileName() ), context, Qgis::MessageLevel::Critical );
-      else
-        notify( QString(), tr( "Could not delete %n file(s)", nullptr, errors.size() ), context, Qgis::MessageLevel::Critical );
-    }
-  } );
-  manageFileMenu->addAction( deleteAction );
-
-  menu->addMenu( manageFileMenu );
-
-  if ( QgsGui::nativePlatformInterface()->capabilities() & QgsNative::NativeFilePropertiesDialog )
-  {
-    if ( QFileInfo::exists( item->path() ) )
-    {
-      if ( !menu->isEmpty() )
-        menu->addSeparator();
-
-      QAction *showInFilesAction = menu->addAction( tr( "Show in Files" ) );
-      connect( showInFilesAction, &QAction::triggered, this, [ = ]
-      {
-        QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( item->path() );
-      } );
-
-      QAction *filePropertiesAction = menu->addAction( tr( "File Properties…" ) );
-      connect( filePropertiesAction, &QAction::triggered, this, [ = ]
-      {
-        QgsGui::nativePlatformInterface()->showFileProperties( item->path() );
-      } );
     }
   }
 }

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -576,14 +576,15 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
       }
     }
 
-    if ( !item->providerKey().isEmpty() && !item->providerKey().startsWith( QStringLiteral( "special:" ) ) )
+    if ( const auto layerItem = qobject_cast< QgsLayerItem * >( item ) )
     {
       QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
       connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
       {
-        QgisApp::instance()->dataSourceManager( item->providerKey() );
+        QgisApp::instance()->dataSourceManager( layerItem->providerKey(), layerItem->uri() );
       } );
       menu->addAction( openDataSourceManagerAction );
+      menu->addSeparator();
     }
   }
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -575,6 +575,16 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
         break;
       }
     }
+
+    if ( !item->providerKey().isEmpty() && !item->providerKey().startsWith( QStringLiteral( "special:" ) ) )
+    {
+      QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
+      connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
+      {
+        QgisApp::instance()->dataSourceManager( item->providerKey() );
+      } );
+      menu->addAction( openDataSourceManagerAction );
+    }
   }
 
   if ( qobject_cast< QgsDataCollectionItem * >( item ) )

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -38,6 +38,8 @@
 #include "qgsaddattrdialog.h"
 #include "qgsabstractdatabaseproviderconnection.h"
 #include "qgsprovidermetadata.h"
+#include "qgssourceselectproviderregistry.h"
+#include "qgssourceselectprovider.h"
 #include "qgsnewvectortabledialog.h"
 #include "qgscolordialog.h"
 #include "qgsdirectoryitem.h"
@@ -578,13 +580,17 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
     if ( const auto layerItem = qobject_cast< QgsLayerItem * >( item ) )
     {
-      QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
-      connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
+      const QList<QgsSourceSelectProvider *> sourceSelectProviders { QgsGui::sourceSelectProviderRegistry()->providersByKey( layerItem->providerKey() ) };
+      if ( ! sourceSelectProviders.isEmpty() && sourceSelectProviders.first()->capabilities().testFlag( QgsSourceSelectProvider::Capability::ConfigureFromUri ) )
       {
-        QgisApp::instance()->dataSourceManager( layerItem->providerKey(), layerItem->uri() );
-      } );
-      menu->addAction( openDataSourceManagerAction );
-      menu->addSeparator();
+        QAction *openDataSourceManagerAction = new QAction( tr( "Open with datasource manager…" ), menu );
+        connect( openDataSourceManagerAction, &QAction::triggered, this, [ = ]
+        {
+          QgisApp::instance()->dataSourceManager( layerItem->providerKey(), layerItem->uri() );
+        } );
+        menu->addAction( openDataSourceManagerAction );
+        menu->addSeparator();
+      }
     }
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2738,7 +2738,7 @@ void QgisApp::dataSourceManager( const QString &pageName, const QString &layerUr
 
     if ( ! layerUri.isEmpty() )
     {
-      mDataSourceManagerDialog->configureFromUri( layerUri, pageName );
+      mDataSourceManagerDialog->configureFromUri( pageName, layerUri );
     }
     else
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2651,7 +2651,7 @@ QgsDockWidget *QgisApp::logDock()
   return mLogDock;
 }
 
-void QgisApp::dataSourceManager( const QString &pageName )
+void QgisApp::dataSourceManager( const QString &pageName, const QString &layerUri )
 {
   if ( ! mDataSourceManagerDialog )
   {
@@ -2735,7 +2735,15 @@ void QgisApp::dataSourceManager( const QString &pageName )
   // Try to open the dialog on a particular page
   if ( ! pageName.isEmpty() )
   {
-    mDataSourceManagerDialog->openPage( pageName );
+
+    if ( ! layerUri.isEmpty() )
+    {
+      mDataSourceManagerDialog->configureFromUri( layerUri, pageName );
+    }
+    else
+    {
+      mDataSourceManagerDialog->openPage( pageName );
+    }
   }
 
   mDataSourceManagerDialog->show();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1170,8 +1170,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \brief dataSourceManager Open the DataSourceManager dialog
      * \param pageName the page name, usually the provider name or "browser" (for the browser panel)
      *        or "ogr" (vector layers) or "raster" (raster layers)
+     * \param layerUri optional layer URI for the source select widget configuration
      */
-    void dataSourceManager( const QString &pageName = QString() );
+    void dataSourceManager( const QString &pageName = QString(), const QString &layerUri = QString() );
 
     //! Add a virtual layer
     void addVirtualLayer();

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -506,6 +506,11 @@ Qgis::DatabaseProviderConnectionCapabilities2 QgsFileDataCollectionItem::databas
   return mCachedCapabilities2;
 }
 
+QList<QgsProviderSublayerDetails> QgsFileDataCollectionItem::sublayers() const
+{
+  return mSublayers;
+}
+
 //
 // QgsFileBasedDataItemProvider
 //

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -171,6 +171,12 @@ class CORE_EXPORT QgsFileDataCollectionItem final: public QgsDataCollectionItem
      */
     Qgis::DatabaseProviderConnectionCapabilities2 databaseConnectionCapabilities2() const;
 
+    /**
+     * Returns the sublayers.
+     * \since QGIS 3.38
+     */
+    QList<QgsProviderSublayerDetails> sublayers() const;
+
   private:
 
     QList< QgsProviderSublayerDetails> mSublayers;

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -201,6 +201,16 @@ class CORE_EXPORT QgsDataProvider : public QObject
     }
 
     /**
+     * Set the data source specification.
+     *
+     * \since QGIS 3.38
+     */
+    void setUri( const QString &uri )
+    {
+      mDataSourceURI = uri;
+    }
+
+    /**
      * Gets the data source specification.
      *
      * \since QGIS 3.0

--- a/src/core/vector/qgsvectordataprovider.h
+++ b/src/core/vector/qgsvectordataprovider.h
@@ -96,6 +96,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features. Since QGIS 3.20.
+      ConfigureSourceSelectFromUri = 1 << 28, //!< Provider is able to configure the source select widget from a layer URI. Since QGIS 3.38.
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )

--- a/src/core/vector/qgsvectordataprovider.h
+++ b/src/core/vector/qgsvectordataprovider.h
@@ -96,7 +96,6 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features. Since QGIS 3.20.
-      ConfigureSourceSelectFromUri = 1 << 28, //!< Provider is able to configure the source select widget from a layer URI. Since QGIS 3.38.
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )

--- a/src/gui/providers/gdal/qgsgdalguiprovider.cpp
+++ b/src/gui/providers/gdal/qgsgdalguiprovider.cpp
@@ -178,6 +178,10 @@ class QgsGdalRasterSourceSelectProvider : public QgsSourceSelectProvider
     {
       return new QgsGdalSourceSelect( parent, fl, widgetMode );
     }
+    QgsSourceSelectProvider::Capabilities capabilities() override
+    {
+      return QgsSourceSelectProvider::Capability::ConfigureFromUri;
+    };
 };
 
 //

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -248,13 +248,20 @@ bool QgsGdalSourceSelect::configureFromUri( const QString &uri )
   mDataSources.clear();
   mDataSources.append( uri );
   const QVariantMap decodedUri = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  const QString layerName { decodedUri.value( QStringLiteral( "layerName" ) ).toString() };
   mFileWidget->setFilePath( decodedUri.value( QStringLiteral( "path" ), QString() ).toString() );
-  const QVariantMap openOptions = decodedUri.value( QStringLiteral( "openOptions" ) ).toMap();
+  QVariantMap openOptions = decodedUri.value( QStringLiteral( "openOptions" ) ).toMap();
+  // layerName becomes TABLE in some driver opening options (e.g. GPKG)
+  if ( !layerName.isEmpty() )
+  {
+    openOptions.insert( QStringLiteral( "TABLE" ), layerName );
+  }
+
   if ( ! openOptions.isEmpty() )
   {
     for ( auto opt = openOptions.constBegin(); opt != openOptions.constEnd(); ++opt )
     {
-      const auto widget { std::find_if( mOpenOptionsWidgets.cend(), mOpenOptionsWidgets.cend(), [ = ]( QWidget * widget )
+      const auto widget { std::find_if( mOpenOptionsWidgets.cbegin(), mOpenOptionsWidgets.cend(), [ = ]( QWidget * widget )
       {
         return widget->objectName() == opt.key();
       } ) };

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -459,18 +459,13 @@ void QgsGdalSourceSelect::fillOpenOptions()
       int idx = cb->findData( QVariant( QVariant::String ) );
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,8,0)
-      bool isVrBag { false };
-      if ( QString( GDALGetDriverShortName( hDriver ) ).compare( QLatin1String( "BAG" ) ) == 0 )
+      if ( QString( GDALGetDriverShortName( hDriver ) ).compare( QLatin1String( "BAG" ) ) == 0 && label->text() == QLatin1String( "MODE" ) && options.contains( QLatin1String( "INTERPOLATED" ) ))
       {
         gdal::dataset_unique_ptr hSrcDS( GDALOpen( firstDataSource.toUtf8().constData(), GA_ReadOnly ) );
-        if ( hSrcDS )
+        if ( hSrcDS && QString{ GDALGetMetadataItem( hSrcDS.get(), "HAS_SUPERGRIDS", nullptr ) } == QLatin1String( "TRUE" ) )
         {
-          isVrBag = QString{ GDALGetMetadataItem( hSrcDS.get(), "HAS_SUPERGRIDS", nullptr ) } == QLatin1String( "TRUE" ) ;
+          idx = cb->findText( QLatin1String( "INTERPOLATED" ) );          
         }
-      }
-      if ( isVrBag && label->text() == QLatin1String( "MODE" ) && options.contains( QLatin1String( "INTERPOLATED" ) ) )
-      {
-        idx = cb->findText( QLatin1String( "INTERPOLATED" ) );
       }
 #endif
 

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -243,6 +243,15 @@ void QgsGdalSourceSelect::addButtonClicked()
   emit addRasterLayers( sources );
 }
 
+bool QgsGdalSourceSelect::configureFromUri( const QString &uri )
+{
+  mDataSources.clear();
+  mDataSources.append( uri );
+  const QVariantMap decodedUri = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  mFileWidget->setFilePath( decodedUri.value( QStringLiteral( "path" ), QString() ).toString() );
+  return true;
+}
+
 void QgsGdalSourceSelect::computeDataSources()
 {
   mDataSources.clear();

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -457,6 +457,23 @@ void QgsGdalSourceSelect::fillOpenOptions()
       }
       cb->addItem( tr( "<Default>" ), QVariant( QVariant::String ) );
       int idx = cb->findData( QVariant( QVariant::String ) );
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,8,0)
+      bool isVrBag { false };
+      if ( QString( GDALGetDriverShortName( hDriver ) ).compare( QLatin1String( "BAG" ) ) == 0 )
+      {
+        gdal::dataset_unique_ptr hSrcDS( GDALOpen( firstDataSource.toUtf8().constData(), GA_ReadOnly ) );
+        if ( hSrcDS )
+        {
+          isVrBag = QString{ GDALGetMetadataItem( hSrcDS.get(), "HAS_SUPERGRIDS", nullptr ) } == QLatin1String( "TRUE" ) ;
+        }
+      }
+      if ( isVrBag && label->text() == QLatin1String( "MODE" ) && options.contains( QLatin1String( "INTERPOLATED" ) ) )
+      {
+        idx = cb->findText( QLatin1String( "INTERPOLATED" ) );
+      }
+#endif
+
       cb->setCurrentIndex( idx );
       control = cb;
     }

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -249,6 +249,34 @@ bool QgsGdalSourceSelect::configureFromUri( const QString &uri )
   mDataSources.append( uri );
   const QVariantMap decodedUri = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
   mFileWidget->setFilePath( decodedUri.value( QStringLiteral( "path" ), QString() ).toString() );
+  const QVariantMap openOptions = decodedUri.value( QStringLiteral( "openOptions" ) ).toMap();
+  if ( ! openOptions.isEmpty() )
+  {
+    for ( auto opt = openOptions.constBegin(); opt != openOptions.constEnd(); ++opt )
+    {
+      const auto widget { std::find_if( mOpenOptionsWidgets.cend(), mOpenOptionsWidgets.cend(), [ = ]( QWidget * widget )
+      {
+        return widget->objectName() == opt.key();
+      } ) };
+
+      if ( widget != mOpenOptionsWidgets.cend() )
+      {
+        if ( auto cb = qobject_cast<QComboBox *>( *widget ) )
+        {
+          const auto idx { cb->findText( opt.value().toString() ) };
+          if ( idx >= 0 )
+          {
+            cb->setCurrentIndex( idx );
+          }
+        }
+        else if ( auto le = qobject_cast<QLineEdit *>( *widget ) )
+        {
+          le->setText( opt.value().toString() );
+        }
+      }
+    }
+  }
+
   return true;
 }
 

--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -459,12 +459,12 @@ void QgsGdalSourceSelect::fillOpenOptions()
       int idx = cb->findData( QVariant( QVariant::String ) );
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,8,0)
-      if ( QString( GDALGetDriverShortName( hDriver ) ).compare( QLatin1String( "BAG" ) ) == 0 && label->text() == QLatin1String( "MODE" ) && options.contains( QLatin1String( "INTERPOLATED" ) ))
+      if ( QString( GDALGetDriverShortName( hDriver ) ).compare( QLatin1String( "BAG" ) ) == 0 && label->text() == QLatin1String( "MODE" ) && options.contains( QLatin1String( "INTERPOLATED" ) ) )
       {
         gdal::dataset_unique_ptr hSrcDS( GDALOpen( firstDataSource.toUtf8().constData(), GA_ReadOnly ) );
         if ( hSrcDS && QString{ GDALGetMetadataItem( hSrcDS.get(), "HAS_SUPERGRIDS", nullptr ) } == QLatin1String( "TRUE" ) )
         {
-          idx = cb->findText( QLatin1String( "INTERPOLATED" ) );          
+          idx = cb->findText( QLatin1String( "INTERPOLATED" ) );
         }
       }
 #endif

--- a/src/gui/providers/gdal/qgsgdalsourceselect.h
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.h
@@ -43,6 +43,7 @@ class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsG
   public slots:
     //! Determines the tables the user selected and closes the dialog
     void addButtonClicked() override;
+    bool configureFromUri( const QString &uri ) override;
     //! Sets protocol-related widget visibility
     void setProtocolWidgetsVisibility();
 

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -407,7 +407,7 @@ bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
   if ( idx >= 0 )
   {
     cmbConnections->setCurrentIndex( idx );
-    if ( ! layerName.isEmpty() )
+    if ( ! layerName.isEmpty() || layerIndex >= 0 )
     {
       btnConnect_clicked();
       // Find table/layer

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -395,8 +395,15 @@ bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
 
   QFileInfo pathInfo { filePath };
   const QString connectionName { pathInfo.fileName() };
-  const QString connectionText { connectionName + tr( "@" ) + QgsOgrDbConnection( connectionName, ogrDriverName( ) ).path() };
-  const int idx { cmbConnections->findText( connectionText ) };
+  const QString connectionText { connectionName + tr( "@" ) + filePath };
+  int idx { cmbConnections->findText( connectionText ) };
+
+  if ( idx < 0 && QgsOgrProviderUtils::saveConnection( filePath, QStringLiteral( "GPKG" ) ) )
+  {
+    populateConnectionList();
+    idx = cmbConnections->findText( connectionText );
+  }
+
   if ( idx >= 0 )
   {
     cmbConnections->setCurrentIndex( idx );

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -108,7 +108,7 @@ void QgsOgrDbSourceSelect::populateConnectionList()
   for ( const QString &name : QgsOgrDbConnection::connectionList( ogrDriverName( ) ) )
   {
     // retrieving the SQLite DB name and full path
-    QString text = name + tr( "@" ) + QgsOgrDbConnection( name, ogrDriverName( ) ).path();
+    const QString text = name + tr( "@" ) + QgsOgrDbConnection( name, ogrDriverName( ) ).path();
     cmbConnections->addItem( text );
   }
 
@@ -375,6 +375,70 @@ void QgsOgrDbSourceSelect::treeWidgetSelectionChanged( const QItemSelection &sel
 void QgsOgrDbSourceSelect::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#GeoPackage-layers" ) );
+}
+
+bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
+{
+  bool isSubLayer;
+  int layerIndex;
+  QString layerName;
+  QString subsetString;
+  OGRwkbGeometryType ogrGeometryType;
+  QStringList openOptions;
+  const QString filePath = QgsOgrProviderUtils::analyzeURI( uri,
+                           isSubLayer,
+                           layerIndex,
+                           layerName,
+                           subsetString,
+                           ogrGeometryType,
+                           openOptions );
+
+  QFileInfo pathInfo { filePath };
+  const QString connectionName { pathInfo.fileName() };
+  const QString connectionText { connectionName + tr( "@" ) + QgsOgrDbConnection( connectionName, ogrDriverName( ) ).path() };
+  const int idx { cmbConnections->findText( connectionText ) };
+  if ( idx >= 0 )
+  {
+    cmbConnections->setCurrentIndex( idx );
+    if ( ! layerName.isEmpty() )
+    {
+      btnConnect_clicked();
+      // Find table/layer
+      QModelIndex index;
+      if ( !layerName.isEmpty() )
+      {
+        const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
+        Q_ASSERT( parentIndex.isValid() );
+        const QModelIndexList indexList { mTableModel->match( mTableModel->index( 0, 0, parentIndex ), Qt::DisplayRole, layerName, 1, Qt::MatchFlag::MatchExactly ) };
+        if ( ! indexList.isEmpty() )
+        {
+          index = indexList.first();
+        }
+      }
+      else if ( layerIndex >= 0 )
+      {
+        const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
+        Q_ASSERT( parentIndex.isValid() );
+        index = mTableModel->index( layerIndex, 0, parentIndex );
+      }
+
+      if ( index.isValid() )
+      {
+        mTablesTreeView->selectionModel()->setCurrentIndex( proxyModel()->mapFromSource( index ), QItemSelectionModel::SelectionFlag::Rows | QItemSelectionModel::SelectionFlag::ClearAndSelect );
+        // Set filter
+        if ( !subsetString.isEmpty() )
+        {
+          mTableModel->setSql( index, subsetString );
+        }
+      }
+
+    }
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -408,7 +408,6 @@ bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
       if ( !layerName.isEmpty() )
       {
         const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
-        Q_ASSERT( parentIndex.isValid() );
         const QModelIndexList indexList { mTableModel->match( mTableModel->index( 0, 0, parentIndex ), Qt::DisplayRole, layerName, 1, Qt::MatchFlag::MatchExactly ) };
         if ( ! indexList.isEmpty() )
         {
@@ -418,13 +417,14 @@ bool QgsOgrDbSourceSelect::configureFromUri( const QString &uri )
       else if ( layerIndex >= 0 )
       {
         const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
-        Q_ASSERT( parentIndex.isValid() );
-        index = mTableModel->index( layerIndex, 0, parentIndex );
+        index = proxyModel()->mapFromSource( mTableModel->index( layerIndex, 0, parentIndex ) );
       }
 
       if ( index.isValid() )
       {
-        mTablesTreeView->selectionModel()->setCurrentIndex( proxyModel()->mapFromSource( index ), QItemSelectionModel::SelectionFlag::Rows | QItemSelectionModel::SelectionFlag::ClearAndSelect );
+        const QModelIndex proxyIndex { proxyModel()->mapFromSource( index ) };
+        mTablesTreeView->selectionModel()->setCurrentIndex( proxyIndex, QItemSelectionModel::SelectionFlag::Rows | QItemSelectionModel::SelectionFlag::ClearAndSelect );
+        mTablesTreeView->scrollTo( proxyIndex );
         // Set filter
         if ( !subsetString.isEmpty() )
         {

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.h
@@ -91,7 +91,6 @@ class QgsOgrDbSourceSelect: public QgsAbstractDbSourceSelect
     void treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
     //!Sets a new regular expression to the model
     void setSearchExpression( const QString &regexp );
-
     void showHelp();
     bool configureFromUri( const QString &uri ) override;
     void setSql( const QModelIndex &index ) override;

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.h
@@ -93,10 +93,11 @@ class QgsOgrDbSourceSelect: public QgsAbstractDbSourceSelect
     void setSearchExpression( const QString &regexp );
 
     void showHelp();
+    bool configureFromUri( const QString &uri ) override;
+    void setSql( const QModelIndex &index ) override;
 
   protected slots:
     void treeviewClicked( const QModelIndex &index ) override;
-    void setSql( const QModelIndex &index ) override;
     void treeviewDoubleClicked( const QModelIndex &index ) override;
 
   private:
@@ -107,6 +108,7 @@ class QgsOgrDbSourceSelect: public QgsAbstractDbSourceSelect
     QString mOgrDriverName;
     QString mName;
     QString mExtension;
+
 };
 
 ///@endcond

--- a/src/gui/providers/ogr/qgsogrguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsogrguiprovider.cpp
@@ -43,6 +43,7 @@ class QgsOgrVectorSourceSelectProvider : public QgsSourceSelectProvider
     int ordering() const override { return QgsSourceSelectProvider::OrderLocalProvider + 10; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddOgrLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override;
+    QgsSourceSelectProvider::Capabilities capabilities() override;
 };
 
 
@@ -57,6 +58,7 @@ class QgsGeoPackageSourceSelectProvider : public QgsSourceSelectProvider
     int ordering() const override { return QgsSourceSelectProvider::OrderLocalProvider + 45; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddGeoPackageLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override;
+    QgsSourceSelectProvider::Capabilities capabilities() override;
 };
 
 
@@ -84,9 +86,19 @@ QgsAbstractDataSourceWidget *QgsGeoPackageSourceSelectProvider::createDataSource
   return new QgsOgrDbSourceSelect( QStringLiteral( "GPKG" ), QObject::tr( "GeoPackage" ), QObject::tr( "GeoPackage Database (*.gpkg)" ), parent, fl, widgetMode );
 }
 
+QgsSourceSelectProvider::Capabilities QgsGeoPackageSourceSelectProvider::capabilities()
+{
+  return QgsSourceSelectProvider::Capability::ConfigureFromUri;
+}
+
 QgsAbstractDataSourceWidget *QgsOgrVectorSourceSelectProvider::createDataSourceWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ) const
 {
   return new QgsOgrSourceSelect( parent, fl, widgetMode );
+}
+
+QgsSourceSelectProvider::Capabilities QgsOgrVectorSourceSelectProvider::capabilities()
+{
+  return QgsSourceSelectProvider::Capability::ConfigureFromUri;
 }
 
 QgsOgrGuiProviderMetadata::QgsOgrGuiProviderMetadata()

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -653,6 +653,43 @@ void QgsOgrSourceSelect::showHelp()
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#loading-a-layer-from-a-file" ) );
 }
 
+bool QgsOgrSourceSelect::configureFromUri( const QString &uri )
+{
+  mDataSources.clear();
+  mDataSources.append( uri );
+  const QVariantMap decodedUri = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri );
+  mFileWidget->setFilePath( decodedUri.value( QStringLiteral( "path" ), QString() ).toString() );
+  const QVariantMap openOptions = decodedUri.value( QStringLiteral( "openOptions" ) ).toMap();
+  if ( ! openOptions.isEmpty() )
+  {
+    for ( auto opt = openOptions.constBegin(); opt != openOptions.constEnd(); ++opt )
+    {
+      const auto widget { std::find_if( mOpenOptionsWidgets.cbegin(), mOpenOptionsWidgets.cend(), [ = ]( QWidget * widget )
+      {
+        return widget->objectName() == opt.key();
+      } ) };
+
+      if ( widget != mOpenOptionsWidgets.cend() )
+      {
+        if ( auto cb = qobject_cast<QComboBox *>( *widget ) )
+        {
+          const auto idx { cb->findText( opt.value().toString() ) };
+          if ( idx >= 0 )
+          {
+            cb->setCurrentIndex( idx );
+          }
+        }
+        else if ( auto le = qobject_cast<QLineEdit *>( *widget ) )
+        {
+          le->setText( opt.value().toString() );
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
 void QgsOgrSourceSelect::clearOpenOptions()
 {
   mOpenOptionsWidgets.clear();

--- a/src/gui/providers/ogr/qgsogrsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrsourceselect.h
@@ -111,6 +111,7 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void cmbConnections_currentIndexChanged( const QString &text );
     void cmbProtocolTypes_currentIndexChanged( const QString &text );
     void showHelp();
+    bool configureFromUri( const QString &uri ) override;
 
   private:
 
@@ -120,6 +121,7 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     std::vector<QWidget *> mOpenOptionsWidgets;
     bool mIsOgcApi = false;
     QString mVectorPath;
+
 
 };
 

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -65,3 +65,9 @@ void QgsAbstractDataSourceWidget::addButtonClicked()
 void QgsAbstractDataSourceWidget::reset()
 {
 }
+
+bool QgsAbstractDataSourceWidget::configureFromUri( const QString &uri )
+{
+  Q_UNUSED( uri );
+  return false;
+}

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -96,6 +96,16 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      */
     virtual void reset();
 
+    /**
+     * Configure the widget from a layer \a uri by selecting the layer path or connection options.
+     * The base implementation does nothing and returns FALSE: providers with ConfigureSourceSelectFromUri capability
+     * must override to implement this functionality.
+     * \note Not all data providers may be able to configure the widget from the provided uri, in that case this method returns FALSE.
+     * \return TRUE on success.
+     * \since 3.38
+     */
+    virtual bool configureFromUri( const QString &uri );
+
   signals:
 
     /**

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -100,8 +100,8 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      * Configure the widget from a layer \a uri by selecting the layer path or connection options.
      * The base implementation does nothing and returns FALSE: providers with ConfigureSourceSelectFromUri capability
      * must override to implement this functionality.
-     * \note Not all data providers may be able to configure the widget from the provided uri, in that case this method returns FALSE.
      * \return TRUE on success.
+     * \note Not all data providers may be able to configure the widget from the provided uri, in that case this method returns FALSE.
      * \since 3.38
      */
     virtual bool configureFromUri( const QString &uri );

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -162,6 +162,16 @@ void QgsDataSourceManagerDialog::reset()
   }
 }
 
+bool QgsDataSourceManagerDialog::configureFromUri( const QString &uri, const QString &pagename )
+{
+  openPage( pagename );
+  if ( QgsAbstractDataSourceWidget *dataSourceWidget = qobject_cast<QgsAbstractDataSourceWidget *>( ui->mOptionsStackedWidget->currentWidget() ) )
+  {
+    return dataSourceWidget->configureFromUri( uri );
+  }
+  return false;
+}
+
 void QgsDataSourceManagerDialog::rasterLayersAdded( const QStringList &layersList )
 {
   emit addRasterLayers( layersList );

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -164,7 +164,7 @@ void QgsDataSourceManagerDialog::reset()
 
 void QgsDataSourceManagerDialog::configureFromUri( const QString &pageName, const QString &uri )
 {
-  const int pageIdx = mPageProviderKeys.indexOf( pageName );
+  const int pageIdx = mPageProviderNames.indexOf( pageName );
   if ( pageIdx != -1 )
   {
     QTimer::singleShot( 0, this, [ = ]

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -162,14 +162,20 @@ void QgsDataSourceManagerDialog::reset()
   }
 }
 
-bool QgsDataSourceManagerDialog::configureFromUri( const QString &uri, const QString &pagename )
+void QgsDataSourceManagerDialog::configureFromUri( const QString &uri, const QString &pageName )
 {
-  openPage( pagename );
-  if ( QgsAbstractDataSourceWidget *dataSourceWidget = qobject_cast<QgsAbstractDataSourceWidget *>( ui->mOptionsStackedWidget->currentWidget() ) )
+  const int pageIdx = mPageProviderKeys.indexOf( pageName );
+  if ( pageIdx != -1 )
   {
-    return dataSourceWidget->configureFromUri( uri );
+    QTimer::singleShot( 0, this, [ = ]
+    {
+      setCurrentPage( pageIdx );
+      if ( QgsAbstractDataSourceWidget *dataSourceWidget = qobject_cast<QgsAbstractDataSourceWidget *>( ui->mOptionsStackedWidget->currentWidget() ) )
+      {
+        dataSourceWidget->configureFromUri( uri );
+      }
+    } );
   }
-  return false;
 }
 
 void QgsDataSourceManagerDialog::rasterLayersAdded( const QStringList &layersList )

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -162,7 +162,7 @@ void QgsDataSourceManagerDialog::reset()
   }
 }
 
-void QgsDataSourceManagerDialog::configureFromUri( const QString &uri, const QString &pageName )
+void QgsDataSourceManagerDialog::configureFromUri( const QString &pageName, const QString &uri )
 {
   const int pageIdx = mPageProviderKeys.indexOf( pageName );
   if ( pageIdx != -1 )

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -109,11 +109,10 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
 
 
     /**
-     * Shows the page \a pagename and configure the source select widget from the layer \a uri.
-     * \returns TRUE on success.
+     * Shows the page \a pageName and configure the source select widget from the layer \a uri.
      * \since QGIS 3.38
      */
-    bool configureFromUri( const QString &uri, const QString &pagename );
+    void configureFromUri( const QString &uri, const QString &pageName );
 
 
   protected:

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -112,7 +112,7 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
      * Shows the page \a pageName and configure the source select widget from the layer \a uri.
      * \since QGIS 3.38
      */
-    void configureFromUri( const QString &uri, const QString &pageName );
+    void configureFromUri( const QString &pageName, const QString &uri );
 
 
   protected:

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -107,6 +107,15 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
      */
     void reset();
 
+
+    /**
+     * Shows the page \a pagename and configure the source select widget from the layer \a uri.
+     * \returns TRUE on success.
+     * \since QGIS 3.38
+     */
+    bool configureFromUri( const QString &uri, const QString &pagename );
+
+
   protected:
     void showEvent( QShowEvent *event ) override;
 

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -103,7 +103,7 @@ class GUI_EXPORT QgsSourceSelectProvider
 
     /**
      * Returns the source select provider capabilities.
-     * The default implementation returns no capabilites.
+     * The default implementation returns no capabilities.
      * \since QGIS 3.38
      */
     virtual Capabilities capabilities()

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsSourceSelectProvider
     enum class Capability : int
     {
       NoCapabilities  = 0, //!< No capabilities
-      ConfigureFromUri = 1  //!< The source select can be configured from a URI
+      ConfigureFromUri = 1  //!< The source select widget can be configured from a URI
     };
     Q_ENUM( Capability )
     //!
@@ -113,5 +113,6 @@ class GUI_EXPORT QgsSourceSelectProvider
 
 };
 
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsSourceSelectProvider::Capabilities )
 
 #endif // QGSSOURCESELECTPROVIDER_H

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -34,6 +34,8 @@ class QWidget;
  */
 class GUI_EXPORT QgsSourceSelectProvider
 {
+    Q_GADGET
+
   public:
 
     //! Provider ordering groups
@@ -45,6 +47,20 @@ class GUI_EXPORT QgsSourceSelectProvider
       OrderSearchProvider = 4000, //!< Starting point for search providers (e.g. Layer Metadata)
       OrderOtherProvider = 5000, //!< Starting point for other providers (e.g. plugin based providers)
     };
+
+    /**
+     * The Capability enum describes the capabilities of the source select implementation.
+     * \since QGIS 3.38
+     */
+    enum class Capability : int
+    {
+      NoCapabilities  = 0, //!< No capabilities
+      ConfigureFromUri = 1  //!< The source select can be configured from a URI
+    };
+    Q_ENUM( Capability )
+    //!
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+    Q_FLAG( Capabilities )
 
     virtual ~QgsSourceSelectProvider() = default;
 
@@ -84,6 +100,17 @@ class GUI_EXPORT QgsSourceSelectProvider
      * Caller takes responsibility of deleting created.
      */
     virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const = 0 SIP_FACTORY;
+
+    /**
+     * Returns the source select provider capabilities.
+     * The default implementation returns no capabilites.
+     * \since QGIS 3.38
+     */
+    virtual Capabilities capabilities()
+    {
+      return Capability::NoCapabilities;
+    }
+
 };
 
 

--- a/src/providers/spatialite/qgsspatialiteprovidergui.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.cpp
@@ -37,6 +37,11 @@ class QgsSpatialiteSourceSelectProvider : public QgsSourceSelectProvider
     {
       return new QgsSpatiaLiteSourceSelect( parent, fl, widgetMode );
     }
+
+    QgsSourceSelectProvider::Capabilities capabilities() override
+    {
+      return QgsSourceSelectProvider::Capability::ConfigureFromUri;
+    }
 };
 
 

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -557,14 +557,11 @@ bool QgsSpatiaLiteSourceSelect::configureFromUri( const QString &uri )
       btnConnect_clicked();
       // Find table/layer
       QModelIndex index;
-      if ( !layerName.isEmpty() )
+      const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
+      const QModelIndexList indexList { mTableModel->match( mTableModel->index( 0, 0, parentIndex ), Qt::DisplayRole, layerName, 1, Qt::MatchFlag::MatchExactly ) };
+      if ( ! indexList.isEmpty() )
       {
-        const QModelIndex parentIndex { mTableModel->index( 0, 0, mTableModel->invisibleRootItem()->index() )};
-        const QModelIndexList indexList { mTableModel->match( mTableModel->index( 0, 0, parentIndex ), Qt::DisplayRole, layerName, 1, Qt::MatchFlag::MatchExactly ) };
-        if ( ! indexList.isEmpty() )
-        {
-          index = indexList.first();
-        }
+        index = indexList.first();
       }
 
       if ( index.isValid() )

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -84,8 +84,8 @@ class QgsSpatiaLiteSourceSelect:  public QgsAbstractDbSourceSelect
     void treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
     //!Sets a new regular expression to the model
     void setSearchExpression( const QString &regexp );
-
     void showHelp();
+    bool configureFromUri( const QString &uri ) override;
 
   protected slots:
     void setSql( const QModelIndex &index ) override;
@@ -120,6 +120,7 @@ class QgsSpatiaLiteSourceSelect:  public QgsAbstractDbSourceSelect
 
     QString layerURI( const QModelIndex &index );
     QPushButton *mStatsButton = nullptr;
+
 };
 
 #endif // QGSSPATIALITESOURCESELECT_H

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -19,8 +19,8 @@ __revision__ = '$Format:%H$'
 import os
 import time
 
-from qgis.PyQt import QtCore, QDir
-from qgis.PyQt.QtCore import QCoreApplication, QVariant
+from qgis.PyQt import QtCore
+from qgis.PyQt.QtCore import QCoreApplication, QVariant, QDir
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -19,7 +19,7 @@ __revision__ = '$Format:%H$'
 import os
 import time
 
-from qgis.PyQt import QtCore
+from qgis.PyQt import QtCore, QDir
 from qgis.PyQt.QtCore import QCoreApplication, QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
@@ -73,6 +73,11 @@ class TestPyQgsProviderConnectionBase():
 
     def setUp(self):
         QgsSettings().clear()
+
+    def tearDown(self):
+        report_file_path = f"{QDir.tempPath()}/qgistest.html"
+        with open(report_file_path, 'a') as report_file:
+            report_file.write(self.report)
 
     def treat_date_as_string(self):
         """Provider test case can override this to treat DATE type as STRING"""

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -11,20 +11,23 @@ the Free Software Foundation; either version 2 of the License, or
 """
 
 from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import (
     QgsAbstractDataSourceWidget,
     QgsGui,
     QgsSourceSelectProvider,
     QgsSourceSelectProviderRegistry,
 )
+from qgis.core import QgsDataSourceUri, QgsSettings
 import unittest
+import os
 from qgis.testing import start_app, QgisTestCase
+from utilities import unitTestDataPath
 
 __author__ = 'Alessandro Pasotti'
 __date__ = '01/09/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
-
-start_app()
 
 
 class ConcreteDataSourceWidget(QgsAbstractDataSourceWidget):
@@ -73,13 +76,18 @@ class ConcreteSourceSelectProvider2(QgsSourceSelectProvider):
         return 2
 
 
-class TestQgsSourceSelectProvider(QgisTestCase):
+class TestQgsSourceSelectProvider(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        QCoreApplication.setOrganizationName("QGIS_Test")
+        QCoreApplication.setOrganizationDomain(cls.__name__)
+        QCoreApplication.setApplicationName(cls.__name__)
+        start_app()
 
     def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
+        QgsSettings().clear()
 
     def testConcreteClass(self):
         provider = ConcreteSourceSelectProvider()
@@ -152,6 +160,64 @@ class TestQgsSourceSelectProvider(QgisTestCase):
         # Check that at least OGR and GDAL are here
         self.assertTrue(registry.providersByKey('ogr'))
         self.assertTrue(registry.providersByKey('gdal'))
+
+    def testSourceSelectProvidersConfigureFromUri(self):
+        """
+        Test configure from URI
+        """
+        registry = QgsGui.sourceSelectProviderRegistry()
+        enabled_entries = {reg_entry.name(): reg_entry for reg_entry in registry.providers() if reg_entry.capabilities() & QgsSourceSelectProvider.Capability.ConfigureFromUri}
+        self.assertTrue('ogr' in enabled_entries.keys())
+        self.assertTrue('gdal' in enabled_entries.keys())
+        self.assertTrue('GeoPackage' in enabled_entries.keys())
+        self.assertTrue('spatialite' in enabled_entries.keys())
+
+       # Test ogr
+        test_path = os.path.join(unitTestDataPath(), 'points.shp')
+        source_select = enabled_entries['ogr'].createDataSourceWidget()
+        self.assertTrue(source_select.configureFromUri(test_path))
+        spy = QSignalSpy(source_select.addVectorLayers)
+        source_select.addButtonClicked()
+        self.assertEqual(len(spy), 1)
+        arg_path, _, arg_type = spy[0]
+        self.assertEqual(arg_path[0], test_path)
+
+        # Test GDAL
+        test_path = os.path.join(unitTestDataPath(), 'raster_layer.tiff')
+        source_select = enabled_entries['gdal'].createDataSourceWidget()
+        spy = QSignalSpy(source_select.addRasterLayers)
+        self.assertTrue(source_select.configureFromUri(test_path))
+        source_select.addButtonClicked()
+        self.assertEqual(len(spy), 1)
+        arg_path = spy[0][0]
+        self.assertEqual(arg_path[0], test_path)
+
+        # Test vector GPKG
+        test_path = os.path.join(unitTestDataPath(), 'mixed_layers.gpkg|layername=points')
+        source_select = enabled_entries['GeoPackage'].createDataSourceWidget()
+        self.assertTrue(source_select.configureFromUri(test_path))
+        spy = QSignalSpy(source_select.addLayer)
+        source_select.addButtonClicked()
+        self.assertEqual(len(spy), 1)
+        _, arg_path, arg_name, arg_key = spy[0]
+        self.assertEqual(arg_path, test_path)
+        self.assertEqual(arg_name, 'points')
+        self.assertEqual(arg_key, 'ogr')
+
+        # Test vector spatialite
+        test_path = os.path.join(unitTestDataPath(), 'provider', 'spatialite.db')
+        uri = QgsDataSourceUri()
+        uri.setDatabase(test_path)
+        uri.setTable('some data')
+        uri.setGeometryColumn('geom')
+        uri.setSql('pk > 0')
+        source_select = enabled_entries['spatialite'].createDataSourceWidget()
+        self.assertTrue(source_select.configureFromUri(uri.uri()))
+        spy = QSignalSpy(source_select.addDatabaseLayers)
+        source_select.addButtonClicked()
+        self.assertEqual(len(spy), 1)
+        arg_tables, arg_key = spy[0]
+        self.assertEqual(arg_tables[0], uri.uri())
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -172,7 +172,7 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
         self.assertTrue('GeoPackage' in enabled_entries.keys())
         self.assertTrue('spatialite' in enabled_entries.keys())
 
-       # Test ogr
+        # Test ogr
         test_path = os.path.join(unitTestDataPath(), 'points.shp')
         source_select = enabled_entries['ogr'].createDataSourceWidget()
         self.assertTrue(source_select.configureFromUri(test_path))


### PR DESCRIPTION
This PR adds an API for source select widgets and data source manager that allows to open and configure the data source manager from a data source URI.

For instance:
```python
registry = QgsGui.sourceSelectProviderRegistry()
# Check for capability
registry.providers()[0].name()
'ogr'
bool(registry.providers()[0].capabilities() & QgsSourceSelectProvider.Capability.ConfigureFromUri)
True
source_select_provider = registry.providers()[0]
widget = source_select_provider.createDataSourceWidget()
widget.configureFromUri('/path/to/file.gpkg|layername=points')
True
```

The datasource manager dialog has also a C++ API:
```C++
    /**
     * Shows the page \a pageName and configure the source select widget from the layer \a uri.
     * \since QGIS 3.38
     */
    void configureFromUri( const QString &pageName, const QString &uri );
```

The dialog will open on the correct page with pre-filled values to open the layer.

This feature is for now implemented for OGR (including the dedicated GPKG source select), GDAL and Spatialite and it is accessible from the context menu in the browser.

The purpose is to allow the user to set opening options when adding a layer from the browser but it could be eventually expanded to include a more sophisticated replace data source functionality where opening options can be specified.

Here is the exposed UI

![configure_from_uri_gpkg_vector](https://github.com/qgis/QGIS/assets/142164/58d9e1ef-bea8-400e-a23c-6b53462d71d6)

![configure_from_uri_gpkg_raster](https://github.com/qgis/QGIS/assets/142164/2cb3221b-800e-486f-bc45-22b410978dde)

A secondary patch (for GDAL >= 3.8 only, and part of the same work package) in this PR is related to a very peculiar use case when opening VR BAG (variable resolution) files, in case no opening options are explicitly specified by the user the MODE=INTERPOLATED option is used as a default.

![configure_from_uri_bag](https://github.com/qgis/QGIS/assets/142164/418972ec-00f3-4fb3-89be-1714c2ccb563)


Funded by: NOAA

