### PR TITLE
Update pdal_wrench to 1.1 and processing algorithms

### DIFF
--- a/external/pdal_wrench/alg.hpp
+++ b/external/pdal_wrench/alg.hpp
@@ -206,6 +206,7 @@ struct Merge : public Alg
     // parameters from the user
     std::string outputFile;
     std::vector<std::string> inputFiles;
+    std::string inputFileList;
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;

--- a/external/pdal_wrench/tile/tile.cpp
+++ b/external/pdal_wrench/tile/tile.cpp
@@ -124,6 +124,7 @@ public:
         int max_threads;
         std::string outputFormat;   // las or laz (for now)
         bool buildVpc = false;
+        std::string inputFileList; // file list with input files
     } opts;
 
     pdal::BOX3D trueBounds;
@@ -434,6 +435,7 @@ void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::A
 {
     programArgs.add("output,o", "Output directory/filename", options.outputDir);
     programArgs.add("files,i", "Input files/directory", options.inputFiles).setPositional();
+    programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
     programArgs.add("output-format", "Output format (las/laz)", options.outputFormat);
@@ -461,7 +463,7 @@ bool handleOptions(pdal::StringList& arglist, BaseInfo::Options& options)
     addArgs(programArgs, options, tempArg, threadsArg);
     try
     {
-        programArgs.parse(arglist);
+        programArgs.parseSimple(arglist);
     }
     catch (const pdal::arg_error& err)
     {
@@ -497,6 +499,22 @@ bool handleOptions(pdal::StringList& arglist, BaseInfo::Options& options)
         if (options.outputFormat != "las" && options.outputFormat != "laz")
             throw FatalError("Unknown output format: " + options.outputFormat);
     }
+
+    if (!options.inputFileList.empty())
+    {
+        std::ifstream inputFile(options.inputFileList);
+        std::string line;
+        if(!inputFile)
+        {
+            throw FatalError("Failed to open input file list: " + options.inputFileList);
+        }
+
+        while (std::getline(inputFile, line))
+        {
+            options.inputFiles.push_back(line);
+        }
+    }
+
 
     return true;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
@@ -117,10 +117,23 @@ QStringList QgsPdalBuildVpcAlgorithm::createArgumentLists( const QVariantMap &pa
 
   applyThreadsParameter( args, context );
 
+  const QString fileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "inputFiles.txt" ), &context );
+  QFile listFile( fileName );
+  if ( !listFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+  {
+    throw QgsProcessingException( QObject::tr( "Could not create input file list %1" ).arg( fileName ) );
+  }
+
+  QTextStream out( &listFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  out.setCodec( "UTF-8" );
+#endif
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {
-    args << layer->source();
+    out << layer->source() << "\n";
   }
+
+  args << QStringLiteral( "--input-file-list=%1" ).arg( fileName );
 
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -98,10 +98,23 @@ QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &param
   applyCommonParameters( args, layers.at( 0 )->crs(), parameters, context );
   applyThreadsParameter( args, context );
 
+  const QString fileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "inputFiles.txt" ), &context );
+  QFile listFile( fileName );
+  if ( !listFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+  {
+    throw QgsProcessingException( QObject::tr( "Could not create input file list %1" ).arg( fileName ) );
+  }
+
+  QTextStream out( &listFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  out.setCodec( "UTF-8" );
+#endif
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {
-    args << layer->source();
+    out << layer->source() << "\n";
   }
+
+  args << QStringLiteral( "--input-file-list=%1" ).arg( fileName );
 
   return args;
 }

--- a/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
@@ -106,10 +106,23 @@ QStringList QgsPdalTileAlgorithm::createArgumentLists( const QVariantMap &parame
 
   applyThreadsParameter( args, context );
 
+  const QString fileName = QgsProcessingUtils::generateTempFilename( QStringLiteral( "inputFiles.txt" ), &context );
+  QFile listFile( fileName );
+  if ( !listFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+  {
+    throw QgsProcessingException( QObject::tr( "Could not create input file list %1" ).arg( fileName ) );
+  }
+
+  QTextStream out( &listFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  out.setCodec( "UTF-8" );
+#endif
   for ( const QgsMapLayer *layer : std::as_const( layers ) )
   {
-    args << layer->source();
+    out << layer->source() << "\n";
   }
+
+  args << QStringLiteral( "--input-file-list=%1" ).arg( fileName );
 
   return args;
 }

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -687,54 +687,59 @@ void TestQgsProcessingPdalAlgs::tile()
   parameters.insert( QStringLiteral( "OUTPUT" ), outputDir );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "tile" )
             << QStringLiteral( "--length=1000" )
             << QStringLiteral( "--output=%1" ).arg( outputDir )
             << QStringLiteral( "--temp_dir=%1" ).arg( tempFolder )
-            << mPointCloudLayerPath
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // override temp folder
   context->setTemporaryFolder( tempDir );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "tile" )
             << QStringLiteral( "--length=1000" )
             << QStringLiteral( "--output=%1" ).arg( outputDir )
             << QStringLiteral( "--temp_dir=%1" ).arg( tempDir )
-            << mPointCloudLayerPath
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // set tile length
   parameters.insert( QStringLiteral( "LENGTH" ), 150 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "tile" )
             << QStringLiteral( "--length=150" )
             << QStringLiteral( "--output=%1" ).arg( outputDir )
             << QStringLiteral( "--temp_dir=%1" ).arg( tempDir )
-            << mPointCloudLayerPath
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // assign crs
   parameters.insert( QStringLiteral( "CRS" ), QStringLiteral( "EPSG:4326" ) );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "tile" )
             << QStringLiteral( "--length=150" )
             << QStringLiteral( "--output=%1" ).arg( outputDir )
             << QStringLiteral( "--temp_dir=%1" ).arg( tempDir )
             << QStringLiteral( "--a_srs=EPSG:4326" )
-            << mPointCloudLayerPath
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // set max threads to 2, a --threads argument should be added
   context->setMaximumThreads( 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "tile" )
             << QStringLiteral( "--length=150" )
             << QStringLiteral( "--output=%1" ).arg( outputDir )
             << QStringLiteral( "--temp_dir=%1" ).arg( tempDir )
             << QStringLiteral( "--a_srs=EPSG:4326" )
             << QStringLiteral( "--threads=2" )
-            << mPointCloudLayerPath
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 }
 
@@ -942,25 +947,14 @@ void TestQgsProcessingPdalAlgs::merge()
 
   QgsProcessingFeedback feedback;
 
-  const QString pointCloud1 = QString( TEST_DATA_DIR ) + "/point_clouds/copc/lone-star.copc.laz";
-  const QString pointCloud2 = QString( TEST_DATA_DIR ) + "/point_clouds/copc/rgb16.copc.laz";
   const QString outputFile = QDir::tempPath() + "/merged.las";
 
-  // single layer
+  // default parameters
   QVariantMap parameters;
-  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 );
+  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << mPointCloudLayerPath );
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
-  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
-  QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
-            << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << QStringLiteral( "--input-file-list=inputFiles.txt" )
-          );
-
-  // multiple layers
-  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 << pointCloud2 );
-  args = alg->createArgumentLists( parameters, *context, &feedback );
   updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
@@ -1011,25 +1005,14 @@ void TestQgsProcessingPdalAlgs::buildVpc()
 
   QgsProcessingFeedback feedback;
 
-  const QString pointCloud1 = QString( TEST_DATA_DIR ) + "/point_clouds/copc/lone-star.copc.laz";
-  const QString pointCloud2 = QString( TEST_DATA_DIR ) + "/point_clouds/copc/rgb16.copc.laz";
   const QString outputFile = QDir::tempPath() + "/test.vpc";
 
-  // single layer
+  // default parameters
   QVariantMap parameters;
-  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 );
+  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << mPointCloudLayerPath );
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
-  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
-  QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
-            << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << QStringLiteral( "--input-file-list=inputFiles.txt" )
-          );
-
-  // multiple layers
-  parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 << pointCloud2 );
-  args = alg->createArgumentLists( parameters, *context, &feedback );
   updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -58,6 +58,8 @@ class TestQgsProcessingPdalAlgs: public QgsTest
     void tile();
 
   private:
+    void updateFileListArg( QStringList &args, const QString &fileName );
+
     QString mPointCloudLayerPath;
 };
 
@@ -87,6 +89,26 @@ void TestQgsProcessingPdalAlgs::cleanupTestCase()
 
 void TestQgsProcessingPdalAlgs::init()
 {
+}
+
+void TestQgsProcessingPdalAlgs::updateFileListArg( QStringList &args, const QString &fileName )
+{
+  int i = 0;
+  bool found = false;
+  for ( const QString &arg : args )
+  {
+    if ( arg.contains( fileName, Qt::CaseInsensitive ) )
+    {
+      found = true;
+      break;
+    }
+    i++;
+  }
+
+  if ( found )
+  {
+    args[ i ] = QStringLiteral( "--input-file-list=%1" ).arg( fileName );
+  }
 }
 
 void TestQgsProcessingPdalAlgs::info()
@@ -998,64 +1020,65 @@ void TestQgsProcessingPdalAlgs::buildVpc()
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << pointCloud1
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // multiple layers
   parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 << pointCloud2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // calculate exact boundaries
   parameters.insert( QStringLiteral( "BOUNDARY" ), true );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--boundary" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // calculate statistics
   parameters.insert( QStringLiteral( "STATISTICS" ), true );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--boundary" )
             << QStringLiteral( "--stats" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // build overview
   parameters.insert( QStringLiteral( "OVERVIEW" ), true );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--boundary" )
             << QStringLiteral( "--stats" )
             << QStringLiteral( "--overview" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // set max threads to 2, a --threads argument should be added
   context->setMaximumThreads( 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "build_vpc" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--boundary" )
             << QStringLiteral( "--stats" )
             << QStringLiteral( "--overview" )
             << QStringLiteral( "--threads=2" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 }
 

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -952,51 +952,52 @@ void TestQgsProcessingPdalAlgs::merge()
   parameters.insert( QStringLiteral( "OUTPUT" ), outputFile );
 
   QStringList args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << pointCloud1
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // multiple layers
   parameters.insert( QStringLiteral( "LAYERS" ), QStringList() << pointCloud1 << pointCloud2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // filter expression
   parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--filter=Intensity > 50" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // filter extent
   parameters.insert( QStringLiteral( "FILTER_EXTENT" ), QgsRectangle( 1, 2, 3, 4 ) );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--filter=Intensity > 50" )
             << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 
   // set max threads to 2, a --threads argument should be added
   context->setMaximumThreads( 2 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
+  updateFileListArg( args, QStringLiteral( "inputFiles.txt" ) );
   QCOMPARE( args, QStringList() << QStringLiteral( "merge" )
             << QStringLiteral( "--output=%1" ).arg( outputFile )
             << QStringLiteral( "--filter=Intensity > 50" )
             << QStringLiteral( "--bounds=([1, 3], [2, 4])" )
             << QStringLiteral( "--threads=2" )
-            << pointCloud1
-            << pointCloud2
+            << QStringLiteral( "--input-file-list=inputFiles.txt" )
           );
 }
 


### PR DESCRIPTION
## Description

Update PDAL wrench to the latest release 1.1. Also update `Merge`, `Tile` and `Build VPC` Processing algorithms to use new `--input-file-list` argument which allows to pass a single text file with the list of input files instead of specifying all input files in the command line.

Fixes #53970.