### PR TITLE
[ui] Fix bad, pixelated QGIS logo in user profile selector dialog on high DPI screens

### DIFF
--- a/src/ui/qgsuserprofileselectiondialog.ui
+++ b/src/ui/qgsuserprofileselectiondialog.ui
@@ -79,20 +79,30 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="pixmap">
-      <pixmap resource="../../images/images.qrc">:/images/icons/qgis-icon-60x60.png</pixmap>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="maximumSize">
+       <size>
+         <width>100</width>
+         <height>100</height>
+       </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../images/images.qrc">:/images/icons/qgis_icon.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QLabel" name="label">


### PR DESCRIPTION
## Description

Before (left) vs fix (right):
![image](https://github.com/qgis/QGIS/assets/1728657/f05bbab3-82b7-40c2-9aa1-146c2f790090)

Because first impressions are everything.