### PR TITLE
Change vector layer data sources ONLY after applying all other settings in the layer properties dialog

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -435,6 +435,7 @@ set(QGIS_GUI_SRCS
   providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.cpp
   providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.cpp
 
+  providers/ogr/qgsogrfilesourcewidget.cpp
   providers/ogr/qgsogrguiprovider.cpp
   providers/ogr/qgsogrdbsourceselect.cpp
   providers/ogr/qgsogrdbtablemodel.cpp
@@ -1390,6 +1391,7 @@ set(QGIS_GUI_HDRS
   providers/mbtilesvectortiles/qgsmbtilesvectortileguiprovider.h
   providers/mbtilesvectortiles/qgsmbtilesvectortilesourcewidget.h
 
+  providers/ogr/qgsogrfilesourcewidget.h
   providers/ogr/qgsgeopackageitemguiprovider.h
   providers/ogr/qgsgeopackageprojectstoragedialog.h
   providers/ogr/qgsgeopackageprojectstorageguiprovider.h

--- a/src/gui/providers/ogr/qgsogrfilesourcewidget.cpp
+++ b/src/gui/providers/ogr/qgsogrfilesourcewidget.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+    qgsogrfilesourcewidget.cpp
+     --------------------------------------
+    Date                 : January 2024
+    Copyright            : (C) 2024 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsogrfilesourcewidget.h"
+///@cond PRIVATE
+
+#include "qgsproviderregistry.h"
+#include "ogr/qgsogrhelperfunctions.h"
+#include "qgsfilewidget.h"
+
+#include <QHBoxLayout>
+#include <gdal.h>
+
+QgsOgrFileSourceWidget::QgsOgrFileSourceWidget( QWidget *parent )
+  : QgsProviderSourceWidget( parent )
+{
+  QHBoxLayout *layout = new QHBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+
+  mFileWidget = new QgsFileWidget();
+  mFileWidget->setDialogTitle( tr( "Open OGR Supported Vector Dataset(s)" ) );
+  mFileWidget->setFilter( QgsProviderRegistry::instance()->fileVectorFilters() );
+  mFileWidget->setStorageMode( QgsFileWidget::GetFile );
+  mFileWidget->setOptions( QFileDialog::HideNameFilterDetails );
+  layout->addWidget( mFileWidget );
+
+  setLayout( layout );
+
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsOgrFileSourceWidget::validate );
+}
+
+void QgsOgrFileSourceWidget::setSourceUri( const QString &uri )
+{
+  mSourceParts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri );
+
+  mFileWidget->setFilePath( mSourceParts.value( QStringLiteral( "path" ) ).toString() );
+  mIsValid = true;
+}
+
+QString QgsOgrFileSourceWidget::sourceUri() const
+{
+  QVariantMap parts = mSourceParts;
+  parts.insert( QStringLiteral( "path" ), mFileWidget->filePath() );
+  return QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "ogr" ), parts );
+}
+
+void QgsOgrFileSourceWidget::validate()
+{
+  const bool valid = !mFileWidget->filePath().isEmpty();
+  if ( valid != mIsValid )
+    emit validChanged( valid );
+  mIsValid = valid;
+}
+
+
+///@endcond

--- a/src/gui/providers/ogr/qgsogrfilesourcewidget.h
+++ b/src/gui/providers/ogr/qgsogrfilesourcewidget.h
@@ -1,9 +1,9 @@
 /***************************************************************************
-      qgsogrguiprovider.h  - GUI for QGIS Data provider for GDAL rasters
-                             -------------------
-    begin                : June, 2019
-    copyright            : (C) 2019 by Peter Petrik
-    email                : zilolv at gmail dot com
+    qgsogrfilesourcewidget.h
+     --------------------------------------
+    Date                 : January 2024
+    Copyright            : (C) 2024 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
  ***************************************************************************/
 
 /***************************************************************************
@@ -14,25 +14,37 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#ifndef QGSOGRFILESOURCEWIDGET_H
+#define QGSOGRFILESOURCEWIDGET_H
 
-#ifndef QGSOGRGUIPROVIDER_H
-#define QGSOGRGUIPROVIDER_H
+#include "qgsprovidersourcewidget.h"
+#include <QVariantMap>
 
-#include "qgsproviderguimetadata.h"
-#include "qgis_sip.h"
+class QgsFileWidget;
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-class QgsOgrGuiProviderMetadata: public QgsProviderGuiMetadata
+class QgsOgrFileSourceWidget : public QgsProviderSourceWidget
 {
+    Q_OBJECT
+
   public:
-    QgsOgrGuiProviderMetadata();
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
-    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override;
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
-    QList<QgsProjectStorageGuiProvider *> projectStorageGuiProviders() override;
+    QgsOgrFileSourceWidget( QWidget *parent = nullptr );
+
+    void setSourceUri( const QString &uri ) override;
+    QString sourceUri() const override;
+
+  private slots:
+
+    void validate();
+
+  private:
+    QgsFileWidget *mFileWidget = nullptr;
+
+    QVariantMap mSourceParts;
+    bool mIsValid = false;
 };
 
 ///@endcond
-#endif
+#endif // QGSOGRFILESOURCEWIDGET_H

--- a/src/gui/providers/ogr/qgsogrguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsogrguiprovider.cpp
@@ -24,12 +24,14 @@
 #include "qgsogrsourceselect.h"
 #include "qgsogrdbsourceselect.h"
 #include "qgsapplication.h"
-#include "qgsprovidermetadata.h"
 #include "qgsdataitemguiprovider.h"
 #include "qgsgeopackageitemguiprovider.h"
 #include "qgsogritemguiprovider.h"
 #include "qgsgeopackageprojectstorageguiprovider.h"
 #include "qgsprojectstorageguiprovider.h"
+#include "qgsprovidersourcewidgetprovider.h"
+#include "qgsogrfilesourcewidget.h"
+#include "qgsmaplayer.h"
 
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "ogr" );
 
@@ -59,6 +61,15 @@ class QgsGeoPackageSourceSelectProvider : public QgsSourceSelectProvider
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddGeoPackageLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override;
     QgsSourceSelectProvider::Capabilities capabilities() override;
+};
+
+class QgsOgrSourceWidgetProvider : public QgsProviderSourceWidgetProvider
+{
+  public:
+    QgsOgrSourceWidgetProvider();
+    QString providerKey() const override;
+    bool canHandleLayer( QgsMapLayer *layer ) const override;
+    QgsProviderSourceWidget *createWidget( QgsMapLayer *layer, QWidget *parent = nullptr ) override;
 };
 
 
@@ -101,6 +112,49 @@ QgsSourceSelectProvider::Capabilities QgsOgrVectorSourceSelectProvider::capabili
   return QgsSourceSelectProvider::Capability::ConfigureFromUri;
 }
 
+
+//
+// QgsOgrSourceWidgetProvider
+//
+
+QgsOgrSourceWidgetProvider::QgsOgrSourceWidgetProvider()
+{
+
+}
+
+QString QgsOgrSourceWidgetProvider::providerKey() const
+{
+  return QStringLiteral( "ogr" );
+}
+
+bool QgsOgrSourceWidgetProvider::canHandleLayer( QgsMapLayer *layer ) const
+{
+  if ( layer->providerType() != QLatin1String( "ogr" ) )
+    return false;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), layer->source() );
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return false;
+
+  return true;
+}
+
+QgsProviderSourceWidget *QgsOgrSourceWidgetProvider::createWidget( QgsMapLayer *layer, QWidget *parent )
+{
+  if ( layer->providerType() != QLatin1String( "ogr" ) )
+    return nullptr;
+
+  const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), layer->source() );
+  if ( parts.value( QStringLiteral( "path" ) ).toString().isEmpty() )
+    return nullptr;
+
+  return new QgsOgrFileSourceWidget( parent );
+}
+
+//
+// QgsOgrGuiProviderMetadata
+//
+
 QgsOgrGuiProviderMetadata::QgsOgrGuiProviderMetadata()
   : QgsProviderGuiMetadata( TEXT_PROVIDER_KEY )
 {
@@ -131,7 +185,13 @@ QList<QgsProjectStorageGuiProvider *> QgsOgrGuiProviderMetadata::projectStorageG
   QList<QgsProjectStorageGuiProvider *> providers;
   providers << new QgsGeoPackageProjectStorageGuiProvider();
   return providers;
+}
 
+QList<QgsProviderSourceWidgetProvider *> QgsOgrGuiProviderMetadata::sourceWidgetProviders()
+{
+  QList<QgsProviderSourceWidgetProvider *> providers;
+  providers << new QgsOgrSourceWidgetProvider();
+  return providers;
 }
 
 ///@endcond

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -742,16 +742,6 @@ void QgsVectorLayerProperties::syncToLayer()
 
 void QgsVectorLayerProperties::apply()
 {
-  if ( mSourceWidget )
-  {
-    const QString newSource = mSourceWidget->sourceUri();
-    if ( newSource != mLayer->source() )
-    {
-      mLayer->setDataSource( newSource, mLayer->name(), mLayer->providerType(),
-                             QgsDataProvider::ProviderOptions(), QgsDataProvider::ReadFlags() );
-    }
-  }
-
   if ( labelingDialog )
   {
     labelingDialog->writeSettingsToLayer();
@@ -923,7 +913,6 @@ void QgsVectorLayerProperties::apply()
     mLayer->renderer()->setReferenceScale( mUseReferenceScaleGroupBox->isChecked() ? mReferenceScaleWidget->scale() : -1 );
   }
 
-
   QgsVectorLayerSelectionProperties *selectionProperties = qobject_cast< QgsVectorLayerSelectionProperties *>( mLayer->selectionProperties() );
   if ( mSelectionColorButton->color() != mSelectionColorButton->defaultColor() )
     selectionProperties->setSelectionColor( mSelectionColorButton->color() );
@@ -964,6 +953,22 @@ void QgsVectorLayerProperties::apply()
   if ( ! mLayer->setDependencies( deps ) )
   {
     QMessageBox::warning( nullptr, tr( "Save Dependency" ), tr( "This configuration introduces a cycle in data dependencies and will be ignored." ) );
+  }
+
+  // Why is this here? Well, we if we're making changes to the layer's source then potentially
+  // we are changing the geometry type of the layer, or even going from spatial <-> non spatial types.
+  // So we need to ensure that anything from the dialog which sets things like renderer properties
+  // happens BEFORE we change the source, otherwise we might end up with a renderer which is not
+  // compatible with the new geometry type of the layer. (And likewise for other properties like
+  // fields!)
+  if ( mSourceWidget )
+  {
+    const QString newSource = mSourceWidget->sourceUri();
+    if ( newSource != mLayer->source() )
+    {
+      mLayer->setDataSource( newSource, mLayer->name(), mLayer->providerType(),
+                             QgsDataProvider::ProviderOptions(), QgsDataProvider::ReadFlags() );
+    }
   }
 
   mLayer->triggerRepaint();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -968,6 +968,11 @@ void QgsVectorLayerProperties::apply()
     {
       mLayer->setDataSource( newSource, mLayer->name(), mLayer->providerType(),
                              QgsDataProvider::ProviderOptions(), QgsDataProvider::ReadFlags() );
+
+      // resync dialog to layer's new state -- this allows any changed layer properties
+      // (such as a forced creation of a new renderer compatible with the new layer, new field configuration, etc)
+      // to show in the dialog correctly
+      syncToLayer();
     }
   }
 

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -228,6 +228,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
     void openPanel( QgsPanelWidget *panel );
 
     friend class QgsAppScreenShots;
+    friend class TestQgsLayerPropertiesDialogs;
 };
 
 #endif

--- a/tests/src/app/testqgslayerpropertiesdialogs.cpp
+++ b/tests/src/app/testqgslayerpropertiesdialogs.cpp
@@ -34,6 +34,31 @@
 #include "qgstiledscenelayerproperties.h"
 #include "qgsannotationlayer.h"
 #include "annotations/qgsannotationlayerproperties.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgssymbol.h"
+#include "qgsmarkersymbol.h"
+#include "qgsprovidersourcewidget.h"
+
+class DummySourceWidget : public QgsProviderSourceWidget
+{
+    Q_OBJECT
+  public:
+
+    DummySourceWidget( QWidget *parent ) : QgsProviderSourceWidget( parent )
+    {
+
+    }
+
+    void setSourceUri( const QString &uri ) override { Q_UNUSED( uri ); }
+
+    QString sourceUri() const override
+    {
+      return newSource;
+    }
+
+    QString newSource;
+
+};
 
 class TestQgsLayerPropertiesDialogs : public QgsTest
 {
@@ -95,6 +120,50 @@ class TestQgsLayerPropertiesDialogs : public QgsTest
       QgsVectorLayerProperties dialog( &canvas, &messageBar, vl.get() );
       dialog.show();
       dialog.accept();
+    }
+
+
+    void testChangeVectorDataSource()
+    {
+      // start with a point layer
+      const QString pointFileName = mTestDataDir + "points.shp";
+      const QFileInfo pointFileInfo( pointFileName );
+      std::unique_ptr< QgsVectorLayer > vl = std::make_unique< QgsVectorLayer >( pointFileInfo.filePath(),
+                                             pointFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+      QVERIFY( vl->isValid() );
+      // point layer should have a marker symbol
+      vl->setRenderer( new QgsSingleSymbolRenderer( new QgsMarkerSymbol() ) );
+      QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer * >( vl->renderer() )->symbol()->type(), Qgis::SymbolType::Marker );
+
+      // no change to data source
+      QgsMapCanvas canvas;
+      QgsMessageBar messageBar;
+      {
+        QgsVectorLayerProperties dialog( &canvas, &messageBar, vl.get() );
+        dialog.show();
+        dialog.accept();
+      }
+
+      // renderer should still be a marker type
+      QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer * >( vl->renderer() )->symbol()->type(), Qgis::SymbolType::Marker );
+
+      // change the data source to a line layer:
+      {
+        QgsVectorLayerProperties dialog( &canvas, &messageBar, vl.get() );
+        DummySourceWidget *sourceWidget = new DummySourceWidget( &dialog );
+        sourceWidget->newSource = mTestDataDir + "lines_touching.shp";
+        dialog.mSourceWidget = sourceWidget;
+        dialog.show();
+        dialog.accept();
+      }
+
+      QCOMPARE( vl->source(), mTestDataDir + "lines_touching.shp" );
+      QCOMPARE( vl->geometryType(), Qgis::GeometryType::Line );
+      // single symbol renderer with marker symbol would be nonsense now, we expected a line symbol
+      // ie the settings for the renderer which were present in the dialog MUST be ignored and overwritten
+      // by the logic which triggers when the geometry type is changed via a data source change
+      QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer * >( vl->renderer() )->symbol()->type(), Qgis::SymbolType::Line );
+
     }
 
     void testValidRasterProperties()

--- a/tests/src/app/testqgslayerpropertiesdialogs.cpp
+++ b/tests/src/app/testqgslayerpropertiesdialogs.cpp
@@ -163,7 +163,6 @@ class TestQgsLayerPropertiesDialogs : public QgsTest
       // ie the settings for the renderer which were present in the dialog MUST be ignored and overwritten
       // by the logic which triggers when the geometry type is changed via a data source change
       QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer * >( vl->renderer() )->symbol()->type(), Qgis::SymbolType::Line );
-
     }
 
     void testValidRasterProperties()


### PR DESCRIPTION
Otherwise we run the risk that logic implemented when changing data source (eg changing the layer's renderer to a type compatible with the new data source) is obliterated when the outdated settings from the dialog are applied.
