### PR TITLE
Sort and filter the list of raster format extensions displayed

### DIFF
--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -1206,7 +1206,7 @@ QList< QgsRasterFileWriter::FilterFormatDetails > QgsRasterFileWriter::supported
 QStringList QgsRasterFileWriter::supportedFormatExtensions( const RasterFormatOptions options )
 {
   const auto formats = supportedFiltersAndFormats( options );
-  QStringList extensions;
+  QSet< QString > extensions;
 
   const thread_local QRegularExpression rx( QStringLiteral( "\\*\\.([a-zA-Z0-9]*)" ) );
 
@@ -1218,7 +1218,31 @@ QStringList QgsRasterFileWriter::supportedFormatExtensions( const RasterFormatOp
       continue;
 
     const QString matched = match.captured( 1 );
-    extensions << matched;
+    extensions.insert( matched );
   }
-  return extensions;
+
+  QStringList extensionList( extensions.constBegin(), extensions.constEnd() );
+
+  std::sort( extensionList.begin(), extensionList.end(), [options]( const QString & a, const QString & b ) -> bool
+  {
+    if ( options & SortRecommended )
+    {
+      if ( a == QLatin1String( "tif" ) )
+        return true;
+      else if ( b == QLatin1String( "tif" ) )
+        return false;
+      if ( a == QLatin1String( "tiff" ) )
+        return true;
+      else if ( b == QLatin1String( "tiff" ) )
+        return false;
+      if ( a == QLatin1String( "gpkg" ) )
+        return true;
+      else if ( b == QLatin1String( "gpkg" ) )
+        return false;
+    }
+
+    return a.toLower().localeAwareCompare( b.toLower() ) < 0;
+  } );
+
+  return extensionList;
 }


### PR DESCRIPTION
 in Processing options > General block
The before and after showcase (we have a number of identical extensions, with no way to know what driver is actually behind and the whole list is unsorted; hard to find one). I follow the logic applied to vector layers.
![image](https://github.com/qgis/QGIS/assets/7983394/93e97176-1d01-4d38-84ff-ef81c0f2379f)
