### PR TITLE
Set SCALE for type decimal AND numeric

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -479,7 +479,7 @@ void QgsMssqlProvider::loadFields()
                           sqlType,
                           sqlTypeName,
                           query.value( QStringLiteral( "PRECISION" ) ).toInt(),
-                          sqlTypeName == QLatin1String( "decimal" ) ? query.value( QStringLiteral( "SCALE" ) ).toInt() : -1 );
+                          sqlTypeName == QLatin1String( "decimal" ) || sqlTypeName == QLatin1String( "numeric" ) ? query.value( QStringLiteral( "SCALE" ) ).toInt() : -1 );
       }
       else if ( sqlType == QVariant::Date || sqlType == QVariant::DateTime || sqlType == QVariant::Time )
       {


### PR DESCRIPTION
## Description
Only the type `decimal` was used when setting the Scale for Number-Types in the MSSQLProvider. This PR adds the same check for type `numeric` which is (according to [Microsoft](https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16)) just an alias for `decimal`. 
This is required to allow the type **numeric** as a primary-key-type with the MSSQLProvider in QGIS, because the Scale needs to be set correctly. With this change the Scale for the type numeric is set to its correct value instead of the fallback value -1.
Here is the check for the Precision: https://github.com/qgis/QGIS/blob/c93f8e772120bf3ffcd69df7fb74c624340f5118/src/providers/mssql/qgsmssqlprovider.cpp#L203C4-L210


Fixes: #52490
