### PR TITLE
CI: add a 'concurrency:' section in workflows where it is missing

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -1,5 +1,9 @@
 name: 🧹 Code Layout
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,5 +1,9 @@
 name: ❄ Flake8
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     paths:

--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -1,5 +1,9 @@
 name: MSYS2 MinGW-w64 Windows 64bit Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/write_failure_comment.yml
+++ b/.github/workflows/write_failure_comment.yml
@@ -1,5 +1,9 @@
 name: Write test failure comment
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_run:
     workflows: [🧪 QGIS tests]


### PR DESCRIPTION
This cancels previous workflow runs when pushing new commits in a pull request, to be able to reuse more quickly workers.
