### PR TITLE
[gui] Fix cursor jump when editing row/column width of a cell in the table designer

### DIFF
--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -128,6 +128,11 @@ void QgsDoubleSpinBox::clear()
 
 void QgsDoubleSpinBox::setClearValue( double customValue, const QString &specialValueText )
 {
+  if ( mClearValueMode == CustomValue && mCustomClearValue == customValue && QAbstractSpinBox::specialValueText() == specialValueText )
+  {
+    return;
+  }
+
   mClearValueMode = CustomValue;
   mCustomClearValue = customValue;
 
@@ -142,6 +147,11 @@ void QgsDoubleSpinBox::setClearValue( double customValue, const QString &special
 
 void QgsDoubleSpinBox::setClearValueMode( QgsDoubleSpinBox::ClearValueMode mode, const QString &clearValueText )
 {
+  if ( mClearValueMode == mode && mCustomClearValue == 0 && QAbstractSpinBox::specialValueText() == clearValueText )
+  {
+    return;
+  }
+
   mClearValueMode = mode;
   mCustomClearValue = 0;
 

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -124,6 +124,11 @@ void QgsSpinBox::clear()
 
 void QgsSpinBox::setClearValue( int customValue, const QString &specialValueText )
 {
+  if ( mClearValueMode == CustomValue && mCustomClearValue == customValue && QAbstractSpinBox::specialValueText() == specialValueText )
+  {
+    return;
+  }
+
   mClearValueMode = CustomValue;
   mCustomClearValue = customValue;
 
@@ -138,6 +143,11 @@ void QgsSpinBox::setClearValue( int customValue, const QString &specialValueText
 
 void QgsSpinBox::setClearValueMode( QgsSpinBox::ClearValueMode mode, const QString &specialValueText )
 {
+  if ( mClearValueMode == mode && mCustomClearValue == 0 && QAbstractSpinBox::specialValueText() == specialValueText )
+  {
+    return;
+  }
+
   mClearValueMode = mode;
   mCustomClearValue = 0;
 


### PR DESCRIPTION
## Description

This PR gets rid of needless clearing and re-setting of value in our QgsSpinBox and QgsDoubleSpinBox when setting a custom clear value (setClearValue) or clear value mode (setClearValueMode).

The improvement fixes #50257 , whereas typing a value in the manual table designer's cell row height / column width spin boxes would have the cursor jump at the end of the line edit at every stroke.