### PR TITLE
Make QgsBookmark string output more explicit about it being EMPTY

### DIFF
--- a/python/core/auto_generated/qgsbookmarkmanager.sip.in
+++ b/python/core/auto_generated/qgsbookmarkmanager.sip.in
@@ -126,7 +126,14 @@ Returns a DOM element representing the bookmark's properties.
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsBookmark: '%1' (%2 - %3)>" ).arg( sipCpp->name(), sipCpp->extent().asWktCoordinates(), sipCpp->extent().crs().authid() );
+    QString str = QStringLiteral( "<QgsBookmark: '%1' (%2)>" )
+                  .arg( sipCpp->name() )
+                  .arg(
+                    sipCpp->extent().isNull() ?
+                    QStringLiteral( "EMPTY" ) :
+                    QStringLiteral( "%1 - %2" )
+                    .arg( sipCpp->extent().asWktCoordinates(), sipCpp->extent().crs().authid() )
+                  );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/src/core/qgsbookmarkmanager.h
+++ b/src/core/qgsbookmarkmanager.h
@@ -128,7 +128,14 @@ class CORE_EXPORT QgsBookmark
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsBookmark: '%1' (%2 - %3)>" ).arg( sipCpp->name(), sipCpp->extent().asWktCoordinates(), sipCpp->extent().crs().authid() );
+    QString str = QStringLiteral( "<QgsBookmark: '%1' (%2)>" )
+                  .arg( sipCpp->name() )
+                  .arg(
+                    sipCpp->extent().isNull() ?
+                    QStringLiteral( "EMPTY" ) :
+                    QStringLiteral( "%1 - %2" )
+                    .arg( sipCpp->extent().asWktCoordinates(), sipCpp->extent().crs().authid() )
+                  );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -258,9 +258,9 @@ class TestPython__repr__(QgisTestCase):
 
     def testQgsBookmark(self):
         b = QgsBookmark()
-        self.assertEqual(b.__repr__(), "<QgsBookmark: '' (0 0, 0 0 - )>")
+        self.assertEqual(b.__repr__(), "<QgsBookmark: '' (EMPTY)>")
         b.setName('test bookmark')
-        self.assertEqual(b.__repr__(), "<QgsBookmark: 'test bookmark' (0 0, 0 0 - )>")
+        self.assertEqual(b.__repr__(), "<QgsBookmark: 'test bookmark' (EMPTY)>")
         b.setExtent(QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('EPSG:3111')))
         self.assertEqual(b.__repr__(), "<QgsBookmark: 'test bookmark' (1 2, 3 4 - EPSG:3111)>")
 


### PR DESCRIPTION
It doesn't make much to print `(0 0,0 0 - )` while `(EMPTY)` seems pretty clear to me.

It also help when changing string output of null QgsRectangle, as done in GH-54646