### PR TITLE
[processing] Fix BACKGROUND_COLOR parameter ignored when exporting XYZ tiles using JPG format

### DIFF
--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -152,6 +152,10 @@ bool QgsXyzTilesBaseAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
   mMaxZoom = parameterAsInt( parameters, QStringLiteral( "ZOOM_MAX" ), context );
   mDpi = parameterAsInt( parameters, QStringLiteral( "DPI" ), context );
   mBackgroundColor = parameterAsColor( parameters, QStringLiteral( "BACKGROUND_COLOR" ), context );
+  if ( mTileFormat != QLatin1String( "PNG" ) && mBackgroundColor.alpha() != 255 )
+  {
+    feedback->pushWarning( QObject::tr( "Background color setting ignored, the JPG format only supports fully opaque colors" ) );
+  }
   mAntialias = parameterAsBool( parameters, QStringLiteral( "ANTIALIAS" ), context );
   mTileFormat = parameterAsEnum( parameters, QStringLiteral( "TILE_FORMAT" ), context ) ? QStringLiteral( "JPG" ) : QStringLiteral( "PNG" );
   mJpgQuality = parameterAsInt( parameters, QStringLiteral( "QUALITY" ), context );
@@ -193,7 +197,7 @@ void QgsXyzTilesBaseAlgorithm::startJobs()
     settings.setDestinationCrs( mMercatorCrs );
     settings.setLayers( mLayers );
     settings.setOutputDpi( mDpi );
-    if ( mTileFormat == QLatin1String( "PNG" ) )
+    if ( mTileFormat == QLatin1String( "PNG" ) || mBackgroundColor.alpha() == 255 )
     {
       settings.setBackgroundColor( mBackgroundColor );
     }


### PR DESCRIPTION
## Description

This PR fixes #54876, whereas the generate XYZ tiles ({directory},{mbtiles}) processing algorithms would ignore the background color when setting the format to JPG. The fix allows for fully opaque background color to be used with the format. If a semi-opaque color is used, the color is ignored and a warning is thrown informing users the parameter has been ignored. 

