### PR TITLE
Fix shapefile extent not shrinking

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1128,7 +1128,10 @@ QgsRectangle QgsOgrProvider::extent() const
     // get the extent_ (envelope) of the layer
     QgsDebugMsgLevel( QStringLiteral( "Starting get extent" ), 3 );
 
-    if ( mForceRecomputeExtent && mValid && mGDALDriverName == QLatin1String( "GPKG" ) && mOgrOrigLayer )
+    if ( mForceRecomputeExtent && mValid &&
+         ( mGDALDriverName == QLatin1String( "GPKG" ) ||
+           ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) && mWriteAccess) ) &&
+         mOgrOrigLayer )
     {
       // works with unquoted layerName
       QByteArray sql = QByteArray( "RECOMPUTE EXTENT ON " ) + mOgrOrigLayer->name();

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1128,9 +1128,9 @@ QgsRectangle QgsOgrProvider::extent() const
     // get the extent_ (envelope) of the layer
     QgsDebugMsgLevel( QStringLiteral( "Starting get extent" ), 3 );
 
-    if ( mForceRecomputeExtent && mValid &&
+    if ( mForceRecomputeExtent && mValid && mWriteAccess &&
          ( mGDALDriverName == QLatin1String( "GPKG" ) ||
-           ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) && mWriteAccess ) ) &&
+           mGDALDriverName == QLatin1String( "ESRI Shapefile" ) ) &&
          mOgrOrigLayer )
     {
       // works with unquoted layerName

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1130,7 +1130,7 @@ QgsRectangle QgsOgrProvider::extent() const
 
     if ( mForceRecomputeExtent && mValid &&
          ( mGDALDriverName == QLatin1String( "GPKG" ) ||
-           ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) && mWriteAccess) ) &&
+           ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) && mWriteAccess ) ) &&
          mOgrOrigLayer )
     {
       // works with unquoted layerName

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -802,6 +802,10 @@ bool QgsVectorLayerEditBuffer::commitChangesChangeAttributes( bool &attributesCh
       return false;
     }
 
+    // recompute extent for Shapefile
+    if ( L->storageType() == QLatin1String( "ESRI Shapefile" ) )
+      L->extent();
+
     if ( L->dataProvider()->changeGeometryValues( mChangedGeometries ) )
     {
       commitErrors << tr( "SUCCESS: %n geometries were changed.", "changed geometries count", mChangedGeometries.size() );

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -802,10 +802,6 @@ bool QgsVectorLayerEditBuffer::commitChangesChangeAttributes( bool &attributesCh
       return false;
     }
 
-    // recompute extent for Shapefile
-    if ( L->storageType() == QLatin1String( "ESRI Shapefile" ) )
-      L->extent();
-
     if ( L->dataProvider()->changeGeometryValues( mChangedGeometries ) )
     {
       commitErrors << tr( "SUCCESS: %n geometries were changed.", "changed geometries count", mChangedGeometries.size() );

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -1142,6 +1142,18 @@ class TestPyQgsShapefileProvider(QgisTestCase, ProviderTestCase):
         f = next(vl.getFeatures())
         self.assertEqual(f['name'], 'Apple')
 
+    def testRecomputeExtent(self):
+        """Test shrink extent correctly"""
+
+        vl = self.getEditableLayer()
+        extent_area = vl.extent().area()
+        vl.startEditing()
+        for fet in vl.getFeatures():
+            vl.translateFeature(fet.id(), -1, -1)
+        vl.commitChanges()
+        self.assertEqual(vl.extent().area(), extent_area)
+        vl = None
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Upstream states that when updating existing features in a shapefile, the extent will not be correct and then recomputation must be forced.
https://gdal.org/drivers/vector/shapefile.html#spatial-extent

With this fix, the attached script will return the correct extent without uncommenting.
https://github.com/qgis/QGIS/files/13325893/bug_extent_of_shapefile.py.txt

Fixes #23661, #13985