### PR TITLE
Fix crash in QgsRasterPipe when removing roles

### DIFF
--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -192,15 +192,12 @@ void QgsRasterPipe::unsetRole( QgsRasterInterface *interface )
   mRoleMap.remove( role );
 
   // Decrease all indexes greater than the removed one
-  const auto roleMapValues {mRoleMap.values()};
-  if ( roleIdx < *std::max_element( roleMapValues.begin(), roleMapValues.end() ) )
+  const QMap<Qgis::RasterPipeInterfaceRole, int> currentRoles = mRoleMap;
+  for ( auto it = currentRoles.cbegin(); it != currentRoles.cend(); ++it )
   {
-    for ( auto it = mRoleMap.cbegin(); it != mRoleMap.cend(); ++it )
+    if ( it.value() > roleIdx )
     {
-      if ( it.value() > roleIdx )
-      {
-        mRoleMap[it.key()] = it.value() - 1;
-      }
+      mRoleMap[it.key()] = it.value() - 1;
     }
   }
 }


### PR DESCRIPTION
If the last role was removed, then the behaviour was undefined and results in a crash on some systems
