### PR TITLE
Fix double apply on update default values on volatile functions

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
@@ -341,16 +341,6 @@ have filter expressions that depend on the parent form scope.
 .. versionadded:: 3.14
 %End
 
-    static const QSet<QString> volatileExpressionFunctions();
-%Docstring
-Static function that returns a set of names of volatile expression functions
-to determine whether a widget should be updated "realtime" or not.*
-
-:return: QSet<QString> of volatile expression functions
-
-.. versionadded:: 3.34.4
-%End
-
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -341,16 +341,6 @@ have filter expressions that depend on the parent form scope.
 .. versionadded:: 3.14
 %End
 
-    static const QSet<QString> volatileExpressionFunctions();
-%Docstring
-Static function that returns a set of names of volatile expression functions
-to determine whether a widget should be updated "realtime" or not.*
-
-:return: QSet<QString> of volatile expression functions
-
-.. versionadded:: 3.34.4
-%End
-
 };
 
 /************************************************************************

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1007,7 +1007,6 @@ void QgsVectorLayer::updateDefaultValues( QgsFeatureId fid, QgsFeature feature )
     {
       if ( idx < 0 || idx >= size )
         continue;
-
       feature.setAttribute( idx, defaultValue( idx, feature ) );
       updateFeature( feature, true );
     }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -548,7 +548,7 @@ void QgsAttributeForm::updateValuesDependenciesDefaultValues( const int originId
   // create updated Feature
   QgsFeature updatedFeature = getUpdatedFeature();
 
-  // go through depending fields and the ones with volatile function and update the fields with defaultexpression
+  // go through depending fields and update the fields with defaultexpression
   QList<QgsWidgetWrapper *> relevantWidgets = mDefaultValueDependencies.values( originIdx );
   for ( QgsWidgetWrapper *ww : std::as_const( relevantWidgets ) )
   {
@@ -588,7 +588,7 @@ void QgsAttributeForm::updateValuesDependenciesVirtualFields( const int originId
   // create updated Feature
   QgsFeature updatedFeature = getUpdatedFeature();
 
-  // go through depending fields and the ones with volatile function and update the virtual field with its expression
+  // go through depending fields and update the virtual field with its expression
   const QList<QgsWidgetWrapper *> relevantWidgets = mVirtualFieldsDependencies.values( originIdx );
   for ( QgsWidgetWrapper *ww : relevantWidgets )
   {
@@ -3151,9 +3151,8 @@ void QgsAttributeForm::updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapp
   if ( exp.needsGeometry() )
     mNeedsGeometry = true;
 
-  //if the expression contains volatile functions, it should have the dependency of every field change
-  //if a function requires all attributes, then as well
-  if ( !exp.referencedFunctions().intersect( volatileExpressionFunctions() ).isEmpty() || exp.referencedColumns().contains( QgsFeatureRequest::ALL_ATTRIBUTES ) )
+  //if a function requires all attributes, it should have the dependency of every field change
+  if ( exp.referencedColumns().contains( QgsFeatureRequest::ALL_ATTRIBUTES ) )
   {
     const QList<int> allAttributeIds( mLayer->fields().allAttributesList() );
 
@@ -3184,9 +3183,8 @@ void QgsAttributeForm::updateFieldDependenciesVirtualFields( QgsEditorWidgetWrap
   if ( exp.needsGeometry() )
     mNeedsGeometry = true;
 
-  //if the expression contains volatile functions, it should have the dependency of every field change
-  //if a function requires all attributes, then as well
-  if ( !exp.referencedFunctions().intersect( volatileExpressionFunctions() ).isEmpty() || exp.referencedColumns().contains( QgsFeatureRequest::ALL_ATTRIBUTES ) )
+  //if a function requires all attributes, it should have the dependency of every field change
+  if ( exp.referencedColumns().contains( QgsFeatureRequest::ALL_ATTRIBUTES ) )
   {
     const QList<int> allAttributeIds( mLayer->fields().allAttributesList() );
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -353,15 +353,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
 
-    /**
-     * Static function that returns a set of names of volatile expression functions
-     * to determine whether a widget should be updated "realtime" or not.*
-     * \returns QSet<QString> of volatile expression functions
-     *
-     * \since QGIS 3.34.4
-     */
-    static const QSet<QString> volatileExpressionFunctions() { return QSet<QString>() << QStringLiteral( "now" ) << QStringLiteral( "rand" ) << QStringLiteral( "randf" ) << QStringLiteral( "uuid" ); }
-
   private slots:
     void onAttributeChanged( const QVariant &value, const QVariantList &additionalFieldValues );
     void onAttributeAdded( int idx );

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -326,7 +326,7 @@ class TestQgsAttributeForm(QgisTestCase):
         self.assertEqual(feature.attribute('birthday'), 2014)
         # don't updated pos (because newly created feature)
         self.assertEqual(feature.attribute('pos'), 110)
-        # don't updated random (becuase newly created feature)
+        # don't updated random (because newly created feature)
         self.assertEqual(feature.attribute('random'), 100)
         # don't updated numbers
         self.assertEqual(feature.attribute('numbers'), [1, 10])
@@ -343,9 +343,9 @@ class TestQgsAttributeForm(QgisTestCase):
         self.assertEqual(form.currentFormFeature()['age'], 10)
         # don't update birthday
         self.assertEqual(form.currentFormFeature()['birthday'], 2014)
-        # don't update pos (because new feature)
+        # don't update pos (because newly created feature)
         self.assertEqual(form.currentFormFeature()['pos'], 110)
-        # don't update random (becuase new feature)
+        # don't update random (because newly created feature)
         self.assertEqual(form.currentFormFeature()['random'], 100)
         # don't update numbers
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -163,7 +163,7 @@ class TestQgsAttributeForm(QgisTestCase):
 
         layer = QgsVectorLayer("Point?field=age:int", "vl", "memory")
         # set default value for numbers to [1, {age}], it will depend on the field age and should update
-        field = QgsField('numbers', QVariant.List, subType=QVariant.Int)
+        field = QgsField('numbers', QVariant.List, 'array')
         field.setEditorWidgetSetup(QgsEditorWidgetSetup('List', {}))
         layer.dataProvider().addAttributes([field])
         layer.updateFields()

--- a/tests/src/python/test_qgsattributeform.py
+++ b/tests/src/python/test_qgsattributeform.py
@@ -163,7 +163,7 @@ class TestQgsAttributeForm(QgisTestCase):
 
         layer = QgsVectorLayer("Point?field=age:int", "vl", "memory")
         # set default value for numbers to [1, {age}], it will depend on the field age and should update
-        field = QgsField('numbers', QVariant.List, 'array')
+        field = QgsField('numbers', QVariant.List, subType=QVariant.Int)
         field.setEditorWidgetSetup(QgsEditorWidgetSetup('List', {}))
         layer.dataProvider().addAttributes([field])
         layer.updateFields()
@@ -214,19 +214,35 @@ class TestQgsAttributeForm(QgisTestCase):
         self.assertEqual(form.currentFormFeature()['number'], 12)
 
     def test_default_value_always_updated_live_edit(self):
-        """Test live update, when:
-        - dependency changed
-        - express1ion contains a volatile function (now, rand, randf, uuid)
-        This means:
-        - changing age -> update number, birthday, pos, random/ not update year
-        - changing year -> update birthday, pos and random / not update number, age
-        - update birthday -> update only pos and random
+        """
+        Live update on edit, when:
+        - dependency changed (depending field and any field on expression with ALL_ATTRIBUTES-dependency)
+        Update on save (after editing an existing feature), when:
+        - it's any other function (with volatile elements like now, rand, randf, uuid)
+        Update on save (after adding a feature):
+        - Keeping the values, no update.
+
+        We have the fields:
+        - age (no expression)
+        - year (no expression)
+        - birthday (depending on year and age): updates live when one of those changes
+        - pos (depending on age and having a volatile function): updates live when age changes and always after save
+        - random (depending on nothing): updates always after save
+        - evaluation - todo : eval('true')
+
+        This means on edit:
+        - changing age -> update live: number, birthday, pos / not update random and year
+        - changing year -> update birthday, pos / not update random, number, age
+        - changing birthday -> update nothing
+
+        On save when edit mode:
+        - update pos and random because of volatile functions
         """
 
         layer = QgsVectorLayer("Point?field=age:int&field=year:int&field=birthday:int&field=pos:int&field=random:int", "vl", "memory")
 
         # add another field numbers
-        field = QgsField('numbers', QVariant.List, 'array')
+        field = QgsField('numbers', QVariant.List, subType=QVariant.Int)
         field.setEditorWidgetSetup(QgsEditorWidgetSetup('List', {}))
         layer.dataProvider().addAttributes([field])
         layer.updateFields()
@@ -240,12 +256,12 @@ class TestQgsAttributeForm(QgisTestCase):
         layer.setDefaultValueDefinition(2, QgsDefaultValue('year - age', apply_on_update))
         layer.setEditorWidgetSetup(2, QgsEditorWidgetSetup('Range', {}))
 
-        # set default value for pos (3), it contains a volatile function and should update always (and it contains it's own value, to evaluate if it's changing)
+        # set default value for pos (3), it will depend on the field age and it contains a volatile function and should update after save (on singleeditmode)
         layer.setDefaultValueDefinition(3, QgsDefaultValue('pos + age + day_of_week( now() ) - day_of_week( now() )', apply_on_update))
         layer.setEditorWidgetSetup(3, QgsEditorWidgetSetup('Range', {}))
 
-        # set default value for pos (4), it contains a volatile function and should update always (and it contains it's own value, to evaluate if it's changing)
-        layer.setDefaultValueDefinition(4, QgsDefaultValue('random + 100 + rand(0,0)', apply_on_update))
+        # set default value for random (4), it contains a volatile function and should update after save (on singleeditmode)
+        layer.setDefaultValueDefinition(4, QgsDefaultValue('random + random + rand(0,0)', apply_on_update))
         layer.setEditorWidgetSetup(4, QgsEditorWidgetSetup('Range', {}))
 
         # set default value for numbers (5), it will depend on the field age
@@ -266,70 +282,120 @@ class TestQgsAttributeForm(QgisTestCase):
 
         QGISAPP.processEvents()
 
-        # changing age
+        # editing age
         form.changeAttribute('age', 10)
         self.assertEqual(form.currentFormFeature()['age'], 10)
-        # no change
+
+        # don't update year
         self.assertEqual(form.currentFormFeature()['year'], 2023)
-        # ubdate birthday because of age
+        # update birthday because of age
         self.assertEqual(form.currentFormFeature()['birthday'], 2013)
-        # 4 changes because now-function (and dependency)
-        # update pos because of age: pos(100) + age (10) = 110
-        # update pos in the process of random, but still having pos(100) + age (10) = 110 (because in this chained update, the value of pos is not yet updated)
-        # update pos because of birthday (what changed because of age): pos(110) + age (10) = 120
-        # update pos in the process of random, but still having pos(110) + age (10) = 120 (because in this chained update, the value of pos is not yet updated)
-        self.assertEqual(form.currentFormFeature()['pos'], 120)
-        # 2 changes because rand-function
-        # update random because change of age: random(100) + 100
-        # update random birthday (what changed because of age): random(200) + 100
-        # not updating because of pos, since it breaks the recursion
-        self.assertEqual(form.currentFormFeature()['random'], 300)
-        # change because dependency
+        # update pos because of age
+        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        # don't update random (yet)
+        self.assertEqual(form.currentFormFeature()['random'], 100)
+        # update number because of age
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])
 
-        # changing year
+        # editing year
         form.changeAttribute('year', 2024)
-
         self.assertEqual(form.currentFormFeature()['year'], 2024)
-        # no change
+
+        # don't update age
         self.assertEqual(form.currentFormFeature()['age'], 10)
-        # change because dependency
+        # update birthday because of year
         self.assertEqual(form.currentFormFeature()['birthday'], 2014)
-        # 4 changes because now-function (and dependency)
-        # update pos because of year: pos(120) + age (10) = 130
-        # update pos in the process of random, but still having pos(120) + age (10) = 130 (because in this chained update, the value of pos is not yet updated)
-        # update pos because of birthday (what changed because of year): pos(130) + age (10) = 140
-        # update pos in the process of random, but still having pos(130) + age (10) = 140 (because in this chained update, the value of pos is not yet updated)
-        self.assertEqual(form.currentFormFeature()['pos'], 140)
-        # 2 changes because rand-function
-        # update random because change of year: random(300) + 100
-        # update random birthday (what changed because of year): random(400) + 100
-        # not updating because of pos, since it breaks the recursion
-        self.assertEqual(form.currentFormFeature()['random'], 500)
-        # no change
+        # don't update pos (yet)
+        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        # don't update random (yet)
+        self.assertEqual(form.currentFormFeature()['random'], 100)
+        # don't update numbers
         self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])
 
-        print("changed year")
-        # changing mode
+        # save form - this leads not to any updates (because it's a newly created features)
         form.save()
 
-        form.setMode(QgsAttributeEditorContext.Mode.SingleEditMode)
-        # changing birthday
-        form.changeAttribute('birthday', 2200)
+        # read the feature and check, that nothing updated after save
+        feature = next(layer.getFeatures())
 
-        self.assertEqual(form.currentFormFeature()['birthday'], 2200)
-        # no change
-        self.assertEqual(form.currentFormFeature()['age'], 10)
-        # no change
+        # don't updated age
+        self.assertEqual(feature.attribute('age'), 10)
+        # don't updated year
+        self.assertEqual(feature.attribute('year'), 2024)
+        # don't updated birthday
+        self.assertEqual(feature.attribute('birthday'), 2014)
+        # don't updated pos (because newly created feature)
+        self.assertEqual(feature.attribute('pos'), 110)
+        # don't updated random (becuase newly created feature)
+        self.assertEqual(feature.attribute('random'), 100)
+        # don't updated numbers
+        self.assertEqual(feature.attribute('numbers'), [1, 10])
+
+        # changing mode of form
+        form.setMode(QgsAttributeEditorContext.Mode.SingleEditMode)
+        # and set the feature
+        form.setFeature(feature)
+
+        # check if nothing updated because of loading it:
+        # don't update year
         self.assertEqual(form.currentFormFeature()['year'], 2024)
-        # 2 changes because now-function
-        # update pos because of birthday:  pos(140) + age (10) = 150
-        # update pos in the process of random, but still having pos(140) + age (10) = 150 (because in this chained update, the value of pos is not yet updated)
-        self.assertEqual(form.currentFormFeature()['pos'], 150)
-        # 1 changes because rand-function
-        # update random because change of birthday: random(500) + 100
-        # not updating because of pos, since it breaks the recursion
-        self.assertEqual(form.currentFormFeature()['random'], 600)
+        # don't update age
+        self.assertEqual(form.currentFormFeature()['age'], 10)
+        # don't update birthday
+        self.assertEqual(form.currentFormFeature()['birthday'], 2014)
+        # don't update pos (because new feature)
+        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        # don't update random (becuase new feature)
+        self.assertEqual(form.currentFormFeature()['random'], 100)
+        # don't update numbers
+        self.assertEqual(form.currentFormFeature()['numbers'], [1, 10])
+
+        # editing birthday
+        form.changeAttribute('birthday', 2200)
+        self.assertEqual(form.currentFormFeature()['birthday'], 2200)
+
+        # don't update age
+        self.assertEqual(form.currentFormFeature()['age'], 10)
+        # don't update year
+        self.assertEqual(form.currentFormFeature()['year'], 2024)
+        # don't update pos
+        self.assertEqual(form.currentFormFeature()['pos'], 110)
+        # don't update random
+        self.assertEqual(form.currentFormFeature()['random'], 100)
+
+        # editing age
+        form.changeAttribute('age', 41)
+        self.assertEqual(form.currentFormFeature()['age'], 41)
+
+        # don't update year
+        self.assertEqual(form.currentFormFeature()['year'], 2024)
+        # update birthday because of age
+        self.assertEqual(form.currentFormFeature()['birthday'], 1983)
+        # update pos because of age
+        self.assertEqual(form.currentFormFeature()['pos'], 151)
+        # don't update random (yet)
+        self.assertEqual(form.currentFormFeature()['random'], 100)
+        # update number because of age
+        self.assertEqual(form.currentFormFeature()['numbers'], [1, 41])
+
+        # save form - this leads to updates, because existing feature
+        form.save()
+
+        # read the feature and check, that other function expressions updated (pos and rand)
+        feature = next(layer.getFeatures())
+
+        # don't updated age
+        self.assertEqual(feature.attribute('age'), 41)
+        # don't updated year
+        self.assertEqual(feature.attribute('year'), 2024)
+        # don't updated birthday
+        self.assertEqual(feature.attribute('birthday'), 1983)
+        # again updated pos
+        self.assertEqual(feature.attribute('pos'), 192)
+        # updated random
+        self.assertEqual(feature.attribute('random'), 200)
+        # don't updated numbers
+        self.assertEqual(feature.attribute('numbers'), [1, 41])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Don't update the widgets on volatile functions in real time. Only update those fields on saving the form (pressig ok) when it's on `*EditMode` (on `AddFeatureMode` it does not update it on save anyway because they are set on form open (like normal default values)).

This fixes #56022 and reverts a part of this fix here #55633 and brings back a behavior that used to be before this bug #54446. It's what originally :

- In attribute table: Default Values are emitted but we don't see it in the widget (but they are updated closing form)
- In form via identify: Default Values are emitted but we don't see it in the widget (but they are updated closing form)

(maybe this confusing concept could be improved by having a marker / icon there, but not as part of this PR here).
