### PR TITLE
rename QgsMeshRendererScalarSettings.DataResampling enum value from None to NoResampling

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmeshrenderersettings.py
+++ b/python/PyQt6/core/auto_additions/qgsmeshrenderersettings.py
@@ -1,5 +1,5 @@
 # The following has been generated automatically from src/core/mesh/qgsmeshrenderersettings.h
-QgsMeshRendererScalarSettings.None_ = QgsMeshRendererScalarSettings.DataResamplingMethod.None_
+QgsMeshRendererScalarSettings.NoResampling = QgsMeshRendererScalarSettings.DataResamplingMethod.NoResampling
 QgsMeshRendererScalarSettings.NeighbourAverage = QgsMeshRendererScalarSettings.DataResamplingMethod.NeighbourAverage
 QgsMeshRendererVectorArrowSettings.MinMax = QgsMeshRendererVectorArrowSettings.ArrowScalingMethod.MinMax
 QgsMeshRendererVectorArrowSettings.Scaled = QgsMeshRendererVectorArrowSettings.ArrowScalingMethod.Scaled

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -100,7 +100,7 @@ Represents a mesh renderer settings for scalar datasets
     enum DataResamplingMethod
     {
 
-      None,
+      NoResampling,
 
       NeighbourAverage,
     };

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -100,7 +100,7 @@ Represents a mesh renderer settings for scalar datasets
     enum DataResamplingMethod
     {
 
-      None,
+      NoResampling,
 
       NeighbourAverage,
     };

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -231,7 +231,7 @@ QString QgsMeshLayer::loadDefaultStyle( bool &resultFlag )
         scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
         break;
       case QgsMeshDatasetGroupMetadata::DataOnVertices:
-        scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
+        scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NoResampling );
         break;
       case QgsMeshDatasetGroupMetadata::DataOnEdges:
         break;
@@ -793,7 +793,7 @@ void QgsMeshLayer::applyClassificationOnScalarSettings( const QgsMeshDatasetGrou
     }
 
     scalarSettings.setColorRampShader( colorRampShader );
-    scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
+    scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NoResampling );
   }
 }
 

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -187,7 +187,7 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
                                     mNativeMesh.faces.count() );
 
     // for data on faces, there could be request to interpolate the data to vertices
-    if ( method != QgsMeshRendererScalarSettings::None )
+    if ( method != QgsMeshRendererScalarSettings::NoResampling )
     {
       if ( mScalarDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnFaces )
       {

--- a/src/core/mesh/qgsmeshlayerrenderer.h
+++ b/src/core/mesh/qgsmeshlayerrenderer.h
@@ -64,7 +64,7 @@ struct CORE_NO_EXPORT QgsMeshLayerRendererCache
   QgsMeshDatasetGroupMetadata::DataType mScalarDataType = QgsMeshDatasetGroupMetadata::DataType::DataOnVertices;
   double mScalarDatasetMinimum = std::numeric_limits<double>::quiet_NaN();
   double mScalarDatasetMaximum = std::numeric_limits<double>::quiet_NaN();
-  QgsMeshRendererScalarSettings::DataResamplingMethod mDataInterpolationMethod = QgsMeshRendererScalarSettings::None;
+  QgsMeshRendererScalarSettings::DataResamplingMethod mDataInterpolationMethod = QgsMeshRendererScalarSettings::NoResampling;
   std::unique_ptr<QgsMesh3DAveragingMethod> mScalarAveragingMethod;
 
   // vector dataset

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -122,8 +122,8 @@ QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc, const Qg
   QString methodTxt;
   switch ( mDataResamplingMethod )
   {
-    case None:
-      methodTxt = QStringLiteral( "none" );
+    case NoResampling:
+      methodTxt = QStringLiteral( "no-resampling" );
       break;
     case NeighbourAverage:
       methodTxt = QStringLiteral( "neighbour-average" );
@@ -154,7 +154,7 @@ void QgsMeshRendererScalarSettings::readXml( const QDomElement &elem, const QgsR
   }
   else
   {
-    mDataResamplingMethod = DataResamplingMethod::None;
+    mDataResamplingMethod = DataResamplingMethod::NoResampling;
   }
   const QDomElement elemShader = elem.firstChildElement( QStringLiteral( "colorrampshader" ) );
   mColorRampShader.readXml( elemShader, context );

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -107,7 +107,7 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
       /**
        * Does not use resampling
        */
-      None = 0,
+      NoResampling = 0,
 
       /**
        * Does a simple average of values defined for all surrounding faces/vertices
@@ -183,7 +183,7 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
 
   private:
     QgsColorRampShader mColorRampShader;
-    DataResamplingMethod mDataResamplingMethod = DataResamplingMethod::None;
+    DataResamplingMethod mDataResamplingMethod = DataResamplingMethod::NoResampling;
     double mClassificationMinimum = 0;
     double mClassificationMaximum = 0;
     double mOpacity = 1;

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -34,7 +34,7 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
   mScalarMaxSpinBox->setSpecialValueText( QString( ) );
 
   // add items to data interpolation combo box
-  mScalarInterpolationTypeComboBox->addItem( tr( "None" ), QgsMeshRendererScalarSettings::None );
+  mScalarInterpolationTypeComboBox->addItem( tr( "No Resampling" ), QgsMeshRendererScalarSettings::NoResampling );
   mScalarInterpolationTypeComboBox->addItem( tr( "Neighbour Average" ), QgsMeshRendererScalarSettings::NeighbourAverage );
   mScalarInterpolationTypeComboBox->setCurrentIndex( 0 );
 

--- a/tests/src/analysis/testqgsmeshcontours.cpp
+++ b/tests/src/analysis/testqgsmeshcontours.cpp
@@ -132,7 +132,7 @@ void TestQgsMeshContours::testQuadAndTriangleVertexScalarLine()
 
   QgsMeshContours contours( mpMeshLayer.get() );
 
-  const QgsGeometry res = contours.exportLines( datasetIndex, value, QgsMeshRendererScalarSettings::None );
+  const QgsGeometry res = contours.exportLines( datasetIndex, value, QgsMeshRendererScalarSettings::NoResampling );
   equals( res, expected );
 }
 
@@ -190,7 +190,7 @@ void TestQgsMeshContours::testQuadAndTriangleVertexScalarPoly()
 
   QgsMeshContours contours( mpMeshLayer.get() );
 
-  const QgsGeometry res = contours.exportPolygons( datasetIndex, min_value, max_value, QgsMeshRendererScalarSettings::None );
+  const QgsGeometry res = contours.exportPolygons( datasetIndex, min_value, max_value, QgsMeshRendererScalarSettings::NoResampling );
   equals( res, expected );
 }
 

--- a/tests/src/core/testqgsmeshlayerrenderer.cpp
+++ b/tests/src/core/testqgsmeshlayerrenderer.cpp
@@ -661,7 +661,7 @@ void TestQgsMeshRenderer::test_stacked_3d_mesh_single_level_averaging()
   QVERIFY( metadata.name() == "temperature" );
   QVERIFY( metadata.maximumVerticalLevelsCount() == 10 );
   QgsMeshRendererScalarSettings scalarSettings = rendererSettings.scalarSettings( ds.group() );
-  scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
+  scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NoResampling );
   rendererSettings.setScalarSettings( ds.group(), scalarSettings );
   // want to set active vector dataset one defined on 3d mesh
   ds = QgsMeshDatasetIndex( 6, 3 );


### PR DESCRIPTION
## Description

The `QgsMeshRendererScalarSettings.DataResampling` enum has a value `None` which seems does not work well with Python bingings as `None` is a reserved keyword in Python. Given that mesh API is still marked as experimental it should be safe to rename that value to `NoResampling` as suggested by @uclaros. This not only should fix the issue with Python bindings but also will make enum value more informative.

Fixes #51033.