### PR TITLE
Fix extent computation in QgsAFSProvider

### DIFF
--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -168,6 +168,15 @@ Returns an empty map if the ``crs`` is not valid.
 .. versionadded:: 3.28
 %End
 
+    static QgsRectangle convertRectangle( const QVariant &value );
+%Docstring
+Converts a rectangle ``value`` to a :py:class:`QgsRectangle`.
+
+Returns a null rectangle if the value cannot be converted.
+
+.. versionadded:: 3.34
+%End
+
     enum class FeatureToJsonFlag
     {
       IncludeGeometry,

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -87,29 +87,7 @@ QgsRectangle QgsArcGisRestQueryUtils::getExtent( const QString &layerurl, const 
     return QgsRectangle();
   }
 
-  QgsRectangle rect;
-  do
-  {
-    const QVariantMap coords = res.value( QStringLiteral( "extent" ) ).toMap();
-    if ( coords.isEmpty() ) break;
-    bool ok;
-    const double xmin = coords.value( QStringLiteral( "xmin" ) ).toDouble( &ok );
-    if ( ! ok ) break;
-    const double ymin = coords.value( QStringLiteral( "ymin" ) ).toDouble( &ok );
-    if ( ! ok ) break;
-    const double xmax = coords.value( QStringLiteral( "xmax" ) ).toDouble( &ok );
-    if ( ! ok ) break;
-    const double ymax = coords.value( QStringLiteral( "ymax" ) ).toDouble( &ok );
-    if ( ! ok ) break;
-
-    rect.setXMinimum( xmin );
-    rect.setYMinimum( ymin );
-    rect.setXMaximum( xmax );
-    rect.setYMaximum( ymax );
-  }
-  while ( 0 );
-
-  return rect;
+  return QgsArcGisRestUtils::convertRectangle( res.value( QStringLiteral( "extent" ) ) );
 }
 
 QVariantMap QgsArcGisRestQueryUtils::getObjects( const QString &layerurl, const QString &authcfg, const QList<quint32> &objectIds, const QString &crs,

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -88,11 +88,27 @@ QgsRectangle QgsArcGisRestQueryUtils::getExtent( const QString &layerurl, const 
   }
 
   QgsRectangle rect;
-  const QVariantMap coords = res.value( QStringLiteral( "extent" ) ).toMap();
-  rect.setXMinimum( coords.value( QStringLiteral( "xmin" ) ).toDouble() );
-  rect.setYMinimum( coords.value( QStringLiteral( "ymin" ) ).toDouble() );
-  rect.setXMaximum( coords.value( QStringLiteral( "xmax" ) ).toDouble() );
-  rect.setYMaximum( coords.value( QStringLiteral( "ymax" ) ).toDouble() );
+  do
+  {
+    const QVariantMap coords = res.value( QStringLiteral( "extent" ) ).toMap();
+    if ( coords.isEmpty() ) break;
+    bool ok;
+    const double xmin = coords.value( QStringLiteral( "xmin" ) ).toDouble( &ok );
+    if ( ! ok ) break;
+    const double ymin = coords.value( QStringLiteral( "ymin" ) ).toDouble( &ok );
+    if ( ! ok ) break;
+    const double xmax = coords.value( QStringLiteral( "xmax" ) ).toDouble( &ok );
+    if ( ! ok ) break;
+    const double ymax = coords.value( QStringLiteral( "ymax" ) ).toDouble( &ok );
+    if ( ! ok ) break;
+
+    rect.setXMinimum( xmin );
+    rect.setYMinimum( ymin );
+    rect.setXMaximum( xmax );
+    rect.setYMaximum( ymax );
+  }
+  while ( 0 );
+
   return rect;
 }
 

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1053,6 +1053,33 @@ QDateTime QgsArcGisRestUtils::convertDateTime( const QVariant &value )
     return dt;
 }
 
+QgsRectangle QgsArcGisRestUtils::convertRectangle( const QVariant &value )
+{
+  if ( QgsVariantUtils::isNull( value ) )
+    return QgsRectangle();
+
+  const QVariantMap coords = value.toMap();
+  if ( coords.isEmpty() ) return QgsRectangle();
+
+  bool ok;
+
+  const double xmin = coords.value( QStringLiteral( "xmin" ) ).toDouble( &ok );
+  if ( ! ok ) return QgsRectangle();
+
+  const double ymin = coords.value( QStringLiteral( "ymin" ) ).toDouble( &ok );
+  if ( ! ok ) return QgsRectangle();
+
+  const double xmax = coords.value( QStringLiteral( "xmax" ) ).toDouble( &ok );
+  if ( ! ok ) return QgsRectangle();
+
+  const double ymax = coords.value( QStringLiteral( "ymax" ) ).toDouble( &ok );
+  if ( ! ok ) return QgsRectangle();
+
+  return QgsRectangle( xmin, ymin, xmax, ymax );
+
+}
+
+
 QVariantMap QgsArcGisRestUtils::geometryToJson( const QgsGeometry &geometry, const QgsArcGisRestContext &, const QgsCoordinateReferenceSystem &crs )
 {
   QVariantMap res;

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -212,6 +212,15 @@ class CORE_EXPORT QgsArcGisRestUtils
     static QVariantMap crsToJson( const QgsCoordinateReferenceSystem &crs );
 
     /**
+     * Converts a rectangle \a value to a QgsRectangle.
+     *
+     * Returns a null rectangle if the value cannot be converted.
+     *
+     * \since QGIS 3.34
+     */
+    static QgsRectangle convertRectangle( const QVariant &value );
+
+    /**
      * Flags which control the behavior of converting features to JSON.
      *
      * \since QGIS 3.28


### PR DESCRIPTION
Extent should be set to null if there are no rows or geometric field or computed min/max envelope ordinates are null.

Without this fix the extent reported by QgsAFSProvider when no features are in the source is a 0,0,0,0 rectangle just because QString("").toDouble() returns 0 (ie: out of chance).

This fix is required for when QgsRectangle(0,0,0,0) will stop being considered null, which is the focus of GH-54646