### PR TITLE
Free up some disk space before running `clang-tidy`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -442,6 +442,14 @@ jobs:
             qt-version: 5
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Might help with failures like https://github.com/qgis/QGIS/actions/runs/6493229254/job/17638277259.
