### PR TITLE
[ui] Improve topology checker's rule activation/deactivation UX for large list of rules

### DIFF
--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -52,8 +52,8 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
     const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
     for ( const QModelIndex index : selectedIndexes )
     {
-      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
-      item->setCheckState( Qt::Checked );
+      if ( QTableWidgetItem *item = mRulesTable->item( index.row(), 0 ) )
+        item->setCheckState( Qt::Checked );
     }
   } );
   mContextMenu->addAction( enableAction );
@@ -63,8 +63,8 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
     const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
     for ( const QModelIndex index : selectedIndexes )
     {
-      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
-      item->setCheckState( Qt::Unchecked );
+      if ( QTableWidgetItem *item = mRulesTable->item( index.row(), 0 ) )
+        item->setCheckState( Qt::Unchecked );
     }
   } );
   mContextMenu->addAction( disableAction );
@@ -74,8 +74,8 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
     const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
     for ( const QModelIndex index : selectedIndexes )
     {
-      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
-      item->setCheckState( item->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked );
+      if ( QTableWidgetItem *item = mRulesTable->item( index.row(), 0 ) )
+        item->setCheckState( item->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked );
     }
   } );
   mContextMenu->addAction( toggleAction );

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -36,6 +36,71 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
 
   mQgisIface = qgisIface;
 
+  mContextMenu = new QMenu( this );
+
+  QAction *selectAllAction = new QAction( tr( "Select All" ), this );
+  connect( selectAllAction, &QAction::triggered, this, [ = ]
+  {
+    mRulesTable->setRangeSelected( QTableWidgetSelectionRange( 0, 0, mRulesTable->rowCount() - 1, mRulesTable->columnCount() - 1 ), true );
+  } );
+  mContextMenu->addAction( selectAllAction );
+  mContextMenu->addSeparator();
+
+  QAction *enableAction = new QAction( tr( "Activate" ), this );
+  connect( enableAction, &QAction::triggered, this, [ = ]
+  {
+    const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
+    for ( const QModelIndex index : selectedIndexes )
+    {
+      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
+      item->setCheckState( Qt::Checked );
+    }
+  } );
+  mContextMenu->addAction( enableAction );
+  QAction *disableAction = new QAction( tr( "Deactivate" ), this );
+  connect( disableAction, &QAction::triggered, this, [ = ]
+  {
+    const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
+    for ( const QModelIndex index : selectedIndexes )
+    {
+      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
+      item->setCheckState( Qt::Unchecked );
+    }
+  } );
+  mContextMenu->addAction( disableAction );
+  QAction *toggleAction = new QAction( tr( "Toggle Activation" ), this );
+  connect( toggleAction, &QAction::triggered, this, [ = ]
+  {
+    const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();
+    for ( const QModelIndex index : selectedIndexes )
+    {
+      QTableWidgetItem *item = mRulesTable->item( index.row(), 0 );
+      item->setCheckState( item->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked );
+    }
+  } );
+  mContextMenu->addAction( toggleAction );
+  mContextMenu->addSeparator();
+
+  QAction *deleteAction = new QAction( tr( "Delete" ), this );
+  connect( deleteAction, &QAction::triggered, this, &rulesDialog::deleteTests );
+  mContextMenu->addAction( deleteAction );
+
+  connect( mContextMenu, &QMenu::aboutToShow, this, [ = ]
+  {
+    selectAllAction->setEnabled( mRulesTable->rowCount() > 0 );
+    const bool hasSelectedItems = !mRulesTable->selectionModel()->selectedIndexes().isEmpty();
+    enableAction->setEnabled( hasSelectedItems );
+    disableAction->setEnabled( hasSelectedItems );
+    toggleAction->setEnabled( hasSelectedItems );
+    deleteAction->setEnabled( hasSelectedItems );
+  } );
+
+  mRulesTable->setContextMenuPolicy( Qt::CustomContextMenu );
+  connect( mRulesTable, &QTableWidget::customContextMenuRequested, this, [ = ]
+  {
+    mContextMenu->exec( QCursor::pos() );
+  } );
+
   //setHorizontalHeaderItems();
   mRulesTable->hideColumn( 3 );
   mRulesTable->hideColumn( 4 );
@@ -56,7 +121,7 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
     mDeleteTestButton->setEnabled( enabled );
   } );
   mDeleteTestButton->setEnabled( !mRulesTable->selectionModel()->selectedIndexes().isEmpty() );
-  connect( mDeleteTestButton, &QAbstractButton::clicked, this, &rulesDialog::deleteTest );
+  connect( mDeleteTestButton, &QAbstractButton::clicked, this, &rulesDialog::deleteTests );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &rulesDialog::showHelp );
 
@@ -261,7 +326,7 @@ void rulesDialog::addRule()
   mLayer2Box->setCurrentIndex( 0 );
 }
 
-void rulesDialog::deleteTest()
+void rulesDialog::deleteTests()
 {
   std::set<int, std::greater<int>> selectedRows;
   const QModelIndexList selectedIndexes = mRulesTable->selectionModel()->selectedRows();

--- a/src/plugins/topology/rulesDialog.h
+++ b/src/plugins/topology/rulesDialog.h
@@ -19,6 +19,7 @@
 #define RULESDIALOG_H_
 
 #include <QDialog>
+#include <QMenu>
 
 
 #include "ui_rulesDialog.h"
@@ -66,6 +67,8 @@ class rulesDialog : public QDialog, private Ui::rulesDialog
     QMap<QString, TopologyRule> mTestConfMap;
     QList<QString> mLayerIds;
     QgisInterface *mQgisIface = nullptr;
+    QMenu *mContextMenu = nullptr;
+
 
     /*
      * Reads a test from the project
@@ -78,8 +81,6 @@ class rulesDialog : public QDialog, private Ui::rulesDialog
      */
     void setHorizontalHeaderItems();
 
-
-
   private slots:
     /*
      * Shows or hides controls according to test settings
@@ -91,9 +92,9 @@ class rulesDialog : public QDialog, private Ui::rulesDialog
      */
     void addRule();
     /*
-     * Deletes test from the table
+     * Deletes selected test from the table
      */
-    void deleteTest();
+    void deleteTests();
     /*
      * Reads tests from the project
      */


### PR DESCRIPTION
## Description

Management of active rules within the topology  checker's rules dialog can be painful for large lists. This PR improves the situation by allowing for the enabling/disabling/toggling of the active state via a right-click menu that applies to selected items.

UI screenshot:
![image](https://github.com/qgis/QGIS/assets/1728657/3e3fcfdc-7200-46a0-838d-89948999c275)
