### PR TITLE
Allow point inputs in "Filter vertices by M/Z values" algorithms

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_points.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_points.gml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_specific_nodes_points.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>2 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:extract_specific_nodes_points gml:id="extract_specific_nodes_points.0">
+      <ogr:fid>points.9</ogr:fid>
+      <ogr:d>5</ogr:d>
+      <ogr:vertex_pos xsi:nil="true"/>
+      <ogr:vertex_index xsi:nil="true"/>
+      <ogr:vertex_part xsi:nil="true"/>
+      <ogr:vertex_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
+    </ogr:extract_specific_nodes_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:extract_specific_nodes_points gml:id="extract_specific_nodes_points.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 1</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="extract_specific_nodes_points.geom.1"><gml:pos>1 1</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:d>1</ogr:d>
+      <ogr:vertex_pos>0</ogr:vertex_pos>
+      <ogr:vertex_index>0</ogr:vertex_index>
+      <ogr:vertex_part>0</ogr:vertex_part>
+      <ogr:vertex_part_index>0</ogr:vertex_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:extract_specific_nodes_points gml:id="extract_specific_nodes_points.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 5</gml:lowerCorner><gml:upperCorner>2 5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="extract_specific_nodes_points.geom.2"><gml:pos>2 5</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:d>2</ogr:d>
+      <ogr:vertex_pos>0</ogr:vertex_pos>
+      <ogr:vertex_index>0</ogr:vertex_index>
+      <ogr:vertex_part>0</ogr:vertex_part>
+      <ogr:vertex_part_index>0</ogr:vertex_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:extract_specific_nodes_points gml:id="extract_specific_nodes_points.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>-5 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="extract_specific_nodes_points.geom.3"><gml:pos>-5 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:d>3</ogr:d>
+      <ogr:vertex_pos>0</ogr:vertex_pos>
+      <ogr:vertex_index>0</ogr:vertex_index>
+      <ogr:vertex_part>0</ogr:vertex_part>
+      <ogr:vertex_part_index>0</ogr:vertex_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_points>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:extract_specific_nodes_points gml:id="extract_specific_nodes_points.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>-1 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="extract_specific_nodes_points.geom.4"><gml:pos>-1 7</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:d>4</ogr:d>
+      <ogr:vertex_pos>0</ogr:vertex_pos>
+      <ogr:vertex_index>0</ogr:vertex_index>
+      <ogr:vertex_part>0</ogr:vertex_part>
+      <ogr:vertex_part_index>0</ogr:vertex_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_points>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_points.xsd
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_points.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="extract_specific_nodes_points" type="ogr:extract_specific_nodes_points_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="extract_specific_nodes_points_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="d" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="vertex_pos" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="vertex_index" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="vertex_part" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="vertex_part_index" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="distance" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="angle" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_points_by_z.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_points_by_z.gml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_points_by_z.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0 1</gml:lowerCorner><gml:upperCorner>1 4 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                        
+  <ogr:featureMember>
+    <ogr:filter_points_by_z gml:id="filter_points_by_z.0">
+      <ogr:fid>points.9</ogr:fid>
+      <ogr:d>5</ogr:d>
+    </ogr:filter_points_by_z>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:filter_points_by_z gml:id="filter_points_by_z.1">
+      <gml:boundedBy><gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 1 1</gml:lowerCorner><gml:upperCorner>1 1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="filter_points_by_z.geom.1"><gml:pointMember><gml:Point gml:id="filter_points_by_z.geom.1.0"><gml:pos>1 1 1</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:d>1</ogr:d>
+    </ogr:filter_points_by_z>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:filter_points_by_z gml:id="filter_points_by_z.2">
+      <gml:boundedBy><gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 4 1</gml:lowerCorner><gml:upperCorner>1 4 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="filter_points_by_z.geom.2"><gml:pointMember><gml:Point gml:id="filter_points_by_z.geom.2.0"><gml:pos>1 4 1</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:d>2</ogr:d>
+    </ogr:filter_points_by_z>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:filter_points_by_z gml:id="filter_points_by_z.3">
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:d>3</ogr:d>
+    </ogr:filter_points_by_z>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:filter_points_by_z gml:id="filter_points_by_z.4">
+      <gml:boundedBy><gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0 1</gml:lowerCorner><gml:upperCorner>-1 0 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="filter_points_by_z.geom.4"><gml:pointMember><gml:Point gml:id="filter_points_by_z.geom.4.0"><gml:pos>-1 0 1</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:d>4</ogr:d>
+    </ogr:filter_points_by_z>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_points_by_z.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_points_by_z.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_points_by_z" type="ogr:filter_points_by_z_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="filter_points_by_z_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiPointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="d" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/multipointsz.gfs
+++ b/python/plugins/processing/tests/testdata/multipointsz.gfs
@@ -1,0 +1,19 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>multipointsz</Name>
+    <ElementPath>multipointsz</ElementPath>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>5</FeatureCount>
+      <ExtentXMin>0.00000</ExtentXMin>
+      <ExtentXMax>8.00000</ExtentXMax>
+      <ExtentYMin>-5.00000</ExtentYMin>
+      <ExtentYMax>3.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>d</Name>
+      <ElementPath>d</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/multipointsz.gml
+++ b/python/plugins/processing/tests/testdata/multipointsz.gml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+
+  <gml:featureMember>
+    <ogr:multipointsz fid="points.9">
+      <ogr:d>5</ogr:d>
+    </ogr:multipointsz>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:multipointsz fid="points.0">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>1</ogr:d>
+    </ogr:multipointsz>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:multipointsz fid="points.3">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>2</ogr:d>
+    </ogr:multipointsz>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:multipointsz fid="points.5">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>3</ogr:d>
+    </ogr:multipointsz>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:multipointsz fid="points.7">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>7,-1,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>0,-1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>4</ogr:d>
+    </ogr:multipointsz>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -359,6 +359,21 @@ tests:
           fields:
             fid: skip
 
+  - algorithm: native:extractspecificvertices
+    name: Extract specific vertices points
+    params:
+      INPUT:
+        name: multipoints.gml
+        type: vector
+      VERTICES: '0'
+    results:
+      OUTPUT:
+        name: expected/extract_specific_nodes_points.gml
+        type: vector
+        compare:
+          fields:
+            fid: skip
+
   - algorithm: native:fuzzifyrasterlinearmembership
     name: Test (native:fuzzifyrasterlinearmembership)
     params:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -1166,6 +1166,22 @@ tests:
         name: expected/filter_by_z.shp
         type: vector
 
+  - algorithm: native:filterverticesbyz
+    name: Filter by z (points)
+    params:
+      INPUT:
+        name: multipointsz.gml
+        type: vector
+      MAX: 1.0
+      MIN: 1.0
+    results:
+      OUTPUT:
+        name: expected/filter_points_by_z.gml
+        type: vector
+        compare:
+          fields:
+            fid: skip
+
   - algorithm: native:arraytranslatedfeatures
     name: Array of point features
     params:

--- a/src/analysis/processing/qgsalgorithmextractspecificvertices.cpp
+++ b/src/analysis/processing/qgsalgorithmextractspecificvertices.cpp
@@ -49,7 +49,7 @@ QString QgsExtractSpecificVerticesAlgorithm::groupId() const
 
 QString QgsExtractSpecificVerticesAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm takes a line or polygon layer and generates a point layer with points "
+  return QObject::tr( "This algorithm takes a vector layer and generates a point layer with points "
                       "representing specific vertices in the input lines or polygons. For instance, this algorithm "
                       "can be used to extract the first or last vertices in the geometry. The attributes associated "
                       "to each point are the same ones associated to the line or polygon that the point belongs to." ) +

--- a/src/analysis/processing/qgsalgorithmfiltervertices.cpp
+++ b/src/analysis/processing/qgsalgorithmfiltervertices.cpp
@@ -47,11 +47,6 @@ QString QgsFilterVerticesAlgorithmBase::shortHelpString() const
                       "the resultant geometries created by this algorithm may no longer be valid." ).arg( componentString() );
 }
 
-QList<int> QgsFilterVerticesAlgorithmBase::inputLayerTypes() const
-{
-  return QList<int>() << QgsProcessing::TypeVectorLine << QgsProcessing::TypeVectorPolygon;
-}
-
 void QgsFilterVerticesAlgorithmBase::initParameters( const QVariantMap & )
 {
   auto min = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "MIN" ),
@@ -212,5 +207,3 @@ void QgsFilterVerticesByZ::filter( QgsGeometry &geometry, double min, double max
 }
 
 ///@endcond
-
-

--- a/src/analysis/processing/qgsalgorithmfiltervertices.h
+++ b/src/analysis/processing/qgsalgorithmfiltervertices.h
@@ -36,7 +36,6 @@ class QgsFilterVerticesAlgorithmBase : public QgsProcessingFeatureBasedAlgorithm
 
     QString group() const override final;
     QString groupId() const override final;
-    QList<int> inputLayerTypes() const override final;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override final;
     QString shortHelpString() const override final;
 
@@ -78,9 +77,7 @@ class QgsFilterVerticesByM : public QgsFilterVerticesAlgorithmBase
 
     QString componentString() const override;
     void filter( QgsGeometry &geometry, double min, double max ) const override;
-
 };
-
 
 /**
  * Filter vertices by Z value algorithm.
@@ -103,9 +100,6 @@ class QgsFilterVerticesByZ : public QgsFilterVerticesAlgorithmBase
     void filter( QgsGeometry &geometry, double min, double max ) const override;
 };
 
-
 ///@endcond PRIVATE
 
 #endif // QGSALGORITHMFILTERVERTICES_H
-
-


### PR DESCRIPTION
## Description

Processing algorithms "Filter vertices by M/Z values" does not accept point layers as input, while "Extract specific vertices" algorithm can be applied to points as well (e.g. to extract some points from multipoint geometry). This is a bit inconsistent behaviour. This PR allows "Filter vertices by M/Z values" to accept point layers to make it uniform with "Extract specific vertices" algorithm.

Fixes #33502.