### PR TITLE
[themes] Fix checkbox styled as enabled within disabled table and tree widgets

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -902,8 +902,14 @@ QAbstractItemView::selected, QListView::selected {
 QAbstractItemView::indicator:checked, QListView::indicator:checked {
     image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
 }
+QAbstractItemView::indicator:checked:disabled, QListView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked-disabled.svg);
+}
 QAbstractItemView::indicator:unchecked, QListView::indicator:unchecked {
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+}
+QAbstractItemView::indicator:unchecked:disabled, QListView::indicator:unchecked:disabled {
+    image: url(@theme_path/icons/qcheckbox-unchecked-disabled.svg);
 }
 
 /* ==================================================================================== */
@@ -951,10 +957,16 @@ QTreeView::indicator:intermediary {
     image: url(@theme_path/icons/qcheckbox-intermediary.svg);
 }
 QTreeView::indicator:checked {
-    image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
+    image: url(@theme_path/icons/qcheckbox-checked.svg);
+}
+QTreeView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked-disabled.svg);
 }
 QTreeView::indicator:unchecked {
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+}
+QTreeView::indicator:unchecked:disabled {
+    image: url(@theme_path/icons/qcheckbox-unchecked-disabled.svg);
 }
 
 QgsLayerTreeView::item,
@@ -1009,8 +1021,14 @@ QTableView::indicator:intermediary {
 QTableView::indicator:checked {
     image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
 }
+QTableView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked-disabled.svg);
+}
 QTableView::indicator:unchecked {
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+}
+QTableView::indicator:unchecked:disabled {
+    image: url(@theme_path/icons/qcheckbox-unchecked-disabled.svg);
 }
 
 QTableView QTableCornerButton::section {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -900,9 +900,18 @@ QAbstractItemView::indicator:checked, QListView::indicator:checked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
 }
+QAbstractItemView::indicator:checked:disabled, QListView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked.svg);
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+}
 QAbstractItemView::indicator:unchecked, QListView::indicator:unchecked {
     border: 1px solid @background;
-    image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+}
+QAbstractItemView::indicator:unchecked:disabled, QListView::indicator:unchecked:disabled {
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+    background-color: rgba(0, 0, 0, 0);
 }
 
 /* ==================================================================================== */
@@ -946,6 +955,10 @@ QTreeView::indicator {
     width:0.8em;
     height:0.8em;
 }
+QTreeView::indicator:disabled {
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+}
 QTreeView::indicator:intermediary {
     background-color: @toggleoff;
     image: url(@theme_path/icons/qcheckbox-intermediary.svg);
@@ -954,10 +967,21 @@ QTreeView::indicator:checked {
     background-color: @toggleon;
     image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
 }
+QTreeView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked.svg);
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+}
 QTreeView::indicator:unchecked {
     background-color: @toggleoff;
-    image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+    image: none;
 }
+QTreeView::indicator:unchecked:disabled {
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+    image: none;
+}
+
 
 QgsLayerTreeView::item,
 QTreeView#viewGraduated::item,
@@ -1029,6 +1053,10 @@ QTableView::indicator {
     width:0.8em;
     height:0.8em;
 }
+QTableView::indicator:disabled {
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+}
 QTableView::indicator:intermediary {
     background-color: @toggleoff;
     image: url(@theme_path/icons/qcheckbox-intermediary.svg);
@@ -1037,9 +1065,19 @@ QTableView::indicator:checked {
     background-color: @toggleon;
     image: url(@theme_path/icons/qcheckbox-checked.svg) !important;
 }
+QTableView::indicator:checked:disabled {
+    image: url(@theme_path/icons/qcheckbox-checked.svg);
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+}
 QTableView::indicator:unchecked {
     background-color: @toggleoff;
-    image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+    image: none;
+}
+QTableView::indicator:unchecked:disabled {
+    border-color: @itemdarkbackground;
+    background-color: rgba(0, 0, 0, 0);
+    image: none;
 }
 
 QTableView QTableCornerButton::section {


### PR DESCRIPTION
## Description

Fixes #54214 whereas non-default themes would fail to properly style checkboxes within disabled table and tree widgets.