### PR TITLE
[Backport to 3.34]  Fix QAction & QShortcut which live in a different module

### DIFF
--- a/python/PyQt/PyQt5/QtGui.py
+++ b/python/PyQt/PyQt5/QtGui.py
@@ -41,3 +41,7 @@ def __qcolor_repr__(self: QColor):
 
 # PyQt doesn't provide __repr__ for QColor, but it's highly desirable!
 QColor.__repr__ = __qcolor_repr__
+
+from PyQt5.QtWidgets import QAction as _QAction, QShortcut as _QShortcut
+QAction = _QAction
+QShortcut = _QShortcut


### PR DESCRIPTION
Backport of #55658

I propose to backport to 3.34 so plugin developer could migrate their plugin to new qt6 import with next LTR in the process of making them compatible with qt 6