### PR TITLE
Export layers to DXF algorithm harmonization

### DIFF
--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -63,14 +63,15 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
   std::unique_ptr<QgsProcessingParameterMapTheme> mapThemeParam = std::make_unique<QgsProcessingParameterMapTheme>( QStringLiteral( "MAP_THEME" ), QObject::tr( "Map theme" ), QVariant(), true );
   mapThemeParam->setHelp( QObject::tr( "Match layer styling to the provided map theme" ) );
   addParameter( mapThemeParam.release() );
-  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "ENCODING" ), QObject::tr( "Encoding" ), QgsDxfExport::encodings(), false, QVariant(), false, true ) );
+  const QStringList encodings = QgsDxfExport::encodings();
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "ENCODING" ), QObject::tr( "Encoding" ), encodings, false, encodings.at( 0 ), false, true ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "CRS" ), QStringLiteral( "EPSG:4326" ) ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
   std::unique_ptr<QgsProcessingParameterExtent> extentParam = std::make_unique<QgsProcessingParameterExtent>( QStringLiteral( "EXTENT" ), QObject::tr( "Extent" ), QVariant(), true );
   extentParam->setHelp( QObject::tr( "Limit exported features to those with geometries intersecting the provided extent" ) );
   addParameter( extentParam.release() );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "DXF" ), QObject::tr( "DXF Files" ) + " (*.dxf *.DXF)" ) );
 }
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.h
+++ b/src/analysis/processing/qgsalgorithmdxfexport.h
@@ -38,6 +38,10 @@ class QgsDxfExportAlgorithm : public QgsProcessingAlgorithm
   protected:
     QVariantMap processAlgorithm( const QVariantMap &parameters,
                                   QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    QMap<QString, QString> mMapThemeStyleOverrides;
 };
 
 ///@endcond PRIVATE

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -43,14 +43,14 @@ struct DxfLayerJob
       , splitLayerAttribute( splitLayerAttribute )
       , layerTitle( vl->title().isEmpty() ? vl->name() : vl->title() )
     {
-      fields = vl->fields();
-      renderer.reset( vl->renderer()->clone() );
-      renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
-
       if ( !layerStyleOverride.isNull() )
       {
         styleOverride.setOverrideStyle( layerStyleOverride );
       }
+
+      fields = vl->fields();
+      renderer.reset( vl->renderer()->clone() );
+      renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
 
       labeling.reset( vl->labelsEnabled() ? vl->labeling()->clone() : nullptr );
 

--- a/src/gui/proj/qgsprojectionselectionwidget.cpp
+++ b/src/gui/proj/qgsprojectionselectionwidget.cpp
@@ -719,7 +719,7 @@ void QgsProjectionSelectionWidget::setShowAccuracyWarnings( bool show )
 void QgsProjectionSelectionWidget::comboIndexChanged( int idx )
 {
   const QgsCoordinateReferenceSystem crs = mModel->data( mModel->index( idx, 0 ), StandardCoordinateReferenceSystemsModel::RoleCrs ).value< QgsCoordinateReferenceSystem >();
-  switch ( static_cast< CrsOption >( mCrsComboBox->itemData( idx ).toInt() ) )
+  switch ( static_cast< CrsOption >( mModel->data( mModel->index( idx, 0 ), StandardCoordinateReferenceSystemsModel::RoleOption ).toInt() ) )
   {
     case QgsProjectionSelectionWidget::Invalid:
     case QgsProjectionSelectionWidget::LayerCrs:


### PR DESCRIPTION
## Description

This PR harmonizes the export layers to DXF algorithm with the DXF export dialog. It basically adds two missing parameters exposing functionality in the QgsDxfExport classes. 

The two parameters are map theme and extent (highlighted below):

![image](https://github.com/qgis/QGIS/assets/1728657/6821e9a5-fa4d-4a9e-8894-aa7c56b2d7db)

While implementing the map theme parameter, I discovered that the QgsDxfExport map theme styling override functionality was broken :fearful: , so I fixed that along the way.

@nyalldawson , as I was testing this, I noticed the projection selector widget wouldn't emit a crsChanged signal when changing the CRS via the combobox. Turns out it was a regression from a recent set of work from you. Fix included here.