### PR TITLE
Exclude virtualraster from processing raster input

### DIFF
--- a/python/PyQt6/analysis/auto_generated/processing/qgsnativealgorithms.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/qgsnativealgorithms.sip.in
@@ -39,6 +39,8 @@ Constructor for QgsNativeAlgorithms.
 
     virtual bool supportsNonFileBasedOutput() const;
 
+    virtual Flags flags() const;
+
 
   protected:
 

--- a/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
@@ -1,5 +1,6 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingprovider.h
 QgsProcessingProvider.FlagDeemphasiseSearchResults = QgsProcessingProvider.Flag.FlagDeemphasiseSearchResults
+QgsProcessingProvider.FlagCompatibleWithVirtualRaster = QgsProcessingProvider.Flag.FlagCompatibleWithVirtualRaster
 QgsProcessingProvider.Flags = lambda flags=0: QgsProcessingProvider.Flag(flags)
 def _force_int(v): return v if isinstance(v, int) else int(v.value)
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -28,6 +28,7 @@ to a common area of analysis.
     enum Flag
     {
       FlagDeemphasiseSearchResults,
+      FlagCompatibleWithVirtualRaster,
     };
     typedef QFlags<QgsProcessingProvider::Flag> Flags;
 

--- a/python/analysis/auto_generated/processing/qgsnativealgorithms.sip.in
+++ b/python/analysis/auto_generated/processing/qgsnativealgorithms.sip.in
@@ -39,6 +39,8 @@ Constructor for QgsNativeAlgorithms.
 
     virtual bool supportsNonFileBasedOutput() const;
 
+    virtual Flags flags() const;
+
 
   protected:
 

--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -28,6 +28,7 @@ to a common area of analysis.
     enum Flag
     {
       FlagDeemphasiseSearchResults,
+      FlagCompatibleWithVirtualRaster,
     };
     typedef QFlags<QgsProcessingProvider::Flag> Flags;
 

--- a/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
@@ -173,3 +173,6 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
 
     def supportsNonFileBasedOutput(self):
         return True
+
+    def flags(self):
+        return QgsProcessingProvider.Flag.FlagCompatibleWithVirtualRaster

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -275,6 +275,11 @@ bool QgsNativeAlgorithms::supportsNonFileBasedOutput() const
   return true;
 }
 
+QgsProcessingProvider::Flags QgsNativeAlgorithms::flags() const
+{
+  return QgsProcessingProvider::Flag::FlagCompatibleWithVirtualRaster;
+}
+
 void QgsNativeAlgorithms::loadAlgorithms()
 {
   const QgsScopedRuntimeProfile profile( QObject::tr( "QGIS native provider" ) );

--- a/src/analysis/processing/qgsnativealgorithms.h
+++ b/src/analysis/processing/qgsnativealgorithms.h
@@ -45,6 +45,7 @@ class ANALYSIS_EXPORT QgsNativeAlgorithms: public QgsProcessingProvider
     QString helpId() const override;
     QString name() const override;
     bool supportsNonFileBasedOutput() const override;
+    Flags flags() const override;
 
   protected:
 

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -45,6 +45,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     enum Flag
     {
       FlagDeemphasiseSearchResults = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
+      FlagCompatibleWithVirtualRaster = 1 << 2, //!< The processing provider's algorithms can work with QGIS virtualraster data provider. Since QGIS 3.36
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -190,12 +190,10 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
 
   mCombo->setExcludedProviders( QStringList() << QStringLiteral( "grass" ) ); // not sure if this is still required...
 
+  // Check compatibility with virtualraster data provider
   // see https://github.com/qgis/QGIS/issues/55890
-  // There is a chance that "qgis" algorithms can handle virtual rasters but other almost certainly cannot
-  // so we exclude them from the list of available layers for processing algorithms
-  const QStringList providersCompatibleWithVirtualRaster {{ QStringLiteral( "qgis" ), QStringLiteral( "native" ) }};
   if ( mayBeRaster &&
-       ( ! mParameter->provider() || ! providersCompatibleWithVirtualRaster.contains( mParameter->provider()->id() ) ) )
+       ( ! mParameter->provider() || ! mParameter->provider()->flags().testFlag( QgsProcessingProvider::Flag::FlagCompatibleWithVirtualRaster ) ) )
   {
     mCombo->setExcludedProviders( mCombo->excludedProviders() << QStringLiteral( "virtualraster" ) );
   }

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -35,14 +35,8 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QgsScrollArea" name="scrollArea">
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAsNeeded</enum>
-       </property>
-       <property name="widgetResizable">
+      <widget class="QgsScrollArea" name="scrollArea" native="true">
+       <property name="widgetResizable" stdset="0">
         <bool>true</bool>
        </property>
        <widget class="QWidget" name="scrollAreaWidgetContents">
@@ -50,7 +44,7 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>650</width>
+          <width>806</width>
           <height>808</height>
          </rect>
         </property>
@@ -256,6 +250,9 @@
               </item>
               <item row="0" column="0" colspan="4">
                <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: the result raster will not be usable with any processing algorithm that expects a materialized raster.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>
                 </property>
@@ -664,6 +661,11 @@
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QWidget</extends>
+   <header>qgsscrollarea.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
Also add a tooltip.

Fixes #55890

There is a chance that "qgis" and "native" algorithms can handle virtual rasters but other almost certainly cannot
so we exclude them from the list of available layers for processing algorithms