### PR TITLE
Add a "Load style from file" button to layers contextual menu in Layers panel

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8417,6 +8417,59 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
   }
 }
 
+void QgisApp::loadStyleFile( QgsMapLayer *layer )
+{
+  if ( !layer )
+  {
+    layer = activeLayer();
+  }
+
+  if ( !layer || !layer->dataProvider() )
+    return;
+
+  switch ( layer->type() )
+  {
+
+    case Qgis::LayerType::Vector:
+      QgsVectorLayerProperties( mMapCanvas,
+                                visibleMessageBar(),
+                                qobject_cast<QgsVectorLayer *>( layer ) ).loadStyle();
+      break;
+
+    case Qgis::LayerType::Raster:
+      QgsRasterLayerProperties( layer, mMapCanvas ).loadStyle();
+      break;
+
+    case Qgis::LayerType::Mesh:
+      QgsMeshLayerProperties( layer, mMapCanvas ).loadStyleFromFile();
+      break;
+
+    case Qgis::LayerType::VectorTile:
+      QgsVectorTileLayerProperties( qobject_cast<QgsVectorTileLayer *>( layer ),
+                                    mMapCanvas,
+                                    visibleMessageBar() ).loadStyle();
+      break;
+
+    case Qgis::LayerType::PointCloud:
+      QgsPointCloudLayerProperties( qobject_cast<QgsPointCloudLayer *>( layer ),
+                                    mMapCanvas,
+                                    visibleMessageBar() ).loadStyleFromFile();
+      break;
+
+    case Qgis::LayerType::TiledScene:
+      QgsTiledSceneLayerProperties( qobject_cast<QgsTiledSceneLayer *>( layer ),
+                                    mMapCanvas,
+                                    visibleMessageBar() ).loadStyleFromFile();
+      break;
+
+    // Not available for these
+    case Qgis::LayerType::Annotation:
+    case Qgis::LayerType::Plugin:
+    case Qgis::LayerType::Group:
+      break;
+  }
+}
+
 ///@cond PRIVATE
 
 /**

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -929,11 +929,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void makeMemoryLayerPermanent( QgsVectorLayer *layer );
 
-    //! save qml style for the current layer
+    //! Loads qml style file to the current layer
+    void loadStyleFile( QgsMapLayer *layer = nullptr );
+    //! Saves qml style for the current layer
     void saveStyleFile( QgsMapLayer *layer = nullptr );
-    //! save qrl definition for the current layer
+    //! Saves qlr definition for the current layer
     void saveAsLayerDefinition();
-    //! save current raster layer
+    //! Saves current raster layer
     QString saveAsRasterFile( QgsRasterLayer *layer = nullptr, bool defaultAddToCanvas = true );
 
     /**

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -555,7 +555,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                 menu->addAction( actionMakePermanent );
               }
               // save as vector file
-              QMenu *menuExportVector = new QMenu( tr( "E&xport" ), menu );
+              QMenu *menuExportVector = new QMenu( tr( "Import/E&xport" ), menu );
               menuExportVector->setObjectName( QStringLiteral( "exportMenu" ) );
               QAction *actionSaveAs = new QAction( tr( "Save Features &As…" ), menuExportVector );
               connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
@@ -573,6 +573,10 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                 QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportVector );
                 connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
                 menuExportVector->addAction( actionSaveStyle );
+                menuExportVector->addSeparator();
+                QAction *actionLoadStyle = new QAction( tr( "&Load a QGIS Layer Style File…" ), menuExportVector );
+                connect( actionLoadStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->loadStyleFile(); } );
+                menuExportVector->addAction( actionLoadStyle );
               }
               menu->addMenu( menuExportVector );
             }
@@ -586,11 +590,12 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             bool enableSaveAs = ( pcLayer && pcLayer->isValid() && pcLayer->dataProvider()->hasValidIndex() ) ||
                                 ( rlayer && rlayer->isValid() );
-            QMenu *menuExportRaster = new QMenu( tr( "E&xport" ), menu );
+            QMenu *menuExportRaster = new QMenu( tr( "Import/E&xport" ), menu );
             menuExportRaster->setObjectName( QStringLiteral( "exportMenu" ) );
             QAction *actionSaveAs = new QAction( tr( "Save &As…" ), menuExportRaster );
             QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer &Definition File…" ), menuExportRaster );
             QAction *actionSaveStyle = new QAction( tr( "Save as &QGIS Layer Style File…" ), menuExportRaster );
+            QAction *actionLoadStyle = new QAction( tr( "&Load a QGIS Layer Style File…" ), menuExportRaster );
             connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
             menuExportRaster->addAction( actionSaveAs );
             actionSaveAs->setEnabled( enableSaveAs );
@@ -598,6 +603,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             menuExportRaster->addAction( actionSaveAsDefinitionLayer );
             connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
             menuExportRaster->addAction( actionSaveStyle );
+            menuExportRaster->addSeparator();
+            connect( actionLoadStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->loadStyleFile(); } );
+            menuExportRaster->addAction( actionLoadStyle );
             menu->addMenu( menuExportRaster );
           }
           break;

--- a/src/gui/qgslayerpropertiesdialog.cpp
+++ b/src/gui/qgslayerpropertiesdialog.cpp
@@ -162,7 +162,7 @@ void QgsLayerPropertiesDialog::loadStyleFromFile()
 
   QString fileName = QFileDialog::getOpenFileName(
                        this,
-                       tr( "Load layer properties from style file" ),
+                       tr( "Load Layer Properties from Style File" ),
                        lastUsedDir,
                        tr( "QGIS Layer Style File" ) + " (*.qml)" );
   if ( fileName.isEmpty() )
@@ -198,7 +198,7 @@ void QgsLayerPropertiesDialog::saveStyleToFile()
 
   QString outputFileName = QFileDialog::getSaveFileName(
                              this,
-                             tr( "Save layer properties as style file" ),
+                             tr( "Save Layer Properties as Style File" ),
                              lastUsedDir,
                              tr( "QGIS Layer Style File" ) + " (*.qml)" );
   // return dialog focus on Mac
@@ -369,7 +369,7 @@ void QgsLayerPropertiesDialog::saveDefaultStyle()
         QString errorMessage;
         if ( QgsProviderRegistry::instance()->styleExists( mLayer->providerType(), mLayer->source(), QString(), errorMessage ) )
         {
-          if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+          if ( QMessageBox::question( nullptr, QObject::tr( "Save Style to Database" ),
                                       QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
                                       QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
           {
@@ -378,7 +378,7 @@ void QgsLayerPropertiesDialog::saveDefaultStyle()
         }
         else if ( !errorMessage.isEmpty() )
         {
-          QMessageBox::warning( nullptr, QObject::tr( "Save style in database" ),
+          QMessageBox::warning( nullptr, QObject::tr( "Save Style to Database" ),
                                 errorMessage );
           return;
         }
@@ -441,13 +441,13 @@ void QgsLayerPropertiesDialog::saveStyleAs()
       }
       case DatasourceDatabase:
       {
-        QString infoWindowTitle = QObject::tr( "Save style to DB (%1)" ).arg( mLayer->providerType() );
+        QString infoWindowTitle = QObject::tr( "Save Style to DB (%1)" ).arg( mLayer->providerType() );
 
         QgsMapLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
 
         if ( QgsProviderRegistry::instance()->styleExists( mLayer->providerType(), mLayer->source(), dbSettings.name, errorMessage ) )
         {
-          if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+          if ( QMessageBox::question( nullptr, QObject::tr( "Save Style to Database" ),
                                       QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
                                       QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
           {
@@ -474,7 +474,7 @@ void QgsLayerPropertiesDialog::saveStyleAs()
       }
       case UserDatabase:
       {
-        QString infoWindowTitle = tr( "Save default style to local database" );
+        QString infoWindowTitle = tr( "Save Default Style to Local Database" );
         errorMessage = mLayer->saveDefaultStyle( defaultLoadedFlag, dlg.styleCategories() );
         if ( !defaultLoadedFlag )
         {

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -305,7 +305,7 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
       break;
 
     case Qgis::LayerType::Raster:
-      QgsRasterLayerProperties( mLayer, mMapCanvas ).loadStyleFromFile();
+      QgsRasterLayerProperties( mLayer, mMapCanvas ).loadStyle();
       break;
 
     case Qgis::LayerType::Mesh:


### PR DESCRIPTION
fixes #55165 
Also Harmonize behavior of raster "load style" button in the styling panel with the one in the raster layer properties dialog.
The button in Styling panel used to only allow loading from QML file while the other also proposes style from DB.
Finally some dialog title fixes

https://github.com/qgis/QGIS/assets/7983394/46fc2a94-5b9b-4950-93ef-5843190ed1ba

PS: is that normal that symbology is the only category you can save/load for raster layers? Bug or feature request?