### PR TITLE
Add current zoom label to tile scale widget

### DIFF
--- a/src/providers/wms/qgstilescalewidget.cpp
+++ b/src/providers/wms/qgstilescalewidget.cpp
@@ -105,6 +105,9 @@ void QgsTileScaleWidget::scaleChanged( double scale )
   mSlider->blockSignals( true );
   mSlider->setValue( i );
   mSlider->blockSignals( false );
+
+
+  mLabelScale->setText( QStringLiteral( "Zoom: %1" ).arg( i ) );
 }
 
 void QgsTileScaleWidget::mSlider_valueChanged( int value )

--- a/src/providers/wms/qgstilescalewidget.cpp
+++ b/src/providers/wms/qgstilescalewidget.cpp
@@ -107,7 +107,7 @@ void QgsTileScaleWidget::scaleChanged( double scale )
   mSlider->blockSignals( false );
 
 
-  mLabelScale->setText( QStringLiteral( "Zoom: %1" ).arg( i ) );
+  mLabelScale->setText( tr( "Zoom: %1" ).arg( i ) );
 }
 
 void QgsTileScaleWidget::mSlider_valueChanged( int value )

--- a/src/ui/qgstilescalewidgetbase.ui
+++ b/src/ui/qgstilescalewidgetbase.ui
@@ -19,9 +19,28 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
    <item>
+    <widget class="QLabel" name="mLabelScale">
+     <property name="text">
+      <string>Zoom</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
     <widget class="QSlider" name="mSlider">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>


### PR DESCRIPTION
## Description

Adds a label on the tile scale widget to display the current zoom level.    I was using this the other day to generate some tiles couldn't see what zoom I was currently at which was a bit annoying.  The tooltip has it but not super clear.

![image](https://github.com/qgis/QGIS/assets/381660/b7d120b9-4b1a-4ced-9649-49353d7b75c5)
