### PR TITLE
Drop the unused Transient flag

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -268,8 +268,6 @@ QgsMapCanvas::~QgsMapCanvas()
     tool->mCanvas = nullptr;
   }
 
-  mLastNonZoomMapTool = nullptr;
-
   cancelJobs();
 
   // delete canvas items prior to deleting the canvas
@@ -2531,25 +2529,6 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
     // call handler of current map tool
     if ( mMapTool )
     {
-      // right button was pressed in zoom tool? return to previous non zoom tool
-      if ( e->button() == Qt::RightButton && mMapTool->flags() & QgsMapTool::Transient )
-      {
-        QgsDebugMsgLevel( QStringLiteral( "Right click in map tool zoom or pan, last tool is %1." ).arg(
-                            mLastNonZoomMapTool ? QStringLiteral( "not null" ) : QStringLiteral( "null" ) ), 2 );
-
-        QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCurrentLayer );
-
-        // change to older non-zoom tool
-        if ( mLastNonZoomMapTool
-             && ( !( mLastNonZoomMapTool->flags() & QgsMapTool::EditTool )
-                  || ( vlayer && vlayer->isEditable() ) ) )
-        {
-          QgsMapTool *t = mLastNonZoomMapTool;
-          mLastNonZoomMapTool = nullptr;
-          setMapTool( t );
-        }
-        return;
-      }
       std::unique_ptr<QgsMapMouseEvent> me( new QgsMapMouseEvent( this, e ) );
       mMapTool->canvasReleaseEvent( me.get() );
     }
@@ -2764,19 +2743,6 @@ void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
     mMapTool->deactivate();
   }
 
-  if ( ( tool->flags() & QgsMapTool::Transient )
-       && mMapTool && !( mMapTool->flags() & QgsMapTool::Transient ) )
-  {
-    // if zoom or pan tool will be active, save old tool
-    // to bring it back on right click
-    // (but only if it wasn't also zoom or pan tool)
-    mLastNonZoomMapTool = mMapTool;
-  }
-  else
-  {
-    mLastNonZoomMapTool = nullptr;
-  }
-
   QgsMapTool *oldTool = mMapTool;
 
   // set new map tool and activate it
@@ -2800,11 +2766,6 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
     oldTool->deactivate();
     emit mapToolSet( nullptr, oldTool );
     setCursor( Qt::ArrowCursor );
-  }
-
-  if ( mLastNonZoomMapTool && mLastNonZoomMapTool == tool )
-  {
-    mLastNonZoomMapTool = nullptr;
   }
 }
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1365,9 +1365,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     //! pointer to current map tool
     QgsMapTool *mMapTool = nullptr;
 
-    //! previous tool if current is for zooming/panning
-    QgsMapTool *mLastNonZoomMapTool = nullptr;
-
     //! Pointer to project linked to this canvas
     QgsProject *mProject = nullptr;
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -109,9 +109,7 @@ class GUI_EXPORT QgsMapTool : public QObject
      */
     enum Flag
     {
-      Transient = 1 << 1, /*!< Indicates that this map tool performs a transient (one-off) operation.
-                               If it does, the tool can be operated once and then a previous map
-                               tool automatically restored. */
+      Transient = 1 << 1, //!< Deprecated since QGIS 3.36 -- no longer used by QGIS and will be removed in QGIS 4.0
       EditTool = 1 << 2, //!< Map tool is an edit tool, which can only be used when layer is editable
       AllowZoomRect = 1 << 3, //!< Allow zooming by rectangle (by holding shift and dragging) while the tool is active
       ShowContextMenu = 1 << 4, //!< Show a context menu when right-clicking with the tool (since QGIS 3.14). See populateContextMenu().

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -51,7 +51,7 @@ void QgsMapToolPan::deactivate()
 
 QgsMapTool::Flags QgsMapToolPan::flags() const
 {
-  return QgsMapTool::Transient | QgsMapTool::AllowZoomRect | QgsMapTool::ShowContextMenu;
+  return QgsMapTool::AllowZoomRect | QgsMapTool::ShowContextMenu;
 }
 
 void QgsMapToolPan::canvasPressEvent( QgsMapMouseEvent *e )

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -49,7 +49,7 @@ QgsMapToolZoom::~QgsMapToolZoom()
 
 QgsMapTool::Flags QgsMapToolZoom::flags() const
 {
-  return QgsMapTool::Transient | QgsMapTool::ShowContextMenu;
+  return QgsMapTool::ShowContextMenu;
 }
 
 void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )


### PR DESCRIPTION
## Description

The QgsMapTool Transient flag is not used anywhere in a meaningful way in QGIS.

It is set on two tools:

- `QgsMapToolPan`
- `QgsMapToolZoom`

But `ShowContextMenu` (also set on both tools) supersedes the `Transient` flag.

This PR removes dead code and marks the Transient Flag as deprecated.