### PR TITLE
[Expressions] Add tags to layer_property function

### DIFF
--- a/resources/function_help/json/age
+++ b/resources/function_help/json/age
@@ -17,5 +17,5 @@
     "expression": "hour(age('2012-05-12','2012-05-02'))",
     "returns": "240"
   }],
-  "tags": ["difference", "needs", "datetimes", "order", "extract", "information", "following", "interval", "dates", "functions", "yearmonthweekdayhourminutesecond"]
+  "tags": ["difference", "needs", "datetimes", "order", "extract", "information", "following", "interval", "dates", "functions", "year", "month", "week", "day", "hour", "minute", "second"]
 }

--- a/resources/function_help/json/layer_property
+++ b/resources/function_help/json/layer_property
@@ -20,5 +20,5 @@
     "expression": "layer_property('landsat','crs')",
     "returns": "'EPSG:4326'"
   }],
-  "tags": ["property", "matching", "metadata"]
+  "tags": ["property", "matching", "metadata", "layer name", "layer id", "title", "abstract", "keywords", "data url", "attribution", "attribution url", "layer source", "minimum scale", "min scale", "maximum scale", "max scale", "is editable", "crs", "crs definition", "crs description", "layer extent", "distance units", "layer type", "storage type", "geometry type", "feature count", "file path"]
 }


### PR DESCRIPTION
All `property` keys are added as tags.

Fix #39828