### PR TITLE
[3D] Support transparent entities in the camera controller

### DIFF
--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -37,9 +37,6 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include <Qt3DRender/QEffect>
 #include <Qt3DRender/QTechnique>
 #include <Qt3DRender/QGraphicsApiFilter>
-#include <Qt3DRender/QNoDepthMask>
-#include <Qt3DRender/QBlendEquation>
-#include <Qt3DRender/QBlendEquationArguments>
 #include <QMap>
 
 
@@ -301,22 +298,6 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::constantColorMaterial( const Qg
                                        mSpecular.greenF() * mSpecularCoefficient,
                                        mSpecular.blueF() * mSpecularCoefficient ) ) );
 
-  if ( mOpacity < 1.0f )
-  {
-    Qt3DRender::QNoDepthMask *noDepthMask = new Qt3DRender::QNoDepthMask( renderPass );
-
-    Qt3DRender::QBlendEquationArguments *blendState = new Qt3DRender::QBlendEquationArguments( renderPass );
-    blendState->setSourceRgb( Qt3DRender::QBlendEquationArguments::SourceAlpha );
-    blendState->setDestinationRgb( Qt3DRender::QBlendEquationArguments::OneMinusSourceAlpha );
-
-    Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation( renderPass );
-    blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
-
-    renderPass->addRenderState( noDepthMask );
-    renderPass->addRenderState( blendState );
-    renderPass->addRenderState( blendEquation );
-  }
-
   eff->addTechnique( technique );
   material->setEffect( eff );
 
@@ -353,22 +334,6 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::dataDefinedMaterial() const
 
   eff->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ),  static_cast< float >( mShininess ) ) );
   eff->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), static_cast< float >( mOpacity ) ) );
-
-  if ( mOpacity < 1.0f )
-  {
-    Qt3DRender::QNoDepthMask *noDepthMask = new Qt3DRender::QNoDepthMask( renderPass );
-
-    Qt3DRender::QBlendEquationArguments *blendState = new Qt3DRender::QBlendEquationArguments( renderPass );
-    blendState->setSourceRgb( Qt3DRender::QBlendEquationArguments::SourceAlpha );
-    blendState->setDestinationRgb( Qt3DRender::QBlendEquationArguments::OneMinusSourceAlpha );
-
-    Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation( renderPass );
-    blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
-
-    renderPass->addRenderState( noDepthMask );
-    renderPass->addRenderState( blendState );
-    renderPass->addRenderState( blendEquation );
-  }
 
   eff->addTechnique( technique );
   material->setEffect( eff );

--- a/src/3d/qgsframegraph.cpp
+++ b/src/3d/qgsframegraph.cpp
@@ -185,12 +185,10 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
     blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
     transparentObjectsRenderStateSet->addRenderState( blendEquation );
 
-    Qt3DRender::QBlendEquationArguments *blenEquationArgs = new Qt3DRender::QBlendEquationArguments;
-    blenEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::One );
-    blenEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
-    blenEquationArgs->setSourceAlpha( Qt3DRender::QBlendEquationArguments::Blending::One );
-    blenEquationArgs->setDestinationAlpha( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
-    transparentObjectsRenderStateSet->addRenderState( blenEquationArgs );
+    Qt3DRender::QBlendEquationArguments *blendEquationArgs = new Qt3DRender::QBlendEquationArguments;
+    blendEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::SourceAlpha );
+    blendEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSourceAlpha );
+    transparentObjectsRenderStateSet->addRenderState( blendEquationArgs );
   }
 
   mDebugOverlay = new Qt3DRender::QDebugOverlay( mForwardClearBuffers );

--- a/src/3d/qgsframegraph.cpp
+++ b/src/3d/qgsframegraph.cpp
@@ -43,6 +43,7 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include <Qt3DRender/QTechnique>
 #include <Qt3DRender/QGraphicsApiFilter>
 #include <Qt3DRender/QBlendEquation>
+#include <Qt3DRender/QColorMask>
 #include <Qt3DRender/QSortPolicy>
 #include <Qt3DRender/QNoDepthMask>
 #include <Qt3DRender/QBlendEquationArguments>
@@ -91,12 +92,13 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
   //  | QRenderStateSet |  cull back faces         |  QSortPolicy    |  back to front
   //  +-----------------+                          +-----------------+
   //         |                                              |
-  //  +-----------------+                          +-----------------+  use depth test
-  //  | QFrustumCulling |                          | QRenderStateSet |  don't write depths
-  //  +-----------------+                          +-----------------+  no culling
-  //         |                                                          use alpha blending
-  //  +-----------------+
-  //  |  QClearBuffers  |  color and depth
+  //  +-----------------+              +--------------------+--------------------+
+  //  | QFrustumCulling |              |                                         |
+  //  +-----------------+     +-----------------+  use depth tests      +-----------------+  use depth tests
+  //         |                | QRenderStateSet |  don't write depths   | QRenderStateSet |  write depths
+  //         |                +-----------------+  write colors         +-----------------+  don't write colors
+  //  +-----------------+                          use alpha blending                        don't use alpha blending
+  //  |  QClearBuffers  |  color and depth         no culling                                no culling
   //  +-----------------+
 
   mMainCameraSelector = new Qt3DRender::QCameraSelector;
@@ -138,6 +140,7 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
   mForwardRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mForwardRenderLayerFilter );
   mForwardRenderTargetSelector->setTarget( forwardRenderTarget );
 
+  // first branch: opaque layer filter
   Qt3DRender::QLayerFilter *opaqueObjectsFilter = new Qt3DRender::QLayerFilter( mForwardRenderTargetSelector );
   opaqueObjectsFilter->addLayer( mTransparentObjectsPassLayer );
   opaqueObjectsFilter->setFilterMode( Qt3DRender::QLayerFilter::DiscardAnyMatchingLayers );
@@ -159,6 +162,7 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
   mForwardClearBuffers->setBuffers( Qt3DRender::QClearBuffers::ColorDepthBuffer );
   mForwardClearBuffers->setClearDepthValue( 1.0f );
 
+  // second branch: transparent layer filter - color
   Qt3DRender::QLayerFilter *transparentObjectsLayerFilter = new Qt3DRender::QLayerFilter( mForwardRenderTargetSelector );
   transparentObjectsLayerFilter->addLayer( mTransparentObjectsPassLayer );
   transparentObjectsLayerFilter->setFilterMode( Qt3DRender::QLayerFilter::AcceptAnyMatchingLayers );
@@ -168,33 +172,52 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
   sortTypes.push_back( Qt3DRender::QSortPolicy::BackToFront );
   sortPolicy->setSortTypes( sortTypes );
 
-  Qt3DRender::QRenderStateSet *transparentObjectsRenderStateSet = new Qt3DRender::QRenderStateSet( sortPolicy );
+  Qt3DRender::QRenderStateSet *transparentObjectsRenderStateSetColor = new Qt3DRender::QRenderStateSet( sortPolicy );
   {
     Qt3DRender::QDepthTest *depthTest = new Qt3DRender::QDepthTest;
     depthTest->setDepthFunction( Qt3DRender::QDepthTest::Less );
-    transparentObjectsRenderStateSet->addRenderState( depthTest );
+    transparentObjectsRenderStateSetColor->addRenderState( depthTest );
 
     Qt3DRender::QNoDepthMask *noDepthMask = new Qt3DRender::QNoDepthMask;
-    transparentObjectsRenderStateSet->addRenderState( noDepthMask );
+    transparentObjectsRenderStateSetColor->addRenderState( noDepthMask );
 
     Qt3DRender::QCullFace *cullFace = new Qt3DRender::QCullFace;
     cullFace->setMode( Qt3DRender::QCullFace::CullingMode::NoCulling );
-    transparentObjectsRenderStateSet->addRenderState( cullFace );
+    transparentObjectsRenderStateSetColor->addRenderState( cullFace );
 
     Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation;
     blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
-    transparentObjectsRenderStateSet->addRenderState( blendEquation );
+    transparentObjectsRenderStateSetColor->addRenderState( blendEquation );
 
     Qt3DRender::QBlendEquationArguments *blendEquationArgs = new Qt3DRender::QBlendEquationArguments;
     blendEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::SourceAlpha );
     blendEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSourceAlpha );
-    transparentObjectsRenderStateSet->addRenderState( blendEquationArgs );
+    transparentObjectsRenderStateSetColor->addRenderState( blendEquationArgs );
+  }
+
+  // third branch: transparent layer filter - depth
+  Qt3DRender::QRenderStateSet *transparentObjectsRenderStateSetDepth = new Qt3DRender::QRenderStateSet( sortPolicy );
+  {
+    Qt3DRender::QDepthTest *depthTest = new Qt3DRender::QDepthTest;
+    depthTest->setDepthFunction( Qt3DRender::QDepthTest::Less );
+    transparentObjectsRenderStateSetDepth->addRenderState( depthTest );
+
+    Qt3DRender::QColorMask *noColorMask = new Qt3DRender::QColorMask;
+    noColorMask->setAlphaMasked( false );
+    noColorMask->setRedMasked( false );
+    noColorMask->setGreenMasked( false );
+    noColorMask->setBlueMasked( false );
+    transparentObjectsRenderStateSetDepth->addRenderState( noColorMask );
+
+    Qt3DRender::QCullFace *cullFace = new Qt3DRender::QCullFace;
+    cullFace->setMode( Qt3DRender::QCullFace::CullingMode::NoCulling );
+    transparentObjectsRenderStateSetDepth->addRenderState( cullFace );
   }
 
   mDebugOverlay = new Qt3DRender::QDebugOverlay( mForwardClearBuffers );
   mDebugOverlay->setEnabled( false );
 
-  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
+  // cppcheck wrongly believes transparentObjectsRenderStateSetColor and transparentObjectsRenderStateSetDepth will leak
   // cppcheck-suppress memleak
   return mMainCameraSelector;
 }


### PR DESCRIPTION
## Description

When clicked on a 3d scene to make a rotation for example, `QgsCameraController` needs to compute 3d coordinates from 2d mouse coordinates. It uses the depth buffer in order to estimate the distance between the camera position and the clicked position. This approach works very well as long as the objects of the scene are not
transparent. Indeed, transparent objects do not appear in the depth buffer. This means that `QgsCameraController` does not work properly on a 3d scene which contains transparent vector layers.

At the moment, this is not really a problem because most of 3d scenes also contain a terrain, which is never transparent. However, I have also been working on adding Z rotation support for the extent of a 3d scene (I will also create a PR for this feature). In that case, the drawing of the texture of a terrain becomes more complicated because of the intersection between the rotated 3d scene extent and the unrotated bounding box of the terrain. After some discussion with @uclaros last year, we came to the conclusion that the best way to support it was to make the terrain transparent in order  to hide parts of the terrain which do not need to be drawn. This means that the current state of the camera controller in that case. Hence, this PR.

This issue is fixed by using a Qt3D ray caster to detect the clicked point + using the camera distance in
`Qgs3DUtils::screenPointToWorldPos` if the clicked point is not an entity.
