### PR TITLE
Correctly add int types to flag style enum classes

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsprojectstylesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectstylesettings.sip.in
@@ -310,7 +310,7 @@ A proxy model for filtering QgsProjectStyleDatabaseModel.
 %End
   public:
 
-    enum class Filter
+    enum class Filter /BaseType=IntFlag/
     {
       FilterHideReadOnly,
     };

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -231,7 +231,7 @@ The development version
       UnknownCount,
     };
 
-    enum class VectorDataProviderAttributeEditCapability
+    enum class VectorDataProviderAttributeEditCapability /BaseType=IntFlag/
     {
       EditAlias,
       EditComment,

--- a/python/PyQt6/core/auto_generated/qgsmapsettingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmapsettingsutils.sip.in
@@ -23,7 +23,7 @@ Utilities for map settings.
 %End
   public:
 
-    enum class EffectsCheckFlag
+    enum class EffectsCheckFlag /BaseType=IntFlag/
     {
       IgnoreGeoPdfSupportedEffects,
     };

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -25,7 +25,7 @@ custom labeling.
 %End
   public:
 
-    enum class Flag
+    enum class Flag /BaseType=IntFlag/
     {
       FlagUsesLineSymbol,
       FlagUsesFillSymbol,

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1368,8 +1368,7 @@ while ($LINE_IDX < $LINE_COUNT){
         $py_flag =~ s/::/./;
 
         if ( any { $_ eq $py_flag } @ENUM_CLASS_NON_INT_TYPES ){
-          # TODO: Clear existing errors and then enable:
-          # exit_with_error("$flag is a flags type, but was not declared with int type. Add ': int' to the enum class declaration line");
+          exit_with_error("$flag is a flags type, but was not declared with int type. Add ': int' to the enum class declaration line");
         }
         elsif ( none { $_ eq $py_flag } @ENUM_INT_TYPES ){
           if ( $is_qt6 ) {

--- a/src/core/project/qgsprojectstylesettings.h
+++ b/src/core/project/qgsprojectstylesettings.h
@@ -375,7 +375,7 @@ class CORE_EXPORT QgsProjectStyleDatabaseProxyModel : public QSortFilterProxyMod
   public:
 
     //! Available filter flags for filtering the model
-    enum class Filter
+    enum class Filter : int
     {
       FilterHideReadOnly = 1 << 0, //!< Hide read-only style databases
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -344,7 +344,7 @@ class CORE_EXPORT Qgis
      *
      * \since QGIS 3.32
      */
-    enum class VectorDataProviderAttributeEditCapability
+    enum class VectorDataProviderAttributeEditCapability : int
     {
       EditAlias = 1 << 0, //!< Allows editing aliases
       EditComment = 1 << 1, //!< Allows editing comments

--- a/src/core/qgsmapsettingsutils.h
+++ b/src/core/qgsmapsettingsutils.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsMapSettingsUtils
      * Flags for controlling the behavior of containsAdvancedEffects()
      * \since QGIS 3.14
      */
-    enum class EffectsCheckFlag
+    enum class EffectsCheckFlag : int
     {
       IgnoreGeoPdfSupportedEffects = 1 << 0, //!< Ignore advanced effects which are supported in GeoPDF exports
     };

--- a/src/core/scalebar/qgsscalebarrenderer.h
+++ b/src/core/scalebar/qgsscalebarrenderer.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsScaleBarRenderer
      * Flags which control scalebar renderer behavior.
      * \since QGIS 3.14
      */
-    enum class Flag
+    enum class Flag : int
     {
       FlagUsesLineSymbol = 1 << 0, //!< Renderer utilizes the scalebar line symbol (see QgsScaleBarSettings::lineSymbol() )
       FlagUsesFillSymbol = 1 << 1, //!< Renderer utilizes the scalebar fill symbol (see QgsScaleBarSettings::fillSymbol() )


### PR DESCRIPTION
As a result sip6 correctly maps these across to IntFlag style python Enums, so things just work as expected.