### PR TITLE
Remove redundant "import qgis" lines from python files

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector_test.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector_test.py
@@ -20,7 +20,6 @@ __date__ = 'May 2017'
 __copyright__ = '(C) 2017, Sandro Santilli'
 
 import os
-import qgis
 import unittest
 from qgis.testing import start_app, QgisTestCase
 from qgis.core import QgsDataSourceUri

--- a/python/plugins/db_manager/db_plugins/postgis/plugin_test.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin_test.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2017, Sandro Santilli'
 
 import os
 import re
-import qgis
 import unittest
 from qgis.testing import start_app, QgisTestCase
 from qgis.core import QgsDataSourceUri

--- a/python/plugins/grassprovider/tests/AlgorithmsTestBase.py
+++ b/python/plugins/grassprovider/tests/AlgorithmsTestBase.py
@@ -19,7 +19,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = 'January 2016'
 __copyright__ = '(C) 2016, Matthias Kuhn'
 
-import qgis  # NOQA switch sip api
 
 import os
 import yaml

--- a/python/plugins/otbprovider/tests/AlgorithmsTestBase.py
+++ b/python/plugins/otbprovider/tests/AlgorithmsTestBase.py
@@ -19,7 +19,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = 'January 2016'
 __copyright__ = '(C) 2016, Matthias Kuhn'
 
-import qgis  # NOQA switch sip api
 
 import os
 import yaml

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -19,7 +19,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = 'January 2016'
 __copyright__ = '(C) 2016, Matthias Kuhn'
 
-import qgis  # NOQA switch sip api
 
 import os
 import yaml

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -46,6 +46,7 @@ from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsNetworkAccessManag
 from qgis.gui import QgsMessageBar, QgsPasswordLineEdit, QgsHelp
 from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin, OverrideCursor,
                         reloadPlugin, updateAvailablePlugins, plugins_metadata_parser, isPluginLoaded)
+from qgis import utils
 from .installer_data import (repositories, plugins, officialRepo,
                              reposGroup, removeDir)
 from .qgsplugininstallerinstallingdialog import QgsPluginInstallerInstallingDialog
@@ -322,7 +323,7 @@ class QgsPluginInstaller(QObject):
         dlg = QgsPluginInstallerInstallingDialog(iface.mainWindow(), plugin, stable=stable)
         dlg.exec_()
 
-        plugin_path = qgis.utils.home_plugin_path + "/" + key
+        plugin_path = utils.home_plugin_path + "/" + key
         if dlg.result():
             error = True
             infoString = (self.tr("Plugin installation failed"), dlg.result())
@@ -386,7 +387,7 @@ class QgsPluginInstaller(QObject):
                 dlg.exec_()
                 if dlg.result():
                     # revert installation
-                    pluginDir = qgis.utils.home_plugin_path + "/" + plugin["id"]
+                    pluginDir = utils.home_plugin_path + "/" + plugin["id"]
                     result = removeDir(pluginDir)
                     if QDir(pluginDir).exists():
                         error = True
@@ -435,7 +436,7 @@ class QgsPluginInstaller(QObject):
             unloadPlugin(key)
         except:
             pass
-        pluginDir = qgis.utils.home_plugin_path + "/" + plugin["id"]
+        pluginDir = utils.home_plugin_path + "/" + plugin["id"]
         result = removeDir(pluginDir)
         if result:
             QApplication.restoreOverrideCursor()
@@ -611,7 +612,7 @@ class QgsPluginInstaller(QObject):
                 QgsHelp.openHelp("plugins/plugins.html#the-install-from-zip-tab")
             return
 
-        pluginsDirectory = qgis.utils.home_plugin_path
+        pluginsDirectory = utils.home_plugin_path
         if not QDir(pluginsDirectory).exists():
             QDir().mkpath(pluginsDirectory)
 

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -44,9 +44,18 @@ from qgis.PyQt.QtNetwork import QNetworkRequest
 
 from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsNetworkAccessManager, QgsSettings, QgsSettingsTree, QgsNetworkRequestParameters
 from qgis.gui import QgsMessageBar, QgsPasswordLineEdit, QgsHelp
-from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin, OverrideCursor,
-                        reloadPlugin, updateAvailablePlugins, plugins_metadata_parser, isPluginLoaded)
-from qgis import utils
+from qgis.utils import (
+    iface,
+    startPlugin,
+    unloadPlugin,
+    loadPlugin,
+    OverrideCursor,
+    reloadPlugin,
+    updateAvailablePlugins,
+    plugins_metadata_parser,
+    isPluginLoaded,
+    HOME_PLUGIN_PATH
+)
 from .installer_data import (repositories, plugins, officialRepo,
                              reposGroup, removeDir)
 from .qgsplugininstallerinstallingdialog import QgsPluginInstallerInstallingDialog
@@ -323,7 +332,7 @@ class QgsPluginInstaller(QObject):
         dlg = QgsPluginInstallerInstallingDialog(iface.mainWindow(), plugin, stable=stable)
         dlg.exec_()
 
-        plugin_path = utils.home_plugin_path + "/" + key
+        plugin_path = HOME_PLUGIN_PATH + "/" + key
         if dlg.result():
             error = True
             infoString = (self.tr("Plugin installation failed"), dlg.result())
@@ -387,7 +396,7 @@ class QgsPluginInstaller(QObject):
                 dlg.exec_()
                 if dlg.result():
                     # revert installation
-                    pluginDir = utils.home_plugin_path + "/" + plugin["id"]
+                    pluginDir = HOME_PLUGIN_PATH + "/" + plugin["id"]
                     result = removeDir(pluginDir)
                     if QDir(pluginDir).exists():
                         error = True
@@ -436,7 +445,7 @@ class QgsPluginInstaller(QObject):
             unloadPlugin(key)
         except:
             pass
-        pluginDir = utils.home_plugin_path + "/" + plugin["id"]
+        pluginDir = HOME_PLUGIN_PATH + "/" + plugin["id"]
         result = removeDir(pluginDir)
         if result:
             QApplication.restoreOverrideCursor()
@@ -612,7 +621,7 @@ class QgsPluginInstaller(QObject):
                 QgsHelp.openHelp("plugins/plugins.html#the-install-from-zip-tab")
             return
 
-        pluginsDirectory = utils.home_plugin_path
+        pluginsDirectory = HOME_PLUGIN_PATH
         if not QDir(pluginsDirectory).exists():
             QDir().mkpath(pluginsDirectory)
 

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -42,7 +42,6 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
-import qgis
 from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsNetworkAccessManager, QgsSettings, QgsSettingsTree, QgsNetworkRequestParameters
 from qgis.gui import QgsMessageBar, QgsPasswordLineEdit, QgsHelp
 from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin, OverrideCursor,

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -42,7 +42,11 @@ import configparser
 import qgis.utils
 from qgis.core import QgsNetworkAccessManager, QgsApplication
 from qgis.gui import QgsGui
-from qgis.utils import iface, plugin_paths
+from qgis.utils import (
+    iface,
+    plugin_paths,
+    HOME_PLUGIN_PATH
+)
 from .version_compare import pyQgisVersion, compareVersions, normalizeVersion, isCompatible
 
 
@@ -133,7 +137,7 @@ def removeDir(path):
     if QFile(path).exists():
         result = QCoreApplication.translate("QgsPluginInstaller", "Failed to remove the directory:") + "\n" + path + "\n" + QCoreApplication.translate("QgsPluginInstaller", "Check permissions or remove it manually")
     # restore plugin directory if removed by QDir().rmpath()
-    pluginDir = qgis.utils.home_plugin_path
+    pluginDir = HOME_PLUGIN_PATH
     if not QDir(pluginDir).exists():
         QDir().mkpath(pluginDir)
     return result

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -29,7 +29,6 @@ from qgis.PyQt.QtCore import QDir, QUrl, QFile, QCoreApplication
 from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
-import qgis
 from qgis.core import QgsNetworkAccessManager, QgsApplication, QgsNetworkRequestParameters
 
 from .ui_qgsplugininstallerinstallingbase import Ui_QgsPluginInstallerInstallingDialogBase

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -30,6 +30,7 @@ from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
 from qgis.core import QgsNetworkAccessManager, QgsApplication, QgsNetworkRequestParameters
+from qgis import utils
 
 from .ui_qgsplugininstallerinstallingbase import Ui_QgsPluginInstallerInstallingDialogBase
 from .installer_data import removeDir, repositories
@@ -141,7 +142,7 @@ class QgsPluginInstallerInstallingDialog(QDialog, Ui_QgsPluginInstallerInstallin
         self.file.close()
         self.stateChanged(0)
         reply.deleteLater()
-        pluginDir = qgis.utils.home_plugin_path
+        pluginDir = utils.home_plugin_path
         tmpPath = self.file.fileName()
         # make sure that the parent directory exists
         if not QDir(pluginDir).exists():

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -30,7 +30,7 @@ from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
 from qgis.core import QgsNetworkAccessManager, QgsApplication, QgsNetworkRequestParameters
-from qgis import utils
+from qgis.utils import HOME_PLUGIN_PATH
 
 from .ui_qgsplugininstallerinstallingbase import Ui_QgsPluginInstallerInstallingDialogBase
 from .installer_data import removeDir, repositories
@@ -142,7 +142,7 @@ class QgsPluginInstallerInstallingDialog(QDialog, Ui_QgsPluginInstallerInstallin
         self.file.close()
         self.stateChanged(0)
         reply.deleteLater()
-        pluginDir = utils.home_plugin_path
+        pluginDir = HOME_PLUGIN_PATH
         tmpPath = self.file.fileName()
         # make sure that the parent directory exists
         if not QDir(pluginDir).exists():

--- a/python/utils.py
+++ b/python/utils.py
@@ -222,6 +222,9 @@ def initInterface(pointer):
 #######################
 # PLUGINS
 
+# The current path for home directory Python plugins.
+HOME_PLUGIN_PATH: Optional[str] = None
+
 # list of plugin paths. it gets filled in by the QGIS python library
 plugin_paths = []
 

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -134,7 +134,7 @@ bool QgsPythonUtilsImpl::checkSystemImports()
   // tell the utils script where to look for the plugins
   runString( QStringLiteral( "qgis.utils.plugin_paths = [%1]" ).arg( pluginpaths.join( ',' ) ) );
   runString( QStringLiteral( "qgis.utils.sys_plugin_path = \"%1\"" ).arg( pluginsPath() ) );
-  runString( QStringLiteral( "qgis.utils.home_plugin_path = %1" ).arg( homePluginsPath() ) ); // note - homePluginsPath() returns a python expression, not a string literal
+  runString( QStringLiteral( "qgis.utils.HOME_PLUGIN_PATH = %1" ).arg( homePluginsPath() ) ); // note - homePluginsPath() returns a python expression, not a string literal
 
 #ifdef Q_OS_WIN
   runString( "if oldhome: os.environ['HOME']=oldhome\n" );

--- a/tests/src/python/qgis_interface.py
+++ b/tests/src/python/qgis_interface.py
@@ -23,7 +23,6 @@ __copyright__ = ('Copyright (c) 2010 by Ivan Mincik, ivan.mincik@gista.sk and '
                  'Copyright (c) 2011 German Carrillo, '
                  'geotux_tuxman@linuxmail.org')
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QObject
 from qgis.core import QgsProject
 

--- a/tests/src/python/test_console.py
+++ b/tests/src/python/test_console.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from console import console
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import QgsSettings

--- a/tests/src/python/test_core_additions.py
+++ b/tests/src/python/test_core_additions.py
@@ -11,7 +11,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '15.5.2018'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_db_manager_gpkg.py
+++ b/tests/src/python/test_db_manager_gpkg.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from osgeo import gdal, ogr, osr
 from plugins.db_manager.db_plugins import createDbPlugin, supportedDbTypes
 from plugins.db_manager.db_plugins.plugin import TableField

--- a/tests/src/python/test_db_manager_spatialite.py
+++ b/tests/src/python/test_db_manager_spatialite.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from osgeo import ogr
 from plugins.db_manager.db_plugins import createDbPlugin, supportedDbTypes
 from plugins.db_manager.db_plugins.plugin import TableField

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPoint, QSize
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_processing_alg_decorator.py
+++ b/tests/src/python/test_processing_alg_decorator.py
@@ -9,7 +9,6 @@ __author__ = 'Nathan Woodrow'
 __date__ = '10.12.2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.processing import alg
 import unittest

--- a/tests/src/python/test_project_storage_base.py
+++ b/tests/src/python/test_project_storage_base.py
@@ -11,7 +11,6 @@ __author__ = 'Julien Cabieces'
 __date__ = '2022-04-19'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from PyQt5.QtCore import QDateTime
 from qgis.core import (

--- a/tests/src/python/test_project_storage_oracle.py
+++ b/tests/src/python/test_project_storage_oracle.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from PyQt5.QtCore import QUrl, QUrlQuery
 from qgis.PyQt.QtSql import QSqlDatabase, QSqlQuery
 from qgis.core import (

--- a/tests/src/python/test_project_storage_postgres.py
+++ b/tests/src/python/test_project_storage_postgres.py
@@ -17,7 +17,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 import os
 
 import psycopg2
-import qgis  # NOQA
 from PyQt5.QtCore import QUrl, QUrlQuery
 from qgis.core import (
     QgsDataSourceUri,

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QDir, QTime, QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -20,7 +20,6 @@ import tempfile
 import time
 from sqlite3 import OperationalError
 
-import qgis  # NOQA
 from osgeo import gdal, ogr
 from qgis.PyQt.QtCore import (
     QCoreApplication,

--- a/tests/src/python/test_provider_ogr_sqlite.py
+++ b/tests/src/python/test_provider_ogr_sqlite.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from osgeo import ogr
 from qgis.PyQt.QtCore import QByteArray, QDate, QDateTime, QTime, QVariant
 from qgis.core import (

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime, QVariant
 from qgis.PyQt.QtSql import QSqlDatabase, QSqlQuery
 from qgis.core import (

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -23,7 +23,6 @@ import time
 from datetime import datetime
 
 import psycopg2
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QByteArray,
     QDate,

--- a/tests/src/python/test_provider_postgres_latency.py
+++ b/tests/src/python/test_provider_postgres_latency.py
@@ -20,7 +20,6 @@ import os
 import time
 
 import psycopg2
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QDir,
     QTemporaryFile,

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -21,7 +21,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 import os
 import time
 
-import qgis  # NOQA
 from qgis.core import (
     QgsDataSourceUri,
     QgsPointXY,

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -16,7 +16,6 @@ import sys
 import tempfile
 from datetime import datetime
 
-import qgis  # NOQA
 from osgeo import ogr
 from qgis.PyQt.QtCore import QByteArray, QVariant
 from qgis.core import (

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir, QUrl, QVariant
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -11,7 +11,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '05.06.2018'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 
 from PyQt5.QtCore import QVariant
 from qgis.core import (

--- a/tests/src/python/test_qgsaction.py
+++ b/tests/src/python/test_qgsaction.py
@@ -14,7 +14,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 import os
 from functools import partial
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.core import (
     QgsAction,

--- a/tests/src/python/test_qgsactionmanager.py
+++ b/tests/src/python/test_qgsactionmanager.py
@@ -15,7 +15,6 @@ import os
 import platform
 import time
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QDir, QTemporaryFile, QUuid
 from qgis.core import (
     QgsAction,

--- a/tests/src/python/test_qgsactionwidgetwrapper.py
+++ b/tests/src/python/test_qgsactionwidgetwrapper.py
@@ -11,7 +11,6 @@ __author__ = 'Alessandro Pasotti'
 __date__ = '16/08/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QUuid
 from qgis.PyQt.QtWidgets import QPushButton, QWidget
 from qgis.core import QgsAction, QgsVectorLayer

--- a/tests/src/python/test_qgsaggregatecalculator.py
+++ b/tests/src/python/test_qgsaggregatecalculator.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsalignmentcombobox.py
+++ b/tests/src/python/test_qgsalignmentcombobox.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '26/06/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import QgsAlignmentComboBox

--- a/tests/src/python/test_qgsanimatedmarkersymbollayer.py
+++ b/tests/src/python/test_qgsanimatedmarkersymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2022, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.core import (
     QgsAnimatedMarkerSymbolLayer,

--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '24/1/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QPointF, QRectF, QSize, QSizeF
 from qgis.PyQt.QtGui import QColor, QImage, QPainter, QTextDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsannotationitemeditoperation.py
+++ b/tests/src/python/test_qgsannotationitemeditoperation.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '09/09/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,

--- a/tests/src/python/test_qgsannotationitemnode.py
+++ b/tests/src/python/test_qgsannotationitemnode.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import Qgis, QgsAnnotationItemNode, QgsPointXY, QgsVertexId
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, QTemporaryDir
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsannotationlineitem.py
+++ b/tests/src/python/test_qgsannotationlineitem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsannotationlinetextitem.py
+++ b/tests/src/python/test_qgsannotationlinetextitem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '10/08/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsannotationmarkeritem.py
+++ b/tests/src/python/test_qgsannotationmarkeritem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsannotationpointtextitem.py
+++ b/tests/src/python/test_qgsannotationpointtextitem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '10/08/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsannotationpolygonitem.py
+++ b/tests/src/python/test_qgsannotationpolygonitem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsapplication.py
+++ b/tests/src/python/test_qgsapplication.py
@@ -9,7 +9,6 @@ __author__ = 'Tim Sutton (tim@linfiniti.com)'
 __date__ = '20/01/2011'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2022 by Nyall Dawson'
 __date__ = '14/07/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime, QTimeZone, QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsarrowsymbollayer.py
+++ b/tests/src/python/test_qgsarrowsymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2016, Hugo Mercier'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsattributeeditoraction.py
+++ b/tests/src/python/test_qgsattributeeditoraction.py
@@ -11,7 +11,6 @@ __author__ = 'Alessandro Pasotti'
 __date__ = '16/08/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QUuid
 from qgis.core import (
     QgsAction,

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2016-05'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtWidgets import QDateTimeEdit, QWidget
 from qgis.core import QgsVectorLayer

--- a/tests/src/python/test_qgsattributetableconfig.py
+++ b/tests/src/python/test_qgsattributetableconfig.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '07/06/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsAttributeTableConfig, QgsVectorLayer
 import unittest

--- a/tests/src/python/test_qgsauxiliarystorage.py
+++ b/tests/src/python/test_qgsauxiliarystorage.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryFile, QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsbabelgpsformat.py
+++ b/tests/src/python/test_qgsbabelgpsformat.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2021-07'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsbearingutils.py
+++ b/tests/src/python/test_qgsbearingutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/10/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 
 from qgis.core import (
     QgsBearingUtils,

--- a/tests/src/python/test_qgsbinarywidget.py
+++ b/tests/src/python/test_qgsbinarywidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '11/11/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QByteArray
 from qgis.core import NULL, QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
 from qgis.gui import QgsGui

--- a/tests/src/python/test_qgsblendmodes.py
+++ b/tests/src/python/test_qgsblendmodes.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2013, Nyall Dawson, Massimo Endrighi'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QColor, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsblockingnetworkrequest.py
+++ b/tests/src/python/test_qgsblockingnetworkrequest.py
@@ -10,7 +10,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/11/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgsblockingprocess.py
+++ b/tests/src/python/test_qgsblockingprocess.py
@@ -22,7 +22,6 @@ __copyright__ = '(C) 2021, Nyall Dawson'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QProcess
 from qgis.core import QgsBlockingProcess, QgsFeedback
 import unittest

--- a/tests/src/python/test_qgsbookmarkmanager.py
+++ b/tests/src/python/test_qgsbookmarkmanager.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QLocale, QTemporaryDir
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsbookmarkmodel.py
+++ b/tests/src/python/test_qgsbookmarkmodel.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2019 by Nyall Dawson'
 __date__ = '02/09/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QLocale, Qt
 from qgis.core import (
     QgsBookmark,

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import sys
 
-import qgis  # NOQA
 
 from qgis.core import QgsBox3d, QgsPoint, QgsRectangle, QgsVector3D
 from qgis.testing import unittest

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale, QSize, Qt, QTemporaryDir, QVariant
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgscesium3dtileslayer.py
+++ b/tests/src/python/test_qgscesium3dtileslayer.py
@@ -12,7 +12,6 @@ __copyright__ = "Copyright 2023, The QGIS Project"
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgscesiumutils.py
+++ b/tests/src/python/test_qgscesiumutils.py
@@ -12,7 +12,6 @@ __date__ = '10/07/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import math
-import qgis  # NOQA
 from qgis.core import (
     QgsCesiumUtils
 )

--- a/tests/src/python/test_qgscheckablecombobox.py
+++ b/tests/src/python/test_qgscheckablecombobox.py
@@ -9,7 +9,6 @@ __author__ = 'Alexander Bruy'
 __date__ = '22/03/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgscheckablecombobox.py
+++ b/tests/src/python/test_qgscheckablecombobox.py
@@ -13,6 +13,8 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtTest import QSignalSpy
 import unittest
+
+from qgis.gui import QgsCheckableComboBox
 from qgis.testing import start_app, QgisTestCase
 
 start_app()
@@ -22,7 +24,7 @@ class TestQgsCheckableComboBox(QgisTestCase):
 
     def testGettersSetters(self):
         """ test widget getters/setters """
-        w = qgis.gui.QgsCheckableComboBox()
+        w = QgsCheckableComboBox()
 
         w.setSeparator('|')
         self.assertEqual(w.separator(), '|')
@@ -44,7 +46,7 @@ class TestQgsCheckableComboBox(QgisTestCase):
     def test_ChangedSignals(self):
         """ test that signals are correctly emitted when clearing"""
 
-        w = qgis.gui.QgsCheckableComboBox()
+        w = QgsCheckableComboBox()
 
         w.addItems(['One', 'Two', 'Three'])
 
@@ -54,7 +56,7 @@ class TestQgsCheckableComboBox(QgisTestCase):
         self.assertEqual(len(checkedItemsChanged_spy), 1)
 
     def test_readonly(self):
-        w = qgis.gui.QgsCheckableComboBox()
+        w = QgsCheckableComboBox()
         w.setEditable(False)
         w.show()  # Should not crash
 

--- a/tests/src/python/test_qgsclassificationmethod.py
+++ b/tests/src/python/test_qgsclassificationmethod.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import random
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale
 from qgis.core import (
     QgsClassificationFixedInterval,

--- a/tests/src/python/test_qgscodeeditor.py
+++ b/tests/src/python/test_qgscodeeditor.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QColor, QFont
 from qgis.core import QgsApplication, QgsSettings

--- a/tests/src/python/test_qgscodeeditorcolorscheme.py
+++ b/tests/src/python/test_qgscodeeditorcolorscheme.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '03/10/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QColor
 from qgis.core import QgsSettings

--- a/tests/src/python/test_qgscodeeditorpython.py
+++ b/tests/src/python/test_qgscodeeditorpython.py
@@ -10,7 +10,6 @@ __date__ = '31/03/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtTest import QTest
 from qgis.core import QgsSettings

--- a/tests/src/python/test_qgscolorbutton.py
+++ b/tests/src/python/test_qgscolorbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '25/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsApplication, QgsProjectColorScheme

--- a/tests/src/python/test_qgscolorramp.py
+++ b/tests/src/python/test_qgscolorramp.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2015-08'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor, QGradient
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgscolorramplegendnode.py
+++ b/tests/src/python/test_qgscolorramplegendnode.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2015-08'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, QSizeF, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgscolorscheme.py
+++ b/tests/src/python/test_qgscolorscheme.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '25/07/2014'
 __copyright__ = 'Copyright 2014, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (

--- a/tests/src/python/test_qgscolorschemeregistry.py
+++ b/tests/src/python/test_qgscolorschemeregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '25/07/2014'
 __copyright__ = 'Copyright 2014, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgscolorutils.py
+++ b/tests/src/python/test_qgscolorutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '06/07/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import QgsColorUtils, QgsReadWriteContext, QgsSymbolLayerUtils

--- a/tests/src/python/test_qgscombinedstylemodel.py
+++ b/tests/src/python/test_qgscombinedstylemodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, Qt
 from qgis.core import QgsStyle, QgsStyleModel, QgsTextFormat
 import unittest

--- a/tests/src/python/test_qgsconnectionregistry.py
+++ b/tests/src/python/test_qgsconnectionregistry.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgscoordinateoperationwidget.py
+++ b/tests/src/python/test_qgscoordinateoperationwidget.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgscoordinatereferencesystem.py
+++ b/tests/src/python/test_qgscoordinatereferencesystem.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2022 by Nyall Dawson'
 __date__ = '06/04/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import Qgis, QgsCoordinateReferenceSystem
 import unittest

--- a/tests/src/python/test_qgscoordinatereferencesystemmodel.py
+++ b/tests/src/python/test_qgscoordinatereferencesystemmodel.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2022 by Nyall Dawson'
 __date__ = '12/07/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.PyQt.QtCore import (
     Qt,

--- a/tests/src/python/test_qgscoordinatereferencesystemutils.py
+++ b/tests/src/python/test_qgscoordinatereferencesystemutils.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2022 by Nyall Dawson'
 __date__ = '06/04/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2012 by Tim Sutton'
 __date__ = '20/08/2012'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgscoordinatetransformcontext.py
+++ b/tests/src/python/test_qgscoordinatetransformcontext.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '11/5/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgscore.py
+++ b/tests/src/python/test_qgscore.py
@@ -9,7 +9,6 @@ __author__ = 'Loïc Bartoletti'
 __date__ = '28.6.2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import qgsDoubleNear, qgsRound
 import unittest

--- a/tests/src/python/test_qgscrsdefinitionwidget.py
+++ b/tests/src/python/test_qgscrsdefinitionwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/12/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsCoordinateReferenceSystem
 from qgis.gui import QgsCrsDefinitionWidget

--- a/tests/src/python/test_qgscrsselectionwidget.py
+++ b/tests/src/python/test_qgscrsselectionwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/12/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsCoordinateReferenceSystem
 from qgis.gui import QgsCrsSelectionWidget

--- a/tests/src/python/test_qgsdatabaseschemacombobox.py
+++ b/tests/src/python/test_qgsdatabaseschemacombobox.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsProviderRegistry

--- a/tests/src/python/test_qgsdatabasetablecombobox.py
+++ b/tests/src/python/test_qgsdatabasetablecombobox.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsdataitemguiproviderregistry.py
+++ b/tests/src/python/test_qgsdataitemguiproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '27/10/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.gui import (
     QgsDataItemGuiContext,

--- a/tests/src/python/test_qgsdataitemproviderregistry.py
+++ b/tests/src/python/test_qgsdataitemproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '27/10/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsdatetimeedit.py
+++ b/tests/src/python/test_qgsdatetimeedit.py
@@ -9,7 +9,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '2018-01-04'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime
 from qgis.gui import QgsDateEdit, QgsDateTimeEdit, QgsTimeEdit
 import unittest

--- a/tests/src/python/test_qgsdatetimestatisticalsummary.py
+++ b/tests/src/python/test_qgsdatetimestatisticalsummary.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '07/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.core import NULL, QgsDateTimeStatisticalSummary, QgsInterval
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsdefaultvalue.py
+++ b/tests/src/python/test_qgsdefaultvalue.py
@@ -10,7 +10,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = '26.9.2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsDefaultValue
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -28,7 +28,6 @@ import time
 from collections.abc import Callable
 from pathlib import Path
 
-import qgis  # NOQA
 
 import test_qgsdelimitedtextprovider_wanted as want  # NOQA
 

--- a/tests/src/python/test_qgsdistancearea.py
+++ b/tests/src/python/test_qgsdistancearea.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2014, The QGIS Project'
 import math
 from pprint import pprint
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgseditformconfig.py
+++ b/tests/src/python/test_qgseditformconfig.py
@@ -14,7 +14,6 @@ import os
 import socketserver
 import threading
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -9,7 +9,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = '20/05/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtWidgets import QTextEdit
 from qgis.core import (

--- a/tests/src/python/test_qgselevationprofilecanvas.py
+++ b/tests/src/python/test_qgselevationprofilecanvas.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '28/3/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QEvent, QPoint, QPointF, Qt
 from qgis.PyQt.QtGui import QKeyEvent, QMouseEvent, QWheelEvent
 from qgis.core import (

--- a/tests/src/python/test_qgsellipsoidutils.py
+++ b/tests/src/python/test_qgsellipsoidutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/4/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsEllipsoidUtils, QgsProjUtils
 import unittest

--- a/tests/src/python/test_qgsembeddedsymbolrenderer.py
+++ b/tests/src/python/test_qgsembeddedsymbolrenderer.py
@@ -24,7 +24,6 @@ __copyright__ = "(C) 2015, Matthias Kuhn"
 
 import unittest
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsEmbeddedSymbolRenderer,

--- a/tests/src/python/test_qgsencodingselectiondialog.py
+++ b/tests/src/python/test_qgsencodingselectiondialog.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '21/11/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsencodingselectiondialog.py
+++ b/tests/src/python/test_qgsencodingselectiondialog.py
@@ -11,6 +11,8 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 
 import unittest
+
+from qgis.gui import QgsEncodingSelectionDialog
 from qgis.testing import start_app, QgisTestCase
 
 start_app()
@@ -20,7 +22,7 @@ class TestQgsEncodingSelectionDialog(QgisTestCase):
 
     def testGettersSetters(self):
         """ test dialog getters/setters """
-        dlg = qgis.gui.QgsEncodingSelectionDialog(encoding='UTF-16')
+        dlg = QgsEncodingSelectionDialog(encoding='UTF-16')
         self.assertEqual(dlg.encoding(), 'UTF-16')
         dlg.setEncoding('UTF-8')
         self.assertEqual(dlg.encoding(), 'UTF-8')

--- a/tests/src/python/test_qgsexiftools.py
+++ b/tests/src/python/test_qgsexiftools.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 import os
 import shutil
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QDateTime, Qt, QTemporaryFile
 from qgis.core import QgsExifTools, QgsPointXY
 import unittest

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -9,7 +9,6 @@ __author__ = 'Nathan Woodrow'
 __date__ = '4/11/2012'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsexpressionbuilderwidget.py
+++ b/tests/src/python/test_qgsexpressionbuilderwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '30/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QListView
 from qgis.core import (

--- a/tests/src/python/test_qgsexpressionlineedit.py
+++ b/tests/src/python/test_qgsexpressionlineedit.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/08/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 try:
     from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgsextentgroupbox.py
+++ b/tests/src/python/test_qgsextentgroupbox.py
@@ -34,7 +34,7 @@ class TestQgsExtentGroupBox(QgisTestCase):
 
     def testGettersSetters(self):
         """ test widget getters/setters """
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         w.setOriginalExtent(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('epsg:3111'))
         self.assertEqual(w.originalExtent(), QgsRectangle(1, 2, 3, 4))
@@ -80,7 +80,7 @@ class TestQgsExtentGroupBox(QgisTestCase):
         self.assertEqual(len(spy), 3)
 
     def test_SettingExtent(self):
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         spy = QSignalSpy(w.extentChanged)
 
@@ -121,7 +121,7 @@ class TestQgsExtentGroupBox(QgisTestCase):
         QgsProject.instance().removeAllMapLayers()
 
     def testSetOutputCrs(self):
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
         w.setCheckable(True)
 
         # ensure setting output crs doesn't change state of group box
@@ -146,7 +146,7 @@ class TestQgsExtentGroupBox(QgisTestCase):
         self.assertEqual(w.outputExtent().toString(20), QgsRectangle(1, 2, 3, 4).toString(20))
 
         # repeat, this time using original extents
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         w.setOutputCrs(QgsCoordinateReferenceSystem('epsg:4326'))
         w.setOriginalExtent(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('epsg:4326'))
@@ -182,7 +182,7 @@ class TestQgsExtentGroupBox(QgisTestCase):
         self.assertEqual(w.outputExtent().toString(20), QgsRectangle(1, 2, 3, 4).toString(20))
 
         # custom extent
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         w.setOutputCrs(QgsCoordinateReferenceSystem('epsg:4326'))
         w.setOutputExtentFromUser(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('epsg:4326'))

--- a/tests/src/python/test_qgsextentgroupbox.py
+++ b/tests/src/python/test_qgsextentgroupbox.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsextentwidget.py
+++ b/tests/src/python/test_qgsextentwidget.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsextentwidget.py
+++ b/tests/src/python/test_qgsextentwidget.py
@@ -20,7 +20,10 @@ from qgis.core import (
     QgsRectangle,
     QgsVectorLayer,
 )
-from qgis.gui import QgsExtentWidget
+from qgis.gui import (
+    QgsExtentWidget,
+    QgsExtentGroupBox
+)
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -112,7 +115,7 @@ class TestQgsExtentWidget(QgisTestCase):
         self.assertEqual(w.outputExtent().toString(20), QgsRectangle(1, 2, 3, 4).toString(20))
 
         # repeat, this time using original extents
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         w.setOutputCrs(QgsCoordinateReferenceSystem('epsg:4326'))
         w.setOriginalExtent(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('epsg:4326'))
@@ -148,7 +151,7 @@ class TestQgsExtentWidget(QgisTestCase):
         self.assertEqual(w.outputExtent().toString(20), QgsRectangle(1, 2, 3, 4).toString(20))
 
         # custom extent
-        w = qgis.gui.QgsExtentGroupBox()
+        w = QgsExtentGroupBox()
 
         w.setOutputCrs(QgsCoordinateReferenceSystem('epsg:4326'))
         w.setOutputExtentFromUser(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('epsg:4326'))

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     NULL,
     QgsFeature,

--- a/tests/src/python/test_qgsfeatureiterator.py
+++ b/tests/src/python/test_qgsfeatureiterator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsfeaturepicker.py
+++ b/tests/src/python/test_qgsfeaturepicker.py
@@ -9,7 +9,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '24/04/2020'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy, QTest
 from qgis.PyQt.QtWidgets import QComboBox
 from qgis.core import (

--- a/tests/src/python/test_qgsfeaturerequest.py
+++ b/tests/src/python/test_qgsfeaturerequest.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/06/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsfeaturesink.py
+++ b/tests/src/python/test_qgsfeaturesink.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '26/04/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsfeaturesource.py
+++ b/tests/src/python/test_qgsfeaturesource.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '26/04/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsfeedback.py
+++ b/tests/src/python/test_qgsfeedback.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/02/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsFeedback
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsfield.py
+++ b/tests/src/python/test_qgsfield.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/08/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsfieldcombobox.py
+++ b/tests/src/python/test_qgsfieldcombobox.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QCoreApplication,
     QDate,

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '14/11/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QModelIndex, Qt, QVariant
 from qgis.core import (
     QgsEditorWidgetSetup,

--- a/tests/src/python/test_qgsfields.py
+++ b/tests/src/python/test_qgsfields.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/08/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QVariant
 from qgis.core import NULL, QgsVectorLayer
 import unittest

--- a/tests/src/python/test_qgsfieldvalidator.py
+++ b/tests/src/python/test_qgsfieldvalidator.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale, QVariant
 from qgis.PyQt.QtGui import QValidator
 from qgis.core import QgsVectorLayer

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.core import Qgis, QgsFileUtils
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsfilledlinesymbollayer.py
+++ b/tests/src/python/test_qgsfilledlinesymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2023, Nyall Dawson'
 
 from typing import Optional
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsfillsymbollayers.py
+++ b/tests/src/python/test_qgsfillsymbollayers.py
@@ -10,7 +10,6 @@ __date__ = '2017-01'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsfilterlineedit.py
+++ b/tests/src/python/test_qgsfilterlineedit.py
@@ -12,11 +12,7 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 
 from qgis.gui import QgsFilterLineEdit
 
-try:
-    from qgis.PyQt.QtTest import QSignalSpy
-    use_signal_spy = True
-except:
-    use_signal_spy = False
+from qgis.PyQt.QtTest import QSignalSpy
 
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -28,7 +24,7 @@ class TestQgsFilterLineEdit(QgisTestCase):
 
     def testGettersSetters(self):
         """ test widget getters/setters """
-        w = qgis.gui.QgsFilterLineEdit()
+        w = QgsFilterLineEdit()
 
         w.setNullValue('null')
         self.assertEqual(w.nullValue(), 'null')
@@ -46,7 +42,7 @@ class TestQgsFilterLineEdit(QgisTestCase):
 
     def testNullValueHandling(self):
         """ test widget handling of null values """
-        w = qgis.gui.QgsFilterLineEdit()
+        w = QgsFilterLineEdit()
 
         # start with no null value
         w.setValue(None)
@@ -77,7 +73,7 @@ class TestQgsFilterLineEdit(QgisTestCase):
 
     def testClearToNull(self):
         """ test clearing widget """
-        w = qgis.gui.QgsFilterLineEdit()
+        w = QgsFilterLineEdit()
 
         w.setValue('abc')
         w.clearValue()
@@ -97,7 +93,7 @@ class TestQgsFilterLineEdit(QgisTestCase):
 
     def testClearToDefault(self):
         # test clearing to default value
-        w = qgis.gui.QgsFilterLineEdit()
+        w = QgsFilterLineEdit()
         w.setClearMode(QgsFilterLineEdit.ClearToDefault)
 
         w.setValue('abc')
@@ -118,7 +114,7 @@ class TestQgsFilterLineEdit(QgisTestCase):
 
     def test_selectedText(self):
         """ test that NULL value is selected on focus and not-null value is not"""
-        w = qgis.gui.QgsFilterLineEdit(nullValue='my_null_value')
+        w = QgsFilterLineEdit(nullValue='my_null_value')
         w.clearValue()
         self.assertEqual(w.selectedText(), 'my_null_value')
 
@@ -128,11 +124,10 @@ class TestQgsFilterLineEdit(QgisTestCase):
         w.clearValue()
         self.assertEqual(w.selectedText(), 'my_null_value')
 
-    @unittest.skipIf(not use_signal_spy, "No QSignalSpy available")
     def test_ChangedSignals(self):
         """ test that signals are correctly emitted when clearing"""
 
-        w = qgis.gui.QgsFilterLineEdit()
+        w = QgsFilterLineEdit()
 
         cleared_spy = QSignalSpy(w.cleared)
         w.setValue('1')

--- a/tests/src/python/test_qgsfilterlineedit.py
+++ b/tests/src/python/test_qgsfilterlineedit.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/08/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.gui import QgsFilterLineEdit
 

--- a/tests/src/python/test_qgsfloatingwidget.py
+++ b/tests/src/python/test_qgsfloatingwidget.py
@@ -40,7 +40,7 @@ class TestQgsFloatingWidget(QgisTestCase):
         main_frame.setAttribute(103)
         main_frame.show()
 
-        fw = qgis.gui.QgsFloatingWidget(main_frame)
+        fw = QgsFloatingWidget(main_frame)
         fw.setMinimumSize(100, 50)
         fw.setAnchorWidget(anchor_widget)
 
@@ -89,7 +89,7 @@ class TestQgsFloatingWidget(QgisTestCase):
         main_frame.setAttribute(103)
         main_frame.show()
 
-        fw = qgis.gui.QgsFloatingWidget(main_frame)
+        fw = QgsFloatingWidget(main_frame)
         fw.setMinimumSize(100, 50)
         fw.setAnchorWidget(anchor_widget)
 
@@ -133,7 +133,7 @@ class TestQgsFloatingWidget(QgisTestCase):
         main_frame.setAttribute(103)
         main_frame.show()
 
-        fw = qgis.gui.QgsFloatingWidget(main_frame)
+        fw = QgsFloatingWidget(main_frame)
         fw.setMinimumSize(100, 50)
         fw.setAnchorWidget(anchor_widget)
 
@@ -171,7 +171,7 @@ class TestQgsFloatingWidget(QgisTestCase):
         main_frame.setAttribute(103)
         main_frame.show()
 
-        fw = qgis.gui.QgsFloatingWidget(main_frame)
+        fw = QgsFloatingWidget(main_frame)
         fw.setMinimumSize(300, 50)
         fw.setAnchorWidget(anchor_widget)
 

--- a/tests/src/python/test_qgsfloatingwidget.py
+++ b/tests/src/python/test_qgsfloatingwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '26/04/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtWidgets import QGridLayout, QWidget
 from qgis.gui import QgsFloatingWidget
 import unittest

--- a/tests/src/python/test_qgsfontbutton.py
+++ b/tests/src/python/test_qgsfontbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '04/06/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsTextFormat

--- a/tests/src/python/test_qgsfontmanager.py
+++ b/tests/src/python/test_qgsfontmanager.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 import os.path
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QUrl
 from qgis.PyQt.QtGui import QFont
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgsgeocoderalgorithm.py
+++ b/tests/src/python/test_qgsgeocoderalgorithm.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '02/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.analysis import QgsBatchGeocodeAlgorithm
 from qgis.core import (

--- a/tests/src/python/test_qgsgeocoderlocatorfilter.py
+++ b/tests/src/python/test_qgsgeocoderlocatorfilter.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '02/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsgeometry_avoid_intersections.py
+++ b/tests/src/python/test_qgsgeometry_avoid_intersections.py
@@ -9,7 +9,6 @@ __author__ = 'Martin Dobias'
 __date__ = '20/08/2012'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsFeature, QgsGeometry, QgsVectorLayer
 import unittest

--- a/tests/src/python/test_qgsgeometrygeneratorsymbollayer.py
+++ b/tests/src/python/test_qgsgeometrygeneratorsymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2015, Matthias Kuhn'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QPointF, QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter, QPolygonF
 from qgis.core import (

--- a/tests/src/python/test_qgsgeometrywidget.py
+++ b/tests/src/python/test_qgsgeometrywidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '15/02/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsgooglemapsgeocoder.py
+++ b/tests/src/python/test_qgsgooglemapsgeocoder.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QUrl
 from qgis.core import (
     QgsCoordinateTransformContext,

--- a/tests/src/python/test_qgsgpslogger.py
+++ b/tests/src/python/test_qgsgpslogger.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '10/11/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QBuffer, QCoreApplication, QDateTime
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsgraduatedsymbolrenderer.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Chris Crook'
 __date__ = '3/10/2014'
 __copyright__ = 'Copyright 2014, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsgraph.py
+++ b/tests/src/python/test_qgsgraph.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '08/11/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.analysis import QgsGraph
 from qgis.core import QgsPointXY

--- a/tests/src/python/test_qgsgrouplayer.py
+++ b/tests/src/python/test_qgsgrouplayer.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 import os
 from tempfile import TemporaryDirectory
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir, QEvent, QSize
 from qgis.PyQt.QtGui import QColor, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgshashlinesymbollayer.py
+++ b/tests/src/python/test_qgshashlinesymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2019, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgshighlight.py
+++ b/tests/src/python/test_qgshighlight.py
@@ -13,7 +13,6 @@ import os
 import unittest
 from typing import Optional
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgshistoryproviderregistry.py
+++ b/tests/src/python/test_qgshistoryproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/10/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import (
     QDate,

--- a/tests/src/python/test_qgsimagecache.py
+++ b/tests/src/python/test_qgsimagecache.py
@@ -15,7 +15,6 @@ import socketserver
 import threading
 import time
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir, QSize
 from qgis.PyQt.QtGui import QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsimagesourcelineedit.py
+++ b/tests/src/python/test_qgsimagesourcelineedit.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import QgsImageSourceLineEdit
 import unittest

--- a/tests/src/python/test_qgsinputcontroller.py
+++ b/tests/src/python/test_qgsinputcontroller.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2022 by Nyall Dawson'
 __date__ = '14/07/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime, QTimeZone, QVariant
 from qgis.gui import (
     QgsInputControllerManager,

--- a/tests/src/python/test_qgsinterpolatedlinesymbollayers.py
+++ b/tests/src/python/test_qgsinterpolatedlinesymbollayers.py
@@ -10,7 +10,6 @@ __date__ = '2021-04'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QPointF
 from qgis.PyQt.QtGui import QColor, QImage, QPainter, QPolygonF
 from qgis.core import (

--- a/tests/src/python/test_qgsinterval.py
+++ b/tests/src/python/test_qgsinterval.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '10/05/2016'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsInterval, QgsUnitTypes
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsissue7244.py
+++ b/tests/src/python/test_qgsissue7244.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import QgsPointXY, QgsVectorLayer
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '3/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale, Qt, QTextCodec, QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgslabellinesettings.py
+++ b/tests/src/python/test_qgslabellinesettings.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     QgsExpressionContext,
     QgsExpressionContextScope,

--- a/tests/src/python/test_qgslabelobstaclesettings.py
+++ b/tests/src/python/test_qgslabelobstaclesettings.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2019-12-07'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsExpressionContext,

--- a/tests/src/python/test_qgslabelsettingswidget.py
+++ b/tests/src/python/test_qgslabelsettingswidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '04/02/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsLabelObstacleSettings,

--- a/tests/src/python/test_qgslabelthinningsettings.py
+++ b/tests/src/python/test_qgslabelthinningsettings.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2019-12-07'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsLabelThinningSettings, QgsPalLayerSettings
 import unittest

--- a/tests/src/python/test_qgslayerdefinition.py
+++ b/tests/src/python/test_qgslayerdefinition.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import os
 import shutil
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import Qgis, QgsLayerDefinition, QgsProject, QgsVectorLayer

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '11/04/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QRegularExpression, QTime
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 import os
 from tempfile import TemporaryDirectory
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir, QEvent
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgslayertreemapcanvasbridge.py
+++ b/tests/src/python/test_qgslayertreemapcanvasbridge.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '8/03/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     QgsProject,
     QgsVectorLayer,

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '02.04.2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QStringListModel, QItemSelectionModel
 from qgis.PyQt.QtTest import QAbstractItemModelTester, QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgslayout.py
+++ b/tests/src/python/test_qgslayout.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QPointF, Qt
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgslayoutaligner.py
+++ b/tests/src/python/test_qgslayoutaligner.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '3/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsLayout,

--- a/tests/src/python/test_qgslayoutatlas.py
+++ b/tests/src/python/test_qgslayoutatlas.py
@@ -14,7 +14,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QFileInfo, QRectF
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutatlasclippingsettings.py
+++ b/tests/src/python/test_qgslayoutatlasclippingsettings.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 Nyall Dawson'
 __date__ = '03/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutcombobox.py
+++ b/tests/src/python/test_qgslayoutcombobox.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2019 by Nyall Dawson'
 __date__ = '11/03/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsLayoutManager,

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -13,7 +13,6 @@ import os
 import subprocess
 import tempfile
 
-import qgis  # NOQA
 from osgeo import gdal
 from qgis.PyQt.QtCore import (
     QDate,

--- a/tests/src/python/test_qgslayoutframe.py
+++ b/tests/src/python/test_qgslayoutframe.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '23/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import QgsLayoutFrame, QgsLayoutItemHtml
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgslayoutgridsettings.py
+++ b/tests/src/python/test_qgslayoutgridsettings.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor, QPen
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutguides.py
+++ b/tests/src/python/test_qgslayoutguides.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QModelIndex, Qt
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgslayouthtml.py
+++ b/tests/src/python/test_qgslayouthtml.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRectF, QUrl, qDebug
 from qgis.core import (
     QgsLayout,

--- a/tests/src/python/test_qgslayoutitem.py
+++ b/tests/src/python/test_qgslayoutitem.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     Qt,
     QRectF

--- a/tests/src/python/test_qgslayoutitemcombobox.py
+++ b/tests/src/python/test_qgslayoutitemcombobox.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2019 by Nyall Dawson'
 __date__ = '11/03/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsLayoutItem,

--- a/tests/src/python/test_qgslayoutitempropertiesdialog.py
+++ b/tests/src/python/test_qgslayoutitempropertiesdialog.py
@@ -9,6 +9,7 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
+import unittest
 
 from qgis.core import (
     QgsLayout,
@@ -18,7 +19,7 @@ from qgis.core import (
     QgsProject,
     QgsUnitTypes,
 )
-import unittest
+from qgis.gui import QgsLayoutItemPropertiesDialog
 from qgis.testing import start_app, QgisTestCase
 
 start_app()
@@ -28,7 +29,7 @@ class TestQgsLayoutItemPropertiesDialog(QgisTestCase):
 
     def testGettersSetters(self):
         """ test dialog getters/setters """
-        dlg = qgis.gui.QgsLayoutItemPropertiesDialog()
+        dlg = QgsLayoutItemPropertiesDialog()
 
         l = QgsLayout(QgsProject.instance())
         l.initializeDefaults()

--- a/tests/src/python/test_qgslayoutitempropertiesdialog.py
+++ b/tests/src/python/test_qgslayoutitempropertiesdialog.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsLayout,

--- a/tests/src/python/test_qgslayoutlabel.py
+++ b/tests/src/python/test_qgslayoutlabel.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '23/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QFileInfo
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutmanager.py
+++ b/tests/src/python/test_qgslayoutmanager.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '15/03/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutmanagermodel.py
+++ b/tests/src/python/test_qgslayoutmanagermodel.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2019 by Nyall Dawson'
 __date__ = '11/03/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QModelIndex, Qt
 from qgis.core import (
     QgsLayoutManager,

--- a/tests/src/python/test_qgslayoutmap.py
+++ b/tests/src/python/test_qgslayoutmap.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     Qt,
     QFileInfo,

--- a/tests/src/python/test_qgslayoutmapgrid.py
+++ b/tests/src/python/test_qgslayoutmapgrid.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '20/10/2017'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QRectF
 from qgis.PyQt.QtGui import QColor, QPainter
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgslayoutmapitemclippingsettings.py
+++ b/tests/src/python/test_qgslayoutmapitemclippingsettings.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 Nyall Dawson'
 __date__ = '03/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QRectF
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutmapoverview.py
+++ b/tests/src/python/test_qgslayoutmapoverview.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QFileInfo, QRectF
 from qgis.PyQt.QtGui import QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutmarker.py
+++ b/tests/src/python/test_qgslayoutmarker.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '05/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRectF, Qt
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutnortharrowhandler.py
+++ b/tests/src/python/test_qgslayoutnortharrowhandler.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '05/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRectF
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutpage.py
+++ b/tests/src/python/test_qgslayoutpage.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '23/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgslayoutpagecollection.py
+++ b/tests/src/python/test_qgslayoutpagecollection.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QPointF, QRectF, Qt
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgslayoutpicture.py
+++ b/tests/src/python/test_qgslayoutpicture.py
@@ -14,7 +14,6 @@ import os
 import socketserver
 import threading
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QRectF
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutpolygon.py
+++ b/tests/src/python/test_qgslayoutpolygon.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2016 by Paul Blottiere'
 __date__ = '14/03/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF, QRectF
 from qgis.PyQt.QtGui import QImage, QPainter, QPolygonF
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgslayoutpolyline.py
+++ b/tests/src/python/test_qgslayoutpolyline.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2016 by Paul Blottiere'
 __date__ = '14/03/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF
 from qgis.PyQt.QtGui import QPolygonF
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutscalebar.py
+++ b/tests/src/python/test_qgslayoutscalebar.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '23/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import QgsLayoutItemScaleBar
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgslayoutshape.py
+++ b/tests/src/python/test_qgslayoutshape.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2017 by Nyall Dawson'
 __date__ = '23/10/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRectF
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutsnapper.py
+++ b/tests/src/python/test_qgslayoutsnapper.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF, QRectF, Qt
 from qgis.PyQt.QtWidgets import QGraphicsLineItem
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslayoutunitscombobox.py
+++ b/tests/src/python/test_qgslayoutunitscombobox.py
@@ -11,7 +11,11 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtWidgets import QDoubleSpinBox
-from qgis.core import QgsLayoutMeasurementConverter, QgsUnitTypes
+from qgis.core import (
+    QgsLayoutMeasurementConverter,
+    QgsUnitTypes
+)
+from qgis.gui import QgsLayoutUnitsComboBox
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -22,14 +26,14 @@ class TestQgsLayoutUnitsComboBox(QgisTestCase):
 
     def testGettersSetters(self):
         """ test widget getters/setters """
-        w = qgis.gui.QgsLayoutUnitsComboBox()
+        w = QgsLayoutUnitsComboBox()
 
         w.setUnit(QgsUnitTypes.LayoutPixels)
         self.assertEqual(w.unit(), QgsUnitTypes.LayoutPixels)
 
     def test_ChangedSignals(self):
         """ test that signals are correctly emitted when setting unit"""
-        w = qgis.gui.QgsLayoutUnitsComboBox()
+        w = QgsLayoutUnitsComboBox()
 
         spy = QSignalSpy(w.changed)
         w.setUnit(QgsUnitTypes.LayoutPixels)
@@ -39,7 +43,7 @@ class TestQgsLayoutUnitsComboBox(QgisTestCase):
 
     def testLinkedWidgets(self):
         """ test linking spin boxes to combobox"""
-        w = qgis.gui.QgsLayoutUnitsComboBox()
+        w = QgsLayoutUnitsComboBox()
         self.assertFalse(w.converter())
         c = QgsLayoutMeasurementConverter()
         w.setConverter(c)

--- a/tests/src/python/test_qgslayoutunitscombobox.py
+++ b/tests/src/python/test_qgslayoutunitscombobox.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtWidgets import QDoubleSpinBox
 from qgis.core import QgsLayoutMeasurementConverter, QgsUnitTypes

--- a/tests/src/python/test_qgslayoutview.py
+++ b/tests/src/python/test_qgslayoutview.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QByteArray, QMimeData, QRectF
 from qgis.PyQt.QtGui import QTransform

--- a/tests/src/python/test_qgslegendpatchshape.py
+++ b/tests/src/python/test_qgslegendpatchshape.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '05/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, QSizeF
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgslegendpatchshapebutton.py
+++ b/tests/src/python/test_qgslegendpatchshapebutton.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '20/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsGeometry, QgsLegendPatchShape, QgsSymbol
 from qgis.gui import QgsLegendPatchShapeButton

--- a/tests/src/python/test_qgslegendpatchshapewidget.py
+++ b/tests/src/python/test_qgslegendpatchshapewidget.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '20/04/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsGeometry, QgsLegendPatchShape, QgsSymbol
 from qgis.gui import QgsLegendPatchShapeWidget

--- a/tests/src/python/test_qgslineburstsymbollayer.py
+++ b/tests/src/python/test_qgslineburstsymbollayer.py
@@ -19,7 +19,6 @@ __author__ = 'Nyall Dawson'
 __date__ = 'October 2021'
 __copyright__ = '(C) 2021, Nyall Dawson'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgslinesegment.py
+++ b/tests/src/python/test_qgslinesegment.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '13/04/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsLineSegment2D, QgsPointXY
 import unittest

--- a/tests/src/python/test_qgslinesymbollayers.py
+++ b/tests/src/python/test_qgslinesymbollayers.py
@@ -10,7 +10,6 @@ __date__ = '2017-01'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgslocaldefaultsettings.py
+++ b/tests/src/python/test_qgslocaldefaultsettings.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsBearingNumericFormat,

--- a/tests/src/python/test_qgslocalizeddatapathregistry.py
+++ b/tests/src/python/test_qgslocalizeddatapathregistry.py
@@ -15,7 +15,6 @@ import tempfile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgslocator.py
+++ b/tests/src/python/test_qgslocator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 from time import sleep
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (

--- a/tests/src/python/test_qgslogger.py
+++ b/tests/src/python/test_qgslogger.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 
 (myFileHandle, myFilename) = tempfile.mkstemp()
 os.environ['QGIS_DEBUG'] = '2'

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     Qt,
     QCoreApplication,

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import time
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QDir, QTime, Qt
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsmapcanvasannotationitem.py
+++ b/tests/src/python/test_qgsmapcanvasannotationitem.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '24/1/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF, QSizeF
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsmapclippingregion.py
+++ b/tests/src/python/test_qgsmapclippingregion.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2020-06'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsGeometry, QgsMapClippingRegion, QgsVectorLayer
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsmapclippingutils.py
+++ b/tests/src/python/test_qgsmapclippingutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2020-06'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 
-import sip
+from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -14,7 +14,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 import sip
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsmaplayeraction.py
+++ b/tests/src/python/test_qgsmaplayeraction.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA switch sip api
 from qgis.core import QgsMapLayer, QgsRasterLayer, QgsVectorLayer
 from qgis.gui import QgsMapLayerAction
 import unittest

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '14/06/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsmaplayerfactory.py
+++ b/tests/src/python/test_qgsmaplayerfactory.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     QgsAnnotationLayer,
     QgsCoordinateTransformContext,

--- a/tests/src/python/test_qgsmaplayermodel.py
+++ b/tests/src/python/test_qgsmaplayermodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/11/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QModelIndex, Qt
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsmaplayerproxymodel.py
+++ b/tests/src/python/test_qgsmaplayerproxymodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '22/08/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsmaplayerutils.py
+++ b/tests/src/python/test_qgsmaplayerutils.py
@@ -10,7 +10,6 @@ __date__ = '2021-05'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.core import (
     QgsAnnotationLayer,
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsmaprenderer.py
+++ b/tests/src/python/test_qgsmaprenderer.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 from random import uniform
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QImage, QPainter
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgsmaprenderercache.py
+++ b/tests/src/python/test_qgsmaprenderercache.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 from time import sleep
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QImage
 from qgis.core import (

--- a/tests/src/python/test_qgsmapthemecollection.py
+++ b/tests/src/python/test_qgsmapthemecollection.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '8/03/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsMapThemeCollection, QgsProject, QgsVectorLayer
 from qgis.gui import QgsLayerTreeMapCanvasBridge, QgsMapCanvas

--- a/tests/src/python/test_qgsmapunitscale.py
+++ b/tests/src/python/test_qgsmapunitscale.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2015-09'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsMapSettings,

--- a/tests/src/python/test_qgsmargins.py
+++ b/tests/src/python/test_qgsmargins.py
@@ -10,8 +10,6 @@ __date__ = '2017-01'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
 
-import qgis  # NOQA
-
 from qgis.core import QgsMargins
 from qgis.testing import unittest
 

--- a/tests/src/python/test_qgsmarkerlinesymbollayer.py
+++ b/tests/src/python/test_qgsmarkerlinesymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2018, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsmatrix4x4.py
+++ b/tests/src/python/test_qgsmatrix4x4.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2023 by Martin Dobias'
 __date__ = '18/07/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsMatrix4x4,

--- a/tests/src/python/test_qgsmediawidget.py
+++ b/tests/src/python/test_qgsmediawidget.py
@@ -9,7 +9,6 @@ __author__ = 'Mathieu Pellerin'
 __date__ = '25/01/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.gui import QgsMediaWidget
 import unittest

--- a/tests/src/python/test_qgsmergedfeaturerenderer.py
+++ b/tests/src/python/test_qgsmergedfeaturerenderer.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (

--- a/tests/src/python/test_qgsmeshlayerelevationproperties.py
+++ b/tests/src/python/test_qgsmeshlayerelevationproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsmeshlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsmeshlayerprofilegenerator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsmessagelog.py
+++ b/tests/src/python/test_qgsmessagelog.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/06/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsmetadatabase.py
+++ b/tests/src/python/test_qgsmetadatabase.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '19/03/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsmetadatawidget.py
+++ b/tests/src/python/test_qgsmetadatawidget.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/03/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsmultiedittoolbutton.py
+++ b/tests/src/python/test_qgsmultiedittoolbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/03/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 
 from qgis.gui import QgsMultiEditToolButton
 import unittest

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -15,7 +15,6 @@ import socketserver
 import threading
 from functools import partial
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtTest import QSignalSpy

--- a/tests/src/python/test_qgsnetworkcontentfetcher.py
+++ b/tests/src/python/test_qgsnetworkcontentfetcher.py
@@ -15,7 +15,6 @@ import os
 import socketserver
 import threading
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.core import QgsNetworkContentFetcher

--- a/tests/src/python/test_qgsnetworkcontentfetcherregistry.py
+++ b/tests/src/python/test_qgsnetworkcontentfetcherregistry.py
@@ -16,7 +16,6 @@ import os
 import socketserver
 import threading
 
-import qgis  # NOQA
 from qgis.PyQt.QtNetwork import QNetworkReply
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsnetworkcontentfetchertask.py
+++ b/tests/src/python/test_qgsnetworkcontentfetchertask.py
@@ -16,7 +16,6 @@ import os
 import socketserver
 import threading
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply
 from qgis.core import (

--- a/tests/src/python/test_qgsnetworkreply.py
+++ b/tests/src/python/test_qgsnetworkreply.py
@@ -10,7 +10,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/06/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsNetworkReplyContent
 import unittest

--- a/tests/src/python/test_qgsnoapplication.py
+++ b/tests/src/python/test_qgsnoapplication.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import QgsApplication
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsnominatimgeocoder.py
+++ b/tests/src/python/test_qgsnominatimgeocoder.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsNominatimGeocoder,

--- a/tests/src/python/test_qgsnullsymbolrenderer.py
+++ b/tests/src/python/test_qgsnullsymbolrenderer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2016, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsMultiRenderChecker,

--- a/tests/src/python/test_qgsnumericformat.py
+++ b/tests/src/python/test_qgsnumericformat.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '6/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     QgsBasicNumericFormat,

--- a/tests/src/python/test_qgsnumericformatgui.py
+++ b/tests/src/python/test_qgsnumericformatgui.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '6/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsobjectcustomproperties.py
+++ b/tests/src/python/test_qgsobjectcustomproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '02/06/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import QgsObjectCustomProperties
 import unittest

--- a/tests/src/python/test_qgsogcutils.py
+++ b/tests/src/python/test_qgsogcutils.py
@@ -13,7 +13,6 @@ __author__ = 'René-Luc Dhont'
 __date__ = '21/06/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import QgsField, QgsOgcUtils, QgsVectorLayer

--- a/tests/src/python/test_qgsopacitywidget.py
+++ b/tests/src/python/test_qgsopacitywidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '30/05/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.PyQt.QtTest import QSignalSpy
 import unittest

--- a/tests/src/python/test_qgsopacitywidget.py
+++ b/tests/src/python/test_qgsopacitywidget.py
@@ -11,6 +11,7 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 
 from qgis.PyQt.QtTest import QSignalSpy
+from qgis.gui import QgsOpacityWidget
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -21,7 +22,7 @@ class TestQgsOpacityWidget(QgisTestCase):
 
     def testGettersSetters(self):
         """ test widget getters/setters """
-        w = qgis.gui.QgsOpacityWidget()
+        w = QgsOpacityWidget()
 
         w.setOpacity(0.2)
         self.assertEqual(w.opacity(), 0.2)
@@ -35,7 +36,7 @@ class TestQgsOpacityWidget(QgisTestCase):
     def test_ChangedSignals(self):
         """ test that signals are correctly emitted when setting opacity"""
 
-        w = qgis.gui.QgsOpacityWidget()
+        w = QgsOpacityWidget()
 
         spy = QSignalSpy(w.opacityChanged)
         w.setOpacity(0.2)

--- a/tests/src/python/test_qgsoptional.py
+++ b/tests/src/python/test_qgsoptional.py
@@ -14,7 +14,6 @@ test_qgsoptional.py
  ***************************************************************************/
 '''
 
-import qgis  # NOQA
 
 from qgis.core import QgsExpression, QgsOptionalExpression
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsorientedbox3d.py
+++ b/tests/src/python/test_qgsorientedbox3d.py
@@ -12,7 +12,6 @@ __date__ = '10/07/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import math
-import qgis  # NOQA
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,

--- a/tests/src/python/test_qgsowsconnection.py
+++ b/tests/src/python/test_qgsowsconnection.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12.09.2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import QgsDataSourceUri, QgsOwsConnection, QgsSettings
 import unittest

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -22,7 +22,6 @@ import shutil
 import sys
 from collections.abc import Callable
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, Qt, qDebug
 from qgis.PyQt.QtGui import QColor, QFont
 from qgis.core import (

--- a/tests/src/python/test_qgspallabeling_canvas.py
+++ b/tests/src/python/test_qgspallabeling_canvas.py
@@ -17,7 +17,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 import os
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import qDebug
 from qgis.core import QgsVectorLayerSimpleLabeling
 

--- a/tests/src/python/test_qgspallabeling_layout.py
+++ b/tests/src/python/test_qgspallabeling_layout.py
@@ -18,7 +18,6 @@ import os
 import subprocess
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRect, QRectF, QSize, QSizeF, qDebug
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtPrintSupport import QPrinter

--- a/tests/src/python/test_qgspallabeling_placement.py
+++ b/tests/src/python/test_qgspallabeling_placement.py
@@ -16,7 +16,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 import os
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import qDebug
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgspallabeling_server.py
+++ b/tests/src/python/test_qgspallabeling_server.py
@@ -19,7 +19,6 @@ import os
 import shutil
 import sys
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import qDebug
 from qgis.core import QgsApplication, QgsProject, QgsSettings
 

--- a/tests/src/python/test_qgspallabeling_tests.py
+++ b/tests/src/python/test_qgspallabeling_tests.py
@@ -15,7 +15,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF, QSizeF, Qt
 from qgis.PyQt.QtGui import QFont
 from qgis.core import (

--- a/tests/src/python/test_qgspanelwidget.py
+++ b/tests/src/python/test_qgspanelwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/08/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtWidgets import QDialog, QWidget
 from qgis.gui import QgsPanelWidget
 import unittest

--- a/tests/src/python/test_qgspanelwidgetstack.py
+++ b/tests/src/python/test_qgspanelwidgetstack.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/10/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import QgsPanelWidget, QgsPanelWidgetStack
 import unittest

--- a/tests/src/python/test_qgspathresolver.py
+++ b/tests/src/python/test_qgspathresolver.py
@@ -13,7 +13,6 @@ import gc
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.core import (
     QgsApplication,
     QgsPathResolver,

--- a/tests/src/python/test_qgsplot.py
+++ b/tests/src/python/test_qgsplot.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '28/3/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSizeF, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspoint.py
+++ b/tests/src/python/test_qgspoint.py
@@ -9,7 +9,6 @@ __author__ = 'Tim Sutton'
 __date__ = '20/08/2012'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF
 from qgis.core import QgsPoint, QgsPointXY, QgsWkbTypes
 import unittest

--- a/tests/src/python/test_qgspointcloudattributebyramprenderer.py
+++ b/tests/src/python/test_qgspointcloudattributebyramprenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, Qt
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgspointcloudattributecombobox.py
+++ b/tests/src/python/test_qgspointcloudattributecombobox.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsPointCloudAttribute,

--- a/tests/src/python/test_qgspointcloudattributemodel.py
+++ b/tests/src/python/test_qgspointcloudattributemodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.core import (
     QgsPointCloudAttribute,

--- a/tests/src/python/test_qgspointcloudclassifiedrenderer.py
+++ b/tests/src/python/test_qgspointcloudclassifiedrenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspointcloudelevationproperties.py
+++ b/tests/src/python/test_qgspointcloudelevationproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspointcloudextentrenderer.py
+++ b/tests/src/python/test_qgspointcloudextentrenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '04/12/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspointcloudlayerprofilegenerator.py
+++ b/tests/src/python/test_qgspointcloudlayerprofilegenerator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (

--- a/tests/src/python/test_qgspointcloudprovider.py
+++ b/tests/src/python/test_qgspointcloudprovider.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     QgsPointCloudLayer,
     QgsProviderRegistry,

--- a/tests/src/python/test_qgspointcloudrgbrenderer.py
+++ b/tests/src/python/test_qgspointcloudrgbrenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -24,7 +24,6 @@ __copyright__ = '(C) 2016, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspolymorphicrelation.py
+++ b/tests/src/python/test_qgspolymorphicrelation.py
@@ -9,7 +9,6 @@ __author__ = 'Ivan Ivanov'
 __date__ = '11/1/2021'
 __copyright__ = 'Copyright 2021, QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsFeature,

--- a/tests/src/python/test_qgspostgresdomain.py
+++ b/tests/src/python/test_qgspostgresdomain.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import QgsProject, QgsVectorLayer
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgspostgrestransaction.py
+++ b/tests/src/python/test_qgspostgrestransaction.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsDataSourceUri,

--- a/tests/src/python/test_qgsprocessingbatch.py
+++ b/tests/src/python/test_qgsprocessingbatch.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsProcessingBatchFeedback, QgsProcessingFeedback
 import unittest

--- a/tests/src/python/test_qgsprofileexporter.py
+++ b/tests/src/python/test_qgsprofileexporter.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsprofilepoint.py
+++ b/tests/src/python/test_qgsprofilepoint.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsProfilePoint
 import unittest

--- a/tests/src/python/test_qgsprofilerequest.py
+++ b/tests/src/python/test_qgsprofilerequest.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -18,7 +18,6 @@ from shutil import copyfile
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
-import qgis  # NOQA
 from osgeo import ogr
 from qgis.PyQt import sip
 from qgis.PyQt.QtCore import QT_VERSION_STR, QTemporaryDir

--- a/tests/src/python/test_qgsprojectbadlayers.py
+++ b/tests/src/python/test_qgsprojectbadlayers.py
@@ -13,7 +13,6 @@ import filecmp
 import os
 from shutil import copyfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, QTemporaryDir
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument, QDomNode

--- a/tests/src/python/test_qgsprojectdisplaysettings.py
+++ b/tests/src/python/test_qgsprojectdisplaysettings.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsprojectelevationproperties.py
+++ b/tests/src/python/test_qgsprojectelevationproperties.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsprojectgpssettings.py
+++ b/tests/src/python/test_qgsprojectgpssettings.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/11/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtWidgets import QComboBox
 from qgis.core import QgsCoordinateReferenceSystem, QgsProject

--- a/tests/src/python/test_qgsprojectmetadata.py
+++ b/tests/src/python/test_qgsprojectmetadata.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '19/03/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsprojectrelationmanager.py
+++ b/tests/src/python/test_qgsprojectrelationmanager.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     QgsProject,
     QgsRelation,

--- a/tests/src/python/test_qgsprojectstylesettings.py
+++ b/tests/src/python/test_qgsprojectstylesettings.py
@@ -9,7 +9,6 @@ __author__ = 'Mathieu Pellerin'
 __date__ = '09/05/2022'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QCoreApplication,
     QEvent,

--- a/tests/src/python/test_qgsprojecttimesettings.py
+++ b/tests/src/python/test_qgsprojecttimesettings.py
@@ -9,7 +9,6 @@ __author__ = 'Samweli Mwakisambwe'
 __date__ = '6/3/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsprojectutils.py
+++ b/tests/src/python/test_qgsprojectutils.py
@@ -10,7 +10,6 @@ __date__ = '2021-07'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
 
-import qgis  # NOQA
 from qgis.core import (
     QgsCoordinateTransformContext,
     QgsGroupLayer,

--- a/tests/src/python/test_qgsprojectviewsettings.py
+++ b/tests/src/python/test_qgsprojectviewsettings.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgspropertyoverridebutton.py
+++ b/tests/src/python/test_qgspropertyoverridebutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '11/01/2019'
 __copyright__ = 'Copyright 2019, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsproviderconnectioncombobox.py
+++ b/tests/src/python/test_qgsproviderconnectioncombobox.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsProviderRegistry, QgsVectorLayer

--- a/tests/src/python/test_qgsproviderguiregistry.py
+++ b/tests/src/python/test_qgsproviderguiregistry.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 
 import sys
 
-import qgis  # NOQA
 from qgis.gui import QgsGui
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/03/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsMapLayerType,

--- a/tests/src/python/test_qgsprovidersublayerdetails.py
+++ b/tests/src/python/test_qgsprovidersublayerdetails.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsCoordinateTransformContext,

--- a/tests/src/python/test_qgsprovidersublayermodel.py
+++ b/tests/src/python/test_qgsprovidersublayermodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '05/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QModelIndex, Qt
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsrandommarkersymbollayer.py
+++ b/tests/src/python/test_qgsrandommarkersymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2019, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsrange.py
+++ b/tests/src/python/test_qgsrange.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '11.04.2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate
 from qgis.core import QgsDateRange, QgsDoubleRange, QgsIntRange
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsrangeslider.py
+++ b/tests/src/python/test_qgsrangeslider.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2020-11-25'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtWidgets import QSlider

--- a/tests/src/python/test_qgsrangewidgets.py
+++ b/tests/src/python/test_qgsrangewidgets.py
@@ -9,7 +9,6 @@ __author__ = 'Tobias Reber'
 __date__ = '20/05/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import NULL, QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
 from qgis.gui import QgsGui

--- a/tests/src/python/test_qgsrasterattributetable.py
+++ b/tests/src/python/test_qgsrasterattributetable.py
@@ -17,7 +17,6 @@ import os
 import shutil
 
 import numpy as np
-import qgis  # NOQA
 from osgeo import gdal, osr
 from qgis.PyQt.QtCore import QTemporaryDir, QVariant
 from qgis.PyQt.QtGui import QColor

--- a/tests/src/python/test_qgsrasterattributetablemodel.py
+++ b/tests/src/python/test_qgsrasterattributetablemodel.py
@@ -13,7 +13,6 @@ __author__ = 'Alessandro Pasotti'
 __date__ = '04/09/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.Qt import Qt
 from qgis.PyQt.QtCore import QModelIndex, QVariant
 from qgis.PyQt.QtGui import QColor

--- a/tests/src/python/test_qgsrasterattributetablewidget.py
+++ b/tests/src/python/test_qgsrasterattributetablewidget.py
@@ -13,7 +13,6 @@ __author__ = 'Alessandro Pasotti'
 __date__ = '20/08/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir, QVariant
 from qgis.PyQt.QtWidgets import QDialog, QVBoxLayout
 from qgis.core import (

--- a/tests/src/python/test_qgsrasterbandcombobox.py
+++ b/tests/src/python/test_qgsrasterbandcombobox.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QFileInfo
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsRasterLayer

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -10,7 +10,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '17/08/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.core import QgsColorRampShader, QgsGradientColorRamp, QgsGradientStop
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -13,7 +13,6 @@ import glob
 import os
 import tempfile
 
-import qgis  # NOQA
 from osgeo import gdal
 from qgis.PyQt.QtCore import QDir, QTemporaryFile
 from qgis.core import (

--- a/tests/src/python/test_qgsrasterfilewritertask.py
+++ b/tests/src/python/test_qgsrasterfilewritertask.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -18,7 +18,6 @@ import os
 from shutil import copyfile
 
 import numpy as np
-import qgis  # NOQA
 from osgeo import gdal
 from qgis.PyQt.QtCore import QFileInfo, QSize, QTemporaryDir
 from qgis.PyQt.QtGui import QColor, QResizeEvent

--- a/tests/src/python/test_qgsrasterlayerelevationproperties.py
+++ b/tests/src/python/test_qgsrasterlayerelevationproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 import os
 
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsrasterlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsrasterlayerprofilegenerator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsrasterlayerproperties.py
+++ b/tests/src/python/test_qgsrasterlayerproperties.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 import pathlib
 import typing
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.core import QgsMapLayer, QgsProject, QgsRasterLayer

--- a/tests/src/python/test_qgsrasterlayerrenderer.py
+++ b/tests/src/python/test_qgsrasterlayerrenderer.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsrasterlinesymbollayer.py
+++ b/tests/src/python/test_qgsrasterlinesymbollayer.py
@@ -20,7 +20,6 @@ __date__ = 'March 2019'
 __copyright__ = '(C) 2019, Nyall Dawson'
 
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsrasterpipe.py
+++ b/tests/src/python/test_qgsrasterpipe.py
@@ -22,7 +22,6 @@ __author__ = 'Nyall Dawson'
 __date__ = 'June 2021'
 __copyright__ = '(C) 2021, Nyall Dawson'
 
-import qgis  # NOQA
 from qgis.core import (
     QgsExpressionContext,
     QgsProperty,

--- a/tests/src/python/test_qgsrasterrange.py
+++ b/tests/src/python/test_qgsrasterrange.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '07/06/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 
 from qgis.core import QgsRasterRange
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsrasterrendererutils.py
+++ b/tests/src/python/test_qgsrasterrendererutils.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '15/09/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtGui import QColor
 from qgis.core import QgsColorRampShader, QgsRasterRendererUtils

--- a/tests/src/python/test_qgsrasterrerderer_createsld.py
+++ b/tests/src/python/test_qgsrasterrerderer_createsld.py
@@ -22,7 +22,6 @@ __copyright__ = '(C) 2018, Luigi Pirelli'
 import os
 import random
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QFileInfo,
 )

--- a/tests/src/python/test_qgsrasterresampler.py
+++ b/tests/src/python/test_qgsrasterresampler.py
@@ -16,7 +16,6 @@ import struct
 import tempfile
 from contextlib import contextmanager
 
-import qgis  # NOQA
 from osgeo import gdal
 from qgis.PyQt.QtGui import qRed
 from qgis.core import (

--- a/tests/src/python/test_qgsrastertransparencywidget.py
+++ b/tests/src/python/test_qgsrastertransparencywidget.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import pathlib
 
-import qgis  # NOQA switch sip api
 from qgis.core import QgsRasterLayer, QgsRasterRange
 from qgis.gui import QgsMapCanvas, QgsRasterTransparencyWidget
 from qgis.testing import TestCase, unittest

--- a/tests/src/python/test_qgsratiolockbutton.py
+++ b/tests/src/python/test_qgsratiolockbutton.py
@@ -9,9 +9,11 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
+import unittest
 
 from qgis.PyQt.QtWidgets import QDoubleSpinBox
-import unittest
+
+from qgis.gui import QgsRatioLockButton
 from qgis.testing import start_app, QgisTestCase
 
 start_app()
@@ -21,7 +23,7 @@ class TestQgsRatioLockButton(QgisTestCase):
 
     def testLinkedWidgets(self):
         """ test linking spin boxes to combobox"""
-        w = qgis.gui.QgsRatioLockButton()
+        w = QgsRatioLockButton()
 
         spin_width = QDoubleSpinBox()
         spin_width.setMaximum(100000)
@@ -94,7 +96,7 @@ class TestQgsRatioLockButton(QgisTestCase):
         self.assertEqual(spin_height.value(), 1000)
 
     def testResetRatio(self):
-        w = qgis.gui.QgsRatioLockButton()
+        w = QgsRatioLockButton()
 
         spin_width = QDoubleSpinBox()
         spin_width.setMaximum(100000)

--- a/tests/src/python/test_qgsratiolockbutton.py
+++ b/tests/src/python/test_qgsratiolockbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.PyQt.QtWidgets import QDoubleSpinBox
 import unittest

--- a/tests/src/python/test_qgsreadwritecontext.py
+++ b/tests/src/python/test_qgsreadwritecontext.py
@@ -10,7 +10,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '28.02.2018'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import Qgis, QgsReadWriteContext
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -9,7 +9,6 @@ __author__ = 'Tim Sutton'
 __date__ = '20/08/2012'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import QgsPointXY, QgsRectangle, QgsVector
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsreferencedgeometry.py
+++ b/tests/src/python/test_qgsreferencedgeometry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '31/08/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     QgsAttributeEditorElement,
     QgsFeature,

--- a/tests/src/python/test_qgsrelationeditorwidgetregistry.py
+++ b/tests/src/python/test_qgsrelationeditorwidgetregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = '28/11/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QGridLayout,

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTimer
 from qgis.PyQt.QtWidgets import (
     QDialog,

--- a/tests/src/python/test_qgsrelationmanager.py
+++ b/tests/src/python/test_qgsrelationmanager.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '17/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsPolymorphicRelation,

--- a/tests/src/python/test_qgsrelationpostgres.py
+++ b/tests/src/python/test_qgsrelationpostgres.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import QgsProject, QgsVectorLayer
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '16/01/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDateTime, QSize
 from qgis.PyQt.QtGui import QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsrendereditemresults.py
+++ b/tests/src/python/test_qgsrendereditemresults.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2021 by Nyall Dawson'
 __date__ = '03/09/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import (
     QgsRectangle,
     QgsRenderContext,

--- a/tests/src/python/test_qgsrenderer.py
+++ b/tests/src/python/test_qgsrenderer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '07/06/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsreport.py
+++ b/tests/src/python/test_qgsreport.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '29/12/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     QgsFeature,

--- a/tests/src/python/test_qgsrubberband.py
+++ b/tests/src/python/test_qgsrubberband.py
@@ -6,7 +6,6 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-import qgis  # NOQA
 
 from qgis.gui import QgsRubberBand
 import unittest

--- a/tests/src/python/test_qgsscalebarrendererregistry.py
+++ b/tests/src/python/test_qgsscalebarrendererregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '20/03/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsScaleBarRenderer, QgsScaleBarRendererRegistry
 import unittest

--- a/tests/src/python/test_qgsscalecalculator.py
+++ b/tests/src/python/test_qgsscalecalculator.py
@@ -9,7 +9,6 @@ __author__ = 'Mathieu Pellerin'
 __date__ = '30/12/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsscalewidget.py
+++ b/tests/src/python/test_qgsscalewidget.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2019, The QGIS Project'
 
 import math
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import QgsScaleWidget
 import unittest

--- a/tests/src/python/test_qgsscreenproperties.py
+++ b/tests/src/python/test_qgsscreenproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '22/06/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QGuiApplication
 from qgis.core import (
     QgsScreenProperties,

--- a/tests/src/python/test_qgssearchwidgettoolbutton.py
+++ b/tests/src/python/test_qgssearchwidgettoolbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '18/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 
 from qgis.gui import QgsSearchWidgetToolButton, QgsSearchWidgetWrapper
 import unittest

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2016-05'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.core import QgsFeature, QgsProject, QgsRelation, QgsVectorLayer

--- a/tests/src/python/test_qgsselectioncontext.py
+++ b/tests/src/python/test_qgsselectioncontext.py
@@ -6,7 +6,6 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-import qgis  # NOQA
 
 from qgis.core import QgsSelectionContext
 from qgis.testing import unittest

--- a/tests/src/python/test_qgssensormanager.py
+++ b/tests/src/python/test_qgssensormanager.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QLocale, QTemporaryDir, QIODevice, QBuffer
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgssensormodel.py
+++ b/tests/src/python/test_qgssensormodel.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QEvent, QLocale, QTemporaryDir, QIODevice, QBuffer, QDateTime
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgssensorregistry.py
+++ b/tests/src/python/test_qgssensorregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Mathieu Pellerin'
 __date__ = '19/03/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsSensorRegistry, QgsSensorAbstractMetadata, QgsTcpSocketSensor, QgsUdpSocketSensor
 import unittest

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -14,7 +14,6 @@ import shutil
 import tempfile
 from math import sqrt
 
-import qgis  # NOQA
 from osgeo import gdal
 from osgeo.gdalconst import GA_ReadOnly
 from qgis.PyQt.QtCore import QSize

--- a/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_accesscontrol_wms_getlegendgraphic.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import urllib.parse
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.testing import unittest
 

--- a/tests/src/python/test_qgsserver_cachemanager.py
+++ b/tests/src/python/test_qgsserver_cachemanager.py
@@ -18,7 +18,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QBuffer, QByteArray, QIODevice, QSize
 from qgis.PyQt.QtGui import QImage
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgsserver_configcache.py
+++ b/tests/src/python/test_qgsserver_configcache.py
@@ -15,7 +15,6 @@ import os
 from pathlib import Path
 from time import time
 
-import qgis  # NOQA
 from qgis.core import QgsApplication
 from qgis.server import QgsConfigCache, QgsServerSettings
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsserver_wms_dimension.py
+++ b/tests/src/python/test_qgsserver_wms_dimension.py
@@ -17,7 +17,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.testing import unittest
 

--- a/tests/src/python/test_qgsshortcutsmanager.py
+++ b/tests/src/python/test_qgsshortcutsmanager.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '28/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QAction, QShortcut, QWidget
 from qgis.core import QgsSettings

--- a/tests/src/python/test_qgssimplefillsymbollayer.py
+++ b/tests/src/python/test_qgssimplefillsymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2020, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QPointF, QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgssimplelinesymbollayer.py
+++ b/tests/src/python/test_qgssimplelinesymbollayer.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2018, Nyall Dawson'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgssingleitemmodel.py
+++ b/tests/src/python/test_qgssingleitemmodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '28/3/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.core import QgsSingleItemModel

--- a/tests/src/python/test_qgssinglesymbolrenderer.py
+++ b/tests/src/python/test_qgssinglesymbolrenderer.py
@@ -24,7 +24,6 @@ __copyright__ = '(C) 2015, Matthias Kuhn'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsFeatureRequest,

--- a/tests/src/python/test_qgssourcewidgetproviderregistry.py
+++ b/tests/src/python/test_qgssourcewidgetproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '23/12/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsVectorLayer
 from qgis.gui import (

--- a/tests/src/python/test_qgsspatialindex.py
+++ b/tests/src/python/test_qgsspatialindex.py
@@ -9,7 +9,6 @@ __author__ = 'Alexander Bruy'
 __date__ = '20/01/2011'
 __copyright__ = 'Copyright 2012, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsFeature,

--- a/tests/src/python/test_qgssphere.py
+++ b/tests/src/python/test_qgssphere.py
@@ -12,7 +12,6 @@ __date__ = '14/07/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import math
-import qgis  # NOQA
 from qgis.core import (
     QgsSphere,
     QgsPoint,

--- a/tests/src/python/test_qgsstringstatisticalsummary.py
+++ b/tests/src/python/test_qgsstringstatisticalsummary.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '07/05/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsStringStatisticalSummary
 from qgis.testing import unittest

--- a/tests/src/python/test_qgsstringutils.py
+++ b/tests/src/python/test_qgsstringutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '30/08/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     QgsStringReplacement,

--- a/tests/src/python/test_qgsstylemodel.py
+++ b/tests/src/python/test_qgsstylemodel.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '10/09/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QModelIndex, QSize, Qt
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
+++ b/tests/src/python/test_qgssubsetstringeditorproviderregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Even Rouault'
 __date__ = '15/11/2020'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import Qt
 from qgis.core import QgsVectorLayer
 from qgis.gui import (

--- a/tests/src/python/test_qgssvgcache.py
+++ b/tests/src/python/test_qgssvgcache.py
@@ -15,7 +15,6 @@ import socketserver
 import threading
 import time
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgssvgsourcelineedit.py
+++ b/tests/src/python/test_qgssvgsourcelineedit.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import QgsSvgSourceLineEdit
 import unittest

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -19,7 +19,6 @@ __author__ = 'Nyall Dawson'
 __date__ = 'January 2016'
 __copyright__ = '(C) 2016, Nyall Dawson'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize, Qt
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgssymbolbutton.py
+++ b/tests/src/python/test_qgssymbolbutton.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '23/07/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsFillSymbol, QgsMarkerSymbol, QgsSymbol

--- a/tests/src/python/test_qgssymbolexpressionvariables.py
+++ b/tests/src/python/test_qgssymbolexpressionvariables.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2016, Matthiasd Kuhn'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsFillSymbol,

--- a/tests/src/python/test_qgssymbollayer.py
+++ b/tests/src/python/test_qgssymbollayer.py
@@ -24,7 +24,6 @@ __copyright__ = '(C) 2012, Massimo Endrighi'
 
 import os
 
-import qgis  # NOQA
 import qgis.core
 from osgeo import ogr
 from qgis.PyQt.QtCore import (

--- a/tests/src/python/test_qgssymbollayer_createsld.py
+++ b/tests/src/python/test_qgssymbollayer_createsld.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2012, Andrea Aime'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QDir,
     QFile,

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -21,7 +21,6 @@ __copyright__ = '(C) 2017, Jorge Gustavo Rocha'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgssymbollayerregistry.py
+++ b/tests/src/python/test_qgssymbollayerregistry.py
@@ -9,7 +9,6 @@ __author__ = 'Denis Rouzaud'
 __date__ = '26/11/2021'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt import sip
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 
 import math
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QMimeData, QPointF, QSize, QSizeF, Qt
 from qgis.PyQt.QtXml import QDomDocument, QDomElement
 from qgis.PyQt.QtGui import QColor, QImage, QPolygonF

--- a/tests/src/python/test_qgstablecell.py
+++ b/tests/src/python/test_qgstablecell.py
@@ -9,7 +9,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '10/01/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     QgsBearingNumericFormat,

--- a/tests/src/python/test_qgstabwidget.py
+++ b/tests/src/python/test_qgstabwidget.py
@@ -14,7 +14,6 @@ test_qgstabwidget.py
  ***************************************************************************/
 '''
 
-import qgis  # NOQA
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.gui import QgsTabWidget
 import unittest

--- a/tests/src/python/test_qgstaskmanager.py
+++ b/tests/src/python/test_qgstaskmanager.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import os
 from time import sleep
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import QgsApplication, QgsTask

--- a/tests/src/python/test_qgstemporalutils.py
+++ b/tests/src/python/test_qgstemporalutils.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '13/3/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime
 from qgis.core import (
     QgsDateTimeRange,

--- a/tests/src/python/test_qgsterrainprovider.py
+++ b/tests/src/python/test_qgsterrainprovider.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 import math
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgstextblock.py
+++ b/tests/src/python/test_qgstextblock.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsStringUtils, QgsTextBlock, QgsTextFragment
 import unittest

--- a/tests/src/python/test_qgstextcharacterformat.py
+++ b/tests/src/python/test_qgstextcharacterformat.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgstextdocument.py
+++ b/tests/src/python/test_qgstextdocument.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgstextformatwidget.py
+++ b/tests/src/python/test_qgstextformatwidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '2016-09'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QPointF, QSizeF, Qt
 from qgis.PyQt.QtGui import QColor, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgstextfragment.py
+++ b/tests/src/python/test_qgstextfragment.py
@@ -11,7 +11,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QColor
 from qgis.core import QgsStringUtils, QgsTextCharacterFormat, QgsTextFragment
 import unittest

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import os
 from typing import Optional
 
-import qgis  # NOQA
 from PyQt5.QtSvg import QSvgGenerator
 from qgis.PyQt.QtCore import (
     QT_VERSION_STR,

--- a/tests/src/python/test_qgstiledsceneboundingvolume.py
+++ b/tests/src/python/test_qgstiledsceneboundingvolume.py
@@ -13,7 +13,6 @@ __copyright__ = "Copyright 2023, The QGIS Project"
 
 import unittest
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsSphere,

--- a/tests/src/python/test_qgstiledsceneelevationproperties.py
+++ b/tests/src/python/test_qgstiledsceneelevationproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '23/08/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 import tempfile
 import os
 

--- a/tests/src/python/test_qgstiledscenelayer.py
+++ b/tests/src/python/test_qgstiledscenelayer.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '27/06/2023'
 __copyright__ = 'Copyright 2023, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgstiledscenerender.py
+++ b/tests/src/python/test_qgstiledscenerender.py
@@ -9,7 +9,6 @@ __author__ = "Nyall Dawson"
 __date__ = "27/06/2023"
 __copyright__ = "Copyright 2023, The QGIS Project"
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsRectangle,

--- a/tests/src/python/test_qgstiledscenerequest.py
+++ b/tests/src/python/test_qgstiledscenerequest.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2023, The QGIS Project'
 
 import unittest
 
-import qgis  # NOQA
 from qgis.core import (
     Qgis,
     QgsTiledSceneRequest,

--- a/tests/src/python/test_qgstiledscenetile.py
+++ b/tests/src/python/test_qgstiledscenetile.py
@@ -13,7 +13,6 @@ __copyright__ = "Copyright 2023, The QGIS Project"
 
 import unittest
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgstiles.py
+++ b/tests/src/python/test_qgstiles.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '04/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgstreewidgetitem.py
+++ b/tests/src/python/test_qgstreewidgetitem.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/07/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 
 from qgis.core import NULL
 from qgis.gui import QgsTreeWidgetItem, QgsTreeWidgetItemObject

--- a/tests/src/python/test_qgsunittypes.py
+++ b/tests/src/python/test_qgsunittypes.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '03.02.2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QLocale
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsunsetattributevalue.py
+++ b/tests/src/python/test_qgsunsetattributevalue.py
@@ -11,7 +11,6 @@ __author__ = '(C) 2020 by Nyall Dawson'
 __date__ = '29/07/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.core import QgsUnsetAttributeValue
 import unittest
 from qgis.testing import start_app, QgisTestCase

--- a/tests/src/python/test_qgsvaliditychecks.py
+++ b/tests/src/python/test_qgsvaliditychecks.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '03/12/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import (
     QgsAbstractValidityCheck,

--- a/tests/src/python/test_qgsvalidityresultswidget.py
+++ b/tests/src/python/test_qgsvalidityresultswidget.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '03/12/2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsValidityCheckResult
 from qgis.gui import QgsValidityCheckResultsModel

--- a/tests/src/python/test_qgsvectorfieldmarkersymbollayer.py
+++ b/tests/src/python/test_qgsvectorfieldmarkersymbollayer.py
@@ -19,7 +19,6 @@ __author__ = 'Nyall Dawson'
 __date__ = 'November 2021'
 __copyright__ = '(C) 2021, Nyall Dawson'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QVariant
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -15,7 +15,6 @@ import tempfile
 import json
 
 import osgeo.gdal  # NOQA
-import qgis  # NOQA
 from osgeo import gdal, ogr
 from qgis.PyQt.QtCore import (
     QByteArray,

--- a/tests/src/python/test_qgsvectorfilewriter_postgres.py
+++ b/tests/src/python/test_qgsvectorfilewriter_postgres.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QVariant
 from qgis.core import (
     QgsCoordinateReferenceSystem,

--- a/tests/src/python/test_qgsvectorfilewritertask.py
+++ b/tests/src/python/test_qgsvectorfilewritertask.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication, QDir
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QDate,
     QDateTime,

--- a/tests/src/python/test_qgsvectorlayercache.py
+++ b/tests/src/python/test_qgsvectorlayercache.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '08/06/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir, QVariant
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsvectorlayereditbuffergroup.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffergroup.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QTemporaryDir
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsvectorlayereditutils.py
+++ b/tests/src/python/test_qgsvectorlayereditutils.py
@@ -15,7 +15,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 import os
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import (
     QVariant,
 )

--- a/tests/src/python/test_qgsvectorlayerelevationproperties.py
+++ b/tests/src/python/test_qgsvectorlayerelevationproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '09/11/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsvectorlayerfeaturecounter.py
+++ b/tests/src/python/test_qgsvectorlayerfeaturecounter.py
@@ -9,7 +9,6 @@ __author__ = 'Mathieu Pellerin'
 __date__ = '08/02/2021'
 __copyright__ = 'Copyright 2021, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2022, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsvectorlayerrenderer.py
+++ b/tests/src/python/test_qgsvectorlayerrenderer.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2020, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QSize
 from qgis.PyQt.QtGui import QColor
 

--- a/tests/src/python/test_qgsvectorlayershapefile.py
+++ b/tests/src/python/test_qgsvectorlayershapefile.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import QgsVectorLayer
 from qgis.gui import QgsGui
 import unittest

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '73/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime, QVariant
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 import shutil
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (
     NULL,

--- a/tests/src/python/test_qgsvectorlayerutils_postgres.py
+++ b/tests/src/python/test_qgsvectorlayerutils_postgres.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2021, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.core import (
     NULL,
     QgsDefaultValue,

--- a/tests/src/python/test_qgsvectortile.py
+++ b/tests/src/python/test_qgsvectortile.py
@@ -18,7 +18,6 @@ import shutil
 import tempfile
 from pathlib import Path
 
-import qgis  # NOQA
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     Qgis,

--- a/tests/src/python/test_qgsvectorwarper.py
+++ b/tests/src/python/test_qgsvectorwarper.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '01/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.analysis import (
     QgsGcpPoint,

--- a/tests/src/python/test_qgsvirtuallayerdefinition.py
+++ b/tests/src/python/test_qgsvirtuallayerdefinition.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QUrl, QVariant
 from qgis.core import (
     QgsField,

--- a/tests/src/python/test_qgsvirtuallayertask.py
+++ b/tests/src/python/test_qgsvirtuallayertask.py
@@ -11,7 +11,6 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 
 import os
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsApplication,

--- a/tests/src/python/test_qgsvtpk.py
+++ b/tests/src/python/test_qgsvtpk.py
@@ -9,7 +9,6 @@ __author__ = 'Nyall Dawson'
 __date__ = '04/03/2022'
 __copyright__ = 'Copyright 2022, The QGIS Project'
 
-import qgis  # NOQA
 from qgis.PyQt.QtXml import QDomDocument
 
 from qgis.core import (

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -9,7 +9,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = '18/11/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA switch sip api
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime, QVariant
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument

--- a/tests/src/python/test_qgszonalstatistics.py
+++ b/tests/src/python/test_qgszonalstatistics.py
@@ -12,7 +12,6 @@ __copyright__ = 'Copyright 2013, The QGIS Project'
 import os
 import shutil
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QDir, QFile, QTemporaryDir
 from qgis.analysis import QgsZonalStatistics
 from qgis.core import (

--- a/tests/src/python/test_selective_masking.py
+++ b/tests/src/python/test_selective_masking.py
@@ -16,7 +16,6 @@ import os
 import subprocess
 import tempfile
 
-import qgis  # NOQA
 from qgis.PyQt.QtCore import QRectF, QSize, Qt, QUuid
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.core import (

--- a/tests/src/python/test_syntactic_sugar.py
+++ b/tests/src/python/test_syntactic_sugar.py
@@ -9,7 +9,6 @@ __author__ = 'Matthias Kuhn'
 __date__ = '12.8.2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import QgsEditError, QgsFeature, QgsVectorLayer, edit
 import unittest

--- a/tests/src/python/test_testrunner.py
+++ b/tests/src/python/test_testrunner.py
@@ -9,7 +9,6 @@ __author__ = 'Alessandro Pasotti'
 __date__ = '19.11.2018'
 __copyright__ = 'Copyright 2018, The QGIS Project'
 
-import qgis  # NOQA
 
 from qgis.core import Qgis
 from qgis.testing import unittest

--- a/tests/src/python/test_versioncompare.py
+++ b/tests/src/python/test_versioncompare.py
@@ -14,7 +14,6 @@ test_versioncompare.py
  ***************************************************************************/
 '''
 
-import qgis  # NOQA
 
 from pyplugin_installer.version_compare import compareVersions
 import unittest

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -16,7 +16,6 @@ import stat
 import sys
 import tempfile
 
-import qgis  # NOQA
 
 try:
     from urllib2 import HTTPError, URLError, urlopen


### PR DESCRIPTION
These were only needed way back in the early days of qgis 3.0 transition, now they have no effect
