### PR TITLE
auto-cancel running builds on PRs when pushing a new commit

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,4 +1,9 @@
 name: 🍏 Mac OS build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -1,5 +1,9 @@
 name: 🪟 MingW64 Windows 64bit Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -1,5 +1,9 @@
 name: 🗺 OGC tests for QGIS Server
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,9 @@
 name: 🧪 QGIS tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -85,7 +89,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: true
-          
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
So, any running QGIS build action will be killed if you push a new commit to the branch.

`+` reduce a bit the resources used to build QGIS on Github infrastructure (*insert Green Washing here*)
`-` in some cases, you still might want to get the result of the former commit
    * you want to introduce a test, check that it fails, and then push the fix commit (that's the only case I faced)
    * *?*

Considering, the ratio of - over + cases, is probably around 1/1000 or even smaller, I would consider introducing this.