### PR TITLE
'orderby' arg in orderPartsFunc was renamed to 'order_by'

### DIFF
--- a/resources/function_help/json/order_parts
+++ b/resources/function_help/json/order_parts
@@ -7,7 +7,7 @@
     "arg": "geometry",
     "description": "a multi-type geometry"
   }, {
-    "arg": "orderby",
+    "arg": "order_by",
     "description": "an expression string defining the order criteria"
   }, {
     "arg": "ascending",

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -8869,7 +8869,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
 
     QgsStaticExpressionFunction *orderPartsFunc = new QgsStaticExpressionFunction( QStringLiteral( "order_parts" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) )
-        << QgsExpressionFunction::Parameter( QStringLiteral( "orderby" ) )
+        << QgsExpressionFunction::Parameter( QStringLiteral( "order_by" ) )
         << QgsExpressionFunction::Parameter( QStringLiteral( "ascending" ), true, true ),
         fcnOrderParts, QStringLiteral( "GeometryGroup" ), QString() );
 


### PR DESCRIPTION
## Description

Some QGIS functions use `order_by` as an argument, unlike the [`order_parts()`](https://docs.qgis.org/latest/en/docs/user_manual/expressions/functions_list.html#order-parts) function, where its argument is defined as `orderby`.

So, to make the code more homogeneous, I am suggesting some tiny edits to the argument of the `order_parts` function.

I edited two files: 

| file | How it was | How I suggest it to be |
|:---:|:-------------:|:------------------------:|
| `resources/function_help/json/order_parts`  | `"arg": "orderby",` | `"arg": "order_by",` |
| `src/core/expression/qgsexpressionfunction.cpp` | `<< QgsExpressionFunction::Parameter( QStringLiteral( "orderby" ) )`  | `<< QgsExpressionFunction::Parameter( QStringLiteral( "order_by" ) )` |


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
