### PR TITLE
[ui] Improve visibility of the output layer attribute in the DXF export dialog

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -431,10 +431,26 @@ void QgsVectorLayerAndAttributeModel::deSelectAll()
   emit dataChanged( index( 0, 0 ), index( rowCount() - 1, 0 ) );
 }
 
+QgsDxfExportLayerTreeView::QgsDxfExportLayerTreeView( QWidget *parent )
+  : QgsLayerTreeView( parent )
+{
+}
+
+void QgsDxfExportLayerTreeView::resizeEvent( QResizeEvent *event )
+{
+  header()->setMinimumSectionSize( viewport()->width() / 2 );
+  header()->setMaximumSectionSize( viewport()->width() / 2 );
+  QTreeView::resizeEvent( event );
+}
+
 QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   : QDialog( parent, f )
 {
   setupUi( this );
+
+  mTreeView = new QgsDxfExportLayerTreeView( this );
+  mTreeViewContainer->layout()->addWidget( mTreeView );
+
   QgsGui::enableAutoGeometryRestore( this );
 
   connect( mVisibilityPresets, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsDxfExportDialog::mVisibilityPresets_currentIndexChanged );
@@ -451,8 +467,8 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
 
   mModel = new QgsVectorLayerAndAttributeModel( mLayerTreeGroup, this );
   mModel->setFlags( QgsLayerTreeModel::Flags() );
+
   mTreeView->setModel( mModel );
-  mTreeView->resizeColumnToContents( 0 );
   mTreeView->header()->show();
 
   mFileName->setStorageMode( QgsFileWidget::SaveFile );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -440,7 +440,7 @@ void QgsDxfExportLayerTreeView::resizeEvent( QResizeEvent *event )
 {
   header()->setMinimumSectionSize( viewport()->width() / 2 );
   header()->setMaximumSectionSize( viewport()->width() / 2 );
-  QTreeView::resizeEvent( event );
+  QTreeView::resizeEvent( event ); // NOLINT(bugprone-parent-virtual-call) clazy:exclude=skipped-base-method
 }
 
 QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -74,6 +74,15 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
     void retrieveAllLayers( QgsLayerTreeNode *node, QSet<QString> &layers );
 };
 
+class QgsDxfExportLayerTreeView : public QgsLayerTreeView
+{
+    Q_OBJECT
+  public:
+    explicit QgsDxfExportLayerTreeView( QWidget *parent = nullptr );
+
+  protected:
+    void resizeEvent( QResizeEvent *event ) override;
+};
 
 class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
 {
@@ -112,6 +121,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QgsLayerTree *mLayerTreeGroup = nullptr;
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
+    QgsDxfExportLayerTreeView *mTreeView = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;
 };

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -60,13 +60,8 @@
     <widget class="QComboBox" name="mEncoding"/>
    </item>
    <item row="7" column="0" colspan="2">
-    <widget class="QgsLayerTreeView" name="mTreeView">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <attribute name="headerDefaultSectionSize">
-      <number>0</number>
-     </attribute>
+    <widget class="QWidget" name="mTreeViewContainer">
+     <layout class="QHBoxLayout" name="mTreeViewLayout"/>
     </widget>
    </item>
    <item row="2" column="1">
@@ -253,7 +248,6 @@
   <tabstop>mEncoding</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mVisibilityPresets</tabstop>
-  <tabstop>mTreeView</tabstop>
   <tabstop>mSelectAllButton</tabstop>
   <tabstop>mDeselectAllButton</tabstop>
   <tabstop>mLayerTitleAsName</tabstop>


### PR DESCRIPTION
## Description

This fixes a UI/UX issue with the DXF export dialog whereas its layer tree widget does a really good job at hiding the 'Output Layer Attribute' column by resizing individual columns to match the width of the widget itself.

With the PR, both columns are visible, making it clear to the user that this option is here, and much easier to navigate:
![image](https://github.com/qgis/QGIS/assets/1728657/4398852a-fc9e-46a7-9adf-d05d157d65a7)

Fixes #45441