### PR TITLE
[themes] Fix Night Mapping making it unjustifiably hard to identify buttons in a UI

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -260,7 +260,7 @@ QPushButton
     border-color: @itembackground;
     border-style: solid;
     border-radius: 0px;
-    background-color:@background;
+    background-color:@darkgradient;
     color:@text;
 }
 
@@ -339,7 +339,11 @@ QToolBar QToolButton, QToolButton::menu-button
     background-color: none;
 }
 
-QPushButton:hover, QToolButton:hover {
+QPushButton:hover {
+    background-color: @darkgradient;
+}
+
+QToolButton:hover {
     background-color: @itemdarkbackground;
 }
 


### PR DESCRIPTION
## Description

Earlier today, for a brief moment, I couldn't spot the [  Renderer Settings...  ] button. Let's not make it unjustifiably hard to spot buttons in our UI :)

Before:
![Screenshot from 2023-11-10 17-22-24](https://github.com/qgis/QGIS/assets/1728657/26440f4a-603e-43ba-bc4a-ec55c0568c9c)

PR:
![Screenshot from 2023-11-10 17-22-02](https://github.com/qgis/QGIS/assets/1728657/67ce7183-aba4-4e3e-bd43-3265275f5da7)
