### PR TITLE
Synchronize point cloud layer's style with the layer properties style widgets

### DIFF
--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -91,7 +91,6 @@ void QgsPointCloudLayer3DRendererWidget::syncToLayer( QgsMapLayer *layer )
   if ( r && r->type() == QLatin1String( "pointcloud" ) )
   {
     pointCloudRenderer = static_cast<QgsPointCloudLayer3DRenderer *>( r );
-    pointCloudRenderer->setSymbol( mWidgetPointCloudSymbol->symbol() );
   }
   setRenderer( pointCloudRenderer );
   mWidgetPointCloudSymbol->setEnabled( true );

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -21,6 +21,7 @@
 #include "qgsapplication.h"
 #include "qgsmetadatawidget.h"
 #include "qgsmaplayerconfigwidget.h"
+#include "qgsmaplayerstylemanager.h"
 #include "qgspointcloudattributemodel.h"
 #include "qgsdatumtransformdialog.h"
 #include "qgspointcloudquerybuilder.h"
@@ -70,6 +71,7 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
 
   // update based on lyr's current state
   syncToLayer();
+  connect( lyr->styleManager(), &QgsMapLayerStyleManager::currentStyleChanged, this, &QgsPointCloudLayerProperties::syncToLayer );
 
   QgsSettings settings;
   if ( !settings.contains( QStringLiteral( "/Windows/PointCloudLayerProperties/tab" ) ) )

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -149,7 +149,14 @@ void QgsPointCloudRendererPropertiesWidget::syncToLayer( QgsMapLayer *layer )
     const QString rendererName = mLayer->renderer()->type();
 
     const int rendererIdx = cboRenderers->findData( rendererName );
-    cboRenderers->setCurrentIndex( rendererIdx );
+    if ( cboRenderers->currentIndex() != rendererIdx )
+    {
+      cboRenderers->setCurrentIndex( rendererIdx );
+    }
+    else
+    {
+      rendererChanged();
+    }
 
     // no renderer found... this mustn't happen
     Q_ASSERT( rendererIdx != -1 && "there must be a renderer!" );


### PR DESCRIPTION
## Description
When switching styles using the layer properties dialog, the style widgets were not updated and kept showing the previous style settings. Those settings where eventually applied again to the layer when ok/apply was pressed.

Now it is possible to switch between styles and also load a style from a qml file.

Fix #53227


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
