### PR TITLE
use correct units in the identify map tool when "map units" are used for distance and area measurements (fix #26995)

### DIFF
--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -35,6 +35,7 @@
 #include "qgsmapmouseevent.h"
 #include "qgslayertreeview.h"
 #include "qgsmaplayeraction.h"
+#include "qgsunittypes.h"
 
 #include <QCursor>
 #include <QPixmap>
@@ -53,7 +54,6 @@ QgsMapToolIdentifyAction::QgsMapToolIdentifyAction( QgsMapCanvas *canvas )
   identifyMenu()->addCustomAction( attrTableAction );
   mSelectionHandler = new QgsMapToolSelectionHandler( canvas, QgsMapToolSelectionHandler::SelectSimple );
   connect( mSelectionHandler, &QgsMapToolSelectionHandler::geometryChanged, this, &QgsMapToolIdentifyAction::identifyFromGeometry );
-
 }
 
 QgsMapToolIdentifyAction::~QgsMapToolIdentifyAction()
@@ -102,7 +102,6 @@ void QgsMapToolIdentifyAction::showAttributeTable( QgsMapLayer *layer, const QLi
   tableDialog->setFilterExpression( filter );
   tableDialog->show();
 }
-
 
 void QgsMapToolIdentifyAction::identifyFromGeometry()
 {
@@ -234,12 +233,24 @@ void QgsMapToolIdentifyAction::showResultsForFeature( QgsVectorLayer *vlayer, Qg
 
 Qgis::DistanceUnit QgsMapToolIdentifyAction::displayDistanceUnits() const
 {
-  return QgsProject::instance()->distanceUnits();
+  Qgis::DistanceUnit units = QgsProject::instance()->distanceUnits();
+  // unknown units used as a placeholder for map units
+  if ( units == Qgis::DistanceUnit::Unknown )
+  {
+    return QgsProject::instance()->crs().mapUnits();
+  }
+  return units;
 }
 
 Qgis::AreaUnit QgsMapToolIdentifyAction::displayAreaUnits() const
 {
-  return QgsProject::instance()->areaUnits();
+  Qgis::AreaUnit units = QgsProject::instance()->areaUnits();
+  // unknown units used as a placeholder for map units
+  if ( units == Qgis::AreaUnit::Unknown )
+  {
+    return QgsUnitTypes::distanceToAreaUnit( QgsProject::instance()->crs().mapUnits() );
+  }
+  return units;
 }
 
 void QgsMapToolIdentifyAction::handleCopyToClipboard( QgsFeatureStore &featureStore )
@@ -262,7 +273,6 @@ void QgsMapToolIdentifyAction::setClickContextScope( const QgsPointXY &point )
   }
 }
 
-
 void QgsMapToolIdentifyAction::keyReleaseEvent( QKeyEvent *e )
 {
   if ( mSelectionHandler->keyReleaseEvent( e ) )
@@ -270,7 +280,6 @@ void QgsMapToolIdentifyAction::keyReleaseEvent( QKeyEvent *e )
 
   QgsMapTool::keyReleaseEvent( e );
 }
-
 
 void QgsMapToolIdentifyAction::showIdentifyResults( const QList<IdentifyResult> &identifyResults )
 {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -790,8 +790,6 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     }
   }
 
-
-
   if ( QgsWkbTypes::isMultiType( wkbType ) )
   {
     QString str = QLocale().toString( static_cast<const QgsGeometryCollection *>( feature.geometry().constGet() )->numGeometries() );


### PR DESCRIPTION
## Description

In the project properties one can set desired units for elispoidal distance and area measurements, among other values it is possible to select "Map units (…)". When the "Map units(…)" value is selected, some of the "Derived" identify values, namely ellipsoidal area and perimeter does not have units text after the value.

This is because in the project properties "Map units(…)" is represented as an unknown unit (`Qgis::DistanceUnit::Unknown` and `Qgis::AreaUnit::Unknown`). As a result, `displayDistanceUnits()` and `displayAreaUnits()` method of the identify action return empty string. This also affects conversion of area and perimeter measurements in identify tool.

Fixes #26995.