### PR TITLE
[Oracle] Fix date filtering

### DIFF
--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -159,10 +159,17 @@ QgsOracleConn::QgsOracleConn( QgsDataSourceUri uri, bool transaction )
     return;
   }
 
+  QSqlQuery qry( mDatabase );
+  if ( !LoggedExecPrivate( QStringLiteral( "QgsOracleConn" ), qry, QStringLiteral( "alter session set nls_date_format = 'yyyy-mm-dd\"T\"HH24:MI:ss'" ),
+                           QVariantList() ) )
+  {
+    const QString error { tr( "Error: Failed to switch the default format date to ISO" ) };
+    QgsMessageLog::logMessage( error, tr( "Oracle" ) );
+    return;
+  }
+
   if ( !workspace.isNull() )
   {
-    QSqlQuery qry( mDatabase );
-
     if ( !qry.prepare( QStringLiteral( "BEGIN\nDBMS_WM.GotoWorkspace(?);\nEND;" ) ) || !( qry.addBindValue( workspace ), qry.exec() ) )
     {
       mDatabase.close();

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -163,8 +163,10 @@ QgsOracleConn::QgsOracleConn( QgsDataSourceUri uri, bool transaction )
   if ( !LoggedExecPrivate( QStringLiteral( "QgsOracleConn" ), qry, QStringLiteral( "alter session set nls_date_format = 'yyyy-mm-dd\"T\"HH24:MI:ss'" ),
                            QVariantList() ) )
   {
+    mDatabase.close();
     const QString error { tr( "Error: Failed to switch the default format date to ISO" ) };
     QgsMessageLog::logMessage( error, tr( "Oracle" ) );
+    mRef = 0;
     return;
   }
 


### PR DESCRIPTION
It fixes an unreported issue: When a WMS request is sent  with an OGC filter, this one is transformed in QgsExpression then compiled in SQL. Issue is that date comparison will generate an SQL error.

This is not necessarily critical because QGIS will fallback on QgsExpression evaluation and then everything will be fine.
But sometimes, for reasons far beyond my understanding of Oracle, the request doesn't fail at execution, but when we fetch result. And so, no Qgsexpression fallback, no results.

The fix is very like #52419 where we force date format at session level.

