### PR TITLE
Make userData a property from locator to avoid crash

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -34,7 +34,6 @@ Constructor for QgsLocatorResult.
 Constructor for QgsLocatorResult.
 %End
 
-
     QVariant getUserData() const;
 %Docstring
 Returns the ``userData``.
@@ -42,13 +41,18 @@ Returns the ``userData``.
 .. versionadded:: 3.18
 %End
 
+    void setUserData( QVariant userData );
+%Docstring
+Set ``userData`` for the locator result
+
+.. versionadded:: 3.34
+%End
+
     QgsLocatorFilter *filter;
 
     QString displayString;
 
     QString description;
-
-    QVariant userData;
 
     QIcon icon;
 
@@ -77,6 +81,9 @@ normally.
     };
 
     QList<QgsLocatorResult::ResultAction> actions;
+
+%Property( name = userData, get = getUserData, set = setUserData )
+
 };
 
 
@@ -360,8 +367,6 @@ during within their :py:func:`~QgsLocatorFilter.fetchResults` implementation.
 };
 
 QFlags<QgsLocatorFilter::Flag> operator|(QgsLocatorFilter::Flag f1, QFlags<QgsLocatorFilter::Flag> f2);
-
-
 
 
 

--- a/src/app/locator/qgsactionlocatorfilter.cpp
+++ b/src/app/locator/qgsactionlocatorfilter.cpp
@@ -50,7 +50,7 @@ void QgsActionLocatorFilter::fetchResults( const QString &string, const QgsLocat
 
 void QgsActionLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  QAction *action = qobject_cast< QAction * >( qvariant_cast<QObject *>( result.userData ) );
+  QAction *action = qobject_cast< QAction * >( qvariant_cast<QObject *>( result.getUserData() ) );
   if ( action )
     action->trigger();
 }
@@ -106,7 +106,7 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
 
     QgsLocatorResult result;
     result.displayString = searchText;
-    result.userData = QVariant::fromValue( action );
+    result.setUserData( QVariant::fromValue( action ) );
     result.icon = action->icon();
     result.score = fuzzyScore( result.displayString, string );
 

--- a/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
+++ b/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp
@@ -175,9 +175,9 @@ void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, c
     QgsLocatorResult result;
     result.displayString = QStringLiteral( "@%1" ).arg( field );
     result.description = tr( "Limit the search to the field '%1'" ).arg( field );
-    result.userData = QVariantMap( {{QStringLiteral( "type" ), QVariant::fromValue( ResultType::FieldRestriction )},
+    result.setUserData( QVariantMap( {{QStringLiteral( "type" ), QVariant::fromValue( ResultType::FieldRestriction )},
       {QStringLiteral( "search_text" ), QStringLiteral( "%1 @%2 " ).arg( prefix(), field ) }
-    } );
+    } ) );
     result.score = 1;
     emit resultFetched( result );
   }
@@ -195,13 +195,13 @@ void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, c
       QgsLocatorResult result;
 
       result.displayString =  mDispExpression.evaluate( &mContext ).toString();
-      result.userData = QVariantMap(
+      result.setUserData( QVariantMap(
       {
         {QStringLiteral( "type" ), QVariant::fromValue( ResultType::Feature )},
         {QStringLiteral( "feature_id" ), f.id()},
         {QStringLiteral( "layer_id" ), mLayerId},
         {QStringLiteral( "layer_is_spatial" ), mLayerIsSpatial}
-      } );
+      } ) );
       result.icon = mLayerIcon;
       result.score = static_cast< double >( searchString.length() ) / result.displayString.size();
       if ( mLayerIsSpatial )
@@ -250,13 +250,13 @@ void QgsActiveLayerFeaturesLocatorFilter::fetchResults( const QString &string, c
       continue; //not sure how this result slipped through...
 
     result.description = mDispExpression.evaluate( &mContext ).toString();
-    result.userData = QVariantMap(
+    result.setUserData( QVariantMap(
     {
       {QStringLiteral( "type" ), QVariant::fromValue( ResultType::Feature )},
       {QStringLiteral( "feature_id" ), f.id()},
       {QStringLiteral( "layer_id" ), mLayerId},
       {QStringLiteral( "layer_is_spatial" ), mLayerIsSpatial}
-    } );
+    } ) );
     result.icon = mLayerIcon;
     result.score = static_cast< double >( searchString.length() ) / result.displayString.size();
     if ( mLayerIsSpatial )
@@ -278,7 +278,7 @@ void QgsActiveLayerFeaturesLocatorFilter::triggerResult( const QgsLocatorResult 
 
 void QgsActiveLayerFeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
 {
-  QVariantMap data = result.userData.value<QVariantMap>();
+  QVariantMap data = result.getUserData().value<QVariantMap>();
   switch ( data.value( QStringLiteral( "type" ) ).value<ResultType>() )
   {
     case ResultType::Feature:

--- a/src/app/locator/qgsalllayersfeatureslocatorfilter.cpp
+++ b/src/app/locator/qgsalllayersfeatureslocatorfilter.cpp
@@ -120,7 +120,7 @@ void QgsAllLayersFeaturesLocatorFilter::fetchResults( const QString &string, con
 
       result.displayString = preparedLayer->expression.evaluate( &( preparedLayer->context ) ).toString();
 
-      result.userData = ResultData( f.id(), preparedLayer->layerId, preparedLayer->layerIsSpatial ).toVariant();
+      result.setUserData( ResultData( f.id(), preparedLayer->layerId, preparedLayer->layerIsSpatial ).toVariant() );
       foundFeatureIds << f.id();
       result.icon = preparedLayer->layerIcon;
       result.score = static_cast< double >( string.length() ) / result.displayString.size();
@@ -154,7 +154,7 @@ void QgsAllLayersFeaturesLocatorFilter::fetchResults( const QString &string, con
 
       result.displayString = preparedLayer->expression.evaluate( &( preparedLayer->context ) ).toString();
 
-      result.userData = ResultData( f.id(), preparedLayer->layerId, preparedLayer->layerIsSpatial ).toVariant();
+      result.setUserData( ResultData( f.id(), preparedLayer->layerId, preparedLayer->layerIsSpatial ).toVariant() );
       result.icon = preparedLayer->layerIcon;
       result.score = static_cast< double >( string.length() ) / result.displayString.size();
 
@@ -179,7 +179,7 @@ void QgsAllLayersFeaturesLocatorFilter::triggerResult( const QgsLocatorResult &r
 
 void QgsAllLayersFeaturesLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
 {
-  ResultData data = ResultData::fromVariant( result.userData );
+  ResultData data = ResultData::fromVariant( result.getUserData() );
   QgsFeatureId fid = data.id();
   QString layerId = data.layerId();
   bool layerIsSpatial = data.layerIsSpatial();

--- a/src/app/locator/qgsbookmarklocatorfilter.cpp
+++ b/src/app/locator/qgsbookmarklocatorfilter.cpp
@@ -48,7 +48,7 @@ void QgsBookmarkLocatorFilter::fetchResults( const QString &string, const QgsLoc
     QgsLocatorResult result;
     result.filter = this;
     result.displayString = name;
-    result.userData = index;
+    result.setUserData( index );
     result.icon = QgsApplication::getThemeIcon( QStringLiteral( "/mItemBookmark.svg" ) );
 
     if ( context.usingPrefix && string.isEmpty() )
@@ -66,6 +66,6 @@ void QgsBookmarkLocatorFilter::fetchResults( const QString &string, const QgsLoc
 
 void QgsBookmarkLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  const QModelIndex index = qvariant_cast<QModelIndex>( result.userData );
+  const QModelIndex index = qvariant_cast<QModelIndex>( result.getUserData() );
   QgisApp::instance()->zoomToBookmarkIndex( index );
 }

--- a/src/app/locator/qgsexpressioncalculatorlocatorfilter.cpp
+++ b/src/app/locator/qgsexpressioncalculatorlocatorfilter.cpp
@@ -53,7 +53,7 @@ void QgsExpressionCalculatorLocatorFilter::fetchResults( const QString &string, 
       QgsLocatorResult result;
       result.filter = this;
       result.displayString = tr( "Copy “%1” to clipboard" ).arg( resultString );
-      result.userData = resultString;
+      result.setUserData( resultString );
       result.score = 1;
       emit resultFetched( result );
     }
@@ -62,5 +62,5 @@ void QgsExpressionCalculatorLocatorFilter::fetchResults( const QString &string, 
 
 void QgsExpressionCalculatorLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  QApplication::clipboard()->setText( result.userData.toString() );
+  QApplication::clipboard()->setText( result.getUserData().toString() );
 }

--- a/src/app/locator/qgsgotolocatorfilter.cpp
+++ b/src/app/locator/qgsgotolocatorfilter.cpp
@@ -134,7 +134,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
       result.displayString = tr( "Go to %1%2 %3%4 (Map CRS, %5)" ).arg( locale.toString( firstNumber, 'g', 10 ), firstSuffix,
                              locale.toString( secondNumber, 'g', 10 ), secondSuffix,
                              currentCrs.userFriendlyIdentifier() );
-      result.userData = data;
+      result.setUserData( data );
       result.score = 0.9;
       emit resultFetched( result );
     }
@@ -165,7 +165,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
       QgsLocatorResult result;
       result.filter = this;
       result.displayString = tr( "Go to %1°N %2°E (%3)" ).arg( locale.toString( point.y(), 'g', 10 ), locale.toString( point.x(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
-      result.userData = data;
+      result.setUserData( data );
       result.score = 1.0;
       emit resultFetched( result );
     }
@@ -305,7 +305,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
       result.displayString = tr( "Go to %1°N %2°E %3(%4)" ).arg( locale.toString( point.y(), 'g', 10 ), locale.toString( point.x(), 'g', 10 ),
                              scale > 0.0 ? tr( "at scale 1:%1 " ).arg( scale ) : QString(),
                              wgs84Crs.userFriendlyIdentifier() );
-      result.userData = data;
+      result.setUserData( data );
       result.score = 1.0;
       emit resultFetched( result );
     }
@@ -316,7 +316,7 @@ void QgsGotoLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
   QgsMapCanvas *mapCanvas = QgisApp::instance()->mapCanvas();
 
-  QVariantMap data = result.userData.toMap();
+  QVariantMap data = result.getUserData().toMap();
   const QgsPointXY point = data[QStringLiteral( "point" )].value<QgsPointXY>();
   mapCanvas->setCenter( point );
   if ( data.contains( QStringLiteral( "scale" ) ) )

--- a/src/app/locator/qgslayermetadatalocatorfilter.cpp
+++ b/src/app/locator/qgslayermetadatalocatorfilter.cpp
@@ -47,7 +47,7 @@ void QgsLayerMetadataLocatorFilter::fetchResults( const QString &string, const Q
       result.displayString = metadata.identifier();
       result.description = metadata.title();
       result.icon = QgsIconUtils::iconForGeometryType( metadata.geometryType() );
-      result.userData = QVariant::fromValue( metadata );
+      result.setUserData( QVariant::fromValue( metadata ) );
       emit resultFetched( result );
     }
   }
@@ -55,7 +55,7 @@ void QgsLayerMetadataLocatorFilter::fetchResults( const QString &string, const Q
 
 void QgsLayerMetadataLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  QgsLayerMetadataProviderResult metadataResult { result.userData.value<QgsLayerMetadataProviderResult>() };
+  QgsLayerMetadataProviderResult metadataResult { result.getUserData().value<QgsLayerMetadataProviderResult>() };
   switch ( metadataResult.layerType() )
   {
     case Qgis::LayerType::Raster:

--- a/src/app/locator/qgslayertreelocatorfilter.cpp
+++ b/src/app/locator/qgslayertreelocatorfilter.cpp
@@ -43,7 +43,7 @@ void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLo
 
     QgsLocatorResult result;
     result.displayString = layer->layer()->name();
-    result.userData = layer->layerId();
+    result.setUserData( layer->layerId() );
     result.icon = QgsIconUtils::iconForLayer( layer->layer() );
 
     // return all the layers in case the string query is empty using an equal default score
@@ -62,7 +62,7 @@ void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLo
 
 void QgsLayerTreeLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  const QString layerId = result.userData.toString();
+  const QString layerId = result.getUserData().toString();
   QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
   QgisApp::instance()->setActiveLayer( layer );
 }

--- a/src/app/locator/qgslayoutlocatorfilter.cpp
+++ b/src/app/locator/qgslayoutlocatorfilter.cpp
@@ -42,7 +42,7 @@ void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocat
 
     QgsLocatorResult result;
     result.displayString = layout->name();
-    result.userData = layout->name();
+    result.setUserData( layout->name() );
 
     if ( context.usingPrefix && string.isEmpty() )
     {
@@ -59,7 +59,7 @@ void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocat
 
 void QgsLayoutLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
-  const QString layoutName = result.userData.toString();
+  const QString layoutName = result.getUserData().toString();
   QgsMasterLayoutInterface *layout = QgsProject::instance()->layoutManager()->layoutByName( layoutName );
   if ( !layout )
     return;

--- a/src/app/locator/qgssettingslocatorfilter.cpp
+++ b/src/app/locator/qgssettingslocatorfilter.cpp
@@ -60,7 +60,7 @@ void QgsSettingsLocatorFilter::fetchResults( const QString &string, const QgsLoc
     QgsLocatorResult result;
     result.filter = this;
     result.displayString = title;
-    result.userData.setValue( settingsPage );
+    result.getUserData().setValue( settingsPage );
 
     if ( context.usingPrefix && string.isEmpty() )
     {
@@ -86,7 +86,7 @@ QMap<QString, QString> QgsSettingsLocatorFilter::settingsPage( const QString &ty
 void QgsSettingsLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
 
-  const QMap<QString, QString> settingsPage = qvariant_cast<QMap<QString, QString>>( result.userData );
+  const QMap<QString, QString> settingsPage = qvariant_cast<QMap<QString, QString>>( result.getUserData() );
   const QString type = settingsPage.value( QStringLiteral( "type" ) );
   const QString page = settingsPage.value( QStringLiteral( "page" ) );
 

--- a/src/core/geocoding/qgsabstractgeocoderlocatorfilter.cpp
+++ b/src/core/geocoding/qgsabstractgeocoderlocatorfilter.cpp
@@ -72,7 +72,7 @@ QgsGeocoderInterface *QgsAbstractGeocoderLocatorFilter::geocoder() const
 
 QgsGeocoderResult QgsAbstractGeocoderLocatorFilter::locatorResultToGeocoderResult( const QgsLocatorResult &result ) const
 {
-  const QVariantMap attrs = result.userData.toMap();
+  const QVariantMap attrs = result.getUserData().toMap();
   QgsGeocoderResult geocodeResult( attrs.value( QStringLiteral( "identifier" ) ).toString(),
                                    attrs.value( QStringLiteral( "geom" ) ).value< QgsGeometry >(),
                                    attrs.value( QStringLiteral( "crs" ) ).value< QgsCoordinateReferenceSystem >() );
@@ -96,4 +96,3 @@ QgsLocatorResult QgsAbstractGeocoderLocatorFilter::geocoderResultToLocatorResult
   res.group = result.group();
   return res;
 }
-

--- a/src/core/locator/qgslocatorfilter.cpp
+++ b/src/core/locator/qgslocatorfilter.cpp
@@ -103,5 +103,10 @@ void QgsLocatorFilter::logMessage( const QString &message, Qgis::MessageLevel le
 
 QVariant QgsLocatorResult::getUserData() const
 {
-  return userData;
+  return mUserData;
+}
+
+void QgsLocatorResult::setUserData( QVariant userData )
+{
+  mUserData = userData;
 }

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -50,9 +50,8 @@ class CORE_EXPORT QgsLocatorResult
     QgsLocatorResult( QgsLocatorFilter *filter, const QString &displayString, const QVariant &userData = QVariant() )
       : filter( filter )
       , displayString( displayString )
-      , userData( userData )
+      , mUserData( userData )
     {}
-
 
     /**
      * Returns the ``userData``.
@@ -60,6 +59,13 @@ class CORE_EXPORT QgsLocatorResult
      * \since QGIS 3.18
      */
     QVariant getUserData() const;
+
+    /**
+     * Set \a userData for the locator result
+     *
+     * \since QGIS 3.34
+     */
+    void setUserData( QVariant userData );
 
     /**
      * Filter from which the result was obtained. This is automatically set.
@@ -75,11 +81,6 @@ class CORE_EXPORT QgsLocatorResult
      * Descriptive text for result.
      */
     QString description;
-
-    /**
-     * Custom reference or other data set by the filter.
-     */
-    QVariant userData;
 
     /**
      * Icon for result.
@@ -135,6 +136,19 @@ class CORE_EXPORT QgsLocatorResult
       * \since QGIS 3.6
       */
     QList<QgsLocatorResult::ResultAction> actions;
+
+#ifdef SIP_RUN
+    SIP_PROPERTY( name = userData, get = getUserData, set = setUserData )
+#endif
+
+  private:
+
+    /**
+     * Custom reference or other data set by the filter.
+     */
+    QVariant mUserData;
+
+
 };
 
 Q_DECLARE_METATYPE( QgsLocatorResult::ResultAction )
@@ -402,5 +416,3 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLocatorFilter::Flags )
 
 
 #endif // QGSLOCATORFILTER_H
-
-

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -461,7 +461,7 @@ void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocat
     QgsLocatorResult result;
     result.displayString = filter->activePrefix();
     result.description = filter->displayName();
-    result.userData = QString( filter->activePrefix() + ' ' );
+    result.setUserData( QString( filter->activePrefix() + ' ' ) );
     result.icon = QgsApplication::getThemeIcon( QStringLiteral( "/search.svg" ) );
     emit resultFetched( result );
   }
@@ -469,7 +469,7 @@ void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocat
 
 void QgsLocatorFilterFilter::triggerResult( const QgsLocatorResult &result )
 {
-  mLocator->search( result.userData.toString() );
+  mLocator->search( result.getUserData().toString() );
 }
 
 QgsLocatorLineEdit::QgsLocatorLineEdit( QgsLocatorWidget *locator, QWidget *parent )

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -81,7 +81,7 @@ void TestQgsAppLocatorFilters::testCalculator()
   // valid expression
   QList< QgsLocatorResult > results = gatherResults( &filter, QStringLiteral( "1+2" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).userData.toInt(), 3 );
+  QCOMPARE( results.at( 0 ).getUserData().toInt(), 3 );
 
   // trigger result
   filter.triggerResult( results.at( 0 ) );
@@ -106,12 +106,12 @@ void TestQgsAppLocatorFilters::testLayers()
 
   results = gatherResults( &filter, QStringLiteral( "aa" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).userData.toString(), l1->id() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), l1->id() );
 
   results = gatherResults( &filter, QStringLiteral( "A" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 2 );
-  QCOMPARE( results.at( 0 ).userData.toString(), l1->id() );
-  QCOMPARE( results.at( 1 ).userData.toString(), l2->id() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), l1->id() );
+  QCOMPARE( results.at( 1 ).getUserData().toString(), l2->id() );
 
   results = gatherResults( &filter, QString(), QgsLocatorContext() );
   QCOMPARE( results.count(), 0 );
@@ -120,9 +120,9 @@ void TestQgsAppLocatorFilters::testLayers()
   context.usingPrefix = true;
   results = gatherResults( &filter, QString(), context );
   QCOMPARE( results.count(), 3 );
-  QCOMPARE( results.at( 0 ).userData.toString(), l1->id() );
-  QCOMPARE( results.at( 1 ).userData.toString(), l2->id() );
-  QCOMPARE( results.at( 2 ).userData.toString(), l3->id() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), l1->id() );
+  QCOMPARE( results.at( 1 ).getUserData().toString(), l2->id() );
+  QCOMPARE( results.at( 2 ).getUserData().toString(), l3->id() );
 }
 
 void TestQgsAppLocatorFilters::testLayouts()
@@ -144,12 +144,12 @@ void TestQgsAppLocatorFilters::testLayouts()
 
   results = gatherResults( &filter, QStringLiteral( "aa" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).userData.toString(), pl1->name() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), pl1->name() );
 
   results = gatherResults( &filter, QStringLiteral( "A" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 2 );
-  QCOMPARE( results.at( 0 ).userData.toString(), pl1->name() );
-  QCOMPARE( results.at( 1 ).userData.toString(), pl2->name() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), pl1->name() );
+  QCOMPARE( results.at( 1 ).getUserData().toString(), pl2->name() );
 
   results = gatherResults( &filter, QString(), QgsLocatorContext() );
   QCOMPARE( results.count(), 0 );
@@ -158,9 +158,9 @@ void TestQgsAppLocatorFilters::testLayouts()
   context.usingPrefix = true;
   results = gatherResults( &filter, QString(), context );
   QCOMPARE( results.count(), 3 );
-  QCOMPARE( results.at( 0 ).userData.toString(), pl1->name() );
-  QCOMPARE( results.at( 1 ).userData.toString(), pl2->name() );
-  QCOMPARE( results.at( 2 ).userData.toString(), pl3->name() );
+  QCOMPARE( results.at( 0 ).getUserData().toString(), pl1->name() );
+  QCOMPARE( results.at( 1 ).getUserData().toString(), pl2->name() );
+  QCOMPARE( results.at( 2 ).getUserData().toString(), pl3->name() );
 }
 
 void TestQgsAppLocatorFilters::testSearchActiveLayer()
@@ -364,69 +364,69 @@ void TestQgsAppLocatorFilters::testGoto()
   QList< QgsLocatorResult > results = gatherResults( &filter, QStringLiteral( "4 5" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 2 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 4 5 (Map CRS, )" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
   QCOMPARE( results.at( 1 ).displayString, QObject::tr( "Go to 4°N 5°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 1 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 5, 4 ) );
+  QCOMPARE( results.at( 1 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 5, 4 ) );
 
   // locale-specific goto
   results = gatherResults( &filter, QStringLiteral( "1,234.56 789.012" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1,234.56 789.012 (Map CRS, )" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
 
   // decimal degree with suffixes
   results = gatherResults( &filter, QStringLiteral( "12.345N, 67.890W" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 12.345°N -67.89°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( -67.890, 12.345 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( -67.890, 12.345 ) );
 
   results = gatherResults( &filter, QStringLiteral( "12.345 e, 67.890 s" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to -67.89°N 12.345°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 12.345, -67.890 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 12.345, -67.890 ) );
 
   // degree/minuste/second coordinates goto
   // easting northing
   results = gatherResults( &filter, QStringLiteral( "40deg 1' 0\" E 11deg  55' 0\" S" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to -11.91666667°N 40.01666667°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 40.0166666667, -11.9166666667 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 40.0166666667, -11.9166666667 ) );
 
   // northing easting
   results = gatherResults( &filter, QStringLiteral( "14°49′48″N 01°48′45″E" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 14.83°N 1.8125°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
   // northing, esting (comma separated)
   results = gatherResults( &filter, QStringLiteral( "14°49′48″N, 01°48′45″E" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 14.83°N 1.8125°E (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
   // OSM/Leaflet/OpenLayers
   results = gatherResults( &filter, QStringLiteral( "https://www.openstreetmap.org/#map=15/44.5546/6.4936" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 44.5546°N 6.4936°E at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
 
   // Google Maps
   results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@44.5546,6.4936,15.25z" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 44.5546°N 6.4936°E at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
 
   results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@7.8750,81.0149,574195m/data=!3m1!1e3" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 81.0149, 7.8750 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 81.0149, 7.8750 ) );
 
   results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@27.7132,85.3288,3a,75y,278.89h,90t/data=!3m8!1e1!3m6!1sAF1QipMrXuXozGc9x9bxx5uPl_3ys4H-rNVqMLr6EYLA!2e10!3e11!6shttps:%2F%2Flh5.googleusercontent.com%2Fp%2FAF1QipMrXuXozGc9x9bxx5uPl_3ys4H-rNVqMLr6EYLA%3Dw203-h100-k-no-pi2.869903-ya293.58762-ro-1.9255565-fo100!7i3840!8i1920" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 27.7132°N 85.3288°E at scale 1:282 (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 85.3288, 27.7132 ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 282.0 );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 85.3288, 27.7132 ) );
+  QCOMPARE( results.at( 0 ).getUserData().toMap()[QStringLiteral( "scale" )].toDouble(), 282.0 );
 }
 
 QGSTEST_MAIN( TestQgsAppLocatorFilters )


### PR DESCRIPTION
Using it when implementing a python locator filter can lead to crash.

for instance [here](https://gitlab.com/Oslandia/qgis/french_locator_filter/-/blob/master/french_locator_filter/core/locator_filter.py?ref_type=heads#L198), if you replace getUserData with userData, type a research, then start some python code again (processing algs locator filter, or open the plugin manager for instance), it would crash QGIS. 

~I propose to set it deprecated.~

EDIT: According to @nyalldawson proposal, I made userData a property

**Sponsored by ANFSI**

