### PR TITLE
When saving master auth pw in keychain, use a unique key per user profile

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -35,6 +35,7 @@
 #include <QDomElement>
 #include <QDomDocument>
 #include <QRegularExpression>
+#include <QCoreApplication>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 #include <QRandomGenerator>
@@ -50,7 +51,6 @@
 #include "keychain.h"
 
 // QGIS includes
-#include "qgsapplication.h"
 #include "qgsauthcertutils.h"
 #include "qgsauthcrypto.h"
 #include "qgsauthmethod.h"
@@ -75,7 +75,7 @@ const QString QgsAuthManager::AUTH_MAN_TAG = QObject::tr( "Authentication Manage
 const QString QgsAuthManager::AUTH_CFG_REGEX = QStringLiteral( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
 
 
-const QLatin1String QgsAuthManager::AUTH_PASSWORD_HELPER_KEY_NAME( "QGIS-Master-Password" );
+const QLatin1String QgsAuthManager::AUTH_PASSWORD_HELPER_KEY_NAME_BASE( "QGIS-Master-Password" );
 const QLatin1String QgsAuthManager::AUTH_PASSWORD_HELPER_FOLDER_NAME( "QGIS" );
 
 
@@ -131,7 +131,7 @@ QSqlDatabase QgsAuthManager::authDatabaseConnection() const
     authdb = QSqlDatabase::addDatabase( QStringLiteral( "QSQLITE" ), connectionName );
     authdb.setDatabaseName( authenticationDatabasePath() );
     // for background threads, remove database when current thread finishes
-    if ( QThread::currentThread() != qApp->thread() )
+    if ( QThread::currentThread() != QCoreApplication::instance()->thread() )
     {
       QgsDebugMsgLevel( QStringLiteral( "Scheduled auth db remove on thread close" ), 2 );
 
@@ -3207,7 +3207,7 @@ bool QgsAuthManager::passwordHelperDelete()
   QgsSettings settings;
   job.setInsecureFallback( settings.value( QStringLiteral( "password_helper_insecure_fallback" ), false, QgsSettings::Section::Auth ).toBool() );
   job.setAutoDelete( false );
-  job.setKey( AUTH_PASSWORD_HELPER_KEY_NAME );
+  job.setKey( authPasswordHelperKeyName() );
   QEventLoop loop;
   connect( &job, &QKeychain::Job::finished, &loop, &QEventLoop::quit );
   job.start();
@@ -3239,7 +3239,7 @@ QString QgsAuthManager::passwordHelperRead()
   QgsSettings settings;
   job.setInsecureFallback( settings.value( QStringLiteral( "password_helper_insecure_fallback" ), false, QgsSettings::Section::Auth ).toBool() );
   job.setAutoDelete( false );
-  job.setKey( AUTH_PASSWORD_HELPER_KEY_NAME );
+  job.setKey( authPasswordHelperKeyName() );
   QEventLoop loop;
   connect( &job, &QKeychain::Job::finished, &loop, &QEventLoop::quit );
   job.start();
@@ -3281,7 +3281,7 @@ bool QgsAuthManager::passwordHelperWrite( const QString &password )
   QgsSettings settings;
   job.setInsecureFallback( settings.value( QStringLiteral( "password_helper_insecure_fallback" ), false, QgsSettings::Section::Auth ).toBool() );
   job.setAutoDelete( false );
-  job.setKey( AUTH_PASSWORD_HELPER_KEY_NAME );
+  job.setKey( authPasswordHelperKeyName() );
   job.setTextData( password );
   QEventLoop loop;
   connect( &job, &QKeychain::Job::finished, &loop, &QEventLoop::quit );
@@ -3955,4 +3955,13 @@ void QgsAuthManager::insertCaCertInCache( QgsAuthCertUtils::CaCertSource source,
     mCaCertsCache.insert( QgsAuthCertUtils::shaHexForCert( cert ),
                           QPair<QgsAuthCertUtils::CaCertSource, QSslCertificate>( source, cert ) );
   }
+}
+
+QString QgsAuthManager::authPasswordHelperKeyName() const
+{
+  const QFileInfo info( mAuthDbPath );
+  const QString dbProfilePath = info.dir().dirName();
+
+  // if not running from the default profile, ensure that a different key is used
+  return AUTH_PASSWORD_HELPER_KEY_NAME_BASE + ( dbProfilePath.compare( QLatin1String( "default" ), Qt::CaseInsensitive ) == 0 ? QString() : dbProfilePath );
 }

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -874,6 +874,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     const QString authDbTrustTable() const { return AUTH_TRUST_TABLE; }
 
+    QString authPasswordHelperKeyName() const;
+
     static QgsAuthManager *sInstance;
     static const QString AUTH_CONFIG_TABLE;
     static const QString AUTH_PASS_TABLE;
@@ -939,7 +941,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
     bool mPasswordHelperFailedInit = false;
 
     //! Master password name in the wallets
-    static const QLatin1String AUTH_PASSWORD_HELPER_KEY_NAME;
+    static const QLatin1String AUTH_PASSWORD_HELPER_KEY_NAME_BASE;
 
     //! password helper folder in the wallets
     static const QLatin1String AUTH_PASSWORD_HELPER_FOLDER_NAME;


### PR DESCRIPTION
Otherwise, the auth db in one profile which is encrypted using a certain key will not be decryptable using the master pw stored in the keychain for a different user profile.