### PR TITLE
Use GDALGetMetadataItem() instead of GDALGetMetadata() on drivers

### DIFF
--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -39,9 +39,8 @@ bool QgsGdalUtils::supportsRasterCreate( GDALDriverH driver )
     // it supports Create() but only for vector side
     return false;
   }
-  char **driverMetadata = GDALGetMetadata( driver, nullptr );
-  return  CSLFetchBoolean( driverMetadata, GDAL_DCAP_CREATE, false ) &&
-          CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false );
+  return GDALGetMetadataItem( driver, GDAL_DCAP_CREATE, nullptr ) &&
+         GDALGetMetadataItem( driver, GDAL_DCAP_RASTER, nullptr );
 }
 
 gdal::dataset_unique_ptr QgsGdalUtils::createSingleBandMemoryDataset( GDALDataType dataType, const QgsRectangle &extent, int width, int height, const QgsCoordinateReferenceSystem &crs )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3856,13 +3856,11 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
       }
 
       GDALDriverH gdalDriver = GDALGetDriverByName( drvName.toLocal8Bit().constData() );
-      char **metadata = nullptr;
+      bool nonSpatialFormat = false;
       if ( gdalDriver )
       {
-        metadata = GDALGetMetadata( gdalDriver, nullptr );
+        nonSpatialFormat = GDALGetMetadataItem( gdalDriver, GDAL_DCAP_NONSPATIAL, nullptr ) != nullptr;
       }
-
-      bool nonSpatialFormat = CSLFetchBoolean( metadata, GDAL_DCAP_NONSPATIAL, false );
 
       if ( OGR_Dr_TestCapability( drv, "CreateDataSource" ) != 0 )
       {


### PR DESCRIPTION
There was nothing wrong per-se, but using GDALGetMetadataItem() will make QGIS compatible of the in-development GDAL capability of delaying the actual loading of GDAL plugin drivers.
Cf https://github.com/OSGeo/gdal/compare/master...rouault:gdal:deferred_plugin?expand=1 (GDAL RFC to follow soon)
