### PR TITLE
Add a QgsRectangle::createNull() temporary static method

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -59,6 +59,7 @@ Copy constructor
 
     ~QgsRectangle();
 
+
     static QgsRectangle fromWkt( const QString &wkt );
 %Docstring
 Creates a new rectangle from a ``wkt`` string.

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -100,6 +100,22 @@ class CORE_EXPORT QgsRectangle
     ~QgsRectangle() = default;
 
     /**
+    * Creates a null rectangle.
+    *
+    * This is a temporary method to use while the default
+    * constructor is still not constructing a null rectangle.
+    *
+    * \since QGIS 3.34
+    */
+    static QgsRectangle createNull() SIP_SKIP
+    {
+      // TODO: remove this method once the default constructor gives a null
+      QgsRectangle rectNull;
+      rectNull.setNull(); // TODO: have setNull() return *this ?
+      return rectNull;
+    }
+
+    /**
     * Creates a new rectangle from a \a wkt string.
     * The WKT must contain only 5 vertices, representing a rectangle aligned with X and Y axes.
     * \since QGIS 3.0


### PR DESCRIPTION
Temporary method to help with refactoring the QgsRectangle class to go null by default.

See https://github.com/qgis/QGIS/pull/54954#issuecomment-1771813330