### PR TITLE
Nicer display of JSON attributes in identify results dialog

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
@@ -42,6 +42,13 @@ Constructor for QgsJsonEditWidget.
 :param parent: parent widget
 %End
 
+    QgsCodeEditorJson *jsonEditor();
+%Docstring
+Returns a reference to the JSON code editor used in the widget.
+
+.. versionadded:: 3.36
+%End
+
     void setJsonText( const QString &jsonText );
 %Docstring
 Set the JSON text in the widget to ``jsonText``.

--- a/python/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsjsoneditwidget.sip.in
@@ -42,6 +42,13 @@ Constructor for QgsJsonEditWidget.
 :param parent: parent widget
 %End
 
+    QgsCodeEditorJson *jsonEditor();
+%Docstring
+Returns a reference to the JSON code editor used in the widget.
+
+.. versionadded:: 3.36
+%End
+
     void setJsonText( const QString &jsonText );
 %Docstring
 Set the JSON text in the widget to ``jsonText``.

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -753,6 +753,7 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
     {
       QgsJsonEditWidget *jsonEditWidget = new QgsJsonEditWidget();
       jsonEditWidget->setJsonText( representedValue );
+      jsonEditWidget->jsonEditor()->setWrapMode( QsciScintilla::WrapWord );
       jsonEditWidget->setView( static_cast<QgsJsonEditWidget::View>( setup.config().value( QStringLiteral( "DefaultView" ) ).toInt() ) );
       jsonEditWidget->setFormatJsonMode( static_cast<QgsJsonEditWidget::FormatJson>( setup.config().value( QStringLiteral( "FormatJson" ) ).toInt() ) );
       jsonEditWidget->setControlsVisible( false );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -749,7 +749,7 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
     attrItem->setToolTip( 1, representedValue );
     attrItem->setData( 1, REPRESENTED_VALUE_ROLE, representedValue );
 
-    if ( setup.type() == QLatin1String( "JsonEdit" ) )
+    if ( !QgsVariantUtils::isNull( attrs.at( i ) ) && setup.type() == QLatin1String( "JsonEdit" ) )
     {
       QgsJsonEditWidget *jsonEditWidget = new QgsJsonEditWidget();
       jsonEditWidget->setJsonText( representedValue );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -754,6 +754,7 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
       QgsJsonEditWidget *jsonEditWidget = new QgsJsonEditWidget();
       jsonEditWidget->setJsonText( representedValue );
       jsonEditWidget->jsonEditor()->setWrapMode( QsciScintilla::WrapWord );
+      jsonEditWidget->jsonEditor()->setLineNumbersVisible( false );
       jsonEditWidget->setView( static_cast<QgsJsonEditWidget::View>( setup.config().value( QStringLiteral( "DefaultView" ) ).toInt() ) );
       jsonEditWidget->setFormatJsonMode( static_cast<QgsJsonEditWidget::FormatJson>( setup.config().value( QStringLiteral( "FormatJson" ) ).toInt() ) );
       jsonEditWidget->setControlsVisible( false );

--- a/src/gui/editorwidgets/qgsjsoneditwidget.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.cpp
@@ -60,6 +60,11 @@ QgsJsonEditWidget::QgsJsonEditWidget( QWidget *parent )
   connect( mCodeEditorJson, &QsciScintillaBase::SCN_DWELLEND, this, &QgsJsonEditWidget::codeEditorJsonDwellEnd );
 }
 
+QgsCodeEditorJson *QgsJsonEditWidget::jsonEditor()
+{
+  return mCodeEditorJson;
+}
+
 void QgsJsonEditWidget::setJsonText( const QString &jsonText )
 {
   mJsonText = jsonText;

--- a/src/gui/editorwidgets/qgsjsoneditwidget.h
+++ b/src/gui/editorwidgets/qgsjsoneditwidget.h
@@ -56,6 +56,13 @@ class GUI_EXPORT QgsJsonEditWidget : public QWidget, private Ui::QgsJsonEditWidg
     explicit QgsJsonEditWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
+     * Returns a reference to the JSON code editor used in the widget.
+     *
+     * \since QGIS 3.36
+     */
+    QgsCodeEditorJson *jsonEditor();
+
+    /**
      * \brief Set the JSON text in the widget to \a jsonText.
      */
     void setJsonText( const QString &jsonText );

--- a/src/ui/editorwidgets/qgsjsoneditwidget.ui
+++ b/src/ui/editorwidgets/qgsjsoneditwidget.ui
@@ -14,6 +14,18 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <widget class="QWidget" name="mControlsWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
@@ -86,6 +98,18 @@
      </property>
      <widget class="QWidget" name="mStackedWidgetPageText">
       <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item row="0" column="0">
         <widget class="QgsCodeEditorJson" name="mCodeEditorJson" native="true"/>
        </item>
@@ -93,6 +117,18 @@
      </widget>
      <widget class="QWidget" name="mStackedWidgetPageTree">
       <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item row="0" column="0">
         <widget class="QTreeWidget" name="mTreeWidget">
          <attribute name="headerVisible">


### PR DESCRIPTION
## Was:

![image](https://github.com/qgis/QGIS/assets/1829991/880a8e20-231d-4571-b00e-7267e7ea1035)

## Now:

![image](https://github.com/qgis/QGIS/assets/1829991/b99276c1-6341-4bd1-a100-c6e19446e24b)


