### PR TITLE
[feature][expressions] Add format_interval function

### DIFF
--- a/resources/function_help/json/format_interval
+++ b/resources/function_help/json/format_interval
@@ -1,0 +1,33 @@
+{
+  "name": "format_interval",
+  "type": "function",
+  "groups": ["String", "Date and Time"],
+  "description": "Formats an interval into a custom string format.",
+  "arguments": [{
+    "arg": "interval",
+    "description": "interval value, such as that returned by make_interval()."
+  }, {
+    "arg": "format",
+    "description": "String template used to format the string. <table><thead><tr><th>Expression</th><th>Output</th></tr></thead><tr valign=\"top\"><td><code>%Y</code></td><td>the number of years</td></tr><tr valign=\"top\"><td><code>%M</code></td><td>the number of months</td></tr><tr valign=\"top\"><td><code>%W</code></td><td>the number of weeks</td></tr><tr valign=\"top\"><td>%D</td><td>the number of days</td></tr><tr valign=\"top\"><td>%h</td><td>the number of hours</td></tr><tr valign=\"top\"><td>%m</td><td>the number of minutes</td></tr><tr valign=\"top\"><td>%s</td><td>the number of seconds</td></tr><tr valign=\"top\"><td>%z</td><td>the number of milliseconds</td></tr></table>A single zero can be inserted before the specifier (e.g. <code>%0m</code>) to add a leading zero if the value would be less than two digits.  Milliseconds can be padded to three digits (<code>%00z</code>) and years up to four digits (<code>%000Y</code>).  This is useful for formats like <code>%h:%0m:%0s.%00z</code> to display as <code>2:04:06.008</code> rather than <code>2:4:6.8</code>.<br/>The interval is only broken down to the largest specifier.  So for an interval of 65 seconds, only using the <code>%s</code> specifier will show 65 as the value for the seconds field, however if the <code>%m</code> specifier is also used, the value will be broken down into minutes instead, so the same interval will show as 1 minute 5 seconds.  This means you do not have to specify all placeholders - if you omit <code>%h</code> for hours, the result is that <code>%m</code> for minutes will increase above 59 if needed.<br/>The least significant placeholder specified (with the year being the most significant and milliseconds the least) will be rounded up or down as appropriate.  This way an interval of 90 seconds will show as 2 minutes if only <code>%m</code> is used, or 1 minute 30 seconds if both <code>%m</code> and <code>%s</code> are used together."
+  }],
+  "examples": [{
+    "expression": "format_interval(make_interval(minutes:=91),'%m min')",
+    "returns": "'91 min'"
+  }, {
+    "expression": "format_interval(make_interval(minutes:=91),'%h hr %m min')",
+    "returns": "'1 hr 31 min'"
+  }, {
+    "expression": "format_interval(make_interval(minutes:=91),'%h hr')",
+    "returns": "'2 hr'"
+  }, {
+    "expression": "format_interval(make_interval(minutes:=62),'%h:%0m')",
+    "returns": "'1:02'"
+  }, {
+    "expression": "format_interval(make_interval(seconds:=3724.008),'%h:%0m:%0s.%00z')",
+    "returns": "'1:02:04.008'"
+  }, {
+    "expression": "format_interval(make_interval(minutes:=1560),'%Dd %mm')",
+    "returns": "'1d 120m'"
+  }],
+  "tags": ["custom", "type", "uses", "format", "strings", "time", "date", "formats", "see", "interval", "tostring"]
+}

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1871,6 +1871,16 @@ class TestQgsExpression: public QObject
       QTest::newRow( "time from format and language" ) << "to_time('12:34:56','HH:mm:ss','fr')" << false << QVariant( QTime( 12, 34, 56 ) );
       QTest::newRow( "formatted string from date" ) << "format_date('2019-06-29','MMMM d, yyyy')" << false << QVariant( QString( "June 29, 2019" ) );
       QTest::newRow( "formatted string from date with language" ) << "format_date('2019-06-29','d MMMM yyyy','fr')" << false << QVariant( QString( "29 juin 2019" ) );
+      QTest::newRow( "formatted string from interval, simple" ) << "format_interval(make_interval(seconds:=62.003),'%m:%0s.%00z')" << false << QVariant( QString( "1:02.003" ) );
+      QTest::newRow( "formatted string from interval, all as int" ) << "format_interval(make_interval(seconds:=38919967), '%Yy %Mm %Ww %Dd %hh %mm %ss')" << false << QVariant( QString( "1y 2m 3w 4d 5h 6m 7s" ) );
+      QTest::newRow( "formatted string from interval, year" ) << "format_interval(make_interval(seconds:=31557600), '%Yy %Mm %Ww %Dd %hh %mm %ss %zms')" << false << QVariant( QString( "1y 0m 0w 0d 0h 0m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, month" ) << "format_interval(make_interval(seconds:=31557600), '%Mm %Ww %Dd %hh %mm %ss %zms')" << false << QVariant( QString( "12m 0w 0d 0h 0m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, week" ) << "format_interval(make_interval(seconds:=31557600), '%Ww %Dd %hh %mm %ss %zms')" << false << QVariant( QString( "52w 1d 6h 0m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, day" ) << "format_interval(make_interval(seconds:=31557600), '%Dd %hh %mm %ss %zms')" << false << QVariant( QString( "365d 6h 0m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, hour" ) << "format_interval(make_interval(seconds:=31557600), '%hh %mm %ss %zms')" << false << QVariant( QString( "8766h 0m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, minute" ) << "format_interval(make_interval(seconds:=31557600), '%mm %ss %zms')" << false << QVariant( QString( "525960m 0s 0ms" ) );
+      QTest::newRow( "formatted string from interval, second" ) << "format_interval(make_interval(seconds:=31557600), '%ss %zms')" << false << QVariant( QString( "31557600s 0ms" ) );
+      QTest::newRow( "formatted string from interval, millisecond" ) << "format_interval(make_interval(seconds:=31557600), '%zms')" << false << QVariant( QString( "31557600000ms" ) );
 
       // Color functions
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)


### PR DESCRIPTION
## Description

This adds a new `format_interval` function to address feature request #54257.  It takes an interval value and a format specifier, and returns a string describing the interval in terms of the format specifier (e.g. `5 years, 2 months` or `3:01`).

I have included some tests and they pass with `make test`.

Here is a screenshot of the help text with some examples:

![format_interval_help](https://github.com/qgis/QGIS/assets/171656/d0055cb8-446d-4549-8b46-ca32dfe147b1)
