### PR TITLE
Handle duplicate names in renderer profile 

### DIFF
--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -64,11 +64,14 @@ Returns a list of all child groups with the specified ``parent``.
 .. versionadded:: 3.14
 %End
 
-    void start( const QString &name, const QString &group = "startup" );
+    void start( const QString &name, const QString &group = "startup", const QString &id = QString() );
 %Docstring
 Start a profile event with the given name.
 The ``name`` of the profile event. Will have the name of
 the active ``group`` appended after ending.
+
+Since QGIS 3.34, the optional ``id`` argument can be used to provide a unique
+ID to disambiguate nodes with the same ``name``.
 %End
 
     void end( const QString &group = "startup" );
@@ -76,9 +79,12 @@ the active ``group`` appended after ending.
 End the current profile event.
 %End
 
-    void record( const QString &name, double time, const QString &group = "startup" );
+    void record( const QString &name, double time, const QString &group = "startup", const QString &id = QString() );
 %Docstring
 Manually adds a profile event with the given name and total ``time`` (in seconds).
+
+The optional ``id`` argument can be used to provider a unique
+ID to disambiguate nodes with the same ``name``.
 
 .. versionadded:: 3.34
 %End
@@ -176,12 +182,15 @@ Python scripts should not use :py:class:`QgsScopedRuntimeProfile` directly. Inst
 %End
   public:
 
-    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup" );
+    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup", const QString &id = QString() );
 %Docstring
 Constructor for QgsScopedRuntimeProfile.
 
 Automatically registers the operation in the :py:func:`QgsApplication.profiler()` instance
 and starts recording the run time of the operation.
+
+Since QGIS 3.34, the optional ``id`` argument can be used to provide a unique
+ID to disambiguate nodes with the same ``name``.
 %End
 
     ~QgsScopedRuntimeProfile();

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -310,7 +310,7 @@ bool QgsMeshLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > preparingProfile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
     preparingProfile = std::make_unique< QgsScopedRuntimeProfile >( QObject::tr( "Preparing render" ), QStringLiteral( "rendering" ) );

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -83,7 +83,7 @@ bool QgsPointCloudLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
   }

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -47,12 +47,15 @@ class CORE_EXPORT QgsRuntimeProfilerNode
       Group, //!< Node group
       Elapsed, //!< Node elapsed time
       ParentElapsed, //!< Total elapsed time for node's parent
+      Id, //!< Internal node ID (since QGIS 3.34)
     };
 
     /**
      * Constructor for QgsRuntimeProfilerNode, with the specified \a group and \a name.
+     *
+     * Since QGIS 3.34 an internal \a id can be specified to disambiguate entries with duplicate names.
      */
-    QgsRuntimeProfilerNode( const QString &group, const QString &name );
+    QgsRuntimeProfilerNode( const QString &group, const QString &name, const QString &id = QString() );
 
     //! QgsRuntimeProfilerNode cannot be copied
     QgsRuntimeProfilerNode( const QgsRuntimeProfilerNode &other ) = delete;
@@ -70,6 +73,8 @@ class CORE_EXPORT QgsRuntimeProfilerNode
 
     /**
      * Returns the full path to the node's parent.
+     *
+     * This will contain node IDs if set, otherwise node names.
      */
     QStringList fullParentPath() const;
 
@@ -96,10 +101,10 @@ class CORE_EXPORT QgsRuntimeProfilerNode
     int indexOf( QgsRuntimeProfilerNode *child ) const;
 
     /**
-     * Finds the child with matching \a group and \a name. Returns NULLPTR if
+     * Finds the child with matching \a group, \a name and \a id (since QGIS 3.34). Returns NULLPTR if
      * a matching child was not found.
      */
-    QgsRuntimeProfilerNode *child( const QString &group, const QString &name );
+    QgsRuntimeProfilerNode *child( const QString &group, const QString &name, const QString &id = QString() );
 
     /**
      * Returns the child at the specified \a index.
@@ -151,6 +156,7 @@ class CORE_EXPORT QgsRuntimeProfilerNode
     QElapsedTimer mProfileTime;
     double mElapsed = 0;
 
+    QString mId;
     QString mName;
     QString mGroup;
 
@@ -211,8 +217,11 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
      * \brief Start a profile event with the given name.
      * The \a name of the profile event. Will have the name of
      * the active \a group appended after ending.
+     *
+     * Since QGIS 3.34, the optional \a id argument can be used to provide a unique
+     * ID to disambiguate nodes with the same \a name.
      */
-    void start( const QString &name, const QString &group = "startup" );
+    void start( const QString &name, const QString &group = "startup", const QString &id = QString() );
 
     /**
      * \brief End the current profile event.
@@ -222,9 +231,12 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
     /**
      * Manually adds a profile event with the given name and total \a time (in seconds).
      *
+     * The optional \a id argument can be used to provider a unique
+     * ID to disambiguate nodes with the same \a name.
+     *
      * \since QGIS 3.34
      */
-    void record( const QString &name, double time, const QString &group = "startup" );
+    void record( const QString &name, double time, const QString &group = "startup", const QString &id = QString() );
 
     /**
      * Returns the profile time for the specified \a name.
@@ -281,8 +293,8 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
     ///@cond PRIVATE
   signals:
 
-    void started( const QString &group, const QStringList &path, const QString &name );
-    void ended( const QString &group, const QStringList &path, const QString &name, double elapsed );
+    void started( const QString &group, const QStringList &path, const QString &name, const QString &id );
+    void ended( const QString &group, const QStringList &path, const QString &name, const QString &id, double elapsed );
 ///@endcond
 #endif
 
@@ -293,8 +305,8 @@ class CORE_EXPORT QgsRuntimeProfiler : public QAbstractItemModel
 
   private slots:
 
-    void otherProfilerStarted( const QString &group, const QStringList &path, const QString &name );
-    void otherProfilerEnded( const QString &group, const QStringList &path, const QString &name, double elapsed );
+    void otherProfilerStarted( const QString &group, const QStringList &path, const QString &name, const QString &id );
+    void otherProfilerEnded( const QString &group, const QStringList &path, const QString &name, const QString &id, double elapsed );
 
   private:
 
@@ -348,8 +360,11 @@ class CORE_EXPORT QgsScopedRuntimeProfile
      *
      * Automatically registers the operation in the QgsApplication::profiler() instance
      * and starts recording the run time of the operation.
+     *
+     * Since QGIS 3.34, the optional \a id argument can be used to provide a unique
+     * ID to disambiguate nodes with the same \a name.
      */
-    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup" );
+    QgsScopedRuntimeProfile( const QString &name, const QString &group = "startup", const QString &id = QString() );
 
     /**
      * Records the final runtime of the operation in the profiler instance.

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -326,7 +326,7 @@ bool QgsRasterLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
   }

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -78,7 +78,7 @@ bool QgsTiledSceneLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
   }

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -244,7 +244,7 @@ bool QgsVectorLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
   }

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -75,7 +75,7 @@ bool QgsVectorTileLayerRenderer::render()
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {
-    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ) );
+    profile = std::make_unique< QgsScopedRuntimeProfile >( mLayerName, QStringLiteral( "rendering" ), layerId() );
     if ( mPreparationTime > 0 )
       QgsApplication::profiler()->record( QObject::tr( "Create renderer" ), mPreparationTime / 1000.0, QStringLiteral( "rendering" ) );
   }


### PR DESCRIPTION
Don't condense profile results from duplicate layers with the same name into one entry in the renderer profile chart