### PR TITLE
[Layout] Remove properties widget when layout item is destroyed

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1338,7 +1338,8 @@ void QgsLayoutDesignerDialog::showItemOptions( QgsLayoutItem *item, bool bringPa
 
   if ( auto widget = qobject_cast< QgsLayoutItemBaseWidget * >( mItemPropertiesStack->mainPanel() ) )
   {
-    if ( widget->layoutObject() == item )
+    const QgsLayoutObject *currentItem = widget->layoutObject();
+    if ( currentItem == item )
     {
       // already showing properties for this item - we don't want to create a new panel
       if ( bringPanelToFront )
@@ -1353,6 +1354,9 @@ void QgsLayoutDesignerDialog::showItemOptions( QgsLayoutItem *item, bool bringPa
       {
         if ( bringPanelToFront )
           mItemDock->setUserVisible( true );
+
+        disconnect( currentItem, &QgsLayoutItem::destroyed, this, &QgsLayoutDesignerDialog::onItemDestroyed );
+        connect( item, &QgsLayoutItem::destroyed, this, &QgsLayoutDesignerDialog::onItemDestroyed );
 
         return;
       }
@@ -1373,10 +1377,7 @@ void QgsLayoutDesignerDialog::showItemOptions( QgsLayoutItem *item, bool bringPa
     connect( ppWidget, &QgsLayoutPagePropertiesWidget::pageOrientationChanged, this, &QgsLayoutDesignerDialog::pageOrientationChanged );
 
   widget->setDockMode( true );
-  connect( item, &QgsLayoutItem::destroyed, widget.get(), [this]
-  {
-    delete mItemPropertiesStack->takeMainPanel();
-  } );
+  connect( item, &QgsLayoutItem::destroyed, this, &QgsLayoutDesignerDialog::onItemDestroyed );
 
   mItemPropertiesStack->setMainPanel( widget.release() );
   if ( bringPanelToFront )
@@ -5074,4 +5075,13 @@ void QgsLayoutDesignerDialog::toolButtonActionTriggered( QAction *action )
     settings.setValue( QStringLiteral( "LayoutDesigner/atlasExportAction" ), 3 );
 
   bt->setDefaultAction( action );
+}
+
+void QgsLayoutDesignerDialog::onItemDestroyed( QObject *item )
+{
+  if ( QgsLayoutItemBaseWidget *widget = qobject_cast< QgsLayoutItemBaseWidget * >( mItemPropertiesStack->mainPanel() ) )
+  {
+    if ( widget->layoutObject() == item )
+      delete mItemPropertiesStack->takeMainPanel();
+  }
 }

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -424,6 +424,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     void backgroundTaskCountChanged( int total );
     void onMapPreviewRefreshed();
     void onItemAdded( QgsLayoutItem *item );
+    void onItemDestroyed( QObject *item );
 
   private:
 
@@ -599,4 +600,3 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
 };
 
 #endif // QGSLAYOUTDESIGNERDIALOG_H
-


### PR DESCRIPTION
Fixes #52740

if not, legend QgsLayerTreeView try to access model which has already been deleted by the item.