### PR TITLE
[dxf] Insure that the DXF export dialog's output attributes are saved/restored properly

### DIFF
--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -58,6 +58,9 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
 
     QList< QgsDxfExport::DxfLayer > layers() const;
 
+    void saveLayersOutputAttribute( QgsLayerTreeNode *node );
+    void loadLayersOutputAttribute( QgsLayerTreeNode *node );
+
     QgsVectorLayer *vectorLayer( const QModelIndex &index ) const;
     int attributeIndex( const QgsVectorLayer *vl ) const;
 


### PR DESCRIPTION
## Description

These fellows are now saved to/restored from project files properly:

![image](https://github.com/qgis/QGIS/assets/1728657/eaac3ced-7edb-46f9-b577-53b64690ca3c)
