### PR TITLE
Fix lengthy hang when restoring projects with temporal layers from remote sources

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -340,7 +340,7 @@ void QgsTemporalControllerWidget::setWidgetStateFromProject()
   }
   else
   {
-    setDatesToProjectTime();
+    setDatesToProjectTime( false );
   }
   updateTemporalExtent();
   updateFrameDuration();
@@ -442,7 +442,7 @@ void QgsTemporalControllerWidget::onLayersAdded( const QList<QgsMapLayer *> &lay
 
 void QgsTemporalControllerWidget::firstTemporalLayerLoaded( QgsMapLayer *layer )
 {
-  setDatesToProjectTime();
+  setDatesToProjectTime( true );
 
   if ( QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( layer ) )
   {
@@ -677,7 +677,7 @@ void QgsTemporalControllerWidget::updateTimeStepInputs( const QgsInterval &timeS
 
 void QgsTemporalControllerWidget::mRangeSetToProjectAction_triggered()
 {
-  setDatesToProjectTime();
+  setDatesToProjectTime( false );
   saveRangeToProject();
 }
 
@@ -702,12 +702,23 @@ void QgsTemporalControllerWidget::setDatesToAllLayers()
   setDates( range );
 }
 
-void QgsTemporalControllerWidget::setDatesToProjectTime()
+void QgsTemporalControllerWidget::setDatesToProjectTime( bool tryLastStoredRange )
 {
   QgsDateTimeRange range;
 
+  if ( tryLastStoredRange )
+  {
+    const QString startString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/StartDateTime" ) );
+    const QString endString = QgsProject::instance()->readEntry( QStringLiteral( "TemporalControllerWidget" ), QStringLiteral( "/EndDateTime" ) );
+    if ( !startString.isEmpty() && !endString.isEmpty() )
+    {
+      range = QgsDateTimeRange( QDateTime::fromString( startString, Qt::ISODateWithMs ),
+                                QDateTime::fromString( endString, Qt::ISODateWithMs ) );
+    }
+  }
+
   // by default try taking the project's fixed temporal extent
-  if ( QgsProject::instance()->timeSettings() )
+  if ( ( !range.begin().isValid() || !range.end().isValid() ) && QgsProject::instance()->timeSettings() )
     range = QgsProject::instance()->timeSettings()->temporalRange();
 
   // if that's not set, calculate the extent from the project's layers

--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -135,7 +135,7 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
      * that isn't defined, the range will fallback to the full range of all
      * layers.
      */
-    void setDatesToProjectTime();
+    void setDatesToProjectTime( bool tryLastStoredRange );
 
     /**
      * Updates the value of the slider


### PR DESCRIPTION
When a project was loaded which previously used the temporal controller, setWidgetStateFromProject would call setDatesToProjectTime in order to set the initial temporal range visible in the canvas. This is a bad thing to do, because calculating the project time can involve iterating through all features from a vector layer if that layer is time enabled. And if the layer is a remote layer (eg a wfs one), then the project will take foreeeeeever to load.

Instead, avoid the calculation of the exact project time range when restoring projects and instead just restore the last time range which was visible when the project was saved.