### PR TITLE
Fix spinbox padding in Blend of Gray theme

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -63,7 +63,7 @@ QMenuBar::item:pressed
 /* ==================================================================================== */
 
 QAbstractSpinBox {
-    padding: 0.12em;
+    padding: 0em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
@@ -72,6 +72,7 @@ QAbstractSpinBox {
     selection-background-color: @selection;
     selection-color: @itemdarkbackground;
     color: @text;
+    contents-margin: 0.12em;
 }
 
 QAbstractSpinBox:no-frame {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -62,12 +62,13 @@ QMenuBar::item:pressed
 /* ==================================================================================== */
 
 QAbstractSpinBox {
-    padding: 0.12em;
+    padding: 0em;
     border: 1px solid @itemdarkbackground;
     background-color: @itembackground;
     selection-background-color: @selection;
     selection-color: @textlight;
     color: @textlight;
+    contents-margin: 0.12em;
 }
 
 QAbstractSpinBox:no-frame {


### PR DESCRIPTION
On my system when using the Blend of Grey theme the bottom of the text in various spinboxes is cut off*:
![image](https://github.com/qgis/QGIS/assets/714600/5d7e4944-0d72-4c72-8c3d-501cbe8e919a)
This commit appears to fix it, although I don't know if it is the "correct" fix.

*Note that I've just discovered a workaround to be able to read the contents of the spinbox - simply type a letter in it, and the contents moves up one pixel.