### PR TITLE
Fix generic exception is raised on PyQt6 builds instead of specific exceptions

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -49,7 +49,6 @@ PyQgsBookmarkModel
 PyQgsCodeEditor
 PyQgsColorRampLegendNode
 PyQgsCombinedStyleModel
-PyQgsConnectionRegistry
 PyQgsDateTimeStatisticalSummary
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
@@ -67,7 +66,6 @@ PyQgsLabelObstacleSettings
 PyQgsLabelSettingsWidget
 PyQgsLabelThinningSettings
 PyQgsLayerMetadata
-PyQgsLayerMetadataProviderPython
 PyQgsLayerMetadataResultsModel
 PyQgsLayoutAtlas
 PyQgsLayoutExporter
@@ -144,7 +142,6 @@ PyQgsDBManagerGpkg
 PyQgsDBManagerSpatialite
 PyQgsSettings
 PyQgsSettingsEntry
-PyQgsSettingsTreeNode
 PyQgsAuxiliaryStorage
 PyQgsDBManagerSQLWindow
 PyQgsSelectiveMasking

--- a/python/PyQt6/core/qgsexception.sip
+++ b/python/PyQt6/core/qgsexception.sip
@@ -22,19 +22,6 @@
 %End
 };
 
-%Exception QgsException(SIP_Exception) /PyName=QgsException/
-{
-%TypeHeaderCode
-#include <qgsexception.h>
-%End
-%RaiseCode
-  SIP_BLOCK_THREADS
-  PyErr_SetString(sipException_QgsException, sipExceptionRef.what().toUtf8().constData() );
-  SIP_UNBLOCK_THREADS
-%End
-};
-
-
 %Exception QgsProviderConnectionException(SIP_Exception) /PyName=QgsProviderConnectionException/
 {
 %TypeHeaderCode
@@ -70,3 +57,22 @@
   SIP_UNBLOCK_THREADS
 %End
 };
+
+
+// IMPORTANT -- QgsException MUST be last listed, or it will greedily prevent the more
+// specialized exceptions from being raised
+
+%Exception QgsException(SIP_Exception) /PyName=QgsException/
+{
+%TypeHeaderCode
+#include <qgsexception.h>
+%End
+%RaiseCode
+  SIP_BLOCK_THREADS
+  PyErr_SetString(sipException_QgsException, sipExceptionRef.what().toUtf8().constData() );
+  SIP_UNBLOCK_THREADS
+%End
+};
+
+// IMPORTANT -- QgsException MUST be last listed, or it will greedily prevent the more
+// specialized exceptions from being raised


### PR DESCRIPTION
QgsException MUST be the last type defined, or it greedily prevents the more specialized exceptions from being raised in PyQGIS

Note that we already do this for PyQt5 builds, so this is just fixing an earlier merge conflict issue