### PR TITLE
CI: macos-build.yml: add missing toplevel permissions section

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -18,6 +18,9 @@ on:
       - queued_ltr_backports
     paths:
 
+permissions:
+  contents: read
+
 env:
   QT_VERSION: 5.15.2
   QGIS_DEPS_VERSION: 0.9


### PR DESCRIPTION
OpenSSF Scorecard report complains about it: https://securityscorecards.dev/viewer/?uri=github.com/qgis/QGIS
