### PR TITLE
rulebasedchunkloader: Do not apply terrain offset if clamping is absolute

### DIFF
--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -128,6 +128,8 @@ class QgsRuleBasedChunkedEntity : public QgsChunkedEntity
     void onTerrainElevationOffsetChanged( float newOffset );
   private:
     Qt3DCore::QTransform *mTransform = nullptr;
+
+    bool applyTerrainOffset() const;
 };
 
 /// @endcond


### PR DESCRIPTION
## Description

If a terrain offset is applied, all the shapes are vertically translated by the size of the offset. However, if the clamping mode of the layer is set to `Absolute` (`Qgis::AltitudeClamping::Absolute`), only the elevation of the shape is taken into account. This means that the terrain offset should not be taken into account.

This issue is fixed by checking the altitude clamping mode of the symbol before applying the offset. If the clamping is `Absolute`, the offset is not applied.

This was already done for `QgsVectorLayerChunkLoader`. See commit bf22a165b3f6f2f10156b1674a1c4f485bc8874b.


This is similar to https://github.com/qgis/QGIS/pull/54508
