### PR TITLE
show warning if width or height of exported image is larger than QPainter limit (refs #41045)

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -161,6 +161,7 @@ void QgsMapSaveDialog::updateDpi( int dpi )
   mDpi = dpi;
 
   updateOutputSize();
+  checkOutputSize();
 }
 
 void QgsMapSaveDialog::updateOutputWidth( int width )
@@ -187,6 +188,8 @@ void QgsMapSaveDialog::updateOutputWidth( int width )
   }
 
   whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+
+  checkOutputSize();
 }
 
 void QgsMapSaveDialog::updateOutputHeight( int height )
@@ -213,6 +216,8 @@ void QgsMapSaveDialog::updateOutputHeight( int height )
   }
 
   whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+
+  checkOutputSize();
 }
 
 void QgsMapSaveDialog::updateExtent( const QgsRectangle &extent )
@@ -244,6 +249,7 @@ void QgsMapSaveDialog::updateExtent( const QgsRectangle &extent )
     mSize.setHeight( mSize.height() * extent.height() / mExtent.height() );
   }
   updateOutputSize();
+  checkOutputSize();
 
   mExtent = extent;
   if ( mLockAspectRatio->locked() )
@@ -268,6 +274,15 @@ void QgsMapSaveDialog::updateOutputSize()
 {
   whileBlocking( mOutputWidthSpinBox )->setValue( mSize.width() );
   whileBlocking( mOutputHeightSpinBox )->setValue( mSize.height() );
+}
+
+void QgsMapSaveDialog::checkOutputSize()
+{
+  // check if image size does not exceed QPainter limitation https://doc.qt.io/qt-5/qpainter.html#limitations
+  if ( mSize.width() > 32768 || mSize.height() > 32768 )
+  {
+    mMessageBar->pushWarning( tr( "Save as image" ), tr( "Image width or height is larger than 32768 pixels. Output raster will be truncated." ) );
+  }
 }
 
 QgsRectangle QgsMapSaveDialog::extent() const

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -281,7 +281,7 @@ void QgsMapSaveDialog::checkOutputSize()
   // check if image size does not exceed QPainter limitation https://doc.qt.io/qt-5/qpainter.html#limitations
   if ( mSize.width() > 32768 || mSize.height() > 32768 )
   {
-    mMessageBar->pushWarning( tr( "Save as image" ), tr( "Image width or height is larger than 32768 pixels. Output raster will be truncated." ) );
+    mMessageBar->pushWarning( tr( "Save as image" ), tr( "Output raster will be truncated, as image width or height is larger than 32768 pixels." ) );
   }
 }
 

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -281,7 +281,7 @@ void QgsMapSaveDialog::checkOutputSize()
   // check if image size does not exceed QPainter limitation https://doc.qt.io/qt-5/qpainter.html#limitations
   if ( mSize.width() > 32768 || mSize.height() > 32768 )
   {
-    mMessageBar->pushWarning( tr( "Save as image" ), tr( "Output raster will be truncated, as image width or height is larger than 32768 pixels." ) );
+    mMessageBar->pushWarning( QString(), tr( "Output will be truncated, as image width or height is larger than 32768 pixels." ) );
   }
 }
 

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -92,6 +92,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
 
     void lockChanged( bool locked );
     void copyToClipboard();
+    void checkOutputSize();
 
     void updateDpi( int dpi );
     void updateOutputWidth( int width );

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -15,6 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QgsMessageBar" name="mMessageBar">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
@@ -399,6 +409,12 @@ Rasterizing the map is recommended when such effects are used.</string>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
    <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QFrame</extends>
+   <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
## Description

When exporting a map to an image via "Project → Import/Export→ Export Map to Image" user can get a truncated output if image width or height hits `QPainter` limits. To make uses aware about this issue and give them a chance to adjust output image dimensions this PR adds a warning message bar to the "Export Map to Image" dialog.

![warning](https://github.com/qgis/QGIS/assets/776954/52721b03-ec61-4b2f-bffe-36a9478fcb08)

Refs #41045.