### PR TITLE
Allow use of minimum/maximum as alias for min/max aggregate argument …

### DIFF
--- a/resources/function_help/json/aggregate
+++ b/resources/function_help/json/aggregate
@@ -8,7 +8,7 @@
     "description": "a string, representing either a layer name or layer ID"
   }, {
     "arg": "aggregate",
-    "description": "a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>concatenate_unique: join unique strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li><li>array_agg: create an array of aggregated values</li></ul>"
+    "description": "a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>minimum or min</li><li>maximum or max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>concatenate_unique: join unique strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li><li>array_agg: create an array of aggregated values</li></ul>"
   }, {
     "arg": "expression",
     "description": "sub expression or field name to aggregate"

--- a/resources/function_help/json/relation_aggregate
+++ b/resources/function_help/json/relation_aggregate
@@ -8,7 +8,7 @@
     "description": "a string, representing a relation ID"
   }, {
     "arg": "aggregate",
-    "description": "a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>concatenate_unique: join unique strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li><li>array_agg: create an array of aggregated values</li></ul>"
+    "description": "a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>minimum or min</li><li>maximum or max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>concatenate_unique: join unique strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li><li>array_agg: create an array of aggregated values</li></ul>"
   }, {
     "arg": "expression",
     "description": "sub expression or field name to aggregate"

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -198,9 +198,9 @@ QgsAggregateCalculator::Aggregate QgsAggregateCalculator::stringToAggregate( con
     return CountDistinct;
   else if ( normalized == QLatin1String( "count_missing" ) )
     return CountMissing;
-  else if ( normalized == QLatin1String( "min" ) )
+  else if ( normalized == QLatin1String( "min" ) ||  normalized == QLatin1String( "minimum" ) )
     return Min;
-  else if ( normalized == QLatin1String( "max" ) )
+  else if ( normalized == QLatin1String( "max" ) ||  normalized == QLatin1String( "maximum" ) )
     return Max;
   else if ( normalized == QLatin1String( "sum" ) )
     return Sum;

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -198,9 +198,9 @@ QgsAggregateCalculator::Aggregate QgsAggregateCalculator::stringToAggregate( con
     return CountDistinct;
   else if ( normalized == QLatin1String( "count_missing" ) )
     return CountMissing;
-  else if ( normalized == QLatin1String( "min" ) ||  normalized == QLatin1String( "minimum" ) )
+  else if ( normalized == QLatin1String( "min" ) || normalized == QLatin1String( "minimum" ) )
     return Min;
-  else if ( normalized == QLatin1String( "max" ) ||  normalized == QLatin1String( "maximum" ) )
+  else if ( normalized == QLatin1String( "max" ) || normalized == QLatin1String( "maximum" ) )
     return Max;
   else if ( normalized == QLatin1String( "sum" ) )
     return Sum;


### PR DESCRIPTION
…in aggregate function (fixes #46230)
![image](https://github.com/qgis/QGIS/assets/7983394/f7f441a2-db62-4246-bc6d-c1cb8784532d)
