### PR TITLE
[processing][ui] When adding multiple layers via 'add directory', skip sidecar DBF files of shapefile datasets

### DIFF
--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -395,6 +395,21 @@ void QgsProcessingMultipleInputPanelWidget::addDirectory()
   while ( it.hasNext() )
   {
     const QString fullPath = it.next();
+    if ( fullPath.endsWith( QLatin1String( ".dbf" ), Qt::CaseInsensitive ) )
+    {
+      if ( QFileInfo::exists( QStringLiteral( "%1.shp" ).arg( fullPath.chopped( 4 ) ) ) ||
+           QFileInfo::exists( QStringLiteral( "%1.SHP" ).arg( fullPath.chopped( 4 ) ) ) )
+      {
+        // Skip DBFs that are sidecar files to a Shapefile
+        continue;
+      }
+    }
+    else if ( fullPath.endsWith( QLatin1String( ".aux.xml" ), Qt::CaseInsensitive ) ||
+              fullPath.endsWith( QLatin1String( ".shp.xml" ), Qt::CaseInsensitive ) )
+    {
+      // Skip XMLs that are sidecar files  to datasets
+      continue;
+    }
     addOption( fullPath, fullPath, true );
   }
   emit selectionChanged();


### PR DESCRIPTION
## Description

This PR fixes  #56010 by adding some logic to avoid adding sidecar files to datasets in the processing multiple input panel widget's addDirectory() function.

Without the PR:
![image](https://github.com/qgis/QGIS/assets/1728657/a1bf29a1-02b5-4c27-8b0c-2fb6f15f2b0e)

With the PR:
![image](https://github.com/qgis/QGIS/assets/1728657/a77b947d-fcd5-437b-b240-398e0ea17e58)

