### PR TITLE
Fix Georeferencer report issues: always include RMS error value and make the text selectable

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -2081,6 +2081,7 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
   QgsLayoutExporter exporter( &layout );
   QgsLayoutExporter::PdfExportSettings settings;
   settings.dpi = 300;
+  settings.textRenderFormat = Qgis::TextRenderFormat::AlwaysText;
   exporter.exportToPdf( fileName, settings );
 
   return true;

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1961,46 +1961,63 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
   }
 
   QGraphicsRectItem *previousItem = layoutMap;
+  QString parameterTitle;
   if ( wldTransform )
   {
-    QString parameterTitle = tr( "Transformation parameters" ) + QStringLiteral( " (" ) + QgsGcpTransformerInterface::methodToString( transform.transformParametrisation() ) + QStringLiteral( ")" );
-    parameterLabel = new QgsLayoutItemLabel( &layout );
-    parameterLabel->setTextFormat( titleFormat );
-    parameterLabel->setText( parameterTitle );
-    parameterLabel->adjustSizeToText();
-    layout.addLayoutItem( parameterLabel );
-    parameterLabel->attemptSetSceneRect( QRectF( leftMargin, layoutMap->rect().bottom() + layoutMap->pos().y() + 5, contentWidth, 8 ) );
-    parameterLabel->setFrameEnabled( false );
-
-    //calculate mean error
-    double meanError = 0;
-    calculateMeanError( meanError );
-
-    parameterTable = new QgsLayoutItemTextTable( &layout );
-    parameterTable->setHeaderTextFormat( tableHeaderFormat );
-    parameterTable->setContentTextFormat( tableContentFormat );
-
-    QgsLayoutTableColumns columns;
-    columns << QgsLayoutTableColumn( tr( "Translation x" ) )
-            << QgsLayoutTableColumn( tr( "Translation y" ) )
-            << QgsLayoutTableColumn( tr( "Scale x" ) )
-            << QgsLayoutTableColumn( tr( "Scale y" ) )
-            << QgsLayoutTableColumn( tr( "Rotation [degrees]" ) )
-            << QgsLayoutTableColumn( tr( "Mean error [%1]" ).arg( residualUnits ) );
-
-    parameterTable->setColumns( columns );
-    QStringList row;
-    row << QString::number( origin.x(), 'f', 3 ) << QString::number( origin.y(), 'f', 3 ) << QString::number( scaleX ) << QString::number( scaleY ) << QString::number( rotation * 180 / M_PI ) << QString::number( meanError );
-    parameterTable->addRow( row );
-
-    QgsLayoutFrame *tableFrame = new QgsLayoutFrame( &layout, parameterTable );
-    tableFrame->attemptSetSceneRect( QRectF( leftMargin, parameterLabel->rect().bottom() + parameterLabel->pos().y() + 5, contentWidth, 12 ) );
-    parameterTable->addFrame( tableFrame );
-
-    parameterTable->setGridStrokeWidth( 0.1 );
-
-    previousItem = tableFrame;
+    parameterTitle = tr( "Transformation parameters" );
   }
+  else
+  {
+    parameterTitle = tr( "Transformation parameter" );
+  }
+  parameterTitle += QStringLiteral( " (" ) + QgsGcpTransformerInterface::methodToString( transform.transformParametrisation() ) + QStringLiteral( ")" );
+  parameterLabel = new QgsLayoutItemLabel( &layout );
+  parameterLabel->setTextFormat( titleFormat );
+  parameterLabel->setText( parameterTitle );
+  parameterLabel->adjustSizeToText();
+  layout.addLayoutItem( parameterLabel );
+  parameterLabel->attemptSetSceneRect( QRectF( leftMargin, layoutMap->rect().bottom() + layoutMap->pos().y() + 5, contentWidth, 8 ) );
+  parameterLabel->setFrameEnabled( false );
+
+  //calculate mean error
+  double meanError = 0;
+  calculateMeanError( meanError );
+
+  parameterTable = new QgsLayoutItemTextTable( &layout );
+  parameterTable->setHeaderTextFormat( tableHeaderFormat );
+  parameterTable->setContentTextFormat( tableContentFormat );
+
+  QgsLayoutTableColumns parameterTableColumns;
+  if ( wldTransform )
+  {
+    parameterTableColumns << QgsLayoutTableColumn( tr( "Translation x" ) )
+                          << QgsLayoutTableColumn( tr( "Translation y" ) )
+                          << QgsLayoutTableColumn( tr( "Scale x" ) )
+                          << QgsLayoutTableColumn( tr( "Scale y" ) )
+                          << QgsLayoutTableColumn( tr( "Rotation [degrees]" ) );
+  }
+  parameterTableColumns << QgsLayoutTableColumn( tr( "Mean error [%1]" ).arg( residualUnits ) );
+  parameterTable->setColumns( parameterTableColumns );
+
+  QStringList parameterTableRow;
+  if ( wldTransform )
+  {
+    parameterTableRow << QString::number( origin.x(), 'f', 3 )
+                      << QString::number( origin.y(), 'f', 3 )
+                      << QString::number( scaleX )
+                      << QString::number( scaleY )
+                      << QString::number( rotation * 180 / M_PI );
+  }
+  parameterTableRow << QString::number( meanError );
+  parameterTable->addRow( parameterTableRow );
+
+  QgsLayoutFrame *tableFrame = new QgsLayoutFrame( &layout, parameterTable );
+  tableFrame->attemptSetSceneRect( QRectF( leftMargin, parameterLabel->rect().bottom() + parameterLabel->pos().y() + 5, contentWidth, 12 ) );
+  parameterTable->addFrame( tableFrame );
+
+  parameterTable->setGridStrokeWidth( 0.1 );
+
+  previousItem = tableFrame;
 
   QgsLayoutItemLabel *residualLabel = new QgsLayoutItemLabel( &layout );
   residualLabel->setTextFormat( titleFormat );
@@ -2023,18 +2040,18 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
   gcpTable->setHeaderTextFormat( tableHeaderFormat );
   gcpTable->setContentTextFormat( tableContentFormat );
   gcpTable->setHeaderMode( QgsLayoutTable::AllFrames );
-  QgsLayoutTableColumns columns;
-  columns << QgsLayoutTableColumn( tr( "ID" ) )
-          << QgsLayoutTableColumn( tr( "Enabled" ) )
-          << QgsLayoutTableColumn( tr( "Pixel X" ) )
-          << QgsLayoutTableColumn( tr( "Pixel Y" ) )
-          << QgsLayoutTableColumn( tr( "Map X" ) )
-          << QgsLayoutTableColumn( tr( "Map Y" ) )
-          << QgsLayoutTableColumn( tr( "Res X (%1)" ).arg( residualUnits ) )
-          << QgsLayoutTableColumn( tr( "Res Y (%1)" ).arg( residualUnits ) )
-          << QgsLayoutTableColumn( tr( "Res Total (%1)" ).arg( residualUnits ) );
+  QgsLayoutTableColumns gcpTableColumns;
+  gcpTableColumns << QgsLayoutTableColumn( tr( "ID" ) )
+                  << QgsLayoutTableColumn( tr( "Enabled" ) )
+                  << QgsLayoutTableColumn( tr( "Pixel X" ) )
+                  << QgsLayoutTableColumn( tr( "Pixel Y" ) )
+                  << QgsLayoutTableColumn( tr( "Map X" ) )
+                  << QgsLayoutTableColumn( tr( "Map Y" ) )
+                  << QgsLayoutTableColumn( tr( "Res X (%1)" ).arg( residualUnits ) )
+                  << QgsLayoutTableColumn( tr( "Res Y (%1)" ).arg( residualUnits ) )
+                  << QgsLayoutTableColumn( tr( "Res Total (%1)" ).arg( residualUnits ) );
 
-  gcpTable->setColumns( columns );
+  gcpTable->setColumns( gcpTableColumns );
 
   QgsGCPList::const_iterator gcpIt = mPoints.constBegin();
   QVector< QStringList > gcpTableContents;


### PR DESCRIPTION
## Description

The PDF report generated by the Georeferencer currently includes the RMS (Root Mean Square) error value only for linear transformation types ("Linear" or "Helmert" types) and only if the "Create world file" is set to true, e.g:
![image](https://github.com/qgis/QGIS/assets/16253859/8d7d30f8-f8cd-4cb0-88ea-7d4167458b69)

Since the RMS error value is calculated and it is relevant for any transformation type, this PR makes sure that the RMS error value is included in the PDF report also for non linear transformation types and also when the "Create world file" is set to false, e.g.:
![image](https://github.com/qgis/QGIS/assets/16253859/fb56eda3-0a03-428a-88ad-020bcf825074)

(I'd like some suggestions on how to improve the wording and / or the layout)

This PR also makes the text in the PDF report selectable (and searchable).

Fixes #55411.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
