### PR TITLE
fix(python/CMakeLists.txt): be sure we only use std 14 for python

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -174,7 +174,7 @@ GENERATE_SIP_PYTHON_MODULE_CODE(qgis._core core/core.sip "${sip_files_core}" cpp
 BUILD_SIP_PYTHON_MODULE(qgis._core core/core.sip ${cpp_files} "" qgis_core)
 set(SIP_CORE_CPP_FILES ${cpp_files})
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
   # Bad hack to fix compilation with gcc 11 - for some reason it's ignoring
   # the c++ standard version set for the target in BUILD_SIP_PYTHON_MODULE!
   add_definitions(-std=c++14)


### PR DESCRIPTION
Fix, for the python/sip tree, the std c++ version to 14 to avoid using the stdc++17. 
Using clang, cmake could use stdc++17 resulting in this error:

```raw
build_23.10/python/core/sip_corepart13.cpp:38456:87: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
    void transform(const  ::QgsCoordinateTransform&, ::Qgis::TransformDirection,bool) throw(QgsCsException) SIP_OVERRIDE;
                                                                                      ^~~~~~~~~~~~~~~~~~~~~
```

[X] can be backported

cc @troopa81 @lbartoletti 