### PR TITLE
pass color ramp name to the color ramp transformer to generate correct expression (fix #48889)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
@@ -640,7 +640,7 @@ Constructor for QgsColorRampTransformer.
 :param maxValue: maximum expected value
 :param ramp: source color ramp. Ownership is transferred to the transformer.
 :param nullColor: color to return for null values
-:param rampName: name of the source color ramp
+:param rampName: name of the source color ramp (since QGIS 3.36)
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );

--- a/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
@@ -631,7 +631,8 @@ color ramp.
     QgsColorRampTransformer( double minValue = 0.0,
                              double maxValue = 1.0,
                              QgsColorRamp *ramp /Transfer/ = 0,
-                             const QColor &nullColor = QColor( 0, 0, 0, 0 ) );
+                             const QColor &nullColor = QColor( 0, 0, 0, 0 ),
+                             const QString &rampName = QString() );
 %Docstring
 Constructor for QgsColorRampTransformer.
 
@@ -639,6 +640,7 @@ Constructor for QgsColorRampTransformer.
 :param maxValue: maximum expected value
 :param ramp: source color ramp. Ownership is transferred to the transformer.
 :param nullColor: color to return for null values
+:param rampName: name of the source color ramp
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );

--- a/python/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/core/auto_generated/qgspropertytransformer.sip.in
@@ -640,7 +640,7 @@ Constructor for QgsColorRampTransformer.
 :param maxValue: maximum expected value
 :param ramp: source color ramp. Ownership is transferred to the transformer.
 :param nullColor: color to return for null values
-:param rampName: name of the source color ramp
+:param rampName: name of the source color ramp (since QGIS 3.36)
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );

--- a/python/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/core/auto_generated/qgspropertytransformer.sip.in
@@ -631,7 +631,8 @@ color ramp.
     QgsColorRampTransformer( double minValue = 0.0,
                              double maxValue = 1.0,
                              QgsColorRamp *ramp /Transfer/ = 0,
-                             const QColor &nullColor = QColor( 0, 0, 0, 0 ) );
+                             const QColor &nullColor = QColor( 0, 0, 0, 0 ),
+                             const QString &rampName = QString() );
 %Docstring
 Constructor for QgsColorRampTransformer.
 
@@ -639,6 +640,7 @@ Constructor for QgsColorRampTransformer.
 :param maxValue: maximum expected value
 :param ramp: source color ramp. Ownership is transferred to the transformer.
 :param nullColor: color to return for null values
+:param rampName: name of the source color ramp
 %End
 
     QgsColorRampTransformer( const QgsColorRampTransformer &other );

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -892,6 +892,3 @@ bool QgsProperty::convertToTransformer()
     setExpressionString( baseExpression );
   return true;
 }
-
-
-

--- a/src/core/qgspropertytransformer.cpp
+++ b/src/core/qgspropertytransformer.cpp
@@ -525,10 +525,12 @@ QgsSizeScaleTransformer *QgsSizeScaleTransformer::fromExpression( const QString 
 
 QgsColorRampTransformer::QgsColorRampTransformer( double minValue, double maxValue,
     QgsColorRamp *ramp,
-    const QColor &nullColor )
+    const QColor &nullColor,
+    const QString &rampName )
   : QgsPropertyTransformer( minValue, maxValue )
   , mGradientRamp( ramp )
   , mNullColor( nullColor )
+  , mRampName( rampName )
 {
 
 }

--- a/src/core/qgspropertytransformer.h
+++ b/src/core/qgspropertytransformer.h
@@ -615,7 +615,7 @@ class CORE_EXPORT QgsColorRampTransformer : public QgsPropertyTransformer
      * \param maxValue maximum expected value
      * \param ramp source color ramp. Ownership is transferred to the transformer.
      * \param nullColor color to return for null values
-     * \param rampName name of the source color ramp
+     * \param rampName name of the source color ramp (since QGIS 3.36)
      */
     QgsColorRampTransformer( double minValue = 0.0,
                              double maxValue = 1.0,

--- a/src/core/qgspropertytransformer.h
+++ b/src/core/qgspropertytransformer.h
@@ -615,11 +615,13 @@ class CORE_EXPORT QgsColorRampTransformer : public QgsPropertyTransformer
      * \param maxValue maximum expected value
      * \param ramp source color ramp. Ownership is transferred to the transformer.
      * \param nullColor color to return for null values
+     * \param rampName name of the source color ramp
      */
     QgsColorRampTransformer( double minValue = 0.0,
                              double maxValue = 1.0,
                              QgsColorRamp *ramp SIP_TRANSFER = nullptr,
-                             const QColor &nullColor = QColor( 0, 0, 0, 0 ) );
+                             const QColor &nullColor = QColor( 0, 0, 0, 0 ),
+                             const QString &rampName = QString() );
 
     //! Copy constructor
     QgsColorRampTransformer( const QgsColorRampTransformer &other );

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -498,7 +498,8 @@ QgsColorRampTransformer *QgsPropertyColorAssistantWidget::createTransformer( dou
     minValue,
     maxValue,
     mColorRampButton->colorRamp(),
-    mNullColorButton->color() );
+    mNullColorButton->color(),
+    mColorRampButton->colorRampName() );
   return transformer;
 }
 


### PR DESCRIPTION
## Description

When configuting data-defined color using Assistant dialog/widget generated expression uses "custom ramp" instead of actual color ramp name. This happens because color ramp name is never passed to the `QgsColorRampTransformer` object.

Fixes #48889.