### PR TITLE
Improve plugin search

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1474,6 +1474,7 @@ void QgsPluginManager::wvDetails_linkClicked( const QUrl &url )
 
 void QgsPluginManager::leFilter_textChanged( QString text )
 {
+  text = text.simplified(); // Trim the string and remove redundant whitespaces
   if ( text.startsWith( QLatin1String( "tag:" ), Qt::CaseInsensitive ) )
   {
     text = text.remove( QStringLiteral( "tag:" ) );

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
@@ -109,7 +109,7 @@ bool QgsPluginSortFilterProxyModel::filterByPhrase( QModelIndex &index ) const
         {
           for ( const QString &tag : tags )
           {
-            if ( tag.contains( regExPart ) )
+            if ( tag.contains( regExPart, Qt::CaseInsensitive ) )
             {
               termFound = true;
               break;

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
@@ -17,6 +17,8 @@
 #ifndef QGSPLUGINSORTFILTERPROXYMODEL_H
 #define QGSPLUGINSORTFILTERPROXYMODEL_H
 
+#include "qgis_app.h"
+
 #include <QSortFilterProxyModel>
 #include <QStringList>
 #include <QString>
@@ -40,7 +42,7 @@ const int SPACER_ROLE = Qt::UserRole + 20;             // for sorting
 /**
  * \brief Proxy model for filtering and sorting items in Plugin Manager
 */
-class QgsPluginSortFilterProxyModel : public QSortFilterProxyModel
+class APP_EXPORT QgsPluginSortFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 

--- a/tests/qt_modeltest/readme.txt
+++ b/tests/qt_modeltest/readme.txt
@@ -4,4 +4,4 @@ Model Test
 This is a simple tool from Qt for checking various errors of custom
 implementations of models for item views.
 
-http://developer.qt.nokia.com/wiki/Model_Test
+https://wiki.qt.io/Model_Test

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+IF(ENABLE_MODELTEST)
+  INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/tests/qt_modeltest)
+ENDIF(ENABLE_MODELTEST)
 
 
 set(TESTS

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TESTS
   testqgsmaptoolsplitfeatures.cpp
   testqgsmeasuretool.cpp
   testqgsmeasurebearingtool.cpp
+  testqgspluginsortfileproxymodel.cpp
   testqgsvertexeditor.cpp
   testqgsvertextool.cpp
   testqgsvectorlayersaveasdialog.cpp

--- a/tests/src/app/testqgspluginsortfileproxymodel.cpp
+++ b/tests/src/app/testqgspluginsortfileproxymodel.cpp
@@ -114,14 +114,14 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->rowCount(), 1 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
 
-  filterRegExp = QRegularExpression( "FanTastI", QRegularExpression::CaseInsensitiveOption );
+  filterRegExp = QRegularExpression( "FanTastI", QRegularExpression::CaseInsensitiveOption );  //#spellok
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 2 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
 
   // Filter by plugin description
-  filterRegExp = QRegularExpression( "new plUgi", QRegularExpression::CaseInsensitiveOption );
+  filterRegExp = QRegularExpression( "new plUgi", QRegularExpression::CaseInsensitiveOption );  //#spellok
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 1 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
@@ -157,7 +157,7 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
 
   // Not found
-  filterRegExp = QRegularExpression( "pluggin", QRegularExpression::CaseInsensitiveOption );
+  filterRegExp = QRegularExpression( "pluggin", QRegularExpression::CaseInsensitiveOption );  //#spellok
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 0 );
 
@@ -171,7 +171,7 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
 
   // Tag not found
-  filterRegExp = QRegularExpression( "tagg", QRegularExpression::CaseInsensitiveOption );
+  filterRegExp = QRegularExpression( "tagg", QRegularExpression::CaseInsensitiveOption );  //#spellok
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 0 );
 

--- a/tests/src/app/testqgspluginsortfileproxymodel.cpp
+++ b/tests/src/app/testqgspluginsortfileproxymodel.cpp
@@ -103,6 +103,11 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->rowCount(), 1 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
 
+  filterRegExp = QRegularExpression( QString( "   gcarrillo   " ).simplified(), QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+
   filterRegExp = QRegularExpression( "caRril", QRegularExpression::CaseInsensitiveOption );
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 1 );
@@ -110,6 +115,11 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
 
   // Filter by plugin title (display role)
   filterRegExp = QRegularExpression( "my fan", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+
+  filterRegExp = QRegularExpression( QString( "   my   fan   " ).simplified(), QRegularExpression::CaseInsensitiveOption );
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 1 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
@@ -126,8 +136,19 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->rowCount(), 1 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
 
+  filterRegExp = QRegularExpression( QString( "   new   plUgi   " ).simplified(), QRegularExpression::CaseInsensitiveOption );  //#spellok
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
   // Filter by tags (full text search)
   filterRegExp = QRegularExpression( "abc", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  filterRegExp = QRegularExpression( QString( "   abc   " ).simplified(), QRegularExpression::CaseInsensitiveOption );
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 2 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
@@ -145,6 +166,12 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
 
   filterRegExp = QRegularExpression( "def ghi abc", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  filterRegExp = QRegularExpression( QString( "   def   ghi   abc   " ).simplified(), QRegularExpression::CaseInsensitiveOption );
   mModelProxy->setFilterRegularExpression( filterRegExp );
   QCOMPARE( mModelProxy->rowCount(), 2 );
   QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );

--- a/tests/src/app/testqgspluginsortfileproxymodel.cpp
+++ b/tests/src/app/testqgspluginsortfileproxymodel.cpp
@@ -69,7 +69,7 @@ void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
   mModelProxy->setFilterRole( 0 );  // Full text search
 
 #ifdef ENABLE_MODELTEST
-  new ModelTest( &mModelProxy, this ); // for model validity checking
+  new ModelTest( mModelProxy, this ); // for model validity checking
 #endif
 
   // Add plugin items

--- a/tests/src/app/testqgspluginsortfileproxymodel.cpp
+++ b/tests/src/app/testqgspluginsortfileproxymodel.cpp
@@ -1,0 +1,182 @@
+/***************************************************************************
+                         testqgspluginsortfileproxymodel.cpp
+                         --------------------------
+    begin                : November 2023
+    copyright            : (C) 2023 by Germán Carrillo
+    email                : gcarrillo at linuxmail dot org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QStandardItemModel>
+
+#include "qgspluginsortfilterproxymodel.h"
+#include "qgssettings.h"
+
+#include <QtTest/QSignalSpy>
+#include "qgstest.h"
+
+#ifdef ENABLE_MODELTEST
+#include "modeltest.h"
+#endif
+
+
+class TestQgsPluginSortFileProxyModel: public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void testProxyModelFilters();
+};
+
+
+void TestQgsPluginSortFileProxyModel::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QgsSettings().clear();
+}
+
+void TestQgsPluginSortFileProxyModel::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsPluginSortFileProxyModel::testProxyModelFilters()
+{
+  QStandardItemModel *model = new QStandardItemModel( 0, 1 );
+  QgsPluginSortFilterProxyModel *mModelProxy = new QgsPluginSortFilterProxyModel( this );
+  mModelProxy->setSourceModel( model );
+  mModelProxy->setSortCaseSensitivity( Qt::CaseInsensitive );
+  mModelProxy->setSortRole( Qt::DisplayRole );
+  mModelProxy->setDynamicSortFilter( true );
+  mModelProxy->sort( 0, Qt::AscendingOrder );
+  mModelProxy->setFilterRole( 0 );  // Full text search
+
+#ifdef ENABLE_MODELTEST
+  new ModelTest( &mModelProxy, this ); // for model validity checking
+#endif
+
+  // Add plugin items
+  QStandardItem *pluginItem = new QStandardItem( "My Fantastic Plugin 1" );
+  pluginItem->setData( "myplugin1", PLUGIN_BASE_NAME_ROLE );
+  pluginItem->setData( "great plugin description", PLUGIN_DESCRIPTION_ROLE );
+  pluginItem->setData( "gcarrillo", PLUGIN_AUTHOR_ROLE );
+  pluginItem->setData( QStringLiteral( "abc,def,ghi" ), PLUGIN_TAGS_ROLE );
+  model->appendRow( pluginItem );
+
+  pluginItem = new QStandardItem( "My New Fantastic Plugin" );
+  pluginItem->setData( "myplugin2", PLUGIN_BASE_NAME_ROLE );
+  pluginItem->setData( "This is a new plugin to do new stuff", PLUGIN_DESCRIPTION_ROLE );
+  pluginItem->setData( "germap", PLUGIN_AUTHOR_ROLE );
+  pluginItem->setData( QStringLiteral( "abc,def,ghi" ), PLUGIN_TAGS_ROLE );
+  model->appendRow( pluginItem );
+
+  pluginItem = new QStandardItem( "Map import tools" );
+  pluginItem->setData( "myplugin3", PLUGIN_BASE_NAME_ROLE );
+  pluginItem->setData( "Tools to import things into maps", PLUGIN_DESCRIPTION_ROLE );
+  pluginItem->setData( "germap", PLUGIN_AUTHOR_ROLE );
+  pluginItem->setData( QStringLiteral( "jkl,mno,pqr" ), PLUGIN_TAGS_ROLE );
+  model->appendRow( pluginItem );
+
+  QCOMPARE( mModelProxy->columnCount(), 1 );
+  QCOMPARE( mModelProxy->rowCount(), 3 );
+
+  // Filter by author
+  QRegularExpression filterRegExp( "gcarrillo", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+
+  filterRegExp = QRegularExpression( "caRril", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+
+  // Filter by plugin title (display role)
+  filterRegExp = QRegularExpression( "my fan", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+
+  filterRegExp = QRegularExpression( "FanTastI", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  // Filter by plugin description
+  filterRegExp = QRegularExpression( "new plUgi", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  // Filter by tags (full text search)
+  filterRegExp = QRegularExpression( "abc", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  filterRegExp = QRegularExpression( "mNo", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 1 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "Map import tools" );
+
+  filterRegExp = QRegularExpression( "abc def", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  filterRegExp = QRegularExpression( "def ghi abc", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  filterRegExp = QRegularExpression( "ghi ab", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  // Not found
+  filterRegExp = QRegularExpression( "pluggin", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 0 );
+
+  // Filter by tag role ('tag:' shortcut)
+  mModelProxy->setFilterRole( PLUGIN_TAGS_ROLE );
+
+  filterRegExp = QRegularExpression( "abc", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 2 );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My Fantastic Plugin 1" );
+  QCOMPARE( mModelProxy->data( mModelProxy->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), "My New Fantastic Plugin" );
+
+  // Tag not found
+  filterRegExp = QRegularExpression( "tagg", QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( filterRegExp );
+  QCOMPARE( mModelProxy->rowCount(), 0 );
+
+}
+
+
+QGSTEST_MAIN( TestQgsPluginSortFileProxyModel )
+#include "testqgspluginsortfileproxymodel.moc"


### PR DESCRIPTION
As of now, plugin search is a bit rigid and can be improved in several ways to allow users to discover plugins easier.

This PR improves plugin search by:

  + [x] Taking combinations of tags into account (plugin devs won't have to manually add all possible tag combinations), and,
  + [x] Removing redundant white-spaces in search terms.

Some examples:

1. Search terms: `batch import` 

    In this case, the "Batch GPS importer" plugin dev has done his best at combining tags (`gpx import, gps import, batch gpx, batch gps`), but he's forgotten one meaningful combination.

    BEFORE...................................................................................AFTER
    ![image](https://github.com/qgis/QGIS/assets/652785/c4869839-313f-4586-ba45-b3679fc6908d)

2. Search terms: `batch point cloud` (tag combinations)

    BEFORE...................................................................................AFTER
    ![image](https://github.com/qgis/QGIS/assets/652785/d9dc9f1c-42f8-4785-9eaf-3f41273384af)

3. Search terms: `batch point clou` (partial matching in tag combinations)

    BEFORE...................................................................................AFTER
    ![image](https://github.com/qgis/QGIS/assets/652785/f238ab81-adbb-4754-bcdc-d4e05e71ca44)

4. Search terms: `  load  them  a` (partial matching in plugin name with redundant white-spaces)

    BEFORE...................................................................................AFTER
    ![image](https://github.com/qgis/QGIS/assets/652785/349c2883-6548-4a23-84a8-f4a02fa2550b)

---------------

This PR introduces unit tests for the `pluginSortFilterProxyModel`.

---------------

Special thanks to @rduivenvoorde and @m-kuhn for their gentle guidance for this PR during the OSGeo Codesprint in Vienna. :+1: 

