### PR TITLE
[3D] Add a terrain layer logic

### DIFF
--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -56,11 +56,6 @@ Calculates the 2D extent viewed by the 3D camera as the vertices of the viewed t
 .. versionadded:: 3.26
 %End
 
-    int terrainPendingJobsCount() const;
-%Docstring
-Returns number of pending jobs of the terrain entity
-%End
-
     int totalPendingJobsCount() const;
 %Docstring
 Returns number of pending jobs for all chunked entities

--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -132,10 +132,6 @@ Returns a map of 3D map scenes (by name) open in the QGIS application.
 %Docstring
 Emitted when the current terrain entity is replaced by a new one
 %End
-    void terrainPendingJobsCountChanged();
-%Docstring
-Emitted when the number of terrain's pending jobs changes
-%End
 
     void totalPendingJobsCountChanged();
 %Docstring

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -56,11 +56,6 @@ Calculates the 2D extent viewed by the 3D camera as the vertices of the viewed t
 .. versionadded:: 3.26
 %End
 
-    int terrainPendingJobsCount() const;
-%Docstring
-Returns number of pending jobs of the terrain entity
-%End
-
     int totalPendingJobsCount() const;
 %Docstring
 Returns number of pending jobs for all chunked entities

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -132,10 +132,6 @@ Returns a map of 3D map scenes (by name) open in the QGIS application.
 %Docstring
 Emitted when the current terrain entity is replaced by a new one
 %End
-    void terrainPendingJobsCountChanged();
-%Docstring
-Emitted when the number of terrain's pending jobs changes
-%End
 
     void totalPendingJobsCountChanged();
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -2281,6 +2281,33 @@ QFlags<QgsMapLayer::ReadFlag> operator|(QgsMapLayer::ReadFlag f1, QFlags<QgsMapL
 
 
 
+
+class QgsDummyLayer : QgsMapLayer
+{
+%Docstring(signature="appended")
+
+Represents a fake/dummy map layer
+
+.. versionadded:: 3.36
+%End
+
+%TypeHeaderCode
+#include "qgsmaplayer.h"
+%End
+  public:
+    QgsDummyLayer( Qgis::LayerType type, const QString &name = QString() );
+%Docstring
+Default constructor
+%End
+    virtual QgsMapLayer *clone() const;
+    virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext & );
+    virtual bool readSymbology( const QDomNode &, QString &, QgsReadWriteContext &, StyleCategories );
+    virtual bool writeSymbology( QDomNode &, QDomDocument &, QString &,
+                                 const QgsReadWriteContext &, QgsMapLayer::StyleCategories ) const;
+
+    virtual void setTransformContext( const QgsCoordinateTransformContext & );
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -2281,6 +2281,33 @@ QFlags<QgsMapLayer::ReadFlag> operator|(QgsMapLayer::ReadFlag f1, QFlags<QgsMapL
 
 
 
+
+class QgsDummyLayer : QgsMapLayer
+{
+%Docstring(signature="appended")
+
+Represents a fake/dummy map layer
+
+.. versionadded:: 3.36
+%End
+
+%TypeHeaderCode
+#include "qgsmaplayer.h"
+%End
+  public:
+    QgsDummyLayer( Qgis::LayerType type, const QString &name = QString() );
+%Docstring
+Default constructor
+%End
+    virtual QgsMapLayer *clone() const;
+    virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext & );
+    virtual bool readSymbology( const QDomNode &, QString &, QgsReadWriteContext &, StyleCategories );
+    virtual bool writeSymbology( QDomNode &, QDomDocument &, QString &,
+                                 const QgsReadWriteContext &, QgsMapLayer::StyleCategories ) const;
+
+    virtual void setTransformContext( const QgsCoordinateTransformContext & );
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -265,11 +265,6 @@ QVector<QgsPointXY> Qgs3DMapScene::viewFrustum2DExtent() const
   return extent;
 }
 
-int Qgs3DMapScene::terrainPendingJobsCount() const
-{
-  return mTerrain ? mTerrain->pendingJobsCount() : 0;
-}
-
 int Qgs3DMapScene::totalPendingJobsCount() const
 {
   int count = 0;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -709,13 +709,11 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     connect( vlayer, &QgsVectorLayer::selectionChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     connect( vlayer, &QgsVectorLayer::layerModified, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
-
-  if ( layer->type() == Qgis::LayerType::Mesh )
+  else if ( layer->type() == Qgis::LayerType::Mesh )
   {
     connect( layer, &QgsMapLayer::rendererChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
-
-  if ( layer->type() == Qgis::LayerType::PointCloud )
+  else if ( layer->type() == Qgis::LayerType::PointCloud )
   {
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
     connect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
@@ -744,13 +742,11 @@ void Qgs3DMapScene::removeLayerEntity( QgsMapLayer *layer )
     disconnect( vlayer, &QgsVectorLayer::layerModified, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
     mModelVectorLayers.removeAll( layer );
   }
-
-  if ( layer->type() == Qgis::LayerType::Mesh )
+  else if ( layer->type() == Qgis::LayerType::Mesh )
   {
     disconnect( layer, &QgsMapLayer::rendererChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );
   }
-
-  if ( layer->type() == Qgis::LayerType::PointCloud )
+  else if ( layer->type() == Qgis::LayerType::PointCloud )
   {
     QgsPointCloudLayer *pclayer = qobject_cast<QgsPointCloudLayer *>( layer );
     disconnect( pclayer, &QgsPointCloudLayer::renderer3DChanged, this, &Qgs3DMapScene::onLayerRenderer3DChanged );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -507,7 +507,6 @@ void Qgs3DMapScene::createTerrainDeferred()
     mSceneEntities << mTerrain;
 
     connect( mTerrain, &QgsChunkedEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::totalPendingJobsCountChanged );
-    connect( mTerrain, &QgsTerrainEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::terrainPendingJobsCountChanged );
   }
   else
   {

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -105,9 +105,6 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
      */
     QVector<QgsPointXY> viewFrustum2DExtent() const;
 
-    //! Returns number of pending jobs of the terrain entity
-    int terrainPendingJobsCount() const;
-
     /**
      * Returns number of pending jobs for all chunked entities
      * \since QGIS 3.12

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -86,7 +86,7 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
      * Returns terrain entity (may be temporarily NULLPTR)
      * \note Not available in Python bindings
      */
-    QgsTerrainEntity *terrainEntity() SIP_SKIP { return mTerrain; }
+    QgsTerrainEntity *terrainEntity() const SIP_SKIP;
 
     //! Resets camera view to show the whole scene (top view)
     void viewZoomFull();
@@ -283,8 +283,7 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     //! Provides a way to have a synchronous function executed each frame
     Qt3DLogic::QFrameAction *mFrameAction = nullptr;
     QgsCameraController *mCameraController = nullptr;
-    QgsTerrainEntity *mTerrain = nullptr;
-    QList<Qgs3DMapSceneEntity *> mSceneEntities;
+    QgsMapLayer *mTerrainLayer = nullptr;
     //! Entity that shows view center - useful for debugging camera issues
     Qt3DCore::QEntity *mEntityCameraViewCenter = nullptr;
     //! Keeps track of entities that belong to a particular layer

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -204,8 +204,6 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
   signals:
     //! Emitted when the current terrain entity is replaced by a new one
     void terrainEntityChanged();
-    //! Emitted when the number of terrain's pending jobs changes
-    void terrainPendingJobsCountChanged();
 
     /**
      * Emitted when the total number of pending jobs changes

--- a/src/3d/terrain/qgsterrainentity_p.h
+++ b/src/3d/terrain/qgsterrainentity_p.h
@@ -34,6 +34,7 @@
 
 #include <memory>
 
+#include "qgsabstract3drenderer.h"
 
 namespace Qt3DCore
 {
@@ -112,6 +113,27 @@ class TerrainMapUpdateJob : public QgsChunkQueueJob
     QgsTerrainTextureGenerator *mTextureGenerator = nullptr;
     int mJobId;
 };
+
+/**
+ * \ingroup core
+ * \brief 3D renderer that renders all mesh triangles of a mesh layer.
+ * \since QGIS 3.6
+ */
+class _3D_EXPORT QgsTerrainLayer3DRenderer : public QgsAbstract3DRenderer
+{
+  public:
+    //! Takes ownership of the symbol object
+    explicit QgsTerrainLayer3DRenderer();
+
+    QString type() const override;
+    QgsTerrainLayer3DRenderer *clone() const override SIP_FACTORY;
+    Qt3DCore::QEntity *createEntity( const Qgs3DMapSettings &map ) const override SIP_SKIP;
+
+    void writeXml( QDomElement &, const QgsReadWriteContext & ) const override {}
+    void readXml( const QDomElement &, const QgsReadWriteContext & ) override {}
+    void resolveReferences( const QgsProject & ) override {}
+};
+
 
 /// @endcond
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -2409,4 +2409,28 @@ typedef QPointer< QgsMapLayer > QgsWeakMapLayerPointer;
 typedef QList< QgsWeakMapLayerPointer > QgsWeakMapLayerPointerList;
 #endif
 
+
+/**
+ * \ingroup core
+ *
+ * \brief Represents a fake/dummy map layer
+ * \since QGIS 3.36
+ */
+class CORE_EXPORT QgsDummyLayer : public QgsMapLayer
+{
+    Q_OBJECT
+  public:
+    //! Default constructor
+    QgsDummyLayer( Qgis::LayerType type, const QString &name = QString() ): QgsMapLayer( type, name ) {}
+    virtual QgsMapLayer *clone() const override { return nullptr;}
+    virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext & ) override { return nullptr;}
+    virtual bool readSymbology( const QDomNode &, QString &, QgsReadWriteContext &, StyleCategories ) override
+    { return false;}
+    virtual bool writeSymbology( QDomNode &, QDomDocument &, QString &,
+                                 const QgsReadWriteContext &, QgsMapLayer::StyleCategories ) const override
+    { return false;}
+
+    virtual void setTransformContext( const QgsCoordinateTransformContext & ) override {}
+};
+
 #endif


### PR DESCRIPTION
## Description

This way, the terrain is now handled as the other layers.

This is achieved with the two following changes:
- add QgsDummyLayer to handle technical layer (for example terrain).
- add QgsTerrainLayer3DRenderer to handle terrain layer.

With this change, this is now possible to remove `mSceneEntities` as
all the entities are now also saved in mLayerEntities.

cc @benoitdm-oslandia 