### PR TITLE
qgs3daxissettings: Correctly read viewport ratio on a saved project

### DIFF
--- a/src/3d/qgs3daxissettings.cpp
+++ b/src/3d/qgs3daxissettings.cpp
@@ -43,11 +43,11 @@ void Qgs3DAxisSettings::readXml( const QDomElement &element, const QgsReadWriteC
 
   sizeStr = element.attribute( QStringLiteral( "minViewportRatio" ) );
   if ( !sizeStr.isEmpty() )
-    mMinViewportRatio = sizeStr.toInt();
+    mMinViewportRatio = sizeStr.toDouble();
 
   sizeStr = element.attribute( QStringLiteral( "maxViewportRatio" ) );
   if ( !sizeStr.isEmpty() )
-    mMaxViewportRatio = sizeStr.toInt();
+    mMaxViewportRatio = sizeStr.toDouble();
 
   const QString modeStr = element.attribute( QStringLiteral( "mode" ) );
   if ( modeStr == QLatin1String( "Off" ) )


### PR DESCRIPTION
## Description

When loading a project which contains a 3D view, the 3D axis is not visible even when it is supposed to be displayed. This is because the min and max viewport ratio settings are always equal to 0 on a saved project. Indeed, these settings are supposed to handle the 3D axis visibility when the 3D view size changes: the axis are hidden when the view becomes too small.
These ratio are stored as double between 0 and 1. However, the logic which reads these parameters from a saved
project (`Qgs3DAxisSettings::readXml`) parses them as integer. Therefore, the min and max ratio are always equal to 0. Then, the 3D axis visibility test is always false and the 3D axis are always hidden.

This issue is fixed by changing `Qgs3DAxisSettings::readXml` to read the ratios as double.

cc @benoitdm-oslandia 
