### PR TITLE
Show partial renders using points while calculating triangles

### DIFF
--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -130,7 +130,13 @@ void QgsPointCloudAttributeByRampRenderer::renderBlock( const QgsPointCloudBlock
       mColorRampShader.shade( attributeValue, &red, &green, &blue, &alpha );
 
       if ( renderAsTriangles() )
+      {
         addPointToTriangulation( x, y, z, QColor( red, green, blue, alpha ), context );
+
+        // We don't want to render any points if we're rendering triangles and there is no preview painter
+        if ( !context.renderContext().previewRenderPainter() )
+          continue;
+      }
 
       drawPoint( x, y, QColor( red, green, blue, alpha ), context );
       if ( renderElevation )

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -130,15 +130,11 @@ void QgsPointCloudAttributeByRampRenderer::renderBlock( const QgsPointCloudBlock
       mColorRampShader.shade( attributeValue, &red, &green, &blue, &alpha );
 
       if ( renderAsTriangles() )
-      {
         addPointToTriangulation( x, y, z, QColor( red, green, blue, alpha ), context );
-      }
-      else
-      {
-        drawPoint( x, y, QColor( red, green, blue, alpha ), context );
-        if ( renderElevation )
-          drawPointToElevationMap( x, y, z, context );
-      }
+
+      drawPoint( x, y, QColor( red, green, blue, alpha ), context );
+      if ( renderElevation )
+        drawPointToElevationMap( x, y, z, context );
 
       rendered++;
     }

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
@@ -149,7 +149,13 @@ void QgsPointCloudClassifiedRenderer::renderBlock( const QgsPointCloudBlock *blo
       }
 
       if ( renderAsTriangles() )
+      {
         addPointToTriangulation( x, y, z, color, context );
+
+        // We don't want to render any points if we're rendering triangles and there is no preview painter
+        if ( !context.renderContext().previewRenderPainter() )
+          continue;
+      }
 
       const double size = pointSizes.value( attributeValue );
       drawPoint( x, y, color, size, context );

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
@@ -149,16 +149,13 @@ void QgsPointCloudClassifiedRenderer::renderBlock( const QgsPointCloudBlock *blo
       }
 
       if ( renderAsTriangles() )
-      {
         addPointToTriangulation( x, y, z, color, context );
-      }
-      else
-      {
-        const double size = pointSizes.value( attributeValue );
-        drawPoint( x, y, color, size, context );
-        if ( renderElevation )
-          drawPointToElevationMap( x, y, z, size, context );
-      }
+
+      const double size = pointSizes.value( attributeValue );
+      drawPoint( x, y, color, size, context );
+      if ( renderElevation )
+        drawPointToElevationMap( x, y, z, size, context );
+
       rendered++;
     }
   }

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -330,6 +330,14 @@ bool QgsPointCloudLayerRenderer::renderIndex( QgsPointCloudIndex *pc )
 
 int QgsPointCloudLayerRenderer::renderNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled )
 {
+  QPainter *finalPainter = context.renderContext().painter();
+  if ( mRenderer->renderAsTriangles() && context.renderContext().previewRenderPainter() )
+  {
+    // swap out the destination painter for the preview render painter to render points
+    // until the actual triangles are ready to be rendered
+    context.renderContext().setPainter( context.renderContext().previewRenderPainter() );
+  }
+
   int nodesDrawn = 0;
   for ( const IndexedPointCloudNode &n : nodes )
   {
@@ -370,6 +378,8 @@ int QgsPointCloudLayerRenderer::renderNodesSync( const QVector<IndexedPointCloud
 
   if ( mRenderer->renderAsTriangles() )
   {
+    // Switch back from the preview painter to the destination painter to render the triangles
+    context.renderContext().setPainter( finalPainter );
     renderTriangulatedSurface( context );
   }
 
@@ -378,6 +388,14 @@ int QgsPointCloudLayerRenderer::renderNodesSync( const QVector<IndexedPointCloud
 
 int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled )
 {
+  QPainter *finalPainter = context.renderContext().painter();
+  if ( mRenderer->renderAsTriangles() && context.renderContext().previewRenderPainter() )
+  {
+    // swap out the destination painter for the preview render painter to render points
+    // until the actual triangles are ready to be rendered
+    context.renderContext().setPainter( context.renderContext().previewRenderPainter() );
+  }
+
   int nodesDrawn = 0;
 
   if ( context.feedback() && context.feedback()->isCanceled() )
@@ -460,6 +478,8 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
 
   if ( mRenderer->renderAsTriangles() )
   {
+    // Switch back from the preview painter to the destination painter to render the triangles
+    context.renderContext().setPainter( finalPainter );
     renderTriangulatedSurface( context );
   }
 
@@ -713,6 +733,14 @@ void QgsPointCloudLayerRenderer::renderTriangulatedSurface( QgsPointCloudRenderC
   }
 
   painter->drawImage( 0, 0, img );
+}
+
+Qgis::MapLayerRendererFlags QgsPointCloudLayerRenderer::flags() const
+{
+  // when rendering as triangles we still want to show temporary incremental renders as points until
+  // the final triangulated surface is ready, which may be slow
+  // So we request here a preview render image for the temporary incremental updates:
+  return Qgis::MapLayerRendererFlag::RenderPartialOutputs | Qgis::MapLayerRendererFlag::RenderPartialOutputOverPreviousCachedImage;
 }
 
 bool QgsPointCloudLayerRenderer::forceRasterRender() const

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -740,7 +740,10 @@ Qgis::MapLayerRendererFlags QgsPointCloudLayerRenderer::flags() const
   // when rendering as triangles we still want to show temporary incremental renders as points until
   // the final triangulated surface is ready, which may be slow
   // So we request here a preview render image for the temporary incremental updates:
-  return Qgis::MapLayerRendererFlag::RenderPartialOutputs | Qgis::MapLayerRendererFlag::RenderPartialOutputOverPreviousCachedImage;
+  if ( mRenderer->renderAsTriangles() )
+    return Qgis::MapLayerRendererFlag::RenderPartialOutputs | Qgis::MapLayerRendererFlag::RenderPartialOutputOverPreviousCachedImage;
+
+  return Qgis::MapLayerRendererFlags();
 }
 
 bool QgsPointCloudLayerRenderer::forceRasterRender() const

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     ~QgsPointCloudLayerRenderer();
 
     bool render() override;
+    Qgis::MapLayerRendererFlags flags() const override;
     bool forceRasterRender() const override;
     void setLayerRenderingTimeHint( int time ) override;
 

--- a/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
@@ -165,15 +165,12 @@ void QgsPointCloudRgbRenderer::renderBlock( const QgsPointCloudBlock *block, Qgs
       blue = std::max( 0, std::min( 255, blue ) );
 
       if ( renderAsTriangles() )
-      {
         addPointToTriangulation( x, y, z, QColor( red, green, blue ), context );
-      }
-      else
-      {
-        drawPoint( x, y, QColor( red, green, blue ), context );
-        if ( renderElevation )
-          drawPointToElevationMap( x, y, z, context );
-      }
+
+      drawPoint( x, y, QColor( red, green, blue ), context );
+      if ( renderElevation )
+        drawPointToElevationMap( x, y, z, context );
+
       rendered++;
     }
   }

--- a/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrgbrenderer.cpp
@@ -165,7 +165,13 @@ void QgsPointCloudRgbRenderer::renderBlock( const QgsPointCloudBlock *block, Qgs
       blue = std::max( 0, std::min( 255, blue ) );
 
       if ( renderAsTriangles() )
+      {
         addPointToTriangulation( x, y, z, QColor( red, green, blue ), context );
+
+        // We don't want to render any points if we're rendering triangles and there is no preview painter
+        if ( !context.renderContext().previewRenderPainter() )
+          continue;
+      }
 
       drawPoint( x, y, QColor( red, green, blue ), context );
       if ( renderElevation )


### PR DESCRIPTION
## Description
When _Render as a surface (triangulate)_ is enabled for point cloud 2d renderers, show a temporary preview render using points while computing the actual triangles.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
