### PR TITLE
[attribute form] Insure that a field features multiple times in a feature form has its constraint properly reflected

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -164,6 +164,16 @@ Update constraint on a feature coming from a specific layer.
 .. versionadded:: 3.0
 %End
 
+    void updateConstraint( QgsEditorWidgetWrapper::ConstraintResult constraintResult, const QString &constraintFailureReason );
+%Docstring
+Update constraint manually by providing the constraint result value and failure reason(s).
+
+:param constraintResult: the constraint result value
+:param constraintFailureReason: the constraint failure reason(s) (blank is the result passes)
+
+.. versionadded:: 3.36
+%End
+
     bool isValidConstraint() const;
 %Docstring
 Gets the current constraint status.

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -164,6 +164,16 @@ Update constraint on a feature coming from a specific layer.
 .. versionadded:: 3.0
 %End
 
+    void updateConstraint( QgsEditorWidgetWrapper::ConstraintResult constraintResult, const QString &constraintFailureReason );
+%Docstring
+Update constraint manually by providing the constraint result value and failure reason(s).
+
+:param constraintResult: the constraint result value
+:param constraintFailureReason: the constraint failure reason(s) (blank is the result passes)
+
+.. versionadded:: 3.36
+%End
+
     bool isValidConstraint() const;
 %Docstring
 Gets the current constraint status.

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -266,6 +266,15 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int 
   }
 }
 
+void QgsEditorWidgetWrapper::updateConstraint( QgsEditorWidgetWrapper::ConstraintResult constraintResult, const QString &constraintFailureReason )
+{
+  mValidConstraint = constraintResult == ConstraintResultPass;
+  mIsBlockingCommit = constraintResult == ConstraintResultFailHard;
+  mConstraintFailureReason = constraintResult != ConstraintResultPass ? constraintFailureReason : QString();
+  mConstraintResult = constraintResult;
+  updateConstraintWidgetStatus();
+}
+
 bool QgsEditorWidgetWrapper::isValidConstraint() const
 {
   return mValidConstraint;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -176,6 +176,14 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void updateConstraint( const QgsVectorLayer *layer, int index, const QgsFeature &feature, QgsFieldConstraints::ConstraintOrigin constraintOrigin = QgsFieldConstraints::ConstraintOriginNotSet );
 
     /**
+     * Update constraint manually by providing the constraint result value and failure reason(s).
+     * \param constraintResult the constraint result value
+     * \param constraintFailureReason the constraint failure reason(s) (blank is the result passes)
+     * \since QGIS 3.36
+     */
+    void updateConstraint( QgsEditorWidgetWrapper::ConstraintResult constraintResult, const QString &constraintFailureReason );
+
+    /**
      * Gets the current constraint status.
      * \returns TRUE if the constraint is valid or if there's no constraint,
      * FALSE otherwise

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1067,9 +1067,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
 
     // formEditorWidget and eww points to the same field, so block signals
     // as there is no need to handle valueChanged again for each duplicate
-    formEditorWidget->editorWidget()->blockSignals( true );
-    formEditorWidget->editorWidget()->setValue( value );
-    formEditorWidget->editorWidget()->blockSignals( false );
+    whileBlocking( formEditorWidget->editorWidget() )->setValue( value );
   }
 
   updateConstraints( eww );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1057,6 +1057,21 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
       break;
   }
 
+  // Update other widgets pointing to the same field, required to happen now to insure
+  // currentFormValuesFeature() gets the right value when processing constraints
+  const QList<QgsAttributeFormEditorWidget *> formEditorWidgets = mFormEditorWidgets.values( eww->fieldIdx() );
+  for ( QgsAttributeFormEditorWidget *formEditorWidget : formEditorWidgets )
+  {
+    if ( formEditorWidget->editorWidget() == eww )
+      continue;
+
+    // formEditorWidget and eww points to the same field, so block signals
+    // as there is no need to handle valueChanged again for each duplicate
+    formEditorWidget->editorWidget()->blockSignals( true );
+    formEditorWidget->editorWidget()->setValue( value );
+    formEditorWidget->editorWidget()->blockSignals( false );
+  }
+
   updateConstraints( eww );
 
   // Update dependent fields (only if form is not initializing)
@@ -1071,20 +1086,6 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
   // Updates expression controlled labels and editable state
   updateLabels();
   updateEditableState();
-
-  // Update other widgets pointing to the same field
-  const QList<QgsAttributeFormEditorWidget *> formEditorWidgets = mFormEditorWidgets.values( eww->fieldIdx() );
-  for ( QgsAttributeFormEditorWidget *formEditorWidget : formEditorWidgets )
-  {
-    if ( formEditorWidget->editorWidget() == eww )
-      continue;
-
-    // formEditorWidget and eww points to the same field, so block signals
-    // as there is no need to handle valueChanged again for each duplicate
-    formEditorWidget->editorWidget()->blockSignals( true );
-    formEditorWidget->editorWidget()->setValue( value );
-    formEditorWidget->editorWidget()->blockSignals( false );
-  }
 
   if ( !signalEmitted )
   {
@@ -1435,7 +1436,13 @@ void QgsAttributeForm::onConstraintStatusChanged( const QString &constraint,
   const QList<QgsAttributeFormEditorWidget *> formEditorWidgets = mFormEditorWidgets.values( eww->fieldIdx() );
 
   for ( QgsAttributeFormEditorWidget *formEditorWidget : formEditorWidgets )
+  {
     formEditorWidget->setConstraintStatus( constraint, description, err, result );
+    if ( formEditorWidget->editorWidget() != eww )
+    {
+      formEditorWidget->editorWidget()->updateConstraint( result, err );
+    }
+  }
 }
 
 QList<QgsEditorWidgetWrapper *> QgsAttributeForm::constraintDependencies( QgsEditorWidgetWrapper *w )


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/55607 , whereas a feature form featuring the same field editor widget multiple times would not have their constraints properly reflected in the UI.