### PR TITLE
Backport 55959 to release 3 34

### DIFF
--- a/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -44,6 +44,13 @@ widget to customize the searches performed by its :py:func:`~QgsLocatorWidget.lo
 as prioritizing results which are near the current canvas extent.
 %End
 
+    void setPlaceholderText( const QString  &text );
+%Docstring
+Set placeholder ``text`` for the line edit.
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void search( const QString &string );

--- a/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -48,7 +48,7 @@ as prioritizing results which are near the current canvas extent.
 %Docstring
 Set placeholder ``text`` for the line edit.
 
-.. versionadded:: 3.36
+.. versionadded:: 3.34
 %End
 
   public slots:

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -150,6 +150,11 @@ void QgsLocatorWidget::setMapCanvas( QgsMapCanvas *canvas )
   }
 }
 
+void QgsLocatorWidget::setPlaceholderText( const QString &text )
+{
+  mLineEdit->setPlaceholderText( text );
+}
+
 void QgsLocatorWidget::search( const QString &string )
 {
   window()->activateWindow(); // window must also be active - otherwise floating docks can steal keystrokes

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -68,7 +68,7 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
 
     /**
      * \brief Set placeholder \a text for the line edit.
-     * \since QGIS 3.36
+     * \since QGIS 3.34
      */
     void setPlaceholderText( const QString  &text );
 

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -66,6 +66,12 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
      */
     void setMapCanvas( QgsMapCanvas *canvas );
 
+    /**
+     * \brief Set placeholder \a text for the line edit.
+     * \since QGIS 3.36
+     */
+    void setPlaceholderText( const QString  &text );
+
   public slots:
 
     /**


### PR DESCRIPTION
## Description

Backport of https://github.com/qgis/QGIS/pull/55959 failed because of create PyQt6 sip file.

This remove the created sip file python/PyQt6/gui/auto_generated/locator/qgslocatorwidget.sip.in and update the since QGIS for 3.34.