### PR TITLE
Keep editorWidgetSetup on fields after committing changes to memory layer

### DIFF
--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -82,6 +82,7 @@ class QgsFieldPrivate : public QSharedData
       , flags( other.flags )
       , defaultValueDefinition( other.defaultValueDefinition )
       , constraints( other.constraints )
+      , editorWidgetSetup( other.editorWidgetSetup )
       , splitPolicy( other.splitPolicy )
       , isReadOnly( other.isReadOnly )
     {

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -104,8 +104,16 @@ void TestQgsField::copy()
   original.setReadOnly( true );
   original.setSplitPolicy( Qgis::FieldDomainSplitPolicy::GeometryRatio );
   original.setMetadata( {{ 1, QStringLiteral( "abc" )}, {2, 5 }} );
+
+  QVariantMap config;
+  config.insert( QStringLiteral( "a" ), "value_a" );
+  const QgsEditorWidgetSetup setup( QStringLiteral( "test" ), config );
+  original.setEditorWidgetSetup( setup );
+
   QgsField copy( original );
   QVERIFY( copy == original );
+  QCOMPARE( copy.editorWidgetSetup().type(), original.editorWidgetSetup().type() );
+  QCOMPARE( copy.editorWidgetSetup().config(), original.editorWidgetSetup().config() );
 
   copy.setName( QStringLiteral( "copy" ) );
   QCOMPARE( original.name(), QString( "original" ) );
@@ -976,8 +984,17 @@ void TestQgsField::editorWidgetSetup()
   const QgsEditorWidgetSetup setup( QStringLiteral( "test" ), config );
   field.setEditorWidgetSetup( setup );
 
+  const QgsField otherField = field;
+
   QCOMPARE( field.editorWidgetSetup().type(), setup.type() );
   QCOMPARE( field.editorWidgetSetup().config(), setup.config() );
+  // trigger copy-on-write with unrelated method call when private pointer is referenced more than once
+  field.setName( QStringLiteral( "original" ) );
+  // verify that editorWidgetSetup still remains
+  QCOMPARE( field.editorWidgetSetup().type(), setup.type() );
+  QCOMPARE( field.editorWidgetSetup().config(), setup.config() );
+  QCOMPARE( otherField.editorWidgetSetup().type(), setup.type() );
+  QCOMPARE( otherField.editorWidgetSetup().config(), setup.config() );
 }
 
 void TestQgsField::collection()

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -15,6 +15,7 @@ from qgis.PyQt.QtCore import QByteArray, QDate, QDateTime, QTime, QVariant
 from qgis.core import (
     NULL,
     QgsCoordinateReferenceSystem,
+    QgsEditorWidgetSetup,
     QgsFeature,
     QgsFeatureRequest,
     QgsFeatureSink,
@@ -475,6 +476,25 @@ class TestPyQgsMemoryProvider(QgisTestCase, ProviderTestCase):
             self.assertEqual(f.subType(), importedFields.field(f.name()).subType())
             self.assertEqual(f.precision(), importedFields.field(f.name()).precision())
             self.assertEqual(f.length(), importedFields.field(f.name()).length())
+
+    def testSaveFieldWithEditorWidget(self):
+        """
+        Test that fields with editor widget retain their widget configuration after calling commitChanges
+        (ref: https://github.com/qgis/QGIS/issues/52288)
+        """
+        layer = QgsVectorLayer("Point", "test", "memory")
+
+        widget = QgsEditorWidgetSetup('ValueMap', {'map': {'key': 'value'}})
+        field = QgsField('my_field', QVariant.String)
+
+        self.assertTrue(layer.startEditing())
+
+        field.setEditorWidgetSetup(widget)
+        layer.addAttribute(field)
+
+        self.assertEqual(layer.fields()[0].editorWidgetSetup().type(), widget.type())
+        self.assertTrue(layer.commitChanges())
+        self.assertEqual(layer.fields()[0].editorWidgetSetup().type(), widget.type())
 
     def testRenameAttributes(self):
         layer = QgsVectorLayer("Point", "test", "memory")


### PR DESCRIPTION
When adding a field without a typeName (i.e. `f = QgsField('my_field', QVariant.String)`), any editor widget config would be lost when committing changes.

This PR adds `editorWidgetSetup` to the copy constructor of `QgsFieldPrivate`, so that the editor widget information is no longer lost when a copy is required.

fixes #52288

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
