### PR TITLE
[gui] Insure that added/removed fields are taken into account by the attribute form panel

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -939,6 +939,13 @@ void QgsAttributesFormProperties::pbnSelectEditForm_clicked()
   mEditFormLineEdit->setText( uifilename );
 }
 
+void QgsAttributesFormProperties::store()
+{
+  storeAttributeWidgetEdit();
+  storeAttributeContainerEdit();
+  storeAttributeTypeDialog();
+}
+
 void QgsAttributesFormProperties::apply()
 {
   storeAttributeWidgetEdit();
@@ -1950,5 +1957,27 @@ void QgsAttributesFormProperties::DnDTreeItemData::setTextElementEditorConfigura
 
 void QgsAttributesFormProperties::updatedFields()
 {
+  // Store configuration to insure changes made are kept after refreshing the list
+  QMap<QString, FieldConfig> fieldConfigs;
+  QTreeWidgetItem *fieldContainer = mAvailableWidgetsTree->invisibleRootItem()->child( 0 );
+  for ( int i = 0; i < fieldContainer->childCount(); i++ )
+  {
+    QTreeWidgetItem *fieldItem = fieldContainer->child( i );
+    const QString fieldName = fieldItem->data( 0, FieldNameRole ).toString();
+    const FieldConfig cfg = fieldItem->data( 0, FieldConfigRole ).value<FieldConfig>();
+    fieldConfigs[fieldName] = cfg;
+  }
+
   initAvailableWidgetsTree();
+
+  fieldContainer = mAvailableWidgetsTree->invisibleRootItem()->child( 0 );
+  for ( int i = 0; i < fieldContainer->childCount(); i++ )
+  {
+    QTreeWidgetItem *fieldItem = fieldContainer->child( i );
+    const QString fieldName = fieldItem->data( 0, FieldNameRole ).toString();
+    if ( fieldConfigs.contains( fieldName ) )
+    {
+      fieldItem->setData( 0, FieldConfigRole, fieldConfigs[fieldName] );
+    }
+  }
 }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -83,6 +83,8 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   connect( mEditorLayoutComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAttributesFormProperties::mEditorLayoutComboBox_currentIndexChanged );
   connect( pbnSelectEditForm, &QToolButton::clicked, this, &QgsAttributesFormProperties::pbnSelectEditForm_clicked );
   connect( mTbInitCode, &QPushButton::clicked, this, &QgsAttributesFormProperties::mTbInitCode_clicked );
+
+  connect( mLayer, &QgsVectorLayer::updatedFields, this, &QgsAttributesFormProperties::updatedFields );
 }
 
 void QgsAttributesFormProperties::init()
@@ -1944,4 +1946,9 @@ QgsAttributesFormProperties::TextElementEditorConfiguration QgsAttributesFormPro
 void QgsAttributesFormProperties::DnDTreeItemData::setTextElementEditorConfiguration( const QgsAttributesFormProperties::TextElementEditorConfiguration &textElementEditorConfiguration )
 {
   mTextElementEditorConfiguration = textElementEditorConfiguration;
+}
+
+void QgsAttributesFormProperties::updatedFields()
+{
+  initAvailableWidgetsTree();
 }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -351,8 +351,17 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QgsAttributeEditorElement *createAttributeEditorWidget( QTreeWidgetItem *item, QgsAttributeEditorElement *parent, bool isTopLevel = false );
 
     void init();
+
+    /**
+     * Applies the attribute from properties to the vector layer.
+     */
     void apply();
 
+    /**
+     * Stores currently opened widget configuration.
+     * \since QGIS 3.34.3
+     */
+    void store();
 
     void loadRelations();
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -359,7 +359,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
 
     /**
      * Stores currently opened widget configuration.
-     * \since QGIS 3.34.3
+     * \since QGIS 3.36
      */
     void store();
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -379,11 +379,18 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QLabel *mInfoTextWidget = nullptr;
 
   private slots:
+    void addContainer();
+    void removeTabOrGroupButton();
+    void mEditorLayoutComboBox_currentIndexChanged( int index );
+    void pbnSelectEditForm_clicked();
+    void mTbInitCode_clicked();
 
     void onInvertSelectionButtonClicked( bool checked );
     void loadAttributeSpecificEditor( QgsAttributesDnDTree *emitter, QgsAttributesDnDTree *receiver );
     void onAttributeSelectionChanged();
     void onFormLayoutSelectionChanged();
+
+    void updatedFields();
 
   private:
     //! this will clean the right panel
@@ -407,12 +414,6 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitFilePath;
     QString mInitCode;
 
-  private slots:
-    void addContainer();
-    void removeTabOrGroupButton();
-    void mEditorLayoutComboBox_currentIndexChanged( int index );
-    void pbnSelectEditForm_clicked();
-    void mTbInitCode_clicked();
 };
 
 

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1688,10 +1688,15 @@ void QgsVectorLayerProperties::optionsStackedWidget_CurrentChanged( int index )
 
   if ( index == mOptStackedWidget->indexOf( mOptsPage_Information ) && ! mMetadataFilled )
   {
-    //set the metadata contents (which can be expensive)
+    // set the metadata contents (which can be expensive)
     teMetadataViewer->clear();
     teMetadataViewer->setHtml( htmlMetadata() );
     mMetadataFilled = true;
+  }
+  else if ( index == mOptStackedWidget->indexOf( mOptsPage_SourceFields ) || index == mOptStackedWidget->indexOf( mOptsPage_Joins ) )
+  {
+    // store any edited attribute form field configuration to prevent loss of edits when adding/removing fields and/or joins
+    mAttributesFormPropertiesDialog->store();
   }
 
   resizeAlltabs( index );


### PR DESCRIPTION
## Description

This PR fixes a long-standing issue whereas adding or deleting fields through the vector layer properties dialog would leave the dialog's attribute form panel out-of-sync, leaving users with no option other than closing and re-opening the dialog to see the newly added field(s). The PR also fixes a related problem when joining layers resulting in fields added to the layer.

Fixes #26350.