### PR TITLE
Faster point cloud rendering by caching decoded data blocks

### DIFF
--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -34,6 +34,12 @@ Ctor
 %End
     virtual ~QgsPointCloudBlock();
 
+    QgsPointCloudBlock *clone() const;
+%Docstring
+Clones the QgsPointCloudBlock returning a new copy.
+Caller takes ownership of the returned object.
+%End
+
     const char *data() const;
 %Docstring
 Returns raw pointer to data

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -34,10 +34,12 @@ Ctor
 %End
     virtual ~QgsPointCloudBlock();
 
-    QgsPointCloudBlock *clone() const;
+    QgsPointCloudBlock *clone() const /Factory/;
 %Docstring
 Clones the QgsPointCloudBlock returning a new copy.
 Caller takes ownership of the returned object.
+
+.. versionadded:: 3.36
 %End
 
     const char *data() const;

--- a/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -34,6 +34,12 @@ Ctor
 %End
     virtual ~QgsPointCloudBlock();
 
+    QgsPointCloudBlock *clone() const;
+%Docstring
+Clones the QgsPointCloudBlock returning a new copy.
+Caller takes ownership of the returned object.
+%End
+
     const char *data() const;
 %Docstring
 Returns raw pointer to data

--- a/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -34,10 +34,12 @@ Ctor
 %End
     virtual ~QgsPointCloudBlock();
 
-    QgsPointCloudBlock *clone() const;
+    QgsPointCloudBlock *clone() const /Factory/;
 %Docstring
 Clones the QgsPointCloudBlock returning a new copy.
 Caller takes ownership of the returned object.
+
+.. versionadded:: 3.36
 %End
 
     const char *data() const;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2145,6 +2145,7 @@ if (WITH_COPC)
       pointcloud/qgscopcpointcloudindex.cpp
       pointcloud/qgsremotecopcpointcloudindex.cpp
       pointcloud/qgscopcpointcloudblockrequest.cpp
+      pointcloud/qgscachedpointcloudblockrequest.cpp
   )
   set(QGIS_CORE_HDRS ${QGIS_CORE_HDRS}
       providers/copc/qgscopcprovider.h
@@ -2152,6 +2153,7 @@ if (WITH_COPC)
       pointcloud/qgscopcpointcloudindex.h
       pointcloud/qgsremotecopcpointcloudindex.h
       pointcloud/qgscopcpointcloudblockrequest.h
+      pointcloud/qgscachedpointcloudblockrequest.h
   )
 
   add_definitions( -DWITH_COPC )

--- a/src/core/pointcloud/qgscachedpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgscachedpointcloudblockrequest.cpp
@@ -25,7 +25,7 @@ QgsCachedPointCloudBlockRequest::QgsCachedPointCloudBlockRequest( QgsPointCloudB
   : QgsPointCloudBlockRequest( node, uri, attributes, requestedAttributes, scale, offset, filterExpression, filterRect )
 {
   mBlock.reset( block );
-  QTimer::singleShot( 0, this, &QgsPointCloudBlockRequest::finished );
+  QMetaObject::invokeMethod( this, &QgsCachedPointCloudBlockRequest::finished, Qt::QueuedConnection );
 }
 
 ///@endcond

--- a/src/core/pointcloud/qgscachedpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgscachedpointcloudblockrequest.cpp
@@ -1,0 +1,31 @@
+/***************************************************************************
+                         qgscachedpointcloudblockrequest.cpp
+                         -----------------------------------
+    begin                : January 2024
+    copyright            : (C) 2024 by Stefanos Natsis
+    email                : stefanos.natsis at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscachedpointcloudblockrequest.h"
+
+///@cond PRIVATE
+
+QgsCachedPointCloudBlockRequest::QgsCachedPointCloudBlockRequest( QgsPointCloudBlock *block, const IndexedPointCloudNode &node, const QString &uri,
+    const QgsPointCloudAttributeCollection &attributes, const QgsPointCloudAttributeCollection &requestedAttributes,
+    const QgsVector3D &scale, const QgsVector3D &offset, const QgsPointCloudExpression &filterExpression, const QgsRectangle &filterRect )
+  : QgsPointCloudBlockRequest( node, uri, attributes, requestedAttributes, scale, offset, filterExpression, filterRect )
+{
+  mBlock.reset( block );
+  QTimer::singleShot( 0, this, &QgsPointCloudBlockRequest::finished );
+}
+
+///@endcond

--- a/src/core/pointcloud/qgscachedpointcloudblockrequest.h
+++ b/src/core/pointcloud/qgscachedpointcloudblockrequest.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+                         qgscachedpointcloudblockrequest.h
+                         ---------------------------------
+    begin                : January 2024
+    copyright            : (C) 2024 by Stefanos Natsis
+    email                : stefanos.natsis at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCACHEDPOINTCLOUDBLOCKREQUEST_H
+#define QGSCACHEDPOINTCLOUDBLOCKREQUEST_H
+
+#include <QObject>
+
+#include "qgspointcloudblockrequest.h"
+
+#define SIP_NO_FILE
+
+class QgsPointCloudAttributeCollection;
+class QgsPointCloudBlock;
+
+/**
+ * \ingroup core
+ * \brief Class for handling a QgsPointCloudBlockRequest using existing cached QgsPointCloudBlock
+ *
+ * \note The API is considered EXPERIMENTAL and can be changed without a notice
+ *
+ * \since QGIS 3.36
+ */
+class CORE_EXPORT QgsCachedPointCloudBlockRequest : public QgsPointCloudBlockRequest
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * QgsCachedPointCloudBlockRequest constructor using an existing \a block
+     * Note: Ownership of \a block is transferred
+     */
+    QgsCachedPointCloudBlockRequest( QgsPointCloudBlock *block, const IndexedPointCloudNode &node, const QString &uri,
+                                     const QgsPointCloudAttributeCollection &attributes, const QgsPointCloudAttributeCollection &requestedAttributes,
+                                     const QgsVector3D &scale, const QgsVector3D &offset, const QgsPointCloudExpression &filterExpression, const QgsRectangle &filterRect );
+
+    ~QgsCachedPointCloudBlockRequest() = default;
+};
+#endif // QGSCACHEDPOINTCLOUDBLOCKREQUEST_H

--- a/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
@@ -35,7 +35,7 @@ QgsCopcPointCloudBlockRequest::QgsCopcPointCloudBlockRequest( const IndexedPoint
   : QgsPointCloudBlockRequest( node, uri, attributes, requestedAttributes, scale, offset, filterExpression, filterRect ),
     mBlockOffset( blockOffset ), mBlockSize( blockSize ), mPointCount( pointCount ), mLazInfo( lazInfo )
 {
-  QNetworkRequest nr( mUri );
+  QNetworkRequest nr = QNetworkRequest( QUrl( mUri ) );
   QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsCopcPointCloudBlockRequest" ) );
   QgsSetRequestInitiatorId( nr, node.toString() );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
@@ -63,6 +63,10 @@ void QgsCopcPointCloudBlockRequest::blockFinishedLoading()
       try
       {
         mBlock = QgsLazDecoder::decompressCopc( mTileDownloadManagerReply->data(), mLazInfo, mPointCount, mRequestedAttributes, mFilterExpression, mFilterRect );
+        QgsPointCloudRequest req;
+        req.setAttributes( mRequestedAttributes );
+        req.setFilterRect( mFilterRect );
+        QgsPointCloudIndex::storeNodeDataToCacheStatic( mBlock.get(), mNode, req, mFilterExpression, mUri );
       }
       catch ( std::exception &e )
       {

--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<QgsPointCloudIndex> QgsCopcPointCloudIndex::clone() const
 
 void QgsCopcPointCloudIndex::load( const QString &fileName )
 {
-  mFileName = fileName;
+  mUri = fileName;
   mCopcFile.open( QgsLazDecoder::toNativePath( fileName ), std::ios::binary );
 
   if ( !mCopcFile.is_open() || !mCopcFile.good() )
@@ -154,12 +154,12 @@ std::unique_ptr<QgsPointCloudBlock> QgsCopcPointCloudIndex::nodeData( const Inde
   requestAttributes.extend( attributes(), filterExpression.referencedAttributes() );
 
   QByteArray rawBlockData( blockSize, Qt::Initialization::Uninitialized );
-  std::ifstream file( QgsLazDecoder::toNativePath( mFileName ), std::ios::binary );
+  std::ifstream file( QgsLazDecoder::toNativePath( mUri ), std::ios::binary );
   file.seekg( blockOffset );
   file.read( rawBlockData.data(), blockSize );
   if ( !file )
   {
-    QgsDebugError( QStringLiteral( "Could not read file %1" ).arg( mFileName ) );
+    QgsDebugError( QStringLiteral( "Could not read file %1" ).arg( mUri ) );
     return nullptr;
   }
   QgsRectangle filterRect = request.filterRect();
@@ -197,14 +197,14 @@ bool QgsCopcPointCloudIndex::writeStatistics( QgsPointCloudStatistics &stats )
   if ( mLazInfo->version() != qMakePair<uint8_t, uint8_t>( 1, 4 ) )
   {
     // EVLR isn't supported in the first place
-    QgsMessageLog::logMessage( tr( "Can't write statistics to \"%1\": laz version != 1.4" ).arg( mFileName ) );
+    QgsMessageLog::logMessage( tr( "Can't write statistics to \"%1\": laz version != 1.4" ).arg( mUri ) );
     return false;
   }
 
   QByteArray statisticsEvlrData = fetchCopcStatisticsEvlrData();
   if ( !statisticsEvlrData.isEmpty() )
   {
-    QgsMessageLog::logMessage( tr( "Can't write statistics to \"%1\": file already contains COPC statistics!" ).arg( mFileName ) );
+    QgsMessageLog::logMessage( tr( "Can't write statistics to \"%1\": file already contains COPC statistics!" ).arg( mUri ) );
     return false;
   }
 
@@ -218,7 +218,7 @@ bool QgsCopcPointCloudIndex::writeStatistics( QgsPointCloudStatistics &stats )
   // Save the EVLRs to the end of the original file (while erasing the exisitng EVLRs in the file)
   mCopcFile.close();
   std::fstream copcFile;
-  copcFile.open( QgsLazDecoder::toNativePath( mFileName ), std::ios_base::binary | std::iostream::in | std::iostream::out );
+  copcFile.open( QgsLazDecoder::toNativePath( mUri ), std::ios_base::binary | std::iostream::in | std::iostream::out );
   if ( copcFile.is_open() && copcFile.good() )
   {
     // Write the new number of EVLRs
@@ -235,11 +235,11 @@ bool QgsCopcPointCloudIndex::writeStatistics( QgsPointCloudStatistics &stats )
   }
   else
   {
-    QgsMessageLog::logMessage( tr( "Couldn't open COPC file \"%1\" to write statistics" ).arg( mFileName ) );
+    QgsMessageLog::logMessage( tr( "Couldn't open COPC file \"%1\" to write statistics" ).arg( mUri ) );
     return false;
   }
   copcFile.close();
-  mCopcFile.open( QgsLazDecoder::toNativePath( mFileName ), std::ios::binary );
+  mCopcFile.open( QgsLazDecoder::toNativePath( mUri ), std::ios::binary );
   return true;
 }
 
@@ -361,8 +361,8 @@ void QgsCopcPointCloudIndex::copyCommonProperties( QgsCopcPointCloudIndex *desti
 
   // QgsCopcPointCloudIndex specific fields
   destination->mIsValid = mIsValid;
-  destination->mFileName = mFileName;
-  destination->mCopcFile.open( QgsLazDecoder::toNativePath( mFileName ), std::ios::binary );
+  destination->mUri = mUri;
+  destination->mCopcFile.open( QgsLazDecoder::toNativePath( mUri ), std::ios::binary );
   destination->mCopcInfoVlr = mCopcInfoVlr;
   destination->mHierarchyNodePos = mHierarchyNodePos;
   destination->mOriginalMetadata = mOriginalMetadata;

--- a/src/core/pointcloud/qgscopcpointcloudindex.h
+++ b/src/core/pointcloud/qgscopcpointcloudindex.h
@@ -104,7 +104,6 @@ class CORE_EXPORT QgsCopcPointCloudIndex: public QgsPointCloudIndex
     QByteArray fetchCopcStatisticsEvlrData();
 
     bool mIsValid = false;
-    QString mFileName;
     mutable std::ifstream mCopcFile;
     mutable lazperf::copc_info_vlr mCopcInfoVlr;
     mutable QHash<IndexedPointCloudNode, QPair<uint64_t, int32_t>> mHierarchyNodePos; //!< Additional data hierarchy for COPC

--- a/src/core/pointcloud/qgseptpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgseptpointcloudblockrequest.cpp
@@ -35,7 +35,7 @@ QgsEptPointCloudBlockRequest::QgsEptPointCloudBlockRequest( const IndexedPointCl
   : QgsPointCloudBlockRequest( node, uri, attributes, requestedAttributes, scale, offset, filterExpression, filterRect ),
     mDataType( dataType )
 {
-  QNetworkRequest nr( mUri );
+  QNetworkRequest nr = QNetworkRequest( QUrl( mUri ) );
   QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsEptPointCloudBlockRequest" ) );
   QgsSetRequestInitiatorId( nr, node.toString() );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
@@ -68,6 +68,13 @@ void QgsEptPointCloudBlockRequest::blockFinishedLoading()
       else
       {
         error = QStringLiteral( "Unknown data type %1;" ).arg( mDataType );
+      }
+      if ( mBlock )
+      {
+        QgsPointCloudRequest req;
+        req.setAttributes( mRequestedAttributes );
+        req.setFilterRect( mFilterRect );
+        QgsPointCloudIndex::storeNodeDataToCacheStatic( mBlock.get(), mNode, req, mFilterExpression, mUri );
       }
     }
     catch ( std::exception &e )

--- a/src/core/pointcloud/qgseptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgseptpointcloudindex.cpp
@@ -311,6 +311,11 @@ bool QgsEptPointCloudIndex::loadSchema( const QByteArray &dataJson )
 
 std::unique_ptr<QgsPointCloudBlock> QgsEptPointCloudIndex::nodeData( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request )
 {
+  if ( QgsPointCloudBlock *cached = getNodeDataFromCache( n, request ) )
+  {
+    return std::unique_ptr<QgsPointCloudBlock>( cached );
+  }
+
   mHierarchyMutex.lock();
   const bool found = mHierarchy.contains( n );
   mHierarchyMutex.unlock();
@@ -325,25 +330,25 @@ std::unique_ptr<QgsPointCloudBlock> QgsEptPointCloudIndex::nodeData( const Index
   requestAttributes.extend( attributes(), filterExpression.referencedAttributes() );
   QgsRectangle filterRect = request.filterRect();
 
+  std::unique_ptr<QgsPointCloudBlock> decoded;
   if ( mDataType == QLatin1String( "binary" ) )
   {
     const QString filename = QStringLiteral( "%1/ept-data/%2.bin" ).arg( mDirectory, n.toString() );
-    return QgsEptDecoder::decompressBinary( filename, attributes(), requestAttributes, scale(), offset(), filterExpression, filterRect );
+    decoded = QgsEptDecoder::decompressBinary( filename, attributes(), requestAttributes, scale(), offset(), filterExpression, filterRect );
   }
   else if ( mDataType == QLatin1String( "zstandard" ) )
   {
     const QString filename = QStringLiteral( "%1/ept-data/%2.zst" ).arg( mDirectory, n.toString() );
-    return QgsEptDecoder::decompressZStandard( filename, attributes(), request.attributes(), scale(), offset(), filterExpression, filterRect );
+    decoded = QgsEptDecoder::decompressZStandard( filename, attributes(), request.attributes(), scale(), offset(), filterExpression, filterRect );
   }
   else if ( mDataType == QLatin1String( "laszip" ) )
   {
     const QString filename = QStringLiteral( "%1/ept-data/%2.laz" ).arg( mDirectory, n.toString() );
-    return QgsLazDecoder::decompressLaz( filename, requestAttributes, filterExpression, filterRect );
+    decoded = QgsLazDecoder::decompressLaz( filename, requestAttributes, filterExpression, filterRect );
   }
-  else
-  {
-    return nullptr;  // unsupported
-  }
+
+  storeNodeDataToCache( decoded.get(), n, request );
+  return decoded;
 }
 
 QgsPointCloudBlockRequest *QgsEptPointCloudIndex::asyncNodeData( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request )

--- a/src/core/pointcloud/qgseptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgseptpointcloudindex.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<QgsPointCloudIndex> QgsEptPointCloudIndex::clone() const
 
 void QgsEptPointCloudIndex::load( const QString &fileName )
 {
+  mUri = fileName;
   QFile f( fileName );
   if ( !f.open( QIODevice::ReadOnly ) )
   {

--- a/src/core/pointcloud/qgspointcloudblock.cpp
+++ b/src/core/pointcloud/qgspointcloudblock.cpp
@@ -34,6 +34,11 @@ QgsPointCloudBlock::QgsPointCloudBlock(
 {
 }
 
+QgsPointCloudBlock *QgsPointCloudBlock::clone() const
+{
+  return new QgsPointCloudBlock( *this );
+}
+
 const char *QgsPointCloudBlock::data() const
 {
   return mStorage.data();

--- a/src/core/pointcloud/qgspointcloudblock.h
+++ b/src/core/pointcloud/qgspointcloudblock.h
@@ -45,6 +45,12 @@ class CORE_EXPORT QgsPointCloudBlock
     //! Dtor
     virtual ~QgsPointCloudBlock() = default;
 
+    /**
+     * Clones the QgsPointCloudBlock returning a new copy.
+     * Caller takes ownership of the returned object.
+     */
+    QgsPointCloudBlock *clone() const;
+
     //! Returns raw pointer to data
     const char *data() const;
 

--- a/src/core/pointcloud/qgspointcloudblock.h
+++ b/src/core/pointcloud/qgspointcloudblock.h
@@ -48,8 +48,9 @@ class CORE_EXPORT QgsPointCloudBlock
     /**
      * Clones the QgsPointCloudBlock returning a new copy.
      * Caller takes ownership of the returned object.
+     * \since QGIS 3.36
      */
-    QgsPointCloudBlock *clone() const;
+    QgsPointCloudBlock *clone() const SIP_FACTORY;
 
     //! Returns raw pointer to data
     const char *data() const;

--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -352,6 +352,7 @@ QgsPointCloudStatistics QgsPointCloudIndex::metadataStatistics() const
 void QgsPointCloudIndex::copyCommonProperties( QgsPointCloudIndex *destination ) const
 {
   // Base QgsPointCloudIndex fields
+  destination->mUri = mUri;
   destination->mExtent = mExtent;
   destination->mZMin = mZMin;
   destination->mZMax = mZMax;

--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -410,6 +410,9 @@ void QgsPointCloudIndex::storeNodeDataToCache( QgsPointCloudBlock *data, const I
 
 void QgsPointCloudIndex::storeNodeDataToCacheStatic( QgsPointCloudBlock *data, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request, const QgsPointCloudExpression &expression, const QString &uri )
 {
+  if ( !data )
+    return;
+
   QgsPointCloudCacheKey key( node, request, expression, uri );
 
   const int cost = data->pointCount() * data->pointRecordSize();

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -25,6 +25,7 @@
 #include <QVector>
 #include <QList>
 #include <QMutex>
+#include <QCache>
 
 #include "qgis_core.h"
 #include "qgsrectangle.h"
@@ -35,6 +36,7 @@
 #include "qgspointcloudattribute.h"
 #include "qgsstatisticalsummary.h"
 #include "qgspointcloudexpression.h"
+#include "qgspointcloudrequest.h"
 
 #define SIP_NO_FILE
 
@@ -105,6 +107,46 @@ Q_DECLARE_TYPEINFO( IndexedPointCloudNode, Q_PRIMITIVE_TYPE );
 
 //! Hash function for indexed nodes
 CORE_EXPORT uint qHash( IndexedPointCloudNode id );
+
+/**
+ * \ingroup core
+ *
+ * \brief Container class for QgsPointCloudBlock cache keys
+ *
+ * \note The API is considered EXPERIMENTAL and can be changed without a notice
+ *
+ * \since QGIS 3.36
+ */
+class CORE_EXPORT QgsPointCloudCacheKey
+{
+  public:
+    //! Ctor
+    QgsPointCloudCacheKey( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request, const QgsPointCloudExpression &expression, const QString &uri );
+
+    //! Compares keys
+    bool operator==( const QgsPointCloudCacheKey &other ) const;
+
+    //! Returns the key's IndexedPointCloudNode
+    IndexedPointCloudNode node() const { return mNode; }
+
+    //! Returns the key's uri
+    QString uri() const { return mUri; }
+
+    //! Returns the key's QgsPointCloudRequest
+    QgsPointCloudRequest request() const { return mRequest; }
+
+    //! Returns the key's QgsPointCloudExpression
+    QgsPointCloudExpression filterExpression() const { return mFilterExpression; }
+
+  private:
+    IndexedPointCloudNode mNode;
+    QString mUri;
+    QgsPointCloudRequest mRequest;
+    QgsPointCloudExpression mFilterExpression;
+};
+
+//! Hash function for QgsPointCloudCacheKey
+uint qHash( const QgsPointCloudCacheKey &key );
 
 /**
  * \ingroup core
@@ -331,6 +373,24 @@ class CORE_EXPORT QgsPointCloudIndex: public QObject
      */
     void copyCommonProperties( QgsPointCloudIndex *destination ) const;
 
+    /**
+     * Fetches the requested node data from the cache for the specified \a node and \a request.
+     * If not found in the cache, nullptr is returned.
+     * Caller takes ownership of the returned object.
+     */
+    QgsPointCloudBlock *getNodeDataFromCache( const IndexedPointCloudNode &node, const QgsPointCloudRequest &request );
+
+    /**
+     * Stores existing \a data to the cache for the specified \a node and \a request. Ownership is not transferred, block gets cloned in the cache.
+     */
+    void storeNodeDataToCache( QgsPointCloudBlock *data, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request );
+
+    /**
+     * Stores existing \a data to the cache for the specified \a node, \a request, \a expression and \a uri. Ownership is not transferred, block gets cloned in the cache.
+     */
+    static void storeNodeDataToCacheStatic( QgsPointCloudBlock *data, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request,
+                                            const QgsPointCloudExpression &expression, const QString &uri );
+
   protected: //TODO private
     //! Sets native attributes of the data
     void setAttributes( const QgsPointCloudAttributeCollection &attributes );
@@ -349,6 +409,8 @@ class CORE_EXPORT QgsPointCloudIndex: public QObject
 
     QString mError;
     QString mUri;
+    static QMutex sBlockCacheMutex;
+    static QCache<QgsPointCloudCacheKey, QgsPointCloudBlock> sBlockCache;
 };
 
 #endif // QGSPOINTCLOUDINDEX_H

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -348,6 +348,7 @@ class CORE_EXPORT QgsPointCloudIndex: public QObject
     QgsPointCloudExpression mFilterExpression;  //!< The filter expression to be evaluated when fetching node data
 
     QString mError;
+    QString mUri;
 };
 
 #endif // QGSPOINTCLOUDINDEX_H

--- a/src/core/pointcloud/qgspointcloudrequest.cpp
+++ b/src/core/pointcloud/qgspointcloudrequest.cpp
@@ -21,6 +21,12 @@
 
 QgsPointCloudRequest::QgsPointCloudRequest() = default;
 
+bool QgsPointCloudRequest::operator==( const QgsPointCloudRequest &other ) const
+{
+  return mFilterRect == other.filterRect() &&
+         mAttributes.toFields() == other.attributes().toFields(); //todo: QgsPointCloudAttributeCollection::operator==
+}
+
 QgsPointCloudAttributeCollection QgsPointCloudRequest::attributes() const
 {
   return mAttributes;
@@ -29,4 +35,9 @@ QgsPointCloudAttributeCollection QgsPointCloudRequest::attributes() const
 void QgsPointCloudRequest::setAttributes( const QgsPointCloudAttributeCollection &attributes )
 {
   mAttributes = attributes;
+}
+
+uint qHash( const QgsPointCloudRequest &request )
+{
+  return qHash( request.filterRect() ) ^ qHash( request.attributes().toFields() );
 }

--- a/src/core/pointcloud/qgspointcloudrequest.cpp
+++ b/src/core/pointcloud/qgspointcloudrequest.cpp
@@ -24,7 +24,7 @@ QgsPointCloudRequest::QgsPointCloudRequest() = default;
 bool QgsPointCloudRequest::operator==( const QgsPointCloudRequest &other ) const
 {
   return mFilterRect == other.filterRect() &&
-         mAttributes.toFields() == other.attributes().toFields(); //todo: QgsPointCloudAttributeCollection::operator==
+         mAttributes.toFields() == other.attributes().toFields();
 }
 
 QgsPointCloudAttributeCollection QgsPointCloudRequest::attributes() const

--- a/src/core/pointcloud/qgspointcloudrequest.h
+++ b/src/core/pointcloud/qgspointcloudrequest.h
@@ -44,6 +44,9 @@ class CORE_EXPORT QgsPointCloudRequest
     //! Ctor
     QgsPointCloudRequest();
 
+    //! Equality operator
+    bool operator==( const QgsPointCloudRequest &other ) const;
+
     //! Returns attributes
     QgsPointCloudAttributeCollection attributes() const;
 
@@ -65,5 +68,8 @@ class CORE_EXPORT QgsPointCloudRequest
     QgsPointCloudAttributeCollection mAttributes;
     QgsRectangle mFilterRect;
 };
+
+//! Hash function for QgsPointCloudRequest
+uint qHash( const QgsPointCloudRequest &request );
 
 #endif // QGSPOINTCLOUDREQUEST_H

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -75,10 +75,11 @@ QList<IndexedPointCloudNode> QgsRemoteCopcPointCloudIndex::nodeChildren( const I
   return lst;
 }
 
-void QgsRemoteCopcPointCloudIndex::load( const QString &url )
+void QgsRemoteCopcPointCloudIndex::load( const QString &uri )
 {
-  mUrl = QUrl( url );
-  mLazInfo.reset( new QgsLazInfo( QgsLazInfo::fromUrl( mUrl ) ) );
+  mUri = uri;
+  QUrl url( uri );
+  mLazInfo.reset( new QgsLazInfo( QgsLazInfo::fromUrl( url ) ) );
   mIsValid = mLazInfo->isValid();
   if ( mIsValid )
   {
@@ -90,7 +91,7 @@ void QgsRemoteCopcPointCloudIndex::load( const QString &url )
   }
   if ( !mIsValid )
   {
-    mError = tr( "Unable to recognize %1 as a LAZ file: \"%2\"" ).arg( url, mLazInfo->error() );
+    mError = tr( "Unable to recognize %1 as a LAZ file: \"%2\"" ).arg( uri, mLazInfo->error() );
   }
 }
 
@@ -129,7 +130,7 @@ QgsPointCloudBlockRequest *QgsRemoteCopcPointCloudIndex::asyncNodeData( const In
   auto [ blockOffset, blockSize ] = mHierarchyNodePos.value( n );
   int pointCount = mHierarchy.value( n );
 
-  return new QgsCopcPointCloudBlockRequest( n, mUrl.toString(), attributes(), requestAttributes,
+  return new QgsCopcPointCloudBlockRequest( n, mUri, attributes(), requestAttributes,
          scale(), offset(), filterExpression, request.filterRect(),
          blockOffset, blockSize, pointCount, *mLazInfo.get() );
 }
@@ -174,7 +175,7 @@ bool QgsRemoteCopcPointCloudIndex::isValid() const
 
 void QgsRemoteCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t byteSize ) const
 {
-  QNetworkRequest nr( mUrl );
+  QNetworkRequest nr = QNetworkRequest( QUrl( mUri ) );
   QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsRemoteCopcPointCloudIndex" ) );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
@@ -189,7 +190,7 @@ void QgsRemoteCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t
 
   if ( reply->error() != QNetworkReply::NoError )
   {
-    QgsDebugError( QStringLiteral( "Request failed: " ) + mUrl.toString() );
+    QgsDebugError( QStringLiteral( "Request failed: " ) + mUri );
     return;
   }
 
@@ -225,7 +226,6 @@ void QgsRemoteCopcPointCloudIndex::copyCommonProperties( QgsRemoteCopcPointCloud
   QgsCopcPointCloudIndex::copyCommonProperties( destination );
 
   // QgsRemoteCopcPointCloudIndex specific fields
-  destination->mUrl = mUrl;
   destination->mHierarchyNodes = mHierarchyNodes;
 }
 

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.h
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsRemoteCopcPointCloudIndex: public QgsCopcPointCloudIndex
 
     QList<IndexedPointCloudNode> nodeChildren( const IndexedPointCloudNode &n ) const override;
 
-    void load( const QString &url ) override;
+    void load( const QString &uri ) override;
 
     std::unique_ptr<QgsPointCloudBlock> nodeData( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request ) override;
     QgsPointCloudBlockRequest *asyncNodeData( const IndexedPointCloudNode &n, const QgsPointCloudRequest &request ) override;

--- a/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremoteeptpointcloudindex.cpp
@@ -78,23 +78,24 @@ QList<IndexedPointCloudNode> QgsRemoteEptPointCloudIndex::nodeChildren( const In
   return lst;
 }
 
-void QgsRemoteEptPointCloudIndex::load( const QString &url )
+void QgsRemoteEptPointCloudIndex::load( const QString &uri )
 {
-  mUrl = QUrl( url );
+  mUri = uri;
+  QUrl url( uri );
 
-  QStringList splitUrl = url.split( '/' );
+  QStringList splitUrl = uri.split( '/' );
 
   mUrlFileNamePart = splitUrl.back();
   splitUrl.pop_back();
   mUrlDirectoryPart = splitUrl.join( '/' );
 
-  QNetworkRequest nr( url );
+  QNetworkRequest nr( uri );
 
   QgsBlockingNetworkRequest req;
   const QgsBlockingNetworkRequest::ErrorCode errCode = req.get( nr );
   if ( errCode != QgsBlockingNetworkRequest::NoError )
   {
-    QgsDebugError( QStringLiteral( "Request failed: " ) + url );
+    QgsDebugError( QStringLiteral( "Request failed: " ) + uri );
     mIsValid = false;
     return;
   }
@@ -206,7 +207,7 @@ bool QgsRemoteEptPointCloudIndex::loadNodeHierarchy( const IndexedPointCloudNode
 
     if ( reply->error() != QNetworkReply::NoError )
     {
-      QgsDebugError( QStringLiteral( "Request failed: " ) + mUrl.toString() );
+      QgsDebugError( QStringLiteral( "Request failed: " ) + mUri );
       return false;
     }
 
@@ -253,7 +254,6 @@ void QgsRemoteEptPointCloudIndex::copyCommonProperties( QgsRemoteEptPointCloudIn
   // QgsRemoteEptPointCloudIndex specific fields
   destination->mUrlDirectoryPart = mUrlDirectoryPart;
   destination->mUrlFileNamePart = mUrlFileNamePart;
-  destination->mUrl = mUrl;
   destination->mHierarchyNodes = mHierarchyNodes;
 }
 


### PR DESCRIPTION
## Description
When rendering point cloud data, QGIS spends a lot of time decompressing the same laz node data over and over again while panning or zooming.
With this PR, the decompressed points are cached for each combination of _layer uri_, _node_, _requested attributes_, _filter extent_ and _filter expression_, allowing for very fast rendering of cached nodes.
A fixed size cache of 200MB is used and shared across all point cloud layers and canvases (2d, 3d, profile)

Performance can vary depending on actual data, but on a local sample copc file I got render times dropping from ~2.7sec to ~0.35sec once the requested nodes got cached.
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
