### PR TITLE
Always run the spell and shell checkers if possible, print warning when not possible

### DIFF
--- a/scripts/prepare_commit.sh
+++ b/scripts/prepare_commit.sh
@@ -57,7 +57,22 @@ if [ -z "$MODIFIED" ]; then
   exit 0
 fi
 
-if [[ -n "$QGIS_CHECK_SPELLING" && -x "${TOPLEVEL}"/scripts/spell_check/check_spelling.sh ]]; then "${TOPLEVEL}"/scripts/spell_check/check_spelling.sh "$MODIFIED"; fi
+# Run spell checker if requirements are met
+if ! command -v ag > /dev/null; then
+  echo "WARNING: the ag(1) executable was not found, spell checker could not run" >&2
+elif ! command -v unbuffer > /dev/null; then
+  echo "WARNING: the unbuffer(1) executable was not found, spell checker could not run" >&2
+else
+  "${TOPLEVEL}"/scripts/spell_check/check_spelling.sh "$MODIFIED"
+fi
+
+# Run shell checker if requirements are met
+if command -v shellcheck > /dev/null; then
+  # TODO: allow passing $MODIFIED
+  ${TOPLEVEL}/tests/code_layout/test_shellcheck.sh || exit 1
+else
+  echo "WARNING: the shellcheck(1) executable was not found, shell checker could not run" >&2
+fi
 
 FILES_CHANGED=0
 


### PR DESCRIPTION
I was annoyed by the CI bot failing due to spellchecker (US vs. UK english) and wondered why the pre-commit hook was not running this locally, then found out I had to set an environment variable to enable that. This commit is to always run the spell checker when requirements are met and print a WARNING when they aren't, so that developers have more probabilities to not disappoint the bot lords