### PR TITLE
[server] Add maptip for raster layer GetFeatureInfo

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -838,7 +838,7 @@ void QgsExpression::initVariableHelp()
 
   // map canvas item variables
   sVariableHelpTexts()->insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );
-  sVariableHelpTexts()->insert( QStringLiteral( "layer_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the current layers's geographical coordinates." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "layer_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the current layers's geographical coordinates. QGIS Server: When used in a maptip expression for a raster layer, this variable holds the GetFeatureInfo position." ) );
 
   // legend canvas item variables
   sVariableHelpTexts()->insert( QStringLiteral( "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2146,7 +2146,7 @@ namespace QgsWms
   bool QgsRenderer::featureInfoFromRasterLayer( QgsRasterLayer *layer,
       const QgsMapSettings &mapSettings,
       const QgsPointXY *infoPoint,
-      QgsRenderContext &renderContext,
+      const QgsRenderContext &renderContext,
       QDomDocument &infoDocument,
       QDomElement &layerElement,
       const QString &version ) const

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1687,7 +1687,7 @@ namespace QgsWms
               getFeatureInfoElement.appendChild( layerElement );
             }
 
-            ( void )featureInfoFromRasterLayer( rasterLayer, mapSettings, &layerInfoPoint, result, layerElement, version );
+            ( void )featureInfoFromRasterLayer( rasterLayer, mapSettings, &layerInfoPoint, renderContext, result, layerElement, version );
           }
           break;
         }
@@ -2146,6 +2146,7 @@ namespace QgsWms
   bool QgsRenderer::featureInfoFromRasterLayer( QgsRasterLayer *layer,
       const QgsMapSettings &mapSettings,
       const QgsPointXY *infoPoint,
+      QgsRenderContext &renderContext,
       QDomDocument &infoDocument,
       QDomElement &layerElement,
       const QString &version ) const
@@ -2306,6 +2307,19 @@ namespace QgsWms
             }
           }
         }
+      }
+      //add maptip attribute based on html/expression
+      QString mapTip = layer->mapTipTemplate();
+      if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
+      {
+        QDomElement maptipElem = infoDocument.createElement( QStringLiteral( "Attribute" ) );
+        maptipElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "maptip" ) );
+        QgsExpressionContext context { renderContext.expressionContext() };
+        QgsExpressionContextScope *scope = QgsExpressionContextUtils::layerScope( layer );
+        scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_cursor_point" ), QVariant::fromValue( QgsGeometry::fromPointXY( QgsPointXY( infoPoint->x(), infoPoint->y() ) ) ) ) );
+        context.appendScope( scope );
+        maptipElem.setAttribute( QStringLiteral( "value" ),  QgsExpression::replaceExpressionText( mapTip, &context ) );
+        layerElement.appendChild( maptipElem );
       }
     }
     return true;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -297,7 +297,7 @@ namespace QgsWms
       bool featureInfoFromRasterLayer( QgsRasterLayer *layer,
                                        const QgsMapSettings &mapSettings,
                                        const QgsPointXY *infoPoint,
-                                       QgsRenderContext &renderContext,
+                                       const QgsRenderContext &renderContext,
                                        QDomDocument &infoDocument,
                                        QDomElement &layerElement,
                                        const QString &version ) const;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -297,6 +297,7 @@ namespace QgsWms
       bool featureInfoFromRasterLayer( QgsRasterLayer *layer,
                                        const QgsMapSettings &mapSettings,
                                        const QgsPointXY *infoPoint,
+                                       QgsRenderContext &renderContext,
                                        QDomDocument &infoDocument,
                                        QDomElement &layerElement,
                                        const QString &version ) const;

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -116,7 +116,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'with_geometry=true',
                                  'wms_getfeatureinfo-text-html-geometry')
 
-        # Test getfeatureinfo response html with maptip and display name
+        # Test getfeatureinfo response html with maptip and display name for vector layer
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fhtml&transparent=true&' +
@@ -127,7 +127,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'with_maptip=true',
                                  'wms_getfeatureinfo-text-html-maptip')
 
-        # Test getfeatureinfo response html with maptip and display name in text mode
+        # Test getfeatureinfo response html with maptip and display name in text mode for vector layer
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fplain&transparent=true&' +
@@ -242,6 +242,16 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'bbox=1989139.6,3522745.0,2015014.9,3537004.5&' +
                                  'query_layers=landsat&X=250&Y=250',
                                  'wms_getfeatureinfo-raster-text-xml')
+
+        # Test GetFeatureInfo on raster layer with maptip
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=landsat&styles=&' +
+                                 'info_format=text%2Fxml&transparent=true&' +
+                                 'width=500&height=500&srs=EPSG%3A3857&' +
+                                 'bbox=1989139.6,3522745.0,2015014.9,3537004.5&' +
+                                 'query_layers=landsat&X=250&Y=250&' +
+                                 'with_maptip=true',
+                                 'wms_getfeatureinfo-raster-text-xml-maptip')
 
     def testGetFeatureInfoValueRelation(self):
         """Test GetFeatureInfo resolves "value relation" widget values. regression 18518"""

--- a/tests/testdata/qgis_server/test_project.qgs
+++ b/tests/testdata/qgis_server/test_project.qgs
@@ -299,6 +299,7 @@
         <property value="0" key="embeddedWidgets/count"/>
         <property value="Value" key="identify/format"/>
       </customproperties>
+      <mapTip enabled="1">[% 'Value Band 5: ' || raster_value(@layer_id, 5, @layer_cursor_point) %]</mapTip>
       <pipe>
         <rasterrenderer opacity="1" type="singlebandgray" grayBand="1" gradient="BlackToWhite" alphaBand="-1">
           <rasterTransparency/>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
@@ -1,0 +1,18 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<GetFeatureInfoResponse>
+ <Layer name="landsat">
+  <Attribute value="125" name="Band 1"/>
+  <Attribute value="138" name="Band 2"/>
+  <Attribute value="112" name="Band 3"/>
+  <Attribute value="75" name="Band 4"/>
+  <Attribute value="90" name="Band 5"/>
+  <Attribute value="132" name="Band 6"/>
+  <Attribute value="165" name="Band 7"/>
+  <Attribute value="217" name="Band 8"/>
+  <Attribute value="175" name="Band 9"/>
+  <Attribute value="Value Band 5: 90" name="maptip"/>
+ </Layer>
+</GetFeatureInfoResponse>


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/50854 raster maptips are available, but they are [currently not included](https://github.com/qgis/QGIS/pull/50854#issuecomment-1310309834) for the raster layer GetFeatureInfo response when requesting with parameter `WITH_MAPTIP=TRUE` like it is the case for vector layers.

This PR is a proposal to implement maptip for raster layer GetFeatureInfo.
In this context, the variable `layer_cursor_point` introduced with https://github.com/qgis/QGIS/pull/50854 holds the GetFeatureInfo position, so that maptips which are working in QGIS desktop are working also with QGIS Server GetFeatureInfo.

closes https://github.com/qgis/QGIS/issues/55569