### PR TITLE
Use valid extent in testRegisterFeatureUnprojectible

### DIFF
--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -938,9 +938,8 @@ void TestQgsLabelingEngine::testRegisterFeatureUnprojectible()
   QgsCoordinateReferenceSystem tgtCrs;
   tgtCrs.createFromString( QStringLiteral( "EPSG:3857" ) );
   mapSettings.setDestinationCrs( tgtCrs );
-
   mapSettings.setOutputSize( size );
-  mapSettings.setExtent( vl2->extent() );
+  mapSettings.setExtent( tgtCrs.bounds() );
   mapSettings.setLayers( QList<QgsMapLayer *>() << vl2.get() );
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -928,7 +928,7 @@ void TestQgsLabelingEngine::testRegisterFeatureUnprojectible()
   QgsVectorLayerLabelProvider *provider = new QgsVectorLayerLabelProvider( vl2.get(), QStringLiteral( "test" ), true, &settings );
   QgsFeature f( vl2->fields(), 1 );
 
-  const QString wkt1 = QStringLiteral( "POLYGON((0 0,8 0,8 -90,0 0))" );
+  const QString wkt1 = QStringLiteral( "POLYGON((0 0,8 0,8 -91,0 0))" );
   f.setGeometry( QgsGeometry::fromWkt( wkt1 ) );
 
   // make a fake render context


### PR DESCRIPTION
The test was meant to catch a crasher upon being unable to project a feature. Today it looks like QGIS is able to project the feature and generate a label for it, but the test still reports no features being added only because the "visible extent" (set to the map) is empty.

I will push a commit making the feature back unprojectible but first I want to verify that the "invisible extent" is the reason why the test did not start failing upon the feature became projectible. If this is the case, we should see the test fail, now that we use a valid map extent.

This is a spin-off of https://github.com/qgis/QGIS/pull/54954#issuecomment-1773744397