### PR TITLE
Fix value relation widget update if form is loaded from ui

### DIFF
--- a/python/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
@@ -200,7 +200,7 @@ in :py:func:`~QgsWidgetWrapper.initWidget`.
 :return: A new widget
 %End
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 %Docstring
 This method should initialize the editor widget with runtime data. Fill your comboboxes here.
 

--- a/python/gui/auto_generated/editorwidgets/qgsactionwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsactionwidgetwrapper.sip.in
@@ -41,7 +41,7 @@ Sets the ``action``.
 
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   public slots:

--- a/python/gui/auto_generated/editorwidgets/qgscheckboxsearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgscheckboxsearchwidgetwrapper.sip.in
@@ -67,7 +67,7 @@ Returns a variant representing the current state of the widget.
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   protected slots:

--- a/python/gui/auto_generated/editorwidgets/qgsdatetimesearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdatetimesearchwidgetwrapper.sip.in
@@ -62,7 +62,7 @@ the editor widget's configured field format for date/time values.
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   protected slots:

--- a/python/gui/auto_generated/editorwidgets/qgsdefaultsearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdefaultsearchwidgetwrapper.sip.in
@@ -53,7 +53,7 @@ Constructor for QgsDefaultSearchWidgetWrapper
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
     virtual bool valid() const;
 

--- a/python/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
@@ -35,7 +35,7 @@ Create a html widget wrapper
     virtual QWidget *createWidget( QWidget *parent );
 
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
     void reinitWidget();

--- a/python/gui/auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip.in
@@ -35,7 +35,7 @@ Create a qml widget wrapper
     virtual QWidget *createWidget( QWidget *parent );
 
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
     void reinitWidget();

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
@@ -67,7 +67,7 @@ Returns the default flags (equalTo)
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   public slots:

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
@@ -43,7 +43,7 @@ Constructor for QgsRelationReferenceWidgetWrapper
 
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
     virtual QVariant value() const;
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -237,7 +237,7 @@ Forward the signal to the embedded form
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
     virtual bool valid() const;
 

--- a/python/gui/auto_generated/editorwidgets/qgsvaluemapsearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsvaluemapsearchwidgetwrapper.sip.in
@@ -49,7 +49,7 @@ Constructor for QgsValueMapSearchWidgetWrapper
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   protected slots:

--- a/python/gui/auto_generated/editorwidgets/qgsvaluerelationsearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsvaluerelationsearchwidgetwrapper.sip.in
@@ -51,7 +51,7 @@ Constructor for QgsValueRelationSearchWidgetWrapper
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = 0 );
 
 
   protected slots:

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
@@ -52,7 +52,7 @@ QWidget *QgsWidgetWrapper::widget()
   if ( !mInitialized )
   {
     mWidget->setProperty( "EWV2Wrapper", QVariant::fromValue<QgsWidgetWrapper *>( this ) );
-    initWidget( mWidget );
+    initWidget( mWidget, mParent );
     mInitialized = true;
   }
 
@@ -104,8 +104,9 @@ void QgsWidgetWrapper::notifyAboutToSave()
   aboutToSave();
 }
 
-void QgsWidgetWrapper::initWidget( QWidget *editor )
+void QgsWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   Q_UNUSED( editor )
 }
 

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.h
@@ -240,7 +240,7 @@ class GUI_EXPORT QgsWidgetWrapper : public QObject
      *
      * \param editor The widget which will represent this attribute editor in a form.
      */
-    virtual void initWidget( QWidget *editor );
+    virtual void initWidget( QWidget *editor, QWidget *parent = nullptr );
 
     //! Data defined property collection
     QgsPropertyCollection mPropertyCollection;

--- a/src/gui/editorwidgets/qgsactionwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsactionwidgetwrapper.cpp
@@ -64,9 +64,9 @@ QWidget *QgsActionWidgetWrapper::createWidget( QWidget *parent )
   return new QPushButton( parent );
 }
 
-void QgsActionWidgetWrapper::initWidget( QWidget *editor )
+void QgsActionWidgetWrapper::initWidget( QWidget *editor, QWidget *parentWidget )
 {
-
+  Q_UNUSED( parentWidget )
   mActionButton = qobject_cast<QPushButton *>( editor );
 
   if ( !mActionButton )

--- a/src/gui/editorwidgets/qgsactionwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsactionwidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsActionWidgetWrapper : public QgsWidgetWrapper
     // QgsWidgetWrapper interface
     bool valid() const override;
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   public slots:
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -74,8 +74,9 @@ QWidget *QgsBinaryWidgetWrapper::createWidget( QWidget *parent )
   return container;
 }
 
-void QgsBinaryWidgetWrapper::initWidget( QWidget *editor )
+void QgsBinaryWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mLabel = editor->findChild<QLabel *>();
   mButton = editor->findChild<QToolButton *>();
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private slots:

--- a/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
@@ -156,8 +156,9 @@ QWidget *QgsCheckboxSearchWidgetWrapper::createWidget( QWidget *parent )
   return c;
 }
 
-void QgsCheckboxSearchWidgetWrapper::initWidget( QWidget *editor )
+void QgsCheckboxSearchWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mCheckBox = qobject_cast<QCheckBox *>( editor );
 
   if ( mCheckBox )

--- a/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.h
@@ -70,7 +70,7 @@ class GUI_EXPORT QgsCheckboxSearchWidgetWrapper : public QgsSearchWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   protected slots:
     void setExpression( const QString &expression ) override;

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -58,8 +58,9 @@ QWidget *QgsCheckboxWidgetWrapper::createWidget( QWidget *parent )
   return new QCheckBox( parent );
 }
 
-void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor )
+void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mCheckBox = qobject_cast<QCheckBox *>( editor );
   mGroupBox = qobject_cast<QGroupBox *>( editor );
 

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -42,8 +42,9 @@ QWidget *QgsClassificationWidgetWrapper::createWidget( QWidget *parent )
   return combo;
 }
 
-void QgsClassificationWidgetWrapper::initWidget( QWidget *editor )
+void QgsClassificationWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mComboBox = qobject_cast<QComboBox *>( editor );
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsClassificationWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -56,8 +56,9 @@ QWidget *QgsColorWidgetWrapper::createWidget( QWidget *parent )
   return container;
 }
 
-void QgsColorWidgetWrapper::initWidget( QWidget *editor )
+void QgsColorWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mColorButton = qobject_cast<QgsColorButton *>( editor );
   if ( !mColorButton )
   {

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -41,8 +41,9 @@ QWidget *QgsDateTimeEditWrapper::createWidget( QWidget *parent )
   return widget;
 }
 
-void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
+void QgsDateTimeEditWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   QgsDateTimeEdit *qgsEditor = dynamic_cast<QgsDateTimeEdit *>( editor );
   if ( qgsEditor )
   {

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
   public:
     QVariant value() const override;
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
     void showIndeterminateState() override;
 

--- a/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
@@ -153,8 +153,9 @@ QWidget *QgsDateTimeSearchWidgetWrapper::createWidget( QWidget *parent )
   return widget;
 }
 
-void QgsDateTimeSearchWidgetWrapper::initWidget( QWidget *editor )
+void QgsDateTimeSearchWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mDateTimeEdit = qobject_cast<QgsDateTimeEdit *>( editor );
 
   if ( mDateTimeEdit )

--- a/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.h
@@ -68,7 +68,7 @@ class GUI_EXPORT QgsDateTimeSearchWidgetWrapper : public QgsSearchWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   protected slots:
     void setExpression( const QString &exp ) override;

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -251,8 +251,9 @@ void QgsDefaultSearchWidgetWrapper::setEnabled( bool enabled )
     mCheckbox->setEnabled( enabled );
 }
 
-void QgsDefaultSearchWidgetWrapper::initWidget( QWidget *widget )
+void QgsDefaultSearchWidgetWrapper::initWidget( QWidget *widget, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mContainer = widget;
   mContainer->setLayout( new QHBoxLayout() );
   mContainer->layout()->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsDefaultSearchWidgetWrapper : public QgsSearchWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
     /**

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -51,8 +51,9 @@ QWidget *QgsEnumerationWidgetWrapper::createWidget( QWidget *parent )
   return combo;
 }
 
-void QgsEnumerationWidgetWrapper::initWidget( QWidget *editor )
+void QgsEnumerationWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mComboBox = qobject_cast<QComboBox *>( editor );
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsEnumerationWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -139,8 +139,9 @@ QWidget *QgsExternalResourceWidgetWrapper::createWidget( QWidget *parent )
   return new QgsExternalResourceWidget( parent );
 }
 
-void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
+void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mLineEdit = qobject_cast<QLineEdit *>( editor );
   mLabel = qobject_cast<QLabel *>( editor );
   mQgsWidget = qobject_cast<QgsExternalResourceWidget *>( editor );

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
     /**

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -35,8 +35,9 @@ QWidget *QgsHiddenWidgetWrapper::createWidget( QWidget *parent )
   return wdg;
 }
 
-void QgsHiddenWidgetWrapper::initWidget( QWidget *editor )
+void QgsHiddenWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   editor->setVisible( false );
 }
 

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
@@ -50,7 +50,7 @@ class GUI_EXPORT QgsHiddenWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
@@ -37,8 +37,9 @@ QWidget *QgsHtmlWidgetWrapper::createWidget( QWidget *parent )
   return new QgsWebView( parent );
 }
 
-void QgsHtmlWidgetWrapper::initWidget( QWidget *editor )
+void QgsHtmlWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mWidget = qobject_cast<QgsWebView *>( editor );
 
   if ( !mWidget )

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
@@ -45,7 +45,7 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
 
     QWidget *createWidget( QWidget *parent ) override;
 
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
     //! Clears the content and makes new initialization
     void reinitWidget();

--- a/src/gui/editorwidgets/qgsjsoneditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwrapper.cpp
@@ -38,8 +38,9 @@ QWidget *QgsJsonEditWrapper::createWidget( QWidget *parent )
   return jsonEditWidget;
 }
 
-void QgsJsonEditWrapper::initWidget( QWidget *editor )
+void QgsJsonEditWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mJsonEditWidget = qobject_cast<QgsJsonEditWidget *>( editor );
   if ( !mJsonEditWidget )
   {

--- a/src/gui/editorwidgets/qgsjsoneditwrapper.h
+++ b/src/gui/editorwidgets/qgsjsoneditwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsJsonEditWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   public slots:

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -51,8 +51,9 @@ QWidget *QgsKeyValueWidgetWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsKeyValueWidgetWrapper::initWidget( QWidget *editor )
+void QgsKeyValueWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mWidget = qobject_cast<QgsKeyValueWidget *>( editor );
   if ( !mWidget )
   {

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private slots:

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -45,8 +45,9 @@ QWidget *QgsListWidgetWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsListWidgetWrapper::initWidget( QWidget *editor )
+void QgsListWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mWidget = qobject_cast<QgsListWidget *>( editor );
   if ( !mWidget )
   {

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private slots:

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
@@ -39,8 +39,9 @@ QWidget *QgsQmlWidgetWrapper::createWidget( QWidget *parent )
   return new QQuickWidget( parent );
 }
 
-void QgsQmlWidgetWrapper::initWidget( QWidget *editor )
+void QgsQmlWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mWidget = qobject_cast<QQuickWidget *>( editor );
 
   if ( !mWidget )

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
@@ -45,7 +45,7 @@ class GUI_EXPORT QgsQmlWidgetWrapper : public QgsWidgetWrapper
 
     QWidget *createWidget( QWidget *parent ) override;
 
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
     //! Clears the content and makes new initialization
     void reinitWidget();

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -79,8 +79,9 @@ static void setupIntEditor( const QVariant &min, const QVariant &max, const QVar
   QObject::connect( slider, SIGNAL( valueChanged( int ) ), wrapper, SLOT( emitValueChanged() ) );
 }
 
-void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
+void QgsRangeWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mDoubleSpinBox = qobject_cast<QDoubleSpinBox *>( editor );
   mIntSpinBox = qobject_cast<QSpinBox *>( editor );
 

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -68,7 +68,7 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   public slots:

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -198,8 +198,9 @@ QWidget *QgsRelationReferenceSearchWidgetWrapper::createWidget( QWidget *parent 
   return new QgsRelationReferenceWidget( parent );
 }
 
-void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
+void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mWidget = qobject_cast<QgsRelationReferenceWidget *>( editor );
   if ( !mWidget )
     return;

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
@@ -74,7 +74,7 @@ class GUI_EXPORT QgsRelationReferenceSearchWidgetWrapper : public QgsSearchWidge
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   public slots:
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -34,8 +34,9 @@ QWidget *QgsRelationReferenceWidgetWrapper::createWidget( QWidget *parent )
   return w;
 }
 
-void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
+void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   QgsRelationReferenceWidget *w = qobject_cast<QgsRelationReferenceWidget *>( editor );
   if ( !w )
   {

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
         QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     QVariant value() const override;
     bool valid() const override;
     void showIndeterminateState() override;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -154,8 +154,9 @@ void QgsRelationWidgetWrapper::setShowLabel( bool showLabel )
   Q_UNUSED( showLabel )
 }
 
-void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
+void QgsRelationWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   QgsAbstractRelationEditorWidget *w = qobject_cast<QgsAbstractRelationEditorWidget *>( editor );
 
   // if the editor cannot be cast to relation editor, insert a new one

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -207,7 +207,7 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   signals:

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -146,8 +146,9 @@ QWidget *QgsTextEditWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsTextEditWrapper::initWidget( QWidget *editor )
+void QgsTextEditWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mInvalidJSON = false;
   mTextBrowser = qobject_cast<QTextBrowser *>( editor );
   mTextEdit = qobject_cast<QTextEdit *>( editor );

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   public slots:

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -59,8 +59,9 @@ QWidget *QgsUniqueValuesWidgetWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )
+void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent );
   mComboBox = qobject_cast<QComboBox *>( editor );
   mLineEdit = qobject_cast<QLineEdit *>( editor );
 

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
@@ -59,7 +59,7 @@ class GUI_EXPORT QgsUniqueValuesWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -55,8 +55,9 @@ QWidget *QgsUuidWidgetWrapper::createWidget( QWidget *parent )
   return new QLineEdit( parent );
 }
 
-void QgsUuidWidgetWrapper::initWidget( QWidget *editor )
+void QgsUuidWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mLineEdit = qobject_cast<QLineEdit *>( editor );
   mLabel = qobject_cast<QLabel *>( editor );
   if ( mLineEdit )

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsUuidWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   public slots:

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -138,8 +138,9 @@ void QgsValueMapSearchWidgetWrapper::setEnabled( bool enabled )
   mComboBox->setEnabled( enabled );
 }
 
-void QgsValueMapSearchWidgetWrapper::initWidget( QWidget *editor )
+void QgsValueMapSearchWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mComboBox = qobject_cast<QComboBox *>( editor );
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsValueMapSearchWidgetWrapper : public QgsSearchWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   protected slots:
     void setExpression( const QString &exp ) override;

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -58,8 +58,9 @@ QWidget *QgsValueMapWidgetWrapper::createWidget( QWidget *parent )
   return combo;
 }
 
-void QgsValueMapWidgetWrapper::initWidget( QWidget *editor )
+void QgsValueMapWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mComboBox = qobject_cast<QComboBox *>( editor );
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
   private:

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -209,8 +209,9 @@ QWidget *QgsValueRelationSearchWidgetWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget *editor )
+void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  Q_UNUSED( parent )
   mCache = QgsValueRelationFieldFormatter::createCache( config() );
 
   mComboBox = qobject_cast<QComboBox *>( editor );

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsSearchWidgetWra
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
 
   protected slots:
     //! Called when current value of search widget changes

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -132,11 +132,7 @@ QVariant QgsValueRelationWidgetWrapper::value() const
 
 QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
 {
-  QgsAttributeForm *form = qobject_cast<QgsAttributeForm *>( parent );
-  if ( form )
-    connect( form, &QgsAttributeForm::widgetValueChanged, this, &QgsValueRelationWidgetWrapper::widgetValueChanged );
-
-  mExpression = config().value( QStringLiteral( "FilterExpression" ) ).toString();
+  //mExpression = config().value( QStringLiteral( "FilterExpression" ) ).toString();
 
   if ( config( QStringLiteral( "AllowMulti" ) ).toBool() )
   {
@@ -155,8 +151,15 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
   }
 }
 
-void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
+void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor, QWidget *parent )
 {
+  QgsAttributeForm *form = qobject_cast<QgsAttributeForm *>( parent );
+  if ( form )
+  {
+    connect( form, &QgsAttributeForm::widgetValueChanged, this, &QgsValueRelationWidgetWrapper::widgetValueChanged );
+  }
+
+  mExpression = config().value( QStringLiteral( "FilterExpression" ) ).toString();
 
   mComboBox = qobject_cast<QComboBox *>( editor );
   mTableWidget = qobject_cast<QTableWidget *>( editor );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
   protected:
     QWidget *createWidget( QWidget *parent ) override;
-    void initWidget( QWidget *editor ) override;
+    void initWidget( QWidget *editor, QWidget *parent = nullptr ) override;
     bool valid() const override;
 
     /**


### PR DESCRIPTION
I have an attribute form with two value relation widgets  (combo boxes). The second one has a filter expression which depends on the value of the first combo box. Therefore, if the first combo box changes value, the values of the other combo box are updated. This works fine with the standard ui form or with the drag and drop form. It does not work with a ui designer form. Looking at the code, it seems to me that (in QgsValueRelationWidgetWrapper ) the signal-slot connection and assigning the value of mExpression should be done in the initWidget function instead of the createWidget function.

This PR provides a fix for it. Passing the parent widget as an argument to the initFunction changes a lot of files, so I'm not sure it is the best solution. Don't know if access to the form might be of use for other widget wrappers too.

This PR is against 3.28, because with 3.34 and master, QGIS crashes when opening the ui-Form. So it was not possible for me to test that on 3.34/master. 
