### PR TITLE
Use a dedicated thread pool for task manager (fix hang when exporting 3d maps)

### DIFF
--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -345,7 +345,7 @@ but will be transferred to a QgsTaskManager.
 
     QThreadPool *threadPool();
 %Docstring
-Returns the threadpool utilised by the task manager.
+Returns the threadpool utilized by the task manager.
 
 .. versionadded:: 3.34
 %End

--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -343,6 +343,13 @@ but will be transferred to a QgsTaskManager.
 
     };
 
+    QThreadPool *threadPool();
+%Docstring
+Returns the threadpool utilised by the task manager.
+
+.. versionadded:: 3.34
+%End
+
     long addTask( QgsTask *task /Transfer/, int priority = 0 );
 %Docstring
 Adds a task to the manager. Ownership of the task is transferred

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -72,6 +72,7 @@ QgsPointCloudLayer::~QgsPointCloudLayer()
 {
   if ( QgsTask *task = QgsApplication::taskManager()->task( mStatsCalculationTask ) )
   {
+    mStatsCalculationTask = 0;
     task->cancel();
   }
 }
@@ -934,8 +935,11 @@ void QgsPointCloudLayer::calculateStatistics()
   // In case the statistics calculation fails, QgsTask::taskTerminated will be called
   connect( task, &QgsTask::taskTerminated, this, [this]()
   {
-    QgsMessageLog::logMessage( QObject::tr( "Failed to calculate statistics of the point cloud %1" ).arg( this->name() ) );
-    mStatsCalculationTask = 0;
+    if ( mStatsCalculationTask )
+    {
+      QgsMessageLog::logMessage( QObject::tr( "Failed to calculate statistics of the point cloud %1" ).arg( this->name() ) );
+      mStatsCalculationTask = 0;
+    }
   } );
 
   mStatsCalculationTask = QgsApplication::taskManager()->addTask( task );

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -74,6 +74,7 @@ QgsPointCloudLayer::~QgsPointCloudLayer()
   {
     mStatsCalculationTask = 0;
     task->cancel();
+    task->waitForFinished();
   }
 }
 

--- a/src/core/qgsproxyprogresstask.cpp
+++ b/src/core/qgsproxyprogresstask.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsproxyprogresstask.h"
 #include "qgsapplication.h"
+#include <QThreadPool>
 
 QgsProxyProgressTask::QgsProxyProgressTask( const QString &description, bool canCancel )
   : QgsTask( description, canCancel ? QgsTask::CanCancel : QgsTask::Flags() )
@@ -34,6 +35,7 @@ void QgsProxyProgressTask::finalize( bool result )
 
 bool QgsProxyProgressTask::run()
 {
+  QgsApplication::taskManager()->threadPool()->releaseThread();
   mNotFinishedMutex.lock();
   if ( !mAlreadyFinished )
   {
@@ -41,6 +43,7 @@ bool QgsProxyProgressTask::run()
   }
   mNotFinishedMutex.unlock();
 
+  QgsApplication::taskManager()->threadPool()->reserveThread();
   return mResult;
 }
 

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -389,6 +389,7 @@ class QgsTaskRunnableWrapper : public QRunnable
 
 QgsTaskManager::QgsTaskManager( QObject *parent )
   : QObject( parent )
+  , mThreadPool( new QThreadPool( this ) )
   , mTaskMutex( new QRecursiveMutex() )
 {
 
@@ -411,6 +412,11 @@ QgsTaskManager::~QgsTaskManager()
   }
 
   delete mTaskMutex;
+}
+
+QThreadPool *QgsTaskManager::threadPool()
+{
+  return mThreadPool;
 }
 
 long QgsTaskManager::addTask( QgsTask *task, int priority )
@@ -717,7 +723,7 @@ void QgsTaskManager::taskStatusChanged( int status )
   mTaskMutex->lock();
   QgsTaskRunnableWrapper *runnable = mTasks.value( id ).runnable;
   mTaskMutex->unlock();
-  if ( runnable && QThreadPool::globalInstance()->tryTake( runnable ) )
+  if ( runnable && mThreadPool->tryTake( runnable ) )
   {
     delete runnable;
     mTasks[ id ].runnable = nullptr;
@@ -824,7 +830,7 @@ bool QgsTaskManager::cleanupAndDeleteTask( QgsTask *task )
   }
   else
   {
-    if ( runnable && QThreadPool::globalInstance()->tryTake( runnable ) )
+    if ( runnable && mThreadPool->tryTake( runnable ) )
     {
       delete runnable;
       mTasks[ id ].runnable = nullptr;
@@ -861,7 +867,7 @@ void QgsTaskManager::processQueue()
     if ( task && task->mStatus == QgsTask::Queued && dependenciesSatisfied( it.key() ) && it.value().added.testAndSetRelaxed( 0, 1 ) )
     {
       it.value().createRunnable();
-      QThreadPool::globalInstance()->start( it.value().runnable, it.value().priority );
+      mThreadPool->start( it.value().runnable, it.value().priority );
     }
 
     if ( task && ( task->mStatus != QgsTask::Complete && task->mStatus != QgsTask::Terminated ) )

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -412,6 +412,7 @@ QgsTaskManager::~QgsTaskManager()
   }
 
   delete mTaskMutex;
+  mThreadPool->waitForDone();
 }
 
 QThreadPool *QgsTaskManager::threadPool()

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -431,6 +431,13 @@ class CORE_EXPORT QgsTaskManager : public QObject
     };
 
     /**
+     * Returns the threadpool utilised by the task manager.
+     *
+     * \since QGIS 3.34
+     */
+    QThreadPool *threadPool();
+
+    /**
      * Adds a task to the manager. Ownership of the task is transferred
      * to the manager, and the task manager will be responsible for starting
      * the task. The priority argument can be used to control the run queue's
@@ -599,6 +606,8 @@ class CORE_EXPORT QgsTaskManager : public QObject
       int priority;
       QgsTaskRunnableWrapper *runnable = nullptr;
     };
+
+    QThreadPool *mThreadPool = nullptr;
 
     bool mInitialized = false;
 

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -431,7 +431,7 @@ class CORE_EXPORT QgsTaskManager : public QObject
     };
 
     /**
-     * Returns the threadpool utilised by the task manager.
+     * Returns the threadpool utilized by the task manager.
      *
      * \since QGIS 3.34
      */

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -626,11 +626,10 @@ void TestQgsTaskManager::subTaskGrandChildren()
 
 void TestQgsTaskManager::subTaskProgress()
 {
-  // we need 3 threads to run this test (one for each task)
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
-
   QgsTaskManager manager;
+  // we need 3 threads to run this test (one for each task)
+  manager.threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager.threadPool()->maxThreadCount(), 3 );
 
   // test parent task progress
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_3" ) );
@@ -714,11 +713,11 @@ void TestQgsTaskManager::subTaskCancelParent()
 
 void TestQgsTaskManager::subTaskTerminateSubTask()
 {
-  // we need 3 threads to run this test (one for each task)
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
-
   QgsTaskManager manager;
+
+  // we need 3 threads to run this test (one for each task)
+  manager.threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager.threadPool()->maxThreadCount(), 3 );
 
   // test that if a subtask terminates the parent task is canceled
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_5" ) );
@@ -754,11 +753,11 @@ void TestQgsTaskManager::subTaskTerminateSubTask()
 
 void TestQgsTaskManager::subTaskPartialComplete()
 {
-  // we need 3 threads to run this test (one for each task)
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
-
   QgsTaskManager manager;
+
+  // we need 3 threads to run this test (one for each task)
+  manager.threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager.threadPool()->maxThreadCount(), 3 );
 
   // test that a task is not marked complete until all subtasks are complete
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_6" ) );
@@ -804,11 +803,11 @@ void TestQgsTaskManager::subTaskPartialComplete()
 
 void TestQgsTaskManager::subTaskPartialComplete2()
 {
-  // we need 3 threads to run this test (one for each task)
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
-
   QgsTaskManager manager;
+
+  // we need 3 threads to run this test (one for each task)
+  manager.threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager.threadPool()->maxThreadCount(), 3 );
 
   // another test
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_7" ) );
@@ -954,11 +953,10 @@ void TestQgsTaskManager::waitForFinished()
 
 void TestQgsTaskManager::waitForFinishedBeforeStart()
 {
-  // backup max thread count and force it to 1 so there is only one slot in task manager queue
-  int maxThreadCount = QThreadPool::globalInstance()->maxThreadCount();
-  QThreadPool::globalInstance()->setMaxThreadCount( 1 );
-
   QgsTaskManager manager;
+
+  // force max thread count to 1 so there is only one slot in task manager queue
+  manager.threadPool()->setMaxThreadCount( 1 );
 
   // add a wait task so the test task is not started when we call waitforfinished
   QPointer<QgsTask> waitTask = new WaitTask( "wait_task" );
@@ -980,9 +978,6 @@ void TestQgsTaskManager::waitForFinishedBeforeStart()
   {
     QCoreApplication::processEvents();
   }
-
-  // restore max thread count (for other tests)
-  QThreadPool::globalInstance()->setMaxThreadCount( maxThreadCount );
 
   flushEvents();
 }
@@ -1423,9 +1418,11 @@ void TestQgsTaskManager::layerDependencies()
 
 void TestQgsTaskManager::managerWithSubTasks()
 {
+  QgsTaskManager *manager = new QgsTaskManager();
+
   // we need 3 threads to run this test (one for each task)
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+  manager->threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager->threadPool()->maxThreadCount(), 3 );
 
   // parent with subtasks
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "parent" ) );
@@ -1434,7 +1431,6 @@ void TestQgsTaskManager::managerWithSubTasks()
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
 
-  QgsTaskManager *manager = new QgsTaskManager();
   QSignalSpy spy( manager, &QgsTaskManager::taskAdded );
   QSignalSpy spyProgress( manager, &QgsTaskManager::progressChanged );
 
@@ -1570,13 +1566,15 @@ void TestQgsTaskManager::managerWithSubTasks3()
 
 void TestQgsTaskManager::cancelBeforeStart()
 {
-  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
-  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+  QgsTaskManager manager;
+
+  manager.threadPool()->setMaxThreadCount( 3 );
+  QCOMPARE( manager.threadPool()->maxThreadCount(), 3 );
 
   // add too much tasks to the manager, so that some are queued and can't start immediately
   // then cancel them all!
   QList< QgsTask * > tasks;
-  QgsTaskManager manager;
+
   for ( int i = 0; i < 10; ++i )
   {
     QgsTask *task = new CancelableTask();


### PR DESCRIPTION
This avoids conflicts with Qt3D framework. As noted in https://github.com/qgis/QGIS/issues/50067#issuecomment-1318081784 "The constructor and destructor of QChangeArbiter require the use of **every** thread in the Qt thread pool."

This causes hangs when exporting layouts containing 3d maps. We have threads from task manager in use from elsewhere, so the application deadlocks waiting for every thread to be freed so that QChangeArbiter can do its thing.

So, use a new dedicated thread pool for task manager's exclusive use. This avoids the hang when exporting 3d maps as it avoids the deadlock between task manager and Qt3D's requirements.

(A side benefit is that we don't get delayed map rendering when the number of queued/running tasks hits the max thread count from the global thread pool.)

Fixes https://github.com/qgis/QGIS/issues/50067
Fixes https://github.com/qgis/QGIS/issues/45038