### PR TITLE
[chore] Migrate ci to new container registry

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis-deps-ogc
           context: .ci/ogc
           dockerfile: Dockerfile

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis3-build-deps-${{ matrix.distro-version }}
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"
@@ -363,7 +363,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--target ${{ matrix.docker-target }} --build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"
@@ -470,7 +470,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"


### PR DESCRIPTION
Tests are failing on master for a while: https://github.com/qgis/QGIS/actions/workflows/run-tests.yml?query=event%3Apush+branch%3Amaster

The problem is a a 401 reported from the container registry.

According to https://github.com/whoan/docker-build-with-cache-action#star2-action-supercharged, with `BUILDKIT` enabled, the new container registry should be used and `BUILDKIT` is enabled by default.
I am not sure if this fixes the problem. But it's probably a good idea to either disable `BUILDKIT` or switch to the new registry as suggested by the docs. This proposes the new registry approach.