### PR TITLE
[wfs] Use a more tolerant approach to matching the desired WFS layer name to those available from the get capabilities

### DIFF
--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -2060,10 +2060,11 @@ bool QgsWFSProvider::getCapabilities()
 
   //find the <FeatureType> for this layer
   QString thisLayerName = mShared->mURI.typeName();
+  const QString searchName = mShared->mCaps.addPrefixIfNeeded( thisLayerName );
   bool foundLayer = false;
   for ( int i = 0; i < mShared->mCaps.featureTypes.size(); i++ )
   {
-    if ( thisLayerName == mShared->mCaps.featureTypes[i].name )
+    if ( searchName == mShared->mCaps.featureTypes[i].name )
     {
       const QgsRectangle &r = mShared->mCaps.featureTypes[i].bbox;
       if ( mShared->mSourceCrs.authid().isEmpty() && mShared->mCaps.featureTypes[i].crslist.size() != 0 )


### PR DESCRIPTION
Allows layer connections to succeed when the layer name is specified without the prefix, when it's safe to do so.

Motivation: a script I have which needs to convert WFS connections from an external list of servers and tables, where the namespace isn't available. I'd prefer to make QGIS more forgiving and handle this vs having to manually parse GetCapabilities and retrieve the missing namespace information by hand.