### PR TITLE
Don't initially sort the feature list in attribute table

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -474,7 +474,6 @@ void QgsDualView::initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &
   connect( mFeatureListView, &QgsFeatureListView::displayExpressionChanged, this, &QgsDualView::displayExpressionChanged );
 
   mFeatureListModel = new QgsFeatureListModel( mFilterModel, mFilterModel );
-  mFeatureListModel->setSortByDisplayExpression( true );
 }
 
 void QgsDualView::restoreRecentDisplayExpressions()


### PR DESCRIPTION
While this may be desirable from a UX point of view, it's incredibly expensive to do so because it force calls QgsAttributeTableModel::prefetchSortData which triggers a complete iteration over the ENTIRE table upfront. This iteration occurs in a blocking manner, so we don't even get the yuck processEvent based progress bar dialog which does give some option to cancel the table opening.

Better to not sort initially, and incur this cost only when the user chooses to sort.
