### PR TITLE
A couple of fixes for QGIS to build against Qt >= 6.6

### DIFF
--- a/src/auth/awss3/core/qgsauthawss3method.cpp
+++ b/src/auth/awss3/core/qgsauthawss3method.cpp
@@ -118,7 +118,7 @@ bool QgsAuthAwsS3Method::updateNetworkRequest( QNetworkRequest &request, const Q
   const QByteArray signingKey = QMessageAuthenticationCode::hash( "aws4_request",
                                 QMessageAuthenticationCode::hash( "s3",
                                     QMessageAuthenticationCode::hash( region,
-                                        QMessageAuthenticationCode::hash( date, "AWS4" + password,
+                                        QMessageAuthenticationCode::hash( date, QByteArray( "AWS4" + password ),
                                             QCryptographicHash::Sha256 ),
                                         QCryptographicHash::Sha256 ),
                                     QCryptographicHash::Sha256 ),

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -1312,12 +1312,12 @@ QgsWcsCoverageSummary *QgsWcsCapabilities::coverageSummary( QString const &ident
   {
     if ( c->identifier == identifier )
     {
-      return c;
+      return &( *c );
     }
     else
     {
       // search sub coverages
-      QgsWcsCoverageSummary *subCoverage = coverageSummary( identifier, c );
+      QgsWcsCoverageSummary *subCoverage = coverageSummary( identifier, &( *c ) );
       if ( subCoverage )
       {
         return subCoverage;
@@ -1343,7 +1343,7 @@ QList<QgsWcsCoverageSummary> QgsWcsCapabilities::coverageSummaries( const QgsWcs
   for ( QVector<QgsWcsCoverageSummary>::const_iterator c = parent->coverageSummary.constBegin(); c != parent->coverageSummary.constEnd(); ++c )
   {
     list.append( *c );
-    list.append( coverageSummaries( c ) );
+    list.append( coverageSummaries( &( *c ) ) );
   }
   return list;
 }

--- a/src/providers/wfs/qgscachedirectorymanager.h
+++ b/src/providers/wfs/qgscachedirectorymanager.h
@@ -19,7 +19,10 @@
 #include <QString>
 #include <QThread>
 #include <QMutex>
+
+#if not defined( Q_OS_ANDROID )
 #include <QSharedMemory>
+#endif
 
 #include <map>
 #include <memory>
@@ -56,8 +59,10 @@ class QgsCacheDirectoryManager
     //! Called by constructor
     void init();
 
+#if not defined( Q_OS_ANDROID )
     //! Create a shared memory segment for the keep-alive mechanism
     std::unique_ptr<QSharedMemory> createAndAttachSHM();
+#endif
 
     //! Returns the name of temporary directory.
     QString getCacheDirectory( bool createIfNotExisting );
@@ -68,6 +73,7 @@ class QgsCacheDirectoryManager
     static bool removeDir( const QString &dirName );
 };
 
+#if not defined( Q_OS_ANDROID )
 //! For internal use of QgsCacheDirectoryManager
 class QgsCacheDirectoryManagerKeepAlive: public QThread
 {
@@ -82,5 +88,6 @@ class QgsCacheDirectoryManagerKeepAlive: public QThread
   private:
     std::unique_ptr<QSharedMemory> mSharedMemory;
 };
+#endif
 
 #endif // QGSCACHEDIRECTORYMANAGER_H


### PR DESCRIPTION
## Description

ATM, QGIS won't build against Qt 6.6; this PR fixes the tiny issues across the code.

Re the authentication fix, Qt 6.6's QMessageAuthenticationCode::hash [documentation](https://doc.qt.io/qt-6/qmessageauthenticationcode.html#hash) says:

> Note: In Qt versions prior to 6.6, this function took its arguments as QByteArray, not QByteArrayView. If you experience compile errors, it's because your code is passing objects that are implicitly convertible to QByteArray, but not QByteArrayView. Wrap the corresponding argument in QByteArray{~~~} to make the cast explicit. This is backwards-compatible with old Qt versions.

Re the WCS fix, it's a miracle the code ever compiled! :wink: whatever dark voodoo casting (from a QList<obj> iterator to a *obj pointer) was happening here, Qt 6.6 doesn't tolerate it anymore.

Re the WFS fix, Qt 6.6 removed the non-functional dummy implementation of QSharedMemory on Android (see https://bugreports.qt.io/browse/QTBUG-114222). The fix merely insures we're not using a class that was not functional to begin with on Android.