### PR TITLE
Use proper model for recent CRS in QgsProjectionSelectionTreeWidget

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -768,6 +768,13 @@ Returns the type of the CRS.
 .. versionadded:: 3.34
 %End
 
+    bool isDeprecated() const;
+%Docstring
+Returns ``True`` if the CRS is considered deprecated.
+
+.. versionadded:: 3.36
+%End
+
     bool isGeographic() const;
 %Docstring
 Returns whether the CRS is a geographic CRS (using lat/lon coordinates)

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1129,11 +1129,12 @@ Removes a CRS from the list of recently used CRS.
    QGIS 3.36 Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.removeRecent` instead.
 %End
 
-    static void clearRecentCoordinateReferenceSystems();
+ static void clearRecentCoordinateReferenceSystems() /Deprecated/;
 %Docstring
 Cleans the list of recently used CRS.
 
-.. versionadded:: 3.32
+.. deprecated::
+   QGIS 3.36 Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.clearRecent` instead.
 %End
 
 

--- a/python/PyQt6/gui/auto_additions/qgsrecentcoordinatereferencesystemsmodel.py
+++ b/python/PyQt6/gui/auto_additions/qgsrecentcoordinatereferencesystemsmodel.py
@@ -1,2 +1,3 @@
 # The following has been generated automatically from src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
 QgsRecentCoordinateReferenceSystemsModel.RoleCrs = QgsRecentCoordinateReferenceSystemsModel.Roles.RoleCrs
+QgsRecentCoordinateReferenceSystemsModel.RoleAuthId = QgsRecentCoordinateReferenceSystemsModel.Roles.RoleAuthId

--- a/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
@@ -11,6 +11,11 @@
 
 
 
+
+
+
+
+
 class QgsProjectionSelectionTreeWidget : QWidget
 {
 %Docstring(signature="appended")

--- a/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -84,15 +84,11 @@ Returns the underlying source model.
     void setFilters( QgsCoordinateReferenceSystemProxyModel::Filters filters );
 %Docstring
 Set ``filters`` that affect how CRS are filtered.
-
-.. seealso:: :py:func:`filters`
 %End
 
     void setFilterDeprecated( bool filter );
 %Docstring
 Sets whether deprecated CRS should be filtered from the results.
-
-.. seealso:: :py:func:`filterDeprecated`
 %End
 
     void setFilterString( const QString &filter );

--- a/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -95,8 +95,6 @@ Sets whether deprecated CRS should be filtered from the results.
 %Docstring
 Sets a ``filter`` string, such that only coordinate reference systems matching the
 specified string will be shown.
-
-.. seealso:: :py:func:`filterString`
 %End
 
     QgsCoordinateReferenceSystemProxyModel::Filters filters() const;

--- a/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -26,9 +26,10 @@ A model for display of recently used coordinate reference systems.
     enum Roles
     {
       RoleCrs,
+      RoleAuthId,
     };
 
-    QgsRecentCoordinateReferenceSystemsModel( QObject *parent /TransferThis/ = 0 );
+    QgsRecentCoordinateReferenceSystemsModel( QObject *parent /TransferThis/ = 0);
 %Docstring
 Constructor for QgsRecentCoordinateReferenceSystemsModel, with the specified ``parent`` object.
 %End
@@ -69,7 +70,7 @@ A sort/filter proxy model for recent coordinate reference systems.
 %End
   public:
 
-    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent /TransferThis/ = 0 );
+    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent /TransferThis/ = 0);
 %Docstring
 Constructor for QgsRecentCoordinateReferenceSystemsProxyModel, with the given ``parent`` object.
 %End
@@ -85,6 +86,21 @@ Returns the underlying source model.
 Set ``filters`` that affect how CRS are filtered.
 
 .. seealso:: :py:func:`filters`
+%End
+
+    void setFilterDeprecated( bool filter );
+%Docstring
+Sets whether deprecated CRS should be filtered from the results.
+
+.. seealso:: :py:func:`filterDeprecated`
+%End
+
+    void setFilterString( const QString &filter );
+%Docstring
+Sets a ``filter`` string, such that only coordinate reference systems matching the
+specified string will be shown.
+
+.. seealso:: :py:func:`filterString`
 %End
 
     QgsCoordinateReferenceSystemProxyModel::Filters filters() const;

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -768,6 +768,13 @@ Returns the type of the CRS.
 .. versionadded:: 3.34
 %End
 
+    bool isDeprecated() const;
+%Docstring
+Returns ``True`` if the CRS is considered deprecated.
+
+.. versionadded:: 3.36
+%End
+
     bool isGeographic() const;
 %Docstring
 Returns whether the CRS is a geographic CRS (using lat/lon coordinates)

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -1129,11 +1129,12 @@ Removes a CRS from the list of recently used CRS.
    QGIS 3.36 Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.removeRecent` instead.
 %End
 
-    static void clearRecentCoordinateReferenceSystems();
+ static void clearRecentCoordinateReferenceSystems() /Deprecated/;
 %Docstring
 Cleans the list of recently used CRS.
 
-.. versionadded:: 3.32
+.. deprecated::
+   QGIS 3.36 Use :py:func:`QgsApplication.coordinateReferenceSystemRegistry()`->:py:func:`~QgsCoordinateReferenceSystem.clearRecent` instead.
 %End
 
 

--- a/python/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/proj/qgsprojectionselectiontreewidget.sip.in
@@ -11,6 +11,11 @@
 
 
 
+
+
+
+
+
 class QgsProjectionSelectionTreeWidget : QWidget
 {
 %Docstring(signature="appended")

--- a/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -84,15 +84,11 @@ Returns the underlying source model.
     void setFilters( QgsCoordinateReferenceSystemProxyModel::Filters filters );
 %Docstring
 Set ``filters`` that affect how CRS are filtered.
-
-.. seealso:: :py:func:`filters`
 %End
 
     void setFilterDeprecated( bool filter );
 %Docstring
 Sets whether deprecated CRS should be filtered from the results.
-
-.. seealso:: :py:func:`filterDeprecated`
 %End
 
     void setFilterString( const QString &filter );

--- a/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -95,8 +95,6 @@ Sets whether deprecated CRS should be filtered from the results.
 %Docstring
 Sets a ``filter`` string, such that only coordinate reference systems matching the
 specified string will be shown.
-
-.. seealso:: :py:func:`filterString`
 %End
 
     QgsCoordinateReferenceSystemProxyModel::Filters filters() const;

--- a/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
+++ b/python/gui/auto_generated/proj/qgsrecentcoordinatereferencesystemsmodel.sip.in
@@ -26,9 +26,10 @@ A model for display of recently used coordinate reference systems.
     enum Roles
     {
       RoleCrs,
+      RoleAuthId,
     };
 
-    QgsRecentCoordinateReferenceSystemsModel( QObject *parent /TransferThis/ = 0 );
+    QgsRecentCoordinateReferenceSystemsModel( QObject *parent /TransferThis/ = 0);
 %Docstring
 Constructor for QgsRecentCoordinateReferenceSystemsModel, with the specified ``parent`` object.
 %End
@@ -69,7 +70,7 @@ A sort/filter proxy model for recent coordinate reference systems.
 %End
   public:
 
-    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent /TransferThis/ = 0 );
+    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent /TransferThis/ = 0);
 %Docstring
 Constructor for QgsRecentCoordinateReferenceSystemsProxyModel, with the given ``parent`` object.
 %End
@@ -85,6 +86,21 @@ Returns the underlying source model.
 Set ``filters`` that affect how CRS are filtered.
 
 .. seealso:: :py:func:`filters`
+%End
+
+    void setFilterDeprecated( bool filter );
+%Docstring
+Sets whether deprecated CRS should be filtered from the results.
+
+.. seealso:: :py:func:`filterDeprecated`
+%End
+
+    void setFilterString( const QString &filter );
+%Docstring
+Sets a ``filter`` string, such that only coordinate reference systems matching the
+specified string will be shown.
+
+.. seealso:: :py:func:`filterString`
 %End
 
     QgsCoordinateReferenceSystemProxyModel::Filters filters() const;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1374,6 +1374,15 @@ Qgis::CrsType QgsCoordinateReferenceSystem::type() const
   // NOLINTEND(bugprone-branch-clone)
 }
 
+bool QgsCoordinateReferenceSystem::isDeprecated() const
+{
+  const PJ *pj = projObject();
+  if ( !pj )
+    return false;
+
+  return proj_is_deprecated( pj );
+}
+
 bool QgsCoordinateReferenceSystem::isGeographic() const
 {
   return d->mIsGeographic;

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -702,6 +702,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     Qgis::CrsType type() const;
 
     /**
+     * Returns TRUE if the CRS is considered deprecated.
+     *
+     * \since QGIS 3.36
+     */
+    bool isDeprecated() const;
+
+    /**
      * Returns whether the CRS is a geographic CRS (using lat/lon coordinates)
      * \returns TRUE if CRS is geographic, or FALSE if it is a projected CRS
      */

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -1060,9 +1060,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Cleans the list of recently used CRS.
-     * \since QGIS 3.32
+     *
+     * \deprecated QGIS 3.36 Use QgsApplication::coordinateReferenceSystemRegistry()->clearRecent() instead.
      */
-    static void clearRecentCoordinateReferenceSystems();
+    Q_DECL_DEPRECATED static void clearRecentCoordinateReferenceSystems() SIP_DEPRECATED;
 
 #ifndef SIP_RUN
 

--- a/src/gui/proj/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/proj/qgsprojectionselectiontreewidget.cpp
@@ -660,6 +660,7 @@ QVariant QgsRecentCoordinateReferenceSystemTableModel::data( const QModelIndex &
         default:
           break;
       }
+      break;
     }
 
     default:

--- a/src/gui/proj/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/proj/qgsprojectionselectiontreewidget.cpp
@@ -47,6 +47,12 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   lstCoordinateSystems->setModel( mCrsModel );
   lstCoordinateSystems->setSelectionBehavior( QAbstractItemView::SelectRows );
 
+  if ( mCrsModel->rowCount() == 1 )
+  {
+    // if only one group, expand it by default
+    lstCoordinateSystems->expand( mCrsModel->index( 0, 0, QModelIndex() ) );
+  }
+
   QFont f = teProjection->font();
   f.setPointSize( f.pointSize() - 2 );
   teProjection->setFont( f );
@@ -263,6 +269,11 @@ QgsCoordinateReferenceSystemProxyModel::Filters QgsProjectionSelectionTreeWidget
 void QgsProjectionSelectionTreeWidget::setFilters( QgsCoordinateReferenceSystemProxyModel::Filters filters )
 {
   mCrsModel->setFilters( filters );
+  if ( mCrsModel->rowCount() == 1 )
+  {
+    // if only one group, expand it by default
+    lstCoordinateSystems->expand( mCrsModel->index( 0, 0, QModelIndex() ) );
+  }
 }
 
 QgsCoordinateReferenceSystem QgsProjectionSelectionTreeWidget::crs() const

--- a/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
+++ b/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
@@ -44,12 +44,13 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsModel : public QAbstractItem
     enum Roles
     {
       RoleCrs = Qt::UserRole, //!< Coordinate reference system
+      RoleAuthId, //!< CRS authority ID
     };
 
     /**
      * Constructor for QgsRecentCoordinateReferenceSystemsModel, with the specified \a parent object.
      */
-    QgsRecentCoordinateReferenceSystemsModel( QObject *parent SIP_TRANSFERTHIS = nullptr );
+    QgsRecentCoordinateReferenceSystemsModel( QObject *parent SIP_TRANSFERTHIS = nullptr, int subclassColumnCount SIP_PYARGREMOVE = 1 );
 
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
@@ -74,6 +75,7 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsModel : public QAbstractItem
   private:
 
     QList< QgsCoordinateReferenceSystem > mCrs;
+    int mColumnCount = 1;
 
 };
 
@@ -93,7 +95,7 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsProxyModel: public QSortFilt
     /**
      * Constructor for QgsRecentCoordinateReferenceSystemsProxyModel, with the given \a parent object.
      */
-    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsRecentCoordinateReferenceSystemsProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr, int subclassColumnCount SIP_PYARGREMOVE = 1 );
 
     /**
      * Returns the underlying source model.
@@ -111,6 +113,21 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsProxyModel: public QSortFilt
      * \see filters()
      */
     void setFilters( QgsCoordinateReferenceSystemProxyModel::Filters filters );
+
+    /**
+     * Sets whether deprecated CRS should be filtered from the results.
+     *
+     * \see filterDeprecated()
+    */
+    void setFilterDeprecated( bool filter );
+
+    /**
+     * Sets a \a filter string, such that only coordinate reference systems matching the
+     * specified string will be shown.
+     *
+     * \see filterString()
+    */
+    void setFilterString( const QString &filter );
 
     /**
      * Returns any filters that affect how CRS are filtered.
@@ -131,6 +148,8 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsProxyModel: public QSortFilt
 
     QgsRecentCoordinateReferenceSystemsModel *mModel = nullptr;
     QgsCoordinateReferenceSystemProxyModel::Filters mFilters = QgsCoordinateReferenceSystemProxyModel::Filters();
+    bool mFilterDeprecated = false;
+    QString mFilterString;
 };
 
 

--- a/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
+++ b/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
@@ -121,8 +121,6 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsProxyModel: public QSortFilt
     /**
      * Sets a \a filter string, such that only coordinate reference systems matching the
      * specified string will be shown.
-     *
-     * \see filterString()
     */
     void setFilterString( const QString &filter );
 

--- a/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
+++ b/src/gui/proj/qgsrecentcoordinatereferencesystemsmodel.h
@@ -110,14 +110,11 @@ class GUI_EXPORT QgsRecentCoordinateReferenceSystemsProxyModel: public QSortFilt
 
     /**
      * Set \a filters that affect how CRS are filtered.
-     * \see filters()
      */
     void setFilters( QgsCoordinateReferenceSystemProxyModel::Filters filters );
 
     /**
      * Sets whether deprecated CRS should be filtered from the results.
-     *
-     * \see filterDeprecated()
     */
     void setFilterDeprecated( bool filter );
 

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -105,7 +105,7 @@
         <property name="childrenCollapsible">
          <bool>false</bool>
         </property>
-        <widget class="QTreeWidget" name="lstRecent">
+        <widget class="QTreeView" name="lstRecent">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
@@ -121,35 +121,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
-         <property name="rootIsDecorated">
-          <bool>false</bool>
-         </property>
          <property name="uniformRowHeights">
           <bool>true</bool>
          </property>
-         <property name="columnCount">
-          <number>4</number>
-         </property>
-         <column>
-          <property name="text">
-           <string>Coordinate Reference System</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Authority ID</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>ID</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string/>
-          </property>
-         </column>
         </widget>
         <widget class="QWidget" name="layoutWidget">
          <layout class="QGridLayout" name="gridLayout">

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -43,6 +43,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void idCtor();
     void copyCtor();
     void assignmentCtor();
+    void testDeprecated();
     void compoundCrs();
     void verticalCrs();
     void projectedCrs();
@@ -259,6 +260,12 @@ void TestQgsCoordinateReferenceSystem::assignmentCtor()
   myCrs3.setCoordinateEpoch( 2021.2 );
   QCOMPARE( myCrs.coordinateEpoch(), 2021.3 );
   QCOMPARE( myCrs3.coordinateEpoch(), 2021.2 );
+}
+
+void TestQgsCoordinateReferenceSystem::testDeprecated()
+{
+  QVERIFY( !QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ).isDeprecated() );
+  QVERIFY( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4226" ) ).isDeprecated() );
 }
 
 void TestQgsCoordinateReferenceSystem::compoundCrs()


### PR DESCRIPTION
This ensures that we correctly apply filters to recent projections too, eg so that a widget showing only vertical crs will ONLY show recent VERTICAL crs, not every recent crs.