### PR TITLE
Fix en language in non EN systems

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -459,6 +459,26 @@ void QgsApplication::init( QString profileFolder )
 
 void QgsApplication::installTranslators()
 {
+  // Remove translators if any are already installed
+  if ( mQgisTranslator )
+  {
+    removeTranslator( mQgisTranslator );
+    delete mQgisTranslator;
+    mQgisTranslator = nullptr;
+  }
+  if ( mQtTranslator )
+  {
+    removeTranslator( mQtTranslator );
+    delete mQtTranslator;
+    mQtTranslator = nullptr;
+  }
+  if ( mQtBaseTranslator )
+  {
+    removeTranslator( mQtBaseTranslator );
+    delete mQtBaseTranslator;
+    mQtBaseTranslator = nullptr;
+  }
+
   if ( *sTranslation() != QLatin1String( "C" ) )
   {
     mQgisTranslator = new QTranslator( this );


### PR DESCRIPTION
## Description

- Fixes #53652

See https://github.com/qgis/QGIS/issues/53652#issuecomment-1847939056

A side effect of the profile selector feature was that QGIS always installed the system language translator before installing the profile language translator on top of it.

As a consequence, on non-english system with an english profile, any untranslated string in qgis_en.ts was displayed in the system language. Even worse, Qt strings (standard button in message boxes mostly) were also displayed in the system langugage.

This PR fixes the issue by removing any installed `QTranslator` before installing the new ones.