### PR TITLE
[server] Add WMS parameter value to request only maptip for HTML feature info response

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -541,8 +541,7 @@ namespace QgsWms
     save( pWithGeometry );
 
     const QgsWmsParameter pWithMapTip( QgsWmsParameter::WITH_MAPTIP,
-                                       QVariant::Bool,
-                                       QVariant( false ) );
+                                       QVariant::String );
     save( pWithMapTip );
 
     const QgsWmsParameter pWithDisplayName( QgsWmsParameter::WITH_DISPLAY_NAME,
@@ -2105,9 +2104,29 @@ namespace QgsWms
     return mWmsParameters.value( QgsWmsParameter::WITH_GEOMETRY ).toBool();
   }
 
+  QString QgsWmsParameters::withMapTipAsString() const
+  {
+    return mWmsParameters.value( QgsWmsParameter::WITH_MAPTIP ).toString();
+  }
+
   bool QgsWmsParameters::withMapTip() const
   {
-    return mWmsParameters.value( QgsWmsParameter::WITH_MAPTIP ).toBool();
+    const QString mStr = withMapTipAsString();
+
+    if ( mStr.startsWith( QLatin1String( "true" ), Qt::CaseInsensitive ) )
+      return true;
+    else
+      return false;
+  }
+
+  bool QgsWmsParameters::htmlInfoOnlyMapTip() const
+  {
+    const QString mStr = withMapTipAsString();
+
+    if ( mStr.startsWith( QLatin1String( "true_and_html_fi_only_maptip" ), Qt::CaseInsensitive ) )
+      return true;
+    else
+      return false;
   }
 
   bool QgsWmsParameters::withDisplayName() const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -2113,7 +2113,10 @@ namespace QgsWms
   {
     const QString mStr = withMapTipAsString();
 
-    if ( mStr.startsWith( QLatin1String( "true" ), Qt::CaseInsensitive ) )
+    if ( mStr.startsWith( QLatin1String( "true" ), Qt::CaseInsensitive ) ||
+         mStr.startsWith( QLatin1String( "on" ), Qt::CaseInsensitive ) ||
+         mStr.startsWith( QLatin1String( "yes" ), Qt::CaseInsensitive ) ||
+         mStr.startsWith( QLatin1String( "1" ) ) )
       return true;
     else
       return false;
@@ -2123,7 +2126,7 @@ namespace QgsWms
   {
     const QString mStr = withMapTipAsString();
 
-    if ( mStr.startsWith( QLatin1String( "true_and_html_fi_only_maptip" ), Qt::CaseInsensitive ) )
+    if ( mStr.startsWith( QLatin1String( "html_fi_only_maptip" ), Qt::CaseInsensitive ) )
       return true;
     else
       return false;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -1309,10 +1309,25 @@ namespace QgsWms
       bool withGeometry() const;
 
       /**
+       * \brief withMapTipAsString
+       * \returns WITH_MAPTIP parameter as string
+       * \since QGIS 3.36
+       */
+      QString withMapTipAsString() const;
+
+      /**
        * \brief withMapTip
        * \returns TRUE if maptip information is requested for feature info response
        */
       bool withMapTip() const;
+
+      /**
+       * Returns TRUE if only maptip information is requested for HTML
+       * feature info response
+       * \returns htmlInfoOnlyMapTip
+       * \since QGIS 3.36
+       */
+      bool htmlInfoOnlyMapTip() const;
 
       /**
        * \brief withDisplayName

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1989,7 +1989,7 @@ namespace QgsWms
 
         //add maptip attribute based on html/expression (in case there is no maptip attribute)
         QString mapTip = layer->mapTipTemplate();
-        if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
+        if ( !mapTip.isEmpty() && ( mWmsParameters.withMapTip() || mWmsParameters.htmlInfoOnlyMapTip() ) )
         {
           QDomElement maptipElem = infoDocument.createElement( QStringLiteral( "Attribute" ) );
           maptipElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "maptip" ) );
@@ -2319,7 +2319,7 @@ namespace QgsWms
       }
       //add maptip attribute based on html/expression
       QString mapTip = layer->mapTipTemplate();
-      if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
+      if ( !mapTip.isEmpty() && ( mWmsParameters.withMapTip() || mWmsParameters.htmlInfoOnlyMapTip() ) )
       {
         QDomElement maptipElem = infoDocument.createElement( QStringLiteral( "Attribute" ) );
         maptipElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "maptip" ) );
@@ -3093,7 +3093,7 @@ namespace QgsWms
     {
       QString mapTip = layer->mapTipTemplate();
 
-      if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
+      if ( !mapTip.isEmpty() && ( mWmsParameters.withMapTip() || mWmsParameters.htmlInfoOnlyMapTip() ) )
       {
         QString fieldTextString = QgsExpression::replaceExpressionText( mapTip, &expressionContext );
         QDomElement fieldElem = doc.createElement( QStringLiteral( "qgs:maptip" ) );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2581,10 +2581,10 @@ namespace QgsWms
   QByteArray QgsRenderer::convertFeatureInfoToHtml( const QDomDocument &doc ) const
   {
     const bool onlyMapTip = mWmsParameters.htmlInfoOnlyMapTip();
-    QString featureInfoString;
+    QString featureInfoString = QStringLiteral( "    <!DOCTYPE html>" );
     if ( !onlyMapTip )
     {
-      featureInfoString.append( QStringLiteral( R"HTML(    <!DOCTYPE html>
+      featureInfoString.append( QStringLiteral( R"HTML(
 
     <head>
       <title>Information</title>
@@ -2672,7 +2672,8 @@ namespace QgsWms
             }
             else if ( name == QStringLiteral( "maptip" ) )
             {
-              featureInfoString.append( value );
+              featureInfoString.append( QStringLiteral( R"HTML(
+      %1)HTML" ).arg( value ) );
               break;
             }
 
@@ -2727,7 +2728,8 @@ namespace QgsWms
             }
             else if ( name == QStringLiteral( "maptip" ) )
             {
-              featureInfoString.append( value );
+              featureInfoString.append( QStringLiteral( R"HTML(
+      %1)HTML" ).arg( value ) );
               break;
             }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2580,7 +2580,11 @@ namespace QgsWms
 
   QByteArray QgsRenderer::convertFeatureInfoToHtml( const QDomDocument &doc ) const
   {
-    QString featureInfoString = QStringLiteral( R"HTML(    <!DOCTYPE html>
+    const bool onlyMapTip = mWmsParameters.htmlInfoOnlyMapTip();
+    QString featureInfoString;
+    if ( !onlyMapTip )
+    {
+      featureInfoString.append( QStringLiteral( R"HTML(    <!DOCTYPE html>
 
     <head>
       <title>Information</title>
@@ -2613,7 +2617,8 @@ namespace QgsWms
     </head>
 
     <body>
-    )HTML" );
+    )HTML" ) );
+    }
 
     const QDomNodeList layerList = doc.elementsByTagName( QStringLiteral( "Layer" ) );
 
@@ -2628,14 +2633,20 @@ namespace QgsWms
 
       if ( !featureNodeList.isEmpty() ) //vector layer
       {
-        const QString featureInfoLayerTitleString = QStringLiteral( "  <div class='layer-title'>%1</div>" ).arg( layerElem.attribute( QStringLiteral( "title" ) ).toHtmlEscaped() );
-        featureInfoString.append( featureInfoLayerTitleString );
+        if ( !onlyMapTip )
+        {
+          const QString featureInfoLayerTitleString = QStringLiteral( "  <div class='layer-title'>%1</div>" ).arg( layerElem.attribute( QStringLiteral( "title" ) ).toHtmlEscaped() );
+          featureInfoString.append( featureInfoLayerTitleString );
+        }
 
         for ( int j = 0; j < featureNodeList.size(); ++j )
         {
           const QDomElement featureElement = featureNodeList.at( j ).toElement();
-          featureInfoString.append( QStringLiteral( R"HTML(
+          if ( !onlyMapTip )
+          {
+            featureInfoString.append( QStringLiteral( R"HTML(
       <table>)HTML" ) );
+          }
 
           //attribute loop
           const QDomNodeList attributeNodeList = featureElement.elementsByTagName( QStringLiteral( "Attribute" ) );
@@ -2649,16 +2660,28 @@ namespace QgsWms
               value = value.toHtmlEscaped();
             }
 
-            const QString featureInfoAttributeString = QStringLiteral( R"HTML(
+            if ( !onlyMapTip )
+            {
+              const QString featureInfoAttributeString = QStringLiteral( R"HTML(
         <tr>
           <th>%1</th>
           <td>%2</td>
         </tr>)HTML" ).arg( name, value );
 
-            featureInfoString.append( featureInfoAttributeString );
+              featureInfoString.append( featureInfoAttributeString );
+            }
+            else if ( name == QStringLiteral( "maptip" ) )
+            {
+              featureInfoString.append( value );
+              break;
+            }
+
           }
-          featureInfoString.append( QStringLiteral( R"HTML(
+          if ( !onlyMapTip )
+          {
+            featureInfoString.append( QStringLiteral( R"HTML(
       </table>)HTML" ) );
+          }
         }
       }
       else //no result or raster layer
@@ -2668,11 +2691,15 @@ namespace QgsWms
         //  raster layer
         if ( !attributeNodeList.isEmpty() )
         {
-          const QString featureInfoLayerTitleString = QStringLiteral( "  <div class='layer-title'>%1</div>" ).arg( layerElem.attribute( QStringLiteral( "title" ) ).toHtmlEscaped() );
-          featureInfoString.append( featureInfoLayerTitleString );
+          if ( !onlyMapTip )
+          {
+            const QString featureInfoLayerTitleString = QStringLiteral( "  <div class='layer-title'>%1</div>" ).arg( layerElem.attribute( QStringLiteral( "title" ) ).toHtmlEscaped() );
+            featureInfoString.append( featureInfoLayerTitleString );
 
-          featureInfoString.append( QStringLiteral( R"HTML(
+            featureInfoString.append( QStringLiteral( R"HTML(
       <table>)HTML" ) );
+          }
+
           for ( int j = 0; j < attributeNodeList.size(); ++j )
           {
             const QDomElement attributeElement = attributeNodeList.at( j ).toElement();
@@ -2687,23 +2714,39 @@ namespace QgsWms
               value = value.toHtmlEscaped();
             }
 
-            const QString featureInfoAttributeString = QStringLiteral( R"HTML(
+            if ( !onlyMapTip )
+            {
+              const QString featureInfoAttributeString = QStringLiteral( R"HTML(
         <tr>
           <th>%1</th>
           <td>%2</td>
         </tr>)HTML" ).arg( name, value );
 
-            featureInfoString.append( featureInfoAttributeString );
+
+              featureInfoString.append( featureInfoAttributeString );
+            }
+            else if ( name == QStringLiteral( "maptip" ) )
+            {
+              featureInfoString.append( value );
+              break;
+            }
+
           }
-          featureInfoString.append( QStringLiteral( R"HTML(
+          if ( !onlyMapTip )
+          {
+            featureInfoString.append( QStringLiteral( R"HTML(
       </table>)HTML" ) );
+          }
         }
       }
     }
 
     //end the html body
-    featureInfoString.append( QStringLiteral( R"HTML(
+    if ( !onlyMapTip )
+    {
+      featureInfoString.append( QStringLiteral( R"HTML(
     </body>)HTML" ) );
+    }
 
     return featureInfoString.toUtf8();
   }

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -145,6 +145,16 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'with_maptip=true',
                                  'wms_getfeatureinfo-text-html-maptip')
 
+        # Test getfeatureinfo response html only with maptip for vector layer
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=text%2Fhtml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_maptip=true_and_html_fi_only_maptip',
+                                 'wms_getfeatureinfo-html-only-with-maptip-vector')
+
         # Test getfeatureinfo response html with maptip and display name in text mode for vector layer
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
@@ -270,6 +280,16 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'query_layers=landsat&X=250&Y=250&' +
                                  'with_maptip=true',
                                  'wms_getfeatureinfo-raster-text-xml-maptip')
+
+        # Test GetFeatureInfo on raster layer HTML only with maptip
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=landsat&styles=&' +
+                                 'info_format=text%2Fhtml&transparent=true&' +
+                                 'width=500&height=500&srs=EPSG%3A3857&' +
+                                 'bbox=1989139.6,3522745.0,2015014.9,3537004.5&' +
+                                 'query_layers=landsat&X=250&Y=250&' +
+                                 'with_maptip=true_and_html_fi_only_maptip',
+                                 'wms_getfeatureinfo-html-only-with-maptip-raster')
 
     def testGetFeatureInfoValueRelation(self):
         """Test GetFeatureInfo resolves "value relation" widget values. regression 18518"""

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -152,7 +152,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
-                                 'with_maptip=true_and_html_fi_only_maptip',
+                                 'with_maptip=html_fi_only_maptip',
                                  'wms_getfeatureinfo-html-only-with-maptip-vector')
 
         # Test getfeatureinfo response html with maptip and display name in text mode for vector layer
@@ -288,7 +288,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'width=500&height=500&srs=EPSG%3A3857&' +
                                  'bbox=1989139.6,3522745.0,2015014.9,3537004.5&' +
                                  'query_layers=landsat&X=250&Y=250&' +
-                                 'with_maptip=true_and_html_fi_only_maptip',
+                                 'with_maptip=html_fi_only_maptip',
                                  'wms_getfeatureinfo-html-only-with-maptip-raster')
 
     def testGetFeatureInfoValueRelation(self):

--- a/tests/testdata/qgis_server/test_project.qgs
+++ b/tests/testdata/qgis_server/test_project.qgs
@@ -315,7 +315,9 @@
         <property value="0" key="embeddedWidgets/count"/>
         <property value="Value" key="identify/format"/>
       </customproperties>
-      <mapTip enabled="1">[% 'Value Band 5: ' || raster_value(@layer_id, 5, @layer_cursor_point) %]</mapTip>
+      <mapTip enabled="1">&lt;!DOCTYPE html>
+&lt;title>Maptip&lt;/title>
+[% 'Value Band 5: ' || raster_value(@layer_id, 5, @layer_cursor_point) %]</mapTip>
       <pipe>
         <rasterrenderer opacity="1" type="singlebandgray" grayBand="1" gradient="BlackToWhite" alphaBand="-1">
           <rasterTransparency/>
@@ -561,7 +563,9 @@
       <labelOnTop/>
       <widgets/>
       <previewExpression>"name"</previewExpression>
-      <mapTip>[% 'Name: ' ||  represent_value( "name" ) %]</mapTip>
+      <mapTip enabled="1">&lt;!DOCTYPE html>
+&lt;title>Maptip&lt;/title>
+[% 'Name: ' ||  represent_value( "name" ) %]</mapTip>
     </maplayer>
     <maplayer refreshOnNotifyEnabled="0" maxScale="-4.65661e-10" refreshOnNotifyMessage="" type="vector" minScale="1e+8" labelsEnabled="1" readOnly="0" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" geometry="Point" simplifyDrawingHints="0" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" simplifyLocal="1" autoRefreshTime="0">
       <extent>

--- a/tests/testdata/qgis_server/test_project.qgs
+++ b/tests/testdata/qgis_server/test_project.qgs
@@ -315,8 +315,7 @@
         <property value="0" key="embeddedWidgets/count"/>
         <property value="Value" key="identify/format"/>
       </customproperties>
-      <mapTip enabled="1">&lt;!DOCTYPE html>
-&lt;title>Maptip&lt;/title>
+      <mapTip enabled="1">&lt;title>Maptip&lt;/title>
 [% 'Value Band 5: ' || raster_value(@layer_id, 5, @layer_cursor_point) %]</mapTip>
       <pipe>
         <rasterrenderer opacity="1" type="singlebandgray" grayBand="1" gradient="BlackToWhite" alphaBand="-1">
@@ -563,8 +562,7 @@
       <labelOnTop/>
       <widgets/>
       <previewExpression>"name"</previewExpression>
-      <mapTip enabled="1">&lt;!DOCTYPE html>
-&lt;title>Maptip&lt;/title>
+      <mapTip enabled="1">&lt;title>Maptip&lt;/title>
 [% 'Name: ' ||  represent_value( "name" ) %]</mapTip>
     </maplayer>
     <maplayer refreshOnNotifyEnabled="0" maxScale="-4.65661e-10" refreshOnNotifyMessage="" type="vector" minScale="1e+8" labelsEnabled="1" readOnly="0" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" geometry="Point" simplifyDrawingHints="0" autoRefreshEnabled="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" simplifyLocal="1" autoRefreshTime="0">

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-raster.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-raster.txt
@@ -1,4 +1,6 @@
 *****
 Content-Type: text/html; charset=utf-8
 
+<!DOCTYPE html>
+<title>Maptip</title>
 Value Band 5: 90

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-raster.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-raster.txt
@@ -1,0 +1,4 @@
+*****
+Content-Type: text/html; charset=utf-8
+
+Value Band 5: 90

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-vector.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-vector.txt
@@ -1,4 +1,6 @@
 *****
 Content-Type: text/html; charset=utf-8
 
+<!DOCTYPE html>
+<title>Maptip</title>
 Name: three

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-vector.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-html-only-with-maptip-vector.txt
@@ -1,0 +1,4 @@
+*****
+Content-Type: text/html; charset=utf-8
+
+Name: three

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
@@ -13,6 +13,6 @@ Content-Type: text/xml; charset=utf-8
   <Attribute value="165" name="Band 7"/>
   <Attribute value="217" name="Band 8"/>
   <Attribute value="175" name="Band 9"/>
-  <Attribute value="&lt;!DOCTYPE html>&#xa;&lt;title>Maptip&lt;/title>&#xa;Value Band 5: 90" name="maptip"/>
+  <Attribute value="&lt;title>Maptip&lt;/title>&#xa;Value Band 5: 90" name="maptip"/>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-raster-text-xml-maptip.txt
@@ -13,6 +13,6 @@ Content-Type: text/xml; charset=utf-8
   <Attribute value="165" name="Band 7"/>
   <Attribute value="217" name="Band 8"/>
   <Attribute value="175" name="Band 9"/>
-  <Attribute value="Value Band 5: 90" name="maptip"/>
+  <Attribute value="&lt;!DOCTYPE html>&#xa;&lt;title>Maptip&lt;/title>&#xa;Value Band 5: 90" name="maptip"/>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
@@ -8,6 +8,8 @@ Feature 2
 id = '3'
 name = 'three'
 utf8nameè = 'three èé↓'
-maptip = 'Name: three'
+maptip = '<!DOCTYPE html>
+<title>Maptip</title>
+Name: three'
 displayName = 'three'
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip-plain.txt
@@ -8,8 +8,7 @@ Feature 2
 id = '3'
 name = 'three'
 utf8nameè = 'three èé↓'
-maptip = '<!DOCTYPE html>
-<title>Maptip</title>
+maptip = '<title>Maptip</title>
 Name: three'
 displayName = 'three'
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
@@ -3,58 +3,60 @@ Content-Type: text/html; charset=utf-8
 
 <!DOCTYPE html>
 
-<head>
-  <title>Information</title>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <style>
-    body {
-      font-family: "Open Sans", "Calluna Sans", "Gill Sans MT", "Calibri", "Trebuchet MS", sans-serif;
-    }
+    <head>
+      <title>Information</title>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <style>
+        body {
+          font-family: "Open Sans", "Calluna Sans", "Gill Sans MT", "Calibri", "Trebuchet MS", sans-serif;
+        }
 
-    table,
-    th,
-    td {
-      width: 100%;
-      border: 1px solid black;
-      border-collapse: collapse;
-      text-align: left;
-      padding: 2px;
-    }
+        table,
+        th,
+        td {
+          width: 100%;
+          border: 1px solid black;
+          border-collapse: collapse;
+          text-align: left;
+          padding: 2px;
+        }
 
-    th {
-      width: 25%;
-      font-weight: bold;
-    }
+        th {
+          width: 25%;
+          font-weight: bold;
+        }
 
-    .layer-title {
-      font-weight: bold;
-      padding: 2px;
-    }
-  </style>
-</head>
+        .layer-title {
+          font-weight: bold;
+          padding: 2px;
+        }
+      </style>
+    </head>
 
-<body>
-  <div class='layer-title'>A test vector layer</div>
-  <table>
-    <tr>
-      <th>id</th>
-      <td>3</td>
-    </tr>
-    <tr>
-      <th>name</th>
-      <td>three</td>
-    </tr>
-    <tr>
-      <th>utf8nameè</th>
-      <td>three èé↓</td>
-    </tr>
-    <tr>
-      <th>maptip</th>
-      <td>Name: three</td>
-    </tr>
-    <tr>
-      <th>displayName</th>
-      <td>three</td>
-    </tr>
-  </table>
-</body>
+    <body>
+      <div class='layer-title'>A test vector layer</div>
+      <table>
+        <tr>
+          <th>id</th>
+          <td>3</td>
+        </tr>
+        <tr>
+          <th>name</th>
+          <td>three</td>
+        </tr>
+        <tr>
+          <th>utf8nameè</th>
+          <td>three èé↓</td>
+        </tr>
+        <tr>
+          <th>maptip</th>
+          <td><!DOCTYPE html>
+<title>Maptip</title>
+Name: three</td>
+        </tr>
+        <tr>
+          <th>displayName</th>
+          <td>three</td>
+        </tr>
+      </table>
+    </body>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
@@ -50,8 +50,7 @@ Content-Type: text/html; charset=utf-8
         </tr>
         <tr>
           <th>maptip</th>
-          <td><!DOCTYPE html>
-<title>Maptip</title>
+          <td><title>Maptip</title>
 Name: three</td>
         </tr>
         <tr>


### PR DESCRIPTION
This is a proposal to add a new value `HTML_FI_ONLY_MAPTIP` for the existing WMS vendor parameter `WITH_MAPTIP`.

If set, the feature info HTML response includes only the maptip, which gives full control over the HTML response using e.g. the built-in maptip editor which has a nice preview since https://github.com/qgis/QGIS/pull/52420 and also got other improvements in https://github.com/qgis/QGIS/pull/54764.

This aims to be fully backward compatible while closing https://github.com/qgis/QGIS/issues/20601.

Tests included.