### PR TITLE
Disable QWT_POLAR on msys2 workflow

### DIFF
--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -83,7 +83,7 @@ jobs:
             -DWITH_3D=ON \
             -DWITH_PDAL=OFF \
             -DWITH_CUSTOM_WIDGETS=ON \
-            -DWITH_QWTPOLAR=ON \
+            -DWITH_QWTPOLAR=OFF \
             -DWITH_BINDINGS=OFF \
             -DWITH_GRASS=OFF \
             -DWITH_DRACO=OFF \


### PR DESCRIPTION
This is a non-default (unsupported) option, and it's broken on latest msys2 builds