### PR TITLE
Fix extent computation in QgsVirtualLayerProvider

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -59,6 +59,7 @@ Copy constructor
 
     ~QgsRectangle();
 
+
     static QgsRectangle fromWkt( const QString &wkt );
 %Docstring
 Creates a new rectangle from a ``wkt`` string.

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -100,6 +100,22 @@ class CORE_EXPORT QgsRectangle
     ~QgsRectangle() = default;
 
     /**
+    * Creates a null rectangle.
+    *
+    * This is a temporary method to use while the default
+    * constructor is still not constructing a null rectangle.
+    *
+    * \since QGIS 3.34
+    */
+    static QgsRectangle createNull() SIP_SKIP
+    {
+      // TODO: remove this method once the default constructor gives a null
+      QgsRectangle rectNull;
+      rectNull.setNull(); // TODO: have setNull() return *this ?
+      return rectNull;
+    }
+
+    /**
     * Creates a new rectangle from a \a wkt string.
     * The WKT must contain only 5 vertices, representing a rectangle aligned with X and Y axes.
     * \since QGIS 3.0

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -50,6 +50,7 @@ QgsVirtualLayerProvider::QgsVirtualLayerProvider( QString const &uri,
   : QgsVectorDataProvider( uri, options, flags )
 {
   mError.clear();
+  mExtent.setNull(); // ideally not needed
 
   const QUrl url = QUrl::fromEncoded( uri.toUtf8() );
   if ( !url.isValid() )

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -41,11 +41,6 @@ const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY = QStringLiteral( "virt
 const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_DESCRIPTION = QStringLiteral( "Virtual layer data provider" );
 const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_QUERY_VIEW = QStringLiteral( "_query" );
 
-static QString quotedColumn( QString name )
-{
-  return "\"" + name.replace( QLatin1String( "\"" ), QLatin1String( "\"\"" ) ) + "\"";
-}
-
 #define PROVIDER_ERROR( msg ) do { mError = QgsError( msg, QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY ); QgsDebugError( msg ); } while(0)
 
 
@@ -560,11 +555,24 @@ QgsRectangle QgsVirtualLayerProvider::extent() const
 void QgsVirtualLayerProvider::updateStatistics() const
 {
   const bool hasGeometry = mDefinition.geometryWkbType() != Qgis::WkbType::NoGeometry;
-  const QString subset = mSubset.isEmpty() ? QString() : " WHERE " + mSubset;
-  const QString sql = QStringLiteral( "SELECT Count(*)%1 FROM %2%3" )
-                      .arg( hasGeometry ? QStringLiteral( ",Min(MbrMinX(%1)),Min(MbrMinY(%1)),Max(MbrMaxX(%1)),Max(MbrMaxY(%1))" ).arg( quotedColumn( mDefinition.geometryField() ) ) : QString(),
-                            mTableName,
-                            subset );
+
+  QString sql = QStringLiteral( "SELECT Count(1)" );
+
+  if ( hasGeometry )
+  {
+    sql += QStringLiteral(
+             ", Min(MbrMinX(%1)), Min(MbrMinY(%1)), Max(MbrMaxX(%1)), Max(MbrMaxY(%1))"
+           ).arg( QgsSqliteUtils::quotedIdentifier( mDefinition.geometryField() ) );
+  }
+
+  sql += QStringLiteral( " FROM %1" ) .arg( mTableName );
+
+  if ( !mSubset.isEmpty() )
+  {
+    sql += " WHERE ( " + mSubset + ')';
+  }
+
+  mExtent.setNull();
 
   try
   {
@@ -572,7 +580,7 @@ void QgsVirtualLayerProvider::updateStatistics() const
     if ( q.step() == SQLITE_ROW )
     {
       mFeatureCount = q.columnInt64( 0 );
-      if ( hasGeometry )
+      if ( mFeatureCount && hasGeometry )
       {
         double x1, y1, x2, y2;
         x1 = q.columnDouble( 1 );

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src/providers/mssql
   ${CMAKE_SOURCE_DIR}/src/providers/ogr
   ${CMAKE_SOURCE_DIR}/src/providers/virtualraster
+  ${CMAKE_SOURCE_DIR}/src/providers/virtual
   ${CMAKE_SOURCE_DIR}/src/test
 )
 include_directories(SYSTEM
@@ -35,6 +36,7 @@ set_target_properties(test_provider_wcsprovider PROPERTIES
 add_qgis_test(testqgswmscapabilities.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
 add_qgis_test(testqgswmsccapabilities.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
 add_qgis_test(testqgswmsprovider.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
+add_qgis_test(testqgsvirtuallayerprovider.cpp MODULE provider LINKEDLIBRARIES provider_virtuallayer_a qgis_core)
 
 if (POSTGRES_FOUND)
   add_qgis_test(testqgspostgresexpressioncompiler.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)

--- a/tests/src/providers/testqgsvirtuallayerprovider.cpp
+++ b/tests/src/providers/testqgsvirtuallayerprovider.cpp
@@ -1,0 +1,91 @@
+/***************************************************************************
+     testqgsvirtuallayerprovider.cpp
+     ------------------------------------
+    Date                 : October 2023
+    Copyright            : (C) 2023 by Sandro Santilli
+    Email                : strk at kbt dot net
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <limits>
+
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QApplication>
+#include <QFileInfo>
+#include <QDir>
+#include <fstream>
+#include <QVector>
+#include <QTest>
+#include <QStandardPaths>
+#include <QQueue>
+
+//qgis includes...
+#include "qgis.h"
+#include "qgsapplication.h"
+//#include "qgsproviderregistry.h"
+#include "qgsvirtuallayerprovider.h"
+//#include "qgsgeometry.h"
+//#include "qgsfeedback.h"
+//#include "qgsprovidermetadata.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the Virtual Layer provider
+ */
+class TestQgsVirtualLayerProvider : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+
+    TestQgsVirtualLayerProvider() : QgsTest( QStringLiteral( "Virtual Layer Provider Tests" ) ) {}
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {}// will be called before each testfunction is executed.
+    void cleanup() {}// will be called after every testfunction.
+
+    void testConstructor();
+
+  private:
+    QString mTestDataDir;
+};
+
+//runs before all tests
+void TestQgsVirtualLayerProvider::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
+}
+
+//runs after all tests
+void TestQgsVirtualLayerProvider::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVirtualLayerProvider::testConstructor()
+{
+  QgsDataProvider::ProviderOptions opts;
+  QString uri;
+  std::unique_ptr<QgsVectorDataProvider> prov( new QgsVirtualLayerProvider( uri, opts ) );
+
+  const QgsRectangle rectNull = QgsRectangle::createNull();
+  QCOMPARE( prov->sourceExtent(), rectNull );
+}
+
+QGSTEST_MAIN( TestQgsVirtualLayerProvider )
+#include "testqgsvirtuallayerprovider.moc"


### PR DESCRIPTION
Extent should be set to null if there are no rows or geometric field or computed min/max envelope ordinates are null.

Also makes the implementation more readable (hopefully).

Spin-off of GH-54646

Similar to GH-54917