### PR TITLE
[symbology] Fix font marker inserting illegal characters in a saved project's XML document

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 typedef QMap<QString, QString> QgsStringMap;
 typedef QMap<QString, QgsSymbol * > QgsSymbolMap;
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1831,19 +1831,30 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
     return false;
   }
 
+  QTextStream textStream( &projectFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  textStream.setCodec( "UTF-8" );
+#endif
+  QString projectString = textStream.readAll();
+  projectFile.close();
+
+  for ( int i = 0; i < 32; i++ )
+  {
+    if ( i == 9 || i == 10 || i == 13 )
+    {
+      continue;
+    }
+    projectString.replace( QChar( i ), QStringLiteral( "%1%2%1" ).arg( FONTMARKER_CHR_FIX, QString::number( i ) ) );
+  }
+
   // location of problem associated with errorMsg
   int line, column;
   QString errorMsg;
-
-  if ( !doc->setContent( &projectFile, &errorMsg, &line, &column ) )
+  if ( !doc->setContent( projectString, &errorMsg, &line, &column ) )
   {
     const QString errorString = tr( "Project file read error in file %1: %2 at line %3 column %4" )
                                 .arg( projectFile.fileName(), errorMsg ).arg( line ).arg( column );
-
     QgsDebugError( errorString );
-
-    projectFile.close();
-
     setError( errorString );
 
     return false;

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -31,6 +31,8 @@
 
 #include <QFile>
 
+#define FONTMARKER_CHR_FIX  "~!_#!#_!~"
+
 class QgsExpression;
 class QgsPathResolver;
 class QgsReadWriteContext;

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2119,41 +2119,6 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
         ids = styles[1]
         self.assertEqual(len(ids), 0)
 
-    def testSaveStyleInvalidXML(self):
-
-        self.execSQLCommand('DROP TABLE IF EXISTS layer_styles CASCADE')
-
-        vl = self.getEditableLayer()
-        self.assertTrue(vl.isValid())
-        self.assertEqual(int(vl.dataProvider().styleStorageCapabilities()) & Qgis.ProviderStyleStorageCapability.LoadFromDatabase, Qgis.ProviderStyleStorageCapability.LoadFromDatabase)
-        self.assertEqual(int(vl.dataProvider().styleStorageCapabilities()) & Qgis.ProviderStyleStorageCapability.SaveToDatabase, Qgis.ProviderStyleStorageCapability.SaveToDatabase)
-        self.assertEqual(int(vl.dataProvider().styleStorageCapabilities()) & Qgis.ProviderStyleStorageCapability.DeleteFromDatabase, Qgis.ProviderStyleStorageCapability.DeleteFromDatabase)
-
-        mFilePath = QDir.toNativeSeparators(
-            f"{unitTestDataPath()}/symbol_layer/fontSymbol.qml")
-        status = vl.loadNamedStyle(mFilePath)
-        self.assertTrue(status)
-
-        errorMsg = vl.saveStyleToDatabase(
-            "fontSymbol", "font with invalid utf8 char", False, "")
-        self.assertEqual(errorMsg, "")
-
-        qml, errmsg = vl.getStyleFromDatabase("1")
-        self.assertEqual(errmsg, "")
-
-        found = False
-        for line in qml.split('\n'):
-            found = 'value="\u001E"' in qml and 'name="chr"' in qml
-            if found:
-                break
-        self.assertTrue(found, f"record separator character (\u001E) not found in qml: {qml}")
-
-        # Test loadStyle from metadata
-        md = QgsProviderRegistry.instance().providerMetadata('postgres')
-        qml = md.loadStyle(self.dbconn + " type=POINT table=\"qgis_test\".\"editData\" (geom)", 'fontSymbol')
-        self.assertTrue(qml.startswith('<!DOCTYPE qgi'), qml)
-        self.assertTrue('value="\u001E"' in qml)
-
     def testHasMetadata(self):
         # views don't have metadata
         vl = QgsVectorLayer(f"{self.dbconn} table=\"qgis_test\".\"bikes_view\" key=\"pk\" sql=", "bikes_view",

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -13,6 +13,7 @@ import math
 
 import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QMimeData, QPointF, QSize, QSizeF, Qt
+from qgis.PyQt.QtXml import QDomDocument, QDomElement
 from qgis.PyQt.QtGui import QColor, QImage, QPolygonF
 from qgis.core import (
     Qgis,
@@ -25,6 +26,7 @@ from qgis.core import (
     QgsMarkerLineSymbolLayer,
     QgsMarkerSymbol,
     QgsProperty,
+    QgsReadWriteContext,
     QgsShapeburstFillSymbolLayer,
     QgsSimpleFillSymbolLayer,
     QgsSimpleLineSymbolLayer,
@@ -752,6 +754,74 @@ class PyQgsSymbolLayerUtils(QgisTestCase):
 
         QgsSymbolLayerUtils.clearSymbolLayerIds(fill_symbol)
         self.assertFalse(child_sl.id())
+
+    def test_font_marker_load(self):
+        """
+        Test the loading of font marker from XML
+        """
+
+        font_marker_xml_string = """<symbol clip_to_extent="1" type="marker" is_animated="0" alpha="1" name="symbol" frame_rate="10" force_rhr="0">
+ <layer pass="0" id="{2aefc556-4eb1-4f56-b96b-e1dea6b58f69}" locked="0" class="FontMarker" enabled="1">
+  <Option type="Map">
+   <Option value="0" type="QString" name="angle"/>
+   <Option value="14" type="int" name="chr"/>
+   <Option value="true" type="bool" name="chrIsDecimal"/>
+   <Option value="0,0,255,255" type="QString" name="color"/>
+   <Option value="Arial" type="QString" name="font"/>
+   <Option value="Italic" type="QString" name="font_style"/>
+   <Option value="1" type="QString" name="horizontal_anchor_point"/>
+   <Option value="miter" type="QString" name="joinstyle"/>
+   <Option value="0,0" type="QString" name="offset"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+   <Option value="Point" type="QString" name="offset_unit"/>
+   <Option value="255,255,255,255" type="QString" name="outline_color"/>
+   <Option value="0" type="QString" name="outline_width"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+   <Option value="MM" type="QString" name="outline_width_unit"/>
+   <Option value="42.4" type="QString" name="size"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+   <Option value="Point" type="QString" name="size_unit"/>
+   <Option value="1" type="QString" name="vertical_anchor_point"/>
+  </Option>
+ </layer>
+</symbol>"""
+
+        doc = QDomDocument()
+        elem = QDomElement()
+        doc.setContent(font_marker_xml_string)
+        elem = doc.documentElement()
+        font_marker = QgsSymbolLayerUtils.loadSymbol(elem, QgsReadWriteContext())
+        self.assertEqual(font_marker.symbolLayers()[0].character(), chr(14))
+
+        font_marker_xml_string = """<symbol clip_to_extent="1" type="marker" is_animated="0" alpha="1" name="symbol" frame_rate="10" force_rhr="0">
+ <layer pass="0" id="{2aefc556-4eb1-4f56-b96b-e1dea6b58f69}" locked="0" class="FontMarker" enabled="1">
+  <Option type="Map">
+   <Option value="0" type="QString" name="angle"/>
+   <Option value="~!_#!#_!~14~!_#!#_!~" type="QString" name="chr"/>
+   <Option value="0,0,255,255" type="QString" name="color"/>
+   <Option value="Arial" type="QString" name="font"/>
+   <Option value="Italic" type="QString" name="font_style"/>
+   <Option value="1" type="QString" name="horizontal_anchor_point"/>
+   <Option value="miter" type="QString" name="joinstyle"/>
+   <Option value="0,0" type="QString" name="offset"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+   <Option value="Point" type="QString" name="offset_unit"/>
+   <Option value="255,255,255,255" type="QString" name="outline_color"/>
+   <Option value="0" type="QString" name="outline_width"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+   <Option value="MM" type="QString" name="outline_width_unit"/>
+   <Option value="42.4" type="QString" name="size"/>
+   <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+   <Option value="Point" type="QString" name="size_unit"/>
+   <Option value="1" type="QString" name="vertical_anchor_point"/>
+  </Option>
+ </layer>
+</symbol>"""
+
+        doc.setContent(font_marker_xml_string)
+        elem = doc.documentElement()
+        font_marker = QgsSymbolLayerUtils.loadSymbol(elem, QgsReadWriteContext())
+        self.assertEqual(font_marker.symbolLayers()[0].character(), chr(14))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -764,8 +764,7 @@ class PyQgsSymbolLayerUtils(QgisTestCase):
  <layer pass="0" id="{2aefc556-4eb1-4f56-b96b-e1dea6b58f69}" locked="0" class="FontMarker" enabled="1">
   <Option type="Map">
    <Option value="0" type="QString" name="angle"/>
-   <Option value="14" type="int" name="chr"/>
-   <Option value="true" type="bool" name="chrIsDecimal"/>
+   <Option value="~!_#!#_!~14~!_#!#_!~" type="QString" name="chr"/>
    <Option value="0,0,255,255" type="QString" name="color"/>
    <Option value="Arial" type="QString" name="font"/>
    <Option value="Italic" type="QString" name="font_style"/>
@@ -797,7 +796,7 @@ class PyQgsSymbolLayerUtils(QgisTestCase):
  <layer pass="0" id="{2aefc556-4eb1-4f56-b96b-e1dea6b58f69}" locked="0" class="FontMarker" enabled="1">
   <Option type="Map">
    <Option value="0" type="QString" name="angle"/>
-   <Option value="~!_#!#_!~14~!_#!#_!~" type="QString" name="chr"/>
+   <Option value="~!_#!#_!~40~!_#!#_!~~!_#!#_!~41~!_#!#_!~" type="QString" name="chr"/>
    <Option value="0,0,255,255" type="QString" name="color"/>
    <Option value="Arial" type="QString" name="font"/>
    <Option value="Italic" type="QString" name="font_style"/>
@@ -821,7 +820,7 @@ class PyQgsSymbolLayerUtils(QgisTestCase):
         doc.setContent(font_marker_xml_string)
         elem = doc.documentElement()
         font_marker = QgsSymbolLayerUtils.loadSymbol(elem, QgsReadWriteContext())
-        self.assertEqual(font_marker.symbolLayers()[0].character(), chr(14))
+        self.assertEqual(font_marker.symbolLayers()[0].character(), "()")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR insures that QGIS does not produce invalid XML when saving project files by saving font marker's 1-character string using their decimal representation. 

Until now, the font marker would introduce illegal characters in project files when users picked a character from decimal range 0 to 31. While Qt5 tolerated this, Qt6 does _not_, and when such a character is present, QDomDocument::setContent() fails. (*)

Furthermore, another fix was added so that QGIS core compiled against Qt6 is able to load project files containing such invalid characters introduced by font marker symbol layers.

Fixes https://github.com/qgis/QGIS/issues/55037.

(*) it's not limited to Qt6, fo e.g. python's lxml also fails to parse XML documents containing those characters too.