### PR TITLE
Don't search for qwt-polar with Qwt>=6.2

### DIFF
--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -84,9 +84,6 @@ jobs:
             -DWITH_PDAL=OFF \
             -DWITH_CUSTOM_WIDGETS=ON \
             -DWITH_QWTPOLAR=ON \
-            -DQWTPOLAR_LIBRARY=${MINGW_PREFIX}/lib/libqwt-qt5.dll.a \
-            -DQWTPOLAR_INCLUDE_DIR=${MINGW_PREFIX}/include/qwt-qt5 \
-            -DWITH_INTERNAL_QWTPOLAR=OFF \
             -DWITH_BINDINGS=OFF \
             -DWITH_GRASS=OFF \
             -DWITH_DRACO=OFF \

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -384,11 +384,17 @@ endif()
 find_package(${QT_VERSION_BASE} COMPONENTS UiTools REQUIRED)
 
 set (WITH_QWTPOLAR FALSE CACHE BOOL "Determines whether QwtPolar is available or whether functionality requiring QwtPolar should be disabled.")
-
-if (WITH_QWTPOLAR)
+# Once we bump the minimum QWT VERSION to 6.2 or newer, we should get rid of WITH_QWTPOLAR
+if(Qwt_VERSION_STRING VERSION_GREATER_EQUAL 6.2 OR WITH_QWTPOLAR)
   add_definitions(-DWITH_QWTPOLAR)
-  # Try to find QwtPolar on the system
-  find_package(QwtPolar)
+
+  if(Qwt_VERSION_STRING VERSION_LESS 6.2)
+    find_package(QwtPolar REQUIRED)
+  else()
+    set(FOUND_QwtPolar TRUE)
+    set(QWTPOLAR_LIBRARY ${QWT_LIBRARY})
+    set(QWTPOLAR_INCLUDE_DIR ${QWT_INCLUDE_DIR})
+  endif()
   # If not found on the system, offer the possibility to build QwtPolar
   # internally
   if(NOT FOUND_QwtPolar)


### PR DESCRIPTION
## Description

CMake fails to find qwtpolar with Qwt>=6.2.0 because It was merged to Qwt.
Don't search for qwt-polar with Qwt>=6.2.