### PR TITLE
use password line edit in auth method editors instead of line edit

### DIFF
--- a/src/auth/awss3/gui/qgsauthawss3edit.cpp
+++ b/src/auth/awss3/gui/qgsauthawss3edit.cpp
@@ -24,7 +24,6 @@ QgsAuthAwsS3Edit::QgsAuthAwsS3Edit( QWidget *parent )
   connect( leUsername, &QLineEdit::textChanged, this, &QgsAuthAwsS3Edit::leUsername_textChanged );
   connect( lePassword, &QLineEdit::textChanged, this, &QgsAuthAwsS3Edit::lePassword_textChanged );
   connect( leRegion, &QLineEdit::textChanged, this, &QgsAuthAwsS3Edit::leRegion_textChanged );
-  connect( chkPasswordShow, &QCheckBox::stateChanged, this, &QgsAuthAwsS3Edit::chkPasswordShow_stateChanged );
 }
 
 bool QgsAuthAwsS3Edit::validateConfig()
@@ -70,7 +69,6 @@ void QgsAuthAwsS3Edit::clearConfig()
   leUsername->clear();
   lePassword->clear();
   leRegion->clear();
-  chkPasswordShow->setChecked( false );
 }
 
 void QgsAuthAwsS3Edit::leUsername_textChanged( const QString &txt )
@@ -89,9 +87,4 @@ void QgsAuthAwsS3Edit::leRegion_textChanged( const QString &txt )
 {
   Q_UNUSED( txt )
   validateConfig();
-}
-
-void QgsAuthAwsS3Edit::chkPasswordShow_stateChanged( int state )
-{
-  lePassword->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
 }

--- a/src/auth/awss3/gui/qgsauthawss3edit.h
+++ b/src/auth/awss3/gui/qgsauthawss3edit.h
@@ -49,8 +49,6 @@ class QgsAuthAwsS3Edit : public QgsAuthMethodEdit, private Ui::QgsAuthAwsS3Edit
 
     void leRegion_textChanged( const QString &txt );
 
-    void chkPasswordShow_stateChanged( int state );
-
   private:
     QgsStringMap mConfigMap;
     bool mValid = false;

--- a/src/auth/awss3/gui/qgsauthawss3edit.ui
+++ b/src/auth/awss3/gui/qgsauthawss3edit.ui
@@ -23,24 +23,17 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="leRegion">
-     <property name="placeholderText">
-      <string>Required</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="leUsername">
+   <item row="1" column="0">
+    <widget class="QLabel" name="lblPassword">
      <property name="toolTip">
-      <string>AWS AccessKeyId</string>
+      <string>AWS SecretAccessKey</string>
      </property>
-     <property name="placeholderText">
-      <string>Required</string>
+     <property name="text">
+      <string>Password</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="lblRegion">
      <property name="text">
       <string>Region</string>
@@ -48,6 +41,23 @@
     </widget>
    </item>
    <item row="3" column="1">
+    <widget class="QLineEdit" name="leRegion">
+     <property name="placeholderText">
+      <string>Required</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblUsername">
+     <property name="toolTip">
+      <string>AWS AccessKeyId</string>
+     </property>
+     <property name="text">
+      <string>Username</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -60,69 +70,44 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="lePassword">
-       <property name="toolTip">
-        <string>AWS SecretAccessKey</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-       <property name="placeholderText">
-        <string>Required</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chkPasswordShow">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Show</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblUsername">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="leUsername">
      <property name="toolTip">
       <string>AWS AccessKeyId</string>
      </property>
-     <property name="text">
-      <string>Username</string>
+     <property name="placeholderText">
+      <string>Required</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lblPassword">
+   <item row="1" column="1">
+    <widget class="QgsPasswordLineEdit" name="lePassword">
      <property name="toolTip">
       <string>AWS SecretAccessKey</string>
      </property>
      <property name="text">
-      <string>Password</string>
+      <string/>
+     </property>
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string>Required</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>leUsername</tabstop>
-  <tabstop>lePassword</tabstop>
   <tabstop>leRegion</tabstop>
-  <tabstop>chkPasswordShow</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/auth/basic/gui/qgsauthbasicedit.cpp
+++ b/src/auth/basic/gui/qgsauthbasicedit.cpp
@@ -23,7 +23,6 @@ QgsAuthBasicEdit::QgsAuthBasicEdit( QWidget *parent )
 {
   setupUi( this );
   connect( leUsername, &QLineEdit::textChanged, this, &QgsAuthBasicEdit::leUsername_textChanged );
-  connect( chkPasswordShow, &QCheckBox::stateChanged, this, &QgsAuthBasicEdit::chkPasswordShow_stateChanged );
 }
 
 bool QgsAuthBasicEdit::validateConfig()
@@ -69,16 +68,10 @@ void QgsAuthBasicEdit::clearConfig()
   leUsername->clear();
   lePassword->clear();
   leRealm->clear();
-  chkPasswordShow->setChecked( false );
 }
 
 void QgsAuthBasicEdit::leUsername_textChanged( const QString &txt )
 {
   Q_UNUSED( txt )
   validateConfig();
-}
-
-void QgsAuthBasicEdit::chkPasswordShow_stateChanged( int state )
-{
-  lePassword->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
 }

--- a/src/auth/basic/gui/qgsauthbasicedit.h
+++ b/src/auth/basic/gui/qgsauthbasicedit.h
@@ -46,8 +46,6 @@ class QgsAuthBasicEdit : public QgsAuthMethodEdit, private Ui::QgsAuthBasicEdit
   private slots:
     void leUsername_textChanged( const QString &txt );
 
-    void chkPasswordShow_stateChanged( int state );
-
   private:
     QgsStringMap mConfigMap;
     bool mValid = false;

--- a/src/auth/basic/gui/qgsauthbasicedit.ui
+++ b/src/auth/basic/gui/qgsauthbasicedit.ui
@@ -23,28 +23,21 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="leRealm">
      <property name="placeholderText">
       <string>Optional</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="leUsername">
-     <property name="placeholderText">
-      <string>Required</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblRealm">
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblUsername">
      <property name="text">
-      <string>Realm</string>
+      <string>Username</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -57,46 +50,6 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="lePassword">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-       <property name="placeholderText">
-        <string>Optional</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chkPasswordShow">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Show</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblUsername">
-     <property name="text">
-      <string>Username</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="lblPassword">
      <property name="text">
@@ -104,13 +57,45 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="leUsername">
+     <property name="placeholderText">
+      <string>Required</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblRealm">
+     <property name="text">
+      <string>Realm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsPasswordLineEdit" name="lePassword">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string>Optional</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>leUsername</tabstop>
-  <tabstop>lePassword</tabstop>
   <tabstop>leRealm</tabstop>
-  <tabstop>chkPasswordShow</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/auth/pkipaths/gui/qgsauthpkipathsedit.cpp
+++ b/src/auth/pkipaths/gui/qgsauthpkipathsedit.cpp
@@ -34,7 +34,6 @@ QgsAuthPkiPathsEdit::QgsAuthPkiPathsEdit( QWidget *parent )
   : QgsAuthMethodEdit( parent )
 {
   setupUi( this );
-  connect( chkPkiPathsPassShow, &QCheckBox::stateChanged, this, &QgsAuthPkiPathsEdit::chkPkiPathsPassShow_stateChanged );
   connect( btnPkiPathsCert, &QToolButton::clicked, this, &QgsAuthPkiPathsEdit::btnPkiPathsCert_clicked );
   connect( btnPkiPathsKey, &QToolButton::clicked, this, &QgsAuthPkiPathsEdit::btnPkiPathsKey_clicked );
   connect( cbAddCas, &QCheckBox::stateChanged, this, [ = ]( int state ) {  cbAddRootCa->setEnabled( state == Qt::Checked ); } );
@@ -169,17 +168,10 @@ void QgsAuthPkiPathsEdit::clearPkiPathsKeyPath()
   lePkiPathsKey->setStyleSheet( QString() );
 }
 
-
 void QgsAuthPkiPathsEdit::clearPkiPathsKeyPass()
 {
   lePkiPathsKeyPass->clear();
   lePkiPathsKeyPass->setStyleSheet( QString() );
-  chkPkiPathsPassShow->setChecked( false );
-}
-
-void QgsAuthPkiPathsEdit::chkPkiPathsPassShow_stateChanged( int state )
-{
-  lePkiPathsKeyPass->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
 }
 
 void QgsAuthPkiPathsEdit::btnPkiPathsCert_clicked()
@@ -213,7 +205,6 @@ bool QgsAuthPkiPathsEdit::validityChange( bool curvalid )
   }
   return curvalid;
 }
-
 
 bool QgsAuthPkiPathsEdit::populateCas()
 {

--- a/src/auth/pkipaths/gui/qgsauthpkipathsedit.h
+++ b/src/auth/pkipaths/gui/qgsauthpkipathsedit.h
@@ -57,8 +57,6 @@ class QgsAuthPkiPathsEdit : public QgsAuthMethodEdit, private Ui::QgsAuthPkiPath
     void clearPkiPathsKeyPath();
     void clearPkiPathsKeyPass();
 
-    void chkPkiPathsPassShow_stateChanged( int state );
-
     void btnPkiPathsCert_clicked();
 
     void btnPkiPathsKey_clicked();

--- a/src/auth/pkipaths/gui/qgsauthpkipathsedit.ui
+++ b/src/auth/pkipaths/gui/qgsauthpkipathsedit.ui
@@ -99,7 +99,7 @@
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QLineEdit" name="lePkiPathsKeyPass">
+    <widget class="QgsPasswordLineEdit" name="lePkiPathsKeyPass">
      <property name="echoMode">
       <enum>QLineEdit::Password</enum>
      </property>
@@ -138,19 +138,6 @@
      </property>
      <property name="popupMode">
       <enum>QToolButton::InstantPopup</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QCheckBox" name="chkPkiPathsPassShow">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Show</string>
      </property>
     </widget>
    </item>
@@ -193,6 +180,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>lePkiPathsCert</tabstop>
   <tabstop>btnPkiPathsCert</tabstop>
@@ -202,7 +196,6 @@
   <tabstop>lePkiPathsKey</tabstop>
   <tabstop>btnPkiPathsKey</tabstop>
   <tabstop>lePkiPathsKeyPass</tabstop>
-  <tabstop>chkPkiPathsPassShow</tabstop>
   <tabstop>lePkiPathsMsg</tabstop>
  </tabstops>
  <resources/>

--- a/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.cpp
+++ b/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.cpp
@@ -34,7 +34,6 @@ QgsAuthPkcs12Edit::QgsAuthPkcs12Edit( QWidget *parent )
 {
   setupUi( this );
   connect( lePkcs12KeyPass, &QLineEdit::textChanged, this, &QgsAuthPkcs12Edit::lePkcs12KeyPass_textChanged );
-  connect( chkPkcs12PassShow, &QCheckBox::stateChanged, this, &QgsAuthPkcs12Edit::chkPkcs12PassShow_stateChanged );
   connect( btnPkcs12Bundle, &QToolButton::clicked, this, &QgsAuthPkcs12Edit::btnPkcs12Bundle_clicked );
   connect( cbAddCas, &QCheckBox::stateChanged, this, [ = ]( int state ) {  cbAddRootCa->setEnabled( state == Qt::Checked ); } );
   lblCas->hide();
@@ -122,8 +121,6 @@ bool QgsAuthPkcs12Edit::validateConfig()
   return validityChange( bundlevalid );
 }
 
-
-
 QgsStringMap QgsAuthPkcs12Edit::configMap() const
 {
   QgsStringMap config;
@@ -201,18 +198,12 @@ void QgsAuthPkcs12Edit::clearPkcs12BundlePass()
   lePkcs12KeyPass->clear();
   lePkcs12KeyPass->setStyleSheet( QString() );
   lePkcs12KeyPass->setPlaceholderText( QStringLiteral( "Optional passphrase" ) );
-  chkPkcs12PassShow->setChecked( false );
 }
 
 void QgsAuthPkcs12Edit::lePkcs12KeyPass_textChanged( const QString &pass )
 {
   Q_UNUSED( pass )
   validateConfig();
-}
-
-void QgsAuthPkcs12Edit::chkPkcs12PassShow_stateChanged( int state )
-{
-  lePkcs12KeyPass->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
 }
 
 void QgsAuthPkcs12Edit::btnPkcs12Bundle_clicked()

--- a/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.h
+++ b/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.h
@@ -57,7 +57,6 @@ class QgsAuthPkcs12Edit : public QgsAuthMethodEdit, private Ui::QgsAuthPkcs12Edi
     void clearPkcs12BundlePass();
 
     void lePkcs12KeyPass_textChanged( const QString &pass );
-    void chkPkcs12PassShow_stateChanged( int state );
 
     void btnPkcs12Bundle_clicked();
 

--- a/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.ui
+++ b/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.ui
@@ -99,25 +99,12 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QLineEdit" name="lePkcs12KeyPass">
+    <widget class="QgsPasswordLineEdit" name="lePkcs12KeyPass">
      <property name="echoMode">
       <enum>QLineEdit::Password</enum>
      </property>
      <property name="placeholderText">
       <string>Optional passphrase</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QCheckBox" name="chkPkcs12PassShow">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Show</string>
      </property>
     </widget>
    </item>
@@ -173,6 +160,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>lePkcs12Bundle</tabstop>
   <tabstop>btnPkcs12Bundle</tabstop>
@@ -180,7 +174,6 @@
   <tabstop>cbAddCas</tabstop>
   <tabstop>cbAddRootCa</tabstop>
   <tabstop>lePkcs12KeyPass</tabstop>
-  <tabstop>chkPkcs12PassShow</tabstop>
   <tabstop>lePkcs12Msg</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## Description

While we have a custom widget for password editing some of the authentication method editors still use combination of plain lineedit and checkbox. This PR replaces such widget combinations with our custom password lineedit. Affected editors:
 - AWS S3
 - Basic authentication
 - PKI PKCS#12
 - PKI paths

For example, basic auth editor (left — before, right — after)
![passwords](https://github.com/qgis/QGIS/assets/776954/7011687d-dbf6-4a8a-8381-e06baba49f47)
