### PR TITLE
Fix math error in shader for instanced point 3d renderer

### DIFF
--- a/src/3d/shaders/instanced.frag
+++ b/src/3d/shaders/instanced.frag
@@ -22,5 +22,5 @@ void main()
     vec3 diffuseColor, specularColor;
     vec3 worldView = normalize(eyePosition - worldPosition);
     adsModel(worldPosition, worldNormal, worldView, shininess, diffuseColor, specularColor);
-    fragColor = vec4( ka + kd * diffuseColor + ks * specularColor, opacity );
+    fragColor = vec4( (ka + kd) * diffuseColor + ks * specularColor, opacity );
 }


### PR DESCRIPTION
I believe this was a typo from when the original qt3d shader was adapted -- see https://github.com/qt/qt3d/blob/dev/src/extras/shaders/gl3/phong.inc.frag#L87 for the original