### PR TITLE
QgsGeos: Add precision when createGeometryEngine

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -3014,7 +3014,7 @@ geometry will retain the same dimensionality as the input geometry.
 
     static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry, double precision = 0.0 ) /Factory/;
 %Docstring
-Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid.
+Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid. The ``precision`` argument was added in 3.36.
 
 A geometry engine is a low-level representation of a :py:class:`QgsAbstractGeometry` object, optimised for use with external
 geometry libraries such as GEOS.

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -3012,9 +3012,9 @@ geometry will retain the same dimensionality as the input geometry.
 .. versionadded:: 2.9
 %End
 
-    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) /Factory/;
+    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry, double precision = 0.0 ) /Factory/;
 %Docstring
-Creates and returns a new geometry engine representing the specified ``geometry``.
+Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid.
 
 A geometry engine is a low-level representation of a :py:class:`QgsAbstractGeometry` object, optimised for use with external
 geometry libraries such as GEOS.

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -3014,7 +3014,7 @@ geometry will retain the same dimensionality as the input geometry.
 
     static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry, double precision = 0.0 ) /Factory/;
 %Docstring
-Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid.
+Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid. The ``precision`` argument was added in 3.36.
 
 A geometry engine is a low-level representation of a :py:class:`QgsAbstractGeometry` object, optimised for use with external
 geometry libraries such as GEOS.

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -3012,9 +3012,9 @@ geometry will retain the same dimensionality as the input geometry.
 .. versionadded:: 2.9
 %End
 
-    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) /Factory/;
+    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry, double precision = 0.0 ) /Factory/;
 %Docstring
-Creates and returns a new geometry engine representing the specified ``geometry``.
+Creates and returns a new geometry engine representing the specified ``geometry`` using ``precision`` on a grid.
 
 A geometry engine is a low-level representation of a :py:class:`QgsAbstractGeometry` object, optimised for use with external
 geometry libraries such as GEOS.

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -4297,9 +4297,9 @@ QgsGeometry QgsGeometry::convertToPolygon( bool destMultipart ) const
   }
 }
 
-QgsGeometryEngine *QgsGeometry::createGeometryEngine( const QgsAbstractGeometry *geometry )
+QgsGeometryEngine *QgsGeometry::createGeometryEngine( const QgsAbstractGeometry *geometry, double precision )
 {
-  return new QgsGeos( geometry );
+  return new QgsGeos( geometry, precision );
 }
 
 QDataStream &operator<<( QDataStream &out, const QgsGeometry &geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -3128,7 +3128,7 @@ class CORE_EXPORT QgsGeometry
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /**
-     * Creates and returns a new geometry engine representing the specified \a geometry.
+     * Creates and returns a new geometry engine representing the specified \a geometry using \a precision on a grid.
      *
      * A geometry engine is a low-level representation of a QgsAbstractGeometry object, optimised for use with external
      * geometry libraries such as GEOS.
@@ -3164,7 +3164,7 @@ class CORE_EXPORT QgsGeometry
      *
      * QgsGeometryEngine operations are backed by the GEOS library (https://trac.osgeo.org/geos/).
      */
-    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) SIP_FACTORY;
+    static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry, double precision = 0.0 ) SIP_FACTORY;
 
     /**
      * Upgrades a point list from QgsPointXY to QgsPoint

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -3128,7 +3128,7 @@ class CORE_EXPORT QgsGeometry
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /**
-     * Creates and returns a new geometry engine representing the specified \a geometry using \a precision on a grid.
+     * Creates and returns a new geometry engine representing the specified \a geometry using \a precision on a grid. The \a precision argument was added in 3.36.
      *
      * A geometry engine is a low-level representation of a QgsAbstractGeometry object, optimised for use with external
      * geometry libraries such as GEOS.


### PR DESCRIPTION
## Description

Geos geometry, via QgsGeos, accepts precision, but was not available using the createGeometryEngine.
