### PR TITLE
Use all nan values to represent a NULL QgsRectangle

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -514,10 +514,8 @@ class CORE_EXPORT QgsRectangle
     bool isNull() const
     {
       // rectangle created QgsRectangle() or with rect.setNull() or
-      // otherwise having NaN ordinates
-      return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmax ) ) ||
-             ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
-               qgsDoubleNear( mXmax, -std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmax, -std::numeric_limits<double>::max() ) );
+      // otherwise having all NaN ordinates
+      return std::isnan( mXmin ) && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmax );
     }
 
     /**

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -177,8 +177,7 @@ class CORE_EXPORT QgsRectangle
      */
     void setNull() SIP_HOLDGIL
     {
-      mXmin = mYmin = std::numeric_limits<double>::max();
-      mXmax = mYmax = -std::numeric_limits<double>::max();
+      mXmin = mYmin = mXmax = mYmax = std::numeric_limits< double >::quiet_NaN();
     }
 
     /**
@@ -648,10 +647,10 @@ class CORE_EXPORT QgsRectangle
 
   private:
 
-    double mXmin = std::numeric_limits<double>::max();
-    double mYmin = std::numeric_limits<double>::max();
-    double mXmax = -std::numeric_limits<double>::max();
-    double mYmax = -std::numeric_limits<double>::max();
+    double mXmin = std::numeric_limits< double >::quiet_NaN();
+    double mYmin = std::numeric_limits< double >::quiet_NaN();
+    double mXmax = std::numeric_limits< double >::quiet_NaN();
+    double mYmax = std::numeric_limits< double >::quiet_NaN();
 
 };
 

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -516,13 +516,13 @@ std::vector<LayerRenderJob> QgsMapRendererJob::prepareJobs( QPainter *painter, Q
     if ( ct.isValid() )
     {
       haveExtentInLayerCrs = reprojectToLayerExtent( ml, ct, r1, r2 );
+      if ( !r1.isFinite() )
+      {
+        mErrors.append( Error( ml->id(), tr( "There was a problem transforming the layer's extent. Layer skipped." ) ) );
+        continue;
+      }
     }
     QgsDebugMsgLevel( "extent: " + r1.toString(), 3 );
-    if ( !r1.isFinite() || !r2.isFinite() )
-    {
-      mErrors.append( Error( ml->id(), tr( "There was a problem transforming the layer's extent. Layer skipped." ) ) );
-      continue;
-    }
 
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
 


### PR DESCRIPTION
This was suggested by Benoit in
https://github.com/qgis/QGIS/pull/54646#discussion_r1330107062

It may make it easier to spot missing isNull() checks by callers.

I'm pretty sure things will fail but chances are that merging various commits currently in other PRs could show why they are needed.

See for instance GH-54976 and GH-54954

I'm marking this as an API break, correct me if I'm wrong