### PR TITLE
Add HAVE_CRASH_HANDLER check before setting exception handler to avoid compilation errors.

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -539,7 +539,9 @@ int main( int argc, char *argv[] )
 #endif
 
 #ifdef _MSC_VER
+#ifdef HAVE_CRASH_HANDLER
   SetUnhandledExceptionFilter( QgsCrashHandler::handle );
+#endif
 #endif
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
Fixes #55715 for those building QGIS on Windows