### PR TITLE
Enable geometry restore for measure bearing/angle dialogs

### DIFF
--- a/src/app/qgsdisplayangle.cpp
+++ b/src/app/qgsdisplayangle.cpp
@@ -21,6 +21,7 @@
 #include "qgsproject.h"
 #include "qgsbearingnumericformat.h"
 #include "qgsmaptool.h"
+#include "qgsgui.h"
 
 #include <cmath>
 
@@ -29,6 +30,7 @@ QgsDisplayAngle::QgsDisplayAngle( QgsMapTool *tool, Qt::WindowFlags f )
   , mTool( tool )
 {
   setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
 }
 
 void QgsDisplayAngle::setAngleInRadians( double value )

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -68,7 +68,6 @@ void QgsMapToolMeasureAngle::canvasMoveEvent( QgsMapMouseEvent *e )
 
     if ( !mResultDisplay->isVisible() )
     {
-      mResultDisplay->move( e->pos() - QPoint( 100, 100 ) );
       mResultDisplay->show();
     }
 

--- a/src/app/qgsmaptoolmeasurebearing.cpp
+++ b/src/app/qgsmaptoolmeasurebearing.cpp
@@ -60,7 +60,6 @@ void QgsMapToolMeasureBearing::canvasMoveEvent( QgsMapMouseEvent *e )
 
       if ( !mResultDisplay->isVisible() )
       {
-        mResultDisplay->move( e->pos() - QPoint( 100, 100 ) );
         mResultDisplay->show();
       }
     }


### PR DESCRIPTION
## Description
Measure bearing/angle dialogs were moved to a fixed offset from the cursor position and _always_ in the main screen.
Let's use the standard `QgsGui::enableAutoGeometryRestore()` for this too. The first time the dialog will appear in the middle of its parent, then on its position/size will be recalled.

Fixes #56192

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
