### PR TITLE
Add convenient buttons for selecting layers in layout map clipping dialog

### DIFF
--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -1985,8 +1985,11 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
   mClipItemComboBox->setCurrentLayout( map->layout() );
   mClipItemComboBox->setItemFlags( QgsLayoutItem::FlagProvidesClipPath );
 
-  connect( mRadioClipSelectedLayers, &QRadioButton::toggled, mLayersTreeView, &QWidget::setEnabled );
+  connect( mRadioClipSelectedLayers, &QRadioButton::toggled, this, &QgsLayoutMapClippingWidget::toggleLayersSelectionGui );
   mLayersTreeView->setEnabled( false );
+  mSelectAllButton->setEnabled( false );
+  mDeselectAllButton->setEnabled( false );
+  mInvertSelectionButton->setEnabled( false );
   mRadioClipAllLayers->setChecked( true );
 
   connect( mClipToAtlasCheckBox, &QGroupBox::toggled, this, [ = ]( bool active )
@@ -2028,6 +2031,11 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
       mBlockUpdates = false;
     }
   } );
+  // layers selection buttons
+  connect( mSelectAllButton, &QPushButton::clicked, this, &QgsLayoutMapClippingWidget::selectAll );
+  connect( mDeselectAllButton, &QPushButton::clicked, this, &QgsLayoutMapClippingWidget::deselectAll );
+  connect( mInvertSelectionButton, &QPushButton::clicked, this, &QgsLayoutMapClippingWidget::invertSelection );
+
   connect( mRadioClipAllLayers, &QCheckBox::toggled, this, [ = ]( bool active )
   {
     if ( active && !mBlockUpdates )
@@ -2183,4 +2191,41 @@ void QgsLayoutMapClippingWidget::atlasToggled( bool atlasEnabled )
     mClipToAtlasCheckBox->setEnabled( false );
     mClipToAtlasCheckBox->setChecked( false );
   }
+}
+
+void QgsLayoutMapClippingWidget::invertSelection()
+{
+  for ( int i = 0; i < mLayerModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mLayerModel->index( i, 0 );
+    Qt::CheckState currentState = Qt::CheckState( mLayerModel->data( index, Qt::CheckStateRole ).toInt() );
+    Qt::CheckState newState = ( currentState == Qt::Checked ) ? Qt::Unchecked : Qt::Checked;
+    mLayerModel->setData( index, newState, Qt::CheckStateRole );
+  }
+}
+
+void QgsLayoutMapClippingWidget::selectAll()
+{
+  for ( int i = 0; i < mLayerModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mLayerModel->index( i, 0 );
+    mLayerModel->setData( index, Qt::Checked, Qt::CheckStateRole );
+  }
+}
+
+void QgsLayoutMapClippingWidget::deselectAll()
+{
+  for ( int i = 0; i < mLayerModel->rowCount( QModelIndex() ); i++ )
+  {
+    QModelIndex index = mLayerModel->index( i, 0 );
+    mLayerModel->setData( index, Qt::Unchecked, Qt::CheckStateRole );
+  }
+}
+
+void QgsLayoutMapClippingWidget::toggleLayersSelectionGui( bool toggled )
+{
+  mLayersTreeView->setEnabled( toggled );
+  mSelectAllButton->setEnabled( toggled );
+  mDeselectAllButton->setEnabled( toggled );
+  mInvertSelectionButton->setEnabled( toggled );
 }

--- a/src/gui/layout/qgslayoutmapwidget.h
+++ b/src/gui/layout/qgslayoutmapwidget.h
@@ -272,6 +272,10 @@ class GUI_EXPORT QgsLayoutMapClippingWidget: public QgsLayoutItemBaseWidget, pri
     void updateGuiElements();
     void atlasLayerChanged( QgsVectorLayer *layer );
     void atlasToggled( bool atlasEnabled );
+    void selectAll();
+    void deselectAll();
+    void invertSelection();
+    void toggleLayersSelectionGui( bool toggled );
 
   private:
     QPointer< QgsLayoutItemMap > mMapItem;

--- a/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapclippingwidgetbase.ui
@@ -41,7 +41,7 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="8" column="0">
+      <item row="6" column="0">
        <widget class="QTreeView" name="mLayersTreeView">
         <property name="headerHidden">
          <bool>true</bool>
@@ -73,6 +73,44 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="7" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mSelectAllButton">
+          <property name="text">
+           <string>Select All</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mDeselectAllButton">
+          <property name="text">
+           <string>Deselect All</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mInvertSelectionButton">
+          <property name="text">
+           <string>Invert Selection</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="5" column="0">
        <widget class="QRadioButton" name="mRadioClipSelectedLayers">
@@ -179,6 +217,9 @@
   <tabstop>mRadioClipAllLayers</tabstop>
   <tabstop>mRadioClipSelectedLayers</tabstop>
   <tabstop>mLayersTreeView</tabstop>
+  <tabstop>mSelectAllButton</tabstop>
+  <tabstop>mDeselectAllButton</tabstop>
+  <tabstop>mInvertSelectionButton</tabstop>
   <tabstop>mClipToItemCheckBox</tabstop>
   <tabstop>mClipItemComboBox</tabstop>
   <tabstop>mItemClippingTypeComboBox</tabstop>


### PR DESCRIPTION
(code highly inspired by #55757 😉 )
Fixes #55829

![image](https://github.com/qgis/QGIS/assets/7983394/26dd497f-5c43-4b7e-8560-eb59f72e5af4)
