### PR TITLE
Do not include a BoundingBox tag in GetFeatureInfo responses, when it is null

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1655,7 +1655,7 @@ namespace QgsWms
       }
     }
 
-    if ( featuresRect )
+    if ( featuresRect && ! featuresRect->isNull() )
     {
       if ( infoFormat == QgsWmsParameters::Format::GML )
       {

--- a/tests/testdata/qgis_server/get_postgres_types_json_dict.txt
+++ b/tests/testdata/qgis_server/get_postgres_types_json_dict.txt
@@ -3,7 +3,6 @@ Content-Type: text/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <GetFeatureInfoResponse>
- <BoundingBox maxy="0" maxx="0" miny="0" CRS="EPSG:3857" minx="0"/>
  <Layer name="json">
   <Feature id="2">
    <Attribute value="2" name="pk"/>

--- a/tests/testdata/qgis_server/get_postgres_types_json_list.txt
+++ b/tests/testdata/qgis_server/get_postgres_types_json_list.txt
@@ -3,7 +3,6 @@ Content-Type: text/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <GetFeatureInfoResponse>
- <BoundingBox maxy="0" maxx="0" miny="0" CRS="EPSG:3857" minx="0"/>
  <Layer name="json">
   <Feature id="1">
    <Attribute value="1" name="pk"/>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_results.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_results.txt
@@ -3,6 +3,5 @@ Content-Type: text/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <GetFeatureInfoResponse>
- <BoundingBox maxy="0" maxx="0" miny="0" CRS="EPSG:3857" minx="0"/>
  <Layer name="testlayer èé"/>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
I've noticed QGIS WMS responses are including a BoundingBox tag with min/max values being all 0.0 when the real bounding box is null, this PR aims at making it more explicit to allow for using other encoding for a null bounding box.

I haven't found the specification of the returned XML to see if a more formal way to express a null bounding box exists.

References https://github.com/qgis/QGIS/pull/54646#issuecomment-1749081658

\cc @elpaso 