### PR TITLE
Don't treat AABB with any non-zero extents as empty

### DIFF
--- a/src/3d/chunks/qgschunknode_p.cpp
+++ b/src/3d/chunks/qgschunknode_p.cpp
@@ -282,7 +282,7 @@ void QgsChunkNode::updateParentBoundingBoxesRecursively() const
 
     // QgsAABB is normalized in its constructor, so that min values are always smaller than max.
     // If all child bboxes were empty, we can end up with min > max, so let's have an empty bbox instead.
-    const QgsAABB currentNodeBbox = xMin <= xMax && yMin <= yMax && zMin <= zMax ? QgsAABB( xMin, yMin, zMin, xMax, yMax, zMax ) : QgsAABB();
+    const QgsAABB currentNodeBbox = xMin > xMax || yMin > yMax || zMin > zMax ? QgsAABB() : QgsAABB( xMin, yMin, zMin, xMax, yMax, zMax );
 
     currentNode->setExactBbox( currentNodeBbox );
     currentNode = currentNode->parent();

--- a/src/3d/chunks/qgschunknode_p.cpp
+++ b/src/3d/chunks/qgschunknode_p.cpp
@@ -282,7 +282,7 @@ void QgsChunkNode::updateParentBoundingBoxesRecursively() const
 
     // QgsAABB is normalized in its constructor, so that min values are always smaller than max.
     // If all child bboxes were empty, we can end up with min > max, so let's have an empty bbox instead.
-    const QgsAABB currentNodeBbox = xMin < xMax && yMin < yMax && zMin < zMax ? QgsAABB( xMin, yMin, zMin, xMax, yMax, zMax ) : QgsAABB();
+    const QgsAABB currentNodeBbox = xMin <= xMax && yMin <= yMax && zMin <= zMax ? QgsAABB( xMin, yMin, zMin, xMax, yMax, zMax ) : QgsAABB();
 
     currentNode->setExactBbox( currentNodeBbox );
     currentNode = currentNode->parent();

--- a/src/3d/qgsaabb.h
+++ b/src/3d/qgsaabb.h
@@ -78,8 +78,11 @@ class _3D_EXPORT QgsAABB
     //! Returns text representation of the bounding box
     QString toString() const;
 
-    //! Returns true if any of xExtent(), yExtent() or zExtent() is zero, false otherwise
-    bool isEmpty() const { return xMin == xMax || yMin == yMax || zMin == zMax; }
+    //! Returns true if xExtent(), yExtent() and zExtent() are all zero, false otherwise
+    bool isEmpty() const
+    {
+      return xMin == xMax && yMin == yMax && zMin == zMax;
+    }
 
     float xMin = 0.0f;
     float yMin = 0.0f;

--- a/tests/src/3d/testqgsaabb.cpp
+++ b/tests/src/3d/testqgsaabb.cpp
@@ -52,17 +52,20 @@ void TestQgsAABB::testIsEmpty()
   QgsAABB bbox = QgsAABB();
   QVERIFY( bbox.isEmpty() );
 
-  // if any dimension extent is zero, AABB is empty
-  bbox = QgsAABB( 0, 0, 0, 0, 1, 1 );
+  // if all dimension extents are zero, AABB is empty
+  bbox = QgsAABB( 1, 2, 3, 1, 2, 3 );
   QVERIFY( bbox.isEmpty() );
+
+  // if any dimension extent is not zero, AABB is NOT empty
+  bbox = QgsAABB( 0, 0, 0, 0, 1, 1 );
+  QVERIFY( !bbox.isEmpty() );
 
   bbox = QgsAABB( 0, 0, 0, 1, 0, 1 );
-  QVERIFY( bbox.isEmpty() );
+  QVERIFY( !bbox.isEmpty() );
 
   bbox = QgsAABB( 0, 0, 0, 1, 1, 0 );
-  QVERIFY( bbox.isEmpty() );
+  QVERIFY( !bbox.isEmpty() );
 
-  // if no dimension extent is zero, AABB is not empty
   bbox = QgsAABB( 0, 0, 0, 1, 1, 1 );
   QVERIFY( !bbox.isEmpty() );
 }


### PR DESCRIPTION
This causes nodes to disappear when they contain data which sits completely within a flat plane. (Eg point billboard symbols, where the z range will always be 0)
