### PR TITLE
QgsAfsSharedData should not be a QObject

### DIFF
--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -94,12 +94,12 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
                              errorTitle, error, mDataSource.httpHeaders(), mLimitBBox ? mExtent : QgsRectangle(), mDataSource.sql() );
   if ( objectIdData.isEmpty() )
   {
-    errorMessage = tr( "getObjectIds failed: %1 - %2" ).arg( errorTitle, error );
+    errorMessage = QObject::tr( "getObjectIds failed: %1 - %2" ).arg( errorTitle, error );
     return false;
   }
   if ( !objectIdData[QStringLiteral( "objectIdFieldName" )].isValid() || !objectIdData[QStringLiteral( "objectIds" )].isValid() )
   {
-    errorMessage = tr( "Failed to determine objectIdFieldName and/or objectIds" );
+    errorMessage = QObject::tr( "Failed to determine objectIdFieldName and/or objectIds" );
     return false;
   }
   mObjectIdFieldName = objectIdData[QStringLiteral( "objectIdFieldName" )].toString();

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -16,7 +16,6 @@
 #ifndef QGSAFSSHAREDDATA_H
 #define QGSAFSSHAREDDATA_H
 
-#include <QObject>
 #include <QMutex>
 #include "qgsfields.h"
 #include "qgsfeature.h"
@@ -29,9 +28,9 @@ class QgsFeedback;
 /**
  * \brief This class holds data, shared between QgsAfsProvider and QgsAfsFeatureIterator
  */
-class QgsAfsSharedData : public QObject
+class QgsAfsSharedData
 {
-    Q_OBJECT
+
   public:
     QgsAfsSharedData( const QgsDataSourceUri &uri );
 


### PR DESCRIPTION
This was probably originally done just to get "tr" working, but it's an object which by design MUST be used across multiple threads and accordingly a QObject base is NOT appropriate.