### PR TITLE
Disable specular color widget when material has no shininess 

### DIFF
--- a/src/app/3d/qgsphongmaterialwidget.h
+++ b/src/app/3d/qgsphongmaterialwidget.h
@@ -35,12 +35,16 @@ class QgsPhongMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Pho
 
     static QgsMaterialSettingsWidget *create();
 
-    void setTechnique( QgsMaterialSettingsRenderingTechnique technique ) override;
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
+    void setTechnique( QgsMaterialSettingsRenderingTechnique technique ) final;
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
     QgsAbstractMaterialSettings *settings() override;
 
     bool hasOpacity() const { return mHasOpacity; }
     void setHasOpacity( const bool opacity );
+
+  private slots:
+
+    void updateWidgetState();
 
   private:
     bool mHasOpacity; //! whether to display the opacity slider

--- a/src/app/3d/qgsphongtexturedmaterialwidget.cpp
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.cpp
@@ -23,6 +23,8 @@ QgsPhongTexturedMaterialWidget::QgsPhongTexturedMaterialWidget( QWidget *parent 
 {
   setupUi( this );
 
+  spinShininess->setClearValue( 0, tr( "None" ) );
+
   QgsPhongTexturedMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
   textureScaleSpinBox->setClearValue( 100 );
@@ -30,7 +32,11 @@ QgsPhongTexturedMaterialWidget::QgsPhongTexturedMaterialWidget( QWidget *parent 
 
   connect( btnAmbient, &QgsColorButton::colorChanged, this, &QgsPhongTexturedMaterialWidget::changed );
   connect( btnSpecular, &QgsColorButton::colorChanged, this, &QgsPhongTexturedMaterialWidget::changed );
-  connect( spinShininess, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPhongTexturedMaterialWidget::changed );
+  connect( spinShininess, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, [ = ]
+  {
+    updateWidgetState();
+    emit changed();
+  } );
   connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsPhongTexturedMaterialWidget::changed );
   connect( textureFile, &QgsImageSourceLineEdit::sourceChanged, this, &QgsPhongTexturedMaterialWidget::changed );
   connect( textureScaleSpinBox, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPhongTexturedMaterialWidget::changed );
@@ -56,6 +62,8 @@ void QgsPhongTexturedMaterialWidget::setSettings( const QgsAbstractMaterialSetti
   textureRotationSpinBox->setValue( phongMaterial->textureRotation() );
 
   mPropertyCollection = settings->dataDefinedProperties();
+
+  updateWidgetState();
 }
 
 QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
@@ -71,4 +79,18 @@ QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
   m->setDataDefinedProperties( mPropertyCollection );
 
   return m.release();
+}
+
+void QgsPhongTexturedMaterialWidget::updateWidgetState()
+{
+  if ( spinShininess->value() > 0 )
+  {
+    btnSpecular->setEnabled( true );
+    btnSpecular->setToolTip( QString() );
+  }
+  else
+  {
+    btnSpecular->setEnabled( false );
+    btnSpecular->setToolTip( tr( "Specular color is disabled because material has no shininess" ) );
+  }
 }

--- a/src/app/3d/qgsphongtexturedmaterialwidget.h
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.h
@@ -33,10 +33,12 @@ class QgsPhongTexturedMaterialWidget : public QgsMaterialSettingsWidget, private
 
     static QgsMaterialSettingsWidget *create();
 
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
-    QgsAbstractMaterialSettings *settings() override;
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
+    QgsAbstractMaterialSettings *settings() final;
 
+  private slots:
 
+    void updateWidgetState();
 };
 
 #endif // QGSPHONGTEXTUREDMATERIALWIDGET_H

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -168,7 +168,7 @@ void QgsColorButton::unlink()
 
 bool QgsColorButton::event( QEvent *e )
 {
-  if ( e->type() == QEvent::ToolTip )
+  if ( e->type() == QEvent::ToolTip && isEnabled() )
   {
     QColor c = linkedProjectColor();
     const bool isProjectColor = c.isValid();


### PR DESCRIPTION
And add an explanatory tooltip when this happens. Makes it clearer
that specular color only has an impact when material has shininess.