### PR TITLE
When running qgis_process commands, defer the model provider loading 

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -202,6 +202,9 @@ class ProcessingPlugin(QObject):
             self.initialized = True
             Processing.initialize()
 
+    def finalizeStartup(self):
+        Processing.perform_deferred_model_initialization()
+
     def initGui(self):
         # port old log, ONCE ONLY!
         settings = QgsSettings()

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -140,9 +140,10 @@ class Processing:
             return
 
         # Add the model providers
+        # note that we don't add the Project Provider, as this cannot be called
+        # from qgis_process
         model_providers = [
-            ModelerAlgorithmProvider,
-            ProjectProvider
+            ModelerAlgorithmProvider
         ]
 
         for c in model_providers:

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -82,7 +82,7 @@ class Processing:
 
     @staticmethod
     def initialize():
-        if "model" in [p.id() for p in QgsApplication.processingRegistry().providers()]:
+        if "script" in [p.id() for p in QgsApplication.processingRegistry().providers()]:
             return
 
         with QgsRuntimeProfiler.profile('Initialize'):
@@ -101,13 +101,20 @@ class Processing:
                     pass
 
             # Add the basic providers
-            for c in [
+            basic_providers = [
                 QgisAlgorithmProvider,
                 GdalAlgorithmProvider,
-                ScriptAlgorithmProvider,
-                ModelerAlgorithmProvider,
-                ProjectProvider
-            ]:
+                ScriptAlgorithmProvider
+            ]
+
+            # model providers are deferred for qgis_process startup
+            if QgsApplication.platform() != 'qgis_process':
+                basic_providers.extend([
+                    ModelerAlgorithmProvider,
+                    ProjectProvider
+                ])
+
+            for c in basic_providers:
                 p = c()
                 if QgsApplication.processingRegistry().addProvider(p):
                     Processing.BASIC_PROVIDERS.append(p)
@@ -126,6 +133,22 @@ class Processing:
             ProcessingConfig.initialize()
             ProcessingConfig.readSettings()
             RenderingStyles.loadStyles()
+
+    @staticmethod
+    def perform_deferred_model_initialization():
+        if "model" in [p.id() for p in QgsApplication.processingRegistry().providers()]:
+            return
+
+        # Add the model providers
+        model_providers = [
+            ModelerAlgorithmProvider,
+            ProjectProvider
+        ]
+
+        for c in model_providers:
+            p = c()
+            if QgsApplication.processingRegistry().addProvider(p):
+                Processing.BASIC_PROVIDERS.append(p)
 
     @staticmethod
     def deinitialize():

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -61,6 +61,9 @@ class ModelerAlgorithmProvider(QgsProcessingProvider):
         QgsApplication.processingRegistry().providerAdded.connect(self.onProviderAdded)
 
     def onProviderAdded(self, provider_id):
+        if provider_id == self.id():
+            return
+
         self.refreshAlgorithms()
 
     def load(self):

--- a/python/plugins/processing/modeler/ProjectProvider.py
+++ b/python/plugins/processing/modeler/ProjectProvider.py
@@ -51,7 +51,10 @@ class ProjectProvider(QgsProcessingProvider):
         self.project.writeProject.connect(self.write_project)
         self.project.cleared.connect(self.clear)
 
-    def on_provider_added(self, _):
+    def on_provider_added(self, provider_id):
+        if provider_id == self.id():
+            return
+
         self.refreshAlgorithms()
 
     def load(self):

--- a/python/utils.py
+++ b/python/utils.py
@@ -493,6 +493,25 @@ def startProcessingPlugin(packageName: str) -> bool:
     return True
 
 
+def finalizeProcessingStartup() -> bool:
+    """
+    Finalizes the startup of the Processing plugin
+
+    This should only be called after the startProcessingPlugin() method has been called
+    for every installed and enabled plugin.
+    """
+    global plugins, active_plugins, iface, plugin_times
+    if 'processing' not in plugins:
+        return False
+
+    try:
+        plugins['processing'].finalizeStartup()
+    except:
+        return False
+
+    return True
+
+
 def canUninstallPlugin(packageName: str) -> bool:
     """ confirm that the plugin can be uninstalled """
     global plugins, active_plugins

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -551,6 +551,12 @@ void QgsProcessingExec::loadPlugins()
       }
     }
   }
+
+  if ( !mPythonUtils->finalizeProcessingStartup() )
+  {
+    std::cerr << "error finalizing Processing plugin startup\n\n";
+  }
+
 #endif
 }
 

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -176,6 +176,17 @@ class PYTHON_EXPORT QgsPythonUtils
     virtual bool startProcessingPlugin( const QString &packageName ) = 0;
 
     /**
+     * Finalizes the startup of the Processing plugin.
+     *
+     * \warning This should only be called after the startProcessingPlugin() method has been called
+     * for every installed and enabled plugin.
+     *
+     * \see startProcessingPlugin()
+     * \since QGIS 3.36
+     */
+    virtual bool finalizeProcessingStartup() = 0;
+
+    /**
      * Helper function to return some information about a plugin.
      *
      * \param function metadata component to return. Must match one of the strings: name, type, version, description, hasProcessingProvider.

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -676,6 +676,13 @@ bool QgsPythonUtilsImpl::startProcessingPlugin( const QString &packageName )
   return ( output == QLatin1String( "True" ) );
 }
 
+bool QgsPythonUtilsImpl::finalizeProcessingStartup()
+{
+  QString output;
+  evalString( QStringLiteral( "qgis.utils.finalizeProcessingStartup()" ), output );
+  return ( output == QLatin1String( "True" ) );
+}
+
 bool QgsPythonUtilsImpl::canUninstallPlugin( const QString &packageName )
 {
   QString output;

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -86,6 +86,7 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     bool loadPlugin( const QString &packageName ) final;
     bool startPlugin( const QString &packageName ) final;
     bool startProcessingPlugin( const QString &packageName ) final;
+    bool finalizeProcessingStartup() final;
     QString getPluginMetadata( const QString &pluginName, const QString &function ) final;
     bool pluginHasProcessingProvider( const QString &pluginName ) final;
     bool canUninstallPlugin( const QString &packageName ) final;


### PR DESCRIPTION
When running qgis_process commands, defer the model provider loading until after ALL plugins have been loaded

This avoids the model provider from refreshing all the model algorithms multiple times, once for each non-default plugin installed which implements a processing provider.

Refs https://github.com/qgis/QGIS/issues/54563