### PR TITLE
Data-defined assistant fixes

### DIFF
--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -27,6 +27,7 @@
 #include "qgsstyle.h"
 #include "qgsmarkersymbol.h"
 #include "qgslinesymbol.h"
+#include "qgsstringutils.h"
 
 QgsPropertyAssistantWidget::QgsPropertyAssistantWidget( QWidget *parent,
     const QgsPropertyDefinition &definition, const QgsProperty &initialState,
@@ -39,7 +40,7 @@ QgsPropertyAssistantWidget::QgsPropertyAssistantWidget( QWidget *parent,
 
   layout()->setContentsMargins( 0, 0, 0, 0 );
 
-  setPanelTitle( mDefinition.description() );
+  setPanelTitle( QgsStringUtils::capitalize( mDefinition.description(), Qgis::Capitalization::TitleCase ) );
 
   mLegendPreview->hide();
 

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -135,6 +135,7 @@ QgsPropertyAssistantWidget::QgsPropertyAssistantWidget( QWidget *parent,
   connect( minValueSpinBox, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsPropertyAssistantWidget::widgetChanged );
   connect( maxValueSpinBox, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsPropertyAssistantWidget::widgetChanged );
   connect( mExpressionWidget, static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) > ( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsPropertyAssistantWidget::widgetChanged );
+  connect( mTransformCurveCheckBox, &QgsCollapsibleGroupBox::toggled, this, &QgsPropertyAssistantWidget::widgetChanged );
   connect( mCurveEditor, &QgsCurveEditorWidget::changed, this, &QgsPropertyAssistantWidget::widgetChanged );
   connect( this, &QgsPropertyAssistantWidget::widgetChanged, this, &QgsPropertyAssistantWidget::updatePreview );
   updatePreview();

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -40,7 +40,7 @@ QgsPropertyAssistantWidget::QgsPropertyAssistantWidget( QWidget *parent,
 
   layout()->setContentsMargins( 0, 0, 0, 0 );
 
-  setPanelTitle( QgsStringUtils::capitalize( mDefinition.description(), Qgis::Capitalization::TitleCase ) );
+  setPanelTitle( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) ? QgsStringUtils::capitalize( mDefinition.description(), Qgis::Capitalization::TitleCase ) : mDefinition.description() );
 
   mLegendPreview->hide();
 

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -28,6 +28,7 @@
 #include "qgsmarkersymbol.h"
 #include "qgslinesymbol.h"
 #include "qgsstringutils.h"
+#include "qgsgui.h"
 
 QgsPropertyAssistantWidget::QgsPropertyAssistantWidget( QWidget *parent,
     const QgsPropertyDefinition &definition, const QgsProperty &initialState,

--- a/src/gui/qgspropertyassistantwidget.h
+++ b/src/gui/qgspropertyassistantwidget.h
@@ -154,7 +154,6 @@ class GUI_EXPORT QgsPropertyAssistantWidget : public QgsPanelWidget, private Ui:
     void computeValuesFromLayer();
     void updatePreview();
 
-
   private:
 
     QgsPropertyDefinition mDefinition;
@@ -170,7 +169,6 @@ class GUI_EXPORT QgsPropertyAssistantWidget : public QgsPanelWidget, private Ui:
 
     bool computeValuesFromExpression( const QString &expression, double &minValue, double &maxValue ) const;
     bool computeValuesFromField( const QString &fieldName, double &minValue, double &maxValue ) const;
-
 };
 
 #ifndef SIP_RUN


### PR DESCRIPTION
## Description

A couple of fixes to data-definied assistant dialog:
 - refresh preview image when transformation curve is enabled/disabled (#24961)
 - use correct capitalization of the dialog title (#26925)