### PR TITLE
Fix db manager test on newer GDAL versions 

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -120,7 +120,6 @@ PyQgsZonalStatistics
 PyQgsVirtualLayerProvider
 PyQgsLayerDefinition
 PyQgsWFSProvider
-PyQgsDBManagerGpkg
 PyQgsSettings
 PyQgsSettingsEntry
 PyQgsSelectiveMasking

--- a/tests/src/python/test_db_manager_gpkg.py
+++ b/tests/src/python/test_db_manager_gpkg.py
@@ -219,7 +219,11 @@ class TestPyQgsDBManagerGpkg(QgisTestCase):
         uri = QgsDataSourceUri()
 
         test_gpkg_new = os.path.join(self.basetestpath, 'testCreateRenameDeleteFields.gpkg')
-        shutil.copy(self.test_gpkg, test_gpkg_new)
+
+        ds = ogr.GetDriverByName('GPKG').CreateDataSource(test_gpkg_new)
+        lyr = ds.CreateLayer('testLayer', geom_type=ogr.wkbLineString, options=['SPATIAL_INDEX=NO'])
+        lyr.CreateField(ogr.FieldDefn('text_field', ogr.OFTString))
+        del ds
 
         uri.setDatabase(test_gpkg_new)
         self.assertTrue(plugin.addConnection(connection_name, uri))


### PR DESCRIPTION
The test was kind of broken - it was trying to create a new field with a not null constraint when existing features where present in the target layer. Newer gdal correctly rejects this. So update the test to use an empty layer instead.