### PR TITLE
Allow clicking processing output file/folder/html names in the log to open the containing folder and preselect the generated file

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -74,6 +74,8 @@ Pushes a general informational message from the algorithm. This can
 be used to report feedback which is neither a status report or an
 error, such as "Found 47 matching features".
 
+.. seealso:: :py:func:`pushFormattedMessage`
+
 .. seealso:: :py:func:`pushWarning`
 
 .. seealso:: :py:func:`pushCommandInfo`
@@ -81,6 +83,26 @@ error, such as "Found 47 matching features".
 .. seealso:: :py:func:`pushDebugInfo`
 
 .. seealso:: :py:func:`pushConsoleInfo`
+%End
+
+    virtual void pushFormattedMessage( const QString &html, const QString &text );
+%Docstring
+Pushes a pre-formatted message from the algorithm.
+
+This can be used to push formatted HTML messages to the feedback object.
+A plain ``text`` version of the message must also be specified.
+
+.. seealso:: :py:func:`pushInfo`
+
+.. seealso:: :py:func:`pushWarning`
+
+.. seealso:: :py:func:`pushCommandInfo`
+
+.. seealso:: :py:func:`pushDebugInfo`
+
+.. seealso:: :py:func:`pushConsoleInfo`
+
+.. versionadded:: 3.36
 %End
 
     virtual void pushCommandInfo( const QString &info );
@@ -198,6 +220,9 @@ to scale the current progress to account for progress through the overall proces
     virtual void pushDebugInfo( const QString &info );
 
     virtual void pushConsoleInfo( const QString &info );
+
+    virtual void pushFormattedMessage( const QString &html, const QString &text );
+
 
     virtual QString htmlLog() const;
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -155,6 +155,13 @@ Pushes a summary of the QGIS (and underlying library) version information to the
 .. versionadded:: 3.4.7
 %End
 
+    void pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QVariantMap &results );
+%Docstring
+Pushes a summary of the execution ``results`` to the log
+
+.. versionadded:: 3.36
+%End
+
     virtual QString htmlLog() const;
 %Docstring
 Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingoutputs.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingoutputs.sip.in
@@ -135,6 +135,27 @@ Returns a string version of the parameter output ``value`` (if possible).
 :return: - value converted to string
          - ok: will be set to ``True`` if value could be represented as a string.
 
+.. seealso:: :py:func:`valueAsFormattedString`
+
+
+.. versionadded:: 3.36
+%End
+
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+%Docstring
+Returns a HTML string version of the parameter output ``value`` (if possible).
+
+By default this will return the same value as :py:func:`~QgsProcessingOutputDefinition.valueAsString`.
+
+:param value: value to convert
+:param context: processing context
+
+:return: - value converted to string
+         - ok: will be set to ``True`` if value could be represented as a string.
+
+.. seealso:: :py:func:`valueAsString`
+
+
 .. versionadded:: 3.36
 %End
 
@@ -328,6 +349,8 @@ Constructor for QgsProcessingOutputHtml.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
 };
 
 
@@ -464,6 +487,9 @@ Constructor for QgsProcessingOutputFolder.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputFile : QgsProcessingOutputDefinition
@@ -489,6 +515,9 @@ Constructor for QgsProcessingOutputFile.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputConditionalBranch : QgsProcessingOutputDefinition

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingoutputs.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingoutputs.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsProcessingOutputDefinition
 {
 %Docstring(signature="appended")
@@ -123,6 +125,19 @@ Returns ``True`` if the output was automatically created when adding a parameter
 .. versionadded:: 3.14
 %End
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+%Docstring
+Returns a string version of the parameter output ``value`` (if possible).
+
+:param value: value to convert
+:param context: processing context
+
+:return: - value converted to string
+         - ok: will be set to ``True`` if value could be represented as a string.
+
+.. versionadded:: 3.36
+%End
+
   protected:
 
 
@@ -158,6 +173,7 @@ Returns the type name for the output class.
 %End
 
     virtual QString type() const;
+
 
 };
 
@@ -284,6 +300,9 @@ Returns the type name for the output class.
 %End
     virtual QString type() const;
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputHtml : QgsProcessingOutputDefinition
@@ -336,6 +355,9 @@ Returns the type name for the output class.
 %End
     virtual QString type() const;
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputNumber : QgsProcessingOutputDefinition
@@ -361,6 +383,9 @@ Constructor for QgsProcessingOutputNumber.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputString : QgsProcessingOutputDefinition
@@ -411,6 +436,8 @@ Constructor for :py:class:`QgsProcessingOutputNumber`.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
 };
 
 class QgsProcessingOutputFolder : QgsProcessingOutputDefinition

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -160,6 +160,15 @@ Pushes a warning information string to the dialog's log.
 Pushes an information string to the dialog's log.
 %End
 
+    void pushFormattedMessage( const QString &html );
+%Docstring
+Pushes a pre-formatted message to the dialog's log
+
+This can be used to push formatted HTML messages to the dialog.
+
+.. versionadded:: 3.36
+%End
+
     void pushDebugInfo( const QString &message );
 %Docstring
 Pushes a debug info string to the dialog's log.

--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -74,6 +74,8 @@ Pushes a general informational message from the algorithm. This can
 be used to report feedback which is neither a status report or an
 error, such as "Found 47 matching features".
 
+.. seealso:: :py:func:`pushFormattedMessage`
+
 .. seealso:: :py:func:`pushWarning`
 
 .. seealso:: :py:func:`pushCommandInfo`
@@ -81,6 +83,26 @@ error, such as "Found 47 matching features".
 .. seealso:: :py:func:`pushDebugInfo`
 
 .. seealso:: :py:func:`pushConsoleInfo`
+%End
+
+    virtual void pushFormattedMessage( const QString &html, const QString &text );
+%Docstring
+Pushes a pre-formatted message from the algorithm.
+
+This can be used to push formatted HTML messages to the feedback object.
+A plain ``text`` version of the message must also be specified.
+
+.. seealso:: :py:func:`pushInfo`
+
+.. seealso:: :py:func:`pushWarning`
+
+.. seealso:: :py:func:`pushCommandInfo`
+
+.. seealso:: :py:func:`pushDebugInfo`
+
+.. seealso:: :py:func:`pushConsoleInfo`
+
+.. versionadded:: 3.36
 %End
 
     virtual void pushCommandInfo( const QString &info );
@@ -198,6 +220,9 @@ to scale the current progress to account for progress through the overall proces
     virtual void pushDebugInfo( const QString &info );
 
     virtual void pushConsoleInfo( const QString &info );
+
+    virtual void pushFormattedMessage( const QString &html, const QString &text );
+
 
     virtual QString htmlLog() const;
 

--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -155,6 +155,13 @@ Pushes a summary of the QGIS (and underlying library) version information to the
 .. versionadded:: 3.4.7
 %End
 
+    void pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QVariantMap &results );
+%Docstring
+Pushes a summary of the execution ``results`` to the log
+
+.. versionadded:: 3.36
+%End
+
     virtual QString htmlLog() const;
 %Docstring
 Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.

--- a/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
@@ -135,6 +135,27 @@ Returns a string version of the parameter output ``value`` (if possible).
 :return: - value converted to string
          - ok: will be set to ``True`` if value could be represented as a string.
 
+.. seealso:: :py:func:`valueAsFormattedString`
+
+
+.. versionadded:: 3.36
+%End
+
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+%Docstring
+Returns a HTML string version of the parameter output ``value`` (if possible).
+
+By default this will return the same value as :py:func:`~QgsProcessingOutputDefinition.valueAsString`.
+
+:param value: value to convert
+:param context: processing context
+
+:return: - value converted to string
+         - ok: will be set to ``True`` if value could be represented as a string.
+
+.. seealso:: :py:func:`valueAsString`
+
+
 .. versionadded:: 3.36
 %End
 
@@ -328,6 +349,8 @@ Constructor for QgsProcessingOutputHtml.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
 };
 
 
@@ -464,6 +487,9 @@ Constructor for QgsProcessingOutputFolder.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputFile : QgsProcessingOutputDefinition
@@ -489,6 +515,9 @@ Constructor for QgsProcessingOutputFile.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputConditionalBranch : QgsProcessingOutputDefinition

--- a/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsProcessingOutputDefinition
 {
 %Docstring(signature="appended")
@@ -123,6 +125,19 @@ Returns ``True`` if the output was automatically created when adding a parameter
 .. versionadded:: 3.14
 %End
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+%Docstring
+Returns a string version of the parameter output ``value`` (if possible).
+
+:param value: value to convert
+:param context: processing context
+
+:return: - value converted to string
+         - ok: will be set to ``True`` if value could be represented as a string.
+
+.. versionadded:: 3.36
+%End
+
   protected:
 
 
@@ -158,6 +173,7 @@ Returns the type name for the output class.
 %End
 
     virtual QString type() const;
+
 
 };
 
@@ -284,6 +300,9 @@ Returns the type name for the output class.
 %End
     virtual QString type() const;
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputHtml : QgsProcessingOutputDefinition
@@ -336,6 +355,9 @@ Returns the type name for the output class.
 %End
     virtual QString type() const;
 
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputNumber : QgsProcessingOutputDefinition
@@ -361,6 +383,9 @@ Constructor for QgsProcessingOutputNumber.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
+
 };
 
 class QgsProcessingOutputString : QgsProcessingOutputDefinition
@@ -411,6 +436,8 @@ Constructor for :py:class:`QgsProcessingOutputNumber`.
 Returns the type name for the output class.
 %End
     virtual QString type() const;
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok /Out/ ) const;
+
 };
 
 class QgsProcessingOutputFolder : QgsProcessingOutputDefinition

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -160,6 +160,15 @@ Pushes a warning information string to the dialog's log.
 Pushes an information string to the dialog's log.
 %End
 
+    void pushFormattedMessage( const QString &html );
+%Docstring
+Pushes a pre-formatted message to the dialog's log
+
+This can be used to push formatted HTML messages to the dialog.
+
+.. versionadded:: 3.36
+%End
+
     void pushDebugInfo( const QString &message );
 %Docstring
 Pushes a debug info string to the dialog's log.

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -19,7 +19,6 @@ __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
-from pprint import pformat
 import datetime
 import time
 
@@ -283,9 +282,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     if ok:
                         self.feedback.pushInfo(
                             self.tr(elapsed_time(start_time, 'Execution completed in')))
-                        self.feedback.pushInfo(self.tr('Results:'))
-                        r = {k: v for k, v in results.items() if k not in ('CHILD_RESULTS', 'CHILD_INPUTS')}
-                        self.feedback.pushCommandInfo(pformat(r))
+                        self.feedback.pushFormattedResults(self.algorithm(), self.context, results)
                     else:
                         self.feedback.reportError(
                             self.tr(elapsed_time(start_time, 'Execution failed after')))

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -83,6 +83,15 @@ void QgsProcessingFeedback::pushInfo( const QString &info )
   mTextLog.append( info + '\n' );
 }
 
+void QgsProcessingFeedback::pushFormattedMessage( const QString &html, const QString &text )
+{
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( text, tr( "Processing" ), Qgis::MessageLevel::Info );
+
+  mHtmlLog.append( html + QStringLiteral( "<br/>" ) );
+  mTextLog.append( text + '\n' );
+}
+
 void QgsProcessingFeedback::pushCommandInfo( const QString &info )
 {
   if ( mLogFeedback )
@@ -197,6 +206,11 @@ void QgsProcessingMultiStepFeedback::pushDebugInfo( const QString &info )
 void QgsProcessingMultiStepFeedback::pushConsoleInfo( const QString &info )
 {
   mFeedback->pushConsoleInfo( info );
+}
+
+void QgsProcessingMultiStepFeedback::pushFormattedMessage( const QString &html, const QString &text )
+{
+  mFeedback->pushFormattedMessage( html, text );
 }
 
 QString QgsProcessingMultiStepFeedback::htmlLog() const

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -148,6 +148,34 @@ void QgsProcessingFeedback::pushVersionInfo( const QgsProcessingProvider *provid
   }
 }
 
+void QgsProcessingFeedback::pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QVariantMap &results )
+{
+  if ( results.empty() )
+    return;
+
+  pushInfo( tr( "Results:" ) );
+
+  const QList< const QgsProcessingOutputDefinition * > outputs = algorithm->outputDefinitions();
+  for ( const QgsProcessingOutputDefinition *output : outputs )
+  {
+    const QString outputName = output->name();
+    if ( outputName == QLatin1String( "CHILD_RESULTS" ) || outputName == QLatin1String( "CHILD_INPUTS" ) )
+      continue;
+
+    if ( !results.contains( outputName ) )
+      continue;
+
+    bool ok = false;
+    const QString textValue = output->valueAsString( results.value( output->name() ), context, ok );
+    const QString formattedValue = output->valueAsFormattedString( results.value( output->name() ), context, ok );
+    if ( ok )
+    {
+      pushFormattedMessage( QStringLiteral( "<code>&nbsp;&nbsp;%1: %2</code>" ).arg( output->name(), formattedValue ),
+                            QStringLiteral( "  %1: %2" ).arg( output->name(), textValue ) );
+    }
+  }
+}
+
 QString QgsProcessingFeedback::htmlLog() const
 {
   return mHtmlLog;

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -23,6 +23,8 @@
 #include "qgsmessagelog.h"
 
 class QgsProcessingProvider;
+class QgsProcessingAlgorithm;
+class QgsProcessingContext;
 
 /**
  * \class QgsProcessingFeedback
@@ -140,6 +142,13 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \since QGIS 3.4.7
      */
     void pushVersionInfo( const QgsProcessingProvider *provider = nullptr );
+
+    /**
+     * Pushes a summary of the execution \a results to the log
+     *
+     * \since QGIS 3.36
+     */
+    void pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QVariantMap &results );
 
     /**
      * Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -79,12 +79,30 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * Pushes a general informational message from the algorithm. This can
      * be used to report feedback which is neither a status report or an
      * error, such as "Found 47 matching features".
+     *
+     * \see pushFormattedMessage()
      * \see pushWarning()
      * \see pushCommandInfo()
      * \see pushDebugInfo()
      * \see pushConsoleInfo()
      */
     virtual void pushInfo( const QString &info );
+
+    /**
+     * Pushes a pre-formatted message from the algorithm.
+     *
+     * This can be used to push formatted HTML messages to the feedback object.
+     * A plain \a text version of the message must also be specified.
+     *
+     * \see pushInfo()
+     * \see pushWarning()
+     * \see pushCommandInfo()
+     * \see pushDebugInfo()
+     * \see pushConsoleInfo()
+     *
+     * \since QGIS 3.36
+     */
+    virtual void pushFormattedMessage( const QString &html, const QString &text );
 
     /**
      * Pushes an informational message containing a command from the algorithm.
@@ -189,6 +207,8 @@ class CORE_EXPORT QgsProcessingMultiStepFeedback : public QgsProcessingFeedback
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
+    void pushFormattedMessage( const QString &html, const QString &text ) override;
+
     QString htmlLog() const override;
     QString textLog() const override;
   private slots:

--- a/src/core/processing/qgsprocessingoutputs.cpp
+++ b/src/core/processing/qgsprocessingoutputs.cpp
@@ -18,6 +18,9 @@
 #include "qgsprocessingoutputs.h"
 #include "qgsvariantutils.h"
 
+#include <QUrl>
+#include <QDir>
+
 QgsProcessingOutputDefinition::QgsProcessingOutputDefinition( const QString &name, const QString &description )
   : mName( name )
   , mDescription( description )
@@ -38,6 +41,11 @@ QString QgsProcessingOutputDefinition::valueAsString( const QVariant &value, Qgs
   }
   ok = false;
   return QString();
+}
+
+QString QgsProcessingOutputDefinition::valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok ) const
+{
+  return valueAsString( value, context, ok );
 }
 
 QgsProcessingOutputVectorLayer::QgsProcessingOutputVectorLayer( const QString &name, const QString &description, QgsProcessing::SourceType type )
@@ -70,6 +78,17 @@ QgsProcessingOutputVectorTileLayer::QgsProcessingOutputVectorTileLayer( const QS
 QgsProcessingOutputHtml::QgsProcessingOutputHtml( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
 {}
+
+QString QgsProcessingOutputHtml::valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok ) const
+{
+  if ( value.type() == QVariant::String && !value.toString().isEmpty() )
+  {
+    ok = true;
+    return QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( value.toString() ).toString(), QDir::toNativeSeparators( value.toString() ) );
+  }
+
+  return valueAsString( value, context, ok );
+}
 
 QgsProcessingOutputNumber::QgsProcessingOutputNumber( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
@@ -116,9 +135,31 @@ QgsProcessingOutputFolder::QgsProcessingOutputFolder( const QString &name, const
   : QgsProcessingOutputDefinition( name, description )
 {}
 
+QString QgsProcessingOutputFolder::valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok ) const
+{
+  if ( value.type() == QVariant::String && !value.toString().isEmpty() )
+  {
+    ok = true;
+    return QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( value.toString() ).toString(), QDir::toNativeSeparators( value.toString() ) );
+  }
+
+  return valueAsString( value, context, ok );
+}
+
 QgsProcessingOutputFile::QgsProcessingOutputFile( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
 {}
+
+QString QgsProcessingOutputFile::valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok ) const
+{
+  if ( value.type() == QVariant::String && !value.toString().isEmpty() )
+  {
+    ok = true;
+    return QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( value.toString() ).toString(), QDir::toNativeSeparators( value.toString() ) );
+  }
+
+  return valueAsString( value, context, ok );
+}
 
 QgsProcessingOutputMapLayer::QgsProcessingOutputMapLayer( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )

--- a/src/core/processing/qgsprocessingoutputs.h
+++ b/src/core/processing/qgsprocessingoutputs.h
@@ -143,9 +143,27 @@ class CORE_EXPORT QgsProcessingOutputDefinition
      * \param ok will be set to TRUE if value could be represented as a string.
      * \returns value converted to string
      *
+     * \see valueAsFormattedString()
+     *
      * \since QGIS 3.36
      */
     virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const;
+
+    /**
+     * Returns a HTML string version of the parameter output \a value (if possible).
+     *
+     * By default this will return the same value as valueAsString().
+     *
+     * \param value value to convert
+     * \param context processing context
+     * \param ok will be set to TRUE if value could be represented as a string.
+     * \returns value converted to string
+     *
+     * \see valueAsString()
+     *
+     * \since QGIS 3.36
+     */
+    virtual QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const;
 
   protected:
 
@@ -322,6 +340,7 @@ class CORE_EXPORT QgsProcessingOutputHtml : public QgsProcessingOutputDefinition
      */
     static QString typeName() { return QStringLiteral( "outputHtml" ); }
     QString type() const override { return typeName(); }
+    QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
 };
 
 
@@ -439,6 +458,8 @@ class CORE_EXPORT QgsProcessingOutputFolder : public QgsProcessingOutputDefiniti
      */
     static QString typeName() { return QStringLiteral( "outputFolder" ); }
     QString type() const override { return typeName(); }
+    QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
+
 };
 
 /**
@@ -461,6 +482,8 @@ class CORE_EXPORT QgsProcessingOutputFile : public QgsProcessingOutputDefinition
      */
     static QString typeName() { return QStringLiteral( "outputFile" ); }
     QString type() const override { return typeName(); }
+    QString valueAsFormattedString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
+
 };
 
 /**

--- a/src/core/processing/qgsprocessingoutputs.h
+++ b/src/core/processing/qgsprocessingoutputs.h
@@ -21,6 +21,9 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsprocessing.h"
+
+class QgsProcessingContext;
+
 //
 // Output definitions
 //
@@ -132,6 +135,18 @@ class CORE_EXPORT QgsProcessingOutputDefinition
      */
     bool autoCreated() const { return mAutoCreated; }
 
+    /**
+     * Returns a string version of the parameter output \a value (if possible).
+     *
+     * \param value value to convert
+     * \param context processing context
+     * \param ok will be set to TRUE if value could be represented as a string.
+     * \returns value converted to string
+     *
+     * \since QGIS 3.36
+     */
+    virtual QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const;
+
   protected:
 
     //! Output name
@@ -171,6 +186,7 @@ class CORE_EXPORT QgsProcessingOutputMapLayer : public QgsProcessingOutputDefini
     static QString typeName() { return QStringLiteral( "outputLayer" ); }
 
     QString type() const override;
+
 };
 
 /**
@@ -282,6 +298,8 @@ class CORE_EXPORT QgsProcessingOutputMultipleLayers : public QgsProcessingOutput
      */
     static QString typeName() { return QStringLiteral( "outputMultilayer" ); }
     QString type() const override;
+    QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
+
 };
 
 /**
@@ -327,6 +345,8 @@ class CORE_EXPORT QgsProcessingOutputVariant : public QgsProcessingOutputDefinit
      */
     static QString typeName() { return QStringLiteral( "outputVariant" ); }
     QString type() const override;
+    QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
+
 };
 
 /**
@@ -349,6 +369,8 @@ class CORE_EXPORT QgsProcessingOutputNumber : public QgsProcessingOutputDefiniti
      */
     static QString typeName() { return QStringLiteral( "outputNumber" ); }
     QString type() const override { return typeName(); }
+    QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
+
 };
 
 /**
@@ -393,6 +415,7 @@ class CORE_EXPORT QgsProcessingOutputBoolean : public QgsProcessingOutputDefinit
      */
     static QString typeName() { return QStringLiteral( "outputBoolean" ); }
     QString type() const override { return typeName(); }
+    QString valueAsString( const QVariant &value, QgsProcessingContext &context, bool &ok SIP_OUT ) const override;
 };
 
 /**

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -27,6 +27,7 @@
 #include "qgspanelwidget.h"
 #include "qgsjsonutils.h"
 #include "qgsunittypes.h"
+#include "qgsnative.h"
 #include <QToolButton>
 #include <QDesktopServices>
 #include <QScrollBar>
@@ -118,6 +119,9 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
   splitterHandle->setLayout( handleLayout );
 
   QgsGui::enableAutoGeometryRestore( this );
+
+  txtLog->setOpenLinks( false );
+  connect( txtLog, &QTextBrowser::anchorClicked, this, &QgsProcessingAlgorithmDialogBase::urlClicked );
 
   const QgsSettings settings;
   splitter->restoreState( settings.value( QStringLiteral( "/Processing/dialogBaseSplitter" ), QByteArray() ).toByteArray() );
@@ -582,6 +586,15 @@ void QgsProcessingAlgorithmDialogBase::closeClicked()
 {
   reject();
   close();
+}
+
+void QgsProcessingAlgorithmDialogBase::urlClicked( const QUrl &url )
+{
+  const QFileInfo file( url.toLocalFile() );
+  if ( file.exists() && !file.isDir() )
+    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+  else
+    QDesktopServices::openUrl( url );
 }
 
 QgsProcessingContext::LogLevel QgsProcessingAlgorithmDialogBase::logLevel() const

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -86,6 +86,12 @@ void QgsProcessingAlgorithmDialogFeedback::pushConsoleInfo( const QString &info 
   emit consoleInfoPushed( info );
 }
 
+void QgsProcessingAlgorithmDialogFeedback::pushFormattedMessage( const QString &html, const QString &text )
+{
+  QgsProcessingFeedback::pushFormattedMessage( html, text );
+  emit formattedMessagePushed( html );
+}
+
 //
 // QgsProcessingAlgorithmDialogBase
 //
@@ -414,6 +420,7 @@ QgsProcessingFeedback *QgsProcessingAlgorithmDialogBase::createFeedback()
   connect( feedback.get(), &QgsProcessingAlgorithmDialogFeedback::errorReported, this, &QgsProcessingAlgorithmDialogBase::reportError );
   connect( feedback.get(), &QgsProcessingAlgorithmDialogFeedback::warningPushed, this, &QgsProcessingAlgorithmDialogBase::pushWarning );
   connect( feedback.get(), &QgsProcessingAlgorithmDialogFeedback::infoPushed, this, &QgsProcessingAlgorithmDialogBase::pushInfo );
+  connect( feedback.get(), &QgsProcessingAlgorithmDialogFeedback::formattedMessagePushed, this, &QgsProcessingAlgorithmDialogBase::pushFormattedMessage );
   connect( feedback.get(), &QgsProcessingAlgorithmDialogFeedback::progressTextChanged, this, &QgsProcessingAlgorithmDialogBase::setProgressText );
   connect( buttonCancel, &QPushButton::clicked, feedback.get(), &QgsProcessingFeedback::cancel );
   return feedback.release();
@@ -605,6 +612,12 @@ void QgsProcessingAlgorithmDialogBase::pushWarning( const QString &warning )
 void QgsProcessingAlgorithmDialogBase::pushInfo( const QString &info )
 {
   setInfo( info );
+  processEvents();
+}
+
+void QgsProcessingAlgorithmDialogBase::pushFormattedMessage( const QString &html )
+{
+  setInfo( html, false, false );
   processEvents();
 }
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -65,6 +65,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
     void commandInfoPushed( const QString &text );
     void debugInfoPushed( const QString &text );
     void consoleInfoPushed( const QString &text );
+    void formattedMessagePushed( const QString &html );
 
   public slots:
 
@@ -75,6 +76,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
+    void pushFormattedMessage( const QString &html, const QString &text ) override;
 
 };
 #endif
@@ -220,6 +222,15 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
      * Pushes an information string to the dialog's log.
      */
     void pushInfo( const QString &info );
+
+    /**
+     * Pushes a pre-formatted message to the dialog's log
+     *
+     * This can be used to push formatted HTML messages to the dialog.
+     *
+     * \since QGIS 3.36
+     */
+    void pushFormattedMessage( const QString &html );
 
     /**
      * Pushes a debug info string to the dialog's log.

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -452,6 +452,7 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     void linkClicked( const QUrl &url );
     void taskTriggered( QgsTask *task );
     void closeClicked();
+    void urlClicked( const QUrl &url );
 
   private:
 

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -146,6 +146,19 @@ void ConsoleFeedback::pushConsoleInfo( const QString &info )
   QgsProcessingFeedback::pushConsoleInfo( info );
 }
 
+void ConsoleFeedback::pushFormattedMessage( const QString &html, const QString &text )
+{
+  if ( !mUseJson )
+    std::cout << text.toLocal8Bit().constData() << '\n';
+  else
+  {
+    if ( !mJsonLog.contains( QStringLiteral( "info" ) ) )
+      mJsonLog.insert( QStringLiteral( "info" ), QStringList() );
+    mJsonLog[ QStringLiteral( "info" )] = mJsonLog.value( QStringLiteral( "info" ) ).toStringList() << text;
+  }
+  QgsProcessingFeedback::pushFormattedMessage( html, text );
+}
+
 QVariantMap ConsoleFeedback::jsonLog() const
 {
   return mJsonLog;

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -50,6 +50,8 @@ class ConsoleFeedback : public QgsProcessingFeedback
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
+    void pushFormattedMessage( const QString &html, const QString &text ) override;
+
     QVariantMap jsonLog() const;
 
   private slots:

--- a/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
+++ b/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
@@ -84,7 +84,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QTextEdit" name="txtLog">
+         <widget class="QTextBrowser" name="txtLog">
           <property name="readOnly">
            <bool>true</bool>
           </property>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -818,6 +818,7 @@ class TestQgsProcessing: public QgsTest
     void formatHelp();
     void preprocessParameters();
     void guiDefaultParameterValues();
+    void testOutputs();
 
   private:
 
@@ -12780,6 +12781,196 @@ void TestQgsProcessing::guiDefaultParameterValues()
 
   s.remove( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testIntegerParameter" ) );
   s.remove( QStringLiteral( "/Processing/DefaultGuiParam/testAlgorithm/testStringParameter" ) );
+}
+
+void TestQgsProcessing::testOutputs()
+{
+  QgsProcessingContext context;
+  bool ok = false;
+  QgsProcessingOutputVectorLayer outputVectorLayer( QStringLiteral( "vl" ) );
+  QCOMPARE( outputVectorLayer.valueAsString( QStringLiteral( "/home/test/test.shp" ), context, ok ),
+            QStringLiteral( "/home/test/test.shp" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVectorLayer.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputRasterLayer outputRasterLayer( QStringLiteral( "rl" ) );
+  QCOMPARE( outputRasterLayer.valueAsString( QStringLiteral( "/home/test/test.tiff" ), context, ok ),
+            QStringLiteral( "/home/test/test.tiff" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputRasterLayer.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputPointCloudLayer outputPointCloudLayer( QStringLiteral( "pcl" ) );
+  QCOMPARE( outputPointCloudLayer.valueAsString( QStringLiteral( "/home/test/test.laz" ), context, ok ),
+            QStringLiteral( "/home/test/test.laz" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputPointCloudLayer.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputVectorTileLayer outputVectorTileLayer( QStringLiteral( "vtl" ) );
+  QCOMPARE( outputVectorTileLayer.valueAsString( QStringLiteral( "/home/test/test.mbtiles" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVectorTileLayer.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputMapLayer outputMapLayer( QStringLiteral( "ml" ) );
+  QCOMPARE( outputMapLayer.valueAsString( QStringLiteral( "/home/test/test.mbtiles" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputMapLayer.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputMultipleLayers outputMultipleLayers( QStringLiteral( "ml" ) );
+  QCOMPARE( outputMultipleLayers.valueAsString( QStringLiteral( "/home/test/test.mbtiles" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputMultipleLayers.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  QCOMPARE( outputMultipleLayers.valueAsString( QStringList() << QStringLiteral( "/home/test/test.mbtiles" )
+            << QStringLiteral( "/home/test/test.shp" )
+            << QStringLiteral( "/home/test/test.tif" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles, /home/test/test.shp, /home/test/test.tif" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputMultipleLayers.valueAsString( QVariantList() << QStringLiteral( "/home/test/test.mbtiles" )
+            << QStringLiteral( "/home/test/test.shp" )
+            << QStringLiteral( "/home/test/test.tif" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles, /home/test/test.shp, /home/test/test.tif" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputHtml outputHtml( QStringLiteral( "html" ) );
+  QCOMPARE( outputHtml.valueAsString( QStringLiteral( "/home/test/test.html" ), context, ok ),
+            QStringLiteral( "/home/test/test.html" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputHtml.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputFile outputFile( QStringLiteral( "file" ) );
+  QCOMPARE( outputFile.valueAsString( QStringLiteral( "/home/test/test.txt" ), context, ok ),
+            QStringLiteral( "/home/test/test.txt" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputFile.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputFolder outputFolder( QStringLiteral( "folder" ) );
+  QCOMPARE( outputFolder.valueAsString( QStringLiteral( "/home/test" ), context, ok ),
+            QStringLiteral( "/home/test" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputFolder.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputNumber outputNumber( QStringLiteral( "number" ) );
+  QCOMPARE( outputNumber.valueAsString( QStringLiteral( "xxx" ), context, ok ),
+            QStringLiteral( "xxx" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputNumber.valueAsString( 5, context, ok ),
+            QStringLiteral( "5" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputNumber.valueAsString( 5.5, context, ok ),
+            QStringLiteral( "5.5" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputNumber.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputString outputString( QStringLiteral( "string" ) );
+  QCOMPARE( outputString.valueAsString( QStringLiteral( "lalala" ), context, ok ),
+            QStringLiteral( "lalala" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputString.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputBoolean outputBoolean( QStringLiteral( "string" ) );
+  QCOMPARE( outputBoolean.valueAsString( QStringLiteral( "lalala" ), context, ok ),
+            QStringLiteral( "lalala" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputBoolean.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputBoolean.valueAsString( QVariant( true ), context, ok ),
+            QStringLiteral( "True" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputBoolean.valueAsString( QVariant( false ), context, ok ),
+            QStringLiteral( "False" ) );
+  QVERIFY( ok );
+  ok = false;
+
+  QgsProcessingOutputVariant outputVariant( QStringLiteral( "variant" ) );
+  QCOMPARE( outputVariant.valueAsString( QStringLiteral( "lalala" ), context, ok ),
+            QStringLiteral( "lalala" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( QVariant(), context, ok ),
+            QStringLiteral( "NULL" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( QVariant( true ), context, ok ),
+            QStringLiteral( "True" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( QVariant( false ), context, ok ),
+            QStringLiteral( "False" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( 5, context, ok ),
+            QStringLiteral( "5" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( 5.5, context, ok ),
+            QStringLiteral( "5.5" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( QStringList() << QStringLiteral( "/home/test/test.mbtiles" )
+                                         << QStringLiteral( "/home/test/test.shp" )
+                                         << QStringLiteral( "/home/test/test.tif" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles, /home/test/test.shp, /home/test/test.tif" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputVariant.valueAsString( QVariantList() << QStringLiteral( "/home/test/test.mbtiles" )
+                                         << QStringLiteral( "/home/test/test.shp" )
+                                         << QStringLiteral( "/home/test/test.tif" ), context, ok ),
+            QStringLiteral( "/home/test/test.mbtiles, /home/test/test.shp, /home/test/test.tif" ) );
+  QVERIFY( ok );
+  ok = false;
 }
 
 QGSTEST_MAIN( TestQgsProcessing )

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -12863,6 +12863,10 @@ void TestQgsProcessing::testOutputs()
             QStringLiteral( "/home/test/test.html" ) );
   QVERIFY( ok );
   ok = false;
+  QCOMPARE( outputHtml.valueAsFormattedString( QStringLiteral( "/home/test/test.html" ), context, ok ),
+            QStringLiteral( "<a href=\"file:///home/test/test.html\">/home/test/test.html</a>" ) );
+  QVERIFY( ok );
+  ok = false;
   QCOMPARE( outputHtml.valueAsString( QVariant(), context, ok ),
             QStringLiteral( "NULL" ) );
   QVERIFY( ok );
@@ -12873,6 +12877,10 @@ void TestQgsProcessing::testOutputs()
             QStringLiteral( "/home/test/test.txt" ) );
   QVERIFY( ok );
   ok = false;
+  QCOMPARE( outputFile.valueAsFormattedString( QStringLiteral( "/home/test/test.txt" ), context, ok ),
+            QStringLiteral( "<a href=\"file:///home/test/test.txt\">/home/test/test.txt</a>" ) );
+  QVERIFY( ok );
+  ok = false;
   QCOMPARE( outputFile.valueAsString( QVariant(), context, ok ),
             QStringLiteral( "NULL" ) );
   QVERIFY( ok );
@@ -12881,6 +12889,10 @@ void TestQgsProcessing::testOutputs()
   QgsProcessingOutputFolder outputFolder( QStringLiteral( "folder" ) );
   QCOMPARE( outputFolder.valueAsString( QStringLiteral( "/home/test" ), context, ok ),
             QStringLiteral( "/home/test" ) );
+  QVERIFY( ok );
+  ok = false;
+  QCOMPARE( outputFolder.valueAsFormattedString( QStringLiteral( "/home/test" ), context, ok ),
+            QStringLiteral( "<a href=\"file:///home/test\">/home/test</a>" ) );
   QVERIFY( ok );
   ok = false;
   QCOMPARE( outputFolder.valueAsString( QVariant(), context, ok ),


### PR DESCRIPTION
Makes algorithm execution results prettier in the log, and makes output file/folder/html types clickable links to open the folder containing the generated file:

![image](https://github.com/qgis/QGIS/assets/1829991/c71ee04b-afcd-4192-8e74-4635ef8722ad)
