### PR TITLE
Correctly delete graduated layout widgets

### DIFF
--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -925,9 +925,10 @@ void QgsGraduatedSymbolRendererWidget::clearParameterWidgets()
     for ( QLayoutItem *item : {row.labelItem, row.fieldItem} )
       if ( item )
       {
-        if ( item->widget() )
-          item->widget()->deleteLater();
+        QWidget *widget = item->widget();
         delete item;
+        if ( widget )
+          delete widget;
       }
   }
   mParameterWidgetWrappers.clear();


### PR DESCRIPTION
Fixes #54549

The issue happens only on french (and german it seems) because of the sort order of graduated method. In french, fixed interval is the first one and adds a processing parameter in the layout before setting the actually renderer one.

When it occurs, the old widget was not immediately cleared and then lead to display it above the table.

@3nids I assume you used *deleteLater* because you wanted to delete the layout first and the widget then, or is there another specific reason?
