### PR TITLE
Add simple-as-possible example to geometries_to_array expr function

### DIFF
--- a/resources/function_help/json/geometries_to_array
+++ b/resources/function_help/json/geometries_to_array
@@ -7,7 +7,8 @@
     "arg": "geometry",
      "description": "the input geometry"
   }],
-  "examples": [{ "expression":"geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))", "returns":"an array of a polygon and a line geometries"},
+  "examples": [{ "expression":"geometries_to_array(geom_from_wkt('MultiPoint (1 2, 5 21)'))", "returns":"An array containing 'Point (1 2)' and 'Point (5 21)'"},
+               { "expression":"geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))", "returns":"an array of a polygon and a line geometries"},
                { "expression":"geom_to_wkt(geometries_to_array(geom_from_wkt('GeometryCollection (Polygon ((5 8, 4 1, 3 2, 5 8)),LineString (3 2, 4 2))'))[0])", "returns":"'Polygon ((5 8, 4 1, 3 2, 5 8))'"},
                { "expression":"geometries_to_array(geom_from_wkt('MULTIPOLYGON(((5 5,0 0,0 10,5 5)),((5 5,10 10,10 0,5 5))'))", "returns":"an array of two polygon geometries"}],
   "tags": [ "split", "convert", "separate", "collection", "multi", "part" ]


### PR DESCRIPTION
## Description

Add another example for the `geometries_to_array` expression function. As simple as possible. The existing examples left me wondering what would happen with a multi geometry.
