### PR TITLE
Fix bad < operator for QgsCoordinateReferenceSystem 

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -3163,18 +3163,16 @@ bool operator> ( const QgsCoordinateReferenceSystem &c1, const QgsCoordinateRefe
   if ( !c1IsUser && c2IsUser )
     return false;
 
-  if ( !c1IsUser && !c2IsUser )
+  if ( !c1IsUser && !c2IsUser && !c1.d->mAuthId.isEmpty() && !c2.d->mAuthId.isEmpty() )
   {
     if ( c1.d->mAuthId != c2.d->mAuthId )
       return c1.d->mAuthId > c2.d->mAuthId;
   }
-  else
-  {
-    const QString wkt1 = c1.toWkt( Qgis::CrsWktVariant::Preferred );
-    const QString wkt2 = c2.toWkt( Qgis::CrsWktVariant::Preferred );
-    if ( wkt1 != wkt2 )
-      return wkt1 > wkt2;
-  }
+
+  const QString wkt1 = c1.toWkt( Qgis::CrsWktVariant::Preferred );
+  const QString wkt2 = c2.toWkt( Qgis::CrsWktVariant::Preferred );
+  if ( wkt1 != wkt2 )
+    return wkt1 > wkt2;
 
   if ( c1.d->mCoordinateEpoch == c2.d->mCoordinateEpoch )
     return false;
@@ -3214,18 +3212,16 @@ bool operator< ( const QgsCoordinateReferenceSystem &c1, const QgsCoordinateRefe
   if ( c1IsUser && !c2IsUser )
     return false;
 
-  if ( !c1IsUser && !c2IsUser )
+  if ( !c1IsUser && !c2IsUser && !c1.d->mAuthId.isEmpty() && !c2.d->mAuthId.isEmpty() )
   {
     if ( c1.d->mAuthId != c2.d->mAuthId )
       return c1.d->mAuthId < c2.d->mAuthId;
   }
-  else
-  {
-    const QString wkt1 = c1.toWkt( Qgis::CrsWktVariant::Preferred );
-    const QString wkt2 = c2.toWkt( Qgis::CrsWktVariant::Preferred );
-    if ( wkt1 != wkt2 )
-      return wkt1 < wkt2;
-  }
+
+  const QString wkt1 = c1.toWkt( Qgis::CrsWktVariant::Preferred );
+  const QString wkt2 = c2.toWkt( Qgis::CrsWktVariant::Preferred );
+  if ( wkt1 != wkt2 )
+    return wkt1 < wkt2;
 
   if ( c1.d->mCoordinateEpoch == c2.d->mCoordinateEpoch )
     return false;

--- a/src/core/proj/qgscoordinatetransformcontext.cpp
+++ b/src/core/proj/qgscoordinatetransformcontext.cpp
@@ -144,14 +144,17 @@ QString QgsCoordinateTransformContext::calculateCoordinateOperation( const QgsCo
     return QString();
 
   d->mLock.lockForRead();
-  QgsCoordinateTransformContextPrivate::OperationDetails res = d->mSourceDestDatumTransforms.value( qMakePair( source, destination ), QgsCoordinateTransformContextPrivate::OperationDetails() );
-  if ( res.operation.isEmpty() )
+
+  auto it = d->mSourceDestDatumTransforms.constFind( qMakePair( source, destination ) );
+  if ( it == d->mSourceDestDatumTransforms.constEnd() )
   {
     // try to reverse
-    res = d->mSourceDestDatumTransforms.value( qMakePair( destination, source ), QgsCoordinateTransformContextPrivate::OperationDetails() );
+    it = d->mSourceDestDatumTransforms.constFind( qMakePair( destination, source ) );
   }
+
+  const QString result = it == d->mSourceDestDatumTransforms.constEnd() ? QString() : it.value().operation;
   d->mLock.unlock();
-  return res.operation;
+  return result;
 }
 
 bool QgsCoordinateTransformContext::allowFallbackTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -952,6 +952,8 @@ void TestQgsCoordinateReferenceSystem::comparison_data()
   QgsCoordinateReferenceSystem noAuthId;
   noAuthId.createFromWkt( QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"unnamed\",DATUM[\"Geocentric_Datum_of_Australia_2020\",SPHEROID[\"GRS 80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",147],PARAMETER[\"scale_factor\",0.1996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]" ) );
 
+  QgsCoordinateReferenceSystem noAuthId2;
+  noAuthId2.createFromProj( QStringLiteral( "+proj=ortho +lat_0=47.686 +lon_0=16.548 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs" ) );
 
   const QgsCoordinateReferenceSystem epsg4326( QStringLiteral( "EPSG:4326" ) );
   const QgsCoordinateReferenceSystem epsg3111( QStringLiteral( "EPSG:3111" ) );
@@ -971,6 +973,8 @@ void TestQgsCoordinateReferenceSystem::comparison_data()
   QTest::newRow( "epsg4326 == epsg4326" ) << epsg4326 << epsg4326 << true;
   QTest::newRow( "user == user" ) << userCrs1 << userCrs1 << true;
   QTest::newRow( "noAuthId == noAuthId" ) << noAuthId << noAuthId << true;
+  QTest::newRow( "noAuthId == noAuthId" ) << noAuthId2 << noAuthId2 << true;
+  QTest::newRow( "noAuthId2 < noAuthId" ) << noAuthId2 << noAuthId << false;
 
   QTest::newRow( "invalid < epsg4326" ) << QgsCoordinateReferenceSystem() << epsg4326 << false;
   QTest::newRow( "invalid < user" ) << QgsCoordinateReferenceSystem() << userCrs1 << false;


### PR DESCRIPTION
This operator was incorrectly treating any two crses which had no auth:id string associated with them as equal.

Notably, this would break lookups of coordinate transforms from the cache and return non-matching coordinate transforms on Qt 6 based builds. (Since qt 6 indirectly relies on the operator< for comparisons during map lookups as qpair is now just an alias for std::pair)

This situation arises in lots of cases. One notable one is when using the measure tool, as this involves creation of
CRS based on the project's current ellipsoid which has NO auth ID associated. Accordingly most common uses of the ellipsoid based distance measurement were broken on Qt6 builds.