### PR TITLE
Allow creating shared PostgreSQL connections for the connection pool

### DIFF
--- a/src/providers/postgres/qgspostgresconnpool.h
+++ b/src/providers/postgres/qgspostgresconnpool.h
@@ -27,7 +27,7 @@ inline QString qgsConnectionPool_ConnectionToName( QgsPostgresConn *c )
 
 inline void qgsConnectionPool_ConnectionCreate( const QString &connInfo, QgsPostgresConn *&c )
 {
-  c = QgsPostgresConn::connectDb( connInfo, true, false );
+  c = QgsPostgresConn::connectDb( connInfo, true, true );
 }
 
 inline void qgsConnectionPool_ConnectionDestroy( QgsPostgresConn *c )


### PR DESCRIPTION
Takes down number of postgisVersion calls to 1.
Closes GH-47391

@elpaso @jef-n do you see any reason for not doing this ? I confirm it reduces number of connections used by DBManager down to 1