### PR TITLE
Ensure that default shape properties for 3d symbols are always accounted for

### DIFF
--- a/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -114,8 +114,25 @@ Sets 3D shape for points
 
     QVariantMap shapeProperties() const;
 %Docstring
-Returns a key-value dictionary of point shape properties
+Returns a key-value dictionary of point shape properties.
+
+In most cases callers should use :py:func:`~QgsPoint3DSymbol.shapeProperty` instead, to
+correctly handle default values when a property has not been
+explicitly set.
+
+.. seealso:: :py:func:`shapeProperty`
 %End
+
+    QVariant shapeProperty( const QString &property ) const;
+%Docstring
+Returns the value for a specific shape ``property``.
+
+This method accounts for default property values for the symbol's :py:func:`~QgsPoint3DSymbol.shape`,
+used when the property has not been explicitly set.
+
+.. versionadded:: 3.36
+%End
+
     void setShapeProperties( const QVariantMap &properties );
 %Docstring
 Sets a key-value dictionary of point shape properties

--- a/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -114,8 +114,25 @@ Sets 3D shape for points
 
     QVariantMap shapeProperties() const;
 %Docstring
-Returns a key-value dictionary of point shape properties
+Returns a key-value dictionary of point shape properties.
+
+In most cases callers should use :py:func:`~QgsPoint3DSymbol.shapeProperty` instead, to
+correctly handle default values when a property has not been
+explicitly set.
+
+.. seealso:: :py:func:`shapeProperty`
 %End
+
+    QVariant shapeProperty( const QString &property ) const;
+%Docstring
+Returns the value for a specific shape ``property``.
+
+This method accounts for default property values for the symbol's :py:func:`~QgsPoint3DSymbol.shape`,
+used when the property has not been explicitly set.
+
+.. versionadded:: 3.36
+%End
+
     void setShapeProperties( const QVariantMap &properties );
 %Docstring
 Sets a key-value dictionary of point shape properties

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -153,7 +153,7 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
         if ( renderer->type() == QLatin1String( "vector" ) )
         {
           const QgsPoint3DSymbol *pointSymbol = static_cast< const QgsPoint3DSymbol * >( static_cast< QgsVectorLayer3DRenderer *>( renderer )->symbol() );
-          if ( pointSymbol->shapeProperties().value( QStringLiteral( "model" ) ).toString() == url )
+          if ( pointSymbol->shapeProperty( QStringLiteral( "model" ) ).toString() == url )
           {
             removeLayerEntity( layer );
             addLayerEntity( layer );
@@ -165,7 +165,7 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
           for ( auto rule : rules )
           {
             const QgsPoint3DSymbol *pointSymbol = dynamic_cast< const QgsPoint3DSymbol * >( rule->symbol() );
-            if ( pointSymbol->shapeProperties().value( QStringLiteral( "model" ) ).toString() == url )
+            if ( pointSymbol->shapeProperty( QStringLiteral( "model" ) ).toString() == url )
             {
               removeLayerEntity( layer );
               addLayerEntity( layer );

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -169,6 +169,109 @@ QString QgsPoint3DSymbol::shapeToString( QgsPoint3DSymbol::Shape shape )
   }
 }
 
+QVariant QgsPoint3DSymbol::shapeProperty( const QString &property ) const
+{
+  switch ( mShape )
+  {
+    case Cylinder:
+    {
+      if ( property == QLatin1String( "length" ) )
+      {
+        const float length = mShapeProperties.value( property ).toFloat();
+        if ( length == 0 )
+          return 10;
+        return length;
+      }
+      else if ( property == QLatin1String( "radius" ) )
+      {
+        const float radius = mShapeProperties.value( property ).toFloat();
+        if ( radius == 0 )
+          return 10;
+        return radius;
+      }
+      break;
+    }
+    case Sphere:
+    {
+      if ( property == QLatin1String( "radius" ) )
+      {
+        const float radius = mShapeProperties.value( property ).toFloat();
+        if ( radius == 0 )
+          return 10;
+        return radius;
+      }
+      break;
+    }
+    case Cone:
+    {
+      if ( property == QLatin1String( "length" ) )
+      {
+        const float length = mShapeProperties.value( property ).toFloat();
+        if ( length == 0 )
+          return 10;
+        return length;
+      }
+      break;
+    }
+    case Cube:
+    {
+      if ( property == QLatin1String( "size" ) )
+      {
+        const float size = mShapeProperties.value( property ).toFloat();
+        if ( size == 0 )
+          return 10;
+        return size;
+      }
+      break;
+    }
+    case Torus:
+    {
+      if ( property == QLatin1String( "radius" ) )
+      {
+        const float radius = mShapeProperties.value( property ).toFloat();
+        if ( radius == 0 )
+          return 10;
+        return radius;
+      }
+      else if ( property == QLatin1String( "minorRadius" ) )
+      {
+        const float minorRadius = mShapeProperties.value( property ).toFloat();
+        if ( minorRadius == 0 )
+          return 5;
+        return minorRadius;
+      }
+      break;
+    }
+    case Plane:
+    {
+      if ( property == QLatin1String( "size" ) )
+      {
+        const float size = mShapeProperties.value( property ).toFloat();
+        if ( size == 0 )
+          return 10;
+        return size;
+      }
+      break;
+    }
+    case ExtrudedText:
+    {
+      if ( property == QLatin1String( "depth" ) )
+      {
+        const float depth = mShapeProperties.value( property ).toFloat();
+        if ( depth == 0 )
+          return 1;
+        return depth;
+      }
+      break;
+    }
+
+    case Model:
+    case Billboard:
+      break;
+  }
+  return mShapeProperties.value( property );
+}
+
 QMatrix4x4 QgsPoint3DSymbol::billboardTransform() const
 {
   QMatrix4x4 billboardTransformMatrix;

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -100,8 +100,27 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     //! Sets 3D shape for points
     void setShape( Shape shape ) { mShape = shape; }
 
-    //! Returns a key-value dictionary of point shape properties
+    /**
+     * Returns a key-value dictionary of point shape properties.
+     *
+     * In most cases callers should use shapeProperty() instead, to
+     * correctly handle default values when a property has not been
+     * explicitly set.
+     *
+     * \see shapeProperty()
+     */
     QVariantMap shapeProperties() const { return mShapeProperties; }
+
+    /**
+     * Returns the value for a specific shape \a property.
+     *
+     * This method accounts for default property values for the symbol's shape(),
+     * used when the property has not been explicitly set.
+     *
+     * \since QGIS 3.36
+     */
+    QVariant shapeProperty( const QString &property ) const;
+
     //! Sets a key-value dictionary of point shape properties
     void setShapeProperties( const QVariantMap &properties ) { mShapeProperties = properties; }
 

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -93,51 +93,51 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
 
   cboAltClamping->setCurrentIndex( static_cast<int>( pointSymbol->altitudeClamping() ) );
 
-  QVariantMap vm = pointSymbol->shapeProperties();
-  const int index = cboShape->findData( pointSymbol->shape() );
-  cboShape->setCurrentIndex( index != -1 ? index : 1 );  // use cylinder by default if shape is not set
+  cboShape->setCurrentIndex( cboShape->findData( pointSymbol->shape() ) );
   QgsMaterialSettingsRenderingTechnique technique = QgsMaterialSettingsRenderingTechnique::InstancedPoints;
   bool forceNullMaterial = false;
-  switch ( cboShape->currentIndex() )
+  switch ( pointSymbol->shape() )
   {
-    case 0:  // sphere
-      spinRadius->setValue( vm[QStringLiteral( "radius" )].toDouble() );
+    case QgsPoint3DSymbol::Sphere:
+      spinRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "radius" ) ).toDouble() );
       break;
-    case 1:  // cylinder
-      spinRadius->setValue( vm[QStringLiteral( "radius" )].toDouble() );
-      spinLength->setValue( vm[QStringLiteral( "length" )].toDouble() );
+    case QgsPoint3DSymbol::Cylinder:
+      spinRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "radius" ) ).toDouble() );
+      spinLength->setValue( pointSymbol->shapeProperty( QStringLiteral( "length" ) ).toDouble() );
       break;
-    case 2:  // cube
-      spinSize->setValue( vm[QStringLiteral( "size" )].toDouble() );
+    case QgsPoint3DSymbol::Cube:
+      spinSize->setValue( pointSymbol->shapeProperty( QStringLiteral( "size" ) ).toDouble() );
       break;
-    case 3:  // cone
-      spinTopRadius->setValue( vm[QStringLiteral( "topRadius" )].toDouble() );
-      spinBottomRadius->setValue( vm[QStringLiteral( "bottomRadius" )].toDouble() );
-      spinLength->setValue( vm[QStringLiteral( "length" )].toDouble() );
+    case QgsPoint3DSymbol::Cone:
+      spinTopRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "topRadius" ) ).toDouble() );
+      spinBottomRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "bottomRadius" ) ).toDouble() );
+      spinLength->setValue( pointSymbol->shapeProperty( QStringLiteral( "length" ) ).toDouble() );
       break;
-    case 4:  // plane
-      spinSize->setValue( vm[QStringLiteral( "size" )].toDouble() );
+    case QgsPoint3DSymbol::Plane:
+      spinSize->setValue( pointSymbol->shapeProperty( QStringLiteral( "size" ) ).toDouble() );
       break;
-    case 5:  // torus
-      spinRadius->setValue( vm[QStringLiteral( "radius" )].toDouble() );
-      spinMinorRadius->setValue( vm[QStringLiteral( "minorRadius" )].toDouble() );
+    case QgsPoint3DSymbol::Torus:
+      spinRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "radius" ) ).toDouble() );
+      spinMinorRadius->setValue( pointSymbol->shapeProperty( QStringLiteral( "minorRadius" ) ).toDouble() );
       break;
-    case 6:  // 3d model
+    case QgsPoint3DSymbol::Model:
     {
-      lineEditModel->setSource( vm[QStringLiteral( "model" )].toString() );
+      lineEditModel->setSource( pointSymbol->shapeProperty( QStringLiteral( "model" ) ).toString() );
       // "overwriteMaterial" is a legacy setting indicating that non-null material should be used
-      forceNullMaterial = ( vm.contains( QStringLiteral( "overwriteMaterial" ) ) && !vm[QStringLiteral( "overwriteMaterial" )].toBool() )
+      forceNullMaterial = ( pointSymbol->shapeProperties().contains( QStringLiteral( "overwriteMaterial" ) ) && !pointSymbol->shapeProperties().value( QStringLiteral( "overwriteMaterial" ) ).toBool() )
                           || !pointSymbol->materialSettings()
                           || pointSymbol->materialSettings()->type() == QLatin1String( "null" );
       technique = QgsMaterialSettingsRenderingTechnique::TrianglesFromModel;
       break;
     }
-    case 7:  // billboard
+    case QgsPoint3DSymbol::Billboard:
       if ( pointSymbol->billboardSymbol() )
       {
         btnChangeSymbol->setSymbol( pointSymbol->billboardSymbol()->clone() );
       }
       technique = QgsMaterialSettingsRenderingTechnique::Points;
+      break;
+    case QgsPoint3DSymbol::ExtrudedText:
       break;
   }
 
@@ -186,35 +186,37 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
   QVariantMap vm;
   std::unique_ptr< QgsPoint3DSymbol > sym = std::make_unique< QgsPoint3DSymbol >();
   sym->setBillboardSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
-  switch ( cboShape->currentIndex() )
+  switch ( static_cast< QgsPoint3DSymbol::Shape >( cboShape->currentData().toInt() ) )
   {
-    case 0:  // sphere
+    case QgsPoint3DSymbol::Sphere:
       vm[QStringLiteral( "radius" )] = spinRadius->value();
       break;
-    case 1:  // cylinder
+    case QgsPoint3DSymbol::Cylinder:
       vm[QStringLiteral( "radius" )] = spinRadius->value();
       vm[QStringLiteral( "length" )] = spinLength->value();
       break;
-    case 2:  // cube
+    case QgsPoint3DSymbol::Cube:
       vm[QStringLiteral( "size" )] = spinSize->value();
       break;
-    case 3:  // cone
+    case QgsPoint3DSymbol::Cone:
       vm[QStringLiteral( "topRadius" )] = spinTopRadius->value();
       vm[QStringLiteral( "bottomRadius" )] = spinBottomRadius->value();
       vm[QStringLiteral( "length" )] = spinLength->value();
       break;
-    case 4:  // plane
+    case QgsPoint3DSymbol::Plane:
       vm[QStringLiteral( "size" )] = spinSize->value();
       break;
-    case 5:  // torus
+    case QgsPoint3DSymbol::Torus:
       vm[QStringLiteral( "radius" )] = spinRadius->value();
       vm[QStringLiteral( "minorRadius" )] = spinMinorRadius->value();
       break;
-    case 6:  // 3d model
+    case QgsPoint3DSymbol::Model:
       vm[QStringLiteral( "model" )] = lineEditModel->source();
       break;
-    case 7:  // billboard
+    case QgsPoint3DSymbol::Billboard:
       sym->setBillboardSymbol( btnChangeSymbol->clonedSymbol<QgsMarkerSymbol>() );
+      break;
+    case QgsPoint3DSymbol::ExtrudedText:
       break;
   }
 
@@ -259,36 +261,38 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
   transformationWidget->show();
   QList<QWidget *> activeWidgets;
   QgsMaterialSettingsRenderingTechnique technique = QgsMaterialSettingsRenderingTechnique::InstancedPoints;
-  switch ( cboShape->currentIndex() )
+  switch ( static_cast< QgsPoint3DSymbol::Shape >( cboShape->currentData().toInt() ) )
   {
-    case 0:  // sphere
+    case QgsPoint3DSymbol::Sphere:
       activeWidgets << labelRadius << spinRadius;
       break;
-    case 1:  // cylinder
+    case QgsPoint3DSymbol::Cylinder:
       activeWidgets << labelRadius << spinRadius << labelLength << spinLength;
       break;
-    case 2:  // cube
+    case QgsPoint3DSymbol::Cube:
       activeWidgets << labelSize << spinSize;
       break;
-    case 3:  // cone
+    case QgsPoint3DSymbol::Cone:
       activeWidgets << labelTopRadius << spinTopRadius << labelBottomRadius << spinBottomRadius << labelLength << spinLength;
       break;
-    case 4:  // plane
+    case QgsPoint3DSymbol::Plane:
       activeWidgets << labelSize << spinSize;
       break;
-    case 5:  // torus
+    case QgsPoint3DSymbol::Torus:
       activeWidgets << labelRadius << spinRadius << labelMinorRadius << spinMinorRadius;
       break;
-    case 6:  // 3d model
+    case QgsPoint3DSymbol::Model:
       activeWidgets << labelModel << lineEditModel;
       technique = QgsMaterialSettingsRenderingTechnique::TrianglesFromModel;
       break;
-    case 7:  // billboard
+    case QgsPoint3DSymbol::Billboard:
       activeWidgets << labelBillboardHeight << spinBillboardHeight << labelBillboardSymbol << btnChangeSymbol;
       // Always hide material and transformationwidget for billboard
       materialsGroupBox->hide();
       transformationWidget->hide();
       technique = QgsMaterialSettingsRenderingTechnique::Points;
+      break;
+    case QgsPoint3DSymbol::ExtrudedText:
       break;
   }
 

--- a/src/app/3d/qgspoint3dsymbolwidget.h
+++ b/src/app/3d/qgspoint3dsymbolwidget.h
@@ -31,9 +31,9 @@ class QgsPoint3DSymbolWidget : public Qgs3DSymbolWidget, private Ui::Point3DSymb
 
     static Qgs3DSymbolWidget *create( QgsVectorLayer *layer );
 
-    void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer ) override;
-    QgsAbstract3DSymbol *symbol() override;
-    QString symbolType() const override;
+    void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer ) final;
+    QgsAbstract3DSymbol *symbol() final;
+    QString symbolType() const final;
 
   private slots:
     void onShapeChanged();


### PR DESCRIPTION
Ensure that default shape properties for 3d symbols are only stored in a single place, and that we always use the default value when its not overwise set

This has two benefits:
1. The user doesn't see confusing "0" values for radius/length etc, which are silently treated as some other fixed value when rendering
2. The default values are correctly accounted for when calculating the layer's AABB, otherwise we end up with a flat AABB by default

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
