### PR TITLE
[themes] Revert commit 7ff0fd6 to fix CSS errors spamming console

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -63,16 +63,13 @@ QMenuBar::item:pressed
 /* ==================================================================================== */
 
 QAbstractSpinBox {
-    padding: 0em;
-    border-width: 1px;
-    border-color: @itemdarkbackground;
-    border-style: solid;
+    padding: 0.12em;
+    border: 1px solid @itemdarkbackground;
     border-radius: 0.2em;
     background-color:@itembackground;
     selection-background-color: @selection;
     selection-color: @itemdarkbackground;
     color: @text;
-    contents-margin: 0.12em;
 }
 
 QAbstractSpinBox:no-frame {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -62,13 +62,12 @@ QMenuBar::item:pressed
 /* ==================================================================================== */
 
 QAbstractSpinBox {
-    padding: 0em;
+    padding: 0.12em;
     border: 1px solid @itemdarkbackground;
     background-color: @itembackground;
     selection-background-color: @selection;
     selection-color: @textlight;
     color: @textlight;
-    contents-margin: 0.12em;
 }
 
 QAbstractSpinBox:no-frame {


### PR DESCRIPTION
## Description

This PR reverts https://github.com/qgis/QGIS/pull/55652 as 'contents-margin' is not a supported property key. In turn, using an unsupported key was spamming the console with warnings, making it much harder to catch important warnings/errors.

The change also led to much shorter spinboxes which don't look harmonized went standing next to line edit / editable combo box / etc.

@AlisterH , we should explore alternative ways to fix the clipped spin boxes. I'm wondering whether you could try to tweak the padding value (e.g. try padding: 0.10em , 0.15em, etc.) to see if you can reach the sweet spot there. Also try to check whether the problem is there if you remove / tweak the border-radius value.