### PR TITLE
[processing] Extract vertices: fix crash with empty polygons

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractspecificvertices.cpp
+++ b/src/analysis/processing/qgsalgorithmextractspecificvertices.cpp
@@ -156,7 +156,7 @@ QgsFeatureList QgsExtractSpecificVerticesAlgorithm::processFeature( const QgsFea
 
   QgsFeature f = feature;
   const QgsGeometry inputGeom = f.geometry();
-  if ( inputGeom.isNull() )
+  if ( inputGeom.isEmpty() )
   {
     QgsAttributes attrs = f.attributes();
     attrs << QVariant()
@@ -170,6 +170,7 @@ QgsFeatureList QgsExtractSpecificVerticesAlgorithm::processFeature( const QgsFea
           << QVariant()
           << QVariant();
 
+    f.clearGeometry();
     f.setAttributes( attrs );
     outputFeatures << f;
   }

--- a/src/analysis/processing/qgsalgorithmextractvertices.cpp
+++ b/src/analysis/processing/qgsalgorithmextractvertices.cpp
@@ -123,7 +123,7 @@ QgsFeatureList QgsExtractVerticesAlgorithm::processFeature( const QgsFeature &fe
 
   QgsFeature f = feature;
   const QgsGeometry inputGeom = f.geometry();
-  if ( inputGeom.isNull() )
+  if ( inputGeom.isEmpty() )
   {
     QgsAttributes attrs = f.attributes();
     attrs << QVariant()
@@ -136,6 +136,7 @@ QgsFeatureList QgsExtractVerticesAlgorithm::processFeature( const QgsFeature &fe
           << QVariant()
           << QVariant();
 
+    f.clearGeometry();
     f.setAttributes( attrs );
     outputFeatures << f;
   }


### PR DESCRIPTION
## Description

Fixes the crash occurring when the input feature's geometry of the "Extract vertices" (native:extractvertices) algorithm is an empty polygon geometry. Fixes #55656.

This PR also fixes an inconsistent behaviour of both the "Extract vertices" (native:extractvertices) and the "Extract specific vertices" (native:extractspecificvertices) algorithms: they create an output feature without geometry for each input feature with a null geometry, while they doesn't create any feature for each input feature with an empty geometry.
This PR fixes such inconsistency making sure that an output feature without geometry is created for both input features with a null geometry and input features with a empty geometry.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
