### PR TITLE
Perform backward compatibility of settings only for changed settings 

### DIFF
--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -328,6 +328,16 @@ Copies the settings to the given key.
 .. versionadded:: 3.30
 %End
 
+    void copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList = QStringList() ) const;
+%Docstring
+Copies the settings to the given key, if it has changed during the current QGIS session (see :py:func:`~QgsSettingsEntryBase.hasChanged`).
+
+:param key: the key to copy the setting value to.
+:param dynamicKeyPartList: is the optional dynamic key part to determine the key. It must be the same for origin and destination keys.
+
+.. versionadded:: 3.36
+%End
+
     QgsSettingsTreeNode *parent() const;
 %Docstring
 Returns the parent tree element
@@ -338,6 +348,13 @@ Returns the parent tree element
     virtual bool checkValueVariant( const QVariant &value ) const;
 %Docstring
 Returns ``True`` if the given ``value`` is valid towards the setting definition
+%End
+
+    bool hasChanged() const;
+%Docstring
+Returns ``True`` if the setting was changed during the current QGIS session.
+
+.. versionadded:: 3.36
 %End
 
 };

--- a/python/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -328,6 +328,16 @@ Copies the settings to the given key.
 .. versionadded:: 3.30
 %End
 
+    void copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList = QStringList() ) const;
+%Docstring
+Copies the settings to the given key, if it has changed during the current QGIS session (see :py:func:`~QgsSettingsEntryBase.hasChanged`).
+
+:param key: the key to copy the setting value to.
+:param dynamicKeyPartList: is the optional dynamic key part to determine the key. It must be the same for origin and destination keys.
+
+.. versionadded:: 3.36
+%End
+
     QgsSettingsTreeNode *parent() const;
 %Docstring
 Returns the parent tree element
@@ -338,6 +348,13 @@ Returns the parent tree element
     virtual bool checkValueVariant( const QVariant &value ) const;
 %Docstring
 Returns ``True`` if the given ``value`` is valid towards the setting definition
+%End
+
+    bool hasChanged() const;
+%Docstring
+Returns ``True`` if the setting was changed during the current QGIS session.
+
+.. versionadded:: 3.36
 %End
 
 };

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -63,10 +63,10 @@ QgsSettingsRegistryApp::~QgsSettingsRegistryApp()
 {
   // TODO QGIS 4.0: Remove
   // backward compatibility for settings
-  QgsIdentifyResultsDialog::settingHideNullValues->copyValueToKey( QStringLiteral( "Map/hideNullValues" ) );
-  QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueToKey( QStringLiteral( "plugins/automatically-check-for-updates" ) );
-  QgsPluginManager::settingsAllowExperimental->copyValueToKey( QStringLiteral( "app/plugin_installer/allowExperimental" ) );
-  QgsPluginManager::settingsAllowDeprecated->copyValueToKey( QStringLiteral( "app/plugin_installer/allowDeprecated" ) );
+  QgsIdentifyResultsDialog::settingHideNullValues->copyValueToKeyIfChanged( QStringLiteral( "Map/hideNullValues" ) );
+  QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueToKeyIfChanged( QStringLiteral( "plugins/automatically-check-for-updates" ) );
+  QgsPluginManager::settingsAllowExperimental->copyValueToKeyIfChanged( QStringLiteral( "app/plugin_installer/allowExperimental" ) );
+  QgsPluginManager::settingsAllowDeprecated->copyValueToKeyIfChanged( QStringLiteral( "app/plugin_installer/allowDeprecated" ) );
   QgsPluginManager::settingsCheckOnStartLastDate->copyValueFromKey( QStringLiteral( "app/plugin_installer/checkOnStartLastDate" ), true );
   QgsPluginManager::settingsSeenPlugins->copyValueFromKey( QStringLiteral( "app/plugin_installer/seen_plugins" ), true );
   QgsPluginManager::settingsLastZipDirectory->copyValueFromKey( QStringLiteral( "app/plugin_installer/lastZipDirectory" ), true );

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -151,6 +151,7 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
 
 bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QStringList &dynamicKeyPartList ) const
 {
+  mHasChanged = true;
   auto settings = QgsSettings::get();
   if ( mOptions.testFlag( Qgis::SettingsOption::SaveFormerValue ) )
   {
@@ -256,6 +257,14 @@ void QgsSettingsEntryBase::copyValueToKey( const QString &key, const QStringList
 {
   const QString completeKey = completeKeyPrivate( key, dynamicKeyPartList );
   QgsSettings::get()->setValue( completeKey, valueAsVariant( dynamicKeyPartList ) );
+}
+
+void QgsSettingsEntryBase::copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList ) const
+{
+  if ( hasChanged() )
+  {
+    copyValueToKey( key, dynamicKeyPartList );
+  }
 }
 
 QString QgsSettingsEntryBase::formerValuekey( const QStringList &dynamicKeyPartList ) const

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -326,6 +326,16 @@ class CORE_EXPORT QgsSettingsEntryBase
     void copyValueToKey( const QString &key, const QStringList &dynamicKeyPartList = QStringList() ) const;
 
     /**
+     * Copies the settings to the given key, if it has changed during the current QGIS session (see hasChanged()).
+     *
+     * \param key the key to copy the setting value to.
+     * \param dynamicKeyPartList is the optional dynamic key part to determine the key. It must be the same for origin and destination keys.
+     *
+     * \since QGIS 3.36
+     */
+    void copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList = QStringList() ) const;
+
+    /**
     * Returns the parent tree element
     * \since QGIS 3.30
     */
@@ -338,6 +348,13 @@ class CORE_EXPORT QgsSettingsEntryBase
       return true;
     }
 
+    /**
+     * Returns TRUE if the setting was changed during the current QGIS session.
+     *
+     * \since QGIS 3.36
+     */
+    bool hasChanged() const { return mHasChanged; }
+
   private:
     QString formerValuekey( const QStringList &dynamicKeyPartList ) const;
 
@@ -349,6 +366,7 @@ class CORE_EXPORT QgsSettingsEntryBase
     QVariant mDefaultValue;
     QString mDescription;
     Qgis::SettingsOptions mOptions;
+    mutable bool mHasChanged = false;
 };
 
 /**

--- a/src/core/settings/qgssettingsentryimpl.cpp
+++ b/src/core/settings/qgssettingsentryimpl.cpp
@@ -262,7 +262,8 @@ bool QgsSettingsEntryColor::copyValueFromKeys( const QString &redKey, const QStr
       settings->remove( alphaKey );
     }
 
-    setVariantValue( oldValue );
+    if ( value() != oldValue )
+      setVariantValue( oldValue );
     return true;
   }
   return false;

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -388,23 +388,27 @@ void QgsSettingsRegistryCore::backwardCompatibility()
   QgsSettings::holdFlush();
   auto settings = QgsSettings::get();
 
+  // CAREFUL! There's a mix of copyValueToKeyIfChanged and copyValueToKey used here.
+  // copyValueToKeyIfChanged should be used if copyValueFromKey did NOT have the removeSettingAtKey argument set to True
+  // in migrateOldSettings
+
   // single settings - added in 3.30
-  QgsLayout::settingsSearchPathForTemplates->copyValueToKey( QStringLiteral( "core/Layout/searchPathsForTemplates" ) );
+  QgsLayout::settingsSearchPathForTemplates->copyValueToKeyIfChanged( QStringLiteral( "core/Layout/searchPathsForTemplates" ) );
 
-  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueToKey( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
-  QgsProcessing::settingsTempPath->copyValueToKey( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
-  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueToKey( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueToKey( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
+  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ) );
+  QgsProcessing::settingsTempPath->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) );
+  QgsProcessing::settingsDefaultOutputVectorLayerExt->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ) );
+  QgsProcessing::settingsDefaultOutputRasterLayerExt->copyValueToKeyIfChanged( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ) );
 
-  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueToKey( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
+  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueToKeyIfChanged( QStringLiteral( "qgis/networkAndProxy/networkTimeout" ) );
 
-  settingsLayerTreeShowFeatureCountForNewLayers->copyValueToKey( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
+  settingsLayerTreeShowFeatureCountForNewLayers->copyValueToKeyIfChanged( QStringLiteral( "core/layer-tree/show_feature_count_for_new_layers" ) );
 
 #if defined( HAVE_QTSERIALPORT )
-  QgsGpsDetector::settingsGpsStopBits->copyValueToKey( QStringLiteral( "core/gps/stop_bits" ) );
-  QgsGpsDetector::settingsGpsFlowControl->copyValueToKey( QStringLiteral( "core/gps/flow_control" ) );
-  QgsGpsDetector::settingsGpsDataBits->copyValueToKey( QStringLiteral( "core/gps/data_bits" ) );
-  QgsGpsDetector::settingsGpsParity->copyValueToKey( QStringLiteral( "core/gps/parity" ) );
+  QgsGpsDetector::settingsGpsStopBits->copyValueToKeyIfChanged( QStringLiteral( "core/gps/stop_bits" ) );
+  QgsGpsDetector::settingsGpsFlowControl->copyValueToKeyIfChanged( QStringLiteral( "core/gps/flow_control" ) );
+  QgsGpsDetector::settingsGpsDataBits->copyValueToKeyIfChanged( QStringLiteral( "core/gps/data_bits" ) );
+  QgsGpsDetector::settingsGpsParity->copyValueToKeyIfChanged( QStringLiteral( "core/gps/parity" ) );
 #endif
 
   QgsRasterLayer::settingsRasterDefaultOversampling->copyValueToKey( QStringLiteral( "Raster/defaultOversampling" ) );
@@ -414,11 +418,12 @@ void QgsSettingsRegistryCore::backwardCompatibility()
   pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueToKey( QStringLiteral( "core/rendering/label_candidates_limit_lines" ) );
   pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueToKey( QStringLiteral( "core/rendering/label_candidates_limit_polygons" ) );
 
-
   // digitizing settings - added in 3.30
   {
-    settingsDigitizingLineColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/line_color_red" ), QStringLiteral( "qgis/digitizing/line_color_green" ), QStringLiteral( "qgis/digitizing/line_color_blue" ), QStringLiteral( "qgis/digitizing/line_color_alpha" ) );
-    settingsDigitizingFillColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/fill_color_red" ), QStringLiteral( "qgis/digitizing/fill_color_green" ), QStringLiteral( "qgis/digitizing/fill_color_blue" ), QStringLiteral( "qgis/digitizing/fill_color_alpha" ) );
+    if ( settingsDigitizingLineColor->hasChanged() )
+      settingsDigitizingLineColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/line_color_red" ), QStringLiteral( "qgis/digitizing/line_color_green" ), QStringLiteral( "qgis/digitizing/line_color_blue" ), QStringLiteral( "qgis/digitizing/line_color_alpha" ) );
+    if ( settingsDigitizingFillColor->hasChanged() )
+      settingsDigitizingFillColor->copyValueToKeys( QStringLiteral( "qgis/digitizing/fill_color_red" ), QStringLiteral( "qgis/digitizing/fill_color_green" ), QStringLiteral( "qgis/digitizing/fill_color_blue" ), QStringLiteral( "qgis/digitizing/fill_color_alpha" ) );
 
     const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
     for ( const QgsSettingsEntryBase *setting : settings )
@@ -437,7 +442,7 @@ void QgsSettingsRegistryCore::backwardCompatibility()
       {
         name.replace( '-', '_' );
       }
-      setting->copyValueToKey( QString( "qgis/digitizing/%1" ).arg( name ) );
+      setting->copyValueToKeyIfChanged( QString( "qgis/digitizing/%1" ).arg( name ) );
     }
   }
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -465,8 +465,7 @@ void QgsSettingsRegistryCore::backwardCompatibility()
       const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( {service.toLower()} );
       if ( connections.count() == 0 )
         continue;
-      QgsSettings settings;
-      settings.beginGroup( QStringLiteral( "qgis/connections-%1" ).arg( service.toLower() ) );
+
       for ( const QString &connection : connections )
       {
         QgsOwsConnection::settingsUrl->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/url" ), {service.toLower(), connection} );
@@ -484,29 +483,27 @@ void QgsSettingsRegistryCore::backwardCompatibility()
         QgsOwsConnection::settingsIgnoreAxisOrientation->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/ignoreAxisOrientation" ), {service.toLower(), connection} );
         QgsOwsConnection::settingsInvertAxisOrientation->copyValueToKey( QStringLiteral( "qgis/connections-%1/%2/invertAxisOrientation" ), {service.toLower(), connection} );
 
-        Q_NOWARN_DEPRECATED_PUSH
-        settings.beginGroup( service );
         if ( QgsOwsConnection::settingsHeaders->exists( connection ) )
-          QgsHttpHeaders( QgsOwsConnection::settingsHeaders->value( {service.toLower(), service} ) ).updateSettings( settings );
-        settings.endGroup();
-        Q_NOWARN_DEPRECATED_POP
+        {
+          Q_NOWARN_DEPRECATED_PUSH
+          const QgsHttpHeaders headers = QgsHttpHeaders( QgsOwsConnection::settingsHeaders->value( {service.toLower(), service} ) );
+          settings->beginGroup( QStringLiteral( "qgis/connections-%1/%2" ).arg( service.toLower(), connection ) );
+          headers.updateSettings( *settings );
+          settings->endGroup();
+          Q_NOWARN_DEPRECATED_POP
+        }
 
         QgsOwsConnection::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/username" ), {service, connection} );
         QgsOwsConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/password" ), {service, connection} );
         QgsOwsConnection::settingsAuthCfg->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ), {service, connection} );
-
-        if ( settings.contains( QStringLiteral( "selected" ) ) )
-          QgsOwsConnection::sTreeOwsConnections->setSelectedItem( settings.value( QStringLiteral( "selected" ) ).toString(), {service.toLower()} );
       }
     }
   }
 
-  // Vector tile - added in 3.30
+// Vector tile - added in 3.30
   {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-vector-tile" ) );
-
     const QStringList connections = QgsVectorTileProviderConnection::sTreeConnectionVectorTile->items();
+
     for ( const QString &connection : connections )
     {
       // do not overwrite already set setting
@@ -518,19 +515,20 @@ void QgsSettingsRegistryCore::backwardCompatibility()
       QgsVectorTileProviderConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/password" ), {connection} );
       QgsVectorTileProviderConnection::settingsStyleUrl->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/styleUrl" ), {connection} );
       QgsVectorTileProviderConnection::settingsServiceType->copyValueToKey( QStringLiteral( "qgis/connections-vector-tile/%1/serviceType" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
+
       if ( QgsVectorTileProviderConnection::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsVectorTileProviderConnection::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
+      {
+        Q_NOWARN_DEPRECATED_PUSH        const QgsHttpHeaders headers = QgsHttpHeaders( QgsVectorTileProviderConnection::settingsHeaders->value( connection ) );
+        settings->beginGroup( QStringLiteral( "qgis/connections-vector-tile/%1" ).arg( connection ) );
+        headers.updateSettings( *settings );
+        settings->endGroup();
+        Q_NOWARN_DEPRECATED_POP
+      }
     }
   }
 
   // xyz - added in 3.30
   {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-xyz" ) );
     const QStringList connections = QgsXyzConnectionSettings::sTreeXyzConnections->items();
     for ( const QString &connection : connections )
     {
@@ -543,20 +541,21 @@ void QgsSettingsRegistryCore::backwardCompatibility()
       QgsXyzConnectionSettings::settingsTilePixelRatio->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/tilePixelRatio" ), {connection} );
       QgsXyzConnectionSettings::settingsHidden->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/hidden" ), {connection} );
       QgsXyzConnectionSettings::settingsInterpretation->copyValueToKey( QStringLiteral( "qgis/connections-xyz/%1/interpretation" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
+
       if ( QgsXyzConnectionSettings::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsXyzConnectionSettings::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
+      {
+        Q_NOWARN_DEPRECATED_PUSH
+        const QgsHttpHeaders headers = QgsHttpHeaders( QgsXyzConnectionSettings::settingsHeaders->value( connection ) );
+        settings->beginGroup( QStringLiteral( "qgis/connections-xyz/%1" ).arg( connection ) );
+        headers.updateSettings( *settings );
+        settings->endGroup();
+        Q_NOWARN_DEPRECATED_POP
+      }
     }
   }
 
   // Arcgis - added in 3.30
   {
-    QgsSettings settings;
-    settings.beginGroup( QStringLiteral( "qgis/connections-arcgisfeatureserver" ) );
-
     const QStringList connections = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
     for ( const QString &connection : connections )
     {
@@ -567,12 +566,18 @@ void QgsSettingsRegistryCore::backwardCompatibility()
       QgsArcGisConnectionSettings::settingsPassword->copyValueToKey( QStringLiteral( "qgis/ARCGISFEATURESERVER/%1/password" ), {connection} );
       QgsArcGisConnectionSettings::settingsContentEndpoint->copyValueToKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/content_endpoint" ), {connection} );
       QgsArcGisConnectionSettings::settingsCommunityEndpoint->copyValueToKey( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1/community_endpoint" ), {connection} );
-      Q_NOWARN_DEPRECATED_PUSH
-      settings.beginGroup( connection );
       if ( QgsArcGisConnectionSettings::settingsHeaders->exists( connection ) )
-        QgsHttpHeaders( QgsArcGisConnectionSettings::settingsHeaders->value( connection ) ).updateSettings( settings );
-      settings.endGroup();
-      Q_NOWARN_DEPRECATED_POP
+      {
+        if ( QgsArcGisConnectionSettings::settingsHeaders->exists( connection ) )
+        {
+          Q_NOWARN_DEPRECATED_PUSH
+          const QgsHttpHeaders headers = QgsHttpHeaders( QgsArcGisConnectionSettings::settingsHeaders->value( connection ) );
+          settings->beginGroup( QStringLiteral( "qgis/connections-arcgisfeatureserver/%1" ).arg( connection ) );
+          headers.updateSettings( *settings );
+          settings->endGroup();
+          Q_NOWARN_DEPRECATED_POP
+        }
+      }
     }
   }
 

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -38,7 +38,7 @@ QgsSettingsRegistryGui::~QgsSettingsRegistryGui()
 {
   // TODO QGIS 4.0: Remove
   // backward compatibility for settings
-  settingsRespectScreenDPI->copyValueToKey( QStringLiteral( "gui/qgis/respect_screen_dpi" ) );
+  settingsRespectScreenDPI->copyValueToKeyIfChanged( QStringLiteral( "gui/qgis/respect_screen_dpi" ) );
 
 }
 

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -39,6 +39,7 @@ class TestQgsSettingsEntry : public QObject
     void enumValue();
     void flagValue();
     void testFormerValue();
+    void testChanged();
 };
 
 void TestQgsSettingsEntry::settingsKey()
@@ -208,6 +209,26 @@ void TestQgsSettingsEntry::testFormerValue()
 
   settingsEntryInteger.setValue( 2 );
   QCOMPARE( settingsEntryInteger.formerValue(), 3 );
+}
+
+void TestQgsSettingsEntry::testChanged()
+{
+  const QString settingsKey( QStringLiteral( "settingsEntryInteger/integer-value" ) );
+  QgsSettings().remove( QStringLiteral( "%1/%2" ).arg( mSettingsSection, settingsKey ) );
+  int defaultValue = 111;
+
+  QgsSettings().setValue( QStringLiteral( "testSetting" ), 1 );
+
+  QgsSettingsEntryInteger settingsEntryInteger = QgsSettingsEntryInteger( settingsKey, mSettingsSection, defaultValue );
+  QVERIFY( !settingsEntryInteger.hasChanged() );
+  settingsEntryInteger.copyValueToKeyIfChanged( QStringLiteral( "testSetting" ) );
+  QCOMPARE( QgsSettings().value( QStringLiteral( "testSetting" ) ).toInt(), 1 );
+
+  settingsEntryInteger.setValue( 11111 );
+  QVERIFY( settingsEntryInteger.hasChanged() );
+
+  settingsEntryInteger.copyValueToKeyIfChanged( QStringLiteral( "testSetting" ) );
+  QCOMPARE( QgsSettings().value( QStringLiteral( "testSetting" ) ).toInt(), 11111 );
 }
 
 


### PR DESCRIPTION
The backward compatibility code is very expensive, as it triggers a huge number of QSetting object creation and destruction.

We only need to perform this for settings which have changed, so add API to flag changed settings and only perform backward migration of changed settings.

This dramatically improves QgsApplication shutdown time (cuts 1.5 seconds off shutdown on a release build!!)

Refs https://github.com/qgis/QGIS/issues/54563