### PR TITLE
Don't use verbose logging when downloading hana client

### DIFF
--- a/.docker/qgis3-qt5-build-deps.dockerfile
+++ b/.docker/qgis3-qt5-build-deps.dockerfile
@@ -151,7 +151,7 @@ RUN  apt-get update \
 
 # HANA: client side
 # Install hdbsql tool
-RUN curl -v -j -k -L -H "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
+RUN curl -j -k -L -H "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
   && tar -xvf hanaclient-latest-linux-x64.tar.gz \
   && mkdir /usr/sap \
   && ./client/hdbinst -a client --sapmnt=/usr/sap \


### PR DESCRIPTION
This causes thousands of lines to be added to the CI logs, which is partially responsible for the github log pages freezing browsers
