### PR TITLE
[3D] Restore zoom with the mouse right button and fix more sequences

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -322,7 +322,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   if ( ( hasLeftButton && hasShift && !hasCtrl ) || ( hasMiddleButton && !hasShift && !hasCtrl ) )
   {
     // rotate/tilt using mouse (camera moves as it rotates around the clicked point)
-    setMouseParameters( MouseOperation::Rotation, mMousePos );
+    setMouseParameters( MouseOperation::RotationCenter, mMousePos );
 
     float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
@@ -377,7 +377,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   }
   else if ( hasLeftButton && hasCtrl && !hasShift )
   {
-    setMouseParameters( MouseOperation::Rotation );
+    setMouseParameters( MouseOperation::RotationCamera );
     // rotate/tilt using mouse (camera stays at one position as it rotates)
     const float diffPitch = 0.2f * dy;
     const float diffYaw = - 0.2f * dx;
@@ -613,14 +613,22 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
 {
   mKeyboardHandler->setFocus( true );
 
-  if ( mouse->button() == Qt3DInput::QMouseEvent::MiddleButton || ( ( mouse->modifiers() & Qt::ShiftModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) )
+  if ( mouse->button() == Qt3DInput::QMouseEvent::MiddleButton ||
+       ( ( mouse->modifiers() & Qt::ShiftModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) ||
+       ( ( mouse->modifiers() & Qt::ControlModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) )
   {
     mMousePos = QPoint( mouse->x(), mouse->y() );
 
     if ( mCaptureFpsMouseMovements )
       mIgnoreNextMouseMove = true;
 
-    setMouseParameters( MouseOperation::Rotation, mMousePos );
+    const MouseOperation operation
+    {
+      ( mouse->modifiers() & Qt::ControlModifier ) != 0 && mouse->button() == Qt3DInput::QMouseEvent::LeftButton  ?
+      MouseOperation::RotationCamera :
+      MouseOperation::RotationCenter
+    };
+    setMouseParameters( operation, mMousePos );
   }
 
   else if ( mouse->button() == Qt3DInput::QMouseEvent::LeftButton || mouse->button() == Qt3DInput::QMouseEvent::RightButton )
@@ -1051,6 +1059,12 @@ void QgsCameraController::depthBufferCaptured( const QImage &depthImage )
   }
 }
 
+bool QgsCameraController::isATranslationRotationSequence( MouseOperation newOperation ) const
+{
+  return std::find( mTranslateOrRotate.begin(), mTranslateOrRotate.end(), newOperation ) != std::end( mTranslateOrRotate ) &&
+         std::find( mTranslateOrRotate.begin(), mTranslateOrRotate.end(), mCurrentOperation ) != std::end( mTranslateOrRotate );
+}
+
 void QgsCameraController::setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint )
 {
   if ( newOperation == mCurrentOperation )
@@ -1068,9 +1082,7 @@ void QgsCameraController::setMouseParameters( const MouseOperation &newOperation
   // Indeed, if the sequence such as rotation -> zoom -> rotation updating mClickPoint on
   // the click point does not need to be updated because the relative mouse position is kept
   // during a zoom operation
-  else if ( mClickPoint.isNull() ||
-            ( ( newOperation == MouseOperation::Rotation || newOperation == MouseOperation::Translation ) &&
-              ( mCurrentOperation == MouseOperation::Rotation ||  mCurrentOperation == MouseOperation::Translation ) ) )
+  else if ( mClickPoint.isNull() || isATranslationRotationSequence( newOperation ) )
   {
     mClickPoint = clickPoint;
     mRotationPitch = mCameraPose.pitchAngle();
@@ -1082,7 +1094,7 @@ void QgsCameraController::setMouseParameters( const MouseOperation &newOperation
   mDragPointCalculated = false;
   mZoomPointCalculated = false;
 
-  if ( mCurrentOperation != MouseOperation::None )
+  if ( mCurrentOperation != MouseOperation::None && mCurrentOperation != MouseOperation::RotationCamera )
   {
     emit requestDepthBufferCapture();
 

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -595,9 +595,9 @@ void QgsCameraController::onWheel( Qt3DInput::QWheelEvent *wheel )
       // see: https://doc.qt.io/qt-5/qwheelevent.html#angleDelta
       mCumulatedWheelY += scaling * wheel->angleDelta().y();
 
-      if ( mCurrentOperation != MouseOperation::Zoom )
+      if ( mCurrentOperation != MouseOperation::ZoomWheel )
       {
-        setMouseParameters( MouseOperation::Zoom );
+        setMouseParameters( MouseOperation::ZoomWheel );
       }
       else
       {
@@ -1045,7 +1045,7 @@ void QgsCameraController::depthBufferCaptured( const QImage &depthImage )
   mDepthBufferImage = depthImage;
   mDepthBufferIsReady = true;
 
-  if ( mCurrentOperation == MouseOperation::Zoom )
+  if ( mCurrentOperation == MouseOperation::ZoomWheel )
   {
     handleTerrainNavigationWheelZoom();
   }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -638,7 +638,6 @@ void QgsCameraController::onMouseReleased( Qt3DInput::QMouseEvent *mouse )
 {
   Q_UNUSED( mouse )
 
-  mClickPoint = QPoint();
   setMouseParameters( MouseOperation::None );
 }
 
@@ -1058,15 +1057,19 @@ void QgsCameraController::setMouseParameters( const MouseOperation &newOperation
     return;
   }
 
+  if ( newOperation == MouseOperation::None )
+  {
+    mClickPoint = QPoint();
+  }
   // click point and rotation angles are updated if:
   // - it has never been computed
   // - the current and new operations are both rotation and translation
   // Indeed, if the sequence such as rotation -> zoom -> rotation updating mClickPoint on
   // the click point does not need to be updated because the relative mouse position is kept
   // during a zoom operation
-  if ( mClickPoint.isNull() ||
-       ( ( newOperation == MouseOperation::Rotation || newOperation == MouseOperation::Translation ) &&
-         ( mCurrentOperation == MouseOperation::Rotation ||  mCurrentOperation == MouseOperation::Translation ) ) )
+  else if ( mClickPoint.isNull() ||
+            ( ( newOperation == MouseOperation::Rotation || newOperation == MouseOperation::Translation ) &&
+              ( mCurrentOperation == MouseOperation::Rotation ||  mCurrentOperation == MouseOperation::Translation ) ) )
   {
     mClickPoint = clickPoint;
     mRotationPitch = mCameraPose.pitchAngle();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -377,6 +377,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   }
   else if ( hasLeftButton && hasCtrl && !hasShift )
   {
+    setMouseParameters( MouseOperation::Rotation );
     // rotate/tilt using mouse (camera stays at one position as it rotates)
     const float diffPitch = 0.2f * dy;
     const float diffYaw = - 0.2f * dx;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -629,7 +629,8 @@ void QgsCameraController::onMousePressed( Qt3DInput::QMouseEvent *mouse )
     if ( mCaptureFpsMouseMovements )
       mIgnoreNextMouseMove = true;
 
-    setMouseParameters( MouseOperation::Translation, mMousePos );
+    const MouseOperation operation = ( mouse->button() == Qt3DInput::QMouseEvent::LeftButton ) ? MouseOperation::Translation : MouseOperation::Zoom;
+    setMouseParameters( operation, mMousePos );
   }
 }
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -230,7 +230,8 @@ class _3D_EXPORT QgsCameraController : public QObject
       None = 0,
       Translation,
       Rotation,
-      Zoom
+      Zoom,
+      ZoomWheel
     };
 
     void setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint = QPoint() );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -225,14 +225,15 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Returns a pointer to the scene's engine's window or nullptr if engine is QgsOffscreen3DEngine
     QWindow *window() const;
 
+    //! List of possible operations with the mouse in TerrainBased navigation
     enum class MouseOperation
     {
-      None = 0,
-      Translation,
-      RotationCamera,
-      RotationCenter,
-      Zoom,
-      ZoomWheel
+      None = 0,       // no operation
+      Translation,    // left button pressed, no modifier
+      RotationCamera, // left button pressed + ctrl modifier
+      RotationCenter, // left button pressed + shift modifier
+      Zoom,           // right button pressed
+      ZoomWheel       // mouse wheel scroll
     };
 
     // This list gathers all the rotation and translation operations.

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -229,10 +229,24 @@ class _3D_EXPORT QgsCameraController : public QObject
     {
       None = 0,
       Translation,
-      Rotation,
+      RotationCamera,
+      RotationCenter,
       Zoom,
       ZoomWheel
     };
+
+    // This list gathers all the rotation and translation operations.
+    // It is used to update the appropriate parameters when successive
+    // translation and rotation happen.
+    const QList<MouseOperation> mTranslateOrRotate =
+    {
+      MouseOperation::Translation,
+      MouseOperation::RotationCamera,
+      MouseOperation::RotationCenter
+    };
+
+    // check that current sequence (current operation and new operation) is a rotation or translation
+    bool isATranslationRotationSequence( MouseOperation newOperation ) const;
 
     void setMouseParameters( const MouseOperation &newOperation, const QPoint &clickPoint = QPoint() );
 


### PR DESCRIPTION
## Description

This is a follow-up of https://github.com/qgis/QGIS/pull/55360.

This fixes a regression introduced by https://github.com/qgis/QGIS/pull/55360 and fixes more sequences: 
- rotate clicked point (shift) -> rotate camera (ctrl) -> rotate clicked point(shift)
- translate -> zoom wheel -> translate
- translate -> rotate camera -> translate

cc @benoitdm-oslandia @soaubier