### PR TITLE
Add QGIS Server tab to QgsVectorTileLayerProperties for configuring shortname/abstract/etc

### DIFF
--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -153,6 +153,22 @@ void QgsVectorTileLayerProperties::apply()
   mLayer->setScaleBasedVisibility( chkUseScaleDependentRendering->isChecked() );
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
+
+  //layer title and abstract
+  mLayer->setShortName( mLayerShortNameLineEdit->text() );
+  mLayer->setTitle( mLayerTitleLineEdit->text() );
+  mLayer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+  mLayer->setKeywordList( mLayerKeywordListLineEdit->text() );
+  mLayer->setDataUrl( mLayerDataUrlLineEdit->text() );
+  mLayer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
+
+  //layer attribution
+  mLayer->setAttribution( mLayerAttributionLineEdit->text() );
+  mLayer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
+
+  // LegendURL
+  mLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mLayer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
 }
 
 void QgsVectorTileLayerProperties::syncToLayer()
@@ -211,6 +227,32 @@ void QgsVectorTileLayerProperties::syncToLayer()
    */
   chkUseScaleDependentRendering->setChecked( mLayer->hasScaleBasedVisibility() );
   mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
+
+  /*
+   * Server
+   */
+  //layer title and abstract
+  mLayer->setShortName( mLayerShortNameLineEdit->text() );
+  mLayerTitleLineEdit->setText( mLayer->title() );
+  mLayerAbstractTextEdit->setPlainText( mLayer->abstract() );
+  mLayerKeywordListLineEdit->setText( mLayer->keywordList() );
+  mLayerDataUrlLineEdit->setText( mLayer->dataUrl() );
+  mLayerDataUrlFormatComboBox->setCurrentIndex(
+    mLayerDataUrlFormatComboBox->findText(
+      mLayer->dataUrlFormat()
+    )
+  );
+  //layer attribution
+  mLayerAttributionLineEdit->setText( mLayer->attribution() );
+  mLayerAttributionUrlLineEdit->setText( mLayer->attributionUrl() );
+
+  // layer legend url
+  mLayerLegendUrlLineEdit->setText( mLayer->legendUrl() );
+  mLayerLegendUrlFormatComboBox->setCurrentIndex(
+    mLayerLegendUrlFormatComboBox->findText(
+      mLayer->legendUrlFormat()
+    )
+  );
 }
 
 void QgsVectorTileLayerProperties::saveDefaultStyle()

--- a/src/ui/qgsvectortilelayerpropertiesbase.ui
+++ b/src/ui/qgsvectortilelayerpropertiesbase.ui
@@ -170,6 +170,15 @@
             <normaloff>:/images/themes/default/propertyicons/editmetadata.svg</normaloff>:/images/themes/default/propertyicons/editmetadata.svg</iconset>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>QGIS Server</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</iconset>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>
@@ -470,6 +479,271 @@
               <enum>QFrame::Raised</enum>
              </property>
             </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Server">
+          <layout class="QVBoxLayout" name="verticalLayout_9">
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="mMetaDescriptionGrpBx">
+             <property name="title">
+              <string>Description</string>
+             </property>
+             <property name="syncGroup" stdset="0">
+              <string notr="true">vectormeta</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_5">
+              <item row="1" column="0">
+               <widget class="QLabel" name="mLayerTitleLabel">
+                <property name="text">
+                 <string>Title</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QLineEdit" name="mLayerKeywordListLineEdit">
+                <property name="toolTip">
+                 <string>List of keywords separated by comma to help catalog searching.</string>
+                </property>
+                <property name="placeholderText">
+                 <string>List of keywords separated by comma to help catalog searching.</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <widget class="QLineEdit" name="mLayerDataUrlLineEdit">
+                  <property name="toolTip">
+                   <string>A URL of the data presentation.</string>
+                  </property>
+                  <property name="placeholderText">
+                   <string>A URL of the data presentation.</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="mLayerDataUrlFormatLabel">
+                  <property name="text">
+                   <string>Format</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
+                  <item>
+                   <property name="text">
+                    <string notr="true">text/html</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string notr="true">text/plain</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string notr="true">application/pdf</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="mLayerKeywordListLabel">
+                <property name="text">
+                 <string>Keyword list</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="mLayerShortNameLabel">
+                <property name="text">
+                 <string>Short name</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="mLayerShortNameLineEdit">
+                <property name="toolTip">
+                 <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
+                </property>
+                <property name="inputMask">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="placeholderText">
+                 <string>A name used to identify the layer. The short name is a text string used for machine-to-machine communication.</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="mLayerTitleLineEdit">
+                <property name="toolTip">
+                 <string>The title is for the benefit of humans to identify layer.</string>
+                </property>
+                <property name="placeholderText">
+                 <string>The title is for the benefit of humans to identify layer.</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="mLayerAbstractLabel">
+                <property name="text">
+                 <string>Abstract</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QPlainTextEdit" name="mLayerAbstractTextEdit">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>150</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>The abstract is a descriptive narrative providing more information about the layer.</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="mLayerDataUrlLabel">
+                <property name="text">
+                 <string>Data URL</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="mMetaAttributionGrpBx">
+             <property name="title">
+              <string>Attribution</string>
+             </property>
+             <property name="syncGroup" stdset="0">
+              <string notr="true">vectormeta</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_7">
+              <item row="0" column="0">
+               <widget class="QLabel" name="mLayerAttributionLabel">
+                <property name="text">
+                 <string>Title</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="mLayerAttributionLineEdit">
+                <property name="toolTip">
+                 <string>Attribution's title indicates the provider of the layer.</string>
+                </property>
+                <property name="placeholderText">
+                 <string>Attribution's title indicates the provider of the data layer.</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="mLayerAttributionUrlLabel">
+                <property name="text">
+                 <string>URL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit">
+                <property name="toolTip">
+                 <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
+                </property>
+                <property name="placeholderText">
+                 <string>Attribution's url gives a link to the webpage of the provider of the data layer.</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
+             <property name="title">
+              <string>Legend URL</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_10">
+              <item row="0" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_11">
+                <item>
+                 <widget class="QLabel" name="mLayerLegendUrlLabel">
+                  <property name="text">
+                   <string>URL</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="mLayerLegendUrlLineEdit">
+                  <property name="toolTip">
+                   <string>A URL of the legend image.</string>
+                  </property>
+                  <property name="placeholderText">
+                   <string>A URL of the legend image.</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
+                  <property name="text">
+                   <string>Format</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
+                  <property name="minimumSize">
+                   <size>
+                    <width>137</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="currentIndex">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <property name="text">
+                    <string notr="true">image/png</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string notr="true">image/jpeg</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>


### PR DESCRIPTION
The Layer Properties dialog for Vector Tile layers will now include a section for editing the QGIS Server layer settings.


![image](https://github.com/qgis/QGIS/assets/1298852/0f639bf9-c108-46a3-9b45-cb3114c8326b)