### PR TITLE
qgswfsparameters: Ensure to get the default value on wrong version

### DIFF
--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -368,10 +368,10 @@ namespace QgsWfs
     const QString vStr = version();
     QgsProjectVersion version;
 
-    if ( vStr.isEmpty() )
-      version = QgsProjectVersion( 1, 1, 0 ); // default value
-    else if ( mVersions.contains( QgsProjectVersion( vStr ) ) )
+    if ( mVersions.contains( QgsProjectVersion( vStr ) ) )
       version = QgsProjectVersion( vStr );
+    else
+      version = QgsProjectVersion( 1, 1, 0 ); // default value
 
     return version;
   }

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -560,6 +560,16 @@ class TestQgsServerWFS(QgsServerTestBase):
         self.wfs_request_compare(
             "GetFeature", '1.1.0', "TYPENAME=testlayer&FEATUREID=testlayer.0", 'wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname')
 
+    def test_get_feature_wrong_version_nomber(self):
+        """Test GetFeature with a wrong version number.
+           This should fall back to the default version: 1.1.0
+        """
+        self.wfs_request_compare(
+            "GetFeature", '2.0.0', "SRSNAME=urn:ogc:def:crs:EPSG::4326&TYPENAME=testlayer&FEATUREID=testlayer.0", 'wfs_getFeature_1_1_0_featureid_0_1_1_0')
+
+        self.wfs_request_compare(
+            "GetFeature", '2.0.0', "TYPENAME=testlayer&FEATUREID=testlayer.0", 'wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname')
+
     def test_getFeature_EXP_FILTER_regression_20927(self):
         """Test expressions with EXP_FILTER"""
 


### PR DESCRIPTION
## Description

`QgsWfsParameters::versionAsNumber` creates a `QgsProjectVersion` from
the version number defined in the request `VERSION` parameter. If the
version is not defined, the version 1.1.0 is used.     
However, if the version number defined in the `VERSION` parameter is
not handled by QGIS (for example 2.0.0), the `QgsProjectVersion` is
nver populated which corresponds to use version 0.0.0 instead of
1.1.0, the default value.

This issue is fixed by always using version number 1.1.0 if the list
of handled versions (`mVersions`) does not contain the requested
version.


 **Funded by Ifremer**