### PR TITLE
If dir does not exist for icon path. attempt to make path

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -785,6 +785,11 @@ QIcon QgsApplication::getThemeIcon( const QString &name, const QColor &fillColor
     const QByteArray svgContent = QgsApplication::svgCache()->svgContent( path, 16, fillColor, strokeColor, 1, 1 );
 
     const QString iconPath = sIconCacheDir()->filePath( cacheKey + QStringLiteral( ".svg" ) );
+    if ( const QDir dir = QFileInfo( iconPath ).dir(); !dir.exists() )
+    {
+      dir.mkpath( "." );
+    }
+
     QFile f( iconPath );
     if ( f.open( QFile::WriteOnly | QFile::Truncate ) )
     {


### PR DESCRIPTION
## Description

Some icon paths lie deeper in the icons folder structure. When calling QgsApplication::getThemeIcon() and subsequently calling iconFromColoredSvg() the new cached icon file can not be opened because its directory does not exist. 

The solution is very simple, just mkpath inside the sIconCacheDir so the icon file can be opened.