### PR TITLE
Add optimised methods to convert GeoJSON geometries to QgsGeometry

### DIFF
--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsJsonExporter
 {
 %Docstring(signature="appended")
@@ -353,6 +354,15 @@ Parse a simple array (depth=1)
 .. versionadded:: 3.0
 %End
 
+
+    static QgsGeometry geometryFromGeoJson( const QString &geometry );
+%Docstring
+Parses a GeoJSON "geometry" value to a :py:class:`QgsGeometry` object.
+
+Returns a null geometry if the geometry could not be parsed.
+
+.. versionadded:: 3.36
+%End
 
 
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -27,6 +27,11 @@
 #include "qgsfieldformatter.h"
 #include "qgsapplication.h"
 #include "qgsfeatureid.h"
+#include "qgslinestring.h"
+#include "qgsmultipoint.h"
+#include "qgsmultilinestring.h"
+#include "qgspolygon.h"
+#include "qgsmultipolygon.h"
 
 #include <QJsonDocument>
 #include <QJsonArray>
@@ -401,6 +406,309 @@ QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type 
   }
 
   return result;
+}
+
+std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords )
+{
+  if ( !coords.is_array() || coords.size() < 2 || coords.size() > 3 )
+  {
+    QgsDebugError( QStringLiteral( "JSON Point geometry coordinates must be an array of two or three numbers" ) );
+    return nullptr;
+  }
+
+  const double x = coords[0].get< double >();
+  const double y = coords[1].get< double >();
+  if ( coords.size() == 2 )
+  {
+    return std::make_unique< QgsPoint >( x, y );
+  }
+  else
+  {
+    const double z = coords[2].get< double >();
+    return std::make_unique< QgsPoint >( x, y, z );
+  }
+}
+
+std::unique_ptr< QgsLineString> parseLineStringFromGeoJson( const json &coords )
+{
+  if ( !coords.is_array() || coords.size() < 2 )
+  {
+    QgsDebugError( QStringLiteral( "JSON LineString geometry coordinates must be an array of at least two points" ) );
+    return nullptr;
+  }
+
+  const std::size_t coordsSize = coords.size();
+
+  QVector< double > x;
+  QVector< double > y;
+  QVector< double > z;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  x.resize( static_cast< int >( coordsSize ) );
+  y.resize( static_cast< int >( coordsSize ) );
+  z.resize( static_cast< int >( coordsSize ) );
+#else
+  x.resize( coordsSize );
+  y.resize( coordsSize );
+  z.resize( coordsSize );
+#endif
+  double *xOut = x.data();
+  double *yOut = y.data();
+  double *zOut = z.data();
+  bool hasZ = false;
+  for ( const auto &coord : coords )
+  {
+    if ( !coord.is_array() || coord.size() < 2 || coord.size() > 3 )
+    {
+      QgsDebugError( QStringLiteral( "JSON LineString geometry coordinates must be an array of two or three numbers" ) );
+      return nullptr;
+    }
+
+    *xOut++ = coord[0].get< double >();
+    *yOut++ = coord[1].get< double >();
+    if ( coord.size() == 3 )
+    {
+      *zOut++ = coord[2].get< double >();
+      hasZ = true;
+    }
+    else
+    {
+      *zOut++ = std::numeric_limits< double >::quiet_NaN();
+    }
+  }
+
+  return std::make_unique< QgsLineString >( x, y, hasZ ? z : QVector<double>() );
+}
+
+std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords )
+{
+  if ( !coords.is_array() || coords.size() < 1 )
+  {
+    QgsDebugError( QStringLiteral( "JSON Polygon geometry coordinates must be an array" ) );
+    return nullptr;
+  }
+
+  const std::size_t coordsSize = coords.size();
+  std::unique_ptr< QgsLineString > exterior = parseLineStringFromGeoJson( coords[0] );
+  if ( !exterior )
+  {
+    return nullptr;
+  }
+
+  std::unique_ptr< QgsPolygon > polygon = std::make_unique< QgsPolygon >( exterior.release() );
+  for ( std::size_t i = 1; i < coordsSize; ++i )
+  {
+    std::unique_ptr< QgsLineString > ring = parseLineStringFromGeoJson( coords[i] );
+    if ( !ring )
+    {
+      return nullptr;
+    }
+    polygon->addInteriorRing( ring.release() );
+  }
+  return polygon;
+}
+
+std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry )
+{
+  if ( !geometry.is_object() )
+  {
+    QgsDebugError( QStringLiteral( "JSON geometry value must be an object" ) );
+    return nullptr;
+  }
+
+  if ( !geometry.contains( "type" ) )
+  {
+    QgsDebugError( QStringLiteral( "JSON geometry must contain 'type'" ) );
+    return nullptr;
+  }
+
+  const QString type = QString::fromStdString( geometry["type"].get< std::string >() );
+  if ( type.compare( QLatin1String( "Point" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON Point geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+    return parsePointFromGeoJson( coords );
+  }
+  else if ( type.compare( QLatin1String( "MultiPoint" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiPoint geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+
+    if ( !coords.is_array() )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiPoint geometry coordinates must be an array" ) );
+      return nullptr;
+    }
+
+    std::unique_ptr< QgsMultiPoint > multiPoint = std::make_unique< QgsMultiPoint >();
+    multiPoint->reserve( static_cast< int >( coords.size() ) );
+    for ( const auto &pointCoords : coords )
+    {
+      std::unique_ptr< QgsPoint > point = parsePointFromGeoJson( pointCoords );
+      if ( !point )
+      {
+        return nullptr;
+      }
+      multiPoint->addGeometry( point.release() );
+    }
+
+    return multiPoint;
+  }
+  else if ( type.compare( QLatin1String( "LineString" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON LineString geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+    return parseLineStringFromGeoJson( coords );
+  }
+  else if ( type.compare( QLatin1String( "MultiLineString" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiLineString geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+
+    if ( !coords.is_array() )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiLineString geometry coordinates must be an array" ) );
+      return nullptr;
+    }
+
+    std::unique_ptr< QgsMultiLineString > multiLineString = std::make_unique< QgsMultiLineString >();
+    multiLineString->reserve( static_cast< int >( coords.size() ) );
+    for ( const auto &lineCoords : coords )
+    {
+      std::unique_ptr< QgsLineString > line = parseLineStringFromGeoJson( lineCoords );
+      if ( !line )
+      {
+        return nullptr;
+      }
+      multiLineString->addGeometry( line.release() );
+    }
+
+    return multiLineString;
+  }
+  else if ( type.compare( QLatin1String( "Polygon" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON Polygon geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+    if ( !coords.is_array() || coords.size() < 1 )
+    {
+      QgsDebugError( QStringLiteral( "JSON Polygon geometry coordinates must be an array of at least one ring" ) );
+      return nullptr;
+    }
+
+    return parsePolygonFromGeoJson( coords );
+  }
+  else if ( type.compare( QLatin1String( "MultiPolygon" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiPolygon geometry must contain 'coordinates'" ) );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+
+    if ( !coords.is_array() )
+    {
+      QgsDebugError( QStringLiteral( "JSON MultiPolygon geometry coordinates must be an array" ) );
+      return nullptr;
+    }
+
+    std::unique_ptr< QgsMultiPolygon > multiPolygon = std::make_unique< QgsMultiPolygon >();
+    multiPolygon->reserve( static_cast< int >( coords.size() ) );
+    for ( const auto &polygonCoords : coords )
+    {
+      std::unique_ptr< QgsPolygon > polygon = parsePolygonFromGeoJson( polygonCoords );
+      if ( !polygon )
+      {
+        return nullptr;
+      }
+      multiPolygon->addGeometry( polygon.release() );
+    }
+
+    return multiPolygon;
+  }
+  else if ( type.compare( QLatin1String( "GeometryCollection" ), Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "geometries" ) )
+    {
+      QgsDebugError( QStringLiteral( "JSON GeometryCollection geometry must contain 'geometries'" ) );
+      return nullptr;
+    }
+
+    const json &geometries = geometry["geometries"];
+
+    if ( !geometries.is_array() )
+    {
+      QgsDebugError( QStringLiteral( "JSON GeometryCollection geometries must be an array" ) );
+      return nullptr;
+    }
+
+    std::unique_ptr< QgsGeometryCollection > collection = std::make_unique< QgsGeometryCollection >();
+    collection->reserve( static_cast< int >( geometries.size() ) );
+    for ( const auto &geometry : geometries )
+    {
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry );
+      if ( !object )
+      {
+        return nullptr;
+      }
+      collection->addGeometry( object.release() );
+    }
+
+    return collection;
+  }
+
+  QgsDebugError( QStringLiteral( "Unhandled GeoJSON geometry type: %1" ).arg( type ) );
+  return nullptr;
+}
+
+QgsGeometry QgsJsonUtils::geometryFromGeoJson( const json &geometry )
+{
+  if ( !geometry.is_object() )
+  {
+    QgsDebugError( QStringLiteral( "JSON geometry value must be an object" ) );
+    return QgsGeometry();
+  }
+
+  return QgsGeometry( parseGeometryFromGeoJson( geometry ) );
+}
+
+QgsGeometry QgsJsonUtils::geometryFromGeoJson( const QString &geometry )
+{
+  try
+  {
+    const auto jObj( json::parse( geometry.toStdString() ) );
+    return geometryFromGeoJson( jObj );
+  }
+  catch ( json::parse_error &ex )
+  {
+    QgsDebugError( QStringLiteral( "Cannot parse json (%1): %2" ).arg( ex.what() ) );
+    return QgsGeometry();
+  }
 }
 
 json QgsJsonUtils::jsonFromVariant( const QVariant &val )

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -706,7 +706,7 @@ QgsGeometry QgsJsonUtils::geometryFromGeoJson( const QString &geometry )
   }
   catch ( json::parse_error &ex )
   {
-    QgsDebugError( QStringLiteral( "Cannot parse json (%1): %2" ).arg( ex.what() ) );
+    QgsDebugError( QStringLiteral( "Cannot parse json (%1): %2" ).arg( geometry, ex.what() ) );
     return QgsGeometry();
   }
 }

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -25,6 +25,11 @@
 #include <QPointer>
 #include <QJsonObject>
 
+#ifndef SIP_RUN
+#include "json_fwd.hpp"
+using namespace nlohmann;
+#endif
+
 class QTextCodec;
 
 /**
@@ -363,6 +368,24 @@ class CORE_EXPORT QgsJsonUtils
      */
     Q_INVOKABLE static QVariantList parseArray( const QString &json, QVariant::Type type = QVariant::Invalid );
 
+    /**
+     * Parses a GeoJSON "geometry" value to a QgsGeometry object.
+     *
+     * Returns a null geometry if the geometry could not be parsed.
+     *
+     * \note Not available in Python bindings.
+     * \since QGIS 3.36
+     */
+    static QgsGeometry geometryFromGeoJson( const json &geometry ) SIP_SKIP;
+
+    /**
+     * Parses a GeoJSON "geometry" value to a QgsGeometry object.
+     *
+     * Returns a null geometry if the geometry could not be parsed.
+     *
+     * \since QGIS 3.36
+     */
+    static QgsGeometry geometryFromGeoJson( const QString &geometry );
 
     /**
      * Converts a QVariant \a v to a json object

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -36,7 +36,6 @@ codec = QTextCodec.codecForName("System")
 
 
 class TestQgsJsonUtils(QgisTestCase):
-
     def testStringToFeatureList(self):
         """Test converting json string to features"""
 
@@ -933,6 +932,583 @@ class TestQgsJsonUtils(QgisTestCase):
   "type": "Feature"
 }"""
         self.assertEqual(exporter.exportFeature(features[0], indent=2), expected)
+
+    def test_geojson_invalid(self):
+        res = QgsJsonUtils.geometryFromGeoJson("")
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson("xxxx")
+        self.assertTrue(res.isNull())
+
+    def test_geojson_point(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+            "type": "Point",
+            "coordinates": [30.0, 10.0]
+        }"""
+        )
+        self.assertEqual(res.asWkt(), "Point (30 10)")
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Point",
+                    "coordinates": [30.0, 10.0, 15.5]
+                }"""
+        )
+        self.assertEqual(res.asWkt(), "PointZ (30 10 15.5)")
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Point",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Point",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Point",
+                    "coordinates": [1,2,3,4]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Point"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_multipoint(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+            "type": "MultiPoint",
+            "coordinates": [[10.0, 40.0],
+            [40.0, 30.0],
+            [20.0, 20.0],
+            [30.0, 10.0]]
+        }"""
+        )
+        self.assertEqual(res.asWkt(), "MultiPoint ((10 40),(40 30),(20 20),(30 10))")
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+            "type": "MultiPoint",
+            "coordinates": [[10.0, 40.0, 15.5],
+            [40.0, 30.0, 12.5],
+            [20.0, 20.0, 1.1],
+            [30.0, 10.0, 2.2]]
+        }"""
+        )
+        self.assertEqual(
+            res.asWkt(1),
+            "MultiPointZ ((10 40 15.5),(40 30 12.5),(20 20 1.1),(30 10 2.2))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint",
+                    "coordinates": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint",
+                    "coordinates": [[1,2,3,4]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_linestring(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "LineString",
+    "coordinates": [
+        [30.0, 10.0],
+        [10.0, 30.0],
+        [40.0, 40.0]
+    ]
+}"""
+        )
+        self.assertEqual(res.asWkt(), "LineString (30 10, 10 30, 40 40)")
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "LineString",
+    "coordinates": [
+        [30.0, 10.0, 12.2],
+        [10.0, 30.0, 12.3],
+        [40.0, 40.0, 12.4]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(1),
+            "LineStringZ (30 10 12.2, 10 30 12.3, 40 40 12.4)",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "LineString",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "LineString",
+                    "coordinates": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "LineString",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "LineString",
+                    "coordinates": [[1,2,3,4]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "LineString"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_multilinestring(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "MultiLineString",
+    "coordinates": [
+        [
+            [10.0, 10.0],
+            [20.0, 20.0],
+            [10.0, 40.0]
+        ],
+        [
+            [40.0, 40.0],
+            [30.0, 30.0],
+            [40.0, 20.0],
+            [30.0, 10.0]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "MultiLineString ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "MultiLineString",
+    "coordinates": [
+        [
+            [10.0, 10.0, 1.2],
+            [20.0, 20.0, 1.3],
+            [10.0, 40.0, 1.4]
+        ],
+        [
+            [40.0, 40.0, 2],
+            [30.0, 30.0, 3],
+            [40.0, 20.0, 4],
+            [30.0, 10.0, 5]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(1),
+            "MultiLineStringZ ((10 10 1.2, 20 20 1.3, 10 40 1.4),(40 40 2, 30 30 3, 40 20 4, 30 10 5))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString",
+                    "coordinates": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString",
+                    "coordinates": [[[30.0]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString",
+                    "coordinates": [[[1,2,3,4]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiLineString"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_polygon(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [35.0, 10.0],
+            [45.0, 45.0],
+            [15.0, 40.0],
+            [10.0, 20.0],
+            [35.0, 10.0]
+        ],
+        [
+            [20.0, 30.0],
+            [35.0, 35.0],
+            [30.0, 20.0],
+            [20.0, 30.0]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "Polygon ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [35.0, 10.0],
+            [45.0, 45.0],
+            [15.0, 40.0],
+            [10.0, 20.0],
+            [35.0, 10.0]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "Polygon ((35 10, 45 45, 15 40, 10 20, 35 10))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [35.0, 10.0, 1.1],
+            [45.0, 45.0, 1.2],
+            [15.0, 40.0, 1.3],
+            [10.0, 20.0, 1.4],
+            [35.0, 10.0, 1.1]
+        ],
+        [
+            [20.0, 30.0, 2],
+            [35.0, 35.0, 3],
+            [30.0, 20.0, 4],
+            [20.0, 30.0, 2]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(1),
+            "PolygonZ ((35 10 1.1, 45 45 1.2, 15 40 1.3, 10 20 1.4, 35 10 1.1),(20 30 2, 35 35 3, 30 20 4, 20 30 2))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon",
+                    "coordinates": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon",
+                    "coordinates": [[[30.0]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon",
+                    "coordinates": [[[1,2,3,4]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "Polygon"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_multipolygon(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [30.0, 20.0],
+                [45.0, 40.0],
+                [10.0, 40.0],
+                [30.0, 20.0]
+            ]
+        ],
+        [
+            [
+                [15.0, 5.0],
+                [40.0, 10.0],
+                [10.0, 20.0],
+                [5.0, 10.0],
+                [15.0, 5.0]
+            ]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "MultiPolygon (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [40.0, 40.0],
+                [20.0, 45.0],
+                [45.0, 30.0],
+                [40.0, 40.0]
+            ]
+        ],
+        [
+            [
+                [20.0, 35.0],
+                [10.0, 30.0],
+                [10.0, 10.0],
+                [30.0, 5.0],
+                [45.0, 20.0],
+                [20.0, 35.0]
+            ],
+            [
+                [30.0, 20.0],
+                [20.0, 15.0],
+                [20.0, 25.0],
+                [30.0, 20.0]
+            ]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "MultiPolygon (((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [30.0, 20.0, 1],
+                [45.0, 40.0, 2],
+                [10.0, 40.0, 3],
+                [30.0, 20.0, 1]
+            ]
+        ],
+        [
+            [
+                [15.0, 5.0, 11],
+                [40.0, 10.0, 12],
+                [10.0, 20.0, 13],
+                [5.0, 10.0, 14],
+                [15.0, 5.0, 11]
+            ]
+        ]
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(1),
+            "MultiPolygonZ (((30 20 1, 45 40 2, 10 40 3, 30 20 1)),((15 5 11, 40 10 12, 10 20 13, 5 10 14, 15 5 11)))",
+        )
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": [[[30.0]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": [[[[30.0]]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon",
+                    "coordinates": [[[1,2,3,4]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPolygon"
+                }"""
+        )
+        self.assertTrue(res.isNull())
+
+    def test_geojson_collection(self):
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+    "type": "GeometryCollection",
+    "geometries": [
+        {
+            "type": "Point",
+            "coordinates": [40.0, 10.0]
+        },
+        {
+            "type": "LineString",
+            "coordinates": [
+                [10.0, 10.0],
+                [20.0, 20.0],
+                [10.0, 40.0]
+            ]
+        },
+        {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [40.0, 40.0],
+                    [20.0, 45.0],
+                    [45.0, 30.0],
+                    [40.0, 40.0]
+                ]
+            ]
+        }
+    ]
+}"""
+        )
+        self.assertEqual(
+            res.asWkt(),
+            "GeometryCollection (Point (40 10),LineString (10 10, 20 20, 10 40),Polygon ((40 40, 20 45, 45 30, 40 40)))",
+        )
+
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "GeometryCollection",
+                    "geometries": [30.0]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "GeometryCollection",
+                    "geometries": [[30.0]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "GeometryCollection",
+                    "geometries": 3
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "GeometryCollection",
+                    "geometries": [[[1,2,3,4]]]
+                }"""
+        )
+        self.assertTrue(res.isNull())
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "GeometryCollection"
+                }"""
+        )
+        self.assertTrue(res.isNull())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows direct construction of geometries from raw json objects, instead of requiring translation through another library's geometry structures.
