### PR TITLE
Allow source widgets to specify the group name for layer source properties

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsprovidersourcewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsprovidersourcewidget.sip.in
@@ -41,6 +41,15 @@ Returns the source URI as currently defined by the widget.
 .. seealso:: :py:func:`setSourceUri`
 %End
 
+    virtual QString groupTitle() const;
+%Docstring
+Returns an optional group title for the source settings, for use in layer properties dialogs.
+
+If not specified, a default title will be used.
+
+.. versionadded:: 3.36
+%End
+
     virtual void setMapCanvas( QgsMapCanvas *mapCanvas );
 %Docstring
 Sets a map ``canvas`` associated with the widget.

--- a/python/gui/auto_generated/qgsprovidersourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsprovidersourcewidget.sip.in
@@ -41,6 +41,15 @@ Returns the source URI as currently defined by the widget.
 .. seealso:: :py:func:`setSourceUri`
 %End
 
+    virtual QString groupTitle() const;
+%Docstring
+Returns an optional group title for the source settings, for use in layer properties dialogs.
+
+If not specified, a default title will be used.
+
+.. versionadded:: 3.36
+%End
+
     virtual void setMapCanvas( QgsMapCanvas *mapCanvas );
 %Docstring
 Sets a map ``canvas`` associated with the widget.

--- a/src/gui/qgsprovidersourcewidget.h
+++ b/src/gui/qgsprovidersourcewidget.h
@@ -55,6 +55,15 @@ class GUI_EXPORT QgsProviderSourceWidget : public QWidget
     virtual QString sourceUri() const = 0;
 
     /**
+     * Returns an optional group title for the source settings, for use in layer properties dialogs.
+     *
+     * If not specified, a default title will be used.
+     *
+     * \since QGIS 3.36
+     */
+    virtual QString groupTitle() const { return QString(); }
+
+    /**
      * Sets a map \a canvas associated with the widget.
      *
      * \since QGIS 3.26

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -740,6 +740,8 @@ void QgsRasterLayerProperties::sync()
       QHBoxLayout *layout = new QHBoxLayout();
       layout->addWidget( mSourceWidget );
       mSourceGroupBox->setLayout( layout );
+      if ( !mSourceWidget->groupTitle().isEmpty() )
+        mSourceGroupBox->setTitle( mSourceWidget->groupTitle() );
       mSourceGroupBox->show();
 
       connect( mSourceWidget, &QgsProviderSourceWidget::validChanged, this, [ = ]( bool isValid )

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -560,6 +560,9 @@ void QgsVectorLayerProperties::syncToLayer()
       QHBoxLayout *layout = new QHBoxLayout();
       layout->addWidget( mSourceWidget );
       mSourceGroupBox->setLayout( layout );
+      if ( !mSourceWidget->groupTitle().isEmpty() )
+        mSourceGroupBox->setTitle( mSourceWidget->groupTitle() );
+
       mSourceGroupBox->show();
 
       connect( mSourceWidget, &QgsProviderSourceWidget::validChanged, this, [ = ]( bool isValid )

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -196,6 +196,8 @@ void QgsVectorTileLayerProperties::syncToLayer()
       QHBoxLayout *layout = new QHBoxLayout();
       layout->addWidget( mSourceWidget );
       mSourceGroupBox->setLayout( layout );
+      if ( !mSourceWidget->groupTitle().isEmpty() )
+        mSourceGroupBox->setTitle( mSourceWidget->groupTitle() );
       mSourceGroupBox->show();
 
       connect( mSourceWidget, &QgsProviderSourceWidget::validChanged, this, [ = ]( bool isValid )


### PR DESCRIPTION
Allows overriding the default "Layer Source" group box title
