### PR TITLE
Fix pointcloud properties dialog minimum size

### DIFF
--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -26,12 +26,15 @@
 #include "qgsdoublevalidator.h"
 #include "qgspointcloudclassifiedrendererwidget.h"
 #include "qgspointcloudlayerelevationproperties.h"
+#include "qgsstackedwidget.h"
 
 QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *layer, QgsPointCloud3DSymbol *symbol, QWidget *parent )
   : QWidget( parent )
   , mLayer( layer )
 {
   setupUi( this );
+
+  mStackedWidget->setSizeMode( QgsStackedWidget::SizeMode::ConsiderCurrentPage );
 
   mPointSizeSpinBox->setClearValue( 2.0 );
   mMaxScreenErrorSpinBox->setClearValue( 1.0 );

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -34,7 +34,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
 {
   setupUi( this );
 
-  mStackedWidget->setSizeMode( QgsStackedWidget::SizeMode::ConsiderCurrentPage );
+  mStackedWidget->setSizeMode( QgsStackedWidget::SizeMode::CurrentPageOnly );
 
   mPointSizeSpinBox->setClearValue( 2.0 );
   mMaxScreenErrorSpinBox->setClearValue( 1.0 );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -727,6 +727,7 @@ set(QGIS_GUI_SRCS
   qgssublayersdialog.cpp
   qgssubstitutionlistwidget.cpp
   qgssqlcomposerdialog.cpp
+  qgsstackedwidget.cpp
   qgsstatusbar.cpp
   qgssymbolbutton.cpp
   qgssymbollayerselectionwidget.cpp
@@ -1000,6 +1001,7 @@ set(QGIS_GUI_HDRS
   qgssourceselectprovider.h
   qgssourceselectproviderregistry.h
   qgssqlcomposerdialog.h
+  qgsstackedwidget.h
   qgsstatusbar.h
   qgsstyleitemslistwidget.h
   qgssublayersdialog.h

--- a/src/gui/qgsstackedwidget.cpp
+++ b/src/gui/qgsstackedwidget.cpp
@@ -21,7 +21,7 @@
 
 QgsStackedWidget::QgsStackedWidget( QWidget *parent )
   : QStackedWidget( parent )
-  , mSizeMode( SizeMode::ConsiderAllPages )
+  , mSizeMode( SizeMode::ConsiderAllPages )  //#spellok
 {
 }
 
@@ -29,7 +29,7 @@ QSize QgsStackedWidget::sizeHint() const
 {
   switch ( mSizeMode )
   {
-    case SizeMode::ConsiderAllPages:
+    case SizeMode::ConsiderAllPages:  //#spellok
       return QStackedWidget::sizeHint();
     case SizeMode::CurrentPageOnly:
       return currentWidget() ? currentWidget()->sizeHint() : QSize();
@@ -41,7 +41,7 @@ QSize QgsStackedWidget::minimumSizeHint() const
 {
   switch ( mSizeMode )
   {
-    case SizeMode::ConsiderAllPages:
+    case SizeMode::ConsiderAllPages:  //#spellok
       return QStackedWidget::sizeHint();
     case SizeMode::CurrentPageOnly:
       return currentWidget() ? currentWidget()->minimumSizeHint() : QSize();

--- a/src/gui/qgsstackedwidget.cpp
+++ b/src/gui/qgsstackedwidget.cpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+    qgsstackedwidget.cpp
+    --------------------
+    begin                : January 2024
+    copyright            : (C) 2024 by Stefanos Natsis
+    email                : uclaros at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsstackedwidget.h"
+
+#include <QStackedWidget>
+#include <QSize>
+
+
+QgsStackedWidget::QgsStackedWidget( QWidget *parent )
+  : QStackedWidget( parent )
+{
+}
+
+QSize QgsStackedWidget::sizeHint() const
+{
+  return currentWidget() ? currentWidget()->sizeHint() : QSize();
+}
+
+QSize QgsStackedWidget::minimumSizeHint() const
+{
+  return currentWidget() ? currentWidget()->minimumSizeHint() : QSize();
+}

--- a/src/gui/qgsstackedwidget.cpp
+++ b/src/gui/qgsstackedwidget.cpp
@@ -21,15 +21,30 @@
 
 QgsStackedWidget::QgsStackedWidget( QWidget *parent )
   : QStackedWidget( parent )
+  , mSizeMode( SizeMode::ConsiderAllPages )
 {
 }
 
 QSize QgsStackedWidget::sizeHint() const
 {
-  return currentWidget() ? currentWidget()->sizeHint() : QSize();
+  switch ( mSizeMode )
+  {
+    case SizeMode::ConsiderAllPages:
+      return QStackedWidget::sizeHint();
+    case SizeMode::ConsiderCurrentPage:
+      return currentWidget() ? currentWidget()->sizeHint() : QSize();
+  }
+  return QSize();
 }
 
 QSize QgsStackedWidget::minimumSizeHint() const
 {
-  return currentWidget() ? currentWidget()->minimumSizeHint() : QSize();
+  switch ( mSizeMode )
+  {
+    case SizeMode::ConsiderAllPages:
+      return QStackedWidget::sizeHint();
+    case SizeMode::ConsiderCurrentPage:
+      return currentWidget() ? currentWidget()->minimumSizeHint() : QSize();
+  }
+  return QSize();
 }

--- a/src/gui/qgsstackedwidget.cpp
+++ b/src/gui/qgsstackedwidget.cpp
@@ -31,7 +31,7 @@ QSize QgsStackedWidget::sizeHint() const
   {
     case SizeMode::ConsiderAllPages:
       return QStackedWidget::sizeHint();
-    case SizeMode::ConsiderCurrentPage:
+    case SizeMode::CurrentPageOnly:
       return currentWidget() ? currentWidget()->sizeHint() : QSize();
   }
   return QSize();
@@ -43,7 +43,7 @@ QSize QgsStackedWidget::minimumSizeHint() const
   {
     case SizeMode::ConsiderAllPages:
       return QStackedWidget::sizeHint();
-    case SizeMode::ConsiderCurrentPage:
+    case SizeMode::CurrentPageOnly:
       return currentWidget() ? currentWidget()->minimumSizeHint() : QSize();
   }
   return QSize();

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -52,7 +52,7 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
 
     /**
      * Constructor for QgsStackedWidget.
-     * SizeMode defaults to SizeMode::ConsiderAllPages #spellok
+     * SizeMode defaults to Consider All Pages, same as QStackedWidget
      */
     explicit QgsStackedWidget( QWidget *parent = nullptr );
 

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -43,7 +43,7 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
     enum class SizeMode
     {
       ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size
-      ConsiderCurrentPage, //!< Only the size of the current page is considered when calculating the stacked widget size
+      CurrentPageOnly, //!< Only the size of the current page is considered when calculating the stacked widget size
     };
 
     /**

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -40,6 +40,9 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
 
   public:
 
+    /**
+     * Possible modes for calculating a QgsStackedWidget's size
+     */
     enum class SizeMode
     {
       ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsstackedwidget.h
+    ------------------
+    begin                : January 2024
+    copyright            : (C) 2024 by Stefanos Natsis
+    email                : uclaros at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSTACKEDWIDGET_H
+#define QGSSTACKEDWIDGET_H
+
+#define SIP_NO_FILE
+
+#include <QStackedWidget>
+#include "qgis_gui.h"
+
+class QSize;
+
+/**
+ * \class QgsStackedWidget
+ * \ingroup gui
+ * \brief A QStackedWidget that can be shrunk to its current widget's size.
+ *
+ * A regular QStackedWidget can be shrunk down the size of its
+ * largest page widget. A QgsStackedWidget only takes the current
+ * page widget into account when resizing.
+ *
+ * \since QGIS 3.36
+ */
+class GUI_EXPORT QgsStackedWidget : public QStackedWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsStackedWidget.
+     */
+    explicit QgsStackedWidget( QWidget *parent = nullptr );
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+};
+
+#endif // QGSSTACKEDWIDGET_H

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -45,13 +45,13 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
      */
     enum class SizeMode
     {
-      ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size
+      ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size #spellok
       CurrentPageOnly, //!< Only the size of the current page is considered when calculating the stacked widget size
     };
 
     /**
      * Constructor for QgsStackedWidget.
-     * SizeMode defaults to SizeMode::ConsiderAllPages
+     * SizeMode defaults to SizeMode::ConsiderAllPages #spellok
      */
     explicit QgsStackedWidget( QWidget *parent = nullptr );
 

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -28,9 +28,9 @@ class QSize;
  * \ingroup gui
  * \brief A QStackedWidget that can be shrunk to its current widget's size.
  *
- * A regular QStackedWidget can be shrunk down the size of its
- * largest page widget. A QgsStackedWidget only takes the current
- * page widget into account when resizing.
+ * A regular QStackedWidget can be shrunk down the size of its largest page widget.
+ * A QgsStackedWidget can be set to only consider the current page widget's sizeHint
+ * and minimumSizeHint when resizing.
  *
  * \since QGIS 3.36
  */
@@ -40,14 +40,37 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
 
   public:
 
+    enum class SizeMode
+    {
+      ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size
+      ConsiderCurrentPage, //!< Only the size of the current page is considered when calculating the stacked widget size
+    };
+
     /**
      * Constructor for QgsStackedWidget.
+     * SizeMode defaults to SizeMode::ConsiderAllPages
      */
     explicit QgsStackedWidget( QWidget *parent = nullptr );
+
+    /**
+     * Returns the SizeMode for this QgsStackedWidget.
+     * See QgsStackedWidget::SizeMode for interpretation
+     * \see setSizeMode()
+     */
+    SizeMode sizeMode() const { return mSizeMode; }
+
+    /**
+     * Sets the \a mode for this QgsStackedWidget.
+     * See QgsStackedWidget::SizeMode for interpretation
+     * \see sizeMode()
+     */
+    void setSizeMode( SizeMode mode ) { mSizeMode = mode; }
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
+  private:
+    SizeMode mSizeMode;
 };
 
 #endif // QGSSTACKEDWIDGET_H

--- a/src/gui/qgsstackedwidget.h
+++ b/src/gui/qgsstackedwidget.h
@@ -45,7 +45,8 @@ class GUI_EXPORT QgsStackedWidget : public QStackedWidget
      */
     enum class SizeMode
     {
-      ConsiderAllPages, //!< The sizes of all pages are considered when calculating the stacked widget size #spellok
+      //! The sizes of all pages are considered when calculating the stacked widget size
+      ConsiderAllPages, //#spellok
       CurrentPageOnly, //!< Only the size of the current page is considered when calculating the stacked widget size
     };
 

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -192,7 +192,7 @@
     </widget>
    </item>
    <item row="2" column="0" colspan="3">
-    <widget class="QStackedWidget" name="mStackedWidget">
+    <widget class="QgsStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -636,6 +636,12 @@ enhancement</string>
    <class>QgsPointCloudAttributeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspointcloudattributecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudclassifiedrendererwidgetbase.ui
@@ -28,7 +28,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>250</height>
+       <height>100</height>
       </size>
      </property>
      <property name="contextMenuPolicy">

--- a/src/ui/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/qgscolorrampshaderwidgetbase.ui
@@ -37,7 +37,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>250</height>
+       <height>100</height>
       </size>
      </property>
      <attribute name="headerMinimumSectionSize">


### PR DESCRIPTION
## Description
The _3D View_ tab in a point cloud's properties dialog was forcing the dialog to relatively big minimum height.
![Peek 2024-01-24 17-45](https://github.com/qgis/QGIS/assets/11358178/5dd3289c-23d7-47ac-b8bf-9d99ba31ccf7)


Probably fixes #43276 , not sure about the disappearing part but I hope it was some QT weirdness when hitting the minimum size.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
