### PR TITLE
Fix Oracle syntax when estimating feature count on views

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2642,7 +2642,7 @@ long long QgsOracleProvider::featureCount() const
   // Else, to estimate feature count, if it is a view or there is a where clause we use the explain plan
   else if ( !mSqlWhereClause.isEmpty() || relkind() == QgsOracleProvider::View )
   {
-    sql = QString( "explain plan for select 1 from %1" ).arg( mTableName );
+    sql = QString( "explain plan for select 1 from %1.%2" ).arg( quotedIdentifier( mOwnerName ) ).arg( quotedIdentifier( mTableName ) );
     if ( !mSqlWhereClause.isEmpty() )
       sql += " WHERE " + mSqlWhereClause;
     if ( LoggedExecStatic( qry,


### PR DESCRIPTION
The feature count when "useEstimatedMetadata" is checked was not working on views.

It was because the quoted identifiers and owner were missing when asking for the SQL explain plan.

Funded by Bordeaux Métropole.