### PR TITLE
Remove custom FALLTHROUGH define

### DIFF
--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2644,7 +2644,6 @@ typedef unsigned long long qgssize;
 
 
 
-
 QString geoWkt();
 %Docstring
 Wkt string that represents a geographic coord sys

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1530,7 +1530,7 @@ const QList<QgsVectorLayerRef> QgsAppLayerHandling::findBrokenLayerDependencies(
         {
           if ( !weakRelation.mappingTable().resolveWeakly( QgsProject::instance(), matchType ) )
             dependencies << weakRelation.mappingTable();
-          FALLTHROUGH;
+          [[fallthrough]];
         }
 
         case Qgis::RelationshipCardinality::OneToOne:

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -688,7 +688,7 @@ QgsMapTool::Flags QgsMapToolEditMeshFrame::flags() const
     case Digitizing:
       if ( !mCadDockWidget->cadEnabled() || !mSelectedVertices.isEmpty() || mCurrentFaceIndex != -1 )
         return QgsMapTool::Flags() | QgsMapTool::ShowContextMenu;
-      FALLTHROUGH
+      [[fallthrough]];
     case AddingNewFace:
     case Selecting:
     case MovingSelection:

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -232,7 +232,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         return QVariant( sL + sR );
       }
       //intentional fall-through
-      FALLTHROUGH
+      [[fallthrough]];
     case boMinus:
     case boMul:
     case boDiv:

--- a/src/core/labeling/qgsvectorlayerlabeling.cpp
+++ b/src/core/labeling/qgsvectorlayerlabeling.cpp
@@ -216,7 +216,7 @@ std::unique_ptr<QgsMarkerSymbolLayer> backgroundToMarkerLayer( const QgsTextBack
         layer.reset( static_cast< QgsMarkerSymbolLayer * >( settings.markerSymbol()->symbolLayer( 0 )->clone() ) );
         break;
       }
-      FALLTHROUGH // not set, just go with the default
+      [[fallthrough]]; // not set, just go with the default
     }
     case QgsTextBackgroundSettings::ShapeCircle:
     case QgsTextBackgroundSettings::ShapeEllipse:

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1301,7 +1301,7 @@ bool QgsLayoutItemMap::nextExportPart()
         mCurrentExportPart = Background;
         return true;
       }
-      FALLTHROUGH
+      [[fallthrough]];
 
     case Background:
       mCurrentExportPart = Layer;
@@ -1330,7 +1330,7 @@ bool QgsLayoutItemMap::nextExportPart()
         mCurrentExportPart = Grid;
         return true;
       }
-      FALLTHROUGH
+      [[fallthrough]];
 
     case Grid:
       for ( int i = 0; i < mOverviewStack->size(); ++i )
@@ -1342,7 +1342,7 @@ bool QgsLayoutItemMap::nextExportPart()
           return true;
         }
       }
-      FALLTHROUGH
+      [[fallthrough]];
 
     case OverviewMapExtent:
       if ( frameEnabled() )
@@ -1351,7 +1351,7 @@ bool QgsLayoutItemMap::nextExportPart()
         return true;
       }
 
-      FALLTHROUGH
+      [[fallthrough]];
 
     case Frame:
       if ( isSelected() && !mLayout->renderContext().isPreviewRender() )
@@ -1359,7 +1359,7 @@ bool QgsLayoutItemMap::nextExportPart()
         mCurrentExportPart = SelectionBoxes;
         return true;
       }
-      FALLTHROUGH
+      [[fallthrough]];
 
     case SelectionBoxes:
       mCurrentExportPart = End;

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -641,7 +641,7 @@ void QgsLayoutItemMapGrid::draw( QPainter *p )
         break;
       }
 
-      FALLTHROUGH
+      [[fallthrough]];
     case CM:
     case MM:
       drawGridNoTransform( context, dotsPerMM );
@@ -2217,7 +2217,7 @@ void QgsLayoutItemMapGrid::calculateMaxExtension( double &top, double &right, do
         break;
       }
     }
-    FALLTHROUGH
+    [[fallthrough]];
     case CM:
     case MM:
       drawGridNoTransform( context, 0, true );

--- a/src/core/layout/qgslayoutitemmapitem.cpp
+++ b/src/core/layout/qgslayoutitemmapitem.cpp
@@ -279,7 +279,7 @@ void QgsLayoutItemMapItemStack::drawItems( QPainter *painter, bool ignoreStackin
         if ( !ignoreStacking )
           break;
 
-        FALLTHROUGH
+        [[fallthrough]];
       case QgsLayoutItemMapItem::StackAboveMapLabels:
         item->draw( painter );
         break;

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -193,7 +193,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsPointCloudAttributeByRampRenderer::creat
                                            mColorRampShader.maximumValue() );
         break;
       }
-      Q_FALLTHROUGH();
+      [[fallthrough]];
     case QgsColorRampShader::Discrete:
     case QgsColorRampShader::Exact:
     {

--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -252,7 +252,7 @@ void QgsPointCloudLayerExporter::doExport()
     case ExportFormat::Csv:
       layerCreationOptions << QStringLiteral( "GEOMETRY=AS_XYZ" )
                            << QStringLiteral( "SEPARATOR=COMMA" ); // just in case ogr changes the default lco
-      FALLTHROUGH
+      [[fallthrough]];
     case ExportFormat::Gpkg:
     case ExportFormat::Dxf:
     case ExportFormat::Shp:

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1914,7 +1914,7 @@ bool QgsOgrProvider::addAttributeOGRLevel( const QgsField &field, bool &ignoreEr
       // other lists are supported at this moment, fall through to default for other types
 
       //intentional fall-through
-      FALLTHROUGH
+      [[fallthrough]];
 
     default:
       pushError( tr( "type %1 for field %2 not found" ).arg( field.typeName(), field.name() ) );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4918,16 +4918,6 @@ typedef unsigned long long qgssize;
 #endif
 #endif
 
-#if __cplusplus >= 201500
-#define FALLTHROUGH [[fallthrough]];
-#elif defined(__clang__)
-#define FALLTHROUGH [[clang::fallthrough]];
-#elif defined(__GNUC__) && __GNUC__ >= 7
-#define FALLTHROUGH [[gnu::fallthrough]];
-#else
-#define FALLTHROUGH
-#endif
-
 // see https://infektor.net/posts/2017-01-19-using-cpp17-attributes-today.html#using-the-nodiscard-attribute
 #if __cplusplus >= 201703L
 #define NODISCARD [[nodiscard]]

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -577,7 +577,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsDefaultMeshLayerLegend::createLayerTreeM
           }
           break;
         }
-        Q_FALLTHROUGH();
+        [[fallthrough]];
       case QgsColorRampShader::Discrete:
       case QgsColorRampShader::Exact:
       {

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1305,7 +1305,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry,
       case Qgis::WkbType::MultiPoint25D:
         hasZValue = true;
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
       case Qgis::WkbType::MultiPoint:
       {
         QDomElement multiPointElem = doc.createElement( QStringLiteral( "gml:MultiPoint" ) );
@@ -1350,7 +1350,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry,
       case Qgis::WkbType::LineString25D:
         hasZValue = true;
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
       case Qgis::WkbType::LineString:
       {
         QDomElement lineStringElem = doc.createElement( QStringLiteral( "gml:LineString" ) );
@@ -1393,7 +1393,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry,
       case Qgis::WkbType::MultiLineString25D:
         hasZValue = true;
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
       case Qgis::WkbType::MultiLineString:
       {
         QDomElement multiLineStringElem = doc.createElement( QStringLiteral( "gml:MultiLineString" ) );
@@ -1451,7 +1451,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry,
       case Qgis::WkbType::Polygon25D:
         hasZValue = true;
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
       case Qgis::WkbType::Polygon:
       {
         QDomElement polygonElem = doc.createElement( QStringLiteral( "gml:Polygon" ) );
@@ -1513,7 +1513,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry,
       case Qgis::WkbType::MultiPolygon25D:
         hasZValue = true;
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
       case Qgis::WkbType::MultiPolygon:
       {
         QDomElement multiPolygonElem = doc.createElement( QStringLiteral( "gml:MultiPolygon" ) );

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -388,7 +388,7 @@ double QgsRenderContext::convertToPainterUnits( double size, Qgis::RenderUnit un
         size = convertMetersToMapUnits( size );
       unit = Qgis::RenderUnit::MapUnits;
       // Fall through to RenderMapUnits with size in meters converted to size in MapUnits
-      FALLTHROUGH
+      [[fallthrough]];
     }
     case Qgis::RenderUnit::MapUnits:
     {
@@ -484,7 +484,7 @@ double QgsRenderContext::convertToMapUnits( double size, Qgis::RenderUnit unit, 
     {
       size = convertMetersToMapUnits( size );
       // Fall through to RenderMapUnits with values of meters converted to MapUnits
-      FALLTHROUGH
+      [[fallthrough]];
     }
     case Qgis::RenderUnit::MapUnits:
     {

--- a/src/core/qgsscalecalculator.cpp
+++ b/src/core/qgsscalecalculator.cpp
@@ -111,7 +111,7 @@ void QgsScaleCalculator::calculateMetrics( const QgsRectangle &mapExtent, double
 
     case Qgis::DistanceUnit::Unknown:
       // assume degrees to maintain old API
-      FALLTHROUGH
+      [[fallthrough]];
 
     case Qgis::DistanceUnit::Degrees:
       // degrees require conversion to meters first

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -733,7 +733,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
           }
 
             //intentional fall-through
-          FALLTHROUGH
+          [[fallthrough]];
 
           case QVariant::List:
             // handle GPKG conversion to JSON
@@ -806,7 +806,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
               break;
             }
             //intentional fall-through
-            FALLTHROUGH
+            [[fallthrough]];
 
           default:
             //assert(0 && "invalid variant type!");
@@ -2996,7 +2996,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
           break;
         }
         //intentional fall-through
-        FALLTHROUGH
+        [[fallthrough]];
 
       case QVariant::Map:
       {
@@ -3017,7 +3017,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
       }
 
         //intentional fall-through
-      FALLTHROUGH
+      [[fallthrough]];
 
 
       default:

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -461,7 +461,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
         }
         break;
       }
-      Q_FALLTHROUGH();
+      [[fallthrough]];
     case QgsColorRampShader::Discrete:
     case QgsColorRampShader::Exact:
     {

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1545,7 +1545,7 @@ void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &cont
         const QgsMultiPoint *mp = qgsgeometry_cast< const QgsMultiPoint * >( processedGeometry );
         markers.reserve( mp->numGeometries() );
       }
-      FALLTHROUGH
+      [[fallthrough]];
       case Qgis::WkbType::MultiCurve:
       case Qgis::WkbType::MultiLineString:
       case Qgis::WkbType::GeometryCollection:

--- a/src/core/textrenderer/qgstextrenderer.cpp
+++ b/src/core/textrenderer/qgstextrenderer.cpp
@@ -478,7 +478,7 @@ void QgsTextRenderer::drawPart( const QRectF &rect, double rotation, Qgis::TextH
       if ( !format.buffer().enabled() )
         break;
     }
-    FALLTHROUGH
+    [[fallthrough]];
     case Qgis::TextComponent::Text:
     case Qgis::TextComponent::Shadow:
     {
@@ -528,7 +528,7 @@ void QgsTextRenderer::drawPart( QPointF origin, double rotation, Qgis::TextHoriz
       if ( !format.buffer().enabled() )
         break;
     }
-    FALLTHROUGH
+    [[fallthrough]];
     case Qgis::TextComponent::Text:
     case Qgis::TextComponent::Shadow:
     {

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -4556,7 +4556,7 @@ QSet<QVariant> QgsVectorLayer::uniqueValues( int index, int limit ) const
         uniqueValues = mDataProvider->uniqueValues( index, limit );
         return uniqueValues;
       }
-      FALLTHROUGH
+      [[fallthrough]];
     //we need to go through each feature
     case QgsFields::OriginJoin:
     case QgsFields::OriginExpression:
@@ -4655,7 +4655,7 @@ QStringList QgsVectorLayer::uniqueStringsMatching( int index, const QString &sub
       {
         return mDataProvider->uniqueStringsMatching( index, substring, limit, feedback );
       }
-      FALLTHROUGH
+      [[fallthrough]];
     //we need to go through each feature
     case QgsFields::OriginJoin:
     case QgsFields::OriginExpression:
@@ -4789,7 +4789,7 @@ void QgsVectorLayer::minimumOrMaximumValue( int index, QVariant *minimum, QVaria
         return;
       }
     }
-    FALLTHROUGH
+    [[fallthrough]];
     // no choice but to go through all features
     case QgsFields::OriginExpression:
     case QgsFields::OriginJoin:

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -68,7 +68,7 @@ QVector<QgsAbstractProfileResults::Feature> QgsVectorLayerProfileResults::asFeat
       if ( type != Qgis::ProfileExportType::DistanceVsElevationTable )
         return asIndividualFeatures( type, feedback );
       // distance vs elevation table results are always handled like a continuous surface
-      FALLTHROUGH
+      [[fallthrough]];
 
     case Qgis::VectorProfileType::ContinuousSurface:
       return QgsAbstractProfileSurfaceResults::asFeatures( type, feedback );

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -537,7 +537,7 @@ void QgsMapToolModifyAnnotation::keyPressEvent( QKeyEvent *event )
         event->ignore(); // disable default shortcut handling (delete vector feature)
         break;
       }
-      FALLTHROUGH
+      [[fallthrough]];
     }
 
     case Action::MoveItem:

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2917,7 +2917,7 @@ QWidget *QgsProcessingEnumWidgetWrapper::createWidget()
         return mCheckboxPanel;
       }
     }
-    FALLTHROUGH
+    [[fallthrough]];
     case QgsProcessingGui::Modeler:
     case QgsProcessingGui::Batch:
     {

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -120,12 +120,12 @@ void QgsPropertyOverrideButton::init( int propertyKey, const QgsProperty &proper
   {
     case QgsPropertyDefinition::DataTypeBoolean:
       ts << tr( "boolean" );
-      FALLTHROUGH
+      [[fallthrough]];
 
     case QgsPropertyDefinition::DataTypeNumeric:
       ts << tr( "int" );
       ts << tr( "double" );
-      FALLTHROUGH
+      [[fallthrough]];
 
     case QgsPropertyDefinition::DataTypeString:
       ts << tr( "string" );

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -299,7 +299,7 @@ int QgsGrassNewMapset::nextId() const
         id = MapSet;
         break;
       }
-      FALLTHROUGH
+      [[fallthrough]];
     case Database:
     case Crs:
     case Region:

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2007,7 +2007,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::Point25D:
       case Qgis::WkbType::PointZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::Point:
         g.srid  = mSrid;
@@ -2022,7 +2022,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::LineStringZ:
       case Qgis::WkbType::MultiLineStringZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::LineString:
       case Qgis::WkbType::MultiLineString:
@@ -2061,7 +2061,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::PolygonZ:
       case Qgis::WkbType::MultiPolygonZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::Polygon:
       case Qgis::WkbType::MultiPolygon:
@@ -2131,7 +2131,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::MultiPoint25D:
       case Qgis::WkbType::MultiPointZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::MultiPoint:
       {
@@ -2157,7 +2157,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::CompoundCurveZ:
       case Qgis::WkbType::MultiCurveZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::CircularString:
       case Qgis::WkbType::CompoundCurve:
@@ -2234,7 +2234,7 @@ void QgsOracleProvider::appendGeomParam( const QgsGeometry &geom, QSqlQuery &qry
       case Qgis::WkbType::CurvePolygonZ:
       case Qgis::WkbType::MultiSurfaceZ:
         dim = 3;
-        FALLTHROUGH
+        [[fallthrough]];
 
       case Qgis::WkbType::CurvePolygon:
       case Qgis::WkbType::MultiSurface:

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1860,7 +1860,7 @@ qint64 QgsPostgresConn::getBinaryInt( QgsPostgresResult &queryResult, int row, i
     default:
       QgsDebugError( QStringLiteral( "unexpected size %1" ).arg( s ) );
       //intentional fall-through
-      FALLTHROUGH
+      [[fallthrough]];
     case 4:
       oid = *( quint32 * )p;
       if ( mSwapEndian )

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -227,7 +227,7 @@ QgsSqlExpressionCompiler::Result QgsPostgresExpressionCompiler::compileNode( con
         return Complete;
       }
 #endif
-      FALLTHROUGH
+      [[fallthrough]];
     }
 
     default:

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -267,7 +267,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::Point25D:
         case Qgis::WkbType::PointZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::Point:
           geometryType = QStringLiteral( "POINT" );
           break;
@@ -275,7 +275,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::LineString25D:
         case Qgis::WkbType::LineStringZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::LineString:
           geometryType = QStringLiteral( "LINESTRING" );
           break;
@@ -283,7 +283,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::Polygon25D:
         case Qgis::WkbType::PolygonZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::Polygon:
           geometryType = QStringLiteral( "POLYGON" );
           break;
@@ -291,7 +291,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::MultiPoint25D:
         case Qgis::WkbType::MultiPointZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::MultiPoint:
           geometryType = QStringLiteral( "MULTIPOINT" );
           break;
@@ -299,7 +299,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::MultiLineString25D:
         case Qgis::WkbType::MultiLineStringZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::MultiLineString:
           geometryType = QStringLiteral( "MULTILINESTRING" );
           break;
@@ -307,7 +307,7 @@ Qgis::VectorExportResult QgsSpatiaLiteProvider::createEmptyLayer( const QString 
         case Qgis::WkbType::MultiPolygon25D:
         case Qgis::WkbType::MultiPolygonZ:
           dim = 3;
-          FALLTHROUGH
+          [[fallthrough]];
         case Qgis::WkbType::MultiPolygon:
           geometryType = QStringLiteral( "MULTIPOLYGON" );
           break;


### PR DESCRIPTION
We don't need this anymore since we require c++17 anyway, and it raises build warnings due to macro redefinition with newer GRASS
