### PR TITLE
[dxf] When exporting to DXF, skip empty layers

### DIFF
--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -146,6 +146,13 @@ Add layers to export
 
     ExportResult writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
 
+    const QString feedbackMessage() const;
+%Docstring
+Returns any feedback message produced while export to dxf file.
+
+.. versionadded:: 3.36
+%End
+
     void setSymbologyScale( double scale );
 %Docstring
 Set reference ``scale`` for output.

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -146,6 +146,13 @@ Add layers to export
 
     ExportResult writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
 
+    const QString feedbackMessage() const;
+%Docstring
+Returns any feedback message produced while export to dxf file.
+
+.. versionadded:: 3.36
+%End
+
     void setSymbologyScale( double scale );
 %Docstring
 Set reference ``scale`` for output.

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -144,6 +144,10 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   switch ( dxfExport.writeToFile( &dxfFile, encoding ) )
   {
     case QgsDxfExport::ExportResult::Success:
+      if ( !dxfExport.feedbackMessage().isEmpty() )
+      {
+        feedback->pushInfo( dxfExport.feedbackMessage() );
+      }
       feedback->pushInfo( QObject::tr( "DXF export completed" ) );
       break;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6865,16 +6865,26 @@ void QgisApp::dxfExport()
     switch ( dxfExport.writeToFile( &dxfFile, d.encoding() ) )
     {
       case QgsDxfExport::ExportResult::Success:
-        visibleMessageBar()->pushMessage( tr( "DXF export" ),
-                                          tr( "Successfully exported DXF to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileName ).toString(), QDir::toNativeSeparators( fileName ) ),
-                                          Qgis::MessageLevel::Success, 0 );
+      {
+        QgsMessageBarItem *message = QgsMessageBar::createMessage( tr( "DXF export" ), tr( "Successfully exported DXF to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileName ).toString(), QDir::toNativeSeparators( fileName ) ), this );
+        message->setLevel( Qgis::MessageLevel::Success );
+        message->setDuration( 0 );
         if ( !dxfExport.feedbackMessage().isEmpty() )
         {
-          visibleMessageBar()->pushMessage( tr( "DXF export" ),
-                                            dxfExport.feedbackMessage(),
-                                            Qgis::MessageLevel::Info );
+          QPushButton *detailsButton = new QPushButton( tr( "More Info" ) );
+          const QString feedbackMessage = dxfExport.feedbackMessage();
+          connect( detailsButton, &QPushButton::clicked, this, [detailsButton, feedbackMessage]
+          {
+            QgsMessageViewer *dialog = new QgsMessageViewer( detailsButton );
+            dialog->setTitle( tr( "DXF Export" ) );
+            dialog->setMessageAsPlainText( feedbackMessage );
+            dialog->showMessage();
+          } );
+          message->layout()->addWidget( detailsButton );
         }
+        visibleMessageBar()->pushItem( message );
         break;
+      }
 
       case QgsDxfExport::ExportResult::DeviceNotWritableError:
         visibleMessageBar()->pushMessage( tr( "DXF export" ),

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6865,21 +6865,32 @@ void QgisApp::dxfExport()
     switch ( dxfExport.writeToFile( &dxfFile, d.encoding() ) )
     {
       case QgsDxfExport::ExportResult::Success:
-        visibleMessageBar()->pushMessage( tr( "DXF export completed" ),
+        visibleMessageBar()->pushMessage( tr( "DXF export" ),
                                           tr( "Successfully exported DXF to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileName ).toString(), QDir::toNativeSeparators( fileName ) ),
                                           Qgis::MessageLevel::Success, 0 );
+        if ( !dxfExport.feedbackMessage().isEmpty() )
+        {
+          visibleMessageBar()->pushMessage( tr( "DXF export" ),
+                                            dxfExport.feedbackMessage(),
+                                            Qgis::MessageLevel::Info );
+        }
         break;
 
       case QgsDxfExport::ExportResult::DeviceNotWritableError:
-        visibleMessageBar()->pushMessage( tr( "DXF export failed, device is not writable" ), Qgis::MessageLevel::Critical );
+        visibleMessageBar()->pushMessage( tr( "DXF export" ),
+                                          tr( "DXF export failed, device is not writable" ),
+                                          Qgis::MessageLevel::Critical );
         break;
 
       case QgsDxfExport::ExportResult::InvalidDeviceError:
-        visibleMessageBar()->pushMessage( tr( "DXF export failed, the device is invalid" ), Qgis::MessageLevel::Critical );
+        visibleMessageBar()->pushMessage( tr( "DXF export" ),
+                                          tr( "DXF export failed, the device is invalid" ),
+                                          Qgis::MessageLevel::Critical );
         break;
 
       case QgsDxfExport::ExportResult::EmptyExtentError:
-        visibleMessageBar()->pushMessage( tr( "DXF export failed, the extent could not be determined" ), Qgis::MessageLevel::Critical );
+        visibleMessageBar()->pushMessage( tr( "DXF export" ),
+                                          tr( "DXF export failed, the extent could not be determined" ), Qgis::MessageLevel::Critical );
         break;
     }
     QApplication::restoreOverrideCursor();

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -86,19 +86,16 @@ QgsDxfExport::Flags QgsDxfExport::flags() const
 
 void QgsDxfExport::addLayers( const QList<DxfLayer> &layers )
 {
-  QList<QgsMapLayer *> layerList;
-
+  mLayerList.clear();
   mLayerNameAttribute.clear();
 
-  layerList.reserve( layers.size() );
+  mLayerList.reserve( layers.size() );
   for ( const DxfLayer &dxfLayer : layers )
   {
-    layerList << dxfLayer.layer();
+    mLayerList << dxfLayer.layer();
     if ( dxfLayer.layerOutputAttributeIndex() >= 0 )
       mLayerNameAttribute.insert( dxfLayer.layer()->id(), dxfLayer.layerOutputAttributeIndex() );
   }
-
-  mMapSettings.setLayers( layerList );
 }
 
 void QgsDxfExport::writeGroup( int code, int i )
@@ -209,8 +206,8 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
 
   if ( mExtent.isEmpty() )
   {
-    const QList< QgsMapLayer * > layers = mMapSettings.layers();
-    for ( QgsMapLayer *ml : layers )
+    QgsRectangle extent;
+    for ( QgsMapLayer *ml : std::as_const( mLayerList ) )
     {
       QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
       if ( !vl )
@@ -222,26 +219,61 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
 
       layerExtent = mMapSettings.layerToMapCoordinates( vl, layerExtent );
 
-      if ( mExtent.isEmpty() )
+      if ( extent.isEmpty() )
       {
-        mExtent = layerExtent;
+        extent = layerExtent;
       }
       else
       {
-        mExtent.combineExtentWith( layerExtent );
+        extent.combineExtentWith( layerExtent );
       }
     }
+    mMapSettings.setExtent( extent );
+  }
+  else
+  {
+    mMapSettings.setExtent( mExtent );
   }
 
-  if ( mExtent.isEmpty() )
+  if ( mMapSettings.extent().isEmpty() )
     return ExportResult::EmptyExtentError;
 
   Qgis::DistanceUnit mapUnits = mCrs.mapUnits();
-  mMapSettings.setExtent( mExtent );
+
+  // Empty layer check to avoid adding those in the exported file
+  QList<QgsMapLayer *> layers;
+  QStringList skippedLayers;
+  for ( QgsMapLayer *ml : std::as_const( mLayerList ) )
+  {
+    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
+    if ( !vl )
+    {
+      continue;
+    }
+
+    QgsFeatureRequest request;
+    request.setLimit( 1 );
+    if ( !mExtent.isEmpty() )
+    {
+      const QgsRectangle extentRect = mMapSettings.mapToLayerCoordinates( vl, mExtent );
+      request.setFilterRect( extentRect );
+    }
+    QgsFeatureIterator featureIt = vl->getFeatures( request );
+    QgsFeature feature;
+    if ( featureIt.nextFeature( feature ) )
+    {
+      layers << ml;
+    }
+    else
+    {
+      skippedLayers << ml->name();
+    }
+  }
+  mMapSettings.setLayers( layers );
 
   int dpi = 96;
   mFactor = 1000 * dpi / mSymbologyScale / 25.4 * QgsUnitTypes::fromUnitToUnitFactor( mapUnits, Qgis::DistanceUnit::Meters );
-  mMapSettings.setOutputSize( QSize( mExtent.width() * mFactor, mExtent.height() * mFactor ) );
+  mMapSettings.setOutputSize( QSize( std::floor( mMapSettings.extent().width() * mFactor ), std::floor( mMapSettings.extent().height() * mFactor ) ) );
   mMapSettings.setOutputDpi( dpi );
 
   writeHeader( dxfEncoding( encoding ) );
@@ -251,6 +283,11 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
   writeEntities();
   writeEndFile();
   stopRenderers();
+
+  if ( !skippedLayers.isEmpty() )
+  {
+    mFeedbackMessage = QObject::tr( "The following empty layers were skipped: %1" ).arg( skippedLayers.join( QStringLiteral( ", " ) ) );
+  }
 
   return ExportResult::Success;
 }
@@ -273,11 +310,11 @@ void QgsDxfExport::writeHeader( const QString &codepage )
 
   // EXTMIN
   writeGroup( 9, QStringLiteral( "$EXTMIN" ) );
-  writeGroup( 0, QgsPoint( Qgis::WkbType::PointZ, mExtent.xMinimum(), mExtent.yMinimum(), 0.0 ) );
+  writeGroup( 0, QgsPoint( Qgis::WkbType::PointZ, mMapSettings.extent().xMinimum(), mMapSettings.extent().yMinimum(), 0.0 ) );
 
   // EXTMAX
   writeGroup( 9, QStringLiteral( "$EXTMAX" ) );
-  writeGroup( 0, QgsPoint( Qgis::WkbType::PointZ, mExtent.xMaximum(), mExtent.yMaximum(), 0.0 ) );
+  writeGroup( 0, QgsPoint( Qgis::WkbType::PointZ, mMapSettings.extent().xMaximum(), mMapSettings.extent().yMaximum(), 0.0 ) );
 
   // Global linetype scale
   writeGroup( 9, QStringLiteral( "$LTSCALE" ) );
@@ -440,10 +477,10 @@ void QgsDxfExport::writeTables()
   writeGroup( 3, QgsPoint( 0.0, 0.0 ) );                            // snap base point
   writeGroup( 4, QgsPoint( 1.0, 1.0 ) );                            // snap spacing
   writeGroup( 5, QgsPoint( 1.0, 1.0 ) );                            // grid spacing
-  writeGroup( 6, QgsPoint( Qgis::WkbType::PointZ, 0.0, 0.0, 1.0 ) );  // view direction from target point
-  writeGroup( 7, QgsPoint( mExtent.center() ) );                    // view target point
-  writeGroup( 40, mExtent.height() );                               // view height
-  writeGroup( 41, mExtent.width() / mExtent.height() );             // view aspect ratio
+  writeGroup( 6, QgsPoint( Qgis::WkbType::PointZ, 0.0, 0.0, 1.0 ) );// view direction from target point
+  writeGroup( 7, QgsPoint( mMapSettings.extent().center() ) );      // view target point
+  writeGroup( 40, mMapSettings.extent().height() );                 // view height
+  writeGroup( 41, mMapSettings.extent().width() / mMapSettings.extent().height() );// view aspect ratio
   writeGroup( 42, 50.0 );                                           // lens length
   writeGroup( 43, 0.0 );                                            // front clipping plane
   writeGroup( 44, 0.0 );                                            // back clipping plane
@@ -682,7 +719,7 @@ void QgsDxfExport::writeEntities()
     QgsFeatureRequest request = QgsFeatureRequest().setSubsetOfAttributes( job->attributes, job->fields ).setExpressionContext( job->renderContext.expressionContext() );
     QgsCoordinateTransform extentTransform = ct;
     extentTransform.setBallparkTransformsAreAppropriate( true );
-    request.setFilterRect( extentTransform.transformBoundingBox( mExtent, Qgis::TransformDirection::Reverse ) );
+    request.setFilterRect( extentTransform.transformBoundingBox( mMapSettings.extent(), Qgis::TransformDirection::Reverse ) );
 
     QgsFeatureIterator featureIt = job->featureSource.getFeatures( request );
 
@@ -782,11 +819,14 @@ void QgsDxfExport::prepareRenderers()
 
   mRenderContext = QgsRenderContext();
   mRenderContext.setRendererScale( mSymbologyScale );
-  mRenderContext.setExtent( mExtent );
+  mRenderContext.setExtent( mMapSettings.extent() );
 
   mRenderContext.setScaleFactor( 96.0 / 25.4 );
-  mRenderContext.setMapToPixel( QgsMapToPixel( 1.0 / mFactor, mExtent.center().x(), mExtent.center().y(), mExtent.width() * mFactor,
-                                mExtent.height() * mFactor, 0 ) );
+  mRenderContext.setMapToPixel( QgsMapToPixel( 1.0 / mFactor,
+                                mMapSettings.extent().center().x(),
+                                mMapSettings.extent().center().y(),
+                                std::floor( mMapSettings.extent().width() * mFactor ),
+                                std::floor( mMapSettings.extent().height() * mFactor ), 0 ) );
 
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) );
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::globalScope() );
@@ -833,7 +873,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( DxfLayerJob *job )
   QgsFeatureRequest req;
   req.setSubsetOfAttributes( job->renderer->usedAttributes( ctx ), job->featureSource.fields() );
   QgsCoordinateTransform ct( mMapSettings.destinationCrs(), job->crs, mMapSettings.transformContext() );
-  req.setFilterRect( ct.transform( mExtent ) );
+  req.setFilterRect( ct.transform( mMapSettings.extent() ) );
 
   QgsFeatureIterator fit = job->featureSource.getFeatures( req );
 
@@ -2179,8 +2219,7 @@ bool QgsDxfExport::layerIsScaleBasedVisible( const QgsMapLayer *layer ) const
 QString QgsDxfExport::layerName( const QString &id, const QgsFeature &f ) const
 {
   // TODO: make this thread safe
-  const QList< QgsMapLayer * > layers = mMapSettings.layers();
-  for ( QgsMapLayer *ml : layers )
+  for ( QgsMapLayer *ml : std::as_const( mLayerList ) )
   {
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
     if ( vl && vl->id() == id )

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -206,6 +206,12 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     ExportResult writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
 
     /**
+     * Returns any feedback message produced while export to dxf file.
+     * \since QGIS 3.36
+     */
+    const QString feedbackMessage() const { return mFeedbackMessage; }
+
+    /**
      * Set reference \a scale for output.
      * The \a scale value indicates the scale denominator, e.g. 1000.0 for a 1:1000 map.
      * \see symbologyScale()
@@ -629,6 +635,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     QMap< QString, QMap<QgsFeatureId, QString> > mDxfLayerNames;
     QgsCoordinateReferenceSystem mCrs;
     QgsMapSettings mMapSettings;
+    QList<QgsMapLayer *> mLayerList;
     QHash<QString, int> mLayerNameAttribute;
     double mFactor = 1.0;
     bool mForce2d = false;
@@ -644,6 +651,8 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     // Internal cache for layer related information required during rendering
     QList<DxfLayerJob *> mJobs;
     std::unique_ptr<QgsLabelingEngine> mLabelingEngine;
+
+    QString mFeedbackMessage;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDxfExport::Flags )

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -72,6 +72,7 @@ class TestQgsDxfExport : public QObject
     void testDashedLine();
     void testTransform();
     void testDataDefinedPoints();
+    void testExtent();
 
   private:
     QgsVectorLayer *mPointLayer = nullptr;
@@ -1406,6 +1407,44 @@ void TestQgsDxfExport::testDataDefinedPoints()
                               "1.0\n"
                               "  0\n"
                               "ENDBLK", &debugInfo ), debugInfo.toUtf8().constData() );
+}
+
+void TestQgsDxfExport::testExtent()
+{
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPolygonLayer ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPolygonLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPolygonLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPolygonLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setExtent( QgsRectangle( -103.9, 25.0, -98.0, 29.8 ) );
+
+  const QString file1 = getTempFileName( "polygon_extent_dxf" );
+  QFile dxfFile1( file1 );
+  QCOMPARE( d.writeToFile( &dxfFile1, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile1.close();
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file1, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), 1L );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::LineString );
+
+  d.setExtent( QgsRectangle( 81.0, 34.0, -77.0, 38.0 ) );
+  const QString file2 = getTempFileName( "polygon_extent_empty_dxf" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  QString debugInfo;
+  QCOMPARE( fileContainsText( file2, "polygons", &debugInfo ), false );
 }
 
 bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &text, QString *debugInfo ) const


### PR DESCRIPTION
## Description

This PR insures that the LAYER groups are only written into the DXF when features are found within those layers. If no features are found (empty layer or no feature overlapping the provided extent), we write nothing.

Test cases were added to cover pre-existing filtering by extent and this additional handling of empty layers.