### PR TITLE
Set project as dirty when editing symbols through layers panel (fixes 55623)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -693,6 +693,7 @@ void QgisApp::layerTreeViewDoubleClicked( const QModelIndex &index )
           if ( dlg.exec() )
           {
             node->setSymbol( symbol.release() );
+            markDirty();
           }
 
           return;

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -635,6 +635,8 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
 
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
+  QgsProject::instance()->setDirty( true );
+
   emit dataChanged();
   vlayer->emitStyleChanged();
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -635,7 +635,8 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
 
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
-  QgsProject::instance()->setDirty( true );
+  if ( QgsProject* project = vlayer->project() )
+     project->setDirty( true );
 
   emit dataChanged();
   vlayer->emitStyleChanged();

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -636,7 +636,7 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
   if ( QgsProject *project = vlayer->project() )
-     project->setDirty( true );
+    project->setDirty( true );
 
   emit dataChanged();
   vlayer->emitStyleChanged();

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -635,7 +635,7 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
 
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
-  if ( QgsProject* project = vlayer->project() )
+  if ( QgsProject *project = vlayer->project() )
      project->setDirty( true );
 
   emit dataChanged();


### PR DESCRIPTION
## Description

Fixes #55623, where project dirty status isn't set when changing the symbology of categorized or graduated vector layers' individual range/category symbols through the layers panel (by double- clicking the symbol). I also noticed that setting a symbol node as visible / not visible didn't mark the project as dirty and a fix for that is included.

![prgif](https://github.com/qgis/QGIS/assets/118284595/478cf9bd-ebc6-47da-b688-e6b8002951eb)

