### PR TITLE
[attributeform] Insure that the checkbox editor widget reflects an 'unset' state to provide accurate constraint validity

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -60,6 +60,16 @@ Be sure to return a NULL QVariant if it should be set to NULL.
 :return: The current value the widget represents
 %End
 
+    virtual QVariant rawValue() const;
+%Docstring
+Returns a raw value that better reflect the feature value passed onto
+the editor widget. For example, while a checkbox has a binary return :py:func:`~QgsEditorWidgetWrapper.value`,
+the raw will also reflect an unset/null state. This function is used
+when updating constraints validity.
+
+.. versionadded:: 3.36
+%End
+
     virtual QStringList additionalFields() const;
 %Docstring
 Returns the list of additional fields which the editor handles

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -60,6 +60,16 @@ Be sure to return a NULL QVariant if it should be set to NULL.
 :return: The current value the widget represents
 %End
 
+    virtual QVariant rawValue() const;
+%Docstring
+Returns a raw value that better reflect the feature value passed onto
+the editor widget. For example, while a checkbox has a binary return :py:func:`~QgsEditorWidgetWrapper.value`,
+the raw will also reflect an unset/null state. This function is used
+when updating constraints validity.
+
+.. versionadded:: 3.36
+%End
+
     virtual QStringList additionalFields() const;
 %Docstring
 Returns the list of additional fields which the editor handles

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -224,7 +224,6 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int 
     }
 
     hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
-
     softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
     errors << softErrors;
   }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -86,10 +86,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     virtual QVariant value() const = 0;
 
     /**
+     * Returns a raw value that better reflect the feature value passed onto
+     * the editor widget. For example, while a checkbox has a binary return value(),
+     * the raw will also reflect an unset/null state. This function is used
+     * when updating constraints validity.
+     * \since QGIS 3.36
+     */
+    virtual QVariant rawValue() const { return value(); }
+
+    /**
      * Returns the list of additional fields which the editor handles
      * \since QGIS 3.10
      */
-    virtual QStringList additionalFields() const {return QStringList();}
+    virtual QStringList additionalFields() const { return QStringList(); }
 
     /**
      * Will be used to access the widget's values for potential additional fields handled by the widget

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -57,6 +57,7 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
     // QgsEditorWidgetWrapper interface
   public:
     QVariant value() const override;
+    QVariant rawValue() const override;
 
     void showIndeterminateState() override;
 
@@ -70,6 +71,8 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
 
     QCheckBox *mCheckBox = nullptr;
     QGroupBox *mGroupBox = nullptr;
+
+    bool mUnsetState = true;
 };
 
 #endif // QGSCHECKBOXWIDGETWRAPPER_H

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1117,7 +1117,7 @@ void QgsAttributeForm::updateConstraints( QgsEditorWidgetWrapper *eww )
 {
   // get the current feature set in the form
   QgsFeature ft;
-  if ( currentFormValuesFeature( ft ) )
+  if ( currentFormValuesFeature( ft, true ) )
   {
     // if the layer is NOT being edited then we only check layer based constraints, and not
     // any constraints enforced by the provider. Because:
@@ -1256,7 +1256,7 @@ void QgsAttributeForm::updateEditableState()
   }
 }
 
-bool QgsAttributeForm::currentFormValuesFeature( QgsFeature &feature )
+bool QgsAttributeForm::currentFormValuesFeature( QgsFeature &feature, bool rawValue )
 {
   bool rc = true;
   feature = QgsFeature( mFeature );
@@ -1272,7 +1272,7 @@ bool QgsAttributeForm::currentFormValuesFeature( QgsFeature &feature )
     if ( dst.count() > eww->fieldIdx() )
     {
       QVariantList dstVars = QVariantList() << dst.at( eww->fieldIdx() );
-      QVariantList srcVars = QVariantList() << eww->value();
+      QVariantList srcVars = QVariantList() << ( rawValue ? eww->rawValue() : eww->value() );
       QList<int> fieldIndexes = QList<int>() << eww->fieldIdx();
 
       // append additional fields

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -450,7 +450,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateConstraint( const QgsFeature &ft, QgsEditorWidgetWrapper *eww );
     void updateLabels();
     void updateEditableState();
-    bool currentFormValuesFeature( QgsFeature &feature );
+    bool currentFormValuesFeature( QgsFeature &feature, bool rawValue = false );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
     bool currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );


### PR DESCRIPTION
## Description

_(Background reading prior to engaging with the PR: https://github.com/qgis/QGIS/issues/55390)_

This PR attempts to address a shortcoming with feature form's constraints check whereas the value used to conduct constraint validity might not be truthful to the 'raw' value passed on by the feature.

For .e.g, the checkbox editor widget's value() - used for constraint checks - always returns true or false, even if the value passed on by the feature was unset/empty/null to begin with. This creates inconsistencies with the attribute table's invalid constraints filter and leads to confusion when users are trying to remedy to invalid constraints.

The solution proposed here is to add a rawValue() function to editor widget wrappers, which by default returns value(). Individual editor widgets can re-implement rawValue() to insure that constraints are dealing with values that will reflect the current state of the feature.

This PR fixes the checkbox editor widget, but once we agree on a way forward we can also fix the range editor widget.