### PR TITLE
use project scales in label rendering and new 2D canvas dock if they are set (fix #51326)

### DIFF
--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -30,6 +30,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
 #include "qgsdockablewidgethelper.h"
+#include "qgsprojectviewsettings.h"
 
 #include <QMessageBox>
 #include <QMenu>
@@ -590,6 +591,22 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   gLayout->addWidget( label, 2, 0 );
 
   mScaleCombo = new QgsScaleComboBox();
+  // use either global scales or project scales
+  if ( QgsProject::instance()->viewSettings()->useProjectScales() )
+  {
+    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
+    QStringList textScales;
+    textScales.reserve( scales.size() );
+    for ( const double scale : scales )
+      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
+    mScaleCombo->updateScales( textScales );
+  }
+  else
+  {
+    // use global scales
+    mScaleCombo->updateScales();
+  }
+
   gLayout->addWidget( mScaleCombo, 2, 1 );
 
   mRotationWidget = new QgsDoubleSpinBox();

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -43,6 +43,7 @@
 #include "qgssymbollayerreference.h"
 #include "qgsconfig.h"
 #include "qgsprojectstylesettings.h"
+#include "qgsprojectviewsettings.h"
 
 #include <QButtonGroup>
 #include <QMessageBox>
@@ -848,6 +849,24 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
   mScaleBasedVisibilityMinDDBtn->setUsageInfo( ddScaleVisInfo );
   registerDataDefinedButton( mScaleBasedVisibilityMaxDDBtn, QgsPalLayerSettings::Property::MaximumScale );
   mScaleBasedVisibilityMaxDDBtn->setUsageInfo( ddScaleVisInfo );
+
+  // use either global scales or project scales
+  if ( QgsProject::instance()->viewSettings()->useProjectScales() )
+  {
+    const QVector< double > scales = QgsProject::instance()->viewSettings()->mapScales();
+    QStringList textScales;
+    textScales.reserve( scales.size() );
+    for ( const double scale : scales )
+      textScales << QStringLiteral( "1:%1" ).arg( QLocale().toString( scale, 'f', 0 ) );
+    mMinScaleWidget->updateScales( textScales );
+    mMaxScaleWidget->updateScales( textScales );
+  }
+  else
+  {
+    // use global scales
+    mMinScaleWidget->updateScales();
+    mMaxScaleWidget->updateScales();
+  }
 
   registerDataDefinedButton( mFontLimitPixelDDBtn, QgsPalLayerSettings::Property::FontLimitPixel );
   mFontLimitPixelDDBtn->registerCheckedWidget( mFontLimitPixelChkBox );


### PR DESCRIPTION
## Description

When user overrides global scales list in the project properties, QGIS uses this overriden list in the scale selector in the status bar, in the atlas settings, in the layer and diagrams rendering settings. However, in it does not applied to the label rendering settings and in the new 2D map views.

Fixes #51326.