### PR TITLE
Processing: Loosen check for uris by not checking whether they actually exist as files

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -326,13 +326,49 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return nullptr;
     name = fi.baseName();
   }
+
   if ( name.isEmpty() )
   {
     name = QgsDataSourceUri( uri ).table();
   }
 
+  QList< Qgis::LayerType > candidateTypes;
+  switch ( typeHint )
+  {
+    case LayerHint::UnknownType:
+    {
+      if ( providerMetadata )
+      {
+        // refine the type hint based on what the provider supports
+        candidateTypes = providerMetadata->supportedLayerTypes();
+      }
+      break;
+    }
+    case LayerHint::Vector:
+      candidateTypes.append( Qgis::LayerType::Vector );
+      break;
+    case LayerHint::Raster:
+      candidateTypes.append( Qgis::LayerType::Raster );
+      break;
+    case LayerHint::Mesh:
+      candidateTypes.append( Qgis::LayerType::Mesh );
+      break;
+    case LayerHint::PointCloud:
+      candidateTypes.append( Qgis::LayerType::PointCloud );
+      break;
+    case LayerHint::Annotation:
+      candidateTypes.append( Qgis::LayerType::Annotation );
+      break;
+    case LayerHint::VectorTile:
+      candidateTypes.append( Qgis::LayerType::VectorTile );
+      break;
+    case LayerHint::TiledScene:
+      candidateTypes.append( Qgis::LayerType::TiledScene );
+      break;
+  }
+
   // brute force attempt to load a matching layer
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::Vector )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::Vector ) )
   {
     QgsVectorLayer::LayerOptions options { transformContext };
     options.loadDefaultStyle = false;
@@ -353,7 +389,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return layer.release();
     }
   }
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::Raster )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::Raster ) )
   {
     QgsRasterLayer::LayerOptions rasterOptions;
     rasterOptions.loadDefaultStyle = false;
@@ -375,7 +411,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return rasterLayer.release();
     }
   }
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::Mesh )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::Mesh ) )
   {
     QgsMeshLayer::LayerOptions meshOptions;
     meshOptions.skipCrsValidation = true;
@@ -394,7 +430,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return meshLayer.release();
     }
   }
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::PointCloud )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::PointCloud ) )
   {
     QgsPointCloudLayer::LayerOptions pointCloudOptions;
     pointCloudOptions.skipCrsValidation = true;
@@ -422,7 +458,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return pointCloudLayer.release();
     }
   }
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::VectorTile )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::VectorTile ) )
   {
     QgsDataSourceUri dsUri;
     dsUri.setParam( "type", "mbtiles" );
@@ -436,7 +472,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return tileLayer.release();
     }
   }
-  if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::TiledScene )
+  if ( candidateTypes.empty() || candidateTypes.contains( Qgis::LayerType::TiledScene ) )
   {
     QgsTiledSceneLayer::LayerOptions tiledSceneOptions;
     tiledSceneOptions.skipCrsValidation = true;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -317,19 +317,19 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     if ( components.isEmpty() )
       return nullptr;
 
-    QFileInfo fi;
-    if ( QFileInfo::exists( uri ) )
-      fi = QFileInfo( uri );
-    else if ( QFileInfo::exists( components.at( 0 ) ) )
-      fi = QFileInfo( components.at( 0 ) );
+    if ( QFileInfo fi( components.at( 0 ) ); fi.isFile() )
+      name = fi.baseName();
     else
-      return nullptr;
-    name = fi.baseName();
+      name = QFileInfo( uri ).baseName();
   }
 
   if ( name.isEmpty() )
   {
     name = QgsDataSourceUri( uri ).table();
+  }
+  if ( name.isEmpty() )
+  {
+    name = uri;
   }
 
   QList< Qgis::LayerType > candidateTypes;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -294,8 +294,11 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     uri = string;
 
   QString name;
+
   // for disk based sources, we use the filename to determine a layer name
-  if ( !useProvider || ( provider == QLatin1String( "ogr" ) || provider == QLatin1String( "gdal" ) || provider == QLatin1String( "mdal" ) || provider == QLatin1String( "pdal" ) || provider == QLatin1String( "ept" ) || provider == QLatin1String( "copc" ) ) )
+  const QgsProviderMetadata *providerMetadata = useProvider ? QgsProviderRegistry::instance()->providerMetadata( provider ) : nullptr;
+  if ( !useProvider
+       || ( providerMetadata && providerMetadata->providerCapabilities() & QgsProviderMetadata::ProviderCapability::FileBasedUris ) )
   {
     QStringList components = uri.split( '|' );
     if ( components.isEmpty() )
@@ -310,7 +313,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
       return nullptr;
     name = fi.baseName();
   }
-  else
+  if ( name.isEmpty() )
   {
     name = QgsDataSourceUri( uri ).table();
   }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -375,9 +375,9 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     options.skipCrsValidation = true;
 
     std::unique_ptr< QgsVectorLayer > layer;
-    if ( useProvider )
+    if ( providerMetadata )
     {
-      layer = std::make_unique<QgsVectorLayer>( uri, name, provider, options );
+      layer = std::make_unique<QgsVectorLayer>( uri, name, providerMetadata->key(), options );
     }
     else
     {
@@ -396,9 +396,9 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     rasterOptions.skipCrsValidation = true;
 
     std::unique_ptr< QgsRasterLayer > rasterLayer;
-    if ( useProvider )
+    if ( providerMetadata )
     {
-      rasterLayer = std::make_unique< QgsRasterLayer >( uri, name, provider, rasterOptions );
+      rasterLayer = std::make_unique< QgsRasterLayer >( uri, name, providerMetadata->key(), rasterOptions );
     }
     else
     {
@@ -417,9 +417,9 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     meshOptions.skipCrsValidation = true;
 
     std::unique_ptr< QgsMeshLayer > meshLayer;
-    if ( useProvider )
+    if ( providerMetadata )
     {
-      meshLayer = std::make_unique< QgsMeshLayer >( uri, name, provider, meshOptions );
+      meshLayer = std::make_unique< QgsMeshLayer >( uri, name, providerMetadata->key(), meshOptions );
     }
     else
     {
@@ -441,9 +441,9 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     }
 
     std::unique_ptr< QgsPointCloudLayer > pointCloudLayer;
-    if ( useProvider )
+    if ( providerMetadata )
     {
-      pointCloudLayer = std::make_unique< QgsPointCloudLayer >( uri, name, provider, pointCloudOptions );
+      pointCloudLayer = std::make_unique< QgsPointCloudLayer >( uri, name, providerMetadata->key(), pointCloudOptions );
     }
     else
     {
@@ -478,9 +478,9 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
     tiledSceneOptions.skipCrsValidation = true;
 
     std::unique_ptr< QgsTiledSceneLayer > tiledSceneLayer;
-    if ( useProvider )
+    if ( providerMetadata )
     {
-      tiledSceneLayer = std::make_unique< QgsTiledSceneLayer >( uri, name, provider, tiledSceneOptions );
+      tiledSceneLayer = std::make_unique< QgsTiledSceneLayer >( uri, name, providerMetadata->key(), tiledSceneOptions );
     }
     else
     {

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1542,14 +1542,17 @@ void TestQgsProcessing::mapLayers()
   // Test layers from a string with parameters
   const QString osmFilePath = testDataDir + "openstreetmap/testdata.xml";
   std::unique_ptr< QgsVectorLayer > osm( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath, QgsCoordinateTransformContext() ) ) );
+  QVERIFY( osm );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), Qgis::GeometryType::Point );
 
   osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3", QgsCoordinateTransformContext() ) ) );
+  QVERIFY( osm );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), Qgis::GeometryType::Polygon );
 
   osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3|subset=\"building\" is not null", QgsCoordinateTransformContext() ) ) );
+  QVERIFY( osm );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), Qgis::GeometryType::Polygon );
   QCOMPARE( osm->subsetString(), QStringLiteral( "\"building\" is not null" ) );
@@ -1678,6 +1681,25 @@ void TestQgsProcessing::mapLayerFromString()
   // since it's now in temporary store, should be accessible even if we deny loading new layers
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( newRaster, c, false ), loadedLayer );
   QCOMPARE( c.getMapLayer( newRaster ), loadedLayer );
+
+  // try something which looks like a valid filename, but doesn't actually exist
+  loadedLayer = QgsProcessingUtils::mapLayerFromString( testDataDir + "looks_like_a_filename_but_does_not_exist.tif", c, true );
+  QVERIFY( !loadedLayer );
+
+  // using GDAL's virtual I/O (/vsizip/, etc.)
+  loadedLayer = QgsProcessingUtils::mapLayerFromString( "/vsizip/" + testDataDir + "zip/points2.zip/points.shp", c, true );
+  QVERIFY( loadedLayer );
+  QVERIFY( loadedLayer->isValid() );
+  QCOMPARE( loadedLayer->type(), Qgis::LayerType::Vector );
+  // should now be in temporary store
+  QCOMPARE( c.temporaryLayerStore()->mapLayer( loadedLayer->id() ), loadedLayer );
+
+  loadedLayer = QgsProcessingUtils::mapLayerFromString( "/vsizip/" + testDataDir + "zip/landsat_b1.zip/landsat_b1.tif", c, true );
+  QVERIFY( loadedLayer );
+  QVERIFY( loadedLayer->isValid() );
+  QCOMPARE( loadedLayer->type(), Qgis::LayerType::Raster );
+  // should now be in temporary store
+  QCOMPARE( c.temporaryLayerStore()->mapLayer( loadedLayer->id() ), loadedLayer );
 }
 
 void TestQgsProcessing::algorithm()
@@ -2396,6 +2418,7 @@ void TestQgsProcessing::createFeatureSink()
   QVERIFY( sink->addFeature( f ) );
   sink.reset( nullptr );
   layer = qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::mapLayerFromString( destination, context, true ) );
+  QVERIFY( layer );
   QVERIFY( layer->isValid() );
   QCOMPARE( layer->wkbType(), Qgis::WkbType::Polygon );
   QVERIFY( layer->getFeatures().nextFeature( f ) );


### PR DESCRIPTION
Its better to defer this to that data provider, as the uri may not need to correspond to an actual on disk file for some providers. Eg ogr provider can load remote http sources

Fixes https://github.com/qgis/QGIS/issues/54264