### PR TITLE
[api] Add iface.blockActiveLayerChanges

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -1749,6 +1749,24 @@ is automatically registered within the :py:func:`QgsApplication.gpsConnectionReg
 .. versionadded:: 3.16
 %End
 
+    virtual void blockActiveLayerChanges( bool blocked ) = 0;
+%Docstring
+Sets whether changes to the active layer should be temporarily
+blocked.
+
+This is a low-level method, designed to avoid unnecessary work when adding lots
+of layers at once. Clients which will be adding many layers may call blockActiveLayerChanges( ``True`` ) upfront,
+add all the layers, and then follow up with a call to blockActiveLayerChanges( ``False`` ). This will defer emitting
+the active layer changed signal until they've added all layers, and only emit the signal once for
+the final layer added.
+
+.. warning::
+
+   This must be accompanied by a subsequent call with ``blocked`` as ``False``.
+
+.. versionadded:: 3.36
+%End
+
   signals:
 
     void currentLayerChanged( QgsMapLayer *layer );

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1749,6 +1749,24 @@ is automatically registered within the :py:func:`QgsApplication.gpsConnectionReg
 .. versionadded:: 3.16
 %End
 
+    virtual void blockActiveLayerChanges( bool blocked ) = 0;
+%Docstring
+Sets whether changes to the active layer should be temporarily
+blocked.
+
+This is a low-level method, designed to avoid unnecessary work when adding lots
+of layers at once. Clients which will be adding many layers may call blockActiveLayerChanges( ``True`` ) upfront,
+add all the layers, and then follow up with a call to blockActiveLayerChanges( ``False`` ). This will defer emitting
+the active layer changed signal until they've added all layers, and only emit the signal once for
+the final layer added.
+
+.. warning::
+
+   This must be accompanied by a subsequent call with ``blocked`` as ``False``.
+
+.. versionadded:: 3.36
+%End
+
   signals:
 
     void currentLayerChanged( QgsMapLayer *layer );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1948,6 +1948,22 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! shows the map styling dock
     void mapStyleDock( bool enabled );
 
+    /**
+     * Sets whether changes to the active layer should be temporarily
+     * blocked.
+     *
+     * This is a low-level method, designed to avoid unnecessary work when adding lots
+     * of layers at once. Clients which will be adding many layers may call blockActiveLayerChanges( TRUE ) upfront,
+     * add all the layers, and then follow up with a call to blockActiveLayerChanges( FALSE ). This will defer emitting
+     * the active layer changed signal until they've added all layers, and only emit the signal once for
+     * the final layer added.
+     *
+     * \warning This must be accompanied by a subsequent call with \a blocked as FALSE.
+     *
+     * \since QGIS 3.36
+     */
+    void blockActiveLayerChanges( bool blocked );
+
     //! diagrams properties
     void diagramProperties();
 
@@ -2693,8 +2709,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsProxyProgressTask *mProjectLoadingProxyTask = nullptr;
 
-    //! True if we are blocking the activeLayerChanged signal from being emitted
-    bool mBlockActiveLayerChanged = false;
+    // Non-zero if we are blocking the activeLayerChanged signal from being emitted
+    int mBlockActiveLayerChanged = 0;
 
     int mBlockBrowser1Refresh = 0;
     int mBlockBrowser2Refresh = 0;

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -1000,3 +1000,8 @@ QgsUserProfileManager *QgisAppInterface::userProfileManager()
   return qgis->userProfileManager();
 }
 
+void QgisAppInterface::blockActiveLayerChanges( bool blocked )
+{
+  qgis->blockActiveLayerChanges( blocked );
+}
+

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -317,6 +317,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void setGpsPanelConnection( QgsGpsConnection *connection ) override;
     QList<QgsMapDecoration *> activeDecorations() override;
     QgsUserProfileManager *userProfileManager() override;
+    void blockActiveLayerChanges( bool blocked ) override;
 
   private slots:
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -1484,6 +1484,22 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual void setGpsPanelConnection( QgsGpsConnection *connection SIP_TRANSFER ) = 0;
 
+    /**
+     * Sets whether changes to the active layer should be temporarily
+     * blocked.
+     *
+     * This is a low-level method, designed to avoid unnecessary work when adding lots
+     * of layers at once. Clients which will be adding many layers may call blockActiveLayerChanges( TRUE ) upfront,
+     * add all the layers, and then follow up with a call to blockActiveLayerChanges( FALSE ). This will defer emitting
+     * the active layer changed signal until they've added all layers, and only emit the signal once for
+     * the final layer added.
+     *
+     * \warning This must be accompanied by a subsequent call with \a blocked as FALSE.
+     *
+     * \since QGIS 3.36
+     */
+    virtual void blockActiveLayerChanges( bool blocked ) = 0;
+
   signals:
 
     /**


### PR DESCRIPTION
Sets whether changes to the active layer should be temporarily blocked. Exposes a previously private optimisation for use by plugins.

This is a low-level method, designed to avoid unnecessary work when adding lots of layers at once. Clients which will be adding many layers may call blockActiveLayerChanges( TRUE ) upfront, add all the layers, and then follow up with a call to blockActiveLayerChanges( FALSE ). This will defer emitting the active layer changed signal until they've added all layers, and only emit the signal once for the final layer added.
