### PR TITLE
SERVER: fix getlegendgraphic with colorramp & JSON

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnode.sip.in
@@ -55,6 +55,8 @@ Constructor for QgsColorRampLegendNode.
 
     virtual QSizeF drawSymbolText( const QgsLegendSettings &settings, ItemContext *ctx, QSizeF symbolSize ) const;
 
+    virtual QJsonObject exportSymbolToJson( const QgsLegendSettings &settings, const QgsRenderContext &context ) const;
+
 
     void setIconSize( QSize size );
 %Docstring

--- a/python/core/auto_generated/layertree/qgscolorramplegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgscolorramplegendnode.sip.in
@@ -55,6 +55,8 @@ Constructor for QgsColorRampLegendNode.
 
     virtual QSizeF drawSymbolText( const QgsLegendSettings &settings, ItemContext *ctx, QSizeF symbolSize ) const;
 
+    virtual QJsonObject exportSymbolToJson( const QgsLegendSettings &settings, const QgsRenderContext &context ) const;
+
 
     void setIconSize( QSize size );
 %Docstring

--- a/src/core/layertree/qgscolorramplegendnode.cpp
+++ b/src/core/layertree/qgscolorramplegendnode.cpp
@@ -25,6 +25,7 @@
 #include "qgsnumericformat.h"
 
 #include <QPalette>
+#include <QBuffer>
 
 QgsColorRampLegendNode::QgsColorRampLegendNode( QgsLayerTreeLayer *nodeLayer, QgsColorRamp *ramp, const QString &minimumLabel, const QString &maximumLabel, QObject *parent )
   : QgsLayerTreeModelLegendNode( nodeLayer, parent )
@@ -475,4 +476,29 @@ QSizeF QgsColorRampLegendNode::drawSymbolText( const QgsLegendSettings &settings
   }
 
   return QSizeF( textWidth, textHeight );
+}
+
+QJsonObject QgsColorRampLegendNode::exportSymbolToJson( const QgsLegendSettings &settings, const QgsRenderContext &context ) const
+{
+  Q_UNUSED( settings );
+  Q_UNUSED( context );
+
+  QJsonObject json;
+
+  const QPixmap icon = data( Qt::DecorationRole ).value<QPixmap>();
+
+  if ( ! icon.isNull() )
+  {
+    const QImage image( icon.toImage() );
+    QByteArray byteArray;
+    QBuffer buffer( &byteArray );
+    image.save( &buffer, "PNG" );
+    const QString base64 = QString::fromLatin1( byteArray.toBase64().data() );
+    json[ QStringLiteral( "icon" ) ] = base64;
+  }
+
+  json [ QStringLiteral( "min" ) ] = mMinimumValue;
+  json [ QStringLiteral( "max" ) ] = mMaximumValue;
+
+  return json;
 }

--- a/src/core/layertree/qgscolorramplegendnode.h
+++ b/src/core/layertree/qgscolorramplegendnode.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsColorRampLegendNode : public QgsLayerTreeModelLegendNode
     QVariant data( int role ) const override;
     QSizeF drawSymbol( const QgsLegendSettings &settings, ItemContext *ctx, double itemHeight ) const override;
     QSizeF drawSymbolText( const QgsLegendSettings &settings, ItemContext *ctx, QSizeF symbolSize ) const override;
+    QJsonObject exportSymbolToJson( const QgsLegendSettings &settings, const QgsRenderContext &context ) const override;
 
     /**
      * Set the icon \a size, which controls how large the ramp will render in a layer tree widget.

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -37,12 +37,17 @@ from qgis.core import (
     QgsMarkerSymbol,
     QgsRuleBasedRenderer,
     QgsVectorLayer,
+    QgsRasterLayer,
 )
 
 from qgis.server import (
     QgsBufferServerRequest,
     QgsBufferServerResponse,
     QgsServer,
+)
+
+from utilities import (
+    unitTestDataPath,
 )
 
 # Strip path and content length because path may vary
@@ -1473,6 +1478,31 @@ class TestQgsServerWMSGetLegendGraphic(TestQgsServerWMSTestBase):
         j = json.loads(bytes(response.body()))
         node = j
         self.assertEqual(node['icon'], icon)
+
+    def test_wms_GetLegendGraphic_JSON_raster_color_ramp(self):
+        """Test raster color ramp legend in JSON format"""
+
+        project = QgsProject()
+
+        path = os.path.join(unitTestDataPath('raster'),
+                            'byte.tif')
+
+        layer = QgsRasterLayer(path, "layer1")
+        self.assertTrue(layer.isValid())
+        project.addMapLayers([layer])
+
+        server = QgsServer()
+        request = QgsBufferServerRequest("/?SERVICE=WMS&VERSION=1.30&REQUEST=GetLegendGraphic" +
+                                         "&LAYERS=layer1" +
+                                         "&FORMAT=application/json")
+        response = QgsBufferServerResponse()
+        server.handleRequest(request, response, project)
+        j = json.loads(bytes(response.body()))
+        node = j
+        self.assertEqual(node['nodes'][0]['symbols'][0]['title'], 'Band 1 (Gray)')
+        self.assertEqual(node['nodes'][0]['symbols'][1]['max'], 255)
+        self.assertEqual(node['nodes'][0]['symbols'][1]['min'], 74)
+        self.assertNotEqual(node['nodes'][0]['symbols'][1]['icon'], '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #55651


Sample output for a typical raster:


```json
{
   "nodes":[
      {
         "symbols":[
            {
               "title":"Band 1 (Red)"
            },
            {
               "icon":"iVBORw0K...........",
               "max":255,
               "min":1,
               "title":""
            }
         ],
         "title":"bluemarble",
         "type":"layer"
      }
   ],
   "title":""
}
```