### PR TITLE
Move ::htmlMetadata from some data provider subclasses up to base class

### DIFF
--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -135,6 +135,12 @@ providing access to (e.g. the comment for postgres table).
 
 .. versionadded:: 3.14
 %End
+    virtual QString htmlMetadata() const;
+%Docstring
+Obtain a formatted HTML string containing assorted metadata for this data provider.
+
+.. versionadded:: 3.36
+%End
 
     void setUri( const QgsDataSourceUri &uri );
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -295,12 +295,6 @@ pyramid layers.
 .. seealso:: :py:func:`buildPyramids`
 %End
 
-    virtual QString htmlMetadata() = 0;
-%Docstring
-Returns metadata in a format suitable for feeding directly
-into a subset of the GUI raster properties "Metadata" tab.
-%End
-
     virtual QgsRasterIdentifyResult identify( const QgsPointXY &point, Qgis::RasterIdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
 %Docstring
 Identify raster value(s) found on the point position. The context

--- a/python/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenedataprovider.sip.in
@@ -49,12 +49,6 @@ Returns flags containing the supported capabilities for the data provider.
 Returns a clone of the data provider.
 %End
 
-    virtual QString htmlMetadata() const;
-%Docstring
-Returns metadata in a format suitable for feeding directly
-into a subset of the GUI properties "Metadata" tab.
-%End
-
     virtual const QgsCoordinateReferenceSystem sceneCrs() const = 0;
 %Docstring
 Returns the original coordinate reference system for the tiled scene data.

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1994,7 +1994,7 @@ QString QgsMeshLayer::htmlMetadata() const
   QLocale locale = QLocale();
   locale.setNumberOptions( locale.numberOptions() &= ~QLocale::NumberOption::OmitGroupSeparator );
 
-  if ( dataProvider() )
+  if ( const QgsMeshDataProvider *provider = dataProvider() )
   {
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" )
                   + tr( "Vertex count" ) + QStringLiteral( "</td><td>" )
@@ -2012,6 +2012,7 @@ QString QgsMeshLayer::htmlMetadata() const
                   + tr( "Dataset groups count" ) + QStringLiteral( "</td><td>" )
                   + ( locale.toString( static_cast<qlonglong>( datasetGroupCount() ) ) )
                   + QStringLiteral( "</td></tr>\n" );
+    myMetadata += provider->htmlMetadata();
   }
 
   // End Provider section

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -578,6 +578,12 @@ QString QgsPointCloudLayer::htmlMetadata() const
                 + tr( "Point count" ) + QStringLiteral( "</td><td>" )
                 + ( pointCount < 0 ? tr( "unknown" ) : locale.toString( static_cast<qlonglong>( pointCount ) ) )
                 + QStringLiteral( "</td></tr>\n" );
+
+  if ( const QgsPointCloudDataProvider *provider = dataProvider() )
+  {
+    myMetadata += provider->htmlMetadata();
+  }
+
   myMetadata += QLatin1String( "</table>\n<br><br>" );
 
   // CRS

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -511,10 +511,10 @@ void QgsGdalProvider::loadMetadata()
   mLayerMetadata.setType( QStringLiteral( "dataset" ) );
 }
 
-QString QgsGdalProvider::htmlMetadata()
+QString QgsGdalProvider::htmlMetadata() const
 {
   QMutexLocker locker( mpMutex );
-  if ( !initIfNeeded() )
+  if ( !const_cast< QgsGdalProvider * >( this )->initIfNeeded() )
     return QString();
 
   GDALDriverH hDriver = GDALGetDriverByName( mDriverName.toLocal8Bit().constData() );

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -159,7 +159,7 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     double bandScale( int bandNo ) const override;
     double bandOffset( int bandNo ) const override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
-    QString htmlMetadata() override;
+    QString htmlMetadata() const override;
     QString bandDescription( int bandNumber ) override;
     QStringList subLayers() const override;
 
@@ -300,7 +300,7 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     GDALDatasetH mGdalDataset = nullptr;
 
     //! \brief Values for mapping pixel to world coordinates. Contents of this array are the same as the GDAL adfGeoTransform
-    double mGeoTransform[6];
+    mutable double mGeoTransform[6];
 
     QgsCoordinateReferenceSystem mCrs;
 

--- a/src/core/providers/qgsdataprovider.cpp
+++ b/src/core/providers/qgsdataprovider.cpp
@@ -28,6 +28,13 @@ QgsDataProvider::QgsDataProvider( const QString &uri, const QgsDataProvider::Pro
   mReadFlags = flags;
 }
 
+QString QgsDataProvider::htmlMetadata() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return QString();
+}
+
 Qgis::DataProviderFlags QgsDataProvider::flags() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -189,6 +189,12 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     virtual QString dataComment() const { return QString(); };
 
+    /**
+     * Obtain a formatted HTML string containing assorted metadata for this data provider.
+     *
+     * \since QGIS 3.36
+     */
+    virtual QString htmlMetadata() const;
 
     /**
      * Set the data source specification.

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -382,12 +382,6 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     bool hasPyramids();
 
     /**
-     * Returns metadata in a format suitable for feeding directly
-     * into a subset of the GUI raster properties "Metadata" tab.
-     */
-    virtual QString htmlMetadata() = 0;
-
-    /**
      * Identify raster value(s) found on the point position. The context
      * parameters extent, width and height are important to identify
      * on the same zoom level as a displayed map and to do effective

--- a/src/core/tiledscene/qgstiledscenedataprovider.cpp
+++ b/src/core/tiledscene/qgstiledscenedataprovider.cpp
@@ -41,13 +41,6 @@ Qgis::TiledSceneProviderCapabilities QgsTiledSceneDataProvider::capabilities() c
   return Qgis::TiledSceneProviderCapabilities();
 }
 
-QString QgsTiledSceneDataProvider::htmlMetadata() const
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  return QString();
-}
-
 QgsDoubleRange QgsTiledSceneDataProvider::zRange() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/tiledscene/qgstiledscenedataprovider.h
+++ b/src/core/tiledscene/qgstiledscenedataprovider.h
@@ -66,12 +66,6 @@ class CORE_EXPORT QgsTiledSceneDataProvider: public QgsDataProvider
     virtual QgsTiledSceneDataProvider *clone() const = 0 SIP_FACTORY;
 
     /**
-     * Returns metadata in a format suitable for feeding directly
-     * into a subset of the GUI properties "Metadata" tab.
-     */
-    virtual QString htmlMetadata() const;
-
-    /**
      * Returns the original coordinate reference system for the tiled scene data.
      *
      * This may differ from the QgsDataProvider::crs(), which is the best CRS representation

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5593,10 +5593,10 @@ QString QgsVectorLayer::htmlMetadata() const
   }
 
   // encoding
-  const QgsVectorDataProvider *provider = dataProvider();
-  if ( provider )
+  if ( const QgsVectorDataProvider *provider = dataProvider() )
   {
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Encoding" ) + QStringLiteral( "</td><td>" ) + provider->encoding() + QStringLiteral( "</td></tr>\n" );
+    myMetadata += provider->htmlMetadata();
   }
 
   if ( isSpatial() )

--- a/src/core/vectortile/qgsvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvectortiledataprovider.cpp
@@ -105,14 +105,6 @@ QImage QgsVectorTileDataProvider::spriteImage() const
   return QImage();
 }
 
-QString QgsVectorTileDataProvider::htmlMetadata() const
-{
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  return QString();
-}
-
-
 
 
 QgsVectorTileDataProviderSharedData::QgsVectorTileDataProviderSharedData()

--- a/src/core/vectortile/qgsvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvectortiledataprovider.h
@@ -179,12 +179,6 @@ class CORE_EXPORT QgsVectorTileDataProvider : public QgsDataProvider
      */
     virtual QImage spriteImage() const;
 
-    /**
-     * Returns metadata in a format suitable for feeding directly
-     * into a subset of the GUI properties "Metadata" tab.
-     */
-    virtual QString htmlMetadata() const;
-
   protected:
 
     std::shared_ptr<QgsVectorTileDataProviderSharedData> mShared;  //!< Mutable data shared between provider instances

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -469,7 +469,7 @@ static inline QString dumpVariantMap( const QVariantMap &variantMap, const QStri
   return result;
 }
 
-QString QgsAmsProvider::htmlMetadata()
+QString QgsAmsProvider::htmlMetadata() const
 {
   // This must return the content of a HTML table starting by tr and ending by tr
   return dumpVariantMap( mServiceInfo, tr( "Service Info" ) ) + dumpVariantMap( mLayerInfo, tr( "Layer Info" ) );

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -102,7 +102,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     Qgis::DataType dataType( int /*bandNo*/ ) const override { return Qgis::DataType::ARGB32; }
     Qgis::DataType sourceDataType( int /*bandNo*/ ) const override { return Qgis::DataType::ARGB32; }
     QgsAmsProvider *clone() const override;
-    QString htmlMetadata() override;
+    QString htmlMetadata() const override;
     bool supportsLegendGraphic() const override { return true; }
     QImage getLegendGraphic( double scale = 0, bool forceRefresh = false, const QgsRectangle *visibleExtent = nullptr ) override;
     QgsImageFetcher *getLegendGraphicFetcher( const QgsMapSettings *mapSettings ) override;

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -509,7 +509,7 @@ Qgis::RasterColorInterpretation QgsGrassRasterProvider::colorInterpretation( int
   return Qgis::RasterColorInterpretation::GrayIndex;
 }
 
-QString QgsGrassRasterProvider::htmlMetadata()
+QString QgsGrassRasterProvider::htmlMetadata() const
 {
   QString myMetadata;
   QStringList myList;
@@ -518,10 +518,9 @@ QString QgsGrassRasterProvider::htmlMetadata()
   myList.append( "MAPSET: " + mMapset );
   myList.append( "MAP: " + mMapName );
 
-  QHash<QString, QString>::iterator i;
-  for ( i = mInfo.begin(); i != mInfo.end(); ++i )
+  for ( auto it = mInfo.constBegin(); it != mInfo.constEnd(); ++it )
   {
-    myList.append( i.key() + " : " + i.value() );
+    myList.append( it.key() + " : " + it.value() );
   }
   myMetadata += QgsHtmlUtils::buildBulletList( myList );
   return myMetadata;

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -201,12 +201,7 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
 
     // void buildSupportedRasterFileFilter( QString & fileFiltersString );
 
-    /**
-     * Gets metadata in a format suitable for feeding directly
-     * into a subset of the GUI raster properties "Metadata" tab.
-     */
-    QString htmlMetadata() override;
-
+    QString htmlMetadata() const override;
     QDateTime dataTimestamp() const override;
 
     // used by GRASS tools

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -812,7 +812,7 @@ static inline QString dumpVariantMap( const QVariantMap &variantMap, const QStri
   return result;
 }
 
-QString QgsPostgresRasterProvider::htmlMetadata()
+QString QgsPostgresRasterProvider::htmlMetadata() const
 {
   // This must return the content of a HTML table starting by tr and ending by tr
   QVariantMap overviews;
@@ -2260,7 +2260,7 @@ void QgsPostgresRasterProvider::determinePrimaryKeyFromUriKeyColumn()
 }
 
 
-QString QgsPostgresRasterProvider::pkSql()
+QString QgsPostgresRasterProvider::pkSql() const
 {
   switch ( mPrimaryKeyType )
   {

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -60,7 +60,7 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
     virtual QgsRasterBandStats bandStatistics( int bandNo, int stats, const QgsRectangle &extent, int sampleSize, QgsRasterBlockFeedback *feedback ) override;
 
     // QgsRasterDataProvider interface
-    virtual QString htmlMetadata() override;
+    virtual QString htmlMetadata() const override;
     virtual QString lastErrorTitle() override;
     virtual QString lastError() override;
     int capabilities() const override;
@@ -223,7 +223,7 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
     /**
      * Returns the quoted SQL frament to retrieve the PK from the raster table
      */
-    QString pkSql();
+    QString pkSql() const;
 
     /**
      * Returns table comment

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
@@ -337,7 +337,7 @@ QString QgsVirtualRasterProvider::lastError()
   return QStringLiteral( "Not implemented" );
 }
 
-QString QgsVirtualRasterProvider::htmlMetadata()
+QString QgsVirtualRasterProvider::htmlMetadata() const
 {
   //only test
   return "Virtual Raster data provider";

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.h
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.h
@@ -58,7 +58,7 @@ class QgsVirtualRasterProvider : public QgsRasterDataProvider
     int ySize() const override;
 
     // QgsRasterDataProvider interface
-    virtual QString htmlMetadata() override;
+    virtual QString htmlMetadata() const override;
     virtual QString lastErrorTitle() override;
     virtual QString lastError() override;
     int capabilities() const override;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -122,7 +122,7 @@ QString QgsWcsCapabilities::prepareUri( QString uri )
   return uri;
 }
 
-QgsWcsCapabilitiesProperty QgsWcsCapabilities::capabilities()
+const QgsWcsCapabilitiesProperty &QgsWcsCapabilities::capabilities() const
 {
   return mCapabilities;
 }
@@ -1327,12 +1327,12 @@ QgsWcsCoverageSummary *QgsWcsCapabilities::coverageSummary( QString const &ident
   return nullptr;
 }
 
-QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverages()
+QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverages() const
 {
   return coverageSummaries();
 }
 
-QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverageSummaries( QgsWcsCoverageSummary *parent )
+QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverageSummaries( const QgsWcsCoverageSummary *parent ) const
 {
   QList<QgsWcsCoverageSummary> list;
   if ( !parent )
@@ -1340,7 +1340,7 @@ QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverageSummaries( QgsWcsCovera
     parent = &( mCapabilities.contents );
   }
 
-  for ( QVector<QgsWcsCoverageSummary>::iterator c = parent->coverageSummary.begin(); c != parent->coverageSummary.end(); ++c )
+  for ( QVector<QgsWcsCoverageSummary>::const_iterator c = parent->coverageSummary.constBegin(); c != parent->coverageSummary.constEnd(); ++c )
   {
     list.append( *c );
     list.append( coverageSummaries( c ) );

--- a/src/providers/wcs/qgswcscapabilities.h
+++ b/src/providers/wcs/qgswcscapabilities.h
@@ -132,7 +132,7 @@ class QgsWcsCapabilities : public QObject
 
     void setUri( QgsDataSourceUri const &uri );
 
-    QgsWcsCapabilitiesProperty capabilities();
+    const QgsWcsCapabilitiesProperty &capabilities() const;
 
     /**
      * \brief   Returns a list of the supported layers of the WCS server
@@ -153,7 +153,7 @@ class QgsWcsCapabilities : public QObject
     QgsWcsCoverageSummary coverage( QString const &identifier );
 
     //! Gets list of all coverage summaries
-    QList<QgsWcsCoverageSummary> coverages();
+    QList<QgsWcsCoverageSummary> coverages() const;
 
     /**
      * \brief Prepare the URI so that we can later simply append param=value
@@ -273,7 +273,7 @@ class QgsWcsCapabilities : public QObject
     QgsWcsCoverageSummary *coverageSummary( QString const &identifier, QgsWcsCoverageSummary *parent = nullptr );
 
     //! Get list of all sub coverages
-    QList<QgsWcsCoverageSummary> coverageSummaries( QgsWcsCoverageSummary *parent = nullptr );
+    QList<QgsWcsCoverageSummary> coverageSummaries( const QgsWcsCoverageSummary *parent = nullptr ) const;
 
     void initCoverageSummary( QgsWcsCoverageSummary &coverageSummary );
 

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1244,7 +1244,7 @@ int QgsWcsProvider::capabilities() const
   return capability;
 }
 
-QString QgsWcsProvider::coverageMetadata( const QgsWcsCoverageSummary &coverage )
+QString QgsWcsProvider::coverageMetadata( const QgsWcsCoverageSummary &coverage ) const
 {
   QString metadata;
 
@@ -1313,7 +1313,7 @@ QString QgsWcsProvider::coverageMetadata( const QgsWcsCoverageSummary &coverage 
   return metadata;
 }
 
-QString QgsWcsProvider::htmlMetadata()
+QString QgsWcsProvider::htmlMetadata() const
 {
   QString metadata;
   metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "WCS Info" ) + QStringLiteral( "</td><td><div>" );
@@ -1377,7 +1377,7 @@ QString QgsWcsProvider::htmlMetadata()
 
   // Dialog takes too long to open if there are too many coverages (1000 for example)
   int count = 0;
-  const auto constCoverages = mCapabilities.coverages();
+  const QList< QgsWcsCoverageSummary> constCoverages = mCapabilities.coverages();
   for ( const QgsWcsCoverageSummary &c : constCoverages )
   {
     metadata += coverageMetadata( c );

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -180,7 +180,7 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     int yBlockSize() const override;
     int xSize() const override;
     int ySize() const override;
-    QString htmlMetadata() override;
+    QString htmlMetadata() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, Qgis::RasterIdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;
@@ -235,7 +235,7 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
      */
     QString prepareUri( QString uri ) const;
 
-    QString coverageMetadata( const QgsWcsCoverageSummary &c );
+    QString coverageMetadata( const QgsWcsCoverageSummary &c ) const;
 
     //! remove query item and replace it with a new value
     void setQueryItem( QUrl &url, const QString &key, const QString &value ) const;
@@ -244,10 +244,10 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     void clearCache() const;
 
     //! Create html cell (used by metadata)
-    QString htmlCell( const QString &text );
+    static QString htmlCell( const QString &text );
 
     //! Create html row with 2 cells (used by metadata)
-    QString htmlRow( const QString &text1, const QString &text2 );
+    static QString htmlRow( const QString &text1, const QString &text2 );
 
     //! Data source URI of the WCS for this layer
     QString mHttpUri;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2366,7 +2366,7 @@ int QgsWmsProvider::capabilities() const
   return capability;
 }
 
-QString QgsWmsProvider::layerMetadata( QgsWmsLayerProperty &layer )
+QString QgsWmsProvider::layerMetadata( const QgsWmsLayerProperty &layer ) const
 {
   QString metadata =
     // Layer Properties section
@@ -2590,7 +2590,7 @@ QString QgsWmsProvider::layerMetadata( QgsWmsLayerProperty &layer )
   return metadata;
 }
 
-QString QgsWmsProvider::htmlMetadata()
+QString QgsWmsProvider::htmlMetadata() const
 {
   QString metadata;
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -297,7 +297,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
     Qgis::DataType dataType( int bandNo ) const override;
     Qgis::DataType sourceDataType( int bandNo ) const override;
     int bandCount() const override;
-    QString htmlMetadata() override;
+    QString htmlMetadata() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, Qgis::RasterIdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
@@ -488,7 +488,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
 
     //QStringList identifyAs( const QgsPointXY &point, QString format );
 
-    QString layerMetadata( QgsWmsLayerProperty &layer );
+    QString layerMetadata( const QgsWmsLayerProperty &layer ) const;
 
     //! remove query item and replace it with a new value
     void setQueryItem( QUrlQuery &url, const QString &key, const QString &value );


### PR DESCRIPTION
Allows all layer types (including vector, mesh and point cloud) providers to show custom metadata in the layer properties dialog. Previously this was limited to raster/vector tile and tiled scene layers only.

Also fix const for a lot of raster providers as a consequence.
