### PR TITLE
[dxf export] Fix map theme visibility not properly reflected by the model

### DIFF
--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -513,7 +513,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   QStringList ids = QgsProject::instance()->mapThemeCollection()->mapThemes();
   ids.prepend( QString() );
   mVisibilityPresets->addItems( ids );
-  mVisibilityPresets->setCurrentIndex( mVisibilityPresets->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibliltyPreset" ), QString() ) ) );
+  mVisibilityPresets->setCurrentIndex( mVisibilityPresets->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibilityPreset" ), QString() ) ) );
 
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -366,8 +366,6 @@ void QgsVectorLayerAndAttributeModel::applyVisibilityPreset( const QString &name
 
   mCheckedLeafs.clear();
   applyVisibility( visibleLayers, rootGroup() );
-
-  emit dataChanged( QModelIndex(), QModelIndex() );
 }
 
 void QgsVectorLayerAndAttributeModel::applyVisibility( QSet<QString> &visibleLayers, QgsLayerTreeNode *node )
@@ -382,10 +380,15 @@ void QgsVectorLayerAndAttributeModel::applyVisibility( QSet<QString> &visibleLay
     if ( QgsLayerTree::isLayer( child ) )
     {
       QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( QgsLayerTree::toLayer( child )->layer() );
-      if ( vl && visibleLayers.contains( vl->id() ) )
+      if ( vl )
       {
-        visibleLayers.remove( vl->id() );
-        mCheckedLeafs.insert( node2index( child ) );
+        QModelIndex idx = node2index( child );
+        if ( visibleLayers.contains( vl->id() ) )
+        {
+          visibleLayers.remove( vl->id() );
+          mCheckedLeafs.insert( idx );
+        }
+        emit dataChanged( idx, idx, QVector<int>() << Qt::CheckStateRole );
       }
       continue;
     }


### PR DESCRIPTION
## Description

The handling of dataChanged signal was not handled properly in the DXF export dialog when changing map theme visibility preset. This PR fixes that. It also fixes a typo that led to failure to restore last used map theme.