### PR TITLE
Fix performance issue when dropping many layers to a GeoPackage (fixes #29510)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstaskmanager.sip.in
@@ -524,6 +524,48 @@ reports or re-open a related dialog.
 
 };
 
+class QgsTaskWithSerialSubTasks : QgsTask
+{
+%Docstring(signature="appended")
+Task that is composed of sub-tasks to be executed in a serial way,
+which may be useful for example to add several layers in a single target
+dataset which does not support concurrent updates.
+
+.. versionadded:: 3.36
+%End
+
+%TypeHeaderCode
+#include "qgstaskmanager.h"
+%End
+  public:
+    QgsTaskWithSerialSubTasks( const QString &desc = QString() );
+%Docstring
+Constructor
+%End
+
+    ~QgsTaskWithSerialSubTasks();
+
+    void addSubTask( QgsTask *subTask /Transfer/ );
+%Docstring
+Add a subtask and transfer its ownership
+
+The parent task must be added to a :py:class:`QgsTaskManager` for subtasks to be utilized.
+Subtasks should not be added manually to a :py:class:`QgsTaskManager`, rather, only the parent
+task should be added to the manager.
+
+For now, subtasks can *NOT* be nested.
+%End
+
+    virtual void cancel();
+
+
+  protected:
+
+
+    virtual bool run();
+
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -524,6 +524,48 @@ reports or re-open a related dialog.
 
 };
 
+class QgsTaskWithSerialSubTasks : QgsTask
+{
+%Docstring(signature="appended")
+Task that is composed of sub-tasks to be executed in a serial way,
+which may be useful for example to add several layers in a single target
+dataset which does not support concurrent updates.
+
+.. versionadded:: 3.36
+%End
+
+%TypeHeaderCode
+#include "qgstaskmanager.h"
+%End
+  public:
+    QgsTaskWithSerialSubTasks( const QString &desc = QString() );
+%Docstring
+Constructor
+%End
+
+    ~QgsTaskWithSerialSubTasks();
+
+    void addSubTask( QgsTask *subTask /Transfer/ );
+%Docstring
+Add a subtask and transfer its ownership
+
+The parent task must be added to a :py:class:`QgsTaskManager` for subtasks to be utilized.
+Subtasks should not be added manually to a :py:class:`QgsTaskManager`, rather, only the parent
+task should be added to the manager.
+
+For now, subtasks can *NOT* be nested.
+%End
+
+    virtual void cancel();
+
+
+  protected:
+
+
+    virtual bool run();
+
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1964,8 +1964,8 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
   bool hasError = false;
 
   // Main task
-  std::unique_ptr< QgsConcurrentFileWriterImportTask > mainTask( new QgsConcurrentFileWriterImportTask( tr( "Layer import" ) ) );
-  QgsTaskList importTasks;
+  std::unique_ptr< QgsTaskWithSerialSubTasks > mainTask( new QgsTaskWithSerialSubTasks( tr( "Layer import" ) ) );
+  bool hasSubTasks = false;
 
   const QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
   for ( const QgsMimeDataUtils::Uri &dropUri : lst )
@@ -2025,8 +2025,8 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
           options.insert( QStringLiteral( "overwrite" ), true );
           options.insert( QStringLiteral( "layerName" ), dropUri.name );
           QgsVectorLayerExporterTask *exportTask = new QgsVectorLayerExporterTask( vectorSrcLayer, uri, QStringLiteral( "ogr" ), vectorSrcLayer->crs(), options, owner );
-          mainTask->addSubTask( exportTask, importTasks );
-          importTasks << exportTask;
+          mainTask->addSubTask( exportTask );
+          hasSubTasks = true;
           // when export is successful:
           connect( exportTask, &QgsVectorLayerExporterTask::exportComplete, item, [ = ]()
           {
@@ -2062,7 +2062,7 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
-  if ( ! importTasks.isEmpty() )
+  if ( hasSubTasks )
   {
     QgsApplication::taskManager()->addTask( mainTask.release() );
   }

--- a/src/core/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.h
@@ -175,28 +175,5 @@ class QgsGeoPackageDataItemProvider final: public QgsDataItemProvider
     QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
 };
 
-
-/**
- * \brief The QgsConcurrentFileWriterImportTask class is the parent task for
- * importing layers from a drag and drop operation in the browser.
- * Individual layers need to be added as individual substask.
- */
-class CORE_EXPORT QgsConcurrentFileWriterImportTask : public QgsTask
-{
-    Q_OBJECT
-
-  public:
-    QgsConcurrentFileWriterImportTask( const QString &desc = QString() ) : QgsTask( desc ) {}
-    void emitProgressChanged( double progress ) { setProgress( progress ); }
-
-  protected:
-
-    bool run() override
-    {
-      return true;
-    }
-
-};
-
 ///@endcond
 #endif // QGSGEOPACKAGEDATAITEMS_H

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -614,6 +614,7 @@ class CORE_EXPORT QgsTaskManager : public QObject
     mutable QRecursiveMutex *mTaskMutex;
 
     QMap< long, TaskInfo > mTasks;
+    QMap< QgsTask *, long> mMapTaskPtrToId;
     QMap< long, QgsTaskList > mTaskDependencies;
     QMap< long, QgsWeakMapLayerPointerList > mLayerDependencies;
 
@@ -649,7 +650,7 @@ class CORE_EXPORT QgsTaskManager : public QObject
      */
     void cancelDependentTasks( long taskId );
 
-    bool resolveDependencies( long firstTaskId, long currentTaskId, QSet< long > &results ) const;
+    bool resolveDependencies( long taskId, QSet< long > &results ) const;
 
     //! Will return TRUE if the specified task has circular dependencies
     bool hasCircularDependencies( long taskId ) const;

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -368,6 +368,7 @@ class CORE_EXPORT QgsTask : public QObject
     void processSubTasksForHold();
 
     friend class QgsTaskManager;
+    friend class QgsTaskWithSerialSubTasks;
     friend class QgsTaskRunnableWrapper;
     friend class TestQgsTaskManager;
 
@@ -656,6 +657,45 @@ class CORE_EXPORT QgsTaskManager : public QObject
     bool hasCircularDependencies( long taskId ) const;
 
     friend class TestQgsTaskManager;
+};
+
+/**
+ * \ingroup core
+ * \class QgsTaskWithSerialSubTasks
+ * \brief Task that is composed of sub-tasks to be executed in a serial way,
+ * which may be useful for example to add several layers in a single target
+ * dataset which does not support concurrent updates.
+ * \since QGIS 3.36
+ */
+class CORE_EXPORT QgsTaskWithSerialSubTasks : public QgsTask
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsTaskWithSerialSubTasks( const QString &desc = QString() ) : QgsTask( desc ) {}
+
+    //! Destructor
+    ~QgsTaskWithSerialSubTasks() override;
+
+    /**
+     * Add a subtask and transfer its ownership
+     *
+     * The parent task must be added to a QgsTaskManager for subtasks to be utilized.
+     * Subtasks should not be added manually to a QgsTaskManager, rather, only the parent
+     * task should be added to the manager.
+     *
+     * For now, subtasks can *NOT* be nested.
+     */
+    void addSubTask( QgsTask *subTask SIP_TRANSFER );
+
+    void cancel() override;
+
+  protected:
+
+    QList< QgsTask *> mSubTasksSerial;
+
+    bool run() override;
 };
 
 #endif //QGSTASKMANAGER_H

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -337,8 +337,8 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
   bool hasError = false;
 
   // Main task
-  std::unique_ptr< QgsConcurrentFileWriterImportTask > mainTask( new QgsConcurrentFileWriterImportTask( tr( "GeoPackage import" ) ) );
-  QgsTaskList importTasks;
+  std::unique_ptr< QgsTaskWithSerialSubTasks > mainTask( new QgsTaskWithSerialSubTasks( tr( "GeoPackage import" ) ) );
+  bool hasSubTasks = false;
 
   const auto lst = QgsMimeDataUtils::decodeUriList( data );
   for ( const QgsMimeDataUtils::Uri &dropUri : lst )
@@ -419,8 +419,8 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
             options.insert( QStringLiteral( "overwrite" ), true );
             options.insert( QStringLiteral( "layerName" ), dropUri.name );
             QgsVectorLayerExporterTask *exportTask = new QgsVectorLayerExporterTask( vectorSrcLayer, uri, QStringLiteral( "ogr" ), vectorSrcLayer->crs(), options, owner );
-            mainTask->addSubTask( exportTask, importTasks );
-            importTasks << exportTask;
+            mainTask->addSubTask( exportTask );
+            hasSubTasks = true;
             // when export is successful:
             connect( exportTask, &QgsVectorLayerExporterTask::exportComplete, item, [ = ]()
             {
@@ -444,8 +444,8 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
           else  // Import raster
           {
             QgsGeoPackageRasterWriterTask  *exportTask = new QgsGeoPackageRasterWriterTask( dropUri, item->path() );
-            mainTask->addSubTask( exportTask, importTasks );
-            importTasks << exportTask;
+            mainTask->addSubTask( exportTask );
+            hasSubTasks = true;
             // when export is successful:
             connect( exportTask, &QgsGeoPackageRasterWriterTask::writeComplete, item, [ = ]()
             {
@@ -487,7 +487,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
-  if ( ! importTasks.isEmpty() )
+  if ( hasSubTasks )
   {
     QgsApplication::taskManager()->addTask( mainTask.release() );
   }

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -352,6 +352,7 @@ class TestQgsTaskManager : public QObject
     void activeTasks();
     void holdTask();
     void dependencies();
+    void lotsOfDependencies();
     void layerDependencies();
     void managerWithSubTasks();
     void managerWithSubTasks2();
@@ -1374,6 +1375,34 @@ void TestQgsTaskManager::dependencies()
   QCOMPARE( task->status(), QgsTask::Terminated );
   QCOMPARE( childTask->status(), QgsTask::Terminated );
   QCOMPARE( grandChildTask->status(), QgsTask::Terminated );
+}
+
+// Check that dependency resolution performs well (O(n*log(n))) with the number
+// of tasks
+void TestQgsTaskManager::lotsOfDependencies()
+{
+  QgsTaskManager manager;
+
+  QList<QPointer<CancelableTask>> tasks;
+  const int N_TASKS = 100;
+  for ( int i = 0; i < N_TASKS; ++i )
+  {
+    tasks.push_back( new CancelableTask() );
+  }
+
+  QList<long> taskIds;
+  taskIds.push_back( manager.addTask( tasks[0] ) );
+  for ( int i = 1; i < N_TASKS; ++i )
+  {
+    QgsTaskList taskList;
+    taskList << tasks[i - 1];
+    if ( ( i % 2 ) == 0 )
+      taskList << tasks[i - 2];
+    taskIds.push_back( manager.addTask( QgsTaskManager::TaskDefinition( tasks[i], taskList ) ) );
+  }
+
+  // check dependency resolution
+  QCOMPARE( manager.dependencies( taskIds.back() ).size(), N_TASKS - 1 );
 }
 
 void TestQgsTaskManager::layerDependencies()

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -362,6 +362,7 @@ class TestQgsTaskManager : public QObject
     void proxyTask2();
     void scopedProxyTask();
     void hiddenTask();
+    void testQgsTaskWithSerialSubTasks();
 };
 
 void TestQgsTaskManager::initTestCase()
@@ -1782,6 +1783,20 @@ void TestQgsTaskManager::hiddenTask()
     QCoreApplication::processEvents();
   }
   flushEvents();
+}
+
+void TestQgsTaskManager::testQgsTaskWithSerialSubTasks()
+{
+  QgsTaskWithSerialSubTasks *taskWithSerialSubTasks = new QgsTaskWithSerialSubTasks();
+  QPointer< QgsTask > p( taskWithSerialSubTasks );
+
+  auto task = new TestTask();
+  taskWithSerialSubTasks->addSubTask( task );
+  taskWithSerialSubTasks->start();
+
+  QVERIFY( task->runCalled );
+
+  taskWithSerialSubTasks->cancel();
 }
 
 QGSTEST_MAIN( TestQgsTaskManager )


### PR DESCRIPTION
- QgsTaskManager::resolveDependencies() and taskId(): fix bad performance when long chain of task dependencies
- Add a QgsTaskWithSerialSubTasks class
- QgsDatabaseItemGuiProvider() and QgsGeoPackageDataItemProvider(): use QgsTaskWithSerialSubTasks to fix performance issue when dropping many layers (fixes #29510)
