### PR TITLE
Adding "Field Calculator" menu item to the attribute table header right click popup. Fixes #55266

### DIFF
--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -30,6 +30,7 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
 #include "qgsfieldcalculator.h"
 %End
   public:
+
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0, int fieldIndex = -1 );
 %Docstring
 Constructor for QgsFieldCalculator, with the specified ``parent`` widget.
@@ -37,7 +38,7 @@ Constructor for QgsFieldCalculator, with the specified ``parent`` widget.
 The target layer must be specified using the ``vl`` argument.
 
 Since QGIS 3.36, the optional ``fieldIndex`` argument can be used to automatically
-select the existing field with the specified index in the dialog. 
+select the existing field with the specified index in the dialog.
 %End
 
     int changedAttributeId() const;

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -30,7 +30,7 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
 #include "qgsfieldcalculator.h"
 %End
   public:
-    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0 );
+    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0, int fieldIndex = -1 );
 
     int changedAttributeId() const;
 %Docstring

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -31,6 +31,14 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
 %End
   public:
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0, int fieldIndex = -1 );
+%Docstring
+Constructor for QgsFieldCalculator, with the specified ``parent`` widget.
+
+The target layer must be specified using the ``vl`` argument.
+
+Since QGIS 3.36, the optional ``fieldIndex`` argument can be used to automatically
+select the existing field with the specified index in the dialog. 
+%End
 
     int changedAttributeId() const;
 %Docstring

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -989,7 +989,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   mHorizontalHeaderMenu->addSeparator();
   bool fieldCalculatorEnabled = false;
 
-  if ( fieldOrigin == 1 || fieldOrigin == 3 )
+  if ( fieldOrigin == QgsFields::OriginProvider || fieldOrigin == QgsFields::OriginEdit )
     fieldCalculatorEnabled = true;
 
   if ( fieldOrigin == 2 )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -992,7 +992,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   if ( fieldOrigin == QgsFields::OriginProvider || fieldOrigin == QgsFields::OriginEdit )
     fieldCalculatorEnabled = true;
 
-  if ( fieldOrigin == 2 )
+  if ( fieldOrigin == QgsFields::OriginJoin )
   {
     int srcFieldIndex;
     const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -984,7 +984,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   mConfig.update( mLayer->fields() );
   // get layer field index from column name
   const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
-  const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
+  const QgsFields::FieldOrigin fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
 
   mHorizontalHeaderMenu->addSeparator();
   bool fieldCalculatorEnabled = false;

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -983,7 +983,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
 
   mConfig.update( mLayer->fields() );
   // get layer field index from column name
-  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col ).name );
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
   const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
 
   bool fieldCalculatorEnabled = false;
@@ -991,9 +991,9 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   mHorizontalHeaderMenu->addSeparator();
   if ( fieldOrigin == 4 )
   {
-    QAction *updateField = new QAction( tr( "Update &Field..." ), mHorizontalHeaderMenu );
+    QAction *updateField = new QAction( tr( "Update &Field…" ), mHorizontalHeaderMenu );
     connect( updateField, &QAction::triggered, this, &QgsDualView::updateField );
-    updateField->setData( col );
+    updateField->setData( fieldIndex );
     mHorizontalHeaderMenu->addAction( updateField );
 
     fieldCalculatorEnabled = true;
@@ -1015,7 +1015,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
 
     QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );
     connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
-    fieldCalculator->setData( col );
+    fieldCalculator->setData( fieldIndex );
     mHorizontalHeaderMenu->addAction( fieldCalculator );
 
     fieldCalculator->setEnabled( fieldCalculatorEnabled );
@@ -1067,10 +1067,10 @@ void QgsDualView::hideColumn()
 void QgsDualView::fieldCalculator()
 {
   QAction *action = qobject_cast<QAction *>( sender() );
-  const int col_idx = action->data().toInt();
+  const int fieldIndex = action->data().toInt();
 
   mConfig.update( mLayer->fields() );
-  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
+  //const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
   QgsFieldCalculator calc( mLayer, this, fieldIndex );
   if ( calc.exec() == QDialog::Accepted )
   {
@@ -1084,10 +1084,10 @@ void QgsDualView::fieldCalculator()
 void QgsDualView::updateField()
 {
   QAction *action = qobject_cast<QAction *>( sender() );
-  const int col_idx = action->data().toInt();
+  const int fieldIndex = action->data().toInt();
 
   mConfig.update( mLayer->fields() );
-  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
+  //const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
 
   // Show expression builder
   const QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
@@ -1099,8 +1099,8 @@ void QgsDualView::updateField()
   if ( dlg.exec() == QDialog::Accepted )
   {
     mLayer->updateExpressionField( fieldIndex, dlg.expressionText() );
-    mLayer->reload();
-    mMasterModel->reload( mMasterModel->index( 0, col_idx ), mMasterModel->index( mMasterModel->rowCount() - 1, col_idx ) );
+    //mLayer->reload();
+    //mMasterModel->reload( mMasterModel->index( 0, col_idx ), mMasterModel->index( mMasterModel->rowCount() - 1, col_idx ) );
   }
 
 }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -981,32 +981,46 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( sort, &QAction::triggered, this, [ = ]() {modifySort();} );
   mHorizontalHeaderMenu->addAction( sort );
 
-  mHorizontalHeaderMenu->addSeparator();
-
-  QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
-  connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
-    fieldCalculator->setData( col );
-  mHorizontalHeaderMenu->addAction( fieldCalculator );
-
   mConfig.update( mLayer->fields() );
   // get layer field index from column name
   const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col ).name );
   const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
 
+  qDebug() << "THE WHAT " << fieldOrigin;
   bool fieldCalculatorEnabled = false;
-  if ( fieldOrigin == 2 )
+
+  mHorizontalHeaderMenu->addSeparator();
+  if ( fieldOrigin == 4 )
   {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+    QAction *updateField = new QAction( tr( "Update &Field..." ), mHorizontalHeaderMenu );
+    connect( updateField, &QAction::triggered, this, &QgsDualView::updateField );
+    updateField->setData( col );
+    mHorizontalHeaderMenu->addAction( updateField );
 
-    if ( info && info->isEditable() )
-      fieldCalculatorEnabled = true;
-  }
-
-  if ( fieldOrigin == 1 || fieldOrigin == 3 )
     fieldCalculatorEnabled = true;
+    updateField->setEnabled( fieldCalculatorEnabled );
+  }
+  else
+  {
+    if ( fieldOrigin == 2 )
+    {
+      int srcFieldIndex;
+      const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
 
-  fieldCalculator->setEnabled( fieldCalculatorEnabled );
+      if ( info && info->isEditable() )
+        fieldCalculatorEnabled = true;
+    }
+
+    if ( fieldOrigin == 1 || fieldOrigin == 3 )
+      fieldCalculatorEnabled = true;
+
+    QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
+    connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
+    fieldCalculator->setData( col );
+    mHorizontalHeaderMenu->addAction( fieldCalculator );
+
+    fieldCalculator->setEnabled( fieldCalculatorEnabled );
+  }
 
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
 }
@@ -1064,10 +1078,32 @@ void QgsDualView::fieldCalculator()
     int col = mMasterModel->fieldCol( calc.changedAttributeId() );
 
     if ( col >= 0 )
-    {
       mMasterModel->reload( mMasterModel->index( 0, col ), mMasterModel->index( mMasterModel->rowCount() - 1, col ) );
-    }
   }
+}
+
+void QgsDualView::updateField()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  const int col_idx = action->data().toInt();
+
+  mConfig.update( mLayer->fields() );
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
+
+  // Show expression builder
+  const QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+
+  QgsExpressionBuilderDialog dlg( mLayer, mFeatureListView->displayExpression(), this, QStringLiteral( "generic" ), context );
+  dlg.setWindowTitle( tr( "Expression Builder" ) );
+  dlg.setExpressionText( mLayer->expressionField( fieldIndex ) );
+
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    mLayer->updateExpressionField( fieldIndex, dlg.expressionText() );
+    mLayer->reload();
+    mMasterModel->reload( mMasterModel->index( 0, col_idx ), mMasterModel->index( mMasterModel->rowCount() - 1, col_idx ) );
+  }
+
 }
 
 void QgsDualView::resizeColumn()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1013,7 +1013,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
     if ( fieldOrigin == 1 || fieldOrigin == 3 )
       fieldCalculatorEnabled = true;
 
-    QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
+    QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );
     connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
     fieldCalculator->setData( col );
     mHorizontalHeaderMenu->addAction( fieldCalculator );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -983,7 +983,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
 
   mHorizontalHeaderMenu->addSeparator();
 
-  QAction *fieldCalculator = new QAction( tr( "&Field Calculator..." ), mHorizontalHeaderMenu );
+  QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
   connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
     fieldCalculator->setData( col );
   mHorizontalHeaderMenu->addAction( fieldCalculator );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -45,8 +45,9 @@
 #include "qgsmapcanvasutils.h"
 #include "qgsmessagebar.h"
 #include "qgsvectorlayereditbuffer.h"
+#include "qgsvectorlayerjoinbuffer.h"
 #include "qgsactionmenu.h"
-
+#include "qgsfieldcalculator.h"
 
 QgsDualView::QgsDualView( QWidget *parent )
   : QStackedWidget( parent )
@@ -951,6 +952,7 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( hide, &QAction::triggered, this, &QgsDualView::hideColumn );
   hide->setData( col );
   mHorizontalHeaderMenu->addAction( hide );
+
   QAction *setWidth = new QAction( tr( "&Set Width…" ), mHorizontalHeaderMenu );
   connect( setWidth, &QAction::triggered, this, &QgsDualView::resizeColumn );
   setWidth->setData( col );
@@ -978,6 +980,33 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   QAction *sort = new QAction( tr( "&Sort…" ), mHorizontalHeaderMenu );
   connect( sort, &QAction::triggered, this, [ = ]() {modifySort();} );
   mHorizontalHeaderMenu->addAction( sort );
+
+  mHorizontalHeaderMenu->addSeparator();
+
+  QAction *fieldCalculator = new QAction( tr( "&Field Calculator..." ), mHorizontalHeaderMenu );
+  connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
+    fieldCalculator->setData( col );
+  mHorizontalHeaderMenu->addAction( fieldCalculator );
+
+  mConfig.update( mLayer->fields() );
+  // get layer field index from column name
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col ).name );
+  const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
+
+  bool fieldCalculatorEnabled = false;
+  if ( fieldOrigin == 2 )
+  {
+    int srcFieldIndex;
+    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+
+    if ( info && info->isEditable() )
+      fieldCalculatorEnabled = true;
+  }
+
+  if ( fieldOrigin == 1 || fieldOrigin == 3 )
+    fieldCalculatorEnabled = true;
+
+  fieldCalculator->setEnabled( fieldCalculatorEnabled );
 
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
 }
@@ -1018,6 +1047,26 @@ void QgsDualView::hideColumn()
   {
     config.setColumnHidden( sourceCol, true );
     setAttributeTableConfig( config );
+  }
+}
+
+
+void QgsDualView::fieldCalculator()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  const int col_idx = action->data().toInt();
+
+  mConfig.update( mLayer->fields() );
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
+  QgsFieldCalculator calc( mLayer, this, fieldIndex );
+  if ( calc.exec() == QDialog::Accepted )
+  {
+    int col = mMasterModel->fieldCol( calc.changedAttributeId() );
+
+    if ( col >= 0 )
+    {
+      mMasterModel->reload( mMasterModel->index( 0, col ), mMasterModel->index( mMasterModel->rowCount() - 1, col ) );
+    }
   }
 }
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -981,32 +981,45 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( sort, &QAction::triggered, this, [ = ]() {modifySort();} );
   mHorizontalHeaderMenu->addAction( sort );
 
-  mHorizontalHeaderMenu->addSeparator();
-
-  QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
-  connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
-    fieldCalculator->setData( col );
-  mHorizontalHeaderMenu->addAction( fieldCalculator );
-
   mConfig.update( mLayer->fields() );
   // get layer field index from column name
   const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col ).name );
   const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
 
   bool fieldCalculatorEnabled = false;
-  if ( fieldOrigin == 2 )
+
+  mHorizontalHeaderMenu->addSeparator();
+  if ( fieldOrigin == 4 )
   {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+    QAction *updateField = new QAction( tr( "Update &Field..." ), mHorizontalHeaderMenu );
+    connect( updateField, &QAction::triggered, this, &QgsDualView::updateField );
+    updateField->setData( col );
+    mHorizontalHeaderMenu->addAction( updateField );
 
-    if ( info && info->isEditable() )
-      fieldCalculatorEnabled = true;
-  }
-
-  if ( fieldOrigin == 1 || fieldOrigin == 3 )
     fieldCalculatorEnabled = true;
+    updateField->setEnabled( fieldCalculatorEnabled );
+  }
+  else
+  {
+    if ( fieldOrigin == 2 )
+    {
+      int srcFieldIndex;
+      const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
 
-  fieldCalculator->setEnabled( fieldCalculatorEnabled );
+      if ( info && info->isEditable() )
+        fieldCalculatorEnabled = true;
+    }
+
+    if ( fieldOrigin == 1 || fieldOrigin == 3 )
+      fieldCalculatorEnabled = true;
+
+    QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator..." ), mHorizontalHeaderMenu );
+    connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
+    fieldCalculator->setData( col );
+    mHorizontalHeaderMenu->addAction( fieldCalculator );
+
+    fieldCalculator->setEnabled( fieldCalculatorEnabled );
+  }
 
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
 }
@@ -1064,10 +1077,32 @@ void QgsDualView::fieldCalculator()
     int col = mMasterModel->fieldCol( calc.changedAttributeId() );
 
     if ( col >= 0 )
-    {
       mMasterModel->reload( mMasterModel->index( 0, col ), mMasterModel->index( mMasterModel->rowCount() - 1, col ) );
-    }
   }
+}
+
+void QgsDualView::updateField()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  const int col_idx = action->data().toInt();
+
+  mConfig.update( mLayer->fields() );
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
+
+  // Show expression builder
+  const QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+
+  QgsExpressionBuilderDialog dlg( mLayer, mFeatureListView->displayExpression(), this, QStringLiteral( "generic" ), context );
+  dlg.setWindowTitle( tr( "Expression Builder" ) );
+  dlg.setExpressionText( mLayer->expressionField( fieldIndex ) );
+
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    mLayer->updateExpressionField( fieldIndex, dlg.expressionText() );
+    mLayer->reload();
+    mMasterModel->reload( mMasterModel->index( 0, col_idx ), mMasterModel->index( mMasterModel->rowCount() - 1, col_idx ) );
+  }
+
 }
 
 void QgsDualView::resizeColumn()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -986,40 +986,27 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
   const int fieldOrigin  = mLayer->fields().fieldOrigin( fieldIndex );
 
+  mHorizontalHeaderMenu->addSeparator();
   bool fieldCalculatorEnabled = false;
 
-  mHorizontalHeaderMenu->addSeparator();
-  if ( fieldOrigin == 4 )
-  {
-    QAction *updateField = new QAction( tr( "Update &Field…" ), mHorizontalHeaderMenu );
-    connect( updateField, &QAction::triggered, this, &QgsDualView::updateField );
-    updateField->setData( fieldIndex );
-    mHorizontalHeaderMenu->addAction( updateField );
-
+  if ( fieldOrigin == 1 || fieldOrigin == 3 )
     fieldCalculatorEnabled = true;
-    updateField->setEnabled( fieldCalculatorEnabled );
-  }
-  else
+
+  if ( fieldOrigin == 2 )
   {
-    if ( fieldOrigin == 2 )
-    {
-      int srcFieldIndex;
-      const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+    int srcFieldIndex;
+    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
 
-      if ( info && info->isEditable() )
-        fieldCalculatorEnabled = true;
-    }
-
-    if ( fieldOrigin == 1 || fieldOrigin == 3 )
+    if ( info && info->isEditable() )
       fieldCalculatorEnabled = true;
-
-    QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );
-    connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
-    fieldCalculator->setData( fieldIndex );
-    mHorizontalHeaderMenu->addAction( fieldCalculator );
-
-    fieldCalculator->setEnabled( fieldCalculatorEnabled );
   }
+
+  QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );
+  connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
+  fieldCalculator->setData( fieldIndex );
+  mHorizontalHeaderMenu->addAction( fieldCalculator );
+
+  fieldCalculator->setEnabled( fieldCalculatorEnabled );
 
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
 }
@@ -1063,14 +1050,11 @@ void QgsDualView::hideColumn()
   }
 }
 
-
 void QgsDualView::fieldCalculator()
 {
   QAction *action = qobject_cast<QAction *>( sender() );
   const int fieldIndex = action->data().toInt();
-
   mConfig.update( mLayer->fields() );
-  //const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
   QgsFieldCalculator calc( mLayer, this, fieldIndex );
   if ( calc.exec() == QDialog::Accepted )
   {
@@ -1079,30 +1063,6 @@ void QgsDualView::fieldCalculator()
     if ( col >= 0 )
       mMasterModel->reload( mMasterModel->index( 0, col ), mMasterModel->index( mMasterModel->rowCount() - 1, col ) );
   }
-}
-
-void QgsDualView::updateField()
-{
-  QAction *action = qobject_cast<QAction *>( sender() );
-  const int fieldIndex = action->data().toInt();
-
-  mConfig.update( mLayer->fields() );
-  //const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( col_idx ).name );
-
-  // Show expression builder
-  const QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
-
-  QgsExpressionBuilderDialog dlg( mLayer, mFeatureListView->displayExpression(), this, QStringLiteral( "generic" ), context );
-  dlg.setWindowTitle( tr( "Expression Builder" ) );
-  dlg.setExpressionText( mLayer->expressionField( fieldIndex ) );
-
-  if ( dlg.exec() == QDialog::Accepted )
-  {
-    mLayer->updateExpressionField( fieldIndex, dlg.expressionText() );
-    //mLayer->reload();
-    //mMasterModel->reload( mMasterModel->index( 0, col_idx ), mMasterModel->index( mMasterModel->rowCount() - 1, col_idx ) );
-  }
-
 }
 
 void QgsDualView::resizeColumn()

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -355,8 +355,6 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void fieldCalculator();
 
-    void updateField();
-
     void resizeColumn();
 
     void resizeAllColumns();

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -355,6 +355,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void fieldCalculator();
 
+    void updateField();
+
     void resizeColumn();
 
     void resizeAllColumns();

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -353,6 +353,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void hideColumn();
 
+    void fieldCalculator();
+
     void resizeColumn();
 
     void resizeAllColumns();

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -129,7 +129,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent, con
     mUpdateExistingGroupBox->setCheckable( false );
   }
 
-  if (fieldIndex != -1)
+  if ( fieldIndex != -1 )
   {
     mNewFieldGroupBox->setEnabled( false );
     mUpdateExistingGroupBox->setEnabled( true );

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -486,7 +486,7 @@ void QgsFieldCalculator::mOutputFieldTypeComboBox_activated( int index )
   setPrecisionMinMax();
 }
 
-void QgsFieldCalculator::populateFields( const int &fieldIndex )
+void QgsFieldCalculator::populateFields( int fieldIndex )
 {
   if ( !mVectorLayer )
     return;

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -43,7 +43,7 @@ constexpr int FTC_MINPREC_IDX = 4;
 constexpr int FTC_MAXPREC_IDX = 5;
 constexpr int FTC_SUBTYPE_IDX = 6;
 
-QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
+QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent, const int fieldIndex )
   : QDialog( parent )
   , mVectorLayer( vl )
   , mAttributeId( -1 )
@@ -72,7 +72,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   expContext.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "row_number" ), 1, true ) );
   expContext.setHighlightedVariables( QStringList() << QStringLiteral( "row_number" ) );
 
-  populateFields();
+  populateFields( fieldIndex );
   populateOutputFieldTypes();
 
   connect( builder, &QgsExpressionBuilderWidget::expressionParsed, this, &QgsFieldCalculator::setOkButtonState );
@@ -129,6 +129,11 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
     mUpdateExistingGroupBox->setCheckable( false );
   }
 
+  if (fieldIndex != -1)
+  {
+    mNewFieldGroupBox->setEnabled( false );
+    mUpdateExistingGroupBox->setEnabled( true );
+  }
   if ( mUpdateExistingGroupBox->isEnabled() )
   {
     mUpdateExistingGroupBox->setChecked( !mNewFieldGroupBox->isEnabled() );
@@ -481,7 +486,7 @@ void QgsFieldCalculator::mOutputFieldTypeComboBox_activated( int index )
   setPrecisionMinMax();
 }
 
-void QgsFieldCalculator::populateFields()
+void QgsFieldCalculator::populateFields( const int &fieldIndex )
 {
   if ( !mVectorLayer )
     return;
@@ -533,7 +538,7 @@ void QgsFieldCalculator::populateFields()
     font.setItalic( true );
     mExistingFieldComboBox->setItemData( mExistingFieldComboBox->count() - 1, font, Qt::FontRole );
   }
-  mExistingFieldComboBox->setCurrentIndex( -1 );
+  mExistingFieldComboBox->setCurrentIndex( fieldIndex );
 }
 
 void QgsFieldCalculator::setOkButtonState()

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -43,13 +43,14 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
 {
     Q_OBJECT
   public:
+
     /**
      * Constructor for QgsFieldCalculator, with the specified \a parent widget.
-     * 
+     *
      * The target layer must be specified using the \a vl argument.
-     * 
+     *
      * Since QGIS 3.36, the optional \a fieldIndex argument can be used to automatically
-     * select the existing field with the specified index in the dialog. 
+     * select the existing field with the specified index in the dialog.
      */
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr, int fieldIndex = -1 );
 

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     //! default constructor forbidden
     QgsFieldCalculator();
     //! Inserts existing fields into the combo box
-    void populateFields( const int &fieldIndex );
+    void populateFields( const int fieldIndex );
     //! Inserts the types supported by the provider into the combo box
     void populateOutputFieldTypes();
 

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -43,6 +43,14 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
 {
     Q_OBJECT
   public:
+    /**
+     * Constructor for QgsFieldCalculator, with the specified \a parent widget.
+     * 
+     * The target layer must be specified using the \a vl argument.
+     * 
+     * Since QGIS 3.36, the optional \a fieldIndex argument can be used to automatically
+     * select the existing field with the specified index in the dialog. 
+     */
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr, int fieldIndex = -1 );
 
     /**

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -43,7 +43,7 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
 {
     Q_OBJECT
   public:
-    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr );
+    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr, int fieldIndex = -1 );
 
     /**
      * \brief Returns the field index of the field for which new attribute values were calculated.
@@ -71,7 +71,7 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     //! default constructor forbidden
     QgsFieldCalculator();
     //! Inserts existing fields into the combo box
-    void populateFields();
+    void populateFields( const int &fieldIndex );
     //! Inserts the types supported by the provider into the combo box
     void populateOutputFieldTypes();
 


### PR DESCRIPTION
## Description

Added a new "Field Calculator" menu item in the popup appearing when right clicking in the header of a column in a vector layer's attribute table. The Field Calculator window opens having the "Update existing field" checkbox checked and the corresponding field already selected in the combo box. 

The action is enabled or disabled according to the field's possibility to be edited. 

This is done by passing an optional field index parameter to QgsFieldCalculator::QgsFieldCalculator constructor (defaults to -1 if null). That makes it like a nice shortcut instead of clicking to open the Field Calculator, then checking "Update existing field" then selected the appropriate field name.

Fixes #55266 

https://github.com/qgis/QGIS/assets/59714546/6fc02c61-8201-446b-a0a0-4b7536f160e6
