### PR TITLE
[afs] Clone shared data before setting filters

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -653,7 +653,9 @@ bool QgsAfsProvider::setSubsetString( const QString &subset, bool )
   if ( trimmedSubset == mSharedData->subsetString() )
     return true;
 
-  // We must not change the subset string of the shared data used in another iterator/data provider ...
+  // We must not change the subset string of the shared data used in another iterator/data provider,
+  // or other layers attached to the same shared data (i.e. layers with a data provider cloned from
+  // this one) will also unwantedly inherit the new subset string.
   mSharedData = mSharedData->clone();
 
   mSharedData->setSubsetString( trimmedSubset );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -653,6 +653,9 @@ bool QgsAfsProvider::setSubsetString( const QString &subset, bool )
   if ( trimmedSubset == mSharedData->subsetString() )
     return true;
 
+  // We must not change the subset string of the shared data used in another iterator/data provider ...
+  mSharedData = mSharedData->clone();
+
   mSharedData->setSubsetString( trimmedSubset );
 
   // Update datasource uri too

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -56,6 +56,25 @@ QgsAfsSharedData::QgsAfsSharedData( const QgsDataSourceUri &uri )
 {
 }
 
+std::shared_ptr< QgsAfsSharedData > QgsAfsSharedData::clone() const
+{
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  std::shared_ptr< QgsAfsSharedData > copy = std::make_shared< QgsAfsSharedData >( mDataSource );
+  copy->mLimitBBox = mLimitBBox;
+  copy->mExtent = mExtent;
+  copy->mGeometryType = mGeometryType;
+  copy->mFields = mFields;
+  copy->mMaximumFetchObjectsCount = mMaximumFetchObjectsCount;
+  copy->mObjectIdFieldName = mObjectIdFieldName;
+  copy->mObjectIdFieldIdx = mObjectIdFieldIdx;
+  copy->mObjectIds = mObjectIds;
+  copy->mObjectIdToFeatureId = mObjectIdToFeatureId;
+  copy->mDeletedFeatureIds = mDeletedFeatureIds;
+  copy->mCache = mCache;
+  copy->mSourceCRS = mSourceCRS;
+  return copy;
+}
+
 QString QgsAfsSharedData::subsetString() const
 {
   return mDataSource.sql();

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -34,6 +34,9 @@ class QgsAfsSharedData
   public:
     QgsAfsSharedData( const QgsDataSourceUri &uri );
 
+    //! Creates a deep copy of this shared data
+    std::shared_ptr< QgsAfsSharedData > clone() const;
+
     long long objectIdCount() const;
     long long featureCount() const;
     bool isDeleted( QgsFeatureId id ) const { return mDeletedFeatureIds.contains( id ); }


### PR DESCRIPTION
We must not change the subset string of the shared data used in another iterator/data provider

Fixes filters applied to a duplicated AFS layer also incorrectly apply to the original layer
