### PR TITLE
Fix #50761 - More human error on expression parser error

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -230,7 +230,8 @@ bool QgsExpression::hasParserError() const
 
 QString QgsExpression::parserErrorString() const
 {
-  return d->mParserErrorString;
+  return d->mParserErrorString.replace( "syntax error, unexpected end of file",
+                                        "Invalid expression. Unexpected end. You might not have finished the full expression" );
 }
 
 QList<QgsExpression::ParserError> QgsExpression::parserErrors() const

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -231,7 +231,7 @@ bool QgsExpression::hasParserError() const
 QString QgsExpression::parserErrorString() const
 {
   return d->mParserErrorString.replace( "syntax error, unexpected end of file",
-                                        "Invalid expression. Unexpected end. You might not have finished the full expression" );
+                                        tr( "Invalid expression. Unexpected end. You might not have finished the full expression" ) );
 }
 
 QList<QgsExpression::ParserError> QgsExpression::parserErrors() const

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -433,6 +433,13 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp.parserErrors().first().lastColumn, lastColumn );
     }
 
+    void parser_error_message_replace()
+    {
+      QgsExpression exp( QString( "1+" ) );
+      QCOMPARE( exp.hasParserError(), true );
+      QCOMPARE( exp.parserErrorString(), "\nInvalid expression. Unexpected end. You might not have finished the full expression" );
+    }
+
     void max_errors()
     {
       QgsExpression e( "wkt_geom&#x9;OBJECTID&#x9;id&#x9;a&#x9;b&#x9;c&#x9;d&#x9;e&#x9;f&#x9;g&#x9;h&#x9;i&#x9;j&#x9;k&#x9;l&#x9;m&#x9;n&#x9;o&#x9;p&#x9;q&#x9;r&#x9;" );
@@ -5821,6 +5828,7 @@ class TestQgsExpression: public QObject
         }
       }
     }
+
 
 };
 


### PR DESCRIPTION
## Description

Adds a bit more of a human facing error to end of input parser errors as raised in #50761.  Open to suggestions on better error wording. 

![image](https://github.com/qgis/QGIS/assets/381660/5cba11ae-0298-4dca-871d-1ede9bf020c0)

I'm only doing a string replace on the parser error here as I wasn't sure if there was a better way in the parser itself.  Have added a test around this message.