### PR TITLE
[3D] line3dsymbol and polygon3dsymbol: Rename height property to offset

### DIFF
--- a/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgsline3dsymbol.sip.in
@@ -80,13 +80,34 @@ Returns width of the line symbol (in map units)
 Sets width of the line symbol (in map units)
 %End
 
-    float height() const;
+ float height() const /Deprecated/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
+
+.. deprecated:: QGIS 3.36.
+   Use :py:func:`~QgsLine3DSymbol.offset` instead.
 %End
-    void setHeight( float height );
+
+ void setHeight( float height ) /Deprecated/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
+
+.. deprecated:: QGIS 3.36.
+   Use :py:func:`~QgsLine3DSymbol.setOffset` instead.
+%End
+
+    float offset() const;
+%Docstring
+Returns vertical offset of the symbol (in map units)
+
+.. versionadded:: 3.36
+%End
+
+    void setOffset( float offset );
+%Docstring
+Sets vertical offset of the symbol (in map units)
+
+.. versionadded:: 3.36
 %End
 
     float extrusionHeight() const;

--- a/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspolygon3dsymbol.sip.in
@@ -72,13 +72,34 @@ Returns method that determines how altitude is bound to individual vertices
 Sets method that determines how altitude is bound to individual vertices
 %End
 
-    float height() const;
+ float height() const /Deprecated/;
 %Docstring
 Returns height (altitude) of the symbol (in map units)
+
+.. deprecated:: QGIS 3.36.
+   Use :py:func:`~QgsPolygon3DSymbol.offset` instead.
 %End
-    void setHeight( float height );
+
+ void setHeight( float height ) /Deprecated/;
 %Docstring
 Sets height (altitude) of the symbol (in map units)
+
+.. deprecated:: QGIS 3.36.
+   Use :py:func:`~QgsPolygon3DSymbol.setOffset` instead.
+%End
+
+    float offset() const;
+%Docstring
+Returns vertical offset of the symbol (in map units)
+
+.. versionadded:: 3.36
+%End
+
+    void setOffset( float offset );
+%Docstring
+Sets vertical offset of the symbol (in map units)
+
+.. versionadded:: 3.36
 %End
 
     float extrusionHeight() const;

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -351,7 +351,7 @@ Qgs3DTypes::CullingMode Qgs3DUtils::cullingModeFromString( const QString &str )
     return Qgs3DTypes::NoCulling;
 }
 
-float Qgs3DUtils::clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float height, const QgsPoint &centroid, const Qgs3DMapSettings &map )
+float Qgs3DUtils::clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float offset, const QgsPoint &centroid, const Qgs3DMapSettings &map )
 {
   float terrainZ = 0;
   switch ( altClamp )
@@ -383,11 +383,11 @@ float Qgs3DUtils::clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altCl
     }
   }
 
-  const float z = ( terrainZ + geomZ ) * map.terrainVerticalScale() + height;
+  const float z = ( terrainZ + geomZ ) * static_cast<float>( map.terrainVerticalScale() ) + offset;
   return z;
 }
 
-void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, const QgsPoint &centroid, float height, const Qgs3DMapSettings &map )
+void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, const QgsPoint &centroid, float offset, const Qgs3DMapSettings &map )
 {
   for ( int i = 0; i < lineString->nCoordinates(); ++i )
   {
@@ -431,13 +431,13 @@ void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClampi
         break;
     }
 
-    const float z = ( terrainZ + geomZ ) * map.terrainVerticalScale() + height;
+    const float z = ( terrainZ + geomZ ) * static_cast<float>( map.terrainVerticalScale() ) + offset;
     lineString->setZAt( i, z );
   }
 }
 
 
-bool Qgs3DUtils::clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float height, const Qgs3DMapSettings &map )
+bool Qgs3DUtils::clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float offset, const Qgs3DMapSettings &map )
 {
   if ( !polygon->is3D() )
     polygon->addZValue( 0 );
@@ -458,7 +458,7 @@ bool Qgs3DUtils::clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping alt
   if ( !lineString )
     return false;
 
-  clampAltitudes( lineString, altClamp, altBind, centroid, height, map );
+  clampAltitudes( lineString, altClamp, altBind, centroid, offset, map );
 
   for ( int i = 0; i < polygon->numInteriorRings(); ++i )
   {
@@ -467,7 +467,7 @@ bool Qgs3DUtils::clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping alt
     if ( !lineString )
       return false;
 
-    clampAltitudes( lineString, altClamp, altBind, centroid, height, map );
+    clampAltitudes( lineString, altClamp, altBind, centroid, offset, map );
   }
   return true;
 }

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -131,11 +131,11 @@ class _3D_EXPORT Qgs3DUtils
     static Qgs3DTypes::CullingMode cullingModeFromString( const QString &str );
 
     //! Clamps altitude of a vertex according to the settings, returns Z value
-    static float clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float height, const QgsPoint &centroid, const Qgs3DMapSettings &map );
+    static float clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float offset, const QgsPoint &centroid, const Qgs3DMapSettings &map );
     //! Clamps altitude of vertices of a linestring according to the settings
-    static void clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, const QgsPoint &centroid, float height, const Qgs3DMapSettings &map );
+    static void clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, const QgsPoint &centroid, float offset, const Qgs3DMapSettings &map );
     //! Clamps altitude of vertices of a polygon according to the settings
-    static bool clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float height, const Qgs3DMapSettings &map );
+    static bool clampAltitudes( QgsPolygon *polygon, Qgis::AltitudeClamping altClamp, Qgis::AltitudeBinding altBind, float offset, const Qgs3DMapSettings &map );
 
     //! Converts a 4x4 transform matrix to a string
     static QString matrix4x4toString( const QMatrix4x4 &m );

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -36,7 +36,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbol::clone() const
   result->mAltClamping = mAltClamping;
   result->mAltBinding = mAltBinding;
   result->mWidth = mWidth;
-  result->mHeight = mHeight;
+  result->mOffset = mOffset;
   result->mExtrusionHeight = mExtrusionHeight;
   result->mRenderAsSimpleLines = mRenderAsSimpleLines;
   result->mMaterialSettings.reset( mMaterialSettings->clone() );
@@ -53,7 +53,7 @@ void QgsLine3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &co
   QDomElement elemDataProperties = doc.createElement( QStringLiteral( "data" ) );
   elemDataProperties.setAttribute( QStringLiteral( "alt-clamping" ), Qgs3DUtils::altClampingToString( mAltClamping ) );
   elemDataProperties.setAttribute( QStringLiteral( "alt-binding" ), Qgs3DUtils::altBindingToString( mAltBinding ) );
-  elemDataProperties.setAttribute( QStringLiteral( "height" ), mHeight );
+  elemDataProperties.setAttribute( QStringLiteral( "offset" ), mOffset );
   elemDataProperties.setAttribute( QStringLiteral( "extrusion-height" ), mExtrusionHeight );
   elemDataProperties.setAttribute( QStringLiteral( "simple-lines" ), mRenderAsSimpleLines ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   elemDataProperties.setAttribute( QStringLiteral( "width" ), mWidth );
@@ -72,7 +72,7 @@ void QgsLine3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   const QDomElement elemDataProperties = elem.firstChildElement( QStringLiteral( "data" ) );
   mAltClamping = Qgs3DUtils::altClampingFromString( elemDataProperties.attribute( QStringLiteral( "alt-clamping" ) ) );
   mAltBinding = Qgs3DUtils::altBindingFromString( elemDataProperties.attribute( QStringLiteral( "alt-binding" ) ) );
-  mHeight = elemDataProperties.attribute( QStringLiteral( "height" ) ).toFloat();
+  mOffset = elemDataProperties.attribute( QStringLiteral( "offset" ) ).toFloat();
   mExtrusionHeight = elemDataProperties.attribute( QStringLiteral( "extrusion-height" ) ).toFloat();
   mWidth = elemDataProperties.attribute( QStringLiteral( "width" ) ).toFloat();
   mRenderAsSimpleLines = elemDataProperties.attribute( QStringLiteral( "simple-lines" ), QStringLiteral( "0" ) ).toInt();
@@ -110,7 +110,7 @@ void QgsLine3DSymbol::setDefaultPropertiesFromLayer( const QgsVectorLayer *layer
   mAltClamping = props->clamping();
   mAltBinding = props->binding();
   mExtrusionHeight = props->extrusionEnabled() ? static_cast< float>( props->extrusionHeight() ) : 0.0f;
-  mHeight = static_cast< float >( props->zOffset() );
+  mOffset = static_cast< float >( props->zOffset() );
 }
 
 QgsAbstract3DSymbol *QgsLine3DSymbol::create()

--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -69,10 +69,33 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
     //! Sets width of the line symbol (in map units)
     void setWidth( float width ) { mWidth = width; }
 
-    //! Returns height (altitude) of the symbol (in map units)
-    float height() const { return mHeight; }
-    //! Sets height (altitude) of the symbol (in map units)
-    void setHeight( float height ) { mHeight = height; }
+    /**
+     * Returns height (altitude) of the symbol (in map units)
+     *
+     * \deprecated since QGIS 3.36. Use offset() instead.
+     */
+    Q_DECL_DEPRECATED float height() const SIP_DEPRECATED { return mOffset; }
+
+    /**
+     * Sets height (altitude) of the symbol (in map units)
+     *
+     * \deprecated since QGIS 3.36. Use setOffset() instead.
+     */
+    Q_DECL_DEPRECATED void setHeight( float height ) SIP_DEPRECATED { mOffset = height; }
+
+    /**
+     * Returns vertical offset of the symbol (in map units)
+     *
+     * \since QGIS 3.36
+     */
+    float offset() const { return mOffset; }
+
+    /**
+     * Sets vertical offset of the symbol (in map units)
+     *
+     * \since QGIS 3.36
+     */
+    void setOffset( float offset ) { mOffset = offset; }
 
     //! Returns extrusion height (in map units)
     float extrusionHeight() const { return mExtrusionHeight; }
@@ -107,7 +130,7 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTORS
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 
     float mWidth = 2.0f;            //!< Line width (horizontally)
-    float mHeight = 0.0f;           //!< Base height of polygons
+    float mOffset = 0.0f;           //!< Base height of polygons
     float mExtrusionHeight = 0.0f;  //!< How much to extrude (0 means no walls)
     bool mRenderAsSimpleLines = false;   //!< Whether to render data with simple lines (otherwise it uses buffer)
     std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings;  //!< Defines appearance of objects

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -150,7 +150,7 @@ void QgsBufferedLine3DSymbolHandler::processFeature( const QgsFeature &f, const 
   if ( QgsWkbTypes::flatType( buffered->wkbType() ) == Qgis::WkbType::Polygon )
   {
     QgsPolygon *polyBuffered = static_cast<QgsPolygon *>( buffered );
-    processPolygon( polyBuffered, f.id(), mSymbol->height(), mSymbol->extrusionHeight(), context, out );
+    processPolygon( polyBuffered, f.id(), mSymbol->offset(), mSymbol->extrusionHeight(), context, out );
   }
   else if ( QgsWkbTypes::flatType( buffered->wkbType() ) == Qgis::WkbType::MultiPolygon )
   {
@@ -158,7 +158,7 @@ void QgsBufferedLine3DSymbolHandler::processFeature( const QgsFeature &f, const 
     for ( int i = 0; i < mpolyBuffered->numGeometries(); ++i )
     {
       QgsPolygon *polyBuffered = static_cast<QgsPolygon *>( mpolyBuffered->polygonN( i ) )->clone(); // need to clone individual geometry parts
-      processPolygon( polyBuffered, f.id(), mSymbol->height(), mSymbol->extrusionHeight(), context, out );
+      processPolygon( polyBuffered, f.id(), mSymbol->offset(), mSymbol->extrusionHeight(), context, out );
     }
     delete buffered;
   }
@@ -262,8 +262,8 @@ bool QgsSimpleLine3DSymbolHandler::prepare( const Qgs3DRenderContext &context, Q
 {
   Q_UNUSED( attributeNames )
 
-  outNormal.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->height(), &context.map() );
-  outSelected.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->height(), &context.map() );
+  outNormal.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->offset(), &context.map() );
+  outSelected.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->offset(), &context.map() );
 
   return true;
 }
@@ -377,8 +377,8 @@ bool QgsThickLine3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QS
 
   outNormal.withAdjacency = true;
   outSelected.withAdjacency = true;
-  outNormal.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->height(), &context.map() );
-  outSelected.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->height(), &context.map() );
+  outNormal.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->offset(), &context.map() );
+  outSelected.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), mSymbol->offset(), &context.map() );
 
   return true;
 }

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -39,7 +39,7 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbol::clone() const
   std::unique_ptr< QgsPolygon3DSymbol > result = std::make_unique< QgsPolygon3DSymbol >();
   result->mAltClamping = mAltClamping;
   result->mAltBinding = mAltBinding;
-  result->mHeight = mHeight;
+  result->mOffset = mOffset;
   result->mExtrusionHeight = mExtrusionHeight;
   result->mMaterialSettings.reset( mMaterialSettings->clone() );
   result->mCullingMode = mCullingMode;
@@ -62,7 +62,7 @@ void QgsPolygon3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext 
   QDomElement elemDataProperties = doc.createElement( QStringLiteral( "data" ) );
   elemDataProperties.setAttribute( QStringLiteral( "alt-clamping" ), Qgs3DUtils::altClampingToString( mAltClamping ) );
   elemDataProperties.setAttribute( QStringLiteral( "alt-binding" ), Qgs3DUtils::altBindingToString( mAltBinding ) );
-  elemDataProperties.setAttribute( QStringLiteral( "height" ), mHeight );
+  elemDataProperties.setAttribute( QStringLiteral( "offset" ), mOffset );
   elemDataProperties.setAttribute( QStringLiteral( "extrusion-height" ), mExtrusionHeight );
   elemDataProperties.setAttribute( QStringLiteral( "culling-mode" ), Qgs3DUtils::cullingModeToString( mCullingMode ) );
   elemDataProperties.setAttribute( QStringLiteral( "invert-normals" ), mInvertNormals ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
@@ -93,7 +93,7 @@ void QgsPolygon3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteCon
   const QDomElement elemDataProperties = elem.firstChildElement( QStringLiteral( "data" ) );
   mAltClamping = Qgs3DUtils::altClampingFromString( elemDataProperties.attribute( QStringLiteral( "alt-clamping" ) ) );
   mAltBinding = Qgs3DUtils::altBindingFromString( elemDataProperties.attribute( QStringLiteral( "alt-binding" ) ) );
-  mHeight = elemDataProperties.attribute( QStringLiteral( "height" ) ).toFloat();
+  mOffset = elemDataProperties.attribute( QStringLiteral( "offset" ) ).toFloat();
   mExtrusionHeight = elemDataProperties.attribute( QStringLiteral( "extrusion-height" ) ).toFloat();
   mCullingMode = Qgs3DUtils::cullingModeFromString( elemDataProperties.attribute( QStringLiteral( "culling-mode" ) ) );
   mInvertNormals = elemDataProperties.attribute( QStringLiteral( "invert-normals" ) ).toInt();
@@ -148,7 +148,7 @@ void QgsPolygon3DSymbol::setDefaultPropertiesFromLayer( const QgsVectorLayer *la
   {
     mDataDefinedProperties.setProperty( PropertyHeight, QgsProperty() );
   }
-  mHeight = static_cast< float >( props->zOffset() );
+  mOffset = static_cast< float >( props->zOffset() );
 }
 
 QgsAbstract3DSymbol *QgsPolygon3DSymbol::create()

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -66,10 +66,33 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
     //! Sets method that determines how altitude is bound to individual vertices
     void setAltitudeBinding( Qgis::AltitudeBinding altBinding ) { mAltBinding = altBinding; }
 
-    //! Returns height (altitude) of the symbol (in map units)
-    float height() const { return mHeight; }
-    //! Sets height (altitude) of the symbol (in map units)
-    void setHeight( float height ) { mHeight = height; }
+    /**
+     * Returns height (altitude) of the symbol (in map units)
+     *
+     * \deprecated since QGIS 3.36. Use offset() instead.
+     */
+    Q_DECL_DEPRECATED float height() const SIP_DEPRECATED { return mOffset; }
+
+    /**
+     * Sets height (altitude) of the symbol (in map units)
+     *
+     * \deprecated since QGIS 3.36. Use setOffset() instead.
+     */
+    Q_DECL_DEPRECATED void setHeight( float height ) SIP_DEPRECATED { mOffset = height; }
+
+    /**
+     * Returns vertical offset of the symbol (in map units)
+     *
+     * \since QGIS 3.36
+     */
+    float offset() const { return mOffset; }
+
+    /**
+     * Sets vertical offset of the symbol (in map units)
+     *
+     * \since QGIS 3.36
+     */
+    void setOffset( float offset ) { mOffset = offset; }
 
     //! Returns extrusion height (in map units)
     float extrusionHeight() const { return mExtrusionHeight; }
@@ -169,7 +192,7 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCT
     //! how to handle clamping of vertices of individual features
     Qgis::AltitudeBinding mAltBinding = Qgis::AltitudeBinding::Centroid;
 
-    float mHeight = 0.0f;           //!< Base height of polygons
+    float mOffset = 0.0f;           //!< Vertical offset of polygons
     float mExtrusionHeight = 0.0f;  //!< How much to extrude (0 means no walls)
     std::unique_ptr< QgsAbstractMaterialSettings > mMaterialSettings; //!< Defines appearance of objects
     Qgs3DTypes::CullingMode mCullingMode = Qgs3DTypes::NoCulling;  //!< Front/back culling mode

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -59,7 +59,7 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVec
     return;
 
   spinWidth->setValue( lineSymbol->width() );
-  spinHeight->setValue( lineSymbol->height() );
+  spinHeight->setValue( lineSymbol->offset() );
   spinExtrusion->setValue( lineSymbol->extrusionHeight() );
   cboAltClamping->setCurrentIndex( cboAltClamping->findData( static_cast< int >( lineSymbol->altitudeClamping() ) ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( lineSymbol->altitudeBinding() ) );
@@ -74,7 +74,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbolWidget::symbol()
 {
   std::unique_ptr< QgsLine3DSymbol > sym = std::make_unique< QgsLine3DSymbol >();
   sym->setWidth( spinWidth->value() );
-  sym->setHeight( spinHeight->value() );
+  sym->setOffset( spinHeight->value() );
   sym->setExtrusionHeight( spinExtrusion->value() );
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentData().toInt() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -23,7 +23,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
 {
   setupUi( this );
 
-  spinHeight->setClearValue( 0.0 );
+  spinOffset->setClearValue( 0.0 );
   spinWidth->setClearValue( 0.0, tr( "Hairline" ) );
   spinExtrusion->setClearValue( 0.0 );
 
@@ -35,7 +35,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   setSymbol( &defaultLine, nullptr );
 
   connect( spinWidth, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );
-  connect( spinHeight, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );
+  connect( spinOffset, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );
   connect( spinExtrusion, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLine3DSymbolWidget::changed );
   connect( cboAltBinding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLine3DSymbolWidget::changed );
@@ -59,7 +59,7 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVec
     return;
 
   spinWidth->setValue( lineSymbol->width() );
-  spinHeight->setValue( lineSymbol->offset() );
+  spinOffset->setValue( lineSymbol->offset() );
   spinExtrusion->setValue( lineSymbol->extrusionHeight() );
   cboAltClamping->setCurrentIndex( cboAltClamping->findData( static_cast< int >( lineSymbol->altitudeClamping() ) ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( lineSymbol->altitudeBinding() ) );
@@ -74,7 +74,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbolWidget::symbol()
 {
   std::unique_ptr< QgsLine3DSymbol > sym = std::make_unique< QgsLine3DSymbol >();
   sym->setWidth( spinWidth->value() );
-  sym->setOffset( spinHeight->value() );
+  sym->setOffset( static_cast<float>( spinOffset->value() ) );
   sym->setExtrusionHeight( spinExtrusion->value() );
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentData().toInt() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -67,7 +67,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
   if ( !polygonSymbol )
     return;
 
-  spinHeight->setValue( polygonSymbol->height() );
+  spinHeight->setValue( polygonSymbol->offset() );
   spinExtrusion->setValue( polygonSymbol->extrusionHeight() );
   cboAltClamping->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeClamping() ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeBinding() ) );
@@ -90,7 +90,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
 QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
 {
   std::unique_ptr< QgsPolygon3DSymbol > sym = std::make_unique< QgsPolygon3DSymbol >();
-  sym->setHeight( spinHeight->value() );
+  sym->setOffset( spinHeight->value() );
   sym->setExtrusionHeight( spinExtrusion->value() );
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -23,7 +23,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   : Qgs3DSymbolWidget( parent )
 {
   setupUi( this );
-  spinHeight->setClearValue( 0.0 );
+  spinOffset->setClearValue( 0.0 );
   spinExtrusion->setClearValue( 0.0 );
   spinEdgeWidth->setClearValue( 1.0 );
 
@@ -38,7 +38,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   QgsPolygon3DSymbol defaultSymbol;
   setSymbol( &defaultSymbol, nullptr );
 
-  connect( spinHeight, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPolygon3DSymbolWidget::changed );
+  connect( spinOffset, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( spinExtrusion, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( cboAltBinding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
@@ -67,7 +67,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
   if ( !polygonSymbol )
     return;
 
-  spinHeight->setValue( polygonSymbol->offset() );
+  spinOffset->setValue( polygonSymbol->offset() );
   spinExtrusion->setValue( polygonSymbol->extrusionHeight() );
   cboAltClamping->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeClamping() ) );
   cboAltBinding->setCurrentIndex( static_cast<int>( polygonSymbol->altitudeBinding() ) );
@@ -90,7 +90,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, Qgs
 QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
 {
   std::unique_ptr< QgsPolygon3DSymbol > sym = std::make_unique< QgsPolygon3DSymbol >();
-  sym->setOffset( spinHeight->value() );
+  sym->setOffset( static_cast<float>( spinOffset->value() ) );
   sym->setExtrusionHeight( spinExtrusion->value() );
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );

--- a/src/ui/3d/line3dsymbolwidget.ui
+++ b/src/ui/3d/line3dsymbolwidget.ui
@@ -29,14 +29,14 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="1" column="0">
-      <widget class="QLabel" name="labelHeight">
+      <widget class="QLabel" name="labelOffset">
        <property name="text">
-        <string>Height</string>
+        <string>Offset</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinHeight">
+      <widget class="QgsDoubleSpinBox" name="spinOffset">
        <property name="minimum">
         <double>-99999.000000000000000</double>
        </property>
@@ -167,7 +167,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>spinWidth</tabstop>
-  <tabstop>spinHeight</tabstop>
+  <tabstop>spinOffset</tabstop>
   <tabstop>spinExtrusion</tabstop>
   <tabstop>cboAltClamping</tabstop>
   <tabstop>cboAltBinding</tabstop>

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -24,7 +24,7 @@
     <number>0</number>
    </property>
    <item row="0" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinHeight">
+    <widget class="QgsDoubleSpinBox" name="spinOffset">
      <property name="minimum">
       <double>-99999.000000000000000</double>
      </property>
@@ -218,9 +218,9 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelOffset">
      <property name="text">
-      <string>Height</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
@@ -291,7 +291,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>spinHeight</tabstop>
+  <tabstop>spinOffset</tabstop>
   <tabstop>btnHeightDD</tabstop>
   <tabstop>spinExtrusion</tabstop>
   <tabstop>btnExtrusionDD</tabstop>

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -522,7 +522,7 @@ void TestQgs3DRendering::testPolygonsEdges()
   QgsPolygon3DSymbol *symbol3d = new QgsPolygon3DSymbol;
   symbol3d->setMaterialSettings( materialSettings.clone() );
   symbol3d->setExtrusionHeight( 10.f );
-  symbol3d->setHeight( 20.f );
+  symbol3d->setOffset( 20.f );
   symbol3d->setEdgesEnabled( true );
   symbol3d->setEdgeWidth( 8 );
   symbol3d->setEdgeColor( QColor( 255, 0, 0 ) );

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -735,7 +735,7 @@ void TestQgs3DRendering::testBufferedLineRenderingWidth()
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setWidth( 20 );
   lineSymbol->setExtrusionHeight( 30 );
-  lineSymbol->setHeight( 10 );
+  lineSymbol->setOffset( 10 );
   QgsPhongMaterialSettings matSettings;
   matSettings.setAmbient( Qt::red );
   lineSymbol->setMaterialSettings( matSettings.clone() );


### PR DESCRIPTION
## Description

The `height` property is in fact a vertical offset applied to the line or the polygon. Also, the `offset` phrase is already used by the terrain for similar purposes.

cc @benoitdm-oslandia @soaubier
