### PR TITLE
Don't fetch 3d scene tiles in main thread

### DIFF
--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -54,7 +54,7 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
 {
     Q_OBJECT
   public:
-    QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneChunkLoaderFactory &factory, const QgsTiledSceneTile &t, double zValueScale, double zValueOffset );
+    QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneIndex &index, const QgsTiledSceneChunkLoaderFactory &factory, double zValueScale, double zValueOffset );
 
     ~QgsTiledSceneChunkLoader();
 
@@ -62,7 +62,7 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
 
   private:
     const QgsTiledSceneChunkLoaderFactory &mFactory;
-    QgsTiledSceneTile mTile;
+    QgsTiledSceneIndex mIndex;
     QFutureWatcher<void> *mFutureWatcher = nullptr;
     Qt3DCore::QEntity *mEntity = nullptr;
 };


### PR DESCRIPTION
This can block the user interface -- instead defer tile loading till we're running on the background thread.
