### PR TITLE
When a creating a new PG connection, use SSL prefer

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -55,6 +55,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
   cbxSSLmode->addItem( tr( "require" ), QgsDataSourceUri::SslRequire );
   cbxSSLmode->addItem( tr( "verify-ca" ), QgsDataSourceUri::SslVerifyCa );
   cbxSSLmode->addItem( tr( "verify-full" ), QgsDataSourceUri::SslVerifyFull );
+  cbxSSLmode->setCurrentIndex( cbxSSLmode->findData( QgsDataSourceUri::SslPrefer ) );
 
   mAuthSettings->setDataprovider( QStringLiteral( "postgres" ) );
   mAuthSettings->showStoreCheckboxes( true );


### PR DESCRIPTION
When creating a new PG connection, I think we can set "SSL prefer by default" in the combobox

SSL prefer is already the default on the API side : 


* https://github.com/qgis/QGIS/blob/746345510c40a3d5aea15dd0ce31a57cc35c38bc/src/core/qgsdatasourceuri.cpp#L581
* https://github.com/qgis/QGIS/blob/746345510c40a3d5aea15dd0ce31a57cc35c38bc/python/plugins/db_manager/db_plugins/postgis/plugin.py#L83

and other places in the code

If accepted, possible to backport ?
