### PR TITLE
Fix global settings file name in Qgis.SettingsOrigin Global value description

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -2915,7 +2915,7 @@ Qgis.CoordinateDisplayType.__doc__ = "Formats for displaying coordinates\n\n.. v
 Qgis.CoordinateDisplayType.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.SettingsOrigin.Any.__doc__ = "From any origin"
-Qgis.SettingsOrigin.Global.__doc__ = "Global settings are stored in `global_settings.ini`"
+Qgis.SettingsOrigin.Global.__doc__ = "Global settings are stored in `qgis_global_settings.ini`"
 Qgis.SettingsOrigin.Local.__doc__ = "Local settings are stored in the user profile"
 Qgis.SettingsOrigin.__doc__ = "The setting origin describes where a setting is stored.\n\n.. versionadded:: 3.30\n\n" + '* ``Any``: ' + Qgis.SettingsOrigin.Any.__doc__ + '\n' + '* ``Global``: ' + Qgis.SettingsOrigin.Global.__doc__ + '\n' + '* ``Local``: ' + Qgis.SettingsOrigin.Local.__doc__
 # --

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3122,7 +3122,7 @@ class CORE_EXPORT Qgis
     enum class SettingsOrigin : int
     {
       Any, //!< From any origin
-      Global, //!< Global settings are stored in `global_settings.ini`
+      Global, //!< Global settings are stored in `qgis_global_settings.ini`
       Local, //!< Local settings are stored in the user profile
     };
     Q_ENUM( SettingsOrigin )


### PR DESCRIPTION
## Description

From:
```
Global settings are stored in `global_settings.ini`
```
to:
```
Global settings are stored in `qgis_global_settings.ini`
```

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
