### PR TITLE
Harmonize user facing labels for GDAL resampling methods

### DIFF
--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -89,10 +89,10 @@ class buildvrt(GdalAlgorithm):
                 return True, ''
 
         self.RESAMPLING_OPTIONS = ((self.tr('Nearest Neighbour'), 'nearest'),
-                                   (self.tr('Bilinear'), 'bilinear'),
-                                   (self.tr('Cubic Convolution'), 'cubic'),
-                                   (self.tr('B-Spline Convolution'), 'cubicspline'),
-                                   (self.tr('Lanczos Windowed Sinc'), 'lanczos'),
+                                   (self.tr('Bilinear (2x2 Kernel)'), 'bilinear'),
+                                   (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                                   (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                                   (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),
                                    (self.tr('Average'), 'average'),
                                    (self.tr('Mode'), 'mode'))
 

--- a/python/plugins/processing/algs/gdal/gdal2tiles.py
+++ b/python/plugins/processing/algs/gdal/gdal2tiles.py
@@ -61,11 +61,11 @@ class gdal2tiles(GdalAlgorithm):
                          (self.tr('Raster'), 'raster'))
 
         self.methods = ((self.tr('Average'), 'average'),
-                        (self.tr('Nearest neighbour'), 'near'),
-                        (self.tr('Bilinear'), 'bilinear'),
-                        (self.tr('Cubic'), 'cubic'),
-                        (self.tr('Cubic spline'), 'cubicspline'),
-                        (self.tr('Lanczos windowed sinc'), 'lanczos'),
+                        (self.tr('Nearest Neighbour'), 'near'),
+                        (self.tr('Bilinear (2x2 Kernel)'), 'bilinear'),
+                        (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                        (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                        (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),
                         (self.tr('Antialias'), 'antialias'))
 
         self.viewers = ((self.tr('All'), 'all'),

--- a/python/plugins/processing/algs/gdal/gdaladdo.py
+++ b/python/plugins/processing/algs/gdal/gdaladdo.py
@@ -52,9 +52,9 @@ class gdaladdo(GdalAlgorithm):
         self.methods = ((self.tr('Nearest Neighbour (default)'), 'nearest'),
                         (self.tr('Average'), 'average'),
                         (self.tr('Gaussian'), 'gauss'),
-                        (self.tr('Cubic Convolution'), 'cubic'),
-                        (self.tr('B-Spline Convolution'), 'cubicspline'),
-                        (self.tr('Lanczos Windowed Sinc'), 'lanczos'),
+                        (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                        (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                        (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),
                         (self.tr('Average MP'), 'average_mp'),
                         (self.tr('Average in Mag/Phase Space'), 'average_magphase'),
                         (self.tr('Mode'), 'mode'))

--- a/python/plugins/processing/algs/gdal/pansharp.py
+++ b/python/plugins/processing/algs/gdal/pansharp.py
@@ -51,10 +51,10 @@ class pansharp(GdalAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.methods = ((self.tr('Nearest Neighbour'), 'nearest'),
-                        (self.tr('Bilinear'), 'bilinear'),
-                        (self.tr('Cubic'), 'cubic'),
-                        (self.tr('Cubic Spline'), 'cubicspline'),
-                        (self.tr('Lanczos Windowed Sinc'), 'lanczos'),
+                        (self.tr('Bilinear (2x2 Kernel)'), 'bilinear'),
+                        (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                        (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                        (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),
                         (self.tr('Average'), 'average'))
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.SPECTRAL,

--- a/python/plugins/processing/algs/gdal/retile.py
+++ b/python/plugins/processing/algs/gdal/retile.py
@@ -61,10 +61,10 @@ class retile(GdalAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.methods = ((self.tr('Nearest Neighbour'), 'near'),
-                        (self.tr('Bilinear'), 'bilinear'),
-                        (self.tr('Cubic'), 'cubic'),
-                        (self.tr('Cubic Spline'), 'cubicspline'),
-                        (self.tr('Lanczos Windowed Sinc'), 'lanczos'),)
+                        (self.tr('Bilinear (2x2 Kernel)'), 'bilinear'),
+                        (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                        (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                        (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),)
 
         self.addParameter(QgsProcessingParameterMultipleLayers(self.INPUT,
                                                                self.tr('Input files'),

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -61,17 +61,17 @@ class warp(GdalAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.methods = ((self.tr('Nearest Neighbour'), 'near'),
-                        (self.tr('Bilinear'), 'bilinear'),
-                        (self.tr('Cubic'), 'cubic'),
-                        (self.tr('Cubic Spline'), 'cubicspline'),
-                        (self.tr('Lanczos Windowed Sinc'), 'lanczos'),
+                        (self.tr('Bilinear (2x2 Kernel)'), 'bilinear'),
+                        (self.tr('Cubic (4x4 Kernel)'), 'cubic'),
+                        (self.tr('Cubic B-Spline (4x4 Kernel)'), 'cubicspline'),
+                        (self.tr('Lanczos (6x6 Kernel)'), 'lanczos'),
                         (self.tr('Average'), 'average'),
                         (self.tr('Mode'), 'mode'),
                         (self.tr('Maximum'), 'max'),
                         (self.tr('Minimum'), 'min'),
                         (self.tr('Median'), 'med'),
-                        (self.tr('First Quartile'), 'q1'),
-                        (self.tr('Third Quartile'), 'q3'))
+                        (self.tr('First Quartile (Q1)'), 'q1'),
+                        (self.tr('Third Quartile (Q3)'), 'q3'))
 
         self.TYPES = [self.tr('Use Input Layer Data Type'), 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64', 'Int8']
 

--- a/src/analysis/processing/qgsalgorithmalignsingleraster.cpp
+++ b/src/analysis/processing/qgsalgorithmalignsingleraster.cpp
@@ -68,18 +68,18 @@ void QgsAlignSingleRasterAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
 
   QStringList resamplingMethods;
-  resamplingMethods << QObject::tr( "Nearest neighbour" )
-                    << QObject::tr( "Bilinear" )
-                    << QObject::tr( "Cubic" )
-                    << QObject::tr( "Cubic spline" )
-                    << QObject::tr( "Lanczos" )
+  resamplingMethods << QObject::tr( "Nearest Neighbour" )
+                    << QObject::tr( "Bilinear (2x2 Kernel)" )
+                    << QObject::tr( "Cubic (4x4 Kernel)" )
+                    << QObject::tr( "Cubic B-Spline (4x4 Kernel)" )
+                    << QObject::tr( "Lanczos (6x6 Kernel)" )
                     << QObject::tr( "Average" )
                     << QObject::tr( "Mode" )
                     << QObject::tr( "Maximum" )
                     << QObject::tr( "Minimum" )
                     << QObject::tr( "Median" )
-                    << QObject::tr( "First quartile" )
-                    << QObject::tr( "Third quartile" );
+                    << QObject::tr( "First Quartile (Q1)" )
+                    << QObject::tr( "Third Quartile (Q3)" );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESAMPLING_METHOD" ), QObject::tr( "Resampling method" ), resamplingMethods, false, 0, false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "RESCALE" ), QObject::tr( "Rescale values according to the cell size" ), false ) );
   addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "REFERENCE_LAYER" ), QObject::tr( "Reference layer" ) ) );

--- a/src/app/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/app/georeferencer/qgstransformsettingsdialog.cpp
@@ -117,10 +117,10 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( Qgis::LayerType type, co
   cmbCompressionComboBox->addItem( tr( "DEFLATE" ), QStringLiteral( "DEFLATE" ) );
 
   cmbResampling->addItem( tr( "Nearest Neighbour" ), static_cast< int >( QgsImageWarper::ResamplingMethod::NearestNeighbour ) );
-  cmbResampling->addItem( tr( "Linear" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Bilinear ) );
-  cmbResampling->addItem( tr( "Cubic" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Cubic ) );
-  cmbResampling->addItem( tr( "Cubic Spline" ), static_cast< int >( QgsImageWarper::ResamplingMethod::CubicSpline ) );
-  cmbResampling->addItem( tr( "Lanczos" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Lanczos ) );
+  cmbResampling->addItem( tr( "Bilinear (2x2 Kernel)" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Bilinear ) );
+  cmbResampling->addItem( tr( "Cubic (4x4 Kernel)" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Cubic ) );
+  cmbResampling->addItem( tr( "Cubic B-Spline (4x4 Kernel)" ), static_cast< int >( QgsImageWarper::ResamplingMethod::CubicSpline ) );
+  cmbResampling->addItem( tr( "Lanczos (6x6 Kernel)" ), static_cast< int >( QgsImageWarper::ResamplingMethod::Lanczos ) );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsTransformSettingsDialog::showHelp );
 }

--- a/src/app/options/qgsrasterrenderingoptions.cpp
+++ b/src/app/options/qgsrasterrenderingoptions.cpp
@@ -39,12 +39,12 @@ QgsRasterRenderingOptionsWidget::QgsRasterRenderingOptionsWidget( QWidget *paren
   spnBlue->setClearValue( 3 );
 
   mZoomedInResamplingComboBox->insertItem( 0, tr( "Nearest Neighbour" ), QStringLiteral( "nearest neighbour" ) );
-  mZoomedInResamplingComboBox->insertItem( 1, tr( "Bilinear" ), QStringLiteral( "bilinear" ) );
-  mZoomedInResamplingComboBox->insertItem( 2, tr( "Cubic" ), QStringLiteral( "cubic" ) );
+  mZoomedInResamplingComboBox->insertItem( 1, tr( "Bilinear (2x2 Kernel)" ), QStringLiteral( "bilinear" ) );
+  mZoomedInResamplingComboBox->insertItem( 2, tr( "Cubic (4x4 Kernel)" ), QStringLiteral( "cubic" ) );
 
   mZoomedOutResamplingComboBox->insertItem( 0, tr( "Nearest Neighbour" ), QStringLiteral( "nearest neighbour" ) );
-  mZoomedOutResamplingComboBox->insertItem( 1, tr( "Bilinear" ), QStringLiteral( "bilinear" ) );
-  mZoomedOutResamplingComboBox->insertItem( 2, tr( "Cubic" ), QStringLiteral( "cubic" ) );
+  mZoomedOutResamplingComboBox->insertItem( 1, tr( "Bilinear (2x2 Kernel)" ), QStringLiteral( "bilinear" ) );
+  mZoomedOutResamplingComboBox->insertItem( 2, tr( "Cubic (4x4 Kernel)" ), QStringLiteral( "cubic" ) );
 
   QString zoomedInResampling = settings.value( QStringLiteral( "/Raster/defaultZoomedInResampling" ), QStringLiteral( "nearest neighbour" ) ).toString();
   mZoomedInResamplingComboBox->setCurrentIndex( mZoomedInResamplingComboBox->findData( zoomedInResampling ) );

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4265,10 +4265,10 @@ QList<QPair<QString, QString> > QgsGdalProviderMetadata::pyramidResamplingMethod
     methods.append( QPair<QString, QString>( QStringLiteral( "NEAREST" ), QObject::tr( "Nearest Neighbour" ) ) );
     methods.append( QPair<QString, QString>( QStringLiteral( "AVERAGE" ), QObject::tr( "Average" ) ) );
     methods.append( QPair<QString, QString>( QStringLiteral( "GAUSS" ), QObject::tr( "Gauss" ) ) );
-    methods.append( QPair<QString, QString>( QStringLiteral( "CUBIC" ), QObject::tr( "Cubic" ) ) );
-    methods.append( QPair<QString, QString>( QStringLiteral( "CUBICSPLINE" ), QObject::tr( "Cubic Spline" ) ) );
-    methods.append( QPair<QString, QString>( QStringLiteral( "LANCZOS" ), QObject::tr( "Lanczos" ) ) );
-    methods.append( QPair<QString, QString>( QStringLiteral( "BILINEAR" ), QObject::tr( "Bilinear" ) ) );
+    methods.append( QPair<QString, QString>( QStringLiteral( "CUBIC" ), QObject::tr( "Cubic (4x4 Kernel)" ) ) );
+    methods.append( QPair<QString, QString>( QStringLiteral( "CUBICSPLINE" ), QObject::tr( "Cubic B-Spline (4x4 Kernel)" ) ) );
+    methods.append( QPair<QString, QString>( QStringLiteral( "LANCZOS" ), QObject::tr( "Lanczos (6x6 Kernel)" ) ) );
+    methods.append( QPair<QString, QString>( QStringLiteral( "BILINEAR" ), QObject::tr( "Bilinear (2x2 Kernel)" ) ) );
     methods.append( QPair<QString, QString>( QStringLiteral( "MODE" ), QObject::tr( "Mode" ) ) );
     methods.append( QPair<QString, QString>( QStringLiteral( "NONE" ), QObject::tr( "None" ) ) );
   }

--- a/src/gui/raster/qgsresamplingutils.cpp
+++ b/src/gui/raster/qgsresamplingutils.cpp
@@ -47,8 +47,8 @@ void QgsResamplingUtils::initWidgets( QgsRasterLayer *rasterLayer,
   for ( QComboBox *combo :  {mZoomedInResamplingComboBox, mZoomedOutResamplingComboBox } )
   {
     combo->addItem( QObject::tr( "Nearest Neighbour" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Nearest ) );
-    combo->addItem( QObject::tr( "Bilinear" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Bilinear ) );
-    combo->addItem( QObject::tr( "Cubic" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Cubic ) );
+    combo->addItem( QObject::tr( "Bilinear (2x2 Kernel)" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Bilinear ) );
+    combo->addItem( QObject::tr( "Cubic (4x4 Kernel)" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Cubic ) );
   }
 
   if ( mCbEarlyResampling->isChecked() )
@@ -222,8 +222,8 @@ void QgsResamplingUtils::addExtraEarlyResamplingMethodsToCombos()
 
   for ( QComboBox *combo : {mZoomedInResamplingComboBox, mZoomedOutResamplingComboBox } )
   {
-    combo->addItem( QObject::tr( "Cubic Spline" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::CubicSpline ) );
-    combo->addItem( QObject::tr( "Lanczos" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Lanczos ) );
+    combo->addItem( QObject::tr( "Cubic B-Spline (4x4 Kernel)" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::CubicSpline ) );
+    combo->addItem( QObject::tr( "Lanczos (6x6 Kernel)" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Lanczos ) );
     combo->addItem( QObject::tr( "Average" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Average ) );
     combo->addItem( QObject::tr( "Mode" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Mode ) );
     combo->addItem( QObject::tr( "Gauss" ), static_cast<int>( QgsRasterDataProvider::ResamplingMethod::Gauss ) );


### PR DESCRIPTION
A search for "Lanczos" in Transifex returns following list while IMHO it could return a single entry (or at least one should just be able to hit the button to reuse existing translation).
![image](https://github.com/qgis/QGIS/assets/7983394/a1bb0449-d406-4715-8be4-2d82bbe14623)
This PR is another step toward simplifying life for translators (and docs writers), reusing same labels when we refer to the same thing (and less confuse users). I don't know what are the most meaningful labels in this context (there are so many combinations: kernel? windowed? convolution?) thus I am simply reusing here the most recent spelling I found, added to the "[Processing align rasters widget](https://github.com/qgis/QGIS/pull/53874/files#diff-29116fa4d2a5dd4411a80c5d170e1b4ba067ee7c605e9093ea71344105600308R53)".

