### PR TITLE
Insure that children from multiple compositon relationships are duplicated when duplicating parent feature

### DIFF
--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -647,17 +647,15 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
   layer->addFeature( newFeature );
 
   const QList<QgsRelation> relations = project->relationManager()->referencedRelations( layer );
+  referencedLayersBranch << layer;
 
   const int effectiveMaxDepth = maxDepth > 0 ? maxDepth : 100;
 
   for ( const QgsRelation &relation : relations )
   {
     //check if composition (and not association)
-    if ( relation.strength() == Qgis::RelationshipStrength::Composition && !referencedLayersBranch.contains( relation.referencedLayer() ) && depth < effectiveMaxDepth )
+    if ( relation.strength() == Qgis::RelationshipStrength::Composition && !referencedLayersBranch.contains( relation.referencingLayer() ) && depth < effectiveMaxDepth )
     {
-      depth++;
-      referencedLayersBranch << layer;
-
       //get features connected over this relation
       QgsFeatureIterator relatedFeaturesIt = relation.getRelatedFeatures( feature );
       QgsFeatureIds childFeatureIds;
@@ -673,7 +671,7 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
           childFeature.setAttribute( fieldPair.first, newFeature.attribute( fieldPair.second ) );
         }
         //call the function for the child
-        childFeatureIds.insert( duplicateFeature( relation.referencingLayer(), childFeature, project, duplicateFeatureContext, maxDepth, depth, referencedLayersBranch ).id() );
+        childFeatureIds.insert( duplicateFeature( relation.referencingLayer(), childFeature, project, duplicateFeatureContext, maxDepth, depth + 1, referencedLayersBranch ).id() );
       }
 
       //store for feedback

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -494,11 +494,16 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         self.assertTrue(layer1.isValid())
         # - add second layer (child)
         layer2 = QgsVectorLayer("Point?field=fldtxt:string&field=id:integer&field=foreign_key:integer",
-                                "childlayer", "memory")
+                                "childlayer1", "memory")
         # > check second layer (child)
         self.assertTrue(layer2.isValid())
+        # - add second layer (child)
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string&field=id:integer&field=foreign_key:integer",
+                                "childlayer2", "memory")
+        # > check second layer (child)
+        self.assertTrue(layer3.isValid())
         # - add layers
-        project.addMapLayers([layer1, layer2])
+        project.addMapLayers([layer1, layer2, layer3])
 
         # FEATURES
         # - add 2 features on layer1 (parent)
@@ -525,34 +530,65 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         l2f4orig.setAttributes(["F_l2f4", 204, 101])
         # > check by adding features
         self.assertTrue(layer2.dataProvider().addFeatures([l2f1orig, l2f2orig, l2f3orig, l2f4orig]))
+        # add 2 features on layer3 (child)
+        l3f1orig = QgsFeature()
+        l3f1orig.setFields(layer3.fields())
+        l3f1orig.setAttributes(["F_l3f1", 201, 100])
+        l3f2orig = QgsFeature()
+        l3f2orig.setFields(layer2.fields())
+        l3f2orig.setAttributes(["F_l3f2", 202, 100])
+        # > check by adding features
+        self.assertTrue(layer3.dataProvider().addFeatures([l3f1orig, l3f2orig]))
 
         # RELATION
         # - create the relationmanager
         relMgr = project.relationManager()
-        # - create the relation
-        rel = QgsRelation()
-        rel.setId('rel1')
-        rel.setName('childrel')
-        rel.setReferencingLayer(layer2.id())
-        rel.setReferencedLayer(layer1.id())
-        rel.addFieldPair('foreign_key', 'pkid')
-        rel.setStrength(QgsRelation.RelationStrength.Composition)
+        # - create the first relation
+        rel1 = QgsRelation()
+        rel1.setId('rel1')
+        rel1.setName('childrel1')
+        rel1.setReferencingLayer(layer2.id())
+        rel1.setReferencedLayer(layer1.id())
+        rel1.addFieldPair('foreign_key', 'pkid')
+        rel1.setStrength(QgsRelation.RelationStrength.Composition)
         # > check relation
-        self.assertTrue(rel.isValid())
+        self.assertTrue(rel1.isValid())
         # - add relation
-        relMgr.addRelation(rel)
+        relMgr.addRelation(rel1)
         # > check if referencedLayer is layer1
-        self.assertEqual(rel.referencedLayer(), layer1)
+        self.assertEqual(rel1.referencedLayer(), layer1)
         # > check if referencingLayer is layer2
-        self.assertEqual(rel.referencingLayer(), layer2)
+        self.assertEqual(rel1.referencingLayer(), layer2)
+        # - create the second relation
+        rel2 = QgsRelation()
+        rel2.setId('rel2')
+        rel2.setName('childrel2')
+        rel2.setReferencingLayer(layer3.id())
+        rel2.setReferencedLayer(layer1.id())
+        rel2.addFieldPair('foreign_key', 'pkid')
+        rel2.setStrength(QgsRelation.RelationStrength.Composition)
+        # > check relation
+        self.assertTrue(rel2.isValid())
+        # - add relation
+        relMgr.addRelation(rel2)
+        # > check if referencedLayer is layer1
+        self.assertEqual(rel2.referencedLayer(), layer1)
+        # > check if referencingLayer is layer2
+        self.assertEqual(rel2.referencingLayer(), layer3)
+
         # > check if the layers are correct in relation when loading from relationManager
-        relations = project.relationManager().relations()
-        relation = relations[list(relations.keys())[0]]
+        relations = project.relationManager().relationsByName('childrel1')
+        relation = relations[0]
         # > check if referencedLayer is layer1
         self.assertEqual(relation.referencedLayer(), layer1)
         # > check if referencingLayer is layer2
         self.assertEqual(relation.referencingLayer(), layer2)
-        # > check the relatedfeatures
+        relations = project.relationManager().relationsByName('childrel2')
+        relation = relations[0]
+        # > check if referencedLayer is layer1
+        self.assertEqual(relation.referencedLayer(), layer1)
+        # > check if referencingLayer is layer2
+        self.assertEqual(relation.referencingLayer(), layer3)
 
         '''
         # testoutput 1
@@ -584,11 +620,14 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         # > check if name is name of duplicated (pk is different)
         result_feature = results[0]
         self.assertEqual(result_feature.attribute('fldtxt'), l1f1orig.attribute('fldtxt'))
-        # > check duplicated child layer
-        result_layer = results[1].layers()[0]
-        self.assertEqual(result_layer, layer2)
-        #  > check duplicated child features
-        self.assertTrue(results[1].duplicatedFeatures(result_layer))
+        # > check duplicated children occurred on both layers
+        self.assertEqual(len(results[1].layers()), 2)
+        idx = results[1].layers().index(layer2)
+        self.assertEqual(results[1].layers()[idx], layer2)
+        self.assertTrue(results[1].duplicatedFeatures(layer2))
+        idx = results[1].layers().index(layer3)
+        self.assertEqual(results[1].layers()[idx], layer3)
+        self.assertTrue(results[1].duplicatedFeatures(layer3))
 
         '''
         # testoutput 2
@@ -616,13 +655,13 @@ class TestQgsVectorLayerUtils(QgisTestCase):
 
         # - create copyValueList
         childFeature = QgsFeature()
-        relfeatit = rel.getRelatedFeatures(result_feature)
+        relfeatit = rel1.getRelatedFeatures(result_feature)
         copyValueList = []
         while relfeatit.nextFeature(childFeature):
             copyValueList.append(childFeature.attribute('fldtxt'))
         # - create origValueList
         childFeature = QgsFeature()
-        relfeatit = rel.getRelatedFeatures(l1f1orig)
+        relfeatit = rel1.getRelatedFeatures(l1f1orig)
         origValueList = []
         while relfeatit.nextFeature(childFeature):
             origValueList.append(childFeature.attribute('fldtxt'))


### PR DESCRIPTION
## Description

This PR fixes the QgsVectorLayerUtils::duplicateFeature 's handling of *multiple* composition strength relationships when duplicating a parent feature. The preexisting logic was flawed and would only work properly when a parent feature being duplicated had a *single* composition strength relationship.

The test covering duplication of features with relationships has been adapted to cover multiple composition strength relationships on the parent feature.

This fixes #55892. 