### PR TITLE
fix(Qgs3DSceneExporter): 3D scene export failed due to bad feature sort

### DIFF
--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -544,8 +544,6 @@ Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeo
   if ( tessGeom )
   {
     QVector<QgsFeatureId> featureIds = tessGeom->featureIds();
-    // sort feature by their id in order to always export them in the same way:
-    std::sort( featureIds.begin(), featureIds.end() );
 
     QVector<uint> triangleIndex = tessGeom->triangleIndexStartingIndices();
     for ( int idx = 0; idx < featureIds.size(); idx++ )

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -1516,15 +1516,16 @@ void TestQgs3DRendering::do3DSceneExport( int zoomLevelsCount, int expectedObjec
   exporter.setScale( 1.0 );
 
   QVERIFY( exporter.parseVectorLayerEntity( scene->layerEntity( layerPoly ), layerPoly ) );
+  exporter.save( QString( "test3DSceneExporter-%1" ).arg( zoomLevelsCount ), "/tmp/" );
+
   int sum = 0;
   for ( auto o : exporter.mObjects )
   {
     QVERIFY( o->indexes().size() * 3 <= o->vertexPosition().size() );
     sum += o->indexes().size();
   }
-  QCOMPARE( sum, maxFaceCount );
-  exporter.save( QString( "test3DSceneExporter-%1" ).arg( zoomLevelsCount ), "/tmp/" );
 
+  QCOMPARE( sum, maxFaceCount );
   QCOMPARE( exporter.mExportedFeatureIds.size(), 3 );
   QCOMPARE( exporter.mObjects.size(), expectedObjectCount );
 }
@@ -1577,9 +1578,9 @@ void TestQgs3DRendering::test3DSceneExporter()
   // =========== check with 4 tiles ==> 3 exported objects
   do3DSceneExport( 2, 1, 165, scene, symbol3d, layerPoly, &engine );
   // =========== check with 9 tiles ==> 3 exported objects
-  do3DSceneExport( 3, 3, 216, scene, symbol3d, layerPoly, &engine );
+  do3DSceneExport( 3, 3, 165, scene, symbol3d, layerPoly, &engine );
   // =========== check with 16 tiles ==> 3 exported objects
-  do3DSceneExport( 4, 3, 132, scene, symbol3d, layerPoly, &engine );
+  do3DSceneExport( 4, 3, 165, scene, symbol3d, layerPoly, &engine );
   // =========== check with 25 tiles ==> 3 exported objects
   do3DSceneExport( 5, 3, 165, scene, symbol3d, layerPoly, &engine );
 


### PR DESCRIPTION
During 3d scene export a feature sort was done but introduced bad object selection. The test is fix accordingly.

[x] could be backported

