### PR TITLE
Add github workflow to upload test failure markdown summary report as a comment to PRs when tests fail

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -416,11 +416,18 @@ jobs:
           mkdir -p /tmp/minio_tests/test-bucket && chmod -R 777 /tmp/minio_tests
           docker-compose -f .docker/$DOCKERFILE run qgis-deps /root/QGIS/.docker/docker-qgis-test.sh $TEST_BATCH
 
+      - name: Save PR number to test report
+        if: ${{ failure() }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > qgis_test_report/pr_number
+
       - name: Archive test results report
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: test-results-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}
+          name: test-results-qt${{ matrix.qt-version }}
           path: qgis_test_report
 
   clang-tidy:

--- a/.github/workflows/write_failure_comment.yml
+++ b/.github/workflows/write_failure_comment.yml
@@ -1,0 +1,55 @@
+name: Write test failure comment
+
+on:
+  workflow_run:
+    workflows: [🧪 QGIS tests]
+    types:
+      - completed
+
+jobs:
+  strategy:
+    matrix:
+      qt-version: [ 5, 6 ]
+
+  on-failure:
+    download:
+      runs-on: ubuntu-latest
+      steps:
+        - name: 'Download artifact'
+          uses: actions/github-script@v6
+          with:
+            script: |
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 run_id: context.payload.workflow_run.id,
+              });
+              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == "test-results-qt${{ matrix.qt-version }}"
+              })[0];
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchArtifact.id,
+                 archive_format: 'zip',
+              });
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/test-results-qt${{ matrix.qt-version }}.zip`, Buffer.from(download.data));
+
+        - name: 'Unzip artifact'
+          run: unzip test-results-qt${{ matrix.qt-version }}.zip
+
+        - name: 'Post test report markdown summary as comment on PR'
+          uses: actions/github-script@v6
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              let fs = require('fs');
+              let issue_number = Number(fs.readFileSync('./test-results-qt${{ matrix.qt-version }}'));
+              let body = String(fs.readFileSync('./summary.md'));
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: body
+              });

--- a/python/core/auto_generated/qgsmultirenderchecker.sip.in
+++ b/python/core/auto_generated/qgsmultirenderchecker.sip.in
@@ -124,9 +124,22 @@ Test using renderer to generate the image to be compared.
 
     QString report() const;
 %Docstring
-Returns a report for this test.
+Returns a HTML report for this test.
 
 The report will be empty if the test was successfully run.
+
+.. seealso:: :py:func:`markdownReport`
+%End
+
+    QString markdownReport() const;
+%Docstring
+Returns a markdown report for this test.
+
+The report will be empty if the test was successfully run.
+
+.. seealso:: :py:func:`report`
+
+.. versionadded:: 3.34
 %End
 
     QString controlImagePath() const;

--- a/python/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/core/auto_generated/qgsrenderchecker.sip.in
@@ -72,6 +72,20 @@ Returns the HTML report describing the results of the test run.
 
 If ``ignoreSuccess`` is ``True`` then the report will always be empty if
 the test was successful.
+
+.. seealso:: :py:func:`markdownReport`
+%End
+
+    QString markdownReport( bool ignoreSuccess = true ) const;
+%Docstring
+Returns the markdown report describing the results of the test run.
+
+If ``ignoreSuccess`` is ``True`` then the report will always be empty if
+the test was successful.
+
+.. seealso:: :py:func:`report`
+
+.. versionadded:: 3.34
 %End
 
     float matchPercent() const;

--- a/src/core/qgsmultirenderchecker.cpp
+++ b/src/core/qgsmultirenderchecker.cpp
@@ -44,6 +44,7 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
   mResult = false;
 
   mReport += "<h2>" + testName + "</h2>\n";
+  mMarkdownReport += QStringLiteral( "### %1\n\n" ).arg( testName );
 
   const QString baseDir = controlImagePath();
   if ( !QFile::exists( baseDir ) )
@@ -97,6 +98,10 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
     dartMeasurements << checker.dartMeasurements();
 
     mReport += checker.report( false );
+    if ( subDirs.count() > 1 )
+      mMarkdownReport += QStringLiteral( "* " ) + checker.markdownReport( false );
+    else
+      mMarkdownReport += checker.markdownReport( false );
 
     if ( !mResult && diffImageFile.isEmpty() )
     {
@@ -171,6 +176,11 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
 QString QgsMultiRenderChecker::report() const
 {
   return !mResult ? mReport : QString();
+}
+
+QString QgsMultiRenderChecker::markdownReport() const
+{
+  return !mResult ? mMarkdownReport : QString();
 }
 
 QString QgsMultiRenderChecker::controlImagePath() const

--- a/src/core/qgsmultirenderchecker.h
+++ b/src/core/qgsmultirenderchecker.h
@@ -128,11 +128,23 @@ class CORE_EXPORT QgsMultiRenderChecker
     bool runTest( const QString &testName, unsigned int mismatchCount = 0 );
 
     /**
-     * Returns a report for this test.
+     * Returns a HTML report for this test.
      *
      * The report will be empty if the test was successfully run.
+     *
+     * \see markdownReport()
      */
     QString report() const;
+
+    /**
+     * Returns a markdown report for this test.
+     *
+     * The report will be empty if the test was successfully run.
+     *
+     * \see report()
+     * \since QGIS 3.34
+     */
+    QString markdownReport() const;
 
     /**
      * Returns the path to the control images.
@@ -148,6 +160,7 @@ class CORE_EXPORT QgsMultiRenderChecker
   private:
     bool mResult = false;
     QString mReport;
+    QString mMarkdownReport;
     QString mRenderedImage;
     QString mControlName;
     QString mControlPathPrefix;

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -62,6 +62,11 @@ QString QgsRenderChecker::report( bool ignoreSuccess ) const
   return ( ( ignoreSuccess && mResult ) || ( mExpectFail && !mResult ) ) ? QString() : mReport;
 }
 
+QString QgsRenderChecker::markdownReport( bool ignoreSuccess ) const
+{
+  return ( ( ignoreSuccess && mResult ) || ( mExpectFail && !mResult ) ) ? QString() : mMarkdownReport;
+}
+
 void QgsRenderChecker::setControlName( const QString &name )
 {
   mControlName = name;
@@ -252,6 +257,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File not set.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because expected image file not set\n" );
     performPostTestActions( flags );
     return mResult;
   }
@@ -266,6 +272,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File could not be loaded.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because expected image file (%1) could not be loaded\n" ).arg( mExpectedImageFile );
     performPostTestActions( flags );
     return mResult;
   }
@@ -304,6 +311,8 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
               "Image File could not be saved.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because rendered image file could not be saved to %1\n" ).arg( mRenderedImageFile );
+
     performPostTestActions( flags );
     return mResult;
   }
@@ -340,6 +349,8 @@ bool QgsRenderChecker::compareImages( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File not set.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because expected image file was not set\n" );
+
     performPostTestActions( flags );
     return mResult;
   }
@@ -365,6 +376,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
               "Image File not set.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because rendered image file was not set\n" );
     performPostTestActions( flags );
     return mResult;
   }
@@ -380,6 +392,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because control "
               "image file could not be loaded.</td></tr></table>\n";
+    mMarkdownReport = QStringLiteral( "Failed because expected image file (%1) could not be loaded\n" ).arg( referenceImageFile );
     performPostTestActions( flags );
     return mResult;
   }
@@ -400,6 +413,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
                               "<tr><td>Test Result:</td><td>%1:</td></tr>\n"
                               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
                               "Image File could not be loaded.</td></tr></table>\n" ).arg( upperFirst( expectedImageString ) );
+    mMarkdownReport = QStringLiteral( "Failed because rendered image (%1) could not be loaded\n" ).arg( mRenderedImageFile );
     performPostTestActions( flags );
     return mResult;
   }
@@ -508,6 +522,11 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += QLatin1String( "<tr><td colspan=3>" );
       mReport += QStringLiteral( "<font color=red>%1 and %2 for " ).arg( upperFirst( expectedImageString ), renderedImageString ) + testName + " are different dimensions - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
+      mMarkdownReport += QStringLiteral( "Failed because rendered image and expected image are different dimensions (%1x%2 v2 %3x%4)\n" )
+                         .arg( myResultImage.width() )
+                         .arg( myResultImage.height() )
+                         .arg( expectedImage.width() )
+                         .arg( expectedImage.height() );
 
       const QString diffSizeImagesString = QString(
                                              "<tr>"
@@ -548,6 +567,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += "<font color=red>Expected image and rendered image for " + testName + " have different formats (8bit format is expected) - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
+
+      mMarkdownReport += QStringLiteral( "Failed because rendered image and expected image have different formats (8bit format is expected)\n" );
       performPostTestActions( flags );
       return mResult;
     }
@@ -655,6 +676,9 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += QLatin1String( "<font color=red>Test failed because render step took too long</font>" );
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
+
+      mMarkdownReport += QStringLiteral( "Test failed because render step took too long\n" );
+
       performPostTestActions( flags );
       return mResult;
     }
@@ -679,6 +703,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   mReport += QStringLiteral( "<font color=red>%1 and %2 for " ).arg( upperFirst( expectedImageString ), renderedImageString ) + testName + " are mismatched</font><br>";
   mReport += QLatin1String( "</td></tr>" );
   mReport += myImagesString;
+
+  mMarkdownReport += QStringLiteral( "Rendered image did not match %1 (found %2 pixels different)\n" ).arg( referenceImageFile ).arg( mMismatchCount );
 
   performPostTestActions( flags );
   return mResult;

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -86,8 +86,21 @@ class CORE_EXPORT QgsRenderChecker
      *
      * If \a ignoreSuccess is TRUE then the report will always be empty if
      * the test was successful.
+     *
+     * \see markdownReport()
      */
     QString report( bool ignoreSuccess = true ) const;
+
+    /**
+     * Returns the markdown report describing the results of the test run.
+     *
+     * If \a ignoreSuccess is TRUE then the report will always be empty if
+     * the test was successful.
+     *
+     * \see report()
+     * \since QGIS 3.34
+     */
+    QString markdownReport( bool ignoreSuccess = true ) const;
 
     /**
      * Returns the percent of pixels which matched the control image.
@@ -277,7 +290,10 @@ class CORE_EXPORT QgsRenderChecker
     QVector<QgsDartMeasurement> dartMeasurements() const { return mDashMessages; }
 
   protected:
+    //! HTML format report
     QString mReport;
+    //! Markdown report
+    QString mMarkdownReport;
     unsigned int mMatchTarget = 0;
     int mElapsedTime = 0;
     QString mRenderedImageFile;

--- a/tests/src/core/testqgscompositionconverter.cpp
+++ b/tests/src/core/testqgscompositionconverter.cpp
@@ -22,7 +22,6 @@
 #include "qgscompositionconverter.h"
 #include "qgsproject.h"
 #include "qgsreadwritecontext.h"
-#include "qgsmultirenderchecker.h"
 #include "qgslayoutmanager.h"
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutitemlabel.h"
@@ -54,7 +53,7 @@ class TestQgsCompositionConverter: public QgsTest
     Q_OBJECT
 
   public:
-    TestQgsCompositionConverter() : QgsTest( QStringLiteral( "Composition Converter Tests" ) ) {}
+    TestQgsCompositionConverter() : QgsTest( QStringLiteral( "Composition Converter Tests" ), QStringLiteral( "compositionconverter" ) ) {}
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
@@ -711,13 +710,15 @@ void TestQgsCompositionConverter::importComposerAtlas()
 
 void TestQgsCompositionConverter::checkRenderedImage( QgsLayout *layout, const QString &testName, const int pageNumber )
 {
-  QgsLayoutChecker checker( testName + '_' + QString::number( pageNumber ), layout );
-  QSize size( layout->pageCollection()->page( pageNumber )->sizeWithUnits().width() * 3.77, layout->pageCollection()->page( pageNumber )->sizeWithUnits().height() * 3.77 );
-  checker.setSize( size );
-  checker.setControlPathPrefix( QStringLiteral( "compositionconverter" ) );
-  QVERIFY( checker.testLayout( mReport, pageNumber, 0, false ) );
-}
+  const QSize size( layout->pageCollection()->page( pageNumber )->sizeWithUnits().width() * 3.77, layout->pageCollection()->page( pageNumber )->sizeWithUnits().height() * 3.77 );
 
+  QVERIFY(
+    layoutCheck(
+      testName + '_' + QString::number( pageNumber ),
+      layout,
+      pageNumber, 0, size, 0 )
+  );
+}
 
 QDomElement TestQgsCompositionConverter::loadComposer( const QString &name )
 {


### PR DESCRIPTION
Relates to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/268

This PR expands the current mechanism which generates HTML summary reports of test failures to also generate a (concise!) markdown summary report. The markdown report is then added as a comment to the PR, providing a much more submitter-friendly way of determining why a PR is failing the test suites.

A few notes:

- In https://github.com/qgis/QGIS-Enhancement-Proposals/issues/268 I wrote: "The goal is that if a rendering test fails, a comment will be automatically added to the Pull Request containing a descriptive message and a link to download the rendered images for debugging". This is unfortunately still **NOT** possible given the available Github APIs.
- Specifically, I was originally hoping to attach the full test summary artifact (html report + rendered images) as a zip file to the autogenerated comment. However, there's no public API to upload assets to Github. (I did find https://github.com/j178/github-s3, but that relies on a private/non-stable API, and I'm dead against relying on private API in our CI setup... there's enough regular ongoing maintainence required here without intentionally heading into unstable territory :scream_cat: )
- For the same reason, I can't directly embed the rendered images into the auto-created comment -- there's no way we can grab the images from the test report artifact and upload them as issue assets. => The test failure comment is PLAIN TEXT ONLY :disappointed: 
- Failing this, I was hoping to at least put a link in the comment to the test results artifact zip, to make it easy to locate this artifact. But again, there's no Github support for this :scream_cat: :scream_cat: . (See https://github.com/actions/upload-artifact/issues/50 , https://github.com/actions/upload-artifact/issues/53 )
- The comment only relates to test failures relating to rendered image checks -- other general test failures are excluded. The rendered image check is our most unusual/trickiest barrier to new contributors wrt failing tests, so I'm exclusively targeting that here.
- Tests MUST use the base class QgsTest / QgisTestCase methods for render/layout rendering checks. If they have ad-hoc implementations then the markdown report won't include the failures from those ad-hoc methods. Updating all tests to use the base class methods is a WIP, being done on demand (see eg https://github.com/qgis/QGIS/pull/54882/commits/117f5087738c3696372534733c937e8c3649259b )
- In the QEP I've mentioned: "If possible, the workflow improvements will be backported to apply to all maintained stable release branches (including LTR).". This **ISN'T** suitable for backporting... there's been many many changes to the test infrastructure since LTR and the delta is just too large to make a backport workable.

**Also note: this workflow won't actually DO anything from this PR -- it will only kick in when the workflow is present in the master branch.**
