### PR TITLE
Indicate actual repository storing the build artifacts in comment

### DIFF
--- a/.github/workflows/build_artifact_comment.yml
+++ b/.github/workflows/build_artifact_comment.yml
@@ -77,10 +77,10 @@ jobs:
             });
             const PREFIX = "## 🪟 Windows builds ready!";
             let body = PREFIX + "\n\n" +
-                "Windows builds of this PR are available for testing [here](https://github.com/qgis/QGIS/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.artifact_id}}).";
+                "Windows builds of this PR are available for testing [here](https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.artifact_id}}).";
             if ( ${{steps.download_artifact.outputs.debug_symbols_artifact_id}} > 0 )
             {
-              body += " Debug symbols for this build are available [here](https://github.com/qgis/QGIS/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.debug_symbols_artifact_id}}).";
+              body += " Debug symbols for this build are available [here](https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.debug_symbols_artifact_id}}).";
             }
             body += "\n\n*(Built from commit " + git_sha + ")*";
 


### PR DESCRIPTION
when using a repo other than qgis/QGIS, let's ensure to provide the correct link and not point to upstream repo.
See it in action at https://github.com/DelazJ/QGIS/pull/70#issuecomment-1898547720.

> ## 🪟 Windows builds ready!
>
> Windows builds of this PR are available for testing [here](https://github.com/DelazJ/QGIS/suites/19921491328/artifacts/1179376371). Debug symbols for this build are available [here](https://github.com/DelazJ/QGIS/suites/19921491328/artifacts/1179376374).
>
> *(Built from commit a0eb2f9b2451b729983db0c86b3e84b35e7f2c60)*