### PR TITLE
Unify appearance of Select All/Deselect All buttons

### DIFF
--- a/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
+++ b/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
@@ -99,13 +99,6 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QPushButton" name="mSelectAllButton">
-         <property name="text">
-          <string>Select All</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -117,6 +110,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="mSelectAllButton">
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="mDeselectAllButton">

--- a/src/ui/pointcloud/qgspointcloudlayersaveasdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudlayersaveasdialogbase.ui
@@ -142,6 +142,19 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QPushButton" name="mSelectAllAttributes">
               <property name="text">
                <string>Select All</string>

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -195,16 +195,16 @@
              </spacer>
             </item>
             <item>
-             <widget class="QPushButton" name="pbDeselectAll">
+             <widget class="QPushButton" name="pbSelectAll">
               <property name="text">
-               <string>Deselect All</string>
+               <string>Select All</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pbSelectAll">
+             <widget class="QPushButton" name="pbDeselectAll">
               <property name="text">
-               <string>Select All</string>
+               <string>Deselect All</string>
               </property>
              </widget>
             </item>
@@ -269,18 +269,17 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mSourceDrawingFileWidget</tabstop>
   <tabstop>pbImportDrawing</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>mDatabaseFileWidget</tabstop>
   <tabstop>pbLoadDatabase</tabstop>
   <tabstop>mBlockModeComboBox</tabstop>
   <tabstop>cbUseCurves</tabstop>
   <tabstop>leLayerGroup</tabstop>
   <tabstop>mLayers</tabstop>
   <tabstop>cbMergeLayers</tabstop>
-  <tabstop>pbDeselectAll</tabstop>
   <tabstop>pbSelectAll</tabstop>
+  <tabstop>pbDeselectAll</tabstop>
+  <tabstop>mMapCanvas</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -107,20 +107,6 @@
    </item>
    <item row="9" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0">
-      <widget class="QPushButton" name="mSelectAllButton">
-       <property name="text">
-        <string>Select All</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="mDeselectAllButton">
-       <property name="text">
-        <string>Deselect All</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -133,6 +119,20 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="0" column="3">
+      <widget class="QPushButton" name="mDeselectAllButton">
+       <property name="text">
+        <string>Deselect All</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="mSelectAllButton">
+       <property name="text">
+        <string>Select All</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/ui/qgsprovidersublayersdialogbase.ui
+++ b/src/ui/qgsprovidersublayersdialogbase.ui
@@ -42,6 +42,19 @@
    <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QPushButton" name="mBtnSelectAll">
        <property name="text">
         <string>Select All</string>
@@ -54,19 +67,6 @@
         <string>Deselect All</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -166,6 +166,19 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QPushButton" name="mSelectAllAttributes">
               <property name="text">
                <string>Select All</string>


### PR DESCRIPTION
- Ensure Select All always appears first
- Right align buttons in layouts consistently


We should also unify the "Deselect" text. We use a mix of "Deselect All" / "Clear Selection".

Any preferences? @nirvn ? @DelazJ ?