### PR TITLE
fix mesh calculator time steps

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -629,15 +629,14 @@ QString QgsMeshCalculatorDialog::currentDatasetGroup() const
 void QgsMeshCalculatorDialog::setTimesByDatasetGroupName( const QString group )
 {
   QgsMeshLayer *layer = meshLayer();
-  if ( !layer || !layer->dataProvider() )
+  if ( !layer )
     return;
-  const QgsMeshDataProvider *dp = layer->dataProvider();
 
   // find group index from group name
   int groupIndex = -1;
-  for ( int i = 0; i < dp->datasetGroupCount(); ++i )
+  for ( int i = 0; i < layer->datasetGroupCount(); ++i )
   {
-    const QgsMeshDatasetGroupMetadata meta = dp->datasetGroupMetadata( i );
+    const QgsMeshDatasetGroupMetadata meta = layer->datasetGroupMetadata( i );
     if ( meta.name() == group )
     {
       groupIndex = i;
@@ -648,18 +647,18 @@ void QgsMeshCalculatorDialog::setTimesByDatasetGroupName( const QString group )
   if ( groupIndex < 0 )
     return; //not found
 
-  const int datasetCount = dp->datasetCount( groupIndex );
+  const int datasetCount = layer->datasetCount( groupIndex );
   if ( datasetCount < 1 )
     return; // group without datasets
 
 
   // find maximum and minimum time in this group
-  const double minTime = dp->datasetMetadata( QgsMeshDatasetIndex( groupIndex, 0 ) ).time();
+  const double minTime = layer->datasetMetadata( QgsMeshDatasetIndex( groupIndex, 0 ) ).time();
   int idx = mStartTimeComboBox->findData( minTime );
   if ( idx >= 0 )
     mStartTimeComboBox->setCurrentIndex( idx );
 
-  const double maxTime = dp->datasetMetadata( QgsMeshDatasetIndex( groupIndex, datasetCount - 1 ) ).time();
+  const double maxTime = layer->datasetMetadata( QgsMeshDatasetIndex( groupIndex, datasetCount - 1 ) ).time();
   idx = mEndTimeComboBox->findData( maxTime );
   if ( idx >= 0 )
     mEndTimeComboBox->setCurrentIndex( idx );
@@ -668,9 +667,8 @@ void QgsMeshCalculatorDialog::setTimesByDatasetGroupName( const QString group )
 void QgsMeshCalculatorDialog::repopulateTimeCombos()
 {
   QgsMeshLayer *layer = meshLayer();
-  if ( !layer || !layer->dataProvider() )
+  if ( !layer )
     return;
-  const QgsMeshDataProvider *dp = layer->dataProvider();
 
   // extract all times from all datasets
   QMap<qint64, double> times;
@@ -684,7 +682,9 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
       qint64 timeMs = layer->datasetRelativeTimeInMilliseconds( QgsMeshDatasetIndex( dsgi, datasetIndex ) );
       if ( timeMs == INVALID_MESHLAYER_TIME )
         continue;
-      const QgsMeshDatasetMetadata meta = dp->datasetMetadata( QgsMeshDatasetIndex( dsgi, datasetIndex ) );
+      const QgsMeshDatasetMetadata meta = layer->datasetMetadata( QgsMeshDatasetIndex( dsgi, datasetIndex ) );
+      if ( !meta.isValid() )
+        continue;
       times[timeMs] = meta.time();
     }
   }


### PR DESCRIPTION
Remove old leftover references to the mesh data provider from the mesh calculator gui. Mesh data provider does not be used anymore to handle dataset group because indexes from the mesh the mesh and from the data provider are not the same due to the eventually presence of virtual dataset group.
These references of the data provider leads to bugs related to time steps, and this PR fixes this issues. 