### PR TITLE
[exif] Insure that Exif.Image.Orientation is written as a ushort to avoid compatibility issues

### DIFF
--- a/src/core/raster/qgsexiftools.cpp
+++ b/src/core/raster/qgsexiftools.cpp
@@ -472,6 +472,7 @@ bool QgsExifTools::tagImage( const QString &imagePath, const QString &tag, const
       return false;
 
     QVariant actualValue;
+    bool actualValueIsUShort = false;
     if ( tag == QLatin1String( "Exif.GPSInfo.GPSLatitude" ) ||
          tag == QLatin1String( "Exif.GPSInfo.GPSLongitude" ) ||
          tag == QLatin1String( "Exif.GPSInfo.GPSDestLatitude" ) ||
@@ -482,6 +483,11 @@ bool QgsExifTools::tagImage( const QString &imagePath, const QString &tag, const
     else if ( tag == QLatin1String( "Exif.GPSInfo.GPSAltitude" ) )
     {
       actualValue = QStringLiteral( "%1/1000" ).arg( static_cast< int>( std::floor( std::abs( value.toDouble() ) * 1000 ) ) );
+    }
+    else if ( tag == QLatin1String( "Exif.Image.Orientation" ) )
+    {
+      actualValueIsUShort = true;
+      actualValue = value;
     }
     else if ( value.type() == QVariant::DateTime )
     {
@@ -529,8 +535,21 @@ bool QgsExifTools::tagImage( const QString &imagePath, const QString &tag, const
 
     const bool isXmp = tag.startsWith( QLatin1String( "Xmp." ) );
     image->readMetadata();
-    if ( actualValue.type() == QVariant::Int ||
-         actualValue.type() == QVariant::LongLong )
+    if ( actualValueIsUShort )
+    {
+      if ( isXmp )
+      {
+        Exiv2::XmpData &xmpData = image->xmpData();
+        xmpData[tag.toStdString()] = static_cast<ushort>( actualValue.toLongLong() );
+      }
+      else
+      {
+        Exiv2::ExifData &exifData = image->exifData();
+        exifData[tag.toStdString()] = static_cast<ushort>( actualValue.toLongLong() );
+      }
+    }
+    else if ( actualValue.type() == QVariant::Int ||
+              actualValue.type() == QVariant::LongLong )
     {
       if ( isXmp )
       {
@@ -543,8 +562,8 @@ bool QgsExifTools::tagImage( const QString &imagePath, const QString &tag, const
         exifData[tag.toStdString()] = static_cast<uint32_t>( actualValue.toLongLong() );
       }
     }
-    if ( actualValue.type() == QVariant::UInt ||
-         actualValue.type() ==  QVariant::ULongLong )
+    else if ( actualValue.type() == QVariant::UInt ||
+              actualValue.type() ==  QVariant::ULongLong )
     {
       if ( isXmp )
       {


### PR DESCRIPTION
## Description

After going down a long, long rabbit hole, I came out of it with this new knowledge: when setting the Exif.Image.Orientation metadata using the Exiv2 library, it *must be* casted as a ushort to insure maximum compatibility with image readers out there. A number of application handling jpeg images will not recognize this tag otherwise. 

This includes - but is not limited to - Qt itself, which chokes if the value isn't in ushort.