### PR TITLE
On systems with keychain support, automatically just create a random master authentication password and store in keychain

### DIFF
--- a/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -27,6 +27,7 @@ and to utilize configurations through various authentication method plugins
 %End
   public:
 
+
     enum MessageLevel /BaseType=IntEnum/
     {
       INFO,
@@ -160,6 +161,7 @@ Returns the authentication database connection URI with the password stripped.
 
 .. versionadded:: 3.40
 %End
+
 
     bool setMasterPassword( bool verify = false );
 %Docstring

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -27,6 +27,7 @@ and to utilize configurations through various authentication method plugins
 %End
   public:
 
+
     enum MessageLevel
     {
       INFO,
@@ -160,6 +161,7 @@ Returns the authentication database connection URI with the password stripped.
 
 .. versionadded:: 3.40
 %End
+
 
     bool setMasterPassword( bool verify = false );
 %Docstring

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16689,6 +16689,13 @@ void QgisApp::masterPasswordSetup()
   connect( QgsApplication::authManager(), &QgsAuthManager::messageLog, this, &QgisApp::authMessageLog );
   connect( QgsApplication::authManager(), &QgsAuthManager::passwordHelperMessageLog, this, &QgisApp::authMessageLog );
   connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseEraseRequested, this, &QgisApp::eraseAuthenticationDatabase );
+
+  if ( QgsAuthManager::settingsGenerateRandomPasswordForPasswordHelper->value()
+       && !QgsApplication::authManager()->masterPasswordHashInDatabase() && QgsApplication::authManager()->passwordHelperEnabled() )
+  {
+    // if no master password set by user yet, just generate a new one and store it in the system keychain
+    QgsApplication::authManager()->createAndStoreRandomMasterPasswordInKeyChain();
+  }
 }
 
 void QgisApp::eraseAuthenticationDatabase()

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -436,7 +436,6 @@ bool QgsAuthManager::createAndStoreRandomMasterPasswordInKeyChain()
   const QString newPassword = generatePassword();
   if ( passwordHelperWrite( newPassword ) )
   {
-    emit passwordHelperMessageLog( tr( "Master password has been successfully written to your %1" ).arg( AUTH_PASSWORD_HELPER_DISPLAY_NAME ), authManTag(), Qgis::MessageLevel::Warning );
     mMasterPass = newPassword;
   }
   else
@@ -3506,7 +3505,6 @@ bool QgsAuthManager::masterPasswordInput()
       {
         ok = true;
         storedPasswordIsValid = true;
-        emit passwordHelperMessageLog( tr( "Master password has been successfully read from your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Info );
       }
       else
       {
@@ -3526,11 +3524,7 @@ bool QgsAuthManager::masterPasswordInput()
     mMasterPass = pass;
     if ( passwordHelperEnabled() && ! storedPasswordIsValid )
     {
-      if ( passwordHelperWrite( pass ) )
-      {
-        emit passwordHelperMessageLog( tr( "Master password has been successfully written to your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Info );
-      }
-      else
+      if ( !passwordHelperWrite( pass ) )
       {
         emit passwordHelperMessageLog( tr( "Master password could not be written to your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
       }

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -445,7 +445,10 @@ bool QgsAuthManager::createAndStoreRandomMasterPasswordInKeyChain()
   }
 
   if ( !verifyMasterPassword() )
+  {
+    emit passwordHelperMessageLog( tr( "Master password was written to the %1 but could not be verified" ).arg( AUTH_PASSWORD_HELPER_DISPLAY_NAME ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
+  }
 
   QgsDebugMsgLevel( QStringLiteral( "Master password is set and verified" ), 2 );
   return true;

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -440,13 +440,13 @@ bool QgsAuthManager::createAndStoreRandomMasterPasswordInKeyChain()
   }
   else
   {
-    emit passwordHelperMessageLog( tr( "Master password could not be written to your %1" ).arg( AUTH_PASSWORD_HELPER_DISPLAY_NAME ), authManTag(), Qgis::MessageLevel::Warning );
+    emit passwordHelperMessageLog( tr( "Master password could not be written to your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
   }
 
   if ( !verifyMasterPassword() )
   {
-    emit passwordHelperMessageLog( tr( "Master password was written to the %1 but could not be verified" ).arg( AUTH_PASSWORD_HELPER_DISPLAY_NAME ), authManTag(), Qgis::MessageLevel::Warning );
+    emit passwordHelperMessageLog( tr( "Master password was written to the %1 but could not be verified" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
   }
 

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -903,6 +903,11 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
   private:
 
+    /**
+     * Generates a random, securely seeded password.
+     */
+    static QString generatePassword();
+
     bool initPrivate( const QString &pluginPath );
 
     //////////////////////////////////////////////////////////////////////////////
@@ -931,8 +936,6 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * access denied or no backend, reset error flags at the end
      */
     void passwordHelperProcessError();
-
-    static QString generatePassword();
 
     bool masterPasswordInput();
 

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -54,6 +54,7 @@ class QgsAuthMethod;
 class QgsAuthMethodEdit;
 class QgsAuthProvider;
 class QgsAuthMethodMetadata;
+class QgsSettingsEntryBool;
 class QTimer;
 class QgsAuthConfigurationStorage;
 class QgsAuthConfigurationStorageDb;
@@ -72,6 +73,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
     Q_OBJECT
 
   public:
+
+    static const QgsSettingsEntryBool *settingsGenerateRandomPasswordForPasswordHelper SIP_SKIP;
 
     //! Message log level (mirrors that of QgsMessageLog, so it can also output there)
     enum MessageLevel
@@ -185,6 +188,15 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \since QGIS 3.40
      */
     const QString authenticationDatabaseUriStripped() const;
+
+    /**
+     * Creates a new securely seeded random password and stores it in the
+     * system keychain as the new master password.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.42
+     */
+    bool createAndStoreRandomMasterPasswordInKeyChain() SIP_SKIP;
 
     /**
      * Main call to initially set or continually check master password is set
@@ -919,6 +931,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * access denied or no backend, reset error flags at the end
      */
     void passwordHelperProcessError();
+
+    static QString generatePassword();
 
     bool masterPasswordInput();
 

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -66,6 +66,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeNetworkCache = treeRoot()->createChildNode( QStringLiteral( "cache" ) );
     static inline QgsSettingsTreeNode *sTreeAttributeTable = treeRoot()->createChildNode( QStringLiteral( "attribute-table" ) );
     static inline QgsSettingsTreeNode *sTreeWindowState = sTreeGui->createChildNode( QStringLiteral( "window-state" ) );
+    static inline QgsSettingsTreeNode *sTreeAuthentication = treeRoot()->createChildNode( QStringLiteral( "authentication" ) );
 
 #endif
 


### PR DESCRIPTION
This avoids the need for users to manually create a pw, and makes things MUCH nicer for plugins which want to utilise the secure authentication framework.

Right now the options for plugins are:
1. Create a auto generated password themselves and force it on the user (basically what we are doing here automatically now)
2. Show a confusing/scary message to users asking them to set a master password. From my experience users have NO idea what this means and consider it a QGIS bug.


Assuming this is acceptable, some follow up is needed:

- If the user goes to change the master password, they'll be prompted to enter the current (random) password which they've never seen. We need some way to handle this more gracefully and skip the existing password re-entry if the password is stored in the keychain
- When the user does change their master password manually, we don't automatically store the new password in the keychain and overwrite the old one. Instead the user must manually select "store / update the master password in your wallet/keychain" from the utilities menu, which is horrible UX and should just happen automatically.

