### PR TITLE
Remove "__revision__" from python files

### DIFF
--- a/.ci/ctest2ci.py
+++ b/.ci/ctest2ci.py
@@ -21,8 +21,6 @@
 __author__ = 'Matthias Kuhn'
 __date__ = 'March 2017'
 __copyright__ = '(C) 2017, Matthias Kuhn'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 # This script parses output from ctest and injects
 #

--- a/tests/src/python/test_qgsaggregatemappingwidget.py
+++ b/tests/src/python/test_qgsaggregatemappingwidget.py
@@ -11,8 +11,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Nyall Dawson'
 __date__ = '03/06/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 from qgis.PyQt.Qt import Qt
 from qgis.PyQt.QtCore import (

--- a/tests/src/python/test_qgsdatabaseschemamodel.py
+++ b/tests/src/python/test_qgsdatabaseschemamodel.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Nyall Dawson'
 __date__ = '07/03/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsdatabasetablemodel.py
+++ b/tests/src/python/test_qgsdatabasetablemodel.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Nyall Dawson'
 __date__ = '07/03/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsfieldmappingwidget.py
+++ b/tests/src/python/test_qgsfieldmappingwidget.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '16/03/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 from qgis.PyQt.Qt import Qt
 from qgis.PyQt.QtCore import (

--- a/tests/src/python/test_qgsnewvectortabledialog.py
+++ b/tests/src/python/test_qgsnewvectortabledialog.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '12/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 
 import shutil

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -13,8 +13,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '05/08/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 import time

--- a/tests/src/python/test_qgsproviderconnection_hana.py
+++ b/tests/src/python/test_qgsproviderconnection_hana.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Maxim Rylov'
 __date__ = '02/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsproviderconnection_mssql.py
+++ b/tests/src/python/test_qgsproviderconnection_mssql.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '12/03/2020'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '10/08/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import shutil
 

--- a/tests/src/python/test_qgsproviderconnection_oracle.py
+++ b/tests/src/python/test_qgsproviderconnection_oracle.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Julien Cabieces'
 __date__ = '28/12/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '10/08/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsproviderconnection_spatialite.py
+++ b/tests/src/python/test_qgsproviderconnection_spatialite.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '28/10/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 import shutil

--- a/tests/src/python/test_qgsproviderconnectionmodel.py
+++ b/tests/src/python/test_qgsproviderconnectionmodel.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Nyall Dawson'
 __date__ = '07/08/2020'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 import shutil

--- a/tests/src/python/test_qgsqueryresultmodel.py
+++ b/tests/src/python/test_qgsqueryresultmodel.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '24/12/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -11,8 +11,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '17/04/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import json
 import os

--- a/tests/src/python/test_qgsserver_apicontext.py
+++ b/tests/src/python/test_qgsserver_apicontext.py
@@ -11,8 +11,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '11/07/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -11,8 +11,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '03/08/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import json
 import os

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo_postgres.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo_postgres.py
@@ -12,8 +12,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '22/01/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsserver_wms_getmap_ignore_bad_layers.py
+++ b/tests/src/python/test_qgsserver_wms_getmap_ignore_bad_layers.py
@@ -12,8 +12,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '13/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 import os
 

--- a/tests/src/python/test_qgsvectorlayer_namedstyle.py
+++ b/tests/src/python/test_qgsvectorlayer_namedstyle.py
@@ -9,8 +9,6 @@ the Free Software Foundation; either version 2 of the License, or
 __author__ = 'Alessandro Pasotti'
 __date__ = '22/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
 
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import QgsMapLayer, QgsReadWriteContext, QgsVectorLayer


### PR DESCRIPTION
This changes the commit hash in every release tarball without any changes to the file content cluttering the diff which needs to be reviewed for license & copyright changes.

As per discussion on the qgis-dev mailing list: https://lists.osgeo.org/pipermail/qgis-developer/2023-November/066209.html
