### PR TITLE
feat(QgsLocatorWidget): define anchors for result container

### DIFF
--- a/python/PyQt6/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -51,6 +51,13 @@ Set placeholder ``text`` for the line edit.
 .. versionadded:: 3.36
 %End
 
+    void setResultContainerAnchors( QgsFloatingWidget::AnchorPoint anchorPoint, QgsFloatingWidget::AnchorPoint anchorWidgetPoint );
+%Docstring
+Sets the result container ``anchorPoint`` and ``anchorWidgetPoint`` position.
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void search( const QString &string );

--- a/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -51,6 +51,13 @@ Set placeholder ``text`` for the line edit.
 .. versionadded:: 3.36
 %End
 
+    void setResultContainerAnchors( QgsFloatingWidget::AnchorPoint anchorPoint, QgsFloatingWidget::AnchorPoint anchorWidgetPoint );
+%Docstring
+Sets the result container ``anchorPoint`` and ``anchorWidgetPoint`` position.
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void search( const QString &string );

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -155,6 +155,12 @@ void QgsLocatorWidget::setPlaceholderText( const QString &text )
   mLineEdit->setPlaceholderText( text );
 }
 
+void QgsLocatorWidget::setResultContainerAnchors( QgsFloatingWidget::AnchorPoint anchorPoint, QgsFloatingWidget::AnchorPoint anchorWidgetPoint )
+{
+  mResultsContainer->setAnchorPoint( anchorPoint );
+  mResultsContainer->setAnchorWidgetPoint( anchorWidgetPoint );
+}
+
 void QgsLocatorWidget::search( const QString &string )
 {
   window()->activateWindow(); // window must also be active - otherwise floating docks can steal keystrokes

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -72,6 +72,13 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
      */
     void setPlaceholderText( const QString  &text );
 
+    /**
+     * Sets the result container \a anchorPoint and \a anchorWidgetPoint position.
+     *
+     * \since QGIS 3.36
+     */
+    void setResultContainerAnchors( QgsFloatingWidget::AnchorPoint anchorPoint, QgsFloatingWidget::AnchorPoint anchorWidgetPoint );
+
   public slots:
 
     /**


### PR DESCRIPTION
## Description
This PR add this new API to `QgsLocatorWidget` :
```cpp
void setResultContainerAnchors( QgsFloatingWidget::AnchorPoint anchorPoint, QgsFloatingWidget::AnchorPoint anchorWidgetPoint );
```

This is needed to add `QgsLocatorWidget` in a toolbar and have correct result display with:
```python
locator_widget.setResultContainerAnchors(
            QgsFloatingWidget.AnchorPoint.TopLeft,
            QgsFloatingWidget.AnchorPoint.BottomLeft
)
```

![image](https://github.com/qgis/QGIS/assets/53606373/8d83bfc2-96d0-401d-8819-aed8b92eb2aa)


Instead of:

![image](https://github.com/qgis/QGIS/assets/53606373/374a6d25-702e-4015-a722-069ad955463e)

This feature is added for Grand Lyon Metropole and a [plugin for feature localization](https://gitlab.com/Oslandia/qgis/locator-grand-lyon) (WIP)