### PR TITLE
Fix opening settings dialog breaks oauth and ssl handling for the rest of the session

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -651,9 +651,11 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
   else
   {
 #ifndef QT_NO_SSL
-    setSslErrorHandler( std::make_unique< QgsSslErrorHandler >() );
+    if ( !mSslErrorHandler )
+      setSslErrorHandler( std::make_unique< QgsSslErrorHandler >() );
 #endif
-    setAuthHandler( std::make_unique< QgsNetworkAuthenticationHandler>() );
+    if ( !mAuthHandler )
+      setAuthHandler( std::make_unique< QgsNetworkAuthenticationHandler>() );
   }
 #ifndef QT_NO_SSL
   connect( this, &QgsNetworkAccessManager::sslErrorsOccurred, sMainNAM, &QgsNetworkAccessManager::handleSslErrors );

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -878,6 +878,8 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     std::unique_ptr< QgsNetworkAuthenticationHandler > mAuthHandler;
     // Used by worker threads to wait for authentication handler run in main thread
     QSemaphore mAuthRequestHandlerSemaphore;
+
+    friend class TestQgsNetworkAccessManager;
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H


### PR DESCRIPTION
Pretty bad bug... when you accept the settings dialog, QgsNetworkAccessManager::setupDefaultProxyAndCache is called to handle proxy and cache updates. This method however was also resetting the manager's ssl error handler and auth handler to default no-op handlers, overridding the app specific handlers which had been setup already.

The consequence is that after accepting the options dialog, oauth authentication and SSL error handling will be broken for the rest of the session...
