### PR TITLE
Speed up retrieval of algorithms by id in some cases

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -178,6 +178,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   if ( map.value( QStringLiteral( "dependencies" ) ).type() == QVariant::StringList )
   {
     const QStringList dependencies = map.value( QStringLiteral( "dependencies" ) ).toStringList();
+    mDependencies.reserve( dependencies.size() );
     for ( const QString &dependency : dependencies )
     {
       QgsProcessingModelChildDependency dep;
@@ -188,6 +189,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   else
   {
     const QVariantList dependencies = map.value( QStringLiteral( "dependencies" ) ).toList();
+    mDependencies.reserve( dependencies.size() );
     for ( const QVariant &dependency : dependencies )
     {
       QgsProcessingModelChildDependency dep;
@@ -205,6 +207,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   {
     QgsProcessingModelChildParameterSources sources;
     const auto constToList = paramIt->toList();
+    sources.reserve( constToList.size() );
     for ( const QVariant &sourceVar : constToList )
     {
       QgsProcessingModelChildParameterSource param;

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -190,26 +190,47 @@ QgsProcessingAlgorithmInformation QgsProcessingRegistry::algorithmInformation( c
 
 const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QString &constId ) const
 {
+  if ( constId.isEmpty() )
+    return nullptr;
+
   // allow mapping of algorithm via registered algorithm aliases
   const QString id = mAlgorithmAliases.value( constId, constId );
 
+  // try to match just the one target provider, if we can determine it from the id easily
+  static thread_local QRegularExpression reSplitProviderId( QStringLiteral( "^(.*?):(.*)$" ) );
+  const QRegularExpressionMatch match = reSplitProviderId.match( id );
+  if ( match.hasMatch() )
+  {
+    if ( QgsProcessingProvider *provider = mProviders.value( match.captured( 1 ) ) )
+    {
+      if ( const QgsProcessingAlgorithm *algorithm = provider->algorithm( match.captured( 2 ) ) )
+        return algorithm;
+    }
+
+    // try mapping 'qgis' algs to 'native' algs - this allows us to freely move algorithms
+    // from the python 'qgis' provider to the c++ 'native' provider without breaking API
+    // or existing models
+    if ( match.captured( 1 ) == QLatin1String( "qgis" ) )
+    {
+      const QString algorithmName = id.mid( 5 );
+      if ( QgsProcessingProvider *provider = mProviders.value( QStringLiteral( "native" ) ) )
+      {
+        if ( const QgsProcessingAlgorithm *algorithm = provider->algorithm( algorithmName ) )
+          return algorithm;
+      }
+    }
+  }
+
+  // slow: iterate through ALL providers to find a match
   QMap<QString, QgsProcessingProvider *>::const_iterator it = mProviders.constBegin();
   for ( ; it != mProviders.constEnd(); ++it )
   {
-    const auto constAlgorithms = it.value()->algorithms();
-    for ( const QgsProcessingAlgorithm *alg : constAlgorithms )
+    const QList< const QgsProcessingAlgorithm * > algorithms = it.value()->algorithms();
+    for ( const QgsProcessingAlgorithm *alg : algorithms )
       if ( alg->id() == id )
         return alg;
   }
 
-  // try mapping 'qgis' algs to 'native' algs - this allows us to freely move algorithms
-  // from the python 'qgis' provider to the c++ 'native' provider without breaking API
-  // or existing models
-  if ( id.startsWith( QLatin1String( "qgis:" ) ) )
-  {
-    const QString newId = QStringLiteral( "native:" ) + id.mid( 5 );
-    return algorithmById( newId );
-  }
   return nullptr;
 }
 


### PR DESCRIPTION
Optimise QgsProcessingRegistry::algorithmById so that we avoid
iterating over all providers and algorithms in some cases. This
method is currently called *a lot* during processing initialization,
and contributes a significant cost to qgis_process startup

Refs https://github.com/qgis/QGIS/issues/54563