### PR TITLE
Fix layout map preview issues on high DPI screens

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1288,11 +1288,11 @@ void QgsLayoutItem::drawRefreshingOverlay( QPainter *painter, const QStyleOption
 {
   const QgsScopedQPainterState painterState( painter );
   bool fitsInCache = false;
-  const int xSize = QFontMetrics( QFont() ).horizontalAdvance( 'X' );
+  const int xSize = std::floor( static_cast<double>( QFontMetrics( QFont() ).horizontalAdvance( 'X' ) ) * painter->device()->devicePixelRatioF() );
   const QImage refreshingImage = QgsApplication::svgCache()->svgAsImage( QStringLiteral( ":/images/composer/refreshing_item.svg" ), xSize * 3, QColor(), QColor(), 1, 1, fitsInCache );
 
   const double previewScaleFactor = QgsLayoutUtils::scaleFactorFromItemStyle( itemStyle, painter );
-  painter->scale( 1.0 / previewScaleFactor, 1.0 / previewScaleFactor );
+  painter->scale( 1.0 / previewScaleFactor / painter->device()->devicePixelRatioF(), 1.0 / previewScaleFactor / painter->device()->devicePixelRatioF() );
   painter->drawImage( xSize, xSize, refreshingImage );
 }
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1073,6 +1073,7 @@ void QgsLayoutItemMap::paint( QPainter *painter, const QStyleOptionGraphicsItem 
   if ( mLayout->renderContext().isPreviewRender() )
   {
     bool renderInProgress = false;
+    mPreviewDevicePixelRatio = painter->device()->devicePixelRatioF();
 
     QgsScopedQPainterState painterState( painter );
     painter->setClipRect( thisPaintRect );
@@ -1594,18 +1595,12 @@ void QgsLayoutItemMap::recreateCachedImageInBackground()
   if ( w <= 0 || h <= 0 )
     return;
 
-  double devicePixelRatio = 1.0;
-  if ( QWidget *activeWindow = QApplication::activeWindow() )
-  {
-    devicePixelRatio = ( activeWindow->screen() ? QApplication::activeWindow()->screen()->devicePixelRatio() : 1.0 );
-  }
-
-  mCacheRenderingImage.reset( new QImage( w * devicePixelRatio, h * devicePixelRatio, QImage::Format_ARGB32 ) );
+  mCacheRenderingImage.reset( new QImage( w * mPreviewDevicePixelRatio, h * mPreviewDevicePixelRatio, QImage::Format_ARGB32 ) );
 
   // set DPI of the image
   mCacheRenderingImage->setDotsPerMeterX( static_cast< int >( std::round( 1000 * w / widthLayoutUnits ) ) );
   mCacheRenderingImage->setDotsPerMeterY( static_cast< int >( std::round( 1000 * h / heightLayoutUnits ) ) );
-  mCacheRenderingImage->setDevicePixelRatio( devicePixelRatio );
+  mCacheRenderingImage->setDevicePixelRatio( mPreviewDevicePixelRatio );
 
   //start with empty fill to avoid artifacts
   mCacheRenderingImage->fill( QColor( 255, 255, 255, 0 ).rgba() );
@@ -1678,12 +1673,7 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   if ( layout()->renderContext().isPreviewRender() )
   {
     jobMapSettings.setDpiTarget( layout()->renderContext().dpi() );
-    double devicePixelRatio = 1.0;
-    if ( QWidget *activeWindow = QApplication::activeWindow() )
-    {
-      devicePixelRatio = ( activeWindow->screen() ? QApplication::activeWindow()->screen()->devicePixelRatio() : 1.0 );
-    }
-    jobMapSettings.setDevicePixelRatio( devicePixelRatio );
+    jobMapSettings.setDevicePixelRatio( mPainter ? mPainter->device()->devicePixelRatioF() : 1.0 );
   }
   jobMapSettings.setBackgroundColor( Qt::transparent );
   jobMapSettings.setRotation( mEvaluatedMapRotation );

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -1012,6 +1012,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
 
     QTimer *mBackgroundUpdateTimer = nullptr;
     double mPreviewScaleFactor = 0;
+    double mPreviewDevicePixelRatio = 1.0;
 
     bool mDrawingPreview = false;
 


### PR DESCRIPTION
## Description

This PR fixes #54579 , another important high DPI issue caused by enabling Qt's auto scaling on high DPI screens. Good to fix before 3.34 becomes the LTR.

Before:
![image](https://github.com/qgis/QGIS/assets/1728657/7f64be74-0211-42f0-95f7-84d14f887a55)

After (fixed refresh icon rendering):
![image](https://github.com/qgis/QGIS/assets/1728657/0e09f76b-397f-43f2-8217-1d306a3dc8c6)

After (fixed map rendering):
![image](https://github.com/qgis/QGIS/assets/1728657/ec06902f-50e3-4ff5-8de2-04bb903e9496)
