### PR TITLE
Fix pgraster statistics collection on Windows

### DIFF
--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -126,9 +126,9 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
     //! Has spatial index
     bool mHasSpatialIndex = false;
     //! Raster size x
-    long mWidth = 0;
+    qlonglong mWidth = 0;
     //! Raster size y
-    long mHeight = 0;
+    qlonglong mHeight = 0;
     //! Raster tile size x
     int mTileWidth = 0;
     //! Raster tile size y


### PR DESCRIPTION
## Description

This PR uses qlonglong type for pgraster width and height to avoid problem with pixelsRatio turning negative when complied on windows with MinGW or MSVC.

Fixes #47815.  
Backport needed for 3.34 and 3.28.