### PR TITLE
Don't try to load plugins which aren't compatible with qt 6

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -438,11 +438,9 @@ class Repositories(QObject):
                     qgisMaximumVersion = pluginNodes.item(i).firstChildElement("qgis_maximum_version").text().strip()
                     if not qgisMaximumVersion:
                         qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
-                    supports_qt6 = pluginNodes.item(i).firstChildElement("supports_qt6").text().strip().upper() in ("TRUE", "YES")
-                    qt_version = int(QT_VERSION_STR.split('.')[0])
                     # if compatible, add the plugin to the list
                     if not pluginNodes.item(i).firstChildElement("disabled").text().strip().upper() in ["TRUE", "YES"]:
-                        if isCompatible(pyQgisVersion(), qgisMinimumVersion, qgisMaximumVersion) and (qt_version != 6 or supports_qt6):
+                        if isCompatible(pyQgisVersion(), qgisMinimumVersion, qgisMaximumVersion):
                             # add the plugin to the cache
                             plugins.addFromRepository(plugin)
                 self.mRepositories[reposName]["state"] = Repositories.STATE_LOADED

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -721,6 +721,13 @@ bool QgsPluginRegistry::checkPythonPlugin( const QString &packageName )
 bool QgsPluginRegistry::isPythonPluginCompatible( const QString &packageName ) const
 {
 #ifdef WITH_BINDINGS
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  const QString supportsQt6 = mPythonUtils->getPluginMetadata( packageName, QStringLiteral( "supportsQt6" ) ).trimmed();
+  if ( supportsQt6.compare( QLatin1String( "YES" ), Qt::CaseInsensitive ) != 0 && supportsQt6.compare( QLatin1String( "TRUE" ), Qt::CaseInsensitive ) != 0 )
+  {
+    return false;
+  }
+#endif
   const QString minVersion = mPythonUtils->getPluginMetadata( packageName, QStringLiteral( "qgisMinimumVersion" ) );
   // try to read qgisMaximumVersion. Note checkQgisVersion can cope with "__error__" value.
   const QString maxVersion = mPythonUtils->getPluginMetadata( packageName, QStringLiteral( "qgisMaximumVersion" ) );


### PR DESCRIPTION
Add a plugin metadata key for "supports_qt6". Plugins which can safely be loaded in QGIS builds based on Qt6 can set

    supportsQt6=yes

in their metadata.txt to advertise that they are safe to load on Qt 6 builds
