### PR TITLE
Expose method to directly convert json object to QVariantMap

### DIFF
--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -368,6 +368,7 @@ Returns a null geometry if the geometry could not be parsed.
 
 
 
+
 };
 
 /************************************************************************

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -781,6 +781,21 @@ QVariant QgsJsonUtils::parseJson( const std::string &jsonString )
 
 QVariant QgsJsonUtils::parseJson( const std::string &jsonString, QString &error )
 {
+  error.clear();
+  try
+  {
+    const json j = json::parse( jsonString );
+    return jsonToVariant( j );
+  }
+  catch ( json::parse_error &ex )
+  {
+    error = QString::fromStdString( ex.what() );
+  }
+  return QVariant();
+}
+
+QVariant QgsJsonUtils::jsonToVariant( const json &value )
+{
   // tracks whether entire json string is a primitive
   bool isPrimitive = true;
 
@@ -870,17 +885,7 @@ QVariant QgsJsonUtils::parseJson( const std::string &jsonString, QString &error 
     }
   };
 
-  error.clear();
-  try
-  {
-    const json j = json::parse( jsonString );
-    return _parser( j );
-  }
-  catch ( json::parse_error &ex )
-  {
-    error = QString::fromStdString( ex.what() );
-  }
-  return QVariant();
+  return _parser( value );
 }
 
 QVariant QgsJsonUtils::parseJson( const QString &jsonString )

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -419,6 +419,13 @@ class CORE_EXPORT QgsJsonUtils
      */
     static QVariant parseJson( const QString &jsonString ) SIP_SKIP;
 
+    /**
+     * Converts a JSON \a value to a QVariant, in case of parsing error an invalid QVariant is returned.
+     * \note Not available in Python bindings
+     * \since QGIS 3.36
+     */
+    static QVariant jsonToVariant( const json &value ) SIP_SKIP;
+
 };
 
 #endif // QGSJSONUTILS_H

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -38,6 +38,7 @@ class TestQgsJsonUtils : public QObject
   private slots:
     void testStringList();
     void testJsonArray();
+    void testJsonToVariant();
     void testParseJson();
     void testIntList();
     void testDoubleList();
@@ -110,6 +111,19 @@ void TestQgsJsonUtils::testJsonArray()
     QVERIFY( value.isValid() );
     QCOMPARE( value, QVariant( QVariant::Type::Double ) );
   }
+}
+
+void TestQgsJsonUtils::testJsonToVariant()
+{
+  const json value = json::parse( "{\"_bool\":true,\"_double\":1234.45,\"_int\":123,\"_list\":[1,2,3.4,null],\"_null\":null,\"_object\":{\"int\":123}}" );
+  const QVariant variant = QgsJsonUtils::jsonToVariant( value );
+  QCOMPARE( variant.type(), QVariant::Map );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_bool" ) ), true );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_double" ) ), 1234.45 );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_int" ) ), 123 );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_list" ) ), QVariantList( {1, 2, 3.4, QVariant()} ) );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_null" ) ), QVariant() );
+  QCOMPARE( variant.toMap().value( QStringLiteral( "_object" ) ), QVariantMap( {{ QStringLiteral( "int" ), 123 }} ) );
 }
 
 void TestQgsJsonUtils::testParseJson()


### PR DESCRIPTION
All the existing methods require intermediate steps through encoded strings, which is inefficient if we already have a json object
