### PR TITLE
Use distinct name for test results artifact

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -416,7 +416,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: test-results
+          name: test-results-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}
           path: qgis_test_report
 
   clang-tidy:


### PR DESCRIPTION
Avoids failures from qt5/qt6 runs overridding each other's test report artifact