### PR TITLE
If password keychain helper is enabled, always sync password stored in keychain when password is changed

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -754,6 +754,14 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
     emit messageLog( tr( err ), authManTag(), Qgis::MessageLevel::Warning );
   }
 
+  if ( passwordHelperEnabled() && !passwordHelperSync() )
+  {
+    ok = false;
+    const QString err = tr( "Master password reset FAILED: could not sync password helper: %1" ).arg( passwordHelperErrorMessage() );
+    QgsDebugError( err );
+    emit messageLog( err, authManTag(), Qgis::MessageLevel::Warning );
+  }
+
   // something went wrong, reinstate previous password and database
   if ( !ok )
   {
@@ -773,7 +781,6 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
 
     return false;
   }
-
 
   if ( !keepbackup && !QFile::remove( dbbackup ) )
   {

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -754,7 +754,7 @@ bool QgsAuthManager::resetMasterPassword( const QString &newpass, const QString 
     emit messageLog( tr( err ), authManTag(), Qgis::MessageLevel::Warning );
   }
 
-  if ( passwordHelperEnabled() && !passwordHelperSync() )
+  if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) != QStringLiteral( "true" ) && passwordHelperEnabled() && !passwordHelperSync() )
   {
     ok = false;
     const QString err = tr( "Master password reset FAILED: could not sync password helper: %1" ).arg( passwordHelperErrorMessage() );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -440,7 +440,7 @@ bool QgsAuthManager::createAndStoreRandomMasterPasswordInKeyChain()
   }
   else
   {
-    emit passwordHelperMessageLog( tr( "Master password could not be written to your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
+    emit passwordHelperMessageLog( tr( "Master password could not be written to the %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
   }
 
@@ -1518,7 +1518,7 @@ bool QgsAuthManager::backupAuthenticationDatabase( QString *backuppath )
 
   if ( sqliteDatabasePath().isEmpty() )
   {
-    const char *err = QT_TR_NOOP( "The authentication database is not filesystem-based" );
+    const char *err = QT_TR_NOOP( "The authentication storage is not filesystem-based" );
     QgsDebugError( err );
     emit messageLog( tr( err ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
@@ -1526,7 +1526,7 @@ bool QgsAuthManager::backupAuthenticationDatabase( QString *backuppath )
 
   if ( !QFile::exists( sqliteDatabasePath() ) )
   {
-    const char *err = QT_TR_NOOP( "No authentication database found" );
+    const char *err = QT_TR_NOOP( "No authentication database file found" );
     QgsDebugError( err );
     emit messageLog( tr( err ), authManTag(), Qgis::MessageLevel::Warning );
     return false;
@@ -3368,7 +3368,7 @@ QString QgsAuthManager::passwordHelperRead()
   if ( job.error() )
   {
     mPasswordHelperErrorCode = job.error();
-    mPasswordHelperErrorMessage = tr( "Retrieving password from your %1 failed: %2." ).arg( passwordHelperDisplayName(), job.errorString() );
+    mPasswordHelperErrorMessage = tr( "Retrieving password from the %1 failed: %2." ).arg( passwordHelperDisplayName(), job.errorString() );
     // Signals used in the tests to exit main application loop
     emit passwordHelperFailure();
   }
@@ -3379,7 +3379,7 @@ QString QgsAuthManager::passwordHelperRead()
     if ( password.isEmpty() )
     {
       mPasswordHelperErrorCode = QKeychain::EntryNotFound;
-      mPasswordHelperErrorMessage = tr( "Empty password retrieved from your %1." ).arg( passwordHelperDisplayName( true ) );
+      mPasswordHelperErrorMessage = tr( "Empty password retrieved from the %1." ).arg( passwordHelperDisplayName( true ) );
       // Signals used in the tests to exit main application loop
       emit passwordHelperFailure();
     }
@@ -3413,7 +3413,7 @@ bool QgsAuthManager::passwordHelperWrite( const QString &password )
   if ( job.error() )
   {
     mPasswordHelperErrorCode = job.error();
-    mPasswordHelperErrorMessage = tr( "Storing password in your %1 failed: %2." ).arg( passwordHelperDisplayName(), job.errorString() );
+    mPasswordHelperErrorMessage = tr( "Storing password in the %1 failed: %2." ).arg( passwordHelperDisplayName(), job.errorString() );
     // Signals used in the tests to exit main application loop
     emit passwordHelperFailure();
     result = false;
@@ -3478,7 +3478,7 @@ void QgsAuthManager::passwordHelperProcessError()
     // we also want to disable the wallet system to prevent annoying
     // notification on each subsequent access.
     setPasswordHelperEnabled( false );
-    mPasswordHelperErrorMessage = tr( "There was an error and integration with your %1 system has been disabled. "
+    mPasswordHelperErrorMessage = tr( "There was an error and integration with your %1 has been disabled. "
                                       "You can re-enable it at any time through the \"Utilities\" menu "
                                       "in the Authentication pane of the options dialog. %2" )
                                   .arg( passwordHelperDisplayName(), mPasswordHelperErrorMessage );
@@ -3518,7 +3518,7 @@ bool QgsAuthManager::masterPasswordInput()
       }
       else
       {
-        emit passwordHelperMessageLog( tr( "Master password stored in your %1 is not valid" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
+        emit passwordHelperMessageLog( tr( "Master password stored in the %1 is not valid" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
       }
     }
   }
@@ -3536,7 +3536,7 @@ bool QgsAuthManager::masterPasswordInput()
     {
       if ( !passwordHelperWrite( pass ) )
       {
-        emit passwordHelperMessageLog( tr( "Master password could not be written to your %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
+        emit passwordHelperMessageLog( tr( "Master password could not be written to the %1" ).arg( passwordHelperDisplayName() ), authManTag(), Qgis::MessageLevel::Warning );
       }
     }
     return true;

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -201,7 +201,7 @@ class CORE_EXPORT QgsExpressionUtils
       return v.userType() == QMetaType::Type::QVariantList || v.userType() == QMetaType::Type::QStringList;
     }
 
-// implicit conversion to string
+    // implicit conversion to string
     static QString getStringValue( const QVariant &value, QgsExpression * )
     {
       return value.toString();

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -430,7 +430,7 @@ void QgsAuthAuthoritiesEditor::btnAddCa_clicked()
     const QList<QSslCertificate> &certs( dlg->certificatesToImport() );
     if ( !QgsApplication::authManager()->storeCertAuthorities( certs ) )
     {
-      messageBar()->pushMessage( tr( "ERROR storing CA(s) in authentication database" ), Qgis::MessageLevel::Critical );
+      messageBar()->pushMessage( tr( "ERROR storing CA(s) in authentication storage" ), Qgis::MessageLevel::Critical );
     }
 
     QgsApplication::authManager()->rebuildCaCertsCache();
@@ -501,19 +501,19 @@ void QgsAuthAuthoritiesEditor::btnRemoveCa_clicked()
 
   if ( cert.isNull() )
   {
-    messageBar()->pushMessage( tr( "Certificate could not be found in database for id %1:" ).arg( digest ), Qgis::MessageLevel::Warning );
+    messageBar()->pushMessage( tr( "Certificate could not be found in the authentication storage for id %1:" ).arg( digest ), Qgis::MessageLevel::Warning );
     return;
   }
 
   if ( !QgsApplication::authManager()->removeCertAuthority( cert ) )
   {
-    messageBar()->pushMessage( tr( "ERROR removing CA from authentication database for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
+    messageBar()->pushMessage( tr( "ERROR removing CA from the authentication storage for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
     return;
   }
 
   if ( !QgsApplication::authManager()->removeCertTrustPolicy( cert ) )
   {
-    messageBar()->pushMessage( tr( "ERROR removing cert trust policy from authentication database for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
+    messageBar()->pushMessage( tr( "ERROR removing cert trust policy from the authentication storage for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
     return;
   }
 
@@ -646,11 +646,11 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
 
     if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafile" ), QVariant( fn ) ) )
     {
-      logMessage( QObject::tr( "Could not store 'CA file path' in authentication database." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
+      logMessage( QObject::tr( "Could not store 'CA file path' in authentication storage." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
     }
     if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafileallowinvalid" ), QVariant( dlg->allowInvalidCerts() ) ) )
     {
-      logMessage( QObject::tr( "Could not store 'CA file allow invalids' setting in authentication database." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
+      logMessage( QObject::tr( "Could not store 'CA file allow invalids' setting in authentication storage." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
     }
 
     QgsApplication::authManager()->rebuildCaCertsCache();
@@ -682,12 +682,12 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
 {
   if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafile" ) ) )
   {
-    logMessage( QObject::tr( "Could not remove 'CA file path' from authentication database." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
+    logMessage( QObject::tr( "Could not remove 'CA file path' from authentication storage." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
     return;
   }
   if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafileallowinvalid" ) ) )
   {
-    logMessage( QObject::tr( "Could not remove 'CA file allow invalids' setting from authentication database." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
+    logMessage( QObject::tr( "Could not remove 'CA file allow invalids' setting from authentication storage." ), QObject::tr( "Authorities Manager" ), Qgis::MessageLevel::Warning );
     return;
   }
 
@@ -702,7 +702,7 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
     {
       if ( !QgsApplication::authManager()->removeCertTrustPolicies( certs ) )
       {
-        messageBar()->pushMessage( tr( "ERROR removing cert(s) trust policy from authentication database." ), Qgis::MessageLevel::Critical );
+        messageBar()->pushMessage( tr( "ERROR removing cert(s) trust policy from authentication storage." ), Qgis::MessageLevel::Critical );
         return;
       }
       QgsApplication::authManager()->rebuildCertTrustCache();

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -164,7 +164,6 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mActionAutoClearAccessCache->setCheckable( true );
   mActionAutoClearAccessCache->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), true, QgsSettings::Section::Auth ).toBool() );
 
-  mActionPasswordHelperSync = new QAction( tr( "Store/update the Master Password in your %1" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
   mActionPasswordHelperDelete = new QAction( tr( "Clear the Master Password from your %1…" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
   mActionPasswordHelperEnable = new QAction( tr( "Integrate Master Password with your %1" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
   mActionPasswordHelperLoggingEnable = new QAction( tr( "Enable Password Helper Debug Log" ), this );
@@ -195,7 +194,6 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   connect( mActionClearCachedMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::clearCachedMasterPassword );
   connect( mActionClearCachedAuthConfigs, &QAction::triggered, this, &QgsAuthEditorWidgets::clearCachedAuthenticationConfigs );
 
-  connect( mActionPasswordHelperSync, &QAction::triggered, this, &QgsAuthEditorWidgets::passwordHelperSync );
   connect( mActionPasswordHelperDelete, &QAction::triggered, this, &QgsAuthEditorWidgets::passwordHelperDelete );
   connect( mActionPasswordHelperEnable, &QAction::triggered, this, &QgsAuthEditorWidgets::passwordHelperEnableTriggered );
   connect( mActionPasswordHelperLoggingEnable, &QAction::triggered, this, &QgsAuthEditorWidgets::passwordHelperLoggingEnableTriggered );
@@ -218,7 +216,6 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mAuthUtilitiesMenu->addAction( mActionAutoClearAccessCache );
   mAuthUtilitiesMenu->addSeparator();
   mAuthUtilitiesMenu->addAction( mActionPasswordHelperEnable );
-  mAuthUtilitiesMenu->addAction( mActionPasswordHelperSync );
   mAuthUtilitiesMenu->addAction( mActionPasswordHelperDelete );
   mAuthUtilitiesMenu->addAction( mActionPasswordHelperLoggingEnable );
   mAuthUtilitiesMenu->addSeparator();
@@ -285,11 +282,6 @@ void QgsAuthEditorWidgets::authMessageLog( const QString &message, const QString
 void QgsAuthEditorWidgets::passwordHelperDelete()
 {
   QgsAuthGuiUtils::passwordHelperDelete( messageBar(), this );
-}
-
-void QgsAuthEditorWidgets::passwordHelperSync()
-{
-  QgsAuthGuiUtils::passwordHelperSync( messageBar() );
 }
 
 void QgsAuthEditorWidgets::passwordHelperEnableTriggered()

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -164,8 +164,8 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mActionAutoClearAccessCache->setCheckable( true );
   mActionAutoClearAccessCache->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), true, QgsSettings::Section::Auth ).toBool() );
 
-  mActionPasswordHelperDelete = new QAction( tr( "Clear the Master Password from your %1…" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
-  mActionPasswordHelperEnable = new QAction( tr( "Integrate Master Password with your %1" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
+  mActionPasswordHelperDelete = new QAction( tr( "Clear the Master Password from the %1…" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
+  mActionPasswordHelperEnable = new QAction( tr( "Integrate Master Password with the %1" ).arg( QgsAuthManager::passwordHelperDisplayName( true ) ), this );
   mActionPasswordHelperLoggingEnable = new QAction( tr( "Enable Password Helper Debug Log" ), this );
 
   mActionPasswordHelperEnable->setCheckable( true );

--- a/src/gui/auth/qgsautheditorwidgets.h
+++ b/src/gui/auth/qgsautheditorwidgets.h
@@ -98,9 +98,6 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     //! Remove master password from wallet
     void passwordHelperDelete();
 
-    //! Store master password into the wallet
-    void passwordHelperSync();
-
     //! Toggle password helper (enable/disable)
     void passwordHelperEnableTriggered();
 
@@ -122,7 +119,6 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     QAction *mActionRemoveAuthConfigs = nullptr;
     QAction *mActionEraseAuthDatabase = nullptr;
     QAction *mActionPasswordHelperDelete = nullptr;
-    QAction *mActionPasswordHelperSync = nullptr;
     QAction *mActionPasswordHelperEnable = nullptr;
     QAction *mActionPasswordHelperLoggingEnable = nullptr;
     QAction *mActionClearAccessCacheNow = nullptr;

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -353,32 +353,6 @@ void QgsAuthGuiUtils::passwordHelperDelete( QgsMessageBar *msgbar, QWidget *pare
   msgbar->pushMessage( QObject::tr( "Password helper delete" ), msg, level );
 }
 
-void QgsAuthGuiUtils::passwordHelperSync( QgsMessageBar *msgbar )
-{
-  QString msg;
-  Qgis::MessageLevel level;
-  if ( !QgsApplication::authManager()->masterPasswordIsSet() )
-  {
-    msg = QObject::tr( "Master password is not set and cannot be stored in your %1." )
-            .arg( QgsAuthManager::passwordHelperDisplayName() );
-    level = Qgis::MessageLevel::Warning;
-  }
-  else if ( !QgsApplication::authManager()->passwordHelperSync() )
-  {
-    msg = QgsApplication::authManager()->passwordHelperErrorMessage();
-    level = Qgis::MessageLevel::Warning;
-  }
-  else
-  {
-    msg = QObject::tr( "Master password has been successfully stored in your %1." )
-            .arg( QgsAuthManager::passwordHelperDisplayName() );
-
-    level = Qgis::MessageLevel::Info;
-  }
-  msgbar->clearWidgets();
-  msgbar->pushMessage( QObject::tr( "Password helper write" ), msg, level );
-}
-
 void QgsAuthGuiUtils::passwordHelperEnable( bool enabled, QgsMessageBar *msgbar )
 {
   QgsApplication::authManager()->setPasswordHelperEnabled( enabled );

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -331,7 +331,7 @@ QString QgsAuthGuiUtils::getOpenFileName( QWidget *parent, const QString &title,
 
 void QgsAuthGuiUtils::passwordHelperDelete( QgsMessageBar *msgbar, QWidget *parent )
 {
-  if ( QMessageBox::warning( parent, QObject::tr( "Delete Password" ), QObject::tr( "Do you really want to delete the master password from your %1?" ).arg( QgsAuthManager::passwordHelperDisplayName() ), QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Cancel )
+  if ( QMessageBox::warning( parent, QObject::tr( "Delete Password" ), QObject::tr( "Do you really want to delete the master password from the %1?" ).arg( QgsAuthManager::passwordHelperDisplayName() ), QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;
   }
@@ -344,7 +344,7 @@ void QgsAuthGuiUtils::passwordHelperDelete( QgsMessageBar *msgbar, QWidget *pare
   }
   else
   {
-    msg = QObject::tr( "Master password was successfully deleted from your %1" )
+    msg = QObject::tr( "Master password was successfully deleted from the %1" )
             .arg( QgsAuthManager::passwordHelperDisplayName() );
 
     level = Qgis::MessageLevel::Info;

--- a/src/gui/auth/qgsauthguiutils.h
+++ b/src/gui/auth/qgsauthguiutils.h
@@ -99,9 +99,6 @@ class GUI_EXPORT QgsAuthGuiUtils
     //! Remove master password from wallet
     static void passwordHelperDelete( QgsMessageBar *msgbar, QWidget *parent = nullptr );
 
-    //! Store master password into the wallet
-    static void passwordHelperSync( QgsMessageBar *msgbar );
-
     //! Sets password helper enabled (enable/disable)
     static void passwordHelperEnable( bool enabled, QgsMessageBar *msgbar );
 

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -278,7 +278,7 @@ void QgsAuthIdentitiesEditor::btnAddIdentity_clicked()
       const QPair<QSslCertificate, QSslKey> &bundle( dlg->certBundleToImport() );
       if ( !QgsApplication::authManager()->storeCertIdentity( bundle.first, bundle.second ) )
       {
-        messageBar()->pushMessage( tr( "ERROR storing identity bundle in authentication database." ), Qgis::MessageLevel::Critical );
+        messageBar()->pushMessage( tr( "ERROR storing identity bundle in authentication storage." ), Qgis::MessageLevel::Critical );
       }
       populateIdentitiesView();
       mRootCertIdentItem->setExpanded( true );
@@ -326,7 +326,7 @@ void QgsAuthIdentitiesEditor::btnRemoveIdentity_clicked()
 
   if ( !QgsApplication::authManager()->removeCertIdentity( digest ) )
   {
-    messageBar()->pushMessage( tr( "ERROR removing cert identity from authentication database for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
+    messageBar()->pushMessage( tr( "ERROR removing cert identity from authentication storage for id %1:" ).arg( digest ), Qgis::MessageLevel::Critical );
     return;
   }
 

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -51,7 +51,7 @@ QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
   QString warning = tr( "Your authentication database will be duplicated and re-encrypted using the new password." );
   if ( QgsApplication::authManager()->passwordHelperEnabled() )
   {
-    warning += QStringLiteral( "<p><b>%1</b></p>" ).arg( tr( "Your new password will automatically be stored in the system %1." ).arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME ) );
+    warning += QStringLiteral( "<p><b>%1</b></p>" ).arg( tr( "Your new password will automatically be stored in the system %1." ).arg( QgsAuthManager::passwordHelperDisplayName() ) );
   }
 
   lblWarning->setText( warning );

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -48,10 +48,10 @@ QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
     }
   }
 
-  QString warning = tr( "Your authentication database will be duplicated and re-encrypted using the new password." );
+  QString warning = tr( "The authentication store will be re-encrypted using the new password." );
   if ( QgsApplication::authManager()->passwordHelperEnabled() )
   {
-    warning += QStringLiteral( "<p><b>%1</b></p>" ).arg( tr( "Your new password will automatically be stored in the system %1." ).arg( QgsAuthManager::passwordHelperDisplayName() ) );
+    warning += QStringLiteral( "<p><b>%1</b></p>" ).arg( tr( "The new password will automatically be stored in the system %1." ).arg( QgsAuthManager::passwordHelperDisplayName() ) );
   }
 
   lblWarning->setText( warning );

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -22,7 +22,6 @@
 
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
-#include "qgslogger.h"
 #include "qgsapplication.h"
 
 
@@ -48,6 +47,14 @@ QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
       chkKeepBackup->hide();
     }
   }
+
+  QString warning = tr( "Your authentication database will be duplicated and re-encrypted using the new password." );
+  if ( QgsApplication::authManager()->passwordHelperEnabled() )
+  {
+    warning += QStringLiteral( "<p><b>%1</b></p>" ).arg( tr( "Your new password will automatically be stored in the system %1." ).arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME ) );
+  }
+
+  lblWarning->setText( warning );
 }
 
 bool QgsMasterPasswordResetDialog::requestMasterPasswordReset( QString *newpass, QString *oldpass, bool *keepbackup )

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -303,7 +303,7 @@ void QgsAuthServersEditor::btnRemoveServer_clicked()
 
   if ( !QgsApplication::authManager()->removeSslCertCustomConfig( digest, hostport ) )
   {
-    messageBar()->pushMessage( tr( "ERROR removing SSL custom config from authentication database for host:port, id %1:" ).arg( hostport, digest ), Qgis::MessageLevel::Critical );
+    messageBar()->pushMessage( tr( "ERROR removing SSL custom config from authentication storage for host:port, id %1:" ).arg( hostport, digest ), Qgis::MessageLevel::Critical );
     return;
   }
 

--- a/src/gui/auth/qgsauthsslconfigwidget.cpp
+++ b/src/gui/auth/qgsauthsslconfigwidget.cpp
@@ -294,7 +294,7 @@ void QgsAuthSslConfigWidget::saveSslCertConfig()
   }
   if ( !QgsApplication::authManager()->storeSslCertCustomConfig( sslCustomConfig() ) )
   {
-    QgsDebugError( QStringLiteral( "SSL custom config FAILED to store in authentication database" ) );
+    QgsDebugError( QStringLiteral( "SSL custom config FAILED to store in authentication storage" ) );
   }
 }
 

--- a/src/ui/auth/qgsauthauthoritieseditor.ui
+++ b/src/ui/auth/qgsauthauthoritieseditor.ui
@@ -107,7 +107,7 @@
        <item>
         <widget class="QToolButton" name="btnAddCa">
          <property name="toolTip">
-          <string>Import certificate(s) to authentication database</string>
+          <string>Import certificate(s) to authentication storage</string>
          </property>
          <property name="text">
           <string/>
@@ -121,7 +121,7 @@
        <item>
         <widget class="QToolButton" name="btnRemoveCa">
          <property name="toolTip">
-          <string>Remove certificate from authentication database</string>
+          <string>Remove certificate from authentication storage</string>
          </property>
          <property name="text">
           <string/>

--- a/src/ui/auth/qgsauthcertificatemanager.ui
+++ b/src/ui/auth/qgsauthcertificatemanager.ui
@@ -92,7 +92,7 @@
       <string notr="true">color: rgb(128, 128, 128);</string>
      </property>
      <property name="text">
-      <string>Note: Editing writes directly to authentication database</string>
+      <string>Note: Editing writes directly to authentication storage</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/ui/auth/qgsauthconfigedit.ui
+++ b/src/ui/auth/qgsauthconfigedit.ui
@@ -59,7 +59,7 @@
       <string notr="true">color: rgb(128, 128, 128);</string>
      </property>
      <property name="text">
-      <string>Note: Saving writes directly to authentication database</string>
+      <string>Note: Saving writes directly to authentication storage</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/ui/auth/qgsauthconfiguriedit.ui
+++ b/src/ui/auth/qgsauthconfiguriedit.ui
@@ -62,7 +62,7 @@
          <string notr="true">color: rgb(128, 128, 128);</string>
         </property>
         <property name="text">
-         <string>Note: Button actions above affect authentication database</string>
+         <string>Note: Button actions above affect authentication storage</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/src/ui/auth/qgsautheditorwidgets.ui
+++ b/src/ui/auth/qgsautheditorwidgets.ui
@@ -145,7 +145,7 @@
       <string notr="true">QLabel {color: rgb(128, 128, 128);}</string>
      </property>
      <property name="text">
-      <string>Note: Editing writes directly to authentication database</string>
+      <string>Note: Editing writes directly to authentication storage</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/ui/auth/qgsauthidentitieseditor.ui
+++ b/src/ui/auth/qgsauthidentitieseditor.ui
@@ -55,7 +55,7 @@
        <item>
         <widget class="QToolButton" name="btnAddIdentity">
          <property name="toolTip">
-          <string>Import identity bundle to authentication database</string>
+          <string>Import identity bundle to authentication storage</string>
          </property>
          <property name="text">
           <string/>
@@ -69,7 +69,7 @@
        <item>
         <widget class="QToolButton" name="btnRemoveIdentity">
          <property name="toolTip">
-          <string>Remove identity bundle from authentication database</string>
+          <string>Remove identity bundle from authentication storage</string>
          </property>
          <property name="text">
           <string/>

--- a/src/ui/auth/qgsauthmasterpassresetdialog.ui
+++ b/src/ui/auth/qgsauthmasterpassresetdialog.ui
@@ -91,18 +91,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <italic>true</italic>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { color: rgb(128, 128, 128); }</string>
-     </property>
+    <widget class="QLabel" name="lblWarning">
      <property name="text">
-      <string>Your authentication database will be duplicated
-and re-encrypted using new password</string>
+      <string/>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -101,7 +101,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Configurations store encrypted credentials in the QGIS authentication database.</string>
+          <string>Configurations store encrypted credentials in the QGIS authentication storage.</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>


### PR DESCRIPTION
This used to be a separate menu action that the user had to remember to run. Let's err on the side of being helpful and assume that if the user is storing the password in their keychain, then they want that stored password always to be the correct one.
