### PR TITLE
[themes] Increase readibility of disabled comboboxes within attribute forms

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1193,3 +1193,13 @@ QWidget#QgsRasterCalcDialogBase QWidget#mOperatorsGroupBox QPushButton {
 QFrame#mUserInputContainer { 
     background-color: @background;
 }
+
+QgsAttributeFormWidget QComboBox:disabled {
+    border: none;
+    background-color: @itembackground;
+    color: @text;
+}
+
+QgsAttributeFormWidget QComboBox::down-arrow:disabled {
+     image: none;
+}

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1235,3 +1235,13 @@ QFrame#mUserInputContainer {
 QgsLayoutRuler {
     color: @textlight;
 }
+
+QgsAttributeFormWidget QComboBox:disabled {
+    border: none;
+    background-color: @itembackground;
+    color: @textlight;
+}
+
+QgsAttributeFormWidget QComboBox::down-arrow:disabled {
+     image: none;
+}


### PR DESCRIPTION
## Description

This PR fixes #54787. Long story short, our attribute forms are misused combobox's disabled state for read-only state when a vector layer is not in editing mode. One day, it'd be nice for Qt to have such a read-only sate. In the meantime, we can insure that the readability of our read-only attribute forms are good with combo boxes too using dedicated styling for night mapping and blend of gray.