### PR TITLE
[Backport release-3_34] Mistype in QgsGeometryUtils::segmentSide description was fixed

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -424,8 +424,8 @@ angular deviation (in radians) allowed when testing for regular point spacing.
 
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) /HoldGIL/;
 %Docstring
-For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+For line defined by points pt1 and pt3, find out on which side of the line is point pt2.
+Returns -1 if pt2 on the left side, 1 if pt2 is on the right side or 0 if pt2 lies on the line.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -433,8 +433,8 @@ class CORE_EXPORT QgsGeometryUtils
                                    double pointSpacingAngleTolerance ) SIP_HOLDGIL;
 
     /**
-     * For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-     * Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+     * For line defined by points pt1 and pt3, find out on which side of the line is point pt2.
+     * Returns -1 if pt2 on the left side, 1 if pt2 is on the right side or 0 if pt2 lies on the line.
      * \since 3.0
      */
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) SIP_HOLDGIL;


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/55366.
Fixes https://github.com/qgis/QGIS/issues/55853.

[It looks like adding the "backport release-3_34" tag to an already merged PR no longer triggers the Backport bot to automatically create the backport.]