### PR TITLE
qgs3dmapscene: Refactorize duplicated code into updateScene

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -369,11 +369,12 @@ void Qgs3DMapScene::updateScene( bool forceUpdate )
   if ( forceUpdate )
     QgsEventTracing::addEvent( QgsEventTracing::Instant, QStringLiteral( "3D" ), QStringLiteral( "Update Scene" ) );
 
+  Qgs3DMapSceneEntity::SceneContext sceneContext = buildSceneContext();
   for ( Qgs3DMapSceneEntity *entity : std::as_const( mSceneEntities ) )
   {
     if ( forceUpdate || ( entity->isEnabled() && entity->needsUpdate() ) )
     {
-      entity->handleSceneUpdate( buildSceneContext() );
+      entity->handleSceneUpdate( sceneContext );
       if ( entity->hasReachedGpuMemoryLimit() )
         emit gpuMemoryLimitReached();
     }

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -277,7 +277,7 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void addCameraRotationCenterEntity( QgsCameraController *controller );
     void setSceneState( SceneState state );
     void updateSceneState();
-    void updateScene();
+    void updateScene( bool forceUpdate = false );
     void finalizeNewEntity( Qt3DCore::QEntity *newEntity );
     int maximumTextureSize() const;
     Qgs3DMapSceneEntity::SceneContext buildSceneContext( ) const;


### PR DESCRIPTION
## Description

The update scene logic is duplicated in two different places:
- `Qgs3DMapScene::updateScene`
- `Qgs3DMapScene::onFrameTriggered`

In `Qgs3DMapScene::updateScene`, it iterates through the different mapscene entities, check if th gpu limit has been reached and updates the scene state flags accordingly.
In `Qgs3DMapScene::onFrameTriggered`, it makes the same thing as `Qgs3DMapScene::updateScene` but only if needed.

These similar approaches are merged into one by adding a `forceupdate` boolean.

cc @benoitdm-oslandia 