### PR TITLE
[feature] array_foreach expression function - add counter variable

### DIFF
--- a/resources/function_help/json/array_foreach
+++ b/resources/function_help/json/array_foreach
@@ -8,7 +8,7 @@
     "description": "an array"
   }, {
     "arg": "expression",
-    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value and the variable `@counter` by the current counter (starting with 0)."
+    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value and the variable `@counter` by the current index (starting with 0)."
   }],
   "examples": [{
     "expression": "array_foreach(array('a','b','c'),upper(@element))",

--- a/resources/function_help/json/array_foreach
+++ b/resources/function_help/json/array_foreach
@@ -8,7 +8,7 @@
     "description": "an array"
   }, {
     "arg": "expression",
-    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value."
+    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value and the variable `@counter` by the current counter."
   }],
   "examples": [{
     "expression": "array_foreach(array('a','b','c'),upper(@element))",
@@ -16,6 +16,9 @@
   }, {
     "expression": "array_foreach(array(1,2,3),@element + 10)",
     "returns": "[ 11, 12, 13 ]"
+  }, {
+    "expression": "array_foreach(array(1,2,3),@element + @counter)",
+    "returns": "[ 1, 3, 5 ]"
   }],
   "tags": ["evaluated", "array", "iterate", "item"]
 }

--- a/resources/function_help/json/array_foreach
+++ b/resources/function_help/json/array_foreach
@@ -8,7 +8,7 @@
     "description": "an array"
   }, {
     "arg": "expression",
-    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value and the variable `@counter` by the current counter."
+    "description": "an expression to evaluate on each item. The variable `@element` will be replaced by the current value and the variable `@counter` by the current counter (starting with 0)."
   }],
   "examples": [{
     "expression": "array_foreach(array('a','b','c'),upper(@element))",

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -9353,9 +9353,11 @@ QVariant QgsArrayForeachExpressionFunction::run( QgsExpressionNode::NodeList *ar
   QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
   subContext->appendScope( subScope );
 
-  for ( QVariantList::const_iterator it = array.constBegin(); it != array.constEnd(); ++it )
+  int i = 0;
+  for ( QVariantList::const_iterator it = array.constBegin(); it != array.constEnd(); ++it, ++i )
   {
     subScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "element" ), *it, true ) );
+    subScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "counter" ), i, true ) );
     result << args->at( 1 )->eval( parent, subContext );
   }
 
@@ -9393,6 +9395,7 @@ bool QgsArrayForeachExpressionFunction::prepare( const QgsExpressionNodeFunction
 
   QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
   subScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "element" ), QVariant(), true ) );
+  subScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "counter" ), QVariant(), true ) );
   subContext.appendScope( subScope );
 
   args->at( 1 )->prepare( parent, &subContext );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4340,6 +4340,7 @@ class TestQgsExpression: public QObject
       QVariantList foreachExpected;
       foreachExpected << 10 << 20 << 40;
       QCOMPARE( QgsExpression( "array_foreach(array(1, 2, 4), @element * 10)" ).evaluate( &context ), QVariant( foreachExpected ) );
+      QCOMPARE( QgsExpression( "array_foreach(array(10, 19, 38), @element + @counter)" ).evaluate( &context ), QVariant( foreachExpected ) );
 
       QVariantList filterExpected = QVariantList() << 1 << 2;
       QCOMPARE( QgsExpression( "array_filter(array(1, 2, 4), @element < 3)" ).evaluate( &context ), QVariant( filterExpected ) );


### PR DESCRIPTION
Original motivation is here to combine values from multiple array fields after OGR GML import for label expressions, e.g.

`array_foreach( "field_1", @element || ' ' || "field_2"[@counter] )`

but there are other use cases for sure.

Test added and function help updated.

