### PR TITLE
[processing] Fix crash when adding a mesh dataset group input

### DIFF
--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.cpp
@@ -782,14 +782,17 @@ QgsProcessingMeshDatasetGroupsParameterDefinitionWidget::QgsProcessingMeshDatase
 
   const QgsProcessingParameterMeshDatasetGroups *datasetGroupDef =
     static_cast< const QgsProcessingParameterMeshDatasetGroups *>( definition );
-  int currentIndex = mParentLayerComboBox->findData( datasetGroupDef->meshLayerParameterName() );
-  if ( currentIndex != -1 )
-    mParentLayerComboBox->setCurrentIndex( currentIndex );
-  else if ( !datasetGroupDef->meshLayerParameterName().isEmpty() )
+  if ( datasetGroupDef )
   {
-    // if no layer parameter candidates found, we just add the existing one as a placeholder
-    mParentLayerComboBox->addItem( datasetGroupDef->meshLayerParameterName(), datasetGroupDef->meshLayerParameterName() );
-    mParentLayerComboBox->setCurrentIndex( mParentLayerComboBox->count() - 1 );
+    int currentIndex = mParentLayerComboBox->findData( datasetGroupDef->meshLayerParameterName() );
+    if ( currentIndex != -1 )
+      mParentLayerComboBox->setCurrentIndex( currentIndex );
+    else if ( !datasetGroupDef->meshLayerParameterName().isEmpty() )
+    {
+      // if no layer parameter candidates found, we just add the existing one as a placeholder
+      mParentLayerComboBox->addItem( datasetGroupDef->meshLayerParameterName(), datasetGroupDef->meshLayerParameterName() );
+      mParentLayerComboBox->setCurrentIndex( mParentLayerComboBox->count() - 1 );
+    }
   }
 
   setLayout( vlayout );


### PR DESCRIPTION
## Description

When adding a mesh dataset group input in a blank processing modeler, QGIS goes :boom: . This PR plugs that crash.

Fixes #54442.