### PR TITLE
WIP: Deprecate QgsPostgresConn::connectDb

### DIFF
--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -233,8 +233,10 @@ class QgsPostgresConn : public QObject
      * \param allowRequestCredentials allow credentials request through current QgsCredentials instance if the provided ones are not valid
      *
      * \returns the PostgreSQL connection
+     *
+     * \deprecated Use QgsPostgresConnPool
      */
-    static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false, bool allowRequestCredentials = true );
+    Q_DECL_DEPRECATED static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false, bool allowRequestCredentials = true );
 
     /**
      * Get a new PostgreSQL connection

--- a/src/providers/postgres/qgspostgresconnpool.h
+++ b/src/providers/postgres/qgspostgresconnpool.h
@@ -27,7 +27,9 @@ inline QString qgsConnectionPool_ConnectionToName( QgsPostgresConn *c )
 
 inline void qgsConnectionPool_ConnectionCreate( const QString &connInfo, QgsPostgresConn *&c )
 {
+  Q_NOWARN_DEPRECATED_PUSH
   c = QgsPostgresConn::connectDb( connInfo, true, false );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 inline void qgsConnectionPool_ConnectionDestroy( QgsPostgresConn *c )


### PR DESCRIPTION
Connection to PostgreSQL should only be created via the connection pool, this deprecation allows doing that