### PR TITLE
Fix warnings when running spell check

### DIFF
--- a/scripts/spell_check/.agignore
+++ b/scripts/spell_check/.agignore
@@ -14,12 +14,12 @@ tests/testdata/provider/postgresraster/
 tests/testdata/newsfeed/
 
 #Extensions
-*.*.orig
-*.*.sortinc
-*.*.png
-*.*.prepare
-*.sld
-*.lintian-overrides
+.*\..*.orig
+.*\..*.sortinc
+.*\..*.png
+.*\..*.prepare
+.*\.sld
+.*\.lintian-overrides
 .agignore
 
 #Specific files


### PR DESCRIPTION
The contents of .agignore are regular expressions, not wildcards
