### PR TITLE
Set input combo box to active layer when importing vector data (Fixes #55168)

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -133,7 +133,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
                 self.cboInputLayer.addItem(layer.name(), layer.id())
 
         # set the current index of the combo box to the active layer in the layer tree (if found in combo box)
-        if iface.activeLayer():
+        if iface is not None and iface.activeLayer():
             index = self.cboInputLayer.findData(iface.activeLayer().id())
             if index != -1:
                 self.cboInputLayer.setCurrentIndex(index)

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -33,7 +33,7 @@ from qgis.core import (QgsDataSourceUri,
                        QgsProject,
                        QgsSettings)
 from qgis.gui import QgsMessageViewer
-from qgis.utils import OverrideCursor
+from qgis.utils import OverrideCursor, iface
 
 from .ui.ui_DlgImportVector import Ui_DbManagerDlgImportVector as Ui_Dialog
 
@@ -131,6 +131,12 @@ class DlgImportVector(QDialog, Ui_Dialog):
             # TODO: add import raster support!
             if layer is not None and layer.type() == QgsMapLayerType.VectorLayer:
                 self.cboInputLayer.addItem(layer.name(), layer.id())
+
+        # set the current index of the combo box to the active layer in the layer tree (if found in combo box)
+        if iface.activeLayer():
+            index = self.cboInputLayer.findData(iface.activeLayer().id())
+            if index != -1:
+                self.cboInputLayer.setCurrentIndex(index)
 
     def deleteInputLayer(self):
         """ unset the input layer, then destroy it but only if it was created from this dialog """


### PR DESCRIPTION
## Description

When importing vector data in the DB Manager core plugin, the value of the "Input" combo box is automatically set to the active layer from the layer tree.

![image](https://github.com/qgis/QGIS/assets/59714546/596b6f0b-6540-40a7-939a-c479f4365b6e)
