### PR TITLE
Allow more space, and resizing for form. Fixes #55817

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1770,6 +1770,8 @@ void QgsAttributeForm::init()
             {
               tabWidget = new QgsTabWidget();
               layout->addWidget( tabWidget, row, column, 1, 2 );
+              // Use row stretch to allocate more vertical space for tab widget.
+              layout->setRowStretch( row, 2 );
               column += 2;
             }
 


### PR DESCRIPTION
## Description

I used `setRowStretch` to allocate more space to the tab widget. It now stretches out to display the contents of the form. It also dynamically changes size when resizing the parent window. When reducing the parent window's size, scroll bars appear so that the widget can still be viewed/edited entirely by the user.

![qgis-form](https://github.com/qgis/QGIS/assets/86184519/257a00cb-dc42-4eed-88dc-06618a6d2ae9)
