### PR TITLE
[OGC] Polygon: fix rings order

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2542,7 +2542,10 @@ QgsCurve.Clockwise.__doc__ = "Clockwise direction"
 QgsCurve.CounterClockwise = Qgis.AngularDirection.CounterClockwise
 QgsCurve.CounterClockwise.is_monkey_patched = True
 QgsCurve.CounterClockwise.__doc__ = "Counter-clockwise direction"
-Qgis.AngularDirection.__doc__ = "Angular directions.\n\n.. versionadded:: 3.24\n\n" + '* ``Clockwise``: ' + Qgis.AngularDirection.Clockwise.__doc__ + '\n' + '* ``CounterClockwise``: ' + Qgis.AngularDirection.CounterClockwise.__doc__
+QgsCurve.NoOrientation = Qgis.AngularDirection.NoOrientation
+QgsCurve.NoOrientation.is_monkey_patched = True
+QgsCurve.NoOrientation.__doc__ = "Unknown orientation or sentinel value"
+Qgis.AngularDirection.__doc__ = "Angular directions.\n\n.. versionadded:: 3.24\n\n" + '* ``Clockwise``: ' + Qgis.AngularDirection.Clockwise.__doc__ + '\n' + '* ``CounterClockwise``: ' + Qgis.AngularDirection.CounterClockwise.__doc__ + '\n' + '* ``NoOrientation``: ' + Qgis.AngularDirection.NoOrientation.__doc__
 # --
 Qgis.AngularDirection.baseClass = Qgis
 # monkey patching scoped based enum

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2560,7 +2560,7 @@ Returns the orientation of the polygon.
 
 .. warning::
 
-   returns :py:class:`Qgis`.AngularDirection.Clockwise if the geometry is not a polygon type
+   returns :py:class:`Qgis`.AngularDirection.NoOrientation if the geometry is not a polygon type or empty
 
 .. versionadded:: 3.36
 %End
@@ -2576,7 +2576,7 @@ Returns True if the Polygon is counter-clockwise.
 
 .. warning::
 
-   returns false if the geometry is not a polygon type
+   returns false if the geometry is not a polygon type or empty
 
 
 .. seealso:: :py:func:`isPolygonClockwise`
@@ -2599,7 +2599,7 @@ Returns True if the Polygon is clockwise.
 
 .. warning::
 
-   returns true if the geometry is not a polygon type
+   returns true if the geometry is not a polygon type or empty
 
 
 .. seealso:: :py:func:`isPolygonCounterClockwise`

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2549,6 +2549,69 @@ They require builds based on GEOS 3.10 or later.
 .. versionadded:: 3.0
 %End
 
+    Qgis::AngularDirection polygonOrientation() const;
+%Docstring
+Returns the orientation of the polygon.
+
+.. warning::
+
+   Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+   you have to perform in deep verification.
+
+.. warning::
+
+   returns :py:class:`Qgis`.AngularDirection.Clockwise if the geometry is not a polygon type
+
+.. versionadded:: 3.36
+%End
+
+    bool isPolygonCounterClockwise() const;
+%Docstring
+Returns True if the Polygon is counter-clockwise.
+
+.. warning::
+
+   Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+   you have to perform in deep verification.
+
+.. warning::
+
+   returns false if the geometry is not a polygon type
+
+
+.. seealso:: :py:func:`isPolygonClockwise`
+
+.. seealso:: :py:func:`forcePolygonClockwise`
+
+.. seealso:: :py:func:`forcePolygonCounterClockwise`
+
+.. versionadded:: 3.36
+%End
+
+    bool isPolygonClockwise() const;
+%Docstring
+Returns True if the Polygon is clockwise.
+
+.. warning::
+
+   Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+   you have to perform in deep verification.
+
+.. warning::
+
+   returns true if the geometry is not a polygon type
+
+
+.. seealso:: :py:func:`isPolygonCounterClockwise`
+
+.. seealso:: :py:func:`forcePolygonClockwise`
+
+.. seealso:: :py:func:`forcePolygonCounterClockwise`
+
+.. versionadded:: 3.36
+%End
+
+
     QgsGeometry forceRHR() const;
 %Docstring
 Forces geometries to respect the Right-Hand-Rule, in which the area that is bounded by a polygon
@@ -2559,6 +2622,10 @@ and the interior rings in a counter-clockwise direction.
 
    Due to the conflicting definitions of the right-hand-rule in general use, it is recommended
    to use the explicit :py:func:`~QgsGeometry.forcePolygonClockwise` or :py:func:`~QgsGeometry.forcePolygonCounterClockwise` methods instead.
+
+.. seealso:: :py:func:`isPolygonClockwise`
+
+.. seealso:: :py:func:`isPolygonCounterClockwise`
 
 .. seealso:: :py:func:`forcePolygonClockwise`
 
@@ -2573,6 +2640,10 @@ Forces geometries to respect the exterior ring is clockwise, interior rings are 
 
 This convention is used primarily by ESRI software.
 
+.. seealso:: :py:func:`isPolygonClockwise`
+
+.. seealso:: :py:func:`isPolygonCounterClockwise`
+
 .. seealso:: :py:func:`forcePolygonCounterClockwise`
 
 .. versionadded:: 3.24
@@ -2583,6 +2654,10 @@ This convention is used primarily by ESRI software.
 Forces geometries to respect the exterior ring is counter-clockwise, interior rings are clockwise convention.
 
 This convention matches the OGC Simple Features specification.
+
+.. seealso:: :py:func:`isPolygonClockwise`
+
+.. seealso:: :py:func:`isPolygonCounterClockwise`
 
 .. seealso:: :py:func:`forcePolygonClockwise`
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1508,6 +1508,7 @@ The development version
       {
       Clockwise,
       CounterClockwise,
+      NoOrientation,
     };
 
     enum class RendererUsage

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3178,7 +3178,7 @@ Qgis::AngularDirection QgsGeometry::polygonOrientation() const
 {
   if ( !d->geometry )
   {
-    return Qgis::AngularDirection::Clockwise;
+    return Qgis::AngularDirection::NoOrientation;
   }
 
   if ( isMultipart() )
@@ -3187,18 +3187,18 @@ Qgis::AngularDirection QgsGeometry::polygonOrientation() const
     const QgsAbstractGeometry *g = collection->geometryN( 0 );
     if ( const QgsCurvePolygon *cp = qgsgeometry_cast< const QgsCurvePolygon * >( g ) )
     {
-      return cp->exteriorRing()->orientation();
+      return cp->exteriorRing() ? cp->exteriorRing()->orientation() : Qgis::AngularDirection::NoOrientation;
     }
   }
   else
   {
     if ( const QgsCurvePolygon *cp = qgsgeometry_cast< const QgsCurvePolygon * >( d->geometry.get() ) )
     {
-      return cp->exteriorRing()->orientation();
+      return cp->exteriorRing() ? cp->exteriorRing()->orientation() : Qgis::AngularDirection::NoOrientation;
     }
   }
 
-  return Qgis::AngularDirection::Clockwise;
+  return Qgis::AngularDirection::NoOrientation;
 
 }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3174,6 +3174,34 @@ QgsGeometry QgsGeometry::forceRHR() const
   return forcePolygonClockwise();
 }
 
+Qgis::AngularDirection QgsGeometry::polygonOrientation() const
+{
+  if ( !d->geometry )
+  {
+    return Qgis::AngularDirection::Clockwise;
+  }
+
+  if ( isMultipart() )
+  {
+    const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( d->geometry.get() );
+    const QgsAbstractGeometry *g = collection->geometryN( 0 );
+    if ( const QgsCurvePolygon *cp = qgsgeometry_cast< const QgsCurvePolygon * >( g ) )
+    {
+      return cp->exteriorRing()->orientation();
+    }
+  }
+  else
+  {
+    if ( const QgsCurvePolygon *cp = qgsgeometry_cast< const QgsCurvePolygon * >( d->geometry.get() ) )
+    {
+      return cp->exteriorRing()->orientation();
+    }
+  }
+
+  return Qgis::AngularDirection::Clockwise;
+
+}
+
 QgsGeometry QgsGeometry::forcePolygonClockwise() const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2647,6 +2647,48 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false ) const SIP_THROW( QgsNotSupportedException );
 
     /**
+     * Returns the orientation of the polygon.
+     * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+     * you have to perform in deep verification.
+     *
+     * \warning returns Qgis::AngularDirection::Clockwise if the geometry is not a polygon type
+     *
+     * \since QGIS 3.36
+     */
+    Qgis::AngularDirection polygonOrientation() const;
+
+    /**
+     * Returns True if the Polygon is counter-clockwise.
+     *
+     * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+     * you have to perform in deep verification.
+     *
+     * \warning returns false if the geometry is not a polygon type
+     *
+     * \see isPolygonClockwise()
+     * \see forcePolygonClockwise()
+     * \see forcePolygonCounterClockwise()
+     * \since QGIS 3.36
+     */
+    bool isPolygonCounterClockwise() const { return polygonOrientation() == Qgis::AngularDirection::CounterClockwise; }
+
+    /**
+     * Returns True if the Polygon is clockwise.
+     *
+     * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
+     * you have to perform in deep verification.
+     *
+     * \warning returns true if the geometry is not a polygon type
+     *
+     * \see isPolygonCounterClockwise()
+     * \see forcePolygonClockwise()
+     * \see forcePolygonCounterClockwise()
+     * \since QGIS 3.36
+     */
+    bool isPolygonClockwise() const { return polygonOrientation() == Qgis::AngularDirection::Clockwise; }
+
+
+    /**
      * Forces geometries to respect the Right-Hand-Rule, in which the area that is bounded by a polygon
      * is to the right of the boundary. In particular, the exterior ring is oriented in a clockwise direction
      * and the interior rings in a counter-clockwise direction.
@@ -2654,6 +2696,8 @@ class CORE_EXPORT QgsGeometry
      * \warning Due to the conflicting definitions of the right-hand-rule in general use, it is recommended
      * to use the explicit forcePolygonClockwise() or forcePolygonCounterClockwise() methods instead.
      *
+     * \see isPolygonClockwise()
+     * \see isPolygonCounterClockwise()
      * \see forcePolygonClockwise()
      * \see forcePolygonCounterClockwise()
      * \since QGIS 3.6
@@ -2665,6 +2709,8 @@ class CORE_EXPORT QgsGeometry
      *
      * This convention is used primarily by ESRI software.
      *
+     * \see isPolygonClockwise()
+     * \see isPolygonCounterClockwise()
      * \see forcePolygonCounterClockwise()
      * \since QGIS 3.24
      */
@@ -2675,6 +2721,8 @@ class CORE_EXPORT QgsGeometry
      *
      * This convention matches the OGC Simple Features specification.
      *
+     * \see isPolygonClockwise()
+     * \see isPolygonCounterClockwise()
      * \see forcePolygonClockwise()
      * \since QGIS 3.24
      */

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2651,7 +2651,7 @@ class CORE_EXPORT QgsGeometry
      * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
      * you have to perform in deep verification.
      *
-     * \warning returns Qgis::AngularDirection::Clockwise if the geometry is not a polygon type
+     * \warning returns Qgis::AngularDirection::NoOrientation if the geometry is not a polygon type or empty
      *
      * \since QGIS 3.36
      */
@@ -2663,7 +2663,7 @@ class CORE_EXPORT QgsGeometry
      * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
      * you have to perform in deep verification.
      *
-     * \warning returns false if the geometry is not a polygon type
+     * \warning returns false if the geometry is not a polygon type or empty
      *
      * \see isPolygonClockwise()
      * \see forcePolygonClockwise()
@@ -2678,7 +2678,7 @@ class CORE_EXPORT QgsGeometry
      * \warning Only the first exterior ring is taken to perform this operation. In case of degenerate orders,
      * you have to perform in deep verification.
      *
-     * \warning returns true if the geometry is not a polygon type
+     * \warning returns true if the geometry is not a polygon type or empty
      *
      * \see isPolygonCounterClockwise()
      * \see forcePolygonClockwise()

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1,17 +1,17 @@
 /***************************************************************************
-    qgsarcgisrestutils.cpp
-    ----------------------
-    begin                : Nov 25, 2015
-    copyright            : (C) 2015 by Sandro Mani
-    email                : manisandro@gmail.com
- ***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+   qgsarcgisrestutils.cpp
+   ----------------------
+   begin                : Nov 25, 2015
+   copyright            : (C) 2015 by Sandro Mani
+   email                : manisandro@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
 
 #include "qgsarcgisrestutils.h"
 #include "qgsfields.h"
@@ -1412,6 +1412,8 @@ QVariantList QgsArcGisRestUtils::polygonToJsonRings( const QgsPolygon *polygon )
         rings.push_back( lineStringToJsonPath( reversed.get() ) );
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
 
@@ -1431,6 +1433,8 @@ QVariantList QgsArcGisRestUtils::polygonToJsonRings( const QgsPolygon *polygon )
         rings.push_back( lineStringToJsonPath( reversed.get() ) );
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
   return rings;
@@ -1457,6 +1461,8 @@ QVariantList QgsArcGisRestUtils::curvePolygonToJsonRings( const QgsCurvePolygon 
         rings.push_back( curveToJsonCurve( reversed.get(), true ) );
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
 
@@ -1476,6 +1482,8 @@ QVariantList QgsArcGisRestUtils::curvePolygonToJsonRings( const QgsCurvePolygon 
         rings.push_back( curveToJsonCurve( reversed.get(), true ) );
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
   return rings;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2565,6 +2565,7 @@ class CORE_EXPORT Qgis
       {
       Clockwise, //!< Clockwise direction
       CounterClockwise, //!< Counter-clockwise direction
+      NoOrientation, //!< Unknown orientation or sentinel value
     };
     Q_ENUM( AngularDirection )
 

--- a/src/core/qgscolorrampimpl.cpp
+++ b/src/core/qgscolorrampimpl.cpp
@@ -1,17 +1,17 @@
 /***************************************************************************
-    qgscolorrampimpl.cpp
-    ---------------------
-    begin                : November 2009
-    copyright            : (C) 2009 by Martin Dobias
-    email                : wonder dot sk at gmail dot com
- ***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+   qgscolorrampimpl.cpp
+   ---------------------
+   begin                : November 2009
+   copyright            : (C) 2009 by Martin Dobias
+   email                : wonder dot sk at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
 
 #include "qgscolorrampimpl.h"
 #include "qgscolorbrewerpalette.h"
@@ -94,6 +94,8 @@ static QColor _interpolateHsv( const QColor &c1, const QColor &c2, const double 
           hue -= 1;
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
 
@@ -151,6 +153,8 @@ static QColor _interpolateHsl( const QColor &c1, const QColor &c2, const double 
           hue -= 1;
         break;
       }
+      case Qgis::AngularDirection::NoOrientation:
+        break;
     }
   }
 
@@ -472,6 +476,8 @@ QVariantMap QgsGradientColorRamp::properties() const
       break;
     case Qgis::AngularDirection::CounterClockwise:
       map[QStringLiteral( "direction" ) ] = QStringLiteral( "ccw" );
+      break;
+    case Qgis::AngularDirection::NoOrientation:
       break;
   }
 

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -183,7 +183,14 @@ Qgis::GeometryOperationResult staticAddRing( QgsVectorLayer *layer, std::unique_
     //add ring takes ownership of ring, and deletes it if there's an error
     QgsGeometry g = f.geometry();
 
-    addRingReturnCode = g.addRing( static_cast< QgsCurve * >( ring->clone() ) );
+    if ( ring->orientation() == Qgis::AngularDirection::Clockwise )
+    {
+      addRingReturnCode = g.addRing( static_cast< QgsCurve * >( ring->clone() ) );
+    }
+    else
+    {
+      addRingReturnCode = g.addRing( static_cast< QgsCurve * >( ring->reversed() ) );
+    }
     if ( addRingReturnCode == Qgis::GeometryOperationResult::Success )
     {
       layer->changeGeometry( f.id(), g );

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -183,7 +183,7 @@ Qgis::GeometryOperationResult staticAddRing( QgsVectorLayer *layer, std::unique_
     //add ring takes ownership of ring, and deletes it if there's an error
     QgsGeometry g = f.geometry();
 
-    if ( ring->orientation() == Qgis::AngularDirection::Clockwise )
+    if ( ring->orientation() != g.polygonOrientation() )
     {
       addRingReturnCode = g.addRing( static_cast< QgsCurve * >( ring->clone() ) );
     }

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -294,6 +294,7 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( const QgsPointSe
 
 Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, QgsFeatureId featureId )
 {
+
   if ( !mLayer->isSpatial() )
     return Qgis::GeometryOperationResult::AddPartSelectedGeometryNotFound;
 
@@ -311,9 +312,13 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, 
   else
   {
     geometry = f.geometry();
+    if ( ring->orientation() != geometry.polygonOrientation() )
+    {
+      ring = ring->reversed();
+    }
   }
-
   Qgis::GeometryOperationResult errorCode = geometry.addPart( ring, mLayer->geometryType() );
+
   if ( errorCode == Qgis::GeometryOperationResult::Success )
   {
     if ( firstPart && QgsWkbTypes::isSingleType( mLayer->wkbType() )
@@ -349,6 +354,7 @@ int QgsVectorLayerEditUtils::translateFeature( QgsFeatureId featureId, double dx
 
 Qgis::GeometryOperationResult QgsVectorLayerEditUtils::splitFeatures( const QVector<QgsPointXY> &splitLine, bool topologicalEditing )
 {
+
   QgsPointSequence l;
   for ( QVector<QgsPointXY>::const_iterator it = splitLine.constBegin(); it != splitLine.constEnd(); ++it )
   {

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TESTS
   testqgslayerpropertiesdialogs.cpp
   testqgsmapcanvasdockwidget.cpp
   testqgsmaptooladdpart.cpp
+  testqgsmaptooladdring.cpp
   testqgsmaptooleditannotation.cpp
   testqgsmaptoolidentifyaction.cpp
   testqgsmaptoollabel.cpp

--- a/tests/src/app/testqgsmaptooladdpart.cpp
+++ b/tests/src/app/testqgsmaptooladdpart.cpp
@@ -41,6 +41,7 @@ class TestQgsMapToolAddPart: public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
 
     void testAddPart();
+    void testAddPartClockWise();
 
   private:
     QPoint mapToPoint( double x, double y );
@@ -172,5 +173,53 @@ void TestQgsMapToolAddPart::testAddPart()
   QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
 }
 
+void TestQgsMapToolAddPart::testAddPartClockWise()
+{
+  mLayerMultiPolygon->select( 1 );
+
+  // Draw in clockwise
+  std::unique_ptr< QgsMapMouseEvent > event( new QgsMapMouseEvent(
+        mCanvas,
+        QEvent::MouseButtonRelease,
+        mapToPoint( 15, 15 ),
+        Qt::LeftButton
+      ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 15, 16 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 16, 16 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 16, 15 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 15, 15 ),
+                 Qt::RightButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  const QString wkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4)),((5 5, 5 5, 6 5, 6 6, 5 6, 5 5)),((15 15, 16 15, 16 16, 15 16, 15 15)))";
+  QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+}
 QGSTEST_MAIN( TestQgsMapToolAddPart )
 #include "testqgsmaptooladdpart.moc"

--- a/tests/src/app/testqgsmaptooladdring.cpp
+++ b/tests/src/app/testqgsmaptooladdring.cpp
@@ -1,0 +1,221 @@
+/***************************************************************************
+     testqgsmaptooladdring.cpp
+     --------------------------------
+    Date                 : 2023-11-22
+    Copyright            : (C) 2023 by Loïc Bartoletti
+    Email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgisapp.h"
+#include "qgsgeometry.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptooladdring.h"
+#include "qgsproject.h"
+#include "qgssettingsregistrycore.h"
+#include "qgsvectorlayer.h"
+#include "qgsmapmouseevent.h"
+#include "testqgsmaptoolutils.h"
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the add ring map tool
+ */
+class TestQgsMapToolAddRing: public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsMapToolAddRing();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+
+    void testAddRing();
+    void testAddRingClockWise();
+
+  private:
+    QPoint mapToPoint( double x, double y );
+
+    QgisApp *mQgisApp = nullptr;
+    QgsMapCanvas *mCanvas = nullptr;
+    QgsMapToolAddRing *mCaptureTool = nullptr;
+    QgsVectorLayer *mLayerMultiPolygon = nullptr;
+};
+
+TestQgsMapToolAddRing::TestQgsMapToolAddRing() = default;
+
+
+//runs before all tests
+void TestQgsMapToolAddRing::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  mQgisApp = new QgisApp();
+
+  mCanvas = new QgsMapCanvas();
+
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
+
+  mCanvas->setFrameStyle( QFrame::NoFrame );
+  mCanvas->resize( 512, 512 );
+  mCanvas->setExtent( QgsRectangle( 0, 0, 8, 8 ) );
+  mCanvas->show(); // to make the canvas resize
+  mCanvas->hide();
+
+  // make testing layers
+  mLayerMultiPolygon = new QgsVectorLayer( QStringLiteral( "MultiPolygon?crs=EPSG:3946" ), QStringLiteral( "multipolygon" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerMultiPolygon->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerMultiPolygon );
+
+  mLayerMultiPolygon->startEditing();
+  QgsFeature f;
+  const QString wkt( "MultiPolygon (((0 0, 5 0, 5 5, 0 5, 0 0)))" );
+  f.setGeometry( QgsGeometry::fromWkt( wkt ) );
+  mLayerMultiPolygon->dataProvider()->addFeatures( QgsFeatureList() << f );
+  QCOMPARE( mLayerMultiPolygon->featureCount(), ( long )1 );
+  QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+
+  mCanvas->setCurrentLayer( mLayerMultiPolygon );
+
+  // create the tool
+  mCaptureTool = new QgsMapToolAddRing( mCanvas );
+  mCanvas->setMapTool( mCaptureTool );
+
+  QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );
+  QCOMPARE( mCanvas->mapSettings().visibleExtent(), QgsRectangle( 0, 0, 8, 8 ) );
+}
+
+//runs after all tests
+void TestQgsMapToolAddRing::cleanupTestCase()
+{
+  delete mCaptureTool;
+  delete mCanvas;
+  QgsApplication::exitQgis();
+}
+
+QPoint TestQgsMapToolAddRing::mapToPoint( double x, double y )
+{
+  const QgsPointXY mapPoint = mCanvas->mapSettings().mapToPixel().transform( x, y );
+
+  return QPoint( static_cast<int>( std::round( mapPoint.x() ) ), static_cast<int>( std::round( mapPoint.y() ) ) );
+}
+
+void TestQgsMapToolAddRing::testAddRing()
+{
+  mLayerMultiPolygon->select( 1 );
+
+  std::unique_ptr< QgsMapMouseEvent > event( new QgsMapMouseEvent(
+        mCanvas,
+        QEvent::MouseButtonRelease,
+        mapToPoint( 1, 1 ),
+        Qt::LeftButton
+      ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 1, 2 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 2, 2 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 2, 1 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 1, 1 ),
+                 Qt::RightButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  // TODO: fix https://github.com/qgis/QGIS/issues/55361
+  // const QString wkt = "MultiPolygon (((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1)))";
+  const QString wkt = "MultiPolygon (((0 0, 5 0, 5 5, 0 5, 0 0),CompoundCurve ((1 1, 1 2, 2 2, 2 1, 1 1))))";
+  QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+}
+
+void TestQgsMapToolAddRing::testAddRingClockWise()
+{
+  mLayerMultiPolygon->select( 1 );
+
+  // Draw in clockwise
+  std::unique_ptr< QgsMapMouseEvent > event( new QgsMapMouseEvent(
+        mCanvas,
+        QEvent::MouseButtonRelease,
+        mapToPoint( 3, 3 ),
+        Qt::LeftButton
+      ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 4, 3 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 4, 4 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 3, 4 ),
+                 Qt::LeftButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event.reset( new QgsMapMouseEvent(
+                 mCanvas,
+                 QEvent::MouseButtonRelease,
+                 mapToPoint( 3, 3 ),
+                 Qt::RightButton
+               ) );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  // TODO: fix https://github.com/qgis/QGIS/issues/55361
+  // const QString wkt = "MultiPolygon (((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (3 3, 3 4, 4 4, 4 3, 3 3)))";
+  const QString wkt = "MultiPolygon (((0 0, 5 0, 5 5, 0 5, 0 0),CompoundCurve ((1 1, 1 2, 2 2, 2 1, 1 1)),CompoundCurve ((3 3, 3 4, 4 4, 4 3, 3 3))))";
+  QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+}
+QGSTEST_MAIN( TestQgsMapToolAddRing )
+#include "testqgsmaptooladdring.moc"

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -7438,6 +7438,121 @@ class TestQgsGeometry(QgisTestCase):
         res = g1.simplifyCoverageVW(10, True)
         self.assertEqual(res.asWkt(0), 'GeometryCollection (Polygon ((10 0, 10 10, 0 10, 0 0, 10 0)),Polygon ((10 0, 20 0, 20 10, 10 10, 10 0)))')
 
+    def testPolygonOrientation(self):
+        """
+        Test QgsGeometry.polygonOrientation, QgsGeometry.isPolygonClockwise and QgsGeometry.isPolygonCounterClockwise
+        """
+
+        # Empty geometry
+        geometry = QgsGeometry()
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.NoOrientation)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # Not a polygon
+        geometry = QgsGeometry.fromWkt('Point(1 2)')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.NoOrientation)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # Closed curve but not a polygon
+        geometry = QgsGeometry.fromWkt('LineString(0 0, 0 1, 1 1, 1 0, 0 0)')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.NoOrientation)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # Polygon Empty
+        geometry = QgsGeometry.fromWkt('Polygon EMPTY')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.NoOrientation)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # Polygon Clockwise
+        geometry = QgsGeometry.fromWkt('Polygon((0 0, 0 1, 1 1, 1 0, 0 0))')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.Clockwise)
+        self.assertEqual(res_isClockwise, True)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # Polygon CounterClockwise
+        geometry = QgsGeometry.fromWkt('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.CounterClockwise)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, True)
+
+        # MultiPolygon Empty
+        geometry = QgsGeometry.fromWkt('MultiPolygon EMPTY')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.NoOrientation)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # MultiPolygon Clockwise
+        geometry = QgsGeometry.fromWkt('MultiPolygon( ((0 0, 0 1, 1 1, 1 0, 0 0)) )')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.Clockwise)
+        self.assertEqual(res_isClockwise, True)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # MultiPolygon Clockwise with a CounterClockwise part
+        geometry = QgsGeometry.fromWkt('MultiPolygon( ((0 0, 0 1, 1 1, 1 0, 0 0)), ((4 4, 5 4, 5 5, 4 5, 4 4)) )')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.Clockwise)
+        self.assertEqual(res_isClockwise, True)
+        self.assertEqual(res_isCounterClockwise, False)
+
+        # MultiPolygon CounterClockwise
+        geometry = QgsGeometry.fromWkt('MultiPolygon( ((0 0, 1 0, 1 1, 0 1, 0 0)) )')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.CounterClockwise)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, True)
+
+        # MultiPolygon CounterClockwise with a Clockwise part
+        geometry = QgsGeometry.fromWkt('MultiPolygon( ((0 0, 1 0, 1 1, 0 1, 0 0)), ((4 4, 4 5, 5 5, 5 4, 4 4)) ) ')
+        res_orientation = geometry.polygonOrientation()
+        res_isClockwise = geometry.isPolygonClockwise()
+        res_isCounterClockwise = geometry.isPolygonCounterClockwise()
+
+        self.assertEqual(res_orientation, Qgis.AngularDirection.CounterClockwise)
+        self.assertEqual(res_isClockwise, False)
+        self.assertEqual(res_isCounterClockwise, True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

I'm reaching out regarding an important initiative aimed at rectifying an anomaly observed in the digitization process within QGIS. Specifically, the adherence to OGC standards, upon which QGIS relies, dictates a distinct orientation requirement for polygon rings.

As per the OGC norm, the exterior boundary LinearRing must define the "top" of the surface, following a counterclockwise traversal along the boundary. Conversely, interior LinearRings should exhibit an opposite orientation, appearing clockwise when viewed from the "top."

Presently, there's a lack of verification within QGIS to ensure adherence to this prescribed behavior. To address this issue, I'll be initiating a series of PR; focusing only on the digitization process here. The primary goal is to align the behavior more closely with the established standards.

Nevertheless, I intend to maintain flexibility in the codebase, allowing for the preservation of the previous behavior programmatically. This approach aims to avoid directly enforcing orientation within the *Polygon classes. So, classes still accept "unordered" rings.

Before:


https://github.com/qgis/QGIS/assets/7521540/1459266c-7c5d-4d91-8d4f-662c1cdcb6c5


After:


https://github.com/qgis/QGIS/assets/7521540/51e43cd4-2cbf-4f95-94fe-5c2ba9d48b21


PS: The motivation behind this is that certain tools perform stricter checks than the ones we currently conduct or those performed with GEOS.
PS2: I'm aware that ESRI Shapefile is CW unlike OGC, but should be a provider role to check this part?

TODO:

- [ ] fix tests
- [x] add test