### PR TITLE
Ensure more specialised exceptions are raised in PyQGIS

### DIFF
--- a/python/core/qgsexception.sip
+++ b/python/core/qgsexception.sip
@@ -22,19 +22,6 @@
 %End
 };
 
-%Exception QgsException(SIP_Exception) /PyName=QgsException/
-{
-%TypeHeaderCode
-#include <qgsexception.h>
-%End
-%RaiseCode
-  SIP_BLOCK_THREADS
-  PyErr_SetString(sipException_QgsException, sipExceptionRef.what().toUtf8().constData() );
-  SIP_UNBLOCK_THREADS
-%End
-};
-
-
 %Exception QgsProviderConnectionException(SIP_Exception) /PyName=QgsProviderConnectionException/
 {
 %TypeHeaderCode
@@ -70,3 +57,22 @@
   SIP_UNBLOCK_THREADS
 %End
 };
+
+// IMPORTANT -- QgsException MUST be last listed, or it will greedily prevent the more
+// specialized exceptions from being raised
+
+%Exception QgsException(SIP_Exception) /PyName=QgsException/
+{
+%TypeHeaderCode
+#include <qgsexception.h>
+%End
+%RaiseCode
+  SIP_BLOCK_THREADS
+  PyErr_SetString(sipException_QgsException, sipExceptionRef.what().toUtf8().constData() );
+  SIP_UNBLOCK_THREADS
+%End
+};
+
+// IMPORTANT -- QgsException MUST be last listed, or it will greedily prevent the more
+// specialized exceptions from being raised
+


### PR DESCRIPTION
instead of the generic QgsException one
Refs warning in https://github.com/qgis/QGIS/issues/55481#issuecomment-1849001802

```
/tmp/work/geography/qgis/work/qgis-3.28.13/build/python/core/build/_core/sip_corepart0.cpp:38168: warning: exception of type 'QgsProviderConnectionException' will be caught
38168 |             catch (QgsProviderConnectionException &sipExceptionRef)
      |
/tmp/work/geography/qgis/work/qgis-3.28.13/build/python/core/build/_core/sip_corepart0.cpp:38158: warning:    by earlier handler for 'QgsException'
38158 |             catch (QgsException &sipExceptionRef)
```
