### PR TITLE
[3D] Fix combination of rotation, combination and zoom 

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -637,7 +637,7 @@ void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 {
   Q_UNUSED( mouse )
 
-  mClickPoint = QPoint( 0, 0 );
+  mClickPoint = QPoint();
   setMouseParameters( MouseOperation::None );
 }
 
@@ -1063,7 +1063,7 @@ void QgsCameraController::setMouseParameters( const MouseOperation &newOperation
   // Indeed, if the sequence such as rotation -> zoom -> rotation updating mClickPoint on
   // the click point does not need to be updated because the relative mouse position is kept
   // during a zoom operation
-  if ( mClickPoint == QPoint( 0, 0 ) ||
+  if ( mClickPoint.isNull() ||
        ( ( newOperation == MouseOperation::Rotation || newOperation == MouseOperation::Translation ) &&
          ( mCurrentOperation == MouseOperation::Rotation ||  mCurrentOperation == MouseOperation::Translation ) ) )
   {

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -325,6 +325,8 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   {
     // rotate/tilt using mouse (camera moves as it rotates around the clicked point)
 
+    setMouseParameters( MouseOperation::Rotation );
+
     float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mMiddleButtonClickPos.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mMiddleButtonClickPos.x() ) / scale;
@@ -386,6 +388,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   else if ( hasLeftButton && !hasShift && !hasCtrl )
   {
     // translation works as if one grabbed a point on the 3D viewer and dragged it
+    setMouseParameters( MouseOperation::Translation );
 
     if ( !mDepthBufferIsReady )
       return;
@@ -444,6 +447,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   }
   else if ( hasRightButton && !hasShift && !hasCtrl )
   {
+    setMouseParameters( MouseOperation::Zoom );
     if ( !mDepthBufferIsReady )
       return;
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -182,11 +182,7 @@ void QgsCameraController::setCameraPose( const QgsCameraPose &camPose )
     return;
 
   mCameraPose = camPose;
-
-  if ( mCamera )
-    mCameraPose.updateCamera( mCamera );
-
-  emit cameraChanged();
+  updateCameraFromPose();
 }
 
 QDomElement QgsCameraController::writeXml( QDomDocument &doc ) const
@@ -260,6 +256,7 @@ void QgsCameraController::updateCameraFromPose()
 {
   if ( mCamera )
     mCameraPose.updateCamera( mCamera );
+
   emit cameraChanged();
 }
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -328,9 +328,9 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   {
     // rotate/tilt using mouse (camera moves as it rotates around the clicked point)
 
-    double scale = std::max( mScene->engine()->size().width(), mScene->engine()->size().height() );
-    float pitchDiff = 180 * ( mouse->y() - mMiddleButtonClickPos.y() ) / scale;
-    float yawDiff = -180 * ( mouse->x() - mMiddleButtonClickPos.x() ) / scale;
+    float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
+    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mMiddleButtonClickPos.y() ) / scale;
+    float yawDiff = -180.0f * static_cast<float>( mouse->x() - mMiddleButtonClickPos.x() ) / scale;
 
     if ( !mDepthBufferIsReady )
       return;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -627,7 +627,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
     mDragButtonClickPos = QPoint( mouse->x(), mouse->y() );
-    mMousePressed = true;
 
     if ( mCaptureFpsMouseMovements )
       mIgnoreNextMouseMove = true;
@@ -650,7 +649,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
     mMiddleButtonClickPos = QPoint( mouse->x(), mouse->y() );
-    mMousePressed = true;
     if ( mCaptureFpsMouseMovements )
       mIgnoreNextMouseMove = true;
     mDepthBufferIsReady = false;
@@ -674,7 +672,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
 void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 {
   Q_UNUSED( mouse )
-  mMousePressed = false;
 
   mDragPointCalculated = false;
   mRotationCenterCalculated = false;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -627,7 +627,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
     mDragButtonClickPos = QPoint( mouse->x(), mouse->y() );
-    mPressedButton = mouse->button();
     mMousePressed = true;
 
     if ( mCaptureFpsMouseMovements )
@@ -651,7 +650,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
     mMiddleButtonClickPos = QPoint( mouse->x(), mouse->y() );
-    mPressedButton = mouse->button();
     mMousePressed = true;
     if ( mCaptureFpsMouseMovements )
       mIgnoreNextMouseMove = true;
@@ -676,7 +674,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
 void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 {
   Q_UNUSED( mouse )
-  mPressedButton = Qt3DInput::QMouseEvent::NoButton;
   mMousePressed = false;
 
   mDragPointCalculated = false;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -623,7 +623,33 @@ void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
 void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
 {
   mKeyboardHandler->setFocus( true );
-  if ( mouse->button() == Qt3DInput::QMouseEvent::LeftButton || mouse->button() == Qt3DInput::QMouseEvent::RightButton )
+
+  if ( mouse->button() == Qt3DInput::QMouseEvent::MiddleButton || ( ( mouse->modifiers() & Qt::ShiftModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) )
+  {
+    mMousePos = QPoint( mouse->x(), mouse->y() );
+    mMiddleButtonClickPos = QPoint( mouse->x(), mouse->y() );
+
+    if ( mCaptureFpsMouseMovements )
+      mIgnoreNextMouseMove = true;
+
+    mDepthBufferIsReady = false;
+    mRotationCenterCalculated = false;
+
+    mRotationPitch = mCameraPose.pitchAngle();
+    mRotationYaw = mCameraPose.headingAngle();
+
+    mCameraPose.updateCamera( mCameraBeforeRotation.get() );
+
+    mCameraBeforeRotation->setProjectionMatrix( mCamera->projectionMatrix() );
+    mCameraBeforeRotation->setNearPlane( mCamera->nearPlane() );
+    mCameraBeforeRotation->setFarPlane( mCamera->farPlane() );
+    mCameraBeforeRotation->setAspectRatio( mCamera->aspectRatio() );
+    mCameraBeforeRotation->setFieldOfView( mCamera->fieldOfView() );
+
+    emit requestDepthBufferCapture();
+  }
+
+  else if ( mouse->button() == Qt3DInput::QMouseEvent::LeftButton || mouse->button() == Qt3DInput::QMouseEvent::RightButton )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
     mDragButtonClickPos = QPoint( mouse->x(), mouse->y() );
@@ -641,29 +667,6 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
 
     mDepthBufferIsReady = false;
     mDragPointCalculated = false;
-
-    emit requestDepthBufferCapture();
-  }
-
-  if ( mouse->button() == Qt3DInput::QMouseEvent::MiddleButton || ( ( mouse->modifiers() & Qt::ShiftModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) )
-  {
-    mMousePos = QPoint( mouse->x(), mouse->y() );
-    mMiddleButtonClickPos = QPoint( mouse->x(), mouse->y() );
-    if ( mCaptureFpsMouseMovements )
-      mIgnoreNextMouseMove = true;
-    mDepthBufferIsReady = false;
-    mRotationCenterCalculated = false;
-
-    mRotationPitch = mCameraPose.pitchAngle();
-    mRotationYaw = mCameraPose.headingAngle();
-
-    mCameraPose.updateCamera( mCameraBeforeRotation.get() );
-
-    mCameraBeforeRotation->setProjectionMatrix( mCamera->projectionMatrix() );
-    mCameraBeforeRotation->setNearPlane( mCamera->nearPlane() );
-    mCameraBeforeRotation->setFarPlane( mCamera->farPlane() );
-    mCameraBeforeRotation->setAspectRatio( mCamera->aspectRatio() );
-    mCameraBeforeRotation->setFieldOfView( mCamera->fieldOfView() );
 
     emit requestDepthBufferCapture();
   }

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -233,7 +233,7 @@ class _3D_EXPORT QgsCameraController : public QObject
       Zoom
     };
 
-    void setMouseParameters( const MouseOperation &newOperation );
+    void setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint = QPoint( 0, 0 ) );
 
   signals:
     //! Emitted when camera has been updated
@@ -305,19 +305,20 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Last mouse position recorded
     QPoint mMousePos;
 
+    //! click point for a rotation or a translation
+    QPoint mClickPoint = QPoint( 0, 0 );
+
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;
 
     std::unique_ptr< Qt3DRender::QCamera > mCameraBefore;
 
-    QPoint mMiddleButtonClickPos;
     bool mRotationCenterCalculated = false;
     QVector3D mRotationCenter;
     double mRotationDistanceFromCenter;
     double mRotationPitch = 0;
     double mRotationYaw = 0;
 
-    QPoint mDragButtonClickPos;
     bool mDragPointCalculated = false;
     QVector3D mDragPoint;
     double mDragDepth;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -225,6 +225,16 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Returns a pointer to the scene's engine's window or nullptr if engine is QgsOffscreen3DEngine
     QWindow *window() const;
 
+    enum class MouseOperation
+    {
+      None = 0,
+      Translation,
+      Rotation,
+      Zoom
+    };
+
+    void setMouseParameters( const MouseOperation &newOperation );
+
   signals:
     //! Emitted when camera has been updated
     void cameraChanged();
@@ -312,7 +322,6 @@ class _3D_EXPORT QgsCameraController : public QObject
     QVector3D mDragPoint;
     double mDragDepth;
 
-    bool mIsInZoomInState = false;
     std::unique_ptr< Qt3DRender::QCamera > mCameraBeforeZoom;
     bool mZoomPointCalculated = false;
     QVector3D mZoomPoint;
@@ -329,6 +338,8 @@ class _3D_EXPORT QgsCameraController : public QObject
     QTimer *mFpsNavTimer = nullptr;
 
     double mCumulatedWheelY = 0;
+
+    MouseOperation mCurrentOperation = MouseOperation::None;
 
     friend QgsCameraController4Test;
 };

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -295,7 +295,6 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Last mouse position recorded
     QPoint mMousePos;
     bool mMousePressed = false;
-    Qt3DInput::QMouseEvent::Buttons mPressedButton = Qt3DInput::QMouseEvent::Buttons::NoButton;
 
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -294,7 +294,6 @@ class _3D_EXPORT QgsCameraController : public QObject
 
     //! Last mouse position recorded
     QPoint mMousePos;
-    bool mMousePressed = false;
 
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -233,7 +233,7 @@ class _3D_EXPORT QgsCameraController : public QObject
       Zoom
     };
 
-    void setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint = QPoint( 0, 0 ) );
+    void setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint = QPoint() );
 
   signals:
     //! Emitted when camera has been updated
@@ -306,7 +306,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     QPoint mMousePos;
 
     //! click point for a rotation or a translation
-    QPoint mClickPoint = QPoint( 0, 0 );
+    QPoint mClickPoint;
 
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -308,21 +308,20 @@ class _3D_EXPORT QgsCameraController : public QObject
     bool mDepthBufferIsReady = false;
     QImage mDepthBufferImage;
 
+    std::unique_ptr< Qt3DRender::QCamera > mCameraBefore;
+
     QPoint mMiddleButtonClickPos;
     bool mRotationCenterCalculated = false;
     QVector3D mRotationCenter;
     double mRotationDistanceFromCenter;
     double mRotationPitch = 0;
     double mRotationYaw = 0;
-    std::unique_ptr< Qt3DRender::QCamera > mCameraBeforeRotation;
 
     QPoint mDragButtonClickPos;
-    std::unique_ptr< Qt3DRender::QCamera > mCameraBeforeDrag;
     bool mDragPointCalculated = false;
     QVector3D mDragPoint;
     double mDragDepth;
 
-    std::unique_ptr< Qt3DRender::QCamera > mCameraBeforeZoom;
     bool mZoomPointCalculated = false;
     QVector3D mZoomPoint;
 

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -123,7 +123,7 @@ class QgsCameraController4Test : public QgsCameraController
     // wraps protected member vars
     QVector3D zoomPoint() { return mZoomPoint; }
     double cumulatedWheelY() { return mCumulatedWheelY; }
-    Qt3DRender::QCamera *cameraBeforeZoom() { return mCameraBeforeZoom.get(); }
+    Qt3DRender::QCamera *cameraBefore() { return mCameraBefore.get(); }
     QgsCameraPose *cameraPose() { return &mCameraPose; }
 };
 
@@ -1357,7 +1357,7 @@ void TestQgs3DRendering::testDepthBuffer()
                           false, Qt::MouseEventSynthesizedByApplication );
   testCam->superOnWheel( new Qt3DInput::QWheelEvent( wheelEvent ) );
   QCOMPARE( testCam->cumulatedWheelY(), wheelEvent.angleDelta().y() * 5 );
-  QCOMPARE( testCam->cameraBeforeZoom()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
+  QCOMPARE( testCam->cameraBefore()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   grayImage = convertDepthImageToGray16Image( depthImage );
@@ -1376,7 +1376,7 @@ void TestQgs3DRendering::testDepthBuffer()
                            false, Qt::MouseEventSynthesizedByApplication );
   testCam->superOnWheel( new Qt3DInput::QWheelEvent( wheelEvent2 ) );
   QCOMPARE( testCam->cumulatedWheelY(), wheelEvent2.angleDelta().y() * 5 );
-  QCOMPARE( testCam->cameraBeforeZoom()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
+  QCOMPARE( testCam->cameraBefore()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   grayImage = convertDepthImageToGray16Image( depthImage );
@@ -1395,7 +1395,7 @@ void TestQgs3DRendering::testDepthBuffer()
                            false, Qt::MouseEventSynthesizedByApplication );
   testCam->superOnWheel( new Qt3DInput::QWheelEvent( wheelEvent3 ) );
   QCOMPARE( testCam->cumulatedWheelY(), wheelEvent3.angleDelta().y() * 5 );
-  QCOMPARE( testCam->cameraBeforeZoom()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
+  QCOMPARE( testCam->cameraBefore()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   grayImage = convertDepthImageToGray16Image( depthImage );
@@ -1414,7 +1414,7 @@ void TestQgs3DRendering::testDepthBuffer()
                            false, Qt::MouseEventSynthesizedByApplication );
   testCam->superOnWheel( new Qt3DInput::QWheelEvent( wheelEvent4 ) );
   QCOMPARE( testCam->cumulatedWheelY(), wheelEvent4.angleDelta().y() * 5 );
-  QCOMPARE( testCam->cameraBeforeZoom()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
+  QCOMPARE( testCam->cameraBefore()->viewCenter(), testCam->cameraPose()->centerPoint().toVector3D() );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   grayImage = convertDepthImageToGray16Image( depthImage );


### PR DESCRIPTION
## Description

Different kind of operations can happen while clicking on the mouse: zoom, rotation or translation. However, combining these different operations while keeping the mouse pressed does not work. This PR fixes those issues.


### Rotation + Zoom In + Rotation

#### Current behavior

The first rotation and the zoom in work but  at the second rotation, the view is reset as if the zoom never happened

[rotate-zoom_broken.webm](https://github.com/qgis/QGIS/assets/497207/9423ce1e-675a-4533-a43a-c6da42957fa3)

#### New behavior

[rotate-zoom_ok.webm](https://github.com/qgis/QGIS/assets/497207/5d0a4e07-ac07-43e3-b17a-61dc8a6187a9)

### Translation + Rotation

#### Current behavior

Once the rotation starts, the camera parameters are broken. 

[drag-rotate_broken.webm](https://github.com/qgis/QGIS/assets/497207/17ee367b-7108-43db-9666-ce366afdf697)

#### New behavior

[drag-rotate_ok.webm](https://github.com/qgis/QGIS/assets/497207/16fcd7b0-98eb-40a1-b256-f82afe510875)


cc @benoitdm-oslandia @soaubier
