### PR TITLE
Increase expression widget text size for long expressions

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -190,6 +190,11 @@ void QgsFieldExpressionWidget::setField( const QString &fieldName )
     return;
   }
 
+  if ( fieldName.size() > mCombo->lineEdit()->maxLength() )
+  {
+    mCombo->lineEdit()->setMaxLength( fieldName.size() );
+  }
+
   QModelIndex idx = mFieldProxyModel->sourceFieldModel()->indexFromName( fieldName );
   if ( !idx.isValid() )
   {

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -49,6 +49,7 @@ class TestQgsFieldExpressionWidget : public QObject
     void testIsValid();
     void testFilters();
     void setNull();
+    void testVeryLongExpression();
 
   private:
     QgsFieldExpressionWidget *mWidget = nullptr;
@@ -371,6 +372,20 @@ void TestQgsFieldExpressionWidget::setNull()
 
   QgsProject::instance()->removeMapLayer( layer );
 }
+
+void TestQgsFieldExpressionWidget::testVeryLongExpression()
+{
+  QString veryLongExpression;
+  for ( int i = 0; i < 32770; i++ )
+  {
+    veryLongExpression += "a";
+  }
+
+  mWidget->setExpression( veryLongExpression );
+  QCOMPARE( veryLongExpression.size(), mWidget->currentText().size() );
+};
+
+
 
 QGSTEST_MAIN( TestQgsFieldExpressionWidget )
 #include "testqgsfieldexpressionwidget.moc"


### PR DESCRIPTION
Fixes #54141 :  the limit 32767 actually comes from QLineEdit default [max length](https://doc.qt.io/qt-6/qlineedit.html#maxLength-prop), so better increase it when the expression is greater than that limit