### PR TITLE
Lazy initialize authentication framework

### DIFF
--- a/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -35,7 +35,7 @@ and to utilize configurations through various authentication method plugins
       CRITICAL
     };
 
-    bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+ bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated/;
 %Docstring
 init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
 
@@ -47,6 +47,20 @@ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authen
 .. seealso:: :py:func:`QgsApplication.pluginPath`
 
 .. seealso:: :py:func:`QgsApplication.qgisAuthDatabaseFilePath`
+
+.. deprecated:: QGIS 3.36
+  use :py:func:`~QgsAuthManager.setup` instead.
+%End
+
+    void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+%Docstring
+Sets up the authentication manager configuration.
+
+This method does not initialize the authentication framework, instead that is deferred
+to lazy-initialize when required.
+
+:param pluginPath: the plugin path
+:param authDatabasePath: the authentication DB path
 %End
 
     ~QgsAuthManager();
@@ -249,7 +263,7 @@ Verify if provided authentication id is unique
 :param id: Id to check
 %End
 
-    bool hasConfigId( const QString &txt ) const;
+    static bool hasConfigId( const QString &txt );
 %Docstring
 Returns whether a string includes an authcfg ID token
 
@@ -595,7 +609,7 @@ Check if a certificate authority exists
 Remove a certificate authority
 %End
 
-    const QList<QSslCertificate> systemRootCAs();
+    static const QList<QSslCertificate> systemRootCAs();
 %Docstring
 systemRootCAs get root system certificate authorities
 
@@ -744,7 +758,7 @@ trustedCaCertsPemText get concatenated string of all trusted CA certificates
 
 
 
-    bool passwordHelperEnabled() const;
+    static bool passwordHelperEnabled();
 %Docstring
 Password helper enabled getter
 

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -35,7 +35,7 @@ and to utilize configurations through various authentication method plugins
       CRITICAL
     };
 
-    bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+ bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) /Deprecated/;
 %Docstring
 init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
 
@@ -47,6 +47,20 @@ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authen
 .. seealso:: :py:func:`QgsApplication.pluginPath`
 
 .. seealso:: :py:func:`QgsApplication.qgisAuthDatabaseFilePath`
+
+.. deprecated:: QGIS 3.36
+  use :py:func:`~QgsAuthManager.setup` instead.
+%End
+
+    void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+%Docstring
+Sets up the authentication manager configuration.
+
+This method does not initialize the authentication framework, instead that is deferred
+to lazy-initialize when required.
+
+:param pluginPath: the plugin path
+:param authDatabasePath: the authentication DB path
 %End
 
     ~QgsAuthManager();
@@ -249,7 +263,7 @@ Verify if provided authentication id is unique
 :param id: Id to check
 %End
 
-    bool hasConfigId( const QString &txt ) const;
+    static bool hasConfigId( const QString &txt );
 %Docstring
 Returns whether a string includes an authcfg ID token
 
@@ -595,7 +609,7 @@ Check if a certificate authority exists
 Remove a certificate authority
 %End
 
-    const QList<QSslCertificate> systemRootCAs();
+    static const QList<QSslCertificate> systemRootCAs();
 %Docstring
 systemRootCAs get root system certificate authorities
 
@@ -744,7 +758,7 @@ trustedCaCertsPemText get concatenated string of all trusted CA certificates
 
 
 
-    bool passwordHelperEnabled() const;
+    static bool passwordHelperEnabled();
 %Docstring
 Password helper enabled getter
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1025,11 +1025,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   qApp->processEvents();
 
   QgsApplication::initQgis();
-  if ( !QgsApplication::authManager()->isDisabled() )
-  {
-    // Most of the auth initialization is now done inside initQgis, no need to profile here
-    masterPasswordSetup();
-  }
+
+  // setup connections to auth system
+  masterPasswordSetup();
 
   QgsSettings settings;
 
@@ -16806,6 +16804,9 @@ void QgisApp::masterPasswordSetup()
 
 void QgisApp::eraseAuthenticationDatabase()
 {
+  if ( QgsApplication::authManager()->isDisabled() )
+    return;
+
   // First check if now is a good time to interact with the user, e.g. project is done loading.
   // If not, ask QgsAuthManager to re-emit authDatabaseEraseRequested from the schedule timer.
   // No way to know if user interaction will interfere with plugins loading layers.

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -84,8 +84,20 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \return TRUE on success
      * \see QgsApplication::pluginPath
      * \see QgsApplication::qgisAuthDatabaseFilePath
+     * \deprecated Since QGIS 3.36, use setup() instead.
      */
-    bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
+    Q_DECL_DEPRECATED bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() ) SIP_DEPRECATED;
+
+    /**
+     * Sets up the authentication manager configuration.
+     *
+     * This method does not initialize the authentication framework, instead that is deferred
+     * to lazy-initialize when required.
+     *
+     * \param pluginPath the plugin path
+     * \param authDatabasePath the authentication DB path
+     */
+    void setup( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
 
     ~QgsAuthManager() override;
 
@@ -271,7 +283,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Returns whether a string includes an authcfg ID token
      * \param txt String to check
      */
-    bool hasConfigId( const QString &txt ) const;
+    static bool hasConfigId( const QString &txt );
 
     //! Returns the regular expression for authcfg=.{7} key/value token for authentication ids
     QString configIdRegex() const { return AUTH_CFG_REGEX;}
@@ -550,7 +562,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \return list of certificate authorities
      * \since QGIS 3.0
      */
-    const QList<QSslCertificate> systemRootCAs();
+    static const QList<QSslCertificate> systemRootCAs();
 
     /**
      * \brief extraFileCAs extra file-based certificate authorities
@@ -678,7 +690,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Password helper enabled getter
      * \note Available in Python bindings since QGIS 3.8.0
      */
-    bool passwordHelperEnabled() const;
+    static bool passwordHelperEnabled();
 
     /**
      * Password helper enabled setter
@@ -690,13 +702,13 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Password helper logging enabled getter
      * \note not available in Python bindings
      */
-    bool passwordHelperLoggingEnabled() const SIP_SKIP;
+    static bool passwordHelperLoggingEnabled() SIP_SKIP;
 
     /**
      * Password helper logging enabled setter
      * \note not available in Python bindings
      */
-    void setPasswordHelperLoggingEnabled( bool enabled ) SIP_SKIP;
+    static void setPasswordHelperLoggingEnabled( bool enabled ) SIP_SKIP;
 
     /**
      * Store the password manager into the wallet
@@ -795,6 +807,14 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
   private:
 
+    /**
+     * Performs lazy initialization of the authentication framework, if it has
+     * not already been done.
+     */
+    bool ensureInitialized() const;
+
+    bool initPrivate( const QString &pluginPath,  const QString &authDatabasePath );
+
     //////////////////////////////////////////////////////////////////////////////
     // Password Helper methods
 
@@ -885,6 +905,10 @@ class CORE_EXPORT QgsAuthManager : public QObject
     static const QString AUTH_AUTHORITIES_TABLE;
     static const QString AUTH_TRUST_TABLE;
     static const QString AUTH_CFG_REGEX;
+
+    QString mPluginPath;
+    QString mAuthDatabasePath;
+    mutable bool mLazyInitResult = false;
 
     bool mAuthInit = false;
     QString mAuthDbPath;

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -732,8 +732,8 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     {
       QgsDebugMsgLevel( QStringLiteral( "setting proxy from stored authentication configuration %1" ).arg( authcfg ), 2 );
       // Never crash! Never.
-      if ( QgsApplication::authManager() )
-        QgsApplication::authManager()->updateNetworkProxy( proxy, authcfg );
+      if ( QgsAuthManager *authManager = QgsApplication::authManager() )
+        authManager->updateNetworkProxy( proxy, authcfg );
     }
   }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1526,8 +1526,8 @@ void QgsApplication::initQgis()
   // create project instance if doesn't exist
   QgsProject::instance();
 
-  // Initialize authentication manager and connect to database
-  authManager()->init( pluginPath(), qgisAuthDatabaseFilePath() );
+  // Setup authentication manager for lazy initialization
+  authManager()->setup( pluginPath(), qgisAuthDatabaseFilePath() );
 
   // Make sure we have a NAM created on the main thread.
   // Note that this might call QgsApplication::authManager to

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -327,11 +327,11 @@ bool QgsServer::init()
 
   QgsApplication::createDatabase(); //init qgis.db (e.g. necessary for user crs)
 
-  // Initialize the authentication system
+  // Sets up the authentication system
   //   creates or uses qgis-auth.db in ~/.qgis3/ or directory defined by QGIS_AUTH_DB_DIR_PATH env variable
   //   set the master password as first line of file defined by QGIS_AUTH_PASSWORD_FILE env variable
   //   (QGIS_AUTH_PASSWORD_FILE variable removed from environment after accessing)
-  QgsApplication::authManager()->init( QgsApplication::pluginPath(), QgsApplication::qgisAuthDatabaseFilePath() );
+  QgsApplication::authManager()->setup( QgsApplication::pluginPath(), QgsApplication::qgisAuthDatabaseFilePath() );
 
   QString defaultConfigFilePath;
   const QFileInfo projectFileInfo = defaultProjectFile(); //try to find a .qgs/.qgz file in the server directory


### PR DESCRIPTION
QCA and SSL certificate initialize can be costly -- so defer startup of authentication framework until it is actually required.

This has no effect on QGIS desktop, as the news feed request and other startup network requests will immediately trigger an initialization of the framework. The use case here is improving the **core** application startup time to benefit non-app based clients, eg. qgis_process.
