### PR TITLE
[feature] Add option to use localhost as redirect host for oauth2

### DIFF
--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -38,6 +38,7 @@ QgsAuthOAuth2Config::QgsAuthOAuth2Config( QObject *parent )
   connect( this, &QgsAuthOAuth2Config::requestUrlChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::tokenUrlChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::refreshTokenUrlChanged, this, &QgsAuthOAuth2Config::configChanged );
+  connect( this, &QgsAuthOAuth2Config::redirectHostChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::redirectUrlChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::redirectPortChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::clientIdChanged, this, &QgsAuthOAuth2Config::configChanged );
@@ -130,6 +131,15 @@ void QgsAuthOAuth2Config::setRefreshTokenUrl( const QString &value )
   mRefreshTokenUrl = value;
   if ( preval != value )
     emit refreshTokenUrlChanged( mRefreshTokenUrl );
+}
+
+void QgsAuthOAuth2Config::setRedirectHost( const QString &host )
+{
+  if ( mRedirectHost != host )
+  {
+    mRedirectHost = host;
+    emit redirectHostChanged( mRedirectHost );
+  }
 }
 
 void QgsAuthOAuth2Config::setRedirectUrl( const QString &value )
@@ -247,6 +257,7 @@ void QgsAuthOAuth2Config::setToDefaults()
   setRequestUrl( QString() );
   setTokenUrl( QString() );
   setRefreshTokenUrl( QString() );
+  setRedirectHost( QStringLiteral( "127.0.0.1" ) );
   setRedirectUrl( QString() );
   setRedirectPort( 7070 );
   setClientId( QString() );
@@ -272,6 +283,7 @@ bool QgsAuthOAuth2Config::operator==( const QgsAuthOAuth2Config &other ) const
            && other.requestUrl() == this->requestUrl()
            && other.tokenUrl() == this->tokenUrl()
            && other.refreshTokenUrl() == this->refreshTokenUrl()
+           && other.redirectHost() == this->redirectHost()
            && other.redirectUrl() == this->redirectUrl()
            && other.redirectPort() == this->redirectPort()
            && other.clientId() == this->clientId()
@@ -421,6 +433,7 @@ QVariantMap QgsAuthOAuth2Config::mappedProperties() const
   vmap.insert( QStringLiteral( "password" ), this->password() );
   vmap.insert( QStringLiteral( "persistToken" ), this->persistToken() );
   vmap.insert( QStringLiteral( "queryPairs" ), this->queryPairs() );
+  vmap.insert( QStringLiteral( "redirectHost" ), this->redirectHost() );
   vmap.insert( QStringLiteral( "redirectPort" ), this->redirectPort() );
   vmap.insert( QStringLiteral( "redirectUrl" ), this->redirectUrl() );
   vmap.insert( QStringLiteral( "refreshTokenUrl" ), this->refreshTokenUrl() );

--- a/src/auth/oauth2/core/qgsauthoauth2config.h
+++ b/src/auth/oauth2/core/qgsauthoauth2config.h
@@ -43,6 +43,7 @@ class QgsAuthOAuth2Config : public QObject
     Q_PROPERTY( QString requestUrl READ requestUrl WRITE setRequestUrl NOTIFY requestUrlChanged )
     Q_PROPERTY( QString tokenUrl READ tokenUrl WRITE setTokenUrl NOTIFY tokenUrlChanged )
     Q_PROPERTY( QString refreshTokenUrl READ refreshTokenUrl WRITE setRefreshTokenUrl NOTIFY refreshTokenUrlChanged )
+    Q_PROPERTY( QString redirectHost READ redirectHost WRITE setRedirectHost NOTIFY redirectHostChanged )
     Q_PROPERTY( QString redirectUrl READ redirectUrl WRITE setRedirectUrl NOTIFY redirectUrlChanged )
     Q_PROPERTY( int redirectPort READ redirectPort WRITE setRedirectPort NOTIFY redirectPortChanged )
     Q_PROPERTY( QString clientId READ clientId WRITE setClientId NOTIFY clientIdChanged )
@@ -118,6 +119,9 @@ class QgsAuthOAuth2Config : public QObject
 
     //! Refresh token url
     QString refreshTokenUrl() const { return mRefreshTokenUrl; }
+
+    //! Returns the redirect host
+    QString redirectHost() const { return mRedirectHost; }
 
     //! Redirect url
     QString redirectUrl() const { return mRedirectURL; }
@@ -282,6 +286,8 @@ class QgsAuthOAuth2Config : public QObject
     void setTokenUrl( const QString &value );
     //! Set refresh token url to \a value
     void setRefreshTokenUrl( const QString &value );
+    //! Setsd the redirect \a host
+    void setRedirectHost( const QString &host );
     //! Set redirect url to \a value
     void setRedirectUrl( const QString &value );
     //! Set redirect port to \a value
@@ -343,6 +349,8 @@ class QgsAuthOAuth2Config : public QObject
     void tokenUrlChanged( const QString & );
     //! Emitted when configuration refresh token url has changed
     void refreshTokenUrlChanged( const QString & );
+    //! Emitted when configuration redirect host has changed
+    void redirectHostChanged( const QString & );
     //! Emitted when configuration redirect url has changed
     void redirectUrlChanged( const QString & );
     //! Emitted when configuration redirect port has changed
@@ -390,6 +398,7 @@ class QgsAuthOAuth2Config : public QObject
     QString mRequestUrl;
     QString mTokenUrl;
     QString mRefreshTokenUrl;
+    QString mRedirectHost = QStringLiteral( "127.0.0.1" );
     QString mRedirectURL;
     int mRedirectPort = 7070;
     QString mClientId;

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -71,7 +71,7 @@ void QgsO2::initOAuthConfig()
   }
 
   // common properties to all grant flows
-  const QString localpolicy = QStringLiteral( "http://127.0.0.1:% 1/%1" ).arg( mOAuth2Config->redirectUrl() ).replace( QLatin1String( "% 1" ), QLatin1String( "%1" ) );
+  const QString localpolicy = QStringLiteral( "http://%1:% 1/%2" ).arg( mOAuth2Config->redirectHost(), mOAuth2Config->redirectUrl() ).replace( QLatin1String( "% 1" ), QLatin1String( "%1" ) );
   QgsDebugMsgLevel( QStringLiteral( "localpolicy(w/port): %1" ).arg( localpolicy.arg( mOAuth2Config->redirectPort() ) ), 2 );
   setLocalhostPolicy( localpolicy );
   setLocalPort( mOAuth2Config->redirectPort() );

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -88,6 +88,9 @@ void QgsAuthOAuth2Edit::initGui()
   btnTokenClear->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
   btnTokenClear->setEnabled( hasTokenCacheFile() );
 
+  comboRedirectHost->addItem( QStringLiteral( "127.0.0.1" ), QStringLiteral( "127.0.0.1" ) );
+  comboRedirectHost->addItem( QStringLiteral( "localhost" ), QStringLiteral( "localhost" ) );
+
   connect( btnTokenClear, &QToolButton::clicked, this, &QgsAuthOAuth2Edit::removeTokenCacheFile );
   tabConfigs->setCornerWidget( btnTokenClear, Qt::TopRightCorner );
 }
@@ -174,6 +177,10 @@ void QgsAuthOAuth2Edit::setupConnections()
   connect( leTokenUrl, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setTokenUrl );
   connect( leRefreshTokenUrl, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setRefreshTokenUrl );
   connect( leRedirectUrl, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setRedirectUrl );
+  connect( comboRedirectHost, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]
+  {
+    mOAuthConfigCustom->setRedirectHost( comboRedirectHost->currentData().toString() );
+  } );
   connect( spnbxRedirectPort, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ),
            mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setRedirectPort );
   connect( leClientId, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setClientId );
@@ -393,6 +400,7 @@ void QgsAuthOAuth2Edit::loadFromOAuthConfig( const QgsAuthOAuth2Config *config )
     leRequestUrl->setText( config->requestUrl() );
     leTokenUrl->setText( config->tokenUrl() );
     leRefreshTokenUrl->setText( config->refreshTokenUrl() );
+    comboRedirectHost->setCurrentIndex( comboRedirectHost->findData( config->redirectHost() ) );
     leRedirectUrl->setText( config->redirectUrl() );
     spnbxRedirectPort->setValue( config->redirectPort() );
     leClientId->setText( config->clientId() );

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.ui
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.ui
@@ -432,7 +432,7 @@
             </item>
             <item row="4" column="1" colspan="3">
              <widget class="QFrame" name="frameRedirectUrl">
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0,0,0,0">
                <property name="spacing">
                 <number>2</number>
                </property>
@@ -449,9 +449,12 @@
                 <number>0</number>
                </property>
                <item>
+                <widget class="QComboBox" name="comboRedirectHost"/>
+               </item>
+               <item>
                 <widget class="QLabel" name="lblRedirectIP">
                  <property name="text">
-                  <string>http://127.0.0.1:</string>
+                  <string>:</string>
                  </property>
                 </widget>
                </item>
@@ -1032,6 +1035,7 @@
   <tabstop>leRequestUrl</tabstop>
   <tabstop>leTokenUrl</tabstop>
   <tabstop>leRefreshTokenUrl</tabstop>
+  <tabstop>comboRedirectHost</tabstop>
   <tabstop>spnbxRedirectPort</tabstop>
   <tabstop>leRedirectUrl</tabstop>
   <tabstop>leClientId</tabstop>

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -112,6 +112,7 @@ QgsAuthOAuth2Config *TestQgsAuthOAuth2Method::baseConfig( bool loaded )
     config->setRequestUrl( "https://request.oauth2.test" );
     config->setTokenUrl( "https://token.oauth2.test" );
     config->setRefreshTokenUrl( "https://refreshtoken.oauth2.test" );
+    config->setRedirectHost( "myhost" );
     config->setRedirectUrl( "subdir" );
     config->setRedirectPort( 7777 );
     config->setClientId( "myclientid" );
@@ -156,6 +157,7 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "        \"pf.password\": \"mypassword\",\n"
            "        \"pf.username\": \"myusername\"\n"
            "    },\n"
+           "    \"redirectHost\": \"myhost\",\n"
            "    \"redirectPort\": 7777,\n"
            "    \"redirectUrl\": \"subdir\",\n"
            "    \"refreshTokenUrl\": \"https://refreshtoken.oauth2.test\",\n"
@@ -183,6 +185,7 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "\"password\":\"mypassword\","
            "\"persistToken\":false,"
            "\"queryPairs\":{\"pf.password\":\"mypassword\",\"pf.username\":\"myusername\"},"
+           "\"redirectHost\":\"myhost\","
            "\"redirectPort\":7777,"
            "\"redirectUrl\":\"subdir\","
            "\"refreshTokenUrl\":\"https://refreshtoken.oauth2.test\","
@@ -216,6 +219,7 @@ QVariantMap TestQgsAuthOAuth2Method::baseVariantMap()
   qpairs.insert( "pf.password", "mypassword" );
   qpairs.insert( "pf.username", "myusername" );
   vmap.insert( "queryPairs", qpairs );
+  vmap.insert( "redirectHost", "myhost" );
   vmap.insert( "redirectPort", 7777 );
   vmap.insert( "redirectUrl", "subdir" );
   vmap.insert( "refreshTokenUrl", "https://refreshtoken.oauth2.test" );


### PR DESCRIPTION
Some oauth2 implementations (eg the MS Sharepoint implementation) do not support http://127.0.0.1 redirects. They allow only https://127.0.0.1 OR http://localhost redirects.

Since https is not simple to support, instead expose an option to allow localhost for redirects.
