### PR TITLE
Show render times in server profile and clear content after each request

### DIFF
--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -593,8 +593,12 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
   }
 
 
-  // Clear the profiler server section after each request
+  // Clear the profiler content after each request
+  QgsApplication::profiler()->clear( QStringLiteral( "startup" ) );
+  QgsApplication::profiler()->clear( QStringLiteral( "projectload" ) );
+  QgsApplication::profiler()->clear( QStringLiteral( "rendering" ) );
   QgsApplication::profiler()->clear( QStringLiteral( "server" ) );
+
 
 }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1415,6 +1415,12 @@ namespace QgsWms
 
     mapSettings.setFlag( Qgis::MapSettingsFlag::RenderMapTile, mContext.renderMapTiles() );
 
+    // enable profiling
+    if ( mContext.settings().logProfile() )
+    {
+      mapSettings.setFlag( Qgis::MapSettingsFlag::RecordProfile );
+    }
+
     // set selection color
     mapSettings.setSelectionColor( mProject->selectionColor() );
 


### PR DESCRIPTION
It would be great to see the layer render times in the profile infos for QGIS server. Also, the profile entries should be completely cleared after each request. Currently there are some time entries from initialization showing up after each request. This creates the wrong impression that they are run on each request.