### PR TITLE
[GUI] Avoid endless stack of signal emission between QgsFilterLineEdit::valueChanged and QgsValueRelationWidgetWrapper::updateValues()

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -331,7 +331,8 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
     {
       connect( filterLineEdit, &QgsFilterLineEdit::valueChanged, this, [ = ]( const QString & )
       {
-        emitValueChanged();
+        if ( mSubWidgetSignalBlocking == 0 )
+          emitValueChanged();
       } );
     }
     else
@@ -399,6 +400,7 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
   }
   else if ( mLineEdit )
   {
+    mSubWidgetSignalBlocking ++;
     mLineEdit->clear();
     bool wasFound { false };
     for ( const QgsValueRelationFieldFormatter::ValueRelationItem &i : std::as_const( mCache ) )
@@ -415,6 +417,7 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
     {
       mLineEdit->setText( tr( "(no selection)" ) );
     }
+    mSubWidgetSignalBlocking --;
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -209,6 +209,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     QgsToolTipComboBox *mComboBox = nullptr;
     QgsFilteredTableWidget *mTableWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
+    int mSubWidgetSignalBlocking = 0; //! Set to non-zero when a endless loop of notifications could happen.
 
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;
     QgsVectorLayer *mLayer = nullptr;


### PR DESCRIPTION
… (fixes #55854)
