### PR TITLE
Add framework to temporarily halt flushing of QgsSettings to ini

### DIFF
--- a/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsSettings : QObject
 {
 %Docstring(signature="appended")
@@ -286,6 +287,10 @@ Returns the sanitized and prefixed key
 %Docstring
 Removes all entries in the user settings
 %End
+
+
+
+
 
 };
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 typedef QgsSettingsEntryBaseTemplate<QVariant> QgsSettingsEntryBaseTemplateQVariantBase;
 
 class QgsSettingsEntryVariant : QgsSettingsEntryBaseTemplateQVariantBase

--- a/python/PyQt6/core/auto_generated/settings/qgssettingstreenode.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingstreenode.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsSettingsTreeNode
 {
 %Docstring(signature="appended")
@@ -151,7 +150,6 @@ Returns the number of named nodes in the complete key
 %Docstring
 Registers a child nodes
 %End
-
 
 
   private:

--- a/python/core/auto_generated/settings/qgssettings.sip.in
+++ b/python/core/auto_generated/settings/qgssettings.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsSettings : QObject
 {
 %Docstring(signature="appended")
@@ -286,6 +287,10 @@ Returns the sanitized and prefixed key
 %Docstring
 Removes all entries in the user settings
 %End
+
+
+
+
 
 };
 

--- a/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 typedef QgsSettingsEntryBaseTemplate<QVariant> QgsSettingsEntryBaseTemplateQVariantBase;
 
 class QgsSettingsEntryVariant : QgsSettingsEntryBaseTemplateQVariantBase

--- a/python/core/auto_generated/settings/qgssettingstreenode.sip.in
+++ b/python/core/auto_generated/settings/qgssettingstreenode.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsSettingsTreeNode
 {
 %Docstring(signature="appended")
@@ -151,7 +150,6 @@ Returns the number of named nodes in the complete key
 %Docstring
 Registers a child nodes
 %End
-
 
 
   private:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -897,6 +897,7 @@ set(QGIS_CORE_SRCS
   settings/qgssettingsentry.cpp
   settings/qgssettingsentrygroup.cpp
   settings/qgssettingsentryimpl.cpp
+  settings/qgssettingsproxy.cpp
   settings/qgssettingsregistry.cpp
   settings/qgssettingsregistrycore.cpp
   settings/qgssettingstree.cpp
@@ -1952,6 +1953,7 @@ set(QGIS_CORE_HDRS
   settings/qgssettingsentrygroup.h
   settings/qgssettingsentryenumflag.h
   settings/qgssettingsentryimpl.h
+  settings/qgssettingsproxy.h
   settings/qgssettingsregistry.h
   settings/qgssettingsregistrycore.h
   settings/qgssettingstree.h

--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -22,8 +22,11 @@
 
 #include "qgssettings.h"
 #include "qgsvariantutils.h"
+#include "qgssettingsproxy.h"
 
 Q_GLOBAL_STATIC( QString, sGlobalSettingsPath )
+
+thread_local QgsSettings *QgsSettings::sThreadSettings;
 
 bool QgsSettings::setGlobalSettingsPath( const QString &path )
 {
@@ -329,4 +332,24 @@ QString QgsSettings::sanitizeKey( const QString &key ) const
 void QgsSettings::clear()
 {
   mUserSettings->clear();
+}
+
+
+void QgsSettings::holdFlush()
+{
+  if ( sThreadSettings )
+    return;
+
+  sThreadSettings = new QgsSettings();
+}
+
+void QgsSettings::releaseFlush()
+{
+  delete sThreadSettings;
+  sThreadSettings = nullptr;
+}
+
+QgsSettingsProxy QgsSettings::get()
+{
+  return QgsSettingsProxy( sThreadSettings );
 }

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -25,6 +25,8 @@
 #include "qgslogger.h"
 #include "qgssettingstreenode.h"
 
+class QgsSettingsProxy;
+
 /**
  * \ingroup core
  * \class QgsSettings
@@ -438,6 +440,65 @@ class CORE_EXPORT QgsSettings : public QObject
     QString prefixedKey( const QString &key, QgsSettings::Section section ) const;
     //! Removes all entries in the user settings
     void clear();
+
+    /**
+     * Temporarily places a hold on flushing QgsSettings objects and writing
+     * new values to the underlying ini files.
+     *
+     * This can be used in code which access multiple settings to avoid creation and
+     * destruction of many QgsSettings objects for each in turn. This can be
+     * a VERY expensive operation due to flushing of new values to disk.
+     *
+     * \warning This method ONLY affects access to the settings from the current thread!
+     *
+     * \warning A corresponding call to releaseFlush() MUST be made from the SAME thread.
+     *
+     * \see releaseFlush()
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 3.36
+     */
+    static void holdFlush() SIP_SKIP;
+
+    /**
+     * Releases a previously made hold on flushing QgsSettings objects and writing
+     * new values to the underlying ini files.
+     *
+     * \warning This method ONLY affects access to the settings from the current thread!
+     *
+     * \warning This must ALWAYS be called after a corresponding call to holdFlush() and MUST be made from the SAME thread.
+     *
+     * \see holdFlush()
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 3.36
+     */
+    static void releaseFlush() SIP_SKIP;
+
+    /**
+     * Returns a proxy for a QgsSettings object.
+     *
+     * This either directly constructs a QgsSettings object, or if a
+     * previous call to holdFlush() has been made then the thread local
+     * QgsSettings object will be used.
+     *
+     * \warning ALWAYS use this function to retrieve a QgsSettings object
+     * for entries, NEVER create one manually!
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.36
+     */
+    static QgsSettingsProxy get() SIP_SKIP;
+
+    /**
+     * Thread local QgsSettings storage.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.36
+     */
+    static thread_local QgsSettings *sThreadSettings SIP_SKIP;
 
   private:
     void init();

--- a/src/core/settings/qgssettingsentryimpl.cpp
+++ b/src/core/settings/qgssettingsentryimpl.cpp
@@ -13,10 +13,10 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "qgssettingsentryimpl.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgssettingsproxy.h"
 
 Qgis::SettingsType QgsSettingsEntryVariant::settingsType() const
 {
@@ -222,7 +222,6 @@ int QgsSettingsEntryDouble::displayHintDecimals() const
   return mDisplayHintDecimals;
 }
 
-
 QColor QgsSettingsEntryColor::convertFromVariant( const QVariant &value ) const
 {
   return value.value<QColor>();
@@ -246,21 +245,21 @@ bool QgsSettingsEntryColor::checkValuePrivate( const QColor &value ) const
 
 bool QgsSettingsEntryColor::copyValueFromKeys( const QString &redKey, const QString &greenKey, const QString &blueKey, const QString &alphaKey, bool removeSettingAtKey ) const
 {
-  QgsSettings settings;
-  if ( settings.contains( redKey ) && settings.contains( greenKey ) && settings.contains( blueKey ) && ( alphaKey.isNull() || settings.contains( alphaKey ) ) )
+  auto settings = QgsSettings::get();
+  if ( settings->contains( redKey ) && settings->contains( greenKey ) && settings->contains( blueKey ) && ( alphaKey.isNull() || settings->contains( alphaKey ) ) )
   {
     QVariant oldValue;
     if ( alphaKey.isNull() )
-      oldValue = QColor( settings.value( redKey ).toInt(), settings.value( greenKey ).toInt(), settings.value( blueKey ).toInt() );
+      oldValue = QColor( settings->value( redKey ).toInt(), settings->value( greenKey ).toInt(), settings->value( blueKey ).toInt() );
     else
-      oldValue = QColor( settings.value( redKey ).toInt(), settings.value( greenKey ).toInt(), settings.value( blueKey ).toInt(), settings.value( alphaKey ).toInt() );
+      oldValue = QColor( settings->value( redKey ).toInt(), settings->value( greenKey ).toInt(), settings->value( blueKey ).toInt(), settings->value( alphaKey ).toInt() );
 
     if ( removeSettingAtKey )
     {
-      settings.remove( redKey );
-      settings.remove( greenKey );
-      settings.remove( blueKey );
-      settings.remove( alphaKey );
+      settings->remove( redKey );
+      settings->remove( greenKey );
+      settings->remove( blueKey );
+      settings->remove( alphaKey );
     }
 
     setVariantValue( oldValue );
@@ -271,13 +270,13 @@ bool QgsSettingsEntryColor::copyValueFromKeys( const QString &redKey, const QStr
 
 void QgsSettingsEntryColor::copyValueToKeys( const QString &redKey, const QString &greenKey, const QString &blueKey, const QString &alphaKey ) const
 {
-  QgsSettings settings;
+  auto settings = QgsSettings::get();
   const QColor color = value();
-  settings.setValue( redKey, color.red() );
-  settings.setValue( greenKey, color.green() );
-  settings.setValue( blueKey, color.blue() );
+  settings->setValue( redKey, color.red() );
+  settings->setValue( greenKey, color.green() );
+  settings->setValue( blueKey, color.blue() );
   if ( !alphaKey.isNull() )
-    settings.setValue( alphaKey, color.alpha() );
+    settings->setValue( alphaKey, color.alpha() );
 }
 
 QVariantMap QgsSettingsEntryVariantMap::convertFromVariant( const QVariant &value ) const

--- a/src/core/settings/qgssettingsentryimpl.h
+++ b/src/core/settings/qgssettingsentryimpl.h
@@ -18,7 +18,6 @@
 
 #include "qgssettingsentry.h"
 
-
 /**
  * \class QgsSettingsEntryVariant
  * \ingroup core
@@ -782,6 +781,7 @@ class CORE_EXPORT QgsSettingsEntryColor : public QgsSettingsEntryBaseTemplate<QC
     QColor convertFromVariant( const QVariant &value ) const override SIP_FORCE;
 
   private:
+
     bool checkValuePrivate( const QColor &value ) const override SIP_FORCE;
     bool mAllowAlpha = true;
 };

--- a/src/core/settings/qgssettingsproxy.cpp
+++ b/src/core/settings/qgssettingsproxy.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+  qgssettingsproxy.cpp
+  --------------------------------------
+  Date                 : January 2024
+  Copyright            : (C) 2024 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgssettingsproxy.h"
+
+QgsSettingsProxy::QgsSettingsProxy( QgsSettings *settings )
+  : mNonOwnedSettings( settings )
+{
+  if ( !mNonOwnedSettings )
+    mOwnedSettings.emplace();
+}

--- a/src/core/settings/qgssettingsproxy.h
+++ b/src/core/settings/qgssettingsproxy.h
@@ -1,0 +1,68 @@
+/***************************************************************************
+  qgssettingsproxy.h
+  --------------------------------------
+  Date                 : January 2024
+  Copyright            : (C) 2024 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSETTINGSPROXY_H
+#define QGSSETTINGSPROXY_H
+
+#define SIP_NO_FILE
+
+#include "qgis_core.h"
+#include "qgssettings.h"
+#include <optional>
+
+/**
+ * \class QgsSettingsProxy
+ * \ingroup core
+ *
+ * \brief A helper class for access to either a temporary QgsSettings object or the thread local object.
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 3.36
+ */
+class CORE_EXPORT QgsSettingsProxy
+{
+  public:
+
+    /**
+     * Constructor for QgsSettingsProxy.
+     *
+     * If \a settings is set, then this object will proxy calls to that settings object.
+     * Otherwise a temporary QgsSettings object will be created for the lifetime of the proxy.
+     */
+    explicit QgsSettingsProxy( QgsSettings *settings = nullptr );
+
+    /**
+     * Returns a pointer to the proxied QgsSettings object.
+     */
+    QgsSettings *operator->()
+    {
+      return mOwnedSettings.has_value() ? &( mOwnedSettings.value() ) : mNonOwnedSettings;
+    }
+
+    /**
+     * Returns a reference to the proxied QgsSettings object.
+     */
+    QgsSettings &operator* ()
+    {
+      return mOwnedSettings.has_value() ? mOwnedSettings.value() : *mNonOwnedSettings;
+    }
+
+  private:
+
+    QgsSettings *mNonOwnedSettings = nullptr;
+    std::optional< QgsSettings > mOwnedSettings;
+
+};
+#endif // QGSSETTINGSPROXY_H

--- a/src/core/settings/qgssettingstreenode.cpp
+++ b/src/core/settings/qgssettingstreenode.cpp
@@ -17,9 +17,9 @@
 #include "qgssettingsentryimpl.h"
 #include "qgsexception.h"
 #include "qgssettings.h"
+#include "qgssettingsproxy.h"
 
 #include <QDir>
-
 
 QgsSettingsTreeNode::~QgsSettingsTreeNode()
 {
@@ -168,9 +168,11 @@ QStringList QgsSettingsTreeNamedListNode::items( Qgis::SettingsOrigin origin, co
 
 
   const QString completeKeyParam = completeKeyWithNamedItems( mItemsCompleteKey, parentsNamedItems );
-  QgsSettings settings;
-  settings.beginGroup( completeKeyParam );
-  return settings.childGroups( origin );
+  auto settings = QgsSettings::get();
+  settings->beginGroup( completeKeyParam );
+  const QStringList res = settings->childGroups( origin );
+  settings->endGroup();
+  return res;
 }
 
 void QgsSettingsTreeNamedListNode::setSelectedItem( const QString &item, const QStringList &parentsNamedItems )
@@ -201,7 +203,7 @@ void QgsSettingsTreeNamedListNode::deleteItem( const QString &item, const QStrin
   QStringList args = parentsNamedItems;
   args << item;
   QString key = completeKeyWithNamedItems( mCompleteKey, args );
-  QgsSettings().remove( key );
+  QgsSettings::get()->remove( key );
 }
 
 void QgsSettingsTreeNamedListNode::deleteAllItems( const QStringList &parentsNamedItems )
@@ -210,12 +212,13 @@ void QgsSettingsTreeNamedListNode::deleteAllItems( const QStringList &parentsNam
     throw QgsSettingsException( QObject::tr( "The number of given parent named items (%1) doesn't match with the number of named items in the key (%2)." ).arg( parentsNamedItems.count(), namedNodesCount() ) );
 
   const QStringList children = items( parentsNamedItems );
+  auto settings = QgsSettings::get();
   for ( const QString &child : children )
   {
     QStringList args = parentsNamedItems;
     args << child;
     QString key = completeKeyWithNamedItems( mCompleteKey, args );
-    QgsSettings().remove( key );
+    settings->remove( key );
   }
 }
 

--- a/src/core/settings/qgssettingstreenode.h
+++ b/src/core/settings/qgssettingstreenode.h
@@ -26,7 +26,6 @@ class QgsSettingsTreeNamedListNode;
 class QgsSettingsEntryBase;
 class QgsSettingsEntryString;
 
-
 /**
  * \ingroup core
  * \class QgsSettingsTreeNode
@@ -144,7 +143,6 @@ class CORE_EXPORT QgsSettingsTreeNode
     void registerChildNode( QgsSettingsTreeNode *node );
 
     Qgis::SettingsTreeNodeType mType = Qgis::SettingsTreeNodeType::Root;
-
 
   private:
 


### PR DESCRIPTION
This adds a mechanism where flushes of QgsSettings to the underlying ini storage file can be temporarily suspended. It is intended for code paths where many settings entries are consecutively read/written, to avoid the very expensive cost of constructing and destructing multiple QgsSettings objects for each in turn.

When QgsSettings::holdFlush() is called, then a temporary thread local QgsSettings object will be created and ALL access to settings entries will use this same object (preventing flushing of it to ini files). An accompanying QgsSettings::releaseFlush() call MUST be made from the same thread to destroy the thread local QgsSettings, flush it to disk, and resume normal operation.

This helps avoid the VERY costly backward migration of settings, and cuts the run time for qgis_process commands like `qgis_process list` by at least half (and considerably more in common setups).

This is related to https://github.com/qgis/QGIS/pull/55548 -- since we can't easily avoid all QgsSettings calls in backward compatibility due to the reasons outlined in that PR, this gives us a mechanism where we can at least significantly reduce the cost of the ones we can't avoid...