### PR TITLE
Handle null in QgsRectangle grow() and include() methods

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -295,7 +295,8 @@ class CORE_EXPORT QgsRectangle
      */
     void grow( double delta )
     {
-      if ( isNull() ) return;
+      if ( isNull() )
+        return;
       mXmin -= delta;
       mXmax += delta;
       mYmin -= delta;

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -295,6 +295,7 @@ class CORE_EXPORT QgsRectangle
      */
     void grow( double delta )
     {
+      if ( isNull() ) return;
       mXmin -= delta;
       mXmax += delta;
       mYmin -= delta;
@@ -306,6 +307,14 @@ class CORE_EXPORT QgsRectangle
      */
     void include( const QgsPointXY &p )
     {
+      if ( isNull() )
+      {
+        setXMinimum( p.x() );
+        setXMaximum( p.x() );
+        setYMinimum( p.y() );
+        setYMaximum( p.y() );
+        return;
+      }
       if ( p.x() < xMinimum() )
         setXMinimum( p.x() );
       if ( p.x() > xMaximum() )

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -373,6 +373,10 @@ void TestQgsRectangle::minimal()
 
 void TestQgsRectangle::grow()
 {
+  QgsRectangle rect_null;
+  rect_null.grow( 11 ); // grow has no effect on null rectangle
+  QCOMPARE( rect_null, QgsRectangle() );
+
   QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
   rect1.grow( 11 );
   QCOMPARE( rect1.xMinimum(), -1.0 );
@@ -390,6 +394,10 @@ void TestQgsRectangle::grow()
 
 void TestQgsRectangle::include()
 {
+  QgsRectangle rect_null;
+  rect_null.include( QgsPoint( 20, 20 ) ); // wraps the included geometry
+  QCOMPARE( rect_null, QgsRectangle( 20, 20, 20, 20 ) );
+
   QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
   // inside
   rect1.include( QgsPointXY( 15, 50 ) );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -373,9 +373,9 @@ void TestQgsRectangle::minimal()
 
 void TestQgsRectangle::grow()
 {
-  QgsRectangle rect_null;
-  rect_null.grow( 11 ); // grow has no effect on null rectangle
-  QCOMPARE( rect_null, QgsRectangle() );
+  QgsRectangle rectNull;
+  rectNull.grow( 11 ); // grow has no effect on null rectangle
+  QCOMPARE( rectNull, QgsRectangle() );
 
   QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
   rect1.grow( 11 );
@@ -394,9 +394,9 @@ void TestQgsRectangle::grow()
 
 void TestQgsRectangle::include()
 {
-  QgsRectangle rect_null;
-  rect_null.include( QgsPoint( 20, 20 ) ); // wraps the included geometry
-  QCOMPARE( rect_null, QgsRectangle( 20, 20, 20, 20 ) );
+  QgsRectangle rectNull;
+  rectNull.include( QgsPoint( 20, 20 ) ); // wraps the included geometry
+  QCOMPARE( rectNull, QgsRectangle( 20, 20, 20, 20 ) );
 
   QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
   // inside


### PR DESCRIPTION
Null rectangle doesn't grow, and including a point makes it wrap the given point.

Spin-off of GH-54646
