### PR TITLE
Use a `QgsScrollArea` when adding or inserting pages to `QgsOptionsDialogBase` 

### DIFF
--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -39,6 +39,7 @@
 #include "qgsguiutils.h"
 #include "qgsapplication.h"
 #include "qgsvariantutils.h"
+#include "qgsscrollarea.h"
 
 QgsOptionsDialogBase::QgsOptionsDialogBase( const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
   : QDialog( parent, fl )
@@ -396,10 +397,15 @@ void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip
       mOptTreeModel->appendRow( item );
   }
 
+  QgsScrollArea *scrollArea = new QgsScrollArea();
+  scrollArea->setWidgetResizable( true );
+  scrollArea->setFrameShape( QFrame::NoFrame );
+  scrollArea->setWidget( widget );
+
   if ( newPage < 0 )
-    mOptStackedWidget->addWidget( widget );
+    mOptStackedWidget->addWidget( scrollArea );
   else
-    mOptStackedWidget->insertWidget( newPage, widget );
+    mOptStackedWidget->insertWidget( newPage, scrollArea );
 }
 
 void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QString &before, const QStringList &path, const QString &key )
@@ -492,7 +498,11 @@ void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tool
         }
       }
 
-      mOptStackedWidget->insertWidget( page, widget );
+      QgsScrollArea *scrollArea = new QgsScrollArea();
+      scrollArea->setWidgetResizable( true );
+      scrollArea->setFrameShape( QFrame::NoFrame );
+      scrollArea->setWidget( widget );
+      mOptStackedWidget->insertWidget( page, scrollArea );
       return;
     }
   }


### PR DESCRIPTION
## Description
Most pages in `QgsOptions` encapsulate their contents within a hard coded `QgsScrollArea` to allow for scrollbars when shrinking.
However, many pages in options and other subclasses use the `QgsOptionsDialogBase::insertPage` or `QgsOptionsDialogBase::addPage` and force a minimum height to the parent dialog which is often quite big. This can also happen by plugins that add a page to the project properties or options dialog.
With this PR, all pages added with those methods are wrapped around a `QgsScrollArea` and now all `QgsOptionsDialogBase` derived dialogs can be resized to fit in smaller screens.

![Peek 2024-01-24 18-07](https://github.com/qgis/QGIS/assets/11358178/d7a7724b-6799-405b-9d17-94afc43e1b08)

Properly fixes the already closed #32021

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
