### PR TITLE
cmake: add a patch to build on fedora38. Fixes #54348

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,6 +1022,14 @@ else()
   find_package(Python ${MIN_PYTHON_VERSION} REQUIRED COMPONENTS Interpreter)
 endif()
 
+# Fix python site-packages for Fedora
+# See https://github.com/qgis/QGIS/issues/54348#issuecomment-1694216152
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if(EXISTS "/etc/fedora-release")
+    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "import sysconfig;print(sysconfig.get_path(\"platlib\", \"rpm_prefix\"), end=\"\")" OUTPUT_VARIABLE Python_SITEARCH)
+  endif()
+endif()
+
 message("-- Found Python executable: ${Python_EXECUTABLE} (version ${Python_VERSION})")
 message("-- Python library: ${Python_LIBRARIES}")
 message("-- Python site-packages: ${Python_SITEARCH}")


### PR DESCRIPTION
## Description

As mentionned in https://github.com/qgis/QGIS/issues/54348 there is an error in Fedora find_package(Python), so it can't be build directly. @manisandro your solution is, obviously, the right and the patch simply add a condition for Fedora.