### PR TITLE
Control visibility of layout item in list by key_space

### DIFF
--- a/src/gui/layout/qgslayoutitemslistview.cpp
+++ b/src/gui/layout/qgslayoutitemslistview.cpp
@@ -119,6 +119,30 @@ void QgsLayoutItemsListView::setCurrentLayout( QgsLayout *layout )
   connect( selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsLayoutItemsListView::updateSelection );
 }
 
+void QgsLayoutItemsListView::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_Space )
+  {
+    const auto constSelectedIndexes = selectionModel()->selectedIndexes();
+    if ( !constSelectedIndexes.isEmpty() )
+    {
+      const bool isFirstItemVisible = mModel->itemFromIndex( constSelectedIndexes[0] )->isVisible();
+
+      for ( const QModelIndex &index : constSelectedIndexes )
+      {
+        if ( QgsLayoutItem *item = mModel->itemFromIndex( index ) )
+        {
+          item->setVisibility( !isFirstItemVisible );
+        }
+      }
+      //return here, because otherwise it will just invert visibility for each item instead setting all the same
+      return;
+    }
+  }
+
+  QTreeView::keyPressEvent( event );
+}
+
 void QgsLayoutItemsListView::updateSelection()
 {
   // Do nothing if we are currenlty updating the selection

--- a/src/gui/layout/qgslayoutitemslistview.h
+++ b/src/gui/layout/qgslayoutitemslistview.h
@@ -83,6 +83,9 @@ class GUI_EXPORT QgsLayoutItemsListView : public QTreeView
     //! Sets the current layout
     void setCurrentLayout( QgsLayout *layout );
 
+  protected:
+    void keyPressEvent( QKeyEvent *event ) override;
+
   private slots:
 
     void showContextMenu( QPoint point );


### PR DESCRIPTION
## Description

Set visibility of layout items by pressing the space bar. It concerns as well item-groups and it sets the visibility status according to the first selected item.

![visibility](https://github.com/qgis/QGIS/assets/28384354/35f8fd15-682d-4e00-a34e-8364cdadec2c)

This was not possible before. Before we had to select the specific cell where the checkbox was drawn (I belief this was more coincidentally):

| before | after |
|---|---|
| ![reg_before](https://github.com/qgis/QGIS/assets/28384354/de33f609-4a4c-4e95-8880-5d342f0c4842) | ![reg_after](https://github.com/qgis/QGIS/assets/28384354/f52ba7bd-0287-4c42-ae2c-b16773817a74) |

I noticed that on pressing delete there is a behavior with groups I don't know if it's on purpose. Anyway, with the visibility it's *not* like this. With space we set the visibility of the current item no matter if it's in a group or not. If it's a group we set the children accordingly. See the IMO weird behavior with delete (not part of this PR):

![reg_delete](https://github.com/qgis/QGIS/assets/28384354/bee78d18-9870-4e55-9966-3ed50e3c06b0)
