### PR TITLE
[attributeform] Fix value relation editor widget fail to bind to a UI form combo box

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -307,8 +307,7 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
 
 void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
 {
-
-  mComboBox = qobject_cast<QgsToolTipComboBox *>( editor );
+  mComboBox = qobject_cast<QComboBox *>( editor );
   mTableWidget = qobject_cast<QgsFilteredTableWidget *>( editor );
   mLineEdit = qobject_cast<QLineEdit *>( editor );
 
@@ -497,7 +496,7 @@ QVariant::Type QgsValueRelationWidgetWrapper::fkType() const
   return QVariant::Type::Invalid;
 }
 
-void QgsValueRelationWidgetWrapper::populate( )
+void QgsValueRelationWidgetWrapper::populate()
 {
   // Initialize, note that signals are blocked, to avoid double signals on new features
   if ( QgsValueRelationFieldFormatter::expressionRequiresFormScope( mExpression ) ||

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -206,7 +206,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     //! Sets the values for the widgets, re-creates the cache when required
     void populate( );
 
-    QgsToolTipComboBox *mComboBox = nullptr;
+    QComboBox *mComboBox = nullptr;
     QgsFilteredTableWidget *mTableWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
 


### PR DESCRIPTION
## Description

This PR a regression introduced when our value relation editor widget gained description tooltip functionality whereas .ui-driven attribute form's value relation editor widget fail to attach properly populate a QComboBox.

Fixes https://github.com/qgis/QGIS/issues/55621.