### PR TITLE
Add --skip-loading-plugins flag for qgis_process

### DIFF
--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -145,6 +145,13 @@ int main( int argc, char *argv[] )
     args.removeAt( noPythonIndex );
   }
 
+  const int skipLoadingPluginsIndex = args.indexOf( QLatin1String( "--skip-loading-plugins" ) );
+  if ( skipLoadingPluginsIndex >= 0 )
+  {
+    flags |= QgsProcessingExec::Flag::SkipLoadingPlugins;
+    args.removeAt( skipLoadingPluginsIndex );
+  }
+
   const QString command = args.value( 1 );
   if ( args.size() == 1 || command == QLatin1String( "--help" ) || command == QLatin1String( "-h" ) )
   {

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -121,11 +121,12 @@ int main( int argc, char *argv[] )
   // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.
   QStringList args = QCoreApplication::arguments();
 
+  QgsProcessingExec::Flags flags;
+
   const int jsonIndex = args.indexOf( QLatin1String( "--json" ) );
-  bool useJson = false;
   if ( jsonIndex >= 0 )
   {
-    useJson = true;
+    flags |= QgsProcessingExec::Flag::UseJson;
     args.removeAt( jsonIndex );
   }
 
@@ -138,10 +139,9 @@ int main( int argc, char *argv[] )
   }
 
   const int noPythonIndex = args.indexOf( QLatin1String( "--no-python" ) );
-  bool skipPython = false;
   if ( noPythonIndex >= 0 )
   {
-    skipPython = true;
+    flags |= QgsProcessingExec::Flag::SkipPython;
     args.removeAt( noPythonIndex );
   }
 
@@ -177,9 +177,9 @@ int main( int argc, char *argv[] )
 
   QgsProcessingExec exec;
   int res = 0;
-  QTimer::singleShot( 0, &app, [&exec, args, useJson, logLevel, skipPython, &res]
+  QTimer::singleShot( 0, &app, [&exec, args, logLevel, flags, &res]
   {
-    res = exec.run( args, useJson, logLevel, skipPython );
+    res = exec.run( args, logLevel, flags );
     QgsApplication::exitQgis();
     QCoreApplication::exit( res );
   } );

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -276,8 +276,11 @@ int QgsProcessingExec::run( const QStringList &args, QgsProcessingContext::LogLe
   {
     if ( args.size() == 2 || ( args.size() == 3 && args.at( 2 ) == QLatin1String( "list" ) ) )
     {
-      loadPlugins();
-      listPlugins( mFlags & Flag::UseJson, true );
+      if ( !( mFlags & Flag::SkipLoadingPlugins ) )
+      {
+        loadPlugins();
+      }
+      listPlugins( mFlags & Flag::UseJson, !( mFlags & Flag::SkipLoadingPlugins ) );
       return 0;
     }
     else if ( args.size() == 4 && args.at( 2 ) == QLatin1String( "enable" ) )
@@ -293,7 +296,10 @@ int QgsProcessingExec::run( const QStringList &args, QgsProcessingContext::LogLe
   }
   else if ( command == QLatin1String( "list" ) )
   {
-    loadPlugins();
+    if ( !( mFlags & Flag::SkipLoadingPlugins ) )
+    {
+      loadPlugins();
+    }
     listAlgorithms();
     return 0;
   }
@@ -305,7 +311,10 @@ int QgsProcessingExec::run( const QStringList &args, QgsProcessingContext::LogLe
       return 1;
     }
 
-    loadPlugins();
+    if ( !( mFlags & Flag::SkipLoadingPlugins ) )
+    {
+      loadPlugins();
+    }
     const QString algId = args.at( 2 );
     return showAlgorithmHelp( algId );
   }
@@ -317,7 +326,10 @@ int QgsProcessingExec::run( const QStringList &args, QgsProcessingContext::LogLe
       return 1;
     }
 
-    loadPlugins();
+    if ( !( mFlags & Flag::SkipLoadingPlugins ) )
+    {
+      loadPlugins();
+    }
 
     const QString algId = args.at( 2 );
 
@@ -501,13 +513,14 @@ void QgsProcessingExec::showUsage( const QString &appName )
 
   msg << "QGIS Processing Executor - " << VERSION << " '" << RELEASE_NAME << "' ("
       << Qgis::version() << ")\n"
-      << "Usage: " << appName <<  " [--help] [--version] [--json] [--verbose] [--no-python] [command] [algorithm id, path to model file, or path to Python script] [parameters]\n"
+      << "Usage: " << appName <<  " [--help] [--version] [--json] [--verbose] [--no-python] [--skip-loading-plugins] [command] [algorithm id, path to model file, or path to Python script] [parameters]\n"
       << "\nOptions:\n"
       << "\t--help or -h\t\tOutput the help\n"
       << "\t--version or -v\t\tOutput all versions related to QGIS Process\n"
       << "\t--json\t\tOutput results as JSON objects\n"
       << "\t--verbose\tOutput verbose logs\n"
       << "\t--no-python\tDisable Python support (results in faster startup)"
+      << "\t--skip-loading-plugins\tAvoid loading enabled plugins (results in faster startup)"
       << "\nAvailable commands:\n"
       << "\tplugins\t\tlist available and active plugins\n"
       << "\tplugins enable\tenables an installed plugin. The plugin name must be specified, e.g. \"plugins enable cartography_tools\"\n"

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -232,9 +232,9 @@ QgsProcessingExec::QgsProcessingExec()
 
 }
 
-int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessingContext::LogLevel logLevel, bool skipPython )
+int QgsProcessingExec::run( const QStringList &args, QgsProcessingContext::LogLevel logLevel, Flags flags )
 {
-  mSkipPython = skipPython;
+  mFlags = flags;
 
   QObject::connect( QgsApplication::messageLog(), static_cast < void ( QgsMessageLog::* )( const QString &message, const QString &tag, Qgis::MessageLevel level ) >( &QgsMessageLog::messageReceived ), QgsApplication::instance(),
                     [ = ]( const QString & message, const QString &, Qgis::MessageLevel level )
@@ -259,7 +259,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
 #endif
 
 #ifdef WITH_BINDINGS
-  if ( !mSkipPython )
+  if ( !( mFlags & Flag::SkipPython ) )
   {
     // give Python plugins a chance to load providers
     mPythonUtils = loadPythonSupport();
@@ -277,7 +277,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
     if ( args.size() == 2 || ( args.size() == 3 && args.at( 2 ) == QLatin1String( "list" ) ) )
     {
       loadPlugins();
-      listPlugins( useJson, true );
+      listPlugins( mFlags & Flag::UseJson, true );
       return 0;
     }
     else if ( args.size() == 4 && args.at( 2 ) == QLatin1String( "enable" ) )
@@ -294,7 +294,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
   else if ( command == QLatin1String( "list" ) )
   {
     loadPlugins();
-    listAlgorithms( useJson );
+    listAlgorithms();
     return 0;
   }
   else if ( command == QLatin1String( "help" ) )
@@ -307,7 +307,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
 
     loadPlugins();
     const QString algId = args.at( 2 );
-    return showAlgorithmHelp( algId, useJson );
+    return showAlgorithmHelp( algId );
   }
   else if ( command == QLatin1String( "run" ) )
   {
@@ -353,7 +353,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
       params = json.value( QStringLiteral( "inputs" ) ).toMap();
 
       // JSON format for input parameters implies JSON output format
-      useJson = true;
+      mFlags |= Flag::UseJson;
 
       ellipsoid = json.value( QStringLiteral( "ellipsoid" ) ).toString();
       projectPath = json.value( QStringLiteral( "project_path" ) ).toString();
@@ -486,7 +486,7 @@ int QgsProcessingExec::run( const QStringList &args, bool useJson, QgsProcessing
       }
     }
 
-    return execute( algId, params, ellipsoid, distanceUnit, areaUnit, logLevel, useJson, projectPath );
+    return execute( algId, params, ellipsoid, distanceUnit, areaUnit, logLevel, projectPath );
   }
   else
   {
@@ -560,10 +560,10 @@ void QgsProcessingExec::loadPlugins()
 #endif
 }
 
-void QgsProcessingExec::listAlgorithms( bool useJson )
+void QgsProcessingExec::listAlgorithms()
 {
   QVariantMap json;
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
   {
     std::cout << "Available algorithms\n\n";
   }
@@ -578,7 +578,7 @@ void QgsProcessingExec::listAlgorithms( bool useJson )
   {
     QVariantMap providerJson;
 
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       std::cout << provider->name().toLocal8Bit().constData() << "\n";
     }
@@ -593,7 +593,7 @@ void QgsProcessingExec::listAlgorithms( bool useJson )
       if ( algorithm->flags() & QgsProcessingAlgorithm::FlagNotAvailableInStandaloneTool )
         continue;
 
-      if ( !useJson )
+      if ( !( mFlags & Flag::UseJson ) )
       {
         if ( algorithm->flags() & QgsProcessingAlgorithm::FlagDeprecated )
           continue;
@@ -607,7 +607,7 @@ void QgsProcessingExec::listAlgorithms( bool useJson )
       }
     }
 
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       std::cout << "\n";
     }
@@ -618,7 +618,7 @@ void QgsProcessingExec::listAlgorithms( bool useJson )
     }
   }
 
-  if ( useJson )
+  if ( mFlags & Flag::UseJson )
   {
     json.insert( QStringLiteral( "providers" ), jsonProviders );
     std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );
@@ -746,7 +746,7 @@ int QgsProcessingExec::enablePlugin( const QString &name, bool enabled )
 #endif
 }
 
-int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
+int QgsProcessingExec::showAlgorithmHelp( const QString &inputId )
 {
   QString id = inputId;
 
@@ -794,7 +794,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
   }
 
   QVariantMap json;
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
   {
     std::cout << QStringLiteral( "%1 (%2)\n" ).arg( alg->displayName(), alg->id() ).toLocal8Bit().constData();
 
@@ -861,7 +861,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
 
     QVariantMap parameterJson;
 
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       QString line = QStringLiteral( "%1: %2" ).arg( p->name(), p->description() );
       if ( p->flags() & QgsProcessingParameterDefinition::FlagOptional )
@@ -906,12 +906,12 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
 
     if ( ! p->help().isEmpty() )
     {
-      if ( !useJson )
+      if ( !( mFlags & Flag::UseJson ) )
         std::cout << QStringLiteral( "\t%1\n" ).arg( p->help() ).toLocal8Bit().constData();
       else
         parameterJson.insert( QStringLiteral( "help" ), p->help() );
     }
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
       std::cout << QStringLiteral( "\tArgument type:\t%1\n" ).arg( p->type() ).toLocal8Bit().constData();
 
     if ( p->type() == QgsProcessingParameterEnum::typeName() )
@@ -925,14 +925,14 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
         jsonOptions.insert( QString::number( i ), enumParam->options().at( i ) );
       }
 
-      if ( !useJson )
+      if ( !( mFlags & Flag::UseJson ) )
         std::cout << QStringLiteral( "\tAvailable values:\n%1\n" ).arg( options.join( '\n' ) ).toLocal8Bit().constData();
       else
         parameterJson.insert( QStringLiteral( "available_options" ), jsonOptions );
     }
 
     // acceptable command line values
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       if ( const QgsProcessingParameterType *type = QgsApplication::processingRegistry()->parameterType( p->type() ) )
       {
@@ -952,7 +952,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
   }
 
   QVariantMap outputsJson;
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
   {
     std::cout << "\n----------------\n";
     std::cout << "Outputs\n";
@@ -962,7 +962,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
   for ( const QgsProcessingOutputDefinition *o : outputs )
   {
     QVariantMap outputJson;
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       std::cout << QStringLiteral( "%1: <%2>\n" ).arg( o->name(), o->type() ).toLocal8Bit().constData();
       if ( !o->description().isEmpty() )
@@ -976,7 +976,7 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
     }
   }
 
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
   {
     std::cout << "\n\n";
   }
@@ -990,10 +990,10 @@ int QgsProcessingExec::showAlgorithmHelp( const QString &inputId, bool useJson )
   return 0;
 }
 
-int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &inputs, const QString &ellipsoid, Qgis::DistanceUnit distanceUnit, Qgis::AreaUnit areaUnit, QgsProcessingContext::LogLevel logLevel, bool useJson, const QString &projectPath )
+int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &inputs, const QString &ellipsoid, Qgis::DistanceUnit distanceUnit, Qgis::AreaUnit areaUnit, QgsProcessingContext::LogLevel logLevel, const QString &projectPath )
 {
   QVariantMap json;
-  if ( useJson )
+  if ( mFlags & Flag::UseJson )
   {
     addVersionInformation( json );
   }
@@ -1051,14 +1051,14 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
       return 1;
     }
 
-    if ( !useJson && alg->flags() & QgsProcessingAlgorithm::FlagKnownIssues )
+    if ( !( mFlags & Flag::UseJson ) && alg->flags() & QgsProcessingAlgorithm::FlagKnownIssues )
     {
       std::cout << "\n****************\n";
       std::cout << "Warning: this algorithm contains known issues and the results may be unreliable!\n";
       std::cout << "****************\n\n";
     }
 
-    if ( !useJson && alg->flags() & QgsProcessingAlgorithm::FlagDeprecated )
+    if ( !( mFlags & Flag::UseJson ) && alg->flags() & QgsProcessingAlgorithm::FlagDeprecated )
     {
       std::cout << "\n****************\n";
       std::cout << "Warning: this algorithm is deprecated and may be removed in a future QGIS version!\n";
@@ -1072,7 +1072,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
     }
   }
 
-  if ( useJson )
+  if ( mFlags & Flag::UseJson )
   {
     QVariantMap algorithmDetails;
     algorithmDetails.insert( QStringLiteral( "id" ), alg->id() );
@@ -1099,7 +1099,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
     json.insert( QStringLiteral( "project_path" ), projectPath );
   }
 
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
   {
     std::cout << "\n----------------\n";
     std::cout << "Inputs\n";
@@ -1108,33 +1108,33 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
   QVariantMap inputsJson;
   for ( auto it = inputs.constBegin(); it != inputs.constEnd(); ++it )
   {
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
       std::cout << it.key().toLocal8Bit().constData() << ":\t" << it.value().toString().toLocal8Bit().constData() << '\n';
     else
       inputsJson.insert( it.key(), it.value() );
   }
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
     std::cout << "\n";
   else
     json.insert( QStringLiteral( "inputs" ), inputsJson );
 
   if ( !ellipsoid.isEmpty() )
   {
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
       std::cout << "Using ellipsoid:\t" << ellipsoid.toLocal8Bit().constData() << '\n';
     else
       json.insert( QStringLiteral( "ellipsoid" ), ellipsoid );
   }
   if ( distanceUnit != Qgis::DistanceUnit::Unknown )
   {
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
       std::cout << "Using distance unit:\t" << QgsUnitTypes::toString( distanceUnit ).toLocal8Bit().constData() << '\n';
     else
       json.insert( QStringLiteral( "distance_unit" ), QgsUnitTypes::toString( distanceUnit ) );
   }
   if ( areaUnit != Qgis::AreaUnit::Unknown )
   {
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
       std::cout << "Using area unit:\t" << QgsUnitTypes::toString( areaUnit ).toLocal8Bit().constData() << '\n';
     else
       json.insert( QStringLiteral( "area_unit" ), QgsUnitTypes::toString( areaUnit ) );
@@ -1181,7 +1181,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
     return 1;
   }
 
-  ConsoleFeedback feedback( useJson );
+  ConsoleFeedback feedback( mFlags & Flag::UseJson );
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
   UnixSignalWatcher sigwatch;
@@ -1202,7 +1202,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
 #endif
 
   ok = false;
-  if ( !useJson )
+  if ( !( mFlags & Flag::UseJson ) )
     std::cout << "\n";
 
   QVariantMap res = alg->run( params, context, &feedback, &ok );
@@ -1210,7 +1210,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
   if ( ok )
   {
     QVariantMap resultsJson;
-    if ( !useJson )
+    if ( !( mFlags & Flag::UseJson ) )
     {
       std::cout << "\n----------------\n";
       std::cout << "Results\n";
@@ -1227,7 +1227,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
         continue;
 
       QVariant result = it.value();
-      if ( !useJson )
+      if ( !( mFlags & Flag::UseJson ) )
       {
         if ( result.type() == QVariant::List || result.type() == QVariant::StringList )
         {
@@ -1244,7 +1244,7 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &input
       }
     }
 
-    if ( useJson )
+    if ( mFlags & Flag::UseJson )
     {
       json.insert( QStringLiteral( "results" ), resultsJson );
       std::cout << QgsJsonUtils::jsonFromVariant( json ).dump( 2 );

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -72,6 +72,7 @@ class QgsProcessingExec
     {
       UseJson = 1 << 0,
       SkipPython = 1 << 1,
+      SkipLoadingPlugins = 1 << 2,
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/process/qgsprocess.h
+++ b/src/process/qgsprocess.h
@@ -68,38 +68,45 @@ class QgsProcessingExec
 
   public:
 
+    enum class Flag
+    {
+      UseJson = 1 << 0,
+      SkipPython = 1 << 1,
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
     QgsProcessingExec();
-    int run( const QStringList &args, bool useJson, QgsProcessingContext::LogLevel logLevel, bool skipPython );
+    int run( const QStringList &args, QgsProcessingContext::LogLevel logLevel, Flags flags );
     static void showUsage( const QString &appName );
     static void showVersionInformation();
 
   private:
 
     void loadPlugins();
-    void listAlgorithms( bool useJson );
+    void listAlgorithms();
     void listPlugins( bool useJson, bool showLoaded );
     int enablePlugin( const QString &name, bool enabled );
-    int showAlgorithmHelp( const QString &id, bool useJson );
+    int showAlgorithmHelp( const QString &id );
     int execute( const QString &algId,
                  const QVariantMap &parameters,
                  const QString &ellipsoid,
                  Qgis::DistanceUnit distanceUnit,
                  Qgis::AreaUnit areaUnit,
                  QgsProcessingContext::LogLevel logLevel,
-                 bool useJson,
                  const QString &projectPath = QString() );
 
     void addVersionInformation( QVariantMap &json );
     void addAlgorithmInformation( QVariantMap &json, const QgsProcessingAlgorithm *algorithm );
     void addProviderInformation( QVariantMap &json, QgsProcessingProvider *provider );
 
-
-    bool mSkipPython = false;
+    Flags mFlags;
 #ifdef WITH_BINDINGS
     std::unique_ptr< QgsPythonUtils > mPythonUtils;
     std::unique_ptr<QgsPythonUtils> loadPythonSupport();
 #endif
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingExec::Flags );
 
 #endif // QGSPROCESS_H
 

--- a/tests/src/python/test_qgsprocessexecutable_pt1.py
+++ b/tests/src/python/test_qgsprocessexecutable_pt1.py
@@ -85,6 +85,16 @@ class TestQgsProcessExecutablePt1(unittest.TestCase):
 
     def testPlugins(self):
         rc, output, err = self.run_process(['plugins'])
+        self.assertIn('indicates loaded plugins', output.lower())
+        self.assertIn('available plugins', output.lower())
+        self.assertIn('processing', output.lower())
+        self.assertNotIn('metasearch', output.lower())
+        self.assertFalse(self._strip_ignorable_errors(err))
+        self.assertEqual(rc, 0)
+
+    def testPluginsSkipLoading(self):
+        rc, output, err = self.run_process(['plugins', '--skip-loading-plugins'])
+        self.assertIn('indicates enabled plugins', output.lower())
         self.assertIn('available plugins', output.lower())
         self.assertIn('processing', output.lower())
         self.assertNotIn('metasearch', output.lower())
@@ -122,7 +132,7 @@ class TestQgsProcessExecutablePt1(unittest.TestCase):
         self.assertEqual(rc, 0)
 
     def testAlgorithmsListJson(self):
-        rc, output, err = self.run_process(['list', '--no-python', '--json'])
+        rc, output, err = self.run_process(['list', '--json'])
         res = json.loads(output)
         self.assertIn('gdal_version', res)
         self.assertIn('geos_version', res)
@@ -135,6 +145,8 @@ class TestQgsProcessExecutablePt1(unittest.TestCase):
         self.assertIn('native', res['providers'])
         self.assertTrue(res['providers']['native']['is_active'])
         self.assertIn('native:buffer', res['providers']['native']['algorithms'])
+        self.assertIn('gdal:translate',
+                      res['providers']['gdal']['algorithms'])
         self.assertFalse(res['providers']['native']['algorithms']['native:buffer']['deprecated'])
 
         self.assertEqual(rc, 0)


### PR DESCRIPTION
When set, plugins will not be loaded. This can result in faster execution times for commands like "qgis_process plugins", when the client just needs to know available plugins and doesn't actually need to LOAD them.