### PR TITLE
Don't use QVariant(QVariant.Type) for NULL values in Python 

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -50,9 +50,7 @@ PyQgsDateTimeStatisticalSummary
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
 PyQgsElevationProfileCanvas
-PyQgsFieldFormattersTest
 PyQgsProject
-PyQgsFields
 PyQgsFieldModel
 PyQgsFloatingWidget
 PyQgsGeometryTest
@@ -94,7 +92,6 @@ PyQgsTextDocument
 PyQgsVectorLayerCache
 PyQgsVectorLayerEditBuffer
 PyQgsVectorLayerEditUtils
-PyQgsVectorLayerUtils
 PyQgsLayerDefinition
 PyQgsWFSProvider
 PyQgsSettings

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -35,7 +35,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterExtent,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterRasterDestination)
+                       QgsProcessingParameterRasterDestination, NULL)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -106,7 +106,7 @@ class rasterize(GdalAlgorithm):
                                                    self.tr('Assign a specified NoData value to output bands'),
                                                    type=QgsProcessingParameterNumber.Type.Double,
                                                    optional=True)
-        nodataParam.setGuiDefaultValueOverride(QVariant(QVariant.Double))
+        nodataParam.setGuiDefaultValueOverride(NULL)
         self.addParameter(nodataParam)
 
         options_param = QgsProcessingParameterString(self.OPTIONS,

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -38,8 +38,7 @@ from qgis.core import (
     QgsVectorLayer,
     QgsVectorLayerExporter,
     QgsVectorLayerUtils,
-    QgsWkbTypes,
-)
+    QgsWkbTypes, NULL)
 import unittest
 from qgis.testing import start_app, QgisTestCase
 from qgis.utils import spatialite_connect
@@ -1869,7 +1868,7 @@ class TestQgsSpatialiteProvider(QgisTestCase, ProviderTestCase):
         f.setGeometry(g)
         f.fields()
         f.fields().names()
-        f.setAttribute(1, QVariant(QVariant.String))
+        f.setAttribute(1, NULL)
         f.setAttribute(0, 'Autogenerate')
         self.assertTrue(layer.addFeatures([f]))
         self.assertFalse(layer.commitChanges())

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -37,8 +37,7 @@ from qgis.core import (
     QgsValueMapFieldFormatter,
     QgsValueRelationFieldFormatter,
     QgsVectorFileWriter,
-    QgsVectorLayer,
-)
+    QgsVectorLayer, NULL)
 import unittest
 from qgis.testing import start_app, QgisTestCase
 from qgis.utils import spatialite_connect
@@ -469,7 +468,7 @@ class TestQgsCheckBoxFieldFormatter(QgisTestCase):
         config['TextDisplayMethod'] = QgsCheckBoxFieldFormatter.TextDisplayMethod.ShowTrueFalse
         self.assertEqual(field_formatter.representValue(layer, 2, config, None, True), 'true')
         self.assertEqual(field_formatter.representValue(layer, 2, config, None, False), 'false')
-        self.assertEqual(field_formatter.representValue(layer, 2, config, None, QVariant(QVariant.Bool)), 'NULL')
+        self.assertEqual(field_formatter.representValue(layer, 2, config, None, NULL), 'NULL')
 
 
 class TestQgsFallbackFieldFormatter(QgisTestCase):
@@ -596,13 +595,13 @@ class TestQgsFallbackFieldFormatter(QgisTestCase):
             self.assertEqual(fieldFormatter.representValue(layer, 3 + offset, {}, None, None), 'NULL')
 
             # Check NULLs (this is what happens in real life inside QGIS)
-            self.assertEqual(fieldFormatter.representValue(layer, 0 + offset, {}, None, QVariant(QVariant.String)),
+            self.assertEqual(fieldFormatter.representValue(layer, 0 + offset, {}, None, NULL),
                              'NULL')
-            self.assertEqual(fieldFormatter.representValue(layer, 1 + offset, {}, None, QVariant(QVariant.String)),
+            self.assertEqual(fieldFormatter.representValue(layer, 1 + offset, {}, None, NULL),
                              'NULL')
-            self.assertEqual(fieldFormatter.representValue(layer, 2 + offset, {}, None, QVariant(QVariant.String)),
+            self.assertEqual(fieldFormatter.representValue(layer, 2 + offset, {}, None, NULL),
                              'NULL')
-            self.assertEqual(fieldFormatter.representValue(layer, 3 + offset, {}, None, QVariant(QVariant.String)),
+            self.assertEqual(fieldFormatter.representValue(layer, 3 + offset, {}, None, NULL),
                              'NULL')
 
         memory_layer = QgsVectorLayer("point?field=int:integer&field=double:double&field=long:long&field=string:string",
@@ -666,7 +665,7 @@ class TestQgsFallbackFieldFormatter(QgisTestCase):
 
         QLocale.setDefault(QLocale('en'))
 
-        self.assertEqual(fieldFormatter.representValue(vl, 1, {}, None, QVariant(QVariant.Int)),
+        self.assertEqual(fieldFormatter.representValue(vl, 1, {}, None, NULL),
                          'NULL')
         self.assertEqual(fieldFormatter.representValue(vl, 1, {}, None, 4),
                          '4')

--- a/tests/src/python/test_qgsfields.py
+++ b/tests/src/python/test_qgsfields.py
@@ -124,7 +124,7 @@ class TestQgsFields(QgisTestCase):
         self.assertTrue(vl.fields()[0].convertCompatible(123))
         # Check NULL/invalid
         self.assertIsNone(vl.fields()[0].convertCompatible(None))
-        self.assertEqual(vl.fields()[0].convertCompatible(QVariant(QVariant.Int)), NULL)
+        self.assertEqual(vl.fields()[0].convertCompatible(NULL), NULL)
         # Not valid
         with self.assertRaises(ValueError) as cm:
             vl.fields()[0].convertCompatible('QGIS Rocks!')

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -780,7 +780,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         features_data.append(
             QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: 'test_2', 1: QVariant()}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'),
-                                                                {0: 'test_3', 1: QVariant(QVariant.Int)}))
+                                                                {0: 'test_3', 1: NULL}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {0: 'test_4'}))
         features = QgsVectorLayerUtils.createFeatures(vl, features_data, context)
 
@@ -795,7 +795,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 44)'), {0: None}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: QVariant()}))
         features_data.append(
-            QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {0: QVariant(QVariant.String)}))
+            QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {0: NULL}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {}))
         features = QgsVectorLayerUtils.createFeatures(vl, features_data, context)
 


### PR DESCRIPTION
Instead use qgis.core.NULL, so that the correct logic applies for Qt6.