### PR TITLE
Fix PyQT6 null/None QVariant handling

### DIFF
--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -3144,7 +3144,7 @@ bool null_from_qvariant_converter( const QVariant *varp, PyObject **objp )
   // maps NULL values)
   // If there are more cases like QByteArray, we should consider using a allowlist
   // instead of a blocklist.
-  if ( varp->isNull()
+  if ( QgsVariantUtils::isNull( *varp )
        && varp->type() != QVariant::ByteArray
        && varp->type() != QMetaType::VoidStar
        && varp->type() != QMetaType::Nullptr
@@ -3157,15 +3157,8 @@ bool null_from_qvariant_converter( const QVariant *varp, PyObject **objp )
     }
 
     sWatchDog = true;
-
-    // TODO fix this
-    // PyObject *vartype = sipConvertFromEnum( varp->type(), sipType_QMetaType_Type );
-    PyObject *vartype = 0;
-    PyObject *args = PyTuple_Pack( 1, vartype );
-    PyTypeObject *typeObj = sipTypeAsPyTypeObject( sipType_QVariant );
-    *objp = PyObject_Call(( PyObject * )typeObj, args, nullptr );
-    Py_DECREF(args);
-    Py_DECREF(vartype);
+    Py_INCREF(Py_None);
+    *objp = Py_None;
     sWatchDog = false;
     return true;
   }
@@ -3178,6 +3171,7 @@ bool null_from_qvariant_converter( const QVariant *varp, PyObject **objp )
 
 %ModuleHeaderCode
 #define SIP_PYQT_FROM_QVARIANT_BY_TYPE "pyqt6_from_qvariant_by_type"
+#include "qgsvariantutils.h"
 %End
 
 // In Qt6 QVector is just an alias to QList but doesn't appear in pyqt
@@ -4256,3 +4250,12 @@ template<_TYPE_>
     return 0;
 %End
 };
+
+%PostInitialisationCode  //#spellok
+
+// Import the Chimera helper registration functions.
+typedef bool ( *FromQVariantConverterFn )( const QVariant *, PyObject ** );
+void (*register_from_qvariant_converter)(FromQVariantConverterFn);
+register_from_qvariant_converter = (void (*)(FromQVariantConverterFn))sipImportSymbol("pyqt6_register_from_qvariant_convertor");  //#spellok
+register_from_qvariant_converter(null_from_qvariant_converter);
+%End


### PR DESCRIPTION
Here we have to break with our previous approach of treating null variants (NULL in Python) different to invalid qvariants (None in Python)

There's simply NO way to construct null variants in PyQt6 -- they are ALWAYS mapped across to Py_None.

This isn't as big a deal as it sounds, we already made the decision in c++ code to move to invalid variants in favour of null variants.

Note that we STILL need the custom sip code here and can't rely on base PyQt6 null variant conversion, as that relies on QVariant::isNull when we must use QgsVariantUtils::isNull so that the underlying type is correctly checked for null values on Qt 6 builds.

Relates to https://github.com/qgis/QGIS/pull/49815