### PR TITLE
Add select/deselect all style categories

### DIFF
--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -140,11 +140,11 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
   mStyleCategoriesListView->adjustSize();
 
   // select and deselect all categories
-  connect( mShowAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::showAll );
-  connect( mHideAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::hideAll );
+  connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::selectAll );
+  connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::deselectAll );
 }
 
-void QgsMapLayerLoadStyleDialog::showAll()
+void QgsMapLayerLoadStyleDialog::selectAll()
 {
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {
@@ -153,7 +153,7 @@ void QgsMapLayerLoadStyleDialog::showAll()
   }
 }
 
-void QgsMapLayerLoadStyleDialog::hideAll()
+void QgsMapLayerLoadStyleDialog::deselectAll()
 {
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {

--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -150,7 +150,7 @@ void QgsMapLayerLoadStyleDialog::invertSelection()
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {
     QModelIndex index = mModel->index( i, 0 );
-    Qt::CheckState currentState = Qt::CheckState( mModel->data(index, Qt::CheckStateRole).toInt() );
+    Qt::CheckState currentState = Qt::CheckState( mModel->data( index, Qt::CheckStateRole ).toInt() );
     Qt::CheckState newState = ( currentState == Qt::Checked ) ? Qt::Unchecked : Qt::Checked;
     mModel->setData( index, newState, Qt::CheckStateRole );
   }

--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -138,6 +138,28 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
   setTabOrder( mRelatedTable, mOthersTable );
 
   mStyleCategoriesListView->adjustSize();
+
+  // select and deselect all categories
+  connect( mShowAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::showAll );
+  connect( mHideAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::hideAll );
+}
+
+void QgsMapLayerLoadStyleDialog::showAll()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    mModel->setData( index, Qt::Checked, Qt::CheckStateRole );
+  }
+}
+
+void QgsMapLayerLoadStyleDialog::hideAll()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    mModel->setData( index, Qt::Unchecked, Qt::CheckStateRole );
+  }
 }
 
 QgsMapLayer::StyleCategories QgsMapLayerLoadStyleDialog::styleCategories() const

--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -142,6 +142,18 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
   // select and deselect all categories
   connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::selectAll );
   connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::deselectAll );
+  connect( mInvertSelectionButton, &QPushButton::clicked, this, &QgsMapLayerLoadStyleDialog::invertSelection );
+}
+
+void QgsMapLayerLoadStyleDialog::invertSelection()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    Qt::CheckState currentState = Qt::CheckState( mModel->data(index, Qt::CheckStateRole).toInt() );
+    Qt::CheckState newState = ( currentState == Qt::Checked ) ? Qt::Unchecked : Qt::Checked;
+    mModel->setData( index, newState, Qt::CheckStateRole );
+  }
 }
 
 void QgsMapLayerLoadStyleDialog::selectAll()

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -84,8 +84,6 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
 
   public slots:
     void accept() override;
-    void selectAll();
-    void deselectAll();
 
   private slots:
     void updateLoadButtonState();
@@ -93,6 +91,9 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
     void onOthersTableSelectionChanged();
     void deleteStyleFromDB();
     void showHelp();
+    void selectAll();
+    void deselectAll();
+    void invertSelection();
 
   private:
     void selectionChanged( QTableWidget *styleTable );

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -84,8 +84,8 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
 
   public slots:
     void accept() override;
-    void showAll();
-    void hideAll();
+    void selectAll();
+    void deselectAll();
 
   private slots:
     void updateLoadButtonState();

--- a/src/gui/qgsmaplayerloadstyledialog.h
+++ b/src/gui/qgsmaplayerloadstyledialog.h
@@ -84,6 +84,8 @@ class GUI_EXPORT QgsMapLayerLoadStyleDialog : public QDialog, private Ui::QgsVec
 
   public slots:
     void accept() override;
+    void showAll();
+    void hideAll();
 
   private slots:
     void updateLoadButtonState();

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -77,8 +77,8 @@ QgsMapLayerSaveStyleDialog::QgsMapLayerSaveStyleDialog( QgsMapLayer *layer, QWid
   mStyleCategoriesListView->setModel( mModel );
 
   // select and deselect all categories
-  connect( mShowAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::showAll );
-  connect( mHideAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::hideAll );
+  connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::showAll );
+  connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::hideAll );
 
   mStyleCategoriesListView->adjustSize();
 

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -92,7 +92,7 @@ void QgsMapLayerSaveStyleDialog::invertSelection()
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {
     QModelIndex index = mModel->index( i, 0 );
-    Qt::CheckState currentState = Qt::CheckState( mModel->data(index, Qt::CheckStateRole).toInt() );
+    Qt::CheckState currentState = Qt::CheckState( mModel->data( index, Qt::CheckStateRole ).toInt() );
     Qt::CheckState newState = ( currentState == Qt::Checked ) ? Qt::Unchecked : Qt::Checked;
     mModel->setData( index, newState, Qt::CheckStateRole );
   }

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -76,10 +76,34 @@ QgsMapLayerSaveStyleDialog::QgsMapLayerSaveStyleDialog( QgsMapLayer *layer, QWid
   mModel->setCategories( lastStyleCategories );
   mStyleCategoriesListView->setModel( mModel );
 
+  // select and deselect all categories
+  connect( mShowAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::showAll );
+  connect( mHideAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::hideAll );
+
   mStyleCategoriesListView->adjustSize();
 
   setupMultipleStyles();
 
+}
+
+void QgsMapLayerSaveStyleDialog::showAll()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    mModel->setData( index, Qt::Checked, Qt::CheckStateRole );
+  }
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+}
+
+void QgsMapLayerSaveStyleDialog::hideAll()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    mModel->setData( index, Qt::Unchecked, Qt::CheckStateRole );
+  }
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
 }
 
 void QgsMapLayerSaveStyleDialog::populateStyleComboBox()

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -79,11 +79,23 @@ QgsMapLayerSaveStyleDialog::QgsMapLayerSaveStyleDialog( QgsMapLayer *layer, QWid
   // select and deselect all categories
   connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::selectAll );
   connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::deselectAll );
+  connect( mInvertSelectionButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::invertSelection );
 
   mStyleCategoriesListView->adjustSize();
 
   setupMultipleStyles();
 
+}
+
+void QgsMapLayerSaveStyleDialog::invertSelection()
+{
+  for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mModel->index( i, 0 );
+    Qt::CheckState currentState = Qt::CheckState( mModel->data(index, Qt::CheckStateRole).toInt() );
+    Qt::CheckState newState = ( currentState == Qt::Checked ) ? Qt::Unchecked : Qt::Checked;
+    mModel->setData( index, newState, Qt::CheckStateRole );
+  }
 }
 
 void QgsMapLayerSaveStyleDialog::selectAll()

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -93,7 +93,6 @@ void QgsMapLayerSaveStyleDialog::showAll()
     QModelIndex index = mModel->index( i, 0 );
     mModel->setData( index, Qt::Checked, Qt::CheckStateRole );
   }
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
 }
 
 void QgsMapLayerSaveStyleDialog::hideAll()
@@ -103,7 +102,6 @@ void QgsMapLayerSaveStyleDialog::hideAll()
     QModelIndex index = mModel->index( i, 0 );
     mModel->setData( index, Qt::Unchecked, Qt::CheckStateRole );
   }
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
 }
 
 void QgsMapLayerSaveStyleDialog::populateStyleComboBox()

--- a/src/gui/qgsmaplayersavestyledialog.cpp
+++ b/src/gui/qgsmaplayersavestyledialog.cpp
@@ -77,8 +77,8 @@ QgsMapLayerSaveStyleDialog::QgsMapLayerSaveStyleDialog( QgsMapLayer *layer, QWid
   mStyleCategoriesListView->setModel( mModel );
 
   // select and deselect all categories
-  connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::showAll );
-  connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::hideAll );
+  connect( mSelectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::selectAll );
+  connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsMapLayerSaveStyleDialog::deselectAll );
 
   mStyleCategoriesListView->adjustSize();
 
@@ -86,7 +86,7 @@ QgsMapLayerSaveStyleDialog::QgsMapLayerSaveStyleDialog( QgsMapLayer *layer, QWid
 
 }
 
-void QgsMapLayerSaveStyleDialog::showAll()
+void QgsMapLayerSaveStyleDialog::selectAll()
 {
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {
@@ -95,7 +95,7 @@ void QgsMapLayerSaveStyleDialog::showAll()
   }
 }
 
-void QgsMapLayerSaveStyleDialog::hideAll()
+void QgsMapLayerSaveStyleDialog::deselectAll()
 {
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); i++ )
   {

--- a/src/gui/qgsmaplayersavestyledialog.h
+++ b/src/gui/qgsmaplayersavestyledialog.h
@@ -104,13 +104,14 @@ class GUI_EXPORT QgsMapLayerSaveStyleDialog : public QDialog, private Ui::QgsMap
 
   public slots:
     void accept() override;
-    void selectAll();
-    void deselectAll();
 
   private slots:
     void updateSaveButtonState();
     void showHelp();
     void readUiFileContent( const QString &filePath );
+    void selectAll();
+    void deselectAll();
+    void invertSelection();
 
   private:
     void setupMultipleStyles();

--- a/src/gui/qgsmaplayersavestyledialog.h
+++ b/src/gui/qgsmaplayersavestyledialog.h
@@ -104,6 +104,8 @@ class GUI_EXPORT QgsMapLayerSaveStyleDialog : public QDialog, private Ui::QgsMap
 
   public slots:
     void accept() override;
+    void showAll();
+    void hideAll();
 
   private slots:
     void updateSaveButtonState();

--- a/src/gui/qgsmaplayersavestyledialog.h
+++ b/src/gui/qgsmaplayersavestyledialog.h
@@ -104,8 +104,8 @@ class GUI_EXPORT QgsMapLayerSaveStyleDialog : public QDialog, private Ui::QgsMap
 
   public slots:
     void accept() override;
-    void showAll();
-    void hideAll();
+    void selectAll();
+    void deselectAll();
 
   private slots:
     void updateSaveButtonState();

--- a/src/ui/qgsmaplayersavestyledialog.ui
+++ b/src/ui/qgsmaplayersavestyledialog.ui
@@ -84,7 +84,7 @@
     </widget>
    </item>
    <item row="3" column="1" colspan="3">
-    <widget class="QgsFileWidget" name="mFileWidget"/>
+    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
    </item>
    <item row="4" column="0" colspan="4">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
@@ -108,7 +108,7 @@
        <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
       </item>
       <item row="2" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
         <property name="toolTip">
          <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
         </property>
@@ -175,16 +175,16 @@
     </spacer>
    </item>
    <item row="6" column="2">
-    <widget class="QPushButton" name="mHideAllButton">
+    <widget class="QPushButton" name="mSelectAllButton">
      <property name="text">
-      <string>Deselect All</string>
+      <string>Select All</string>
      </property>
     </widget>
    </item>
    <item row="6" column="3">
-    <widget class="QPushButton" name="mShowAllButton">
+    <widget class="QPushButton" name="mDeselectAllButton">
      <property name="text">
-      <string>Select All</string>
+      <string>Deselect All</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsmaplayersavestyledialog.ui
+++ b/src/ui/qgsmaplayersavestyledialog.ui
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="3">
+   <item row="0" column="1" colspan="2">
     <widget class="QComboBox" name="mStyleTypeComboBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -38,10 +38,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="3">
+   <item row="1" column="1" colspan="4">
     <widget class="QListWidget" name="mStylesWidget"/>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="2" column="0" colspan="5">
     <widget class="QWidget" name="mSaveToSldWidget" native="true">
      <layout class="QFormLayout" name="formLayout">
       <property name="leftMargin">
@@ -84,9 +84,9 @@
     </widget>
    </item>
    <item row="3" column="1" colspan="3">
-    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+    <widget class="QgsFileWidget" name="mFileWidget"/>
    </item>
-   <item row="4" column="0" colspan="4">
+   <item row="4" column="0" colspan="5">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="leftMargin">
@@ -108,7 +108,7 @@
        <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
       </item>
       <item row="2" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget">
         <property name="toolTip">
          <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
         </property>
@@ -158,21 +158,8 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="3">
+   <item row="5" column="1" colspan="4">
     <widget class="QListView" name="mStyleCategoriesListView"/>
-   </item>
-   <item row="6" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>185</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="6" column="2">
     <widget class="QPushButton" name="mSelectAllButton">
@@ -188,7 +175,14 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="4">
+   <item row="6" column="4">
+    <widget class="QPushButton" name="mInvertSelectionButton">
+     <property name="text">
+      <string>Invert Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="5">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/ui/qgsmaplayersavestyledialog.ui
+++ b/src/ui/qgsmaplayersavestyledialog.ui
@@ -21,16 +21,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mStyleTypeComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="mStylesWidgetLabel">
      <property name="text">
@@ -82,9 +72,6 @@
       <string>File</string>
      </property>
     </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QgsFileWidget" name="mFileWidget"/>
    </item>
    <item row="4" column="0" colspan="5">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
@@ -191,6 +178,19 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QComboBox" name="mStyleTypeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="4">
+    <widget class="QgsFileWidget" name="mFileWidget"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsmaplayersavestyledialog.ui
+++ b/src/ui/qgsmaplayersavestyledialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>492</width>
-    <height>728</height>
+    <width>486</width>
+    <height>742</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="1" colspan="3">
     <widget class="QComboBox" name="mStyleTypeComboBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -38,10 +38,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="1" colspan="3">
     <widget class="QListWidget" name="mStylesWidget"/>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="2" column="0" colspan="3">
     <widget class="QWidget" name="mSaveToSldWidget" native="true">
      <layout class="QFormLayout" name="formLayout">
       <property name="leftMargin">
@@ -83,10 +83,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+   <item row="3" column="1" colspan="3">
+    <widget class="QgsFileWidget" name="mFileWidget"/>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="0" colspan="4">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="leftMargin">
@@ -101,8 +101,14 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
+      </item>
       <item row="2" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget">
         <property name="toolTip">
          <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
         </property>
@@ -115,10 +121,10 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="nameLabel">
+      <item row="2" column="0">
+       <widget class="QLabel" name="mUILabel">
         <property name="text">
-         <string>Style name</string>
+         <string>UI</string>
         </property>
         <property name="buddy">
          <cstring>mDbStyleNameEdit</cstring>
@@ -132,21 +138,15 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="mUILabel">
+      <item row="0" column="0">
+       <widget class="QLabel" name="nameLabel">
         <property name="text">
-         <string>UI</string>
+         <string>Style name</string>
         </property>
         <property name="buddy">
          <cstring>mDbStyleNameEdit</cstring>
         </property>
        </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
       </item>
      </layout>
     </widget>
@@ -158,17 +158,37 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QListView" name="mStyleCategoriesListView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="5" column="1" colspan="3">
+    <widget class="QListView" name="mStyleCategoriesListView"/>
+   </item>
+   <item row="6" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>185</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="2">
+    <widget class="QPushButton" name="mHideAllButton">
+     <property name="text">
+      <string>Deselect All</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="6" column="3">
+    <widget class="QPushButton" name="mShowAllButton">
+     <property name="text">
+      <string>Select All</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/ui/qgsvectorlayerloadstyledialog.ui
+++ b/src/ui/qgsvectorlayerloadstyledialog.ui
@@ -23,6 +23,16 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1" colspan="5">
+    <widget class="QListView" name="mStyleCategoriesListView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="mModeLabel">
      <property name="text">
@@ -30,7 +40,31 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="4">
+   <item row="5" column="0" colspan="6">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Open</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Categories</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mFileLabel">
+     <property name="text">
+      <string>File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="5">
+    <widget class="QgsFileWidget" name="mFileWidget"/>
+   </item>
+   <item row="1" column="0" colspan="6">
     <widget class="QWidget" name="mFromDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
@@ -76,67 +110,27 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="mFileLabel">
+   <item row="0" column="1" colspan="5">
+    <widget class="QComboBox" name="mStyleTypeComboBox"/>
+   </item>
+   <item row="4" column="5">
+    <widget class="QPushButton" name="mInvertSelectionButton">
      <property name="text">
-      <string>File</string>
+      <string>Invert Selection</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Categories</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QListView" name="mStyleCategoriesListView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>235</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="2">
-    <widget class="QPushButton" name="mSelectAllButton">
-     <property name="text">
-      <string>Select All</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
+   <item row="4" column="4">
     <widget class="QPushButton" name="mDeselectAllButton">
      <property name="text">
       <string>Deselect All</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="3">
-    <widget class="QComboBox" name="mStyleTypeComboBox"/>
-   </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QgsFileWidget" name="mFileWidget"/>
-   </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Open</set>
+   <item row="4" column="3">
+    <widget class="QPushButton" name="mSelectAllButton">
+     <property name="text">
+      <string>Select All</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsvectorlayerloadstyledialog.ui
+++ b/src/ui/qgsvectorlayerloadstyledialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>475</width>
-    <height>546</height>
+    <width>500</width>
+    <height>597</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,19 +23,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mStyleTypeComboBox"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="mFileLabel">
-     <property name="text">
-      <string>File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="mModeLabel">
      <property name="text">
@@ -43,24 +30,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Categories</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QListView" name="mStyleCategoriesListView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0" colspan="4">
     <widget class="QWidget" name="mFromDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
@@ -106,7 +76,64 @@
      </layout>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mFileLabel">
+     <property name="text">
+      <string>File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Categories</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QListView" name="mStyleCategoriesListView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0" colspan="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>235</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="2">
+    <widget class="QPushButton" name="mHideAllButton">
+     <property name="text">
+      <string>Deselect All</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QPushButton" name="mShowAllButton">
+     <property name="text">
+      <string>Select All</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QComboBox" name="mStyleTypeComboBox"/>
+   </item>
+   <item row="2" column="1" colspan="3">
+    <widget class="QgsFileWidget" name="mFileWidget"/>
+   </item>
+   <item row="5" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Open</set>

--- a/src/ui/qgsvectorlayerloadstyledialog.ui
+++ b/src/ui/qgsvectorlayerloadstyledialog.ui
@@ -114,16 +114,16 @@
     </spacer>
    </item>
    <item row="4" column="2">
-    <widget class="QPushButton" name="mHideAllButton">
+    <widget class="QPushButton" name="mSelectAllButton">
      <property name="text">
-      <string>Deselect All</string>
+      <string>Select All</string>
      </property>
     </widget>
    </item>
    <item row="4" column="3">
-    <widget class="QPushButton" name="mShowAllButton">
+    <widget class="QPushButton" name="mDeselectAllButton">
      <property name="text">
-      <string>Select All</string>
+      <string>Deselect All</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds two buttons to select and deselect all style categories when saving or loading a style:

![image](https://github.com/qgis/QGIS/assets/2884884/91842d41-16f7-4b1c-89dd-bb8440046f7b)


![image](https://github.com/qgis/QGIS/assets/2884884/c94b2d1c-ccc8-40fd-99a6-c8f3d1513530)

