### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -112,13 +112,13 @@ jobs:
           zip -u qgis-portable-win64-debugsym.zip git_commit
 
       - name: Upload QGIS for Windows 64bit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: QGIS for Windows 64bit
           path: qgis-portable-win64.zip
 
       - name: Upload QGIS for Windows 64bit Debug Symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: QGIS for Windows 64bit Debug Symbols
           path: qgis-portable-win64-debugsym.zip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -192,7 +192,7 @@ jobs:
         if: ${{ matrix.run-tests }}
         run: tar --exclude='*.o' -cvzf build.tgz build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: ${{ matrix.run-tests }}
         with:
           name: build-${{ matrix.distro-version }}-qt${{ matrix.qt-version }}.tgz
@@ -438,7 +438,7 @@ jobs:
 
       - name: Archive test results report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-qt${{ matrix.qt-version }}
           path: qgis_test_report


### PR DESCRIPTION
Reverts qgis/QGIS#55737

This breaks things - see https://github.com/actions/download-artifact/issues/267