### PR TITLE
fix windows build

### DIFF
--- a/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
@@ -291,8 +291,8 @@ Removes all entries in the user settings
 
 
 
-
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/settings/qgssettings.sip.in
+++ b/python/core/auto_generated/settings/qgssettings.sip.in
@@ -291,8 +291,8 @@ Removes all entries in the user settings
 
 
 
-
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -26,7 +26,7 @@
 
 Q_GLOBAL_STATIC( QString, sGlobalSettingsPath )
 
-thread_local QgsSettings *QgsSettings::sThreadSettings;
+thread_local QgsSettings *sQgsSettingsThreadSettings = nullptr;
 
 bool QgsSettings::setGlobalSettingsPath( const QString &path )
 {
@@ -337,19 +337,19 @@ void QgsSettings::clear()
 
 void QgsSettings::holdFlush()
 {
-  if ( sThreadSettings )
+  if ( sQgsSettingsThreadSettings )
     return;
 
-  sThreadSettings = new QgsSettings();
+  sQgsSettingsThreadSettings = new QgsSettings();
 }
 
 void QgsSettings::releaseFlush()
 {
-  delete sThreadSettings;
-  sThreadSettings = nullptr;
+  delete sQgsSettingsThreadSettings;
+  sQgsSettingsThreadSettings = nullptr;
 }
 
 QgsSettingsProxy QgsSettings::get()
 {
-  return QgsSettingsProxy( sThreadSettings );
+  return QgsSettingsProxy( sQgsSettingsThreadSettings );
 }

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -492,14 +492,6 @@ class CORE_EXPORT QgsSettings : public QObject
      */
     static QgsSettingsProxy get() SIP_SKIP;
 
-    /**
-     * Thread local QgsSettings storage.
-     *
-     * \note Not available in Python bindings
-     * \since QGIS 3.36
-     */
-    static thread_local QgsSettings *sThreadSettings SIP_SKIP;
-
   private:
     void init();
     QString sanitizeKey( const QString &key ) const;
@@ -509,5 +501,8 @@ class CORE_EXPORT QgsSettings : public QObject
     Q_DISABLE_COPY( QgsSettings )
 
 };
+
+// as static members cannot be CORE_EXPORTed
+extern thread_local QgsSettings *sQgsSettingsThreadSettings SIP_SKIP;
 
 #endif // QGSSETTINGS_H


### PR DESCRIPTION
nightly error:
```
…/src/core/settings/qgssettings.h(501): error C2487: 'sThreadSettings': member of dll interface class may not be declared with dll interface
…/src/core/settings/qgssettings.h(501): error C2492: 'QgsSettings::sThreadSettings': data with thread storage duration may not have dll interface
…/src/core/settings/qgssettings.h(501): error C2492: 'public: static QgsSettings * QgsSettings::sThreadSettings': data with thread storage duration may not have dll interface
```