### PR TITLE
Only run selected SQL code

### DIFF
--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -172,7 +172,11 @@ void QgsQueryResultWidget::executeQuery()
   cancelRunningQuery();
   if ( mConnection )
   {
-    const QString sql { mSqlEditor->text( ) };
+    QString sql { mSqlEditor->text() };
+    if ( mSqlEditor->hasSelectedText() )
+    {
+      sql = mSqlEditor->selectedText();
+    }
 
     bool ok = false;
     mCurrentHistoryEntryId = QgsGui::historyProviderRegistry()->addEntry( QStringLiteral( "dbquery" ),


### PR DESCRIPTION
## Description

When there is a selection, only run the selected SQL code. Most SQL editors work this way, including the one in the DB Browser plugin.
