### PR TITLE
Manually patch in Qgis.FeatureCountState on qt 6 builds

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -109,13 +109,11 @@ PyQgsProviderConnectionModel
 PyQgsProviderConnectionGpkg
 PyQgsProviderConnectionSpatialite
 PyQgsSensorModel
-PyQgsProviderSublayerDetails
 PyQgsRasterAttributeTable
 PyQgsRasterAttributeTableModel
 PyQgsRasterLayer
 PyQgsRasterLayerRenderer
 PyQgsRasterPipe
-PyQgsProviderUtils
 PyQgsShapefileProvider
 PyQgsTextRenderer
 PyQgsOGRProvider

--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -24,6 +24,8 @@ __copyright__ = '(C) 2014, Nathan Woodrow'
 from qgis.PyQt.QtCore import NULL
 from qgis._core import *
 
+from enum import IntEnum
+
 @MONKEYPATCH_INJECTIONS@
 
 from .additions.edit import edit, QgsEditError
@@ -159,3 +161,24 @@ PROJECT_SCALES = Qgis.defaultProjectScales()
 GEOPROJ4 = geoProj4()
 GEO_EPSG_CRS_AUTHID = geoEpsgCrsAuthId()
 GEO_NONE = geoNone()
+
+# manually patch this in -- it's not referenced anywhere in the sip bindings
+# and we need it to have negative values, which aren't supported by sip
+class _FeatureCountState(IntEnum):
+    Uncounted = -2
+    UnknownCount = -1
+
+
+Qgis.FeatureCountState = _FeatureCountState
+Qgis.FeatureCountState.Uncounted.__doc__ = "Feature count not yet computed"
+Qgis.FeatureCountState.UnknownCount.__doc__ = "Provider returned an unknown feature count"
+QgsVectorDataProvider.FeatureCountState = Qgis.FeatureCountState
+QgsVectorDataProvider.Uncounted = Qgis.FeatureCountState.Uncounted
+QgsVectorDataProvider.Uncounted.is_monkey_patched = True
+QgsVectorDataProvider.Uncounted.__doc__ = "Feature count not yet computed"
+QgsVectorDataProvider.UnknownCount = Qgis.FeatureCountState.UnknownCount
+QgsVectorDataProvider.UnknownCount.is_monkey_patched = True
+QgsVectorDataProvider.UnknownCount.__doc__ = "Provider returned an unknown feature count"
+Qgis.FeatureCountState.__doc__ = "Enumeration of feature count states\n\n.. versionadded:: 3.20\n\n" + '* ``Uncounted``: ' + Qgis.FeatureCountState.Uncounted.__doc__ + '\n' + '* ``UnknownCount``: ' + Qgis.FeatureCountState.UnknownCount.__doc__
+Qgis.FeatureCountState.baseClass = Qgis
+

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -394,17 +394,6 @@ Qgis.NotForThisSession.__doc__ = "Macros will not be run for this session"
 Qgis.PythonMacroMode.__doc__ = "Authorisation to run Python Macros\n\n.. versionadded:: 3.10\n\n" + '* ``Never``: ' + Qgis.PythonMacroMode.Never.__doc__ + '\n' + '* ``Ask``: ' + Qgis.PythonMacroMode.Ask.__doc__ + '\n' + '* ``SessionOnly``: ' + Qgis.PythonMacroMode.SessionOnly.__doc__ + '\n' + '* ``Always``: ' + Qgis.PythonMacroMode.Always.__doc__ + '\n' + '* ``NotForThisSession``: ' + Qgis.PythonMacroMode.NotForThisSession.__doc__
 # --
 Qgis.PythonMacroMode.baseClass = Qgis
-QgsVectorDataProvider.FeatureCountState = Qgis.FeatureCountState
-# monkey patching scoped based enum
-QgsVectorDataProvider.Uncounted = Qgis.FeatureCountState.Uncounted
-QgsVectorDataProvider.Uncounted.is_monkey_patched = True
-QgsVectorDataProvider.Uncounted.__doc__ = "Feature count not yet computed"
-QgsVectorDataProvider.UnknownCount = Qgis.FeatureCountState.UnknownCount
-QgsVectorDataProvider.UnknownCount.is_monkey_patched = True
-QgsVectorDataProvider.UnknownCount.__doc__ = "Provider returned an unknown feature count"
-Qgis.FeatureCountState.__doc__ = "Enumeration of feature count states\n\n.. versionadded:: 3.20\n\n" + '* ``Uncounted``: ' + Qgis.FeatureCountState.Uncounted.__doc__ + '\n' + '* ``UnknownCount``: ' + Qgis.FeatureCountState.UnknownCount.__doc__
-# --
-Qgis.FeatureCountState.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.VectorDataProviderAttributeEditCapability.EditAlias.__doc__ = "Allows editing aliases"
 Qgis.VectorDataProviderAttributeEditCapability.EditComment.__doc__ = "Allows editing comments"

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -225,11 +225,6 @@ The development version
       NotForThisSession,
     };
 
-    enum class FeatureCountState /BaseType=IntFlag/
-      {
-      Uncounted,
-      UnknownCount,
-    };
 
     enum class VectorDataProviderAttributeEditCapability /BaseType=IntFlag/
     {

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -225,6 +225,7 @@ The development version
       NotForThisSession,
     };
 
+
     enum class FeatureCountState
       {
       Uncounted,

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -327,6 +327,9 @@ class CORE_EXPORT Qgis
     };
     Q_ENUM( PythonMacroMode )
 
+    // this is manually patched in Qt6 builds to allow for negative values
+#ifdef SIP_PYQT5_RUN
+
     /**
      * \ingroup core
      * \brief Enumeration of feature count states
@@ -338,6 +341,7 @@ class CORE_EXPORT Qgis
       UnknownCount = -1, //!< Provider returned an unknown feature count
     };
     Q_ENUM( FeatureCountState )
+#endif
 
     /**
      * Attribute editing capabilities which may be supported by vector data providers.


### PR DESCRIPTION
it's not referenced anywhere in the sip bindings and we need it
to have negative values, which aren't supported by sip