### PR TITLE
[ui][themes] Fix clipped user profile selector icon size combobox content

### DIFF
--- a/src/ui/qgsuserprofileoptionswidgetbase.ui
+++ b/src/ui/qgsuserprofileoptionswidgetbase.ui
@@ -90,7 +90,7 @@
        <widget class="QComboBox" name="mIconSize">
         <property name="maximumSize">
          <size>
-          <width>50</width>
+          <width>200</width>
           <height>16777215</height>
          </size>
         </property>


### PR DESCRIPTION
## Description

This PR fixes #54202 by setting a larger maximum width value for the icon size combo box (the current max. was derived from fusion's default combo box styling, didn't play well with non-default styling).