### PR TITLE
Add a .clang-tidy file based on tests/code_layout/clangtidy_checks.txt and remove this file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: 'bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-virtual-near-miss'

--- a/.docker/docker-qgis-clangtidy.sh
+++ b/.docker/docker-qgis-clangtidy.sh
@@ -35,12 +35,11 @@ curl -XGET https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-14.0.6/cl
 echo "::endgroup::"
 
 echo "${bold}Run clang-tidy on modifications...${endbold}"
-CLANG_TIDY_CHECKS=$(cat tests/code_layout/clangtidy_checks.txt | grep -ve "^#" | grep -ve "^$" | tr -d '\n')
 
 # We need to add build/src/test dir as extra include directories because when clang-tidy tries to process qgstest.h
 # it has no compile_commands.json instructions to know what are include directories
 # It manages to figure out for other headers though, I don't get how...
-git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -checks="$CLANG_TIDY_CHECKS" -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ | tee clang-tidy.log
+git diff -U0 HEAD^ | python3 clang-tidy-diff.py -p1 -path=${CTEST_BUILD_DIR} -use-color -extra-arg=-I${CTEST_BUILD_DIR}/src/test/ | tee clang-tidy.log
 
 echo -e "\e[1;34mTo reproduce locally:"
 echo -e "\e[1;34m - launch cmake with option -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -52,8 +52,6 @@ while getopts "p:am:" o; do
 done
 shift $((OPTIND-1))
 
-CLANG_TIDY_CHECKS=$(cat ${SOURCE_DIR}/tests/code_layout/clangtidy_checks.txt | grep -ve "^#" | grep -ve "^$" | tr -d '\n')
-
 if [[ ! -f "$BUILD_DIR/compile_commands.json" ]]; then
   echo "compile_commands.json file is missing, you need to add -DCMAKE_EXPORT_COMPILE_COMMANDS=ON when you run cmake to generate it."
   exit 1
@@ -80,5 +78,5 @@ set +e
 
 for file in $FILES;
 do
-  clang-tidy -p=$BUILD_DIR -checks="$CLANG_TIDY_CHECKS" $file
+  clang-tidy -p=$BUILD_DIR $file
 done

--- a/tests/code_layout/clangtidy_checks.txt
+++ b/tests/code_layout/clangtidy_checks.txt
@@ -1,5 +1,0 @@
-bugprone-*,
-
-# Those we don't want to fix
--bugprone-easily-swappable-parameters,
--bugprone-virtual-near-miss


### PR DESCRIPTION
## Description

Since we use clang-tidy in CI, we should use this dot file too.

@troopa81 I think, we could suppress  tests/code_layout/clangtidy_checks.txt and simply use this file.

Moreover, there is a py script included with clang: run-clang-tidy whose purpose is the same as your script (but multiprocessor, and can apply fix with -fix* options and clang-apply-replacements bin).

```bash
CLANG_TIDY_BIN=${CLANG_TIDY_BIN:-/usr/bin/clang-tidy}
RUN_CLANG_TIDY_BIN=${RUN_CLANG_TIDY_BIN:-/usr/bin/run-clang-tidy}
APPLY_CLANG_TIDY_BIN=${APPLY_CLANG_TIDY_BIN:-/usr/bin/clang-apply-replacements}

${RUN_CLANG_TIDY_BIN} -p $BUILD_DIR -clang-tidy-binary=${CLANG_TIDY_BIN} -clang-apply-replacements-binary=${APPLY_CLANG_TIDY_BIN} -j nproc $file
```