### PR TITLE
Fix copy/pasting of features to/from the same layer ignores avoid overlap settings

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10202,6 +10202,37 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
   if ( duplicateFeature )
   {
     pastedFeatures = features;
+
+    for ( auto &feature : pastedFeatures )
+    {
+      QgsGeometry geom = feature.geometry();
+
+      if ( !( geom.isEmpty() || geom.isNull( ) ) )
+      {
+        // avoid intersection if enabled in digitize settings
+        QList<QgsVectorLayer *>  avoidIntersectionsLayers;
+        switch ( QgsProject::instance()->avoidIntersectionsMode() )
+        {
+          case Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer:
+            avoidIntersectionsLayers.append( pasteVectorLayer );
+            break;
+          case Qgis::AvoidIntersectionsMode::AvoidIntersectionsLayers:
+            avoidIntersectionsLayers = QgsProject::instance()->avoidIntersectionsLayers();
+            break;
+          case Qgis::AvoidIntersectionsMode::AllowIntersections:
+            break;
+        }
+        if ( avoidIntersectionsLayers.size() > 0 )
+        {
+          geom.avoidIntersectionsV2( avoidIntersectionsLayers );
+          feature.setGeometry( geom );
+        }
+
+        // count collapsed geometries
+        if ( geom.isEmpty() || geom.isNull( ) )
+          invalidGeometriesCount++;
+      }
+    }
   }
   else
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10222,7 +10222,7 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
           case Qgis::AvoidIntersectionsMode::AllowIntersections:
             break;
         }
-        if ( avoidIntersectionsLayers.size() > 0 )
+        if ( !avoidIntersectionsLayers.empty() )
         {
           geom.avoidIntersectionsV2( avoidIntersectionsLayers );
           feature.setGeometry( geom );


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in July whereas features being copied and pasted *onto the same layer* would ignore the avoid overlap settings.

Fixes #54492.