### PR TITLE
Hide query builder entirely from vector layer source tab if provider does not support subset strings

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -589,6 +589,11 @@ void QgsVectorLayerProperties::syncToLayer()
   txtSubsetSQL->setCaretWidth( 0 );
   txtSubsetSQL->setCaretLineVisible( false );
   setPbnQueryBuilderEnabled();
+  if ( mLayer->dataProvider() && !mLayer->dataProvider()->supportsSubsetString() )
+  {
+    // hide subset box entirely if not supported by data provider
+    mSubsetGroupBox->hide();
+  }
 
   mDisplayExpressionWidget->setField( mLayer->displayExpression() );
   mEnableMapTips->setChecked( mLayer->mapTipsEnabled() );


### PR DESCRIPTION
There's little benefit to showing a setting which can never be set by a user...!