### PR TITLE
Do not mark draft PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -90,4 +90,6 @@ jobs:
         days-before-issue-stale: 14
         days-before-issue-close: 28
 
+        exempt-draft-pr: true
+
         operations-per-run: 1000


### PR DESCRIPTION
Some developers (me included) use WIP pull requests to handle work at slow pace. Such pull requests should not consume reviewers times as the reviewers could just avoid reviewing work-in-progress PRs.

The fact that Stalebot closes those WIP PRs is frustrating, so this PR is aimed at preventing Stalebot from closing them.

See https://github.com/qgis/QGIS/pull/54902#issuecomment-1873378376
