### PR TITLE
do not duplicate band description in the band name (fix #55156)

### DIFF
--- a/src/gui/raster/qgsrasterbandcombobox.cpp
+++ b/src/gui/raster/qgsrasterbandcombobox.cpp
@@ -168,5 +168,12 @@ QString QgsRasterBandComboBox::displayBandName( QgsRasterDataProvider *provider,
 
   QString name {  provider->displayBandName( band ) };
   const QString description { provider->bandDescription( band ) };
-  return description.isEmpty() ? name : QStringLiteral( "%1 - %2" ).arg( name, description );
+  // displayBandName() includes band description and this description can be the same
+  // as a band description from the metadata, so let's not append description to the band
+  // name if it is already there
+  if ( !description.isEmpty() )
+  {
+    return name.contains( description, Qt::CaseInsensitive ) ? name : QStringLiteral( "%1 - %2" ).arg( name, description );
+  }
+  return name;
 }


### PR DESCRIPTION
## Description

In #53841 we have added support for  raster band descriptions and show them in the raster band combobox. However, if band description from the metadata is the same as description returned by `GDALGetDescription()` it will be shown twice as `displayBandName()` genereated by QGIS already contains description from `GDALGetDescription()`.

Fixes #55156.