### PR TITLE
Add `USE_ALTERNATE_LINKER` to the CMake cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,7 +783,7 @@ if(ENABLE_COVERAGE)
   SETUP_TARGET_FOR_COVERAGE(qgis_coverage ctest coverage)
 endif()
 
-if(USE_ALTERNATE_LINKER)
+if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
   include("cmake/modules/linker.cmake")
 endif()
 

--- a/cmake/modules/linker.cmake
+++ b/cmake/modules/linker.cmake
@@ -31,12 +31,10 @@ macro(set_alternate_linker linker)
   endif()
 endmacro()
 
-if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default; potential alternatives are 'gold', 'lld', 'bfd', 'mold'")
-  if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
-    set_alternate_linker(${USE_ALTERNATE_LINKER})
-  endif()
-  set(USE_ALTERNATE_LINKER_OLD_CACHED
-      ${USE_ALTERNATE_LINKER}
-      CACHE INTERNAL "Previous value of USE_ALTERNATE_LINKER")
+set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default; potential alternatives are 'gold', 'lld', 'bfd', 'mold'")
+if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
+  set_alternate_linker(${USE_ALTERNATE_LINKER})
 endif()
+set(USE_ALTERNATE_LINKER_OLD_CACHED
+    ${USE_ALTERNATE_LINKER}
+    CACHE INTERNAL "Previous value of USE_ALTERNATE_LINKER")


### PR DESCRIPTION
## Description

Currently, you need to set `USE_ALTERNATE_LINKER` in order for `cmake/modules/linker.cmake` to be included, which means that `USE_ALTERNATE_LINKER` never gets added to the cache unless set explicitly.

Always add it to the cache if available, so users know it's there.