### PR TITLE
Mistype in QgsGeometryUtils::segmentSide description was fixed

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -424,8 +424,8 @@ angular deviation (in radians) allowed when testing for regular point spacing.
 
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) /HoldGIL/;
 %Docstring
-For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+For line defined by points pt1 and pt3, find out on which side of the line is point pt2.
+Returns -1 if pt2 on the left side, 1 if pt2 is on the right side or 0 if pt2 lies on the line.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -433,8 +433,8 @@ class CORE_EXPORT QgsGeometryUtils
                                    double pointSpacingAngleTolerance ) SIP_HOLDGIL;
 
     /**
-     * For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-     * Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+     * For line defined by points pt1 and pt3, find out on which side of the line is point pt2.
+     * Returns -1 if pt2 on the left side, 1 if pt2 is on the right side or 0 if pt2 lies on the line.
      * \since 3.0
      */
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) SIP_HOLDGIL;


### PR DESCRIPTION
## Description

There is a mistype in the `segmentSide` method of the `QgsGeometryUtils` class, see https://api.qgis.org/api/3.34/classQgsGeometryUtils.html#a64471f7abd516f4ff9608fdcdd5d0105.

It must be `pt2` instead of `pt3`, because `pt3` is only the ending point of the line segment, for which the condition is checked.

So, I am suggesting some tiny edits to the  `segmentSide` method description.

How it was:

> For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
> Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.

How I suggest it to be:

> For line defined by points pt1 and pt3, find out on which side of the line is point pt2.
> Returns -1 if pt2 on the left side, 1 if pt2 is on the right side or 0 if pt2 lies on the line.

I edited two files: `python/core/auto_generated/geometry/qgsgeometryutils.sip.in` and `src/core/geometry/qgsgeometryutils.h`.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
