### PR TITLE
Fix test on python 3.12

### DIFF
--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -333,8 +333,10 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
             "name 'foo' is not defined:<pre>Traceback \\(most recent call last\\):\n"
             "  File \".*qgsfunction.py\", line [0-9]+, in func\n"
             "    return self.function\\(\\*values, \\*\\*kwvalues\\)\n"
+            "(.*?\n)?"
             "  File \".*test_qgsexpression.py\", line [0-9]+, in raise_exception\n"
             "    foo  # noqa: F821\n"
+            "(.*?\n)?"
             "NameError: name \'foo\' is not defined"
             "\n</pre>"
         )


### PR DESCRIPTION
Builtin exception string format has changed
