### PR TITLE
Enable draco support on MSYS2/MinGW-w64

### DIFF
--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -88,6 +88,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DPython_EXECUTABLE=${MINGW_PREFIX}/bin/python \
             -DWITH_3D=ON \
+            -DWITH_DRACO=ON \
             -DWITH_PDAL=OFF \
             -DWITH_CUSTOM_WIDGETS=ON \
             -DWITH_QWTPOLAR=OFF \

--- a/.github/workflows/mingw-w64-msys2.yml
+++ b/.github/workflows/mingw-w64-msys2.yml
@@ -48,10 +48,10 @@ jobs:
           msystem: UCRT64
           install: base-devel
           pacboy: >-
-            protobuf:p gdal:p libzip:p qca-qt5:p gsl:p exiv2:p hdf5:p libxml2:p netcdf:p opencl-icd:p
-            pdal:p proj:p qt5-3d:p qt5-base:p qt5-declarative:p qt5-gamepad:p qt5-location:p
-            qt5-serialport:p qt5-svg:p qtkeychain-qt5:p qtwebkit:p qscintilla-qt5:p qwt-qt5:p
-            spatialindex:p cc:p cmake:p ninja:p opencl-clhpp:p qt5-tools:p python:p ccache:p
+            draco:p exiv2:p gdal:p gsl:p hdf5:p libxml2:p libzip:p netcdf:p opencl-icd:p pdal:p
+            protobuf:p proj:p qca-qt5:p qscintilla-qt5:p qt5-3d:p qt5-base:p qt5-declarative:p
+            qt5-gamepad:p qt5-location:p qt5-serialport:p qt5-svg:p qtkeychain-qt5:p qtwebkit:p
+            qwt-qt5:p spatialindex:p cc:p cmake:p ninja:p opencl-clhpp:p qt5-tools:p python:p ccache:p
           update: true
           release: false
 
@@ -93,7 +93,6 @@ jobs:
             -DWITH_QWTPOLAR=OFF \
             -DWITH_BINDINGS=OFF \
             -DWITH_GRASS=OFF \
-            -DWITH_DRACO=OFF \
             -DUSE_CCACHE=ON \
             -S . \
             -B build


### PR DESCRIPTION
## Description

Enable draco support on MSYS2/MinGW-w64, as the package is now available in their repos.

The packages were just reordered alphabetically.