### PR TITLE
[tiledscene] Catch type error exception when parsing tilesetVersion

### DIFF
--- a/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
@@ -729,8 +729,15 @@ void QgsCesiumTilesDataProviderSharedData::initialize( const QString &tileset, c
     const auto &asset = mTileset[ "asset" ];
     if ( asset.contains( "tilesetVersion" ) )
     {
-      const QString tilesetVersion = QString::fromStdString( asset["tilesetVersion"].get<std::string>() );
-      mLayerMetadata.setIdentifier( tilesetVersion );
+      try
+      {
+        const QString tilesetVersion = QString::fromStdString( asset["tilesetVersion"].get<std::string>() );
+        mLayerMetadata.setIdentifier( tilesetVersion );
+      }
+      catch ( json::type_error & )
+      {
+        QgsDebugError( QStringLiteral( "Error when parsing tilesetVersion value" ) );
+      }
     }
   }
 
@@ -1150,8 +1157,15 @@ QString QgsCesiumTilesDataProvider::htmlMetadata() const
 
     if ( asset.contains( "tilesetVersion" ) )
     {
-      const QString tilesetVersion = QString::fromStdString( asset["tilesetVersion"].get<std::string>() );
-      metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Tileset Version" ) % QStringLiteral( "</td><td>%1</a>" ).arg( tilesetVersion ) % QStringLiteral( "</td></tr>\n" );
+      try
+      {
+        const QString tilesetVersion = QString::fromStdString( asset["tilesetVersion"].get<std::string>() );
+        metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Tileset Version" ) % QStringLiteral( "</td><td>%1</a>" ).arg( tilesetVersion ) % QStringLiteral( "</td></tr>\n" );
+      }
+      catch ( json::type_error & )
+      {
+        QgsDebugError( QStringLiteral( "Error when parsing tilesetVersion value" ) );
+      }
     }
 
     if ( asset.contains( "generator" ) )


### PR DESCRIPTION
## Description

Be more tolerant of cesium tileset.json files (e.g. https://vectortiles.geo.admin.ch/3d-tiles/ch.swisstopo.swisstlm3d.3d/20201020/tileset.json) instead of crashing (on mac) or throwing an obscure exception (on linux).