### PR TITLE
[Processing] init first algorithms from geometry_checker

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -60,6 +60,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmcategorizeusingstyle.cpp
   processing/qgsalgorithmcellstatistics.cpp
   processing/qgsalgorithmcentroid.cpp
+  processing/qgsalgorithmcheckgeometryarea.cpp
   processing/qgsalgorithmcheckgeometrydangle.cpp
   processing/qgsalgorithmcheckgeometrymultipart.cpp
   processing/qgsalgorithmclip.cpp

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -60,6 +60,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmcategorizeusingstyle.cpp
   processing/qgsalgorithmcellstatistics.cpp
   processing/qgsalgorithmcentroid.cpp
+  processing/qgsalgorithmcheckgeometrydangle.cpp
   processing/qgsalgorithmclip.cpp
   processing/qgsalgorithmconcavehull.cpp
   processing/qgsalgorithmconditionalbranch.cpp

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -61,6 +61,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmcellstatistics.cpp
   processing/qgsalgorithmcentroid.cpp
   processing/qgsalgorithmcheckgeometrydangle.cpp
+  processing/qgsalgorithmcheckgeometrymultipart.cpp
   processing/qgsalgorithmclip.cpp
   processing/qgsalgorithmconcavehull.cpp
   processing/qgsalgorithmconditionalbranch.cpp

--- a/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
@@ -1,0 +1,302 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometryarea.cpp
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmcheckgeometryarea.h"
+#include "qgsgeometrycheckcontext.h"
+#include "qgsgeometrycheckerror.h"
+#include "qgsgeometryareacheck.h"
+#include "qgspoint.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataproviderfeaturepool.h"
+
+///@cond PRIVATE
+
+auto QgsGeometryCheckAreaAlgorithm::name() const -> QString
+{
+  return QStringLiteral( "checkgeometryarea" );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::displayName() const -> QString
+{
+  return QObject::tr( "Check Geometry (Area)" );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::tags() const -> QStringList
+{
+  return QObject::tr( "check,geometry,area" ).split( ',' );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::group() const -> QString
+{
+  return QObject::tr( "Check geometry" );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::groupId() const -> QString
+{
+  return QStringLiteral( "checkgeometry" );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::shortHelpString() const -> QString
+{
+  return QObject::tr( "This algorithm check the area of geometry (polygon)." );
+}
+
+auto QgsGeometryCheckAreaAlgorithm::flags() const -> QgsProcessingAlgorithm::Flags
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagSupportsInPlaceEdits;
+}
+
+auto QgsGeometryCheckAreaAlgorithm::createInstance() const -> QgsGeometryCheckAreaAlgorithm *
+{
+  return new QgsGeometryCheckAreaAlgorithm();
+}
+
+static auto resolutionMethods() -> QStringList
+{
+  static const QStringList methods = QStringList()
+                                     << QObject::tr( "Merge with neighboring polygon with longest shared edge" )
+                                     << QObject::tr( "Merge with neighboring polygon with largest area" )
+                                     << QObject::tr( "Merge with neighboring polygon with identical attribute value, if any, or leave as is" )
+                                     << QObject::tr( "Delete feature" )
+                                     << QObject::tr( "No action" );
+  return methods;
+}
+
+void QgsGeometryCheckAreaAlgorithm::initAlgorithm( const QVariantMap &configuration )
+{
+
+  mIsInPlace = configuration.value( QStringLiteral( "IN_PLACE" ) ).toBool();
+
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "ERRORS" ), QObject::tr( "Errors layer" ), QgsProcessing::TypeVectorPoint ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Output layer" ), QgsProcessing::TypeVectorPolygon ) );
+
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "AREATHRESHOLD" ), QObject::tr( "area threshold" ), QgsProcessingParameterNumber::Double, 0, false, 0.0 ) );
+
+  std::unique_ptr< QgsProcessingParameterNumber > tolerance = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "TOLERANCE" ),
+      QObject::tr( "Tolerance" ), QgsProcessingParameterNumber::Integer, 8, false, 1, 13 );
+  tolerance->setFlags( tolerance->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( tolerance.release() );
+
+  if ( mIsInPlace )
+  {
+    // resolutionMethod is deprecated and not static and availableResolutionmethod is not static either
+    // We need a QStringList here, so copy/paste from resolutionMethod()
+//  Q_NOWARN_DEPRECATED_PUSH
+//  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD"), QObject::tr( "Resolution method"), QgsGeometryAreaCheck::resolutionMethods() ) );
+//  Q_NOWARN_DEPRECATED_POP
+    addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD" ), QObject::tr( "Resolution method" ), resolutionMethods(), false, resolutionMethods().size() - 1 ) );
+  }
+}
+
+auto QgsGeometryCheckAreaAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) -> bool
+{
+  mTolerance = parameterAsInt( parameters, QStringLiteral( "TOLERANCE" ), context );
+
+  return true;
+}
+
+auto QgsGeometryCheckAreaAlgorithm::createFeaturePool( QgsVectorLayer *layer, bool selectedOnly ) const -> QgsFeaturePool *
+{
+
+  return new QgsVectorDataProviderFeaturePool( layer, selectedOnly );
+}
+
+static auto outputFields( ) -> QgsFields
+{
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "gc_layerid" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_layername" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_featid" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_partidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_ringidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_vertidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_errorx" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_errory" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_error" ), QVariant::String ) );
+  return fields;
+}
+
+
+auto QgsGeometryCheckAreaAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) -> QVariantMap
+{
+  QString dest_output;
+  QString dest_errors;
+  std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+  if ( !source )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  mInputLayer.reset( source->materialize( QgsFeatureRequest() ) );
+
+  if ( !mInputLayer.get() )
+    throw QgsProcessingException( QObject::tr( "Could not load source layer for INPUT" ) );
+
+  QgsFields fields = outputFields();
+
+  std::unique_ptr< QgsFeatureSink > sink_output( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest_output, fields, mInputLayer->wkbType(), mInputLayer->sourceCrs() ) );
+  if ( !sink_output )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+  }
+  std::unique_ptr< QgsFeatureSink > sink_errors( parameterAsSink( parameters, QStringLiteral( "ERRORS" ), context, dest_errors, fields, Qgis::WkbType::Point, mInputLayer->sourceCrs() ) );
+  if ( !sink_errors )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "ERRORS" ) ) );
+  }
+
+  int resolutionMethod{-1};
+  if ( mIsInPlace )
+  {
+    resolutionMethod = parameterAsEnum( parameters, QStringLiteral( "RESOLUTIONMETHOD" ), context );
+  }
+
+  QgsProcessingMultiStepFeedback multiStepFeedback( mIsInPlace ? 4 : 3, feedback );
+
+  QgsProject *project = mInputLayer->project() ? mInputLayer->project() : QgsProject::instance();
+
+  std::unique_ptr<QgsGeometryCheckContext> checkContext = std::make_unique<QgsGeometryCheckContext>( mTolerance, mInputLayer->sourceCrs(), project->transformContext(), project );
+
+  // Test detection
+  QList<QgsGeometryCheckError *> checkErrors;
+  QStringList messages;
+
+  double areaThreshold = parameterAsDouble( parameters, QStringLiteral( "AREATHRESHOLD" ), context );
+
+  QVariantMap configurationCheck;
+  configurationCheck.insert( "areaThreshold", areaThreshold );
+  const QgsGeometryAreaCheck check( checkContext.get(), configurationCheck );
+
+  multiStepFeedback.setCurrentStep( 1 );
+  feedback->setProgressText( QObject::tr( "Preparing features…" ) );
+  QMap<QString, QgsFeaturePool *> featurePools;
+  featurePools.insert( mInputLayer->id(), createFeaturePool( mInputLayer.get() ) );
+
+  multiStepFeedback.setCurrentStep( 2 );
+  feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
+  check.collectErrors( featurePools, checkErrors, messages, feedback );
+
+  multiStepFeedback.setCurrentStep( 3 );
+  feedback->setProgressText( QObject::tr( "Exporting errors…" ) );
+  double step{checkErrors.size() > 0 ? 100.0 / checkErrors.size() : 1};
+  long i = 0;
+  feedback->setProgress( 0.0 );
+
+
+  for ( QgsGeometryCheckError *error : checkErrors )
+  {
+
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+    QgsFeature f;
+    QgsAttributes attrs = f.attributes();
+
+    attrs << error->layerId()
+          << mInputLayer->name()
+          << error->featureId()
+          << error->vidx().part
+          << error->vidx().ring
+          << error->vidx().vertex
+          << error->location().x()
+          << error->location().y()
+          << error->value().toString();
+    f.setAttributes( attrs );
+
+    if ( mIsInPlace )
+    {
+      QgsGeometryCheck::Changes changes;
+      QMap<QString, int> mergeIndice;
+      check.fixError( featurePools, error, resolutionMethod, mergeIndice, changes );
+    }
+    else
+    {
+      f.setGeometry( error->geometry() );
+      if ( !sink_output->addFeature( f, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+
+    f.setGeometry( QgsGeometry::fromPoint( QgsPoint( error->location().x(), error->location().y() ) ) );
+    if ( !sink_errors->addFeature( f, QgsFeatureSink::FastInsert ) )
+      throw QgsProcessingException( writeFeatureError( sink_errors.get(), parameters, QStringLiteral( "ERRORS" ) ) );
+
+    i++;
+    feedback->setProgress( 100.0 * step * static_cast<double>( i ) );
+  }
+
+
+  multiStepFeedback.setCurrentStep( 4 );
+  feedback->setProgressText( QObject::tr( "Exporting (fixed) layer…" ) );
+
+  if ( mIsInPlace )
+  {
+    const QgsFeaturePool *featurePool = featurePools[ mInputLayer->id() ];
+    QgsFeatureIds featureIds{featurePool->allFeatureIds()};
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( featureIds )};
+
+    step = featureIds.size() > 0 ? 100.0 / featureIds.size() : 0;
+    feedback->setProgress( 100.0 * step );
+
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+  else
+  {
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( )};
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest_output );
+  outputs.insert( QStringLiteral( "ERRORS" ), dest_errors );
+
+  return outputs;
+}
+
+bool QgsGeometryCheckAreaAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  if ( const QgsVectorLayer *vl = qobject_cast< const QgsVectorLayer * >( layer ) )
+  {
+    return vl->geometryType() == Qgis::GeometryType::Polygon;
+  }
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmcheckgeometryarea.h
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryarea.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometryarea.h
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMCHECKGEOMETRYAREA_H
+#define QGSALGORITHMCHECKGEOMETRYAREA_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsfeaturepool.h"
+
+///@cond PRIVATE
+
+class QgsGeometryCheckAreaAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+
+    QgsGeometryCheckAreaAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    Flags flags() const override;
+    QgsGeometryCheckAreaAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+    QgsFeaturePool *createFeaturePool( QgsVectorLayer *layer, bool selectedOnly = false ) const;
+
+    std::unique_ptr< QgsVectorLayer > mInputLayer;
+    int mTolerance{8};
+    bool mIsInPlace{false};
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMCHECKGEOMETRYAREA_H

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
@@ -1,0 +1,289 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometrydangle.cpp
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmcheckgeometrydangle.h"
+#include "qgsgeometrycheckcontext.h"
+#include "qgsgeometrycheckerror.h"
+#include "qgsgeometrydanglecheck.h"
+#include "qgspoint.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataproviderfeaturepool.h"
+
+///@cond PRIVATE
+
+auto QgsGeometryCheckDangleAlgorithm::name() const -> QString
+{
+  return QStringLiteral( "checkgeometrydangle" );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::displayName() const -> QString
+{
+  return QObject::tr( "Check Geometry (Dangle)" );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::tags() const -> QStringList
+{
+  return QObject::tr( "check,geometry,dangle" ).split( ',' );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::group() const -> QString
+{
+  return QObject::tr( "Check geometry" );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::groupId() const -> QString
+{
+  return QStringLiteral( "checkgeometry" );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::shortHelpString() const -> QString
+{
+  return QObject::tr( "This algorithm check the dangle of geometry (linestring)." );
+}
+
+auto QgsGeometryCheckDangleAlgorithm::flags() const -> QgsProcessingAlgorithm::Flags
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagSupportsInPlaceEdits;
+}
+
+auto QgsGeometryCheckDangleAlgorithm::createInstance() const -> QgsGeometryCheckDangleAlgorithm *
+{
+  return new QgsGeometryCheckDangleAlgorithm();
+}
+
+static auto resolutionMethods() -> QStringList
+{
+  return QStringList() << QObject::tr( "No action" );
+}
+
+void QgsGeometryCheckDangleAlgorithm::initAlgorithm( const QVariantMap &configuration )
+{
+
+  mIsInPlace = configuration.value( QStringLiteral( "IN_PLACE" ) ).toBool();
+
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList< int >() << QgsProcessing::TypeVectorLine ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "ERRORS" ), QObject::tr( "Errors layer" ), QgsProcessing::TypeVectorPoint ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Output layer" ), QgsProcessing::TypeVectorLine ) );
+
+  std::unique_ptr< QgsProcessingParameterNumber > tolerance = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "TOLERANCE" ),
+      QObject::tr( "Tolerance" ), QgsProcessingParameterNumber::Integer, 8, false, 1, 13 );
+  tolerance->setFlags( tolerance->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( tolerance.release() );
+
+  if ( mIsInPlace )
+  {
+    // resolutionMethod is deprecated and not static and availableResolutionmethod is not static either
+    // We need a QStringList here, so copy/paste from resolutionMethod()
+//  Q_NOWARN_DEPRECATED_PUSH
+//  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD"), QObject::tr( "Resolution method"), QgsGeometryDangleCheck::resolutionMethods() ) );
+//  Q_NOWARN_DEPRECATED_POP
+    addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD" ), QObject::tr( "Resolution method" ), resolutionMethods(), false, resolutionMethods().size() - 1 ) );
+  }
+}
+
+auto QgsGeometryCheckDangleAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) -> bool
+{
+  mTolerance = parameterAsInt( parameters, QStringLiteral( "TOLERANCE" ), context );
+
+  return true;
+}
+
+auto QgsGeometryCheckDangleAlgorithm::createFeaturePool( QgsVectorLayer *layer, bool selectedOnly ) const -> QgsFeaturePool *
+{
+
+  return new QgsVectorDataProviderFeaturePool( layer, selectedOnly );
+}
+
+static auto outputFields( ) -> QgsFields
+{
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "gc_layerid" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_layername" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_featid" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_partidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_ringidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_vertidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_errorx" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_errory" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_error" ), QVariant::String ) );
+  return fields;
+}
+
+
+auto QgsGeometryCheckDangleAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) -> QVariantMap
+{
+  QString dest_output;
+  QString dest_errors;
+  std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+  if ( !source )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  mInputLayer.reset( source->materialize( QgsFeatureRequest() ) );
+
+  if ( !mInputLayer.get() )
+    throw QgsProcessingException( QObject::tr( "Could not load source layer for INPUT" ) );
+
+  QgsFields fields = outputFields();
+
+  std::unique_ptr< QgsFeatureSink > sink_output( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest_output, fields, mInputLayer->wkbType(), mInputLayer->sourceCrs() ) );
+  if ( !sink_output )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+  }
+  std::unique_ptr< QgsFeatureSink > sink_errors( parameterAsSink( parameters, QStringLiteral( "ERRORS" ), context, dest_errors, fields, Qgis::WkbType::Point, mInputLayer->sourceCrs() ) );
+  if ( !sink_errors )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "ERRORS" ) ) );
+  }
+
+  int resolutionMethod{-1};
+  if ( mIsInPlace )
+  {
+    resolutionMethod = parameterAsEnum( parameters, QStringLiteral( "RESOLUTIONMETHOD" ), context );
+  }
+
+  QgsProcessingMultiStepFeedback multiStepFeedback( mIsInPlace ? 4 : 3, feedback );
+
+  QgsProject *project = mInputLayer->project() ? mInputLayer->project() : QgsProject::instance();
+  std::unique_ptr<QgsGeometryCheckContext> checkContext = std::make_unique<QgsGeometryCheckContext>( mTolerance, mInputLayer->sourceCrs(), project->transformContext(), project );
+
+  // Test detection
+  QList<QgsGeometryCheckError *> checkErrors;
+  QStringList messages;
+
+  const QgsGeometryDangleCheck check( checkContext.get(), QVariantMap() );
+
+  multiStepFeedback.setCurrentStep( 1 );
+  feedback->setProgressText( QObject::tr( "Preparing features…" ) );
+  QMap<QString, QgsFeaturePool *> featurePools;
+  featurePools.insert( mInputLayer->id(), createFeaturePool( mInputLayer.get() ) );
+
+  multiStepFeedback.setCurrentStep( 2 );
+  feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
+  check.collectErrors( featurePools, checkErrors, messages, feedback );
+
+  multiStepFeedback.setCurrentStep( 3 );
+  feedback->setProgressText( QObject::tr( "Exporting errors…" ) );
+  double step{checkErrors.size() > 0 ? 100.0 / checkErrors.size() : 1};
+  long i = 0;
+  feedback->setProgress( 0.0 );
+
+
+  for ( QgsGeometryCheckError *error : checkErrors )
+  {
+
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+    QgsFeature f;
+    QgsAttributes attrs = f.attributes();
+
+    attrs << error->layerId()
+          << mInputLayer->name()
+          << error->featureId()
+          << error->vidx().part
+          << error->vidx().ring
+          << error->vidx().vertex
+          << error->location().x()
+          << error->location().y()
+          << error->value().toString();
+    f.setAttributes( attrs );
+
+    if ( mIsInPlace )
+    {
+      QgsGeometryCheck::Changes changes;
+      QMap<QString, int> mergeIndice;
+      check.fixError( featurePools, error, resolutionMethod, mergeIndice, changes );
+    }
+    else
+    {
+      f.setGeometry( error->geometry() );
+      if ( !sink_output->addFeature( f, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+
+    f.setGeometry( QgsGeometry::fromPoint( QgsPoint( error->location().x(), error->location().y() ) ) );
+    if ( !sink_errors->addFeature( f, QgsFeatureSink::FastInsert ) )
+      throw QgsProcessingException( writeFeatureError( sink_errors.get(), parameters, QStringLiteral( "ERRORS" ) ) );
+
+    i++;
+    feedback->setProgress( 100.0 * step * static_cast<double>( i ) );
+  }
+
+
+  multiStepFeedback.setCurrentStep( 4 );
+  feedback->setProgressText( QObject::tr( "Exporting (fixed) layer…" ) );
+
+  if ( mIsInPlace )
+  {
+    const QgsFeaturePool *featurePool = featurePools[ mInputLayer->id() ];
+    QgsFeatureIds featureIds{featurePool->allFeatureIds()};
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( featureIds )};
+
+    step = featureIds.size() > 0 ? 100.0 / featureIds.size() : 0;
+    feedback->setProgress( 100.0 * step );
+
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+  else
+  {
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( )};
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest_output );
+  outputs.insert( QStringLiteral( "ERRORS" ), dest_errors );
+
+  return outputs;
+}
+
+bool QgsGeometryCheckDangleAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  if ( const QgsVectorLayer *vl = qobject_cast< const QgsVectorLayer * >( layer ) )
+  {
+    return vl->geometryType() == Qgis::GeometryType::Line;
+  }
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.h
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometrydangle.h
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMCHECKGEOMETRYDANGLE_H
+#define QGSALGORITHMCHECKGEOMETRYDANGLE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsfeaturepool.h"
+
+///@cond PRIVATE
+
+class QgsGeometryCheckDangleAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+
+    QgsGeometryCheckDangleAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    Flags flags() const override;
+    QgsGeometryCheckDangleAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+    QgsFeaturePool *createFeaturePool( QgsVectorLayer *layer, bool selectedOnly = false ) const;
+
+    std::unique_ptr< QgsVectorLayer > mInputLayer;
+    int mTolerance{8};
+    bool mIsInPlace{false};
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMCHECKGEOMETRYDANGLE_H

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
@@ -1,0 +1,291 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometrymultipart.cpp
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmcheckgeometrymultipart.h"
+#include "qgsgeometrycheckcontext.h"
+#include "qgsgeometrycheckerror.h"
+#include "qgsgeometrymultipartcheck.h"
+#include "qgspoint.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataproviderfeaturepool.h"
+
+///@cond PRIVATE
+
+auto QgsGeometryCheckMultipartAlgorithm::name() const -> QString
+{
+  return QStringLiteral( "checkgeometrymultipart" );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::displayName() const -> QString
+{
+  return QObject::tr( "Check Geometry (Multipart)" );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::tags() const -> QStringList
+{
+  return QObject::tr( "check,geometry,multipart" ).split( ',' );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::group() const -> QString
+{
+  return QObject::tr( "Check geometry" );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::groupId() const -> QString
+{
+  return QStringLiteral( "checkgeometry" );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::shortHelpString() const -> QString
+{
+  return QObject::tr( "This algorithm check the multipart of geometry." );
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::flags() const -> QgsProcessingAlgorithm::Flags
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagSupportsInPlaceEdits;
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::createInstance() const -> QgsGeometryCheckMultipartAlgorithm *
+{
+  return new QgsGeometryCheckMultipartAlgorithm();
+}
+
+static auto resolutionMethods() -> QStringList
+{
+  return QStringList() << QObject::tr( "Convert to single part feature" )
+         << QObject::tr( "Delete feature" )
+         << QObject::tr( "No action" );
+}
+
+void QgsGeometryCheckMultipartAlgorithm::initAlgorithm( const QVariantMap &configuration )
+{
+
+  mIsInPlace = configuration.value( QStringLiteral( "IN_PLACE" ) ).toBool();
+
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList< int >() << QgsProcessing::TypeVectorLine ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "ERRORS" ), QObject::tr( "Errors layer" ), QgsProcessing::TypeVectorPoint ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Output layer" ), QgsProcessing::TypeVectorLine ) );
+
+  std::unique_ptr< QgsProcessingParameterNumber > tolerance = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "TOLERANCE" ),
+      QObject::tr( "Tolerance" ), QgsProcessingParameterNumber::Integer, 8, false, 1, 13 );
+  tolerance->setFlags( tolerance->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( tolerance.release() );
+
+  if ( mIsInPlace )
+  {
+    // resolutionMethod is deprecated and not static and availableResolutionmethod is not static either
+    // We need a QStringList here, so copy/paste from resolutionMethod()
+//  Q_NOWARN_DEPRECATED_PUSH
+//  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD"), QObject::tr( "Resolution method"), QgsGeometryMultipartCheck::resolutionMethods() ) );
+//  Q_NOWARN_DEPRECATED_POP
+    addParameter( new QgsProcessingParameterEnum( QStringLiteral( "RESOLUTIONMETHOD" ), QObject::tr( "Resolution method" ), resolutionMethods(), false, resolutionMethods().size() - 1 ) );
+  }
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * ) -> bool
+{
+  mTolerance = parameterAsInt( parameters, QStringLiteral( "TOLERANCE" ), context );
+
+  return true;
+}
+
+auto QgsGeometryCheckMultipartAlgorithm::createFeaturePool( QgsVectorLayer *layer, bool selectedOnly ) const -> QgsFeaturePool *
+{
+
+  return new QgsVectorDataProviderFeaturePool( layer, selectedOnly );
+}
+
+static auto outputFields( ) -> QgsFields
+{
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "gc_layerid" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_layername" ), QVariant::String ) );
+  fields.append( QgsField( QStringLiteral( "gc_featid" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_partidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_ringidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_vertidx" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "gc_errorx" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_errory" ), QVariant::Double ) );
+  fields.append( QgsField( QStringLiteral( "gc_error" ), QVariant::String ) );
+  return fields;
+}
+
+
+auto QgsGeometryCheckMultipartAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) -> QVariantMap
+{
+  QString dest_output;
+  QString dest_errors;
+  std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+  if ( !source )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  mInputLayer.reset( source->materialize( QgsFeatureRequest() ) );
+
+  if ( !mInputLayer.get() )
+    throw QgsProcessingException( QObject::tr( "Could not load source layer for INPUT" ) );
+
+  QgsFields fields = outputFields();
+
+  std::unique_ptr< QgsFeatureSink > sink_output( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest_output, fields, mInputLayer->wkbType(), mInputLayer->sourceCrs() ) );
+  if ( !sink_output )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+  }
+  std::unique_ptr< QgsFeatureSink > sink_errors( parameterAsSink( parameters, QStringLiteral( "ERRORS" ), context, dest_errors, fields, Qgis::WkbType::Point, mInputLayer->sourceCrs() ) );
+  if ( !sink_errors )
+  {
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "ERRORS" ) ) );
+  }
+
+  int resolutionMethod{-1};
+  if ( mIsInPlace )
+  {
+    resolutionMethod = parameterAsEnum( parameters, QStringLiteral( "RESOLUTIONMETHOD" ), context );
+  }
+
+  QgsProcessingMultiStepFeedback multiStepFeedback( mIsInPlace ? 4 : 3, feedback );
+
+  QgsProject *project = mInputLayer->project() ? mInputLayer->project() : QgsProject::instance();
+  std::unique_ptr<QgsGeometryCheckContext> checkContext = std::make_unique<QgsGeometryCheckContext>( mTolerance, mInputLayer->sourceCrs(), project->transformContext(), project );
+
+  // Test detection
+  QList<QgsGeometryCheckError *> checkErrors;
+  QStringList messages;
+
+  const QgsGeometryMultipartCheck check( checkContext.get(), QVariantMap() );
+
+  multiStepFeedback.setCurrentStep( 1 );
+  feedback->setProgressText( QObject::tr( "Preparing features…" ) );
+  QMap<QString, QgsFeaturePool *> featurePools;
+  featurePools.insert( mInputLayer->id(), createFeaturePool( mInputLayer.get() ) );
+
+  multiStepFeedback.setCurrentStep( 2 );
+  feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
+  check.collectErrors( featurePools, checkErrors, messages, feedback );
+
+  multiStepFeedback.setCurrentStep( 3 );
+  feedback->setProgressText( QObject::tr( "Exporting errors…" ) );
+  double step{checkErrors.size() > 0 ? 100.0 / checkErrors.size() : 1};
+  long i = 0;
+  feedback->setProgress( 0.0 );
+
+
+  for ( QgsGeometryCheckError *error : checkErrors )
+  {
+
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+    QgsFeature f;
+    QgsAttributes attrs = f.attributes();
+
+    attrs << error->layerId()
+          << mInputLayer->name()
+          << error->featureId()
+          << error->vidx().part
+          << error->vidx().ring
+          << error->vidx().vertex
+          << error->location().x()
+          << error->location().y()
+          << error->value().toString();
+    f.setAttributes( attrs );
+
+    if ( mIsInPlace )
+    {
+      QgsGeometryCheck::Changes changes;
+      QMap<QString, int> mergeIndice;
+      check.fixError( featurePools, error, resolutionMethod, mergeIndice, changes );
+    }
+    else
+    {
+      f.setGeometry( error->geometry() );
+      if ( !sink_output->addFeature( f, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+
+    f.setGeometry( QgsGeometry::fromPoint( QgsPoint( error->location().x(), error->location().y() ) ) );
+    if ( !sink_errors->addFeature( f, QgsFeatureSink::FastInsert ) )
+      throw QgsProcessingException( writeFeatureError( sink_errors.get(), parameters, QStringLiteral( "ERRORS" ) ) );
+
+    i++;
+    feedback->setProgress( 100.0 * step * static_cast<double>( i ) );
+  }
+
+
+  multiStepFeedback.setCurrentStep( 4 );
+  feedback->setProgressText( QObject::tr( "Exporting (fixed) layer…" ) );
+
+  if ( mIsInPlace )
+  {
+    const QgsFeaturePool *featurePool = featurePools[ mInputLayer->id() ];
+    QgsFeatureIds featureIds{featurePool->allFeatureIds()};
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( featureIds )};
+
+    step = featureIds.size() > 0 ? 100.0 / featureIds.size() : 0;
+    feedback->setProgress( 100.0 * step );
+
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+  else
+  {
+    QgsFeatureIterator featIt{mInputLayer->getFeatures( )};
+    QgsFeature feat;
+    while ( featIt.nextFeature( feat ) )
+    {
+      if ( feedback->isCanceled() )
+      {
+        break;
+      }
+
+      if ( !sink_output->addFeature( feat, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink_output.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest_output );
+  outputs.insert( QStringLiteral( "ERRORS" ), dest_errors );
+
+  return outputs;
+}
+
+bool QgsGeometryCheckMultipartAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  if ( const QgsVectorLayer *vl = qobject_cast< const QgsVectorLayer * >( layer ) )
+  {
+    return vl->geometryType() == Qgis::GeometryType::Line;
+  }
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.h
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+                        qgsalgorithmcheckgeometrymultipart.h
+                        ---------------------
+   begin                : November 2023
+   copyright            : (C) 2023 by Loïc Bartoletti
+   email                : loic dot bartoletti at oslandia dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMCHECKGEOMETRYMULTIPART_H
+#define QGSALGORITHMCHECKGEOMETRYMULTIPART_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsfeaturepool.h"
+
+///@cond PRIVATE
+
+class QgsGeometryCheckMultipartAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+
+    QgsGeometryCheckMultipartAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    Flags flags() const override;
+    QgsGeometryCheckMultipartAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+    QgsFeaturePool *createFeaturePool( QgsVectorLayer *layer, bool selectedOnly = false ) const;
+
+    std::unique_ptr< QgsVectorLayer > mInputLayer;
+    int mTolerance{8};
+    bool mIsInPlace{false};
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMCHECKGEOMETRYMULTIPART_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -41,6 +41,7 @@
 #include "qgsalgorithmcategorizeusingstyle.h"
 #include "qgsalgorithmcellstatistics.h"
 #include "qgsalgorithmcentroid.h"
+#include "qgsalgorithmcheckgeometrydangle.h"
 #include "qgsalgorithmclip.h"
 #include "qgsalgorithmconcavehull.h"
 #include "qgsalgorithmconditionalbranch.h"
@@ -308,6 +309,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCellStatisticsPercentRankFromRasterAlgorithm() );
   addAlgorithm( new QgsCellStatisticsPercentRankFromValueAlgorithm() );
   addAlgorithm( new QgsCentroidAlgorithm() );
+  addAlgorithm( new QgsGeometryCheckDangleAlgorithm() );
   addAlgorithm( new QgsClipAlgorithm() );
   addAlgorithm( new QgsCollectAlgorithm() );
   addAlgorithm( new QgsCombineStylesAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -42,6 +42,7 @@
 #include "qgsalgorithmcellstatistics.h"
 #include "qgsalgorithmcentroid.h"
 #include "qgsalgorithmcheckgeometrydangle.h"
+#include "qgsalgorithmcheckgeometrymultipart.h"
 #include "qgsalgorithmclip.h"
 #include "qgsalgorithmconcavehull.h"
 #include "qgsalgorithmconditionalbranch.h"
@@ -310,6 +311,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCellStatisticsPercentRankFromValueAlgorithm() );
   addAlgorithm( new QgsCentroidAlgorithm() );
   addAlgorithm( new QgsGeometryCheckDangleAlgorithm() );
+  addAlgorithm( new QgsGeometryCheckMultipartAlgorithm() );
   addAlgorithm( new QgsClipAlgorithm() );
   addAlgorithm( new QgsCollectAlgorithm() );
   addAlgorithm( new QgsCombineStylesAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -41,6 +41,7 @@
 #include "qgsalgorithmcategorizeusingstyle.h"
 #include "qgsalgorithmcellstatistics.h"
 #include "qgsalgorithmcentroid.h"
+#include "qgsalgorithmcheckgeometryarea.h"
 #include "qgsalgorithmcheckgeometrydangle.h"
 #include "qgsalgorithmcheckgeometrymultipart.h"
 #include "qgsalgorithmclip.h"
@@ -310,6 +311,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCellStatisticsPercentRankFromRasterAlgorithm() );
   addAlgorithm( new QgsCellStatisticsPercentRankFromValueAlgorithm() );
   addAlgorithm( new QgsCentroidAlgorithm() );
+  addAlgorithm( new QgsGeometryCheckAreaAlgorithm() );
   addAlgorithm( new QgsGeometryCheckDangleAlgorithm() );
   addAlgorithm( new QgsGeometryCheckMultipartAlgorithm() );
   addAlgorithm( new QgsClipAlgorithm() );

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TESTS
  testqgsinterpolator.cpp
  testqgsprocessingalgspt1.cpp
  testqgsprocessingalgspt2.cpp
+ testqgsprocessingcheckgeometry.cpp
  testqgsprocessingmodelalgorithm.cpp
  testqgszonalstatistics.cpp
  testqgsrastercalculator.cpp

--- a/tests/src/analysis/testqgsprocessingcheckgeometry.cpp
+++ b/tests/src/analysis/testqgsprocessingcheckgeometry.cpp
@@ -1,0 +1,121 @@
+/***************************************************************************
+                         testqgsprocessingcheckgeometry.cpp
+                         ---------------------
+    begin                : December 2023
+    copyright            : (C) 2023 by Jacky Volpes
+    email                : jacky dot volpes at oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include "qgsprocessingregistry.h"
+#include "qgsprocessingutils.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsnativealgorithms.h"
+#include "qgsvectorlayer.h"
+#include "qgscategorizedsymbolrenderer.h"
+#include "qgsrasteranalysisutils.h"
+#include "qgsrasteranalysisutils.cpp"
+#include "qgslayoutmanager.h"
+#include "qgspallabeling.h"
+#include "annotations/qgsannotationmanager.h"
+#include "qgsvectorlayerlabeling.h"
+#include "qgsbookmarkmanager.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgsrelationmanager.h"
+#include <qtestcase.h>
+
+class TestQgsProcessingCheckGeometry: public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsProcessingCheckGeometry() : QgsTest( QStringLiteral( "Processing Algorithms Check Geometry" ) ) {}
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+    void areaAlg();
+    // void multipartAlg();
+    // void dangleAlg();
+
+  private:
+
+    QgsVectorLayer *mLineLayer = nullptr;
+    QgsVectorLayer *mPolygonLayer = nullptr;
+
+    void exportToSpreadsheet( const QString &outputPath );
+};
+
+void TestQgsProcessingCheckGeometry::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QgsApplication::processingRegistry()->addProvider( new QgsNativeAlgorithms( QgsApplication::processingRegistry() ) );
+
+  const QDir testDataDir( QDir( TEST_DATA_DIR ).absoluteFilePath( "geometry_checker" ) );
+
+  //create a line layer that will be used in all tests
+  mLineLayer = new QgsVectorLayer( testDataDir.absoluteFilePath( "line_layer.shp" ), QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
+  // Register the layer with the registry
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLineLayer );
+  QVERIFY( mLineLayer->isValid() );
+
+  //create a poly layer that will be used in all tests
+  mPolygonLayer = new QgsVectorLayer( testDataDir.absoluteFilePath( "polygon_layer.shp" ), QStringLiteral( "polygons" ), QStringLiteral( "ogr" ) );
+  // Register the layer with the registry
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mPolygonLayer );
+  QVERIFY( mPolygonLayer->isValid() );
+}
+
+void TestQgsProcessingCheckGeometry::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsProcessingCheckGeometry::areaAlg()
+{
+  std::unique_ptr< QgsProcessingAlgorithm > alg(
+    QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:checkgeometryarea" ) )
+  );
+  QVERIFY( alg != nullptr );
+
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "INPUT" ), QVariant::fromValue( mPolygonLayer ) );
+  parameters.insert( QStringLiteral( "AREATHRESHOLD" ), 0.04 );
+  parameters.insert( QStringLiteral( "OUTPUT" ), QgsProcessing::TEMPORARY_OUTPUT );
+  parameters.insert( QStringLiteral( "ERRORS" ), QgsProcessing::TEMPORARY_OUTPUT );
+
+  bool ok = false;
+  QgsProcessingFeedback feedback;
+  std::unique_ptr< QgsProcessingContext > context = std::make_unique< QgsProcessingContext >();
+
+  QVariantMap results;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  std::unique_ptr<QgsVectorLayer> outputLayer( qobject_cast< QgsVectorLayer * >( context->getMapLayer( results.value( QStringLiteral( "OUTPUT" ) ).toString() ) ) );
+  std::unique_ptr<QgsVectorLayer> errorsLayer( qobject_cast< QgsVectorLayer * >( context->getMapLayer( results.value( QStringLiteral( "ERRORS" ) ).toString() ) ) );
+  QVERIFY( outputLayer->isValid() );
+  QVERIFY( errorsLayer->isValid() );
+  QCOMPARE( outputLayer->featureCount(), 8 );
+  QCOMPARE( errorsLayer->featureCount(), 8 );
+}
+
+QGSTEST_MAIN( TestQgsProcessingCheckGeometry )
+#include "testqgsprocessingcheckgeometry.moc"


### PR DESCRIPTION
## Description

This Pull Request presents three new processing examples for integration within the scope of QEP 236.

The main goal is to adapt the initial algorithms from Geometry Checker to function within Processing. Each process will follow a consistent logic: one input layer and two distinct outputs for erroneous geometries and identified errors through "error->location". These outputs will be based on QgsGeometryCheckError fields, providing users with additional manipulation possibilities. Other Geometry Checker processes will be added following this review, and we plan to include additional correction/manipulation processes.

The aim is to adapt QGIS verification and correction tools (topology and geometry checker plugins) to make them compatible with Processing. Our foundation lies in some verification and data correction scripts we have encountered or developed during various projects.

To ensure a consistent user experience, each process will operate similarly:

- An input layer, with the ability to select a single layer for each algorithm (using batch mode for multiple layers if needed).
- A default tolerance parameter set at 8 (for 1e-8) in the advanced settings.
- Specific configurations for algorithms (QVariantMap configurationCheck).
- Outputs will display erroneous geometries and their associated points without modification, empowering users to decide on subsequent actions. While direct modifications to the layer could be considered (see native:truncate), we've chosen to separate these actions to allow users to make their own decisions. The idea of copying the input layer before applying changes to the input layer is also under consideration for future steps. Correction algorithms based on these outputs will be developed later to address various use cases. Moreover, even processes with a "No action" mode will be offered for in-place editing for consistency purposes.


Regarding the code:

- During development, I encountered several crashes with Processing, influencing certain parts of the code.
- It's essential to note that the algorithms are not thread-safe, hence the use of the NoThreading flag.
- To use QgsFeaturePool, it's necessary to convert QgsProcessingFeatureSource into a layer (where "materialize" proved helpful for this). It's also worth mentioning that the input layer cannot be a QgsProcessingParameterVectorLayer; cloning is necessary to avoid crashes when a layer is already loaded, especially with the editinplace option.
- I refrained from altering the geometry_checker code in this PR. However, QgsGeometry*Check::resolutionMethod is deprecated and not static, just like availableResolutionmethod. We require a QStringList here, thus a copy/paste from resolutionMethod() was performed. It would be beneficial to reconsider these methods/enums to avoid repetition.
- The new processes are grouped under a new category named "Check geometry". Suggestions for improved naming are welcome. The aim is to unify verification and correction processes from topology and geometry_checker plugins within this category.
- The current displayName, "Check Geometry (algorithm name)", is provisional. Any suggestions for enhancing this designation are welcome.
- To avoid overwhelming process options, I've opted to enforce the "gc_" prefix for field names (see outputFields). It's worth considering whether to make this parameter configurable.
- The creation of QgsGeometryCheckContext requires a QgsProject. Currently, I utilize the one from the input layer if available, otherwise QgsProject(). However, the optimal method for this is yet to be determined.

Lastly, this initial proposal introduces three algorithms to initiate the discussion. For ease of review, we'll open a PR for each process.

Funded by QGIS (Grant OpenSource 2023) and Oslandia

Part of https://github.com/qgis/QGIS-Enhancement-Proposals/issues/236

cc @Djedouas @manisandro 