### PR TITLE
[ui][themes] Make attribute form constraints background coloring compatible with dark themes

### DIFF
--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -120,11 +120,11 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
         break;
 
       case ConstraintResultFailHard:
-        widget()->setStyleSheet( QStringLiteral( "background-color: #FFE0B2;" ) );
+        widget()->setStyleSheet( QStringLiteral( "background-color: rgba(255, 150, 0, 0.3);" ) );
         break;
 
       case ConstraintResultFailSoft:
-        widget()->setStyleSheet( QStringLiteral( "background-color: #FFECB3;" ) );
+        widget()->setStyleSheet( QStringLiteral( "background-color: rgba(255, 200, 45, 0.3);" ) );
         break;
     }
   }


### PR DESCRIPTION
## Description

Before (left) vs. PR (right:
![ba](https://github.com/qgis/QGIS/assets/1728657/5aa9b10e-5b2a-44b7-8498-8744219a9b3c)

It's always preferable to use semi-opaque colors to taint a background instead of a fully opaque color, the latter is not flexible across various light/dark themes.