### PR TITLE
[Postgres] Remove listener wait condition

### DIFF
--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -318,9 +318,7 @@ class QgsPostgresConn : public QObject
 
     QString uniqueCursorName();
 
-#if 0
     PGconn *pgConnection() { return mConn; }
-#endif
 
     //
     // libpq wrapper

--- a/src/providers/postgres/qgspostgreslistener.h
+++ b/src/providers/postgres/qgspostgreslistener.h
@@ -24,6 +24,9 @@
 #include <QWaitCondition>
 #include <QMutex>
 
+class QgsPostgresConn;
+
+
 /**
  * \class QgsPostgresListener
  * \brief Launch a thread to listen on postgres notifications on the "qgis" channel, the notify signal is emitted on postgres notify.
@@ -51,9 +54,8 @@ class QgsPostgresListener : public QThread
 
   private:
     volatile bool mStop = false;
-    const QString mConnString;
-    QWaitCondition mIsReadyCondition;
-    QMutex mMutex;
+
+    QgsPostgresConn *mConn = nullptr;
 
     QgsPostgresListener( const QString &connString );
 


### PR DESCRIPTION
Fixes #54260

The issue was because of 2 things:
- credential were requested though it was not necessary (auth configuration needed to be extended)
- Display the credential dialog was not possible because of the main thread blocking waitCondition 

This PR propose to create the connection and execute the listen request in the main thread and then doing the listening on the thread. This way, we still can garantee listening is set when setListening() ends and not block UI if credentials dialog need to popup.

I also reworked code a bit to use a plain QgsPostgresConn and log the listen connection.

