### PR TITLE
QgsGeometryUtilsBase: add sqrDistance3D and distance3D

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -538,7 +538,11 @@ Returns the squared 2D distance between two points.
 %Docstring
 Returns the squared 3D distance between two points.
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
  static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
@@ -558,7 +562,11 @@ Returns the 2D distance between two points.
 %Docstring
 Returns the 3D distance between two points.
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -534,6 +534,13 @@ Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 Returns the squared 2D distance between two points.
 %End
 
+    static double sqrDistance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;
+%Docstring
+Returns the squared 3D distance between two points.
+
+No check is done, if z contains NaN value.
+%End
+
  static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
 %Docstring
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
@@ -546,6 +553,14 @@ Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 %Docstring
 Returns the 2D distance between two points.
 %End
+
+    static double distance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;
+%Docstring
+Returns the 3D distance between two points.
+
+No check is done, if z contains NaN value.
+%End
+
 
  static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated,HoldGIL/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -21,6 +21,20 @@ Convenience functions for geometry utils.
 %End
   public:
 
+    static double sqrDistance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
+%Docstring
+Returns the squared 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
+
+No check is done, if z contains NaN value.
+%End
+
+    static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
+%Docstring
+Returns the 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
+
+No check is done, if z contains NaN value.
+%End
+
     static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /HoldGIL/;
 %Docstring
 Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -25,14 +25,22 @@ Convenience functions for geometry utils.
 %Docstring
 Returns the squared 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
     static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
 %Docstring
 Returns the 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
     static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -538,7 +538,11 @@ Returns the squared 2D distance between two points.
 %Docstring
 Returns the squared 3D distance between two points.
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
  static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
@@ -558,7 +562,11 @@ Returns the 2D distance between two points.
 %Docstring
 Returns the 3D distance between two points.
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
 

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -534,6 +534,13 @@ Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 Returns the squared 2D distance between two points.
 %End
 
+    static double sqrDistance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;
+%Docstring
+Returns the squared 3D distance between two points.
+
+No check is done, if z contains NaN value.
+%End
+
  static double distance2D( double x1, double y1, double x2, double y2 ) /Deprecated,HoldGIL/;
 %Docstring
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
@@ -546,6 +553,14 @@ Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 %Docstring
 Returns the 2D distance between two points.
 %End
+
+    static double distance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) /HoldGIL/;
+%Docstring
+Returns the 3D distance between two points.
+
+No check is done, if z contains NaN value.
+%End
+
 
  static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /Deprecated,HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -21,6 +21,20 @@ Convenience functions for geometry utils.
 %End
   public:
 
+    static double sqrDistance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
+%Docstring
+Returns the squared 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
+
+No check is done, if z contains NaN value.
+%End
+
+    static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
+%Docstring
+Returns the 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
+
+No check is done, if z contains NaN value.
+%End
+
     static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /HoldGIL/;
 %Docstring
 Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).

--- a/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -25,14 +25,22 @@ Convenience functions for geometry utils.
 %Docstring
 Returns the squared 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
     static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) /HoldGIL/;
 %Docstring
 Returns the 3D distance between (``x1``, ``y1``), (``x2``, ``y2``) and (``z2``, ``z2``).
 
-No check is done, if z contains NaN value.
+.. warning::
+
+   No check is done if z contains NaN value. This is the caller's responsibility.
+
+.. versionadded:: 3.36
 %End
 
     static double sqrDistance2D( double x1, double y1, double x2, double y2 ) /HoldGIL/;

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -685,7 +685,8 @@ class CORE_EXPORT QgsGeometryUtils
     /**
      * Returns the squared 3D distance between two points.
      *
-     * No check is done, if z contains NaN value.
+     * \warning No check is done if z contains NaN value. This is the caller's responsibility.
+     * \since QGIS 3.36
      */
     static double sqrDistance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL
     {
@@ -707,7 +708,8 @@ class CORE_EXPORT QgsGeometryUtils
     /**
      * Returns the 3D distance between two points.
      *
-     * No check is done, if z contains NaN value.
+     * \warning No check is done if z contains NaN value. This is the caller's responsibility.
+     * \since QGIS 3.36
      */
     static double distance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL
     {

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -683,6 +683,16 @@ class CORE_EXPORT QgsGeometryUtils
     }
 
     /**
+     * Returns the squared 3D distance between two points.
+     *
+     * No check is done, if z contains NaN value.
+     */
+    static double sqrDistance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL
+    {
+      return QgsGeometryUtilsBase::sqrDistance3D( pt1.x(), pt1.y(), pt1.z(), pt2.x(), pt2.y(), pt2.z() );
+    }
+
+    /**
      * Returns the 2D distance between (\a x1, \a y1) and (\a x2, \a y2).
      *
      * \deprecated Use QgsGeometryUtilsBase methods instead.
@@ -693,6 +703,17 @@ class CORE_EXPORT QgsGeometryUtils
      * Returns the 2D distance between two points.
      */
     static double distance2D( const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL { return QgsGeometryUtilsBase::distance2D( pt1.x(), pt1.y(), pt2.x(), pt2.y() );}
+
+    /**
+     * Returns the 3D distance between two points.
+     *
+     * No check is done, if z contains NaN value.
+     */
+    static double distance3D( const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL
+    {
+      return QgsGeometryUtilsBase::distance3D( pt1.x(), pt1.y(), pt1.z(), pt2.x(), pt2.y(), pt2.z() );
+    }
+
 
     /**
      * Returns the squared distance between a point and a line.

--- a/src/core/geometry/qgsgeometryutils_base.h
+++ b/src/core/geometry/qgsgeometryutils_base.h
@@ -34,14 +34,16 @@ class CORE_EXPORT QgsGeometryUtilsBase
     /**
      * Returns the squared 3D distance between (\a x1, \a y1), (\a x2, \a y2) and (\a z2, \a z2).
      *
-     * No check is done, if z contains NaN value.
+     * \warning No check is done if z contains NaN value. This is the caller's responsibility.
+     * \since QGIS 3.36
      */
     static double sqrDistance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) SIP_HOLDGIL {return ( x1 - x2 ) * ( x1 - x2 ) + ( y1 - y2 ) * ( y1 - y2 ) + ( z1 - z2 ) * ( z1 - z2 ); }
 
     /**
      * Returns the 3D distance between (\a x1, \a y1), (\a x2, \a y2) and (\a z2, \a z2).
      *
-     * No check is done, if z contains NaN value.
+     * \warning No check is done if z contains NaN value. This is the caller's responsibility.
+     * \since QGIS 3.36
      */
     static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) SIP_HOLDGIL {return std::sqrt( sqrDistance3D( x1, y1, z1, x2, y2, z2 ) ); }
 

--- a/src/core/geometry/qgsgeometryutils_base.h
+++ b/src/core/geometry/qgsgeometryutils_base.h
@@ -32,6 +32,20 @@ class CORE_EXPORT QgsGeometryUtilsBase
   public:
 
     /**
+     * Returns the squared 3D distance between (\a x1, \a y1), (\a x2, \a y2) and (\a z2, \a z2).
+     *
+     * No check is done, if z contains NaN value.
+     */
+    static double sqrDistance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) SIP_HOLDGIL {return ( x1 - x2 ) * ( x1 - x2 ) + ( y1 - y2 ) * ( y1 - y2 ) + ( z1 - z2 ) * ( z1 - z2 ); }
+
+    /**
+     * Returns the 3D distance between (\a x1, \a y1), (\a x2, \a y2) and (\a z2, \a z2).
+     *
+     * No check is done, if z contains NaN value.
+     */
+    static double distance3D( double x1, double y1, double z1, double x2, double y2, double z2 ) SIP_HOLDGIL {return std::sqrt( sqrDistance3D( x1, y1, z1, x2, y2, z2 ) ); }
+
+    /**
      * Returns the squared 2D distance between (\a x1, \a y1) and (\a x2, \a y2).
      */
     static double sqrDistance2D( double x1, double y1, double x2, double y2 ) SIP_HOLDGIL {return ( x1 - x2 ) * ( x1 - x2 ) + ( y1 - y2 ) * ( y1 - y2 ); }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -679,42 +679,6 @@ void QgsPoint::transformVertices( const std::function<QgsPoint( const QgsPoint &
   clearCache();
 }
 
-double QgsPoint::distance3D( double x, double y, double z ) const
-{
-  double zDistSquared = 0.0;
-  if ( is3D() || !std::isnan( z ) )
-    zDistSquared = ( mZ - z ) * ( mZ - z );
-
-  return std::sqrt( ( mX - x ) * ( mX - x ) + ( mY - y ) * ( mY - y ) + zDistSquared );
-}
-
-double QgsPoint::distance3D( const QgsPoint &other ) const
-{
-  double zDistSquared = 0.0;
-  if ( is3D() || other.is3D() )
-    zDistSquared = ( mZ - other.z() ) * ( mZ - other.z() );
-
-  return std::sqrt( ( mX - other.x() ) * ( mX - other.x() ) + ( mY - other.y() ) * ( mY - other.y() ) + zDistSquared );
-}
-
-double QgsPoint::distanceSquared3D( double x, double y, double z ) const
-{
-  double zDistSquared = 0.0;
-  if ( is3D() || !std::isnan( z ) )
-    zDistSquared = ( mZ - z ) * ( mZ - z );
-
-  return ( mX - x ) * ( mX - x ) + ( mY - y ) * ( mY - y ) + zDistSquared;
-}
-
-double QgsPoint::distanceSquared3D( const QgsPoint &other ) const
-{
-  double zDistSquared = 0.0;
-  if ( is3D() || other.is3D() )
-    zDistSquared = ( mZ - other.z() ) * ( mZ - other.z() );
-
-  return ( mX - other.x() ) * ( mX - other.x() ) + ( mY - other.y() ) * ( mY - other.y() ) + zDistSquared;
-}
-
 double QgsPoint::azimuth( const QgsPoint &other ) const
 {
   const double dx = other.x() - mX;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -389,7 +389,14 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see distanceSquared3D()
      * \since QGIS 3.0
     */
-    double distance3D( double x, double y, double z ) const SIP_HOLDGIL;
+    double distance3D( double x, double y, double z ) const SIP_HOLDGIL
+    {
+      if ( is3D() || !std::isnan( z ) )
+      {
+        return QgsGeometryUtilsBase::distance3D( mX, mY, mZ, x, y, z );
+      }
+      return QgsGeometryUtilsBase::distance2D( mX, mY, x, y );
+    }
 
     /**
      * Returns the Cartesian 3D distance between this point and another point. In certain
@@ -398,7 +405,14 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see distanceSquared3D()
      * \since QGIS 3.0
     */
-    double distance3D( const QgsPoint &other ) const SIP_HOLDGIL;
+    double distance3D( const QgsPoint &other ) const SIP_HOLDGIL
+    {
+      if ( is3D() || other.is3D() )
+      {
+        return QgsGeometryUtilsBase::distance3D( mX, mY, mZ, other.x(), other.y(), other.z() );
+      }
+      return QgsGeometryUtilsBase::distance2D( mX, mY, other.x(), other.y() );
+    }
 
     /**
      * Returns the Cartesian 3D squared distance between this point and a specified x, y, z coordinate. Calling
@@ -407,7 +421,14 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see distance3D()
      * \since QGIS 3.0
     */
-    double distanceSquared3D( double x, double y, double z ) const SIP_HOLDGIL;
+    double distanceSquared3D( double x, double y, double z ) const SIP_HOLDGIL
+    {
+      if ( is3D() || !std::isnan( z ) )
+      {
+        return QgsGeometryUtilsBase::sqrDistance3D( mX, mY, mZ, x, y, z );
+      }
+      return QgsGeometryUtilsBase::sqrDistance2D( mX, mY, x, y );
+    }
 
     /**
      * Returns the Cartesian 3D squared distance between this point and another point. Calling
@@ -416,7 +437,14 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see distance3D()
      * \since QGIS 3.0
     */
-    double distanceSquared3D( const QgsPoint &other ) const SIP_HOLDGIL;
+    double distanceSquared3D( const QgsPoint &other ) const SIP_HOLDGIL
+    {
+      if ( is3D() || other.is3D() )
+      {
+        return QgsGeometryUtilsBase::sqrDistance3D( mX, mY, mZ, other.x(), other.y(), other.z() );
+      }
+      return QgsGeometryUtilsBase::sqrDistance2D( mX, mY, other.x(), other.y() );
+    }
 
     /**
      * Calculates Cartesian azimuth between this point and other one (clockwise in degree, starting from north)


### PR DESCRIPTION
## Description

As for the [sqrDistance and Distance 2D](https://github.com/qgis/QGIS/pull/55000) functions, this adds functions for 3D.
To maintain the lowest level, the specific case where a Z could be NaN
is not handled.
It is left to the responsibility of other methods using these functions.

@m-kuhn I've kept [your logic](https://github.com/qgis/QGIS/pull/4712) for distance calculation involving NaNs in QgsPoint. Just a slight rewrite using the new available functions.