### PR TITLE
[processing] Fix GDAL "Fill NoData" algorithm (Fixes #56014)

### DIFF
--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -68,9 +68,15 @@ class fillnodata(GdalAlgorithm):
                                                        type=QgsProcessingParameterNumber.Type.Integer,
                                                        minValue=0,
                                                        defaultValue=0))
-        self.addParameter(QgsProcessingParameterBoolean(self.NO_MASK,
-                                                        self.tr('Do not use the default validity mask for the input band'),
-                                                        defaultValue=False))
+
+        nomask_param = QgsProcessingParameterBoolean(self.NO_MASK,
+                                                     self.tr('Do not use the default validity mask for the input band'),
+                                                     defaultValue=False,
+                                                     optional=True)
+        # The -nomask option is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201
+        if GdalUtils.version() >= 3040000:
+            nomask_param.setFlags(nomask_param.flags() | QgsProcessingParameterDefinition.FlagHidden)
+        self.addParameter(nomask_param)
         self.addParameter(QgsProcessingParameterRasterLayer(self.MASK_LAYER,
                                                             self.tr('Validity mask'),
                                                             optional=True))
@@ -136,7 +142,11 @@ class fillnodata(GdalAlgorithm):
         arguments.append(str(self.parameterAsInt(parameters, self.BAND, context)))
 
         if self.parameterAsBoolean(parameters, self.NO_MASK, context):
-            arguments.append('-nomask')
+            if GdalUtils.version() >= 3040000:
+                # The -nomask option is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201
+                feedback.pushInfo(self.tr('The -nomask option is no longer supported since GDAL 3.4.0'))
+            else:
+                arguments.append('-nomask')
 
         mask = self.parameterAsRasterLayer(parameters, self.MASK_LAYER, context)
         if mask:

--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -69,13 +69,13 @@ class fillnodata(GdalAlgorithm):
                                                        minValue=0,
                                                        defaultValue=0))
 
+        # The -nomask option is no longer supported since GDAL 3.4 and
+        # it doesn't work as expected even using GDAL < 3.4 https://github.com/OSGeo/gdal/pull/4201
         nomask_param = QgsProcessingParameterBoolean(self.NO_MASK,
                                                      self.tr('Do not use the default validity mask for the input band'),
                                                      defaultValue=False,
                                                      optional=True)
-        # The -nomask option is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201
-        if GdalUtils.version() >= 3040000:
-            nomask_param.setFlags(nomask_param.flags() | QgsProcessingParameterDefinition.FlagHidden)
+        nomask_param.setFlags(nomask_param.flags() | QgsProcessingParameterDefinition.FlagHidden)
         self.addParameter(nomask_param)
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.MASK_LAYER,
@@ -141,13 +141,6 @@ class fillnodata(GdalAlgorithm):
 
         arguments.append('-b')
         arguments.append(str(self.parameterAsInt(parameters, self.BAND, context)))
-
-        if self.parameterAsBoolean(parameters, self.NO_MASK, context):
-            if GdalUtils.version() >= 3040000:
-                # The -nomask option is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201
-                raise QgsProcessingException(self.tr('The -nomask option is no longer supported since GDAL 3.4.0'))
-            else:
-                arguments.append('-nomask')
 
         mask = self.parameterAsRasterLayer(parameters, self.MASK_LAYER, context)
         if mask:

--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -77,6 +77,7 @@ class fillnodata(GdalAlgorithm):
         if GdalUtils.version() >= 3040000:
             nomask_param.setFlags(nomask_param.flags() | QgsProcessingParameterDefinition.FlagHidden)
         self.addParameter(nomask_param)
+
         self.addParameter(QgsProcessingParameterRasterLayer(self.MASK_LAYER,
                                                             self.tr('Validity mask'),
                                                             optional=True))
@@ -144,7 +145,7 @@ class fillnodata(GdalAlgorithm):
         if self.parameterAsBoolean(parameters, self.NO_MASK, context):
             if GdalUtils.version() >= 3040000:
                 # The -nomask option is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201
-                feedback.pushInfo(self.tr('The -nomask option is no longer supported since GDAL 3.4.0'))
+                raise QgsProcessingException(self.tr('The -nomask option is no longer supported since GDAL 3.4.0'))
             else:
                 arguments.append('-nomask')
 

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2305,17 +2305,18 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ['gdal_fillnodata.py',
                  f'{source} {outsource} -md 10 -b 1 -of GTiff'])
 
-            if not GdalUtils.version() >= 3040000:
-                # nomask true
-                self.assertEqual(
-                    alg.getConsoleCommands({'INPUT': source,
-                                            'BAND': 1,
-                                            'DISTANCE': 10,
-                                            'ITERATIONS': 0,
-                                            'NO_MASK': True,
-                                            'OUTPUT': outsource}, context, feedback),
-                    ['gdal_fillnodata.py',
-                     f'{source} {outsource} -md 10 -b 1 -nomask -of GTiff'])
+            # The -nomask option is no longer supported since GDAL 3.4 and
+            # it doesn't work as expected even using GDAL < 3.4 https://github.com/OSGeo/gdal/pull/4201
+            # Silently ignore the NO_MASK parameter
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'DISTANCE': 10,
+                                        'ITERATIONS': 0,
+                                        'NO_MASK': True,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal_fillnodata.py',
+                 f'{source} {outsource} -md 10 -b 1 -of GTiff'])
 
             # creation options
             self.assertEqual(

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2315,7 +2315,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                                             'NO_MASK': True,
                                             'OUTPUT': outsource}, context, feedback),
                     ['gdal_fillnodata.py',
-                    f'{source} {outsource} -md 10 -b 1 -nomask -of GTiff'])
+                     f'{source} {outsource} -md 10 -b 1 -nomask -of GTiff'])
 
             # creation options
             self.assertEqual(

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2305,16 +2305,17 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ['gdal_fillnodata.py',
                  f'{source} {outsource} -md 10 -b 1 -of GTiff'])
 
-            # nomask true
-            self.assertEqual(
-                alg.getConsoleCommands({'INPUT': source,
-                                        'BAND': 1,
-                                        'DISTANCE': 10,
-                                        'ITERATIONS': 0,
-                                        'NO_MASK': True,
-                                        'OUTPUT': outsource}, context, feedback),
-                ['gdal_fillnodata.py',
-                 f'{source} {outsource} -md 10 -b 1 -nomask -of GTiff'])
+            if not GdalUtils.version() >= 3040000:
+                # nomask true
+                self.assertEqual(
+                    alg.getConsoleCommands({'INPUT': source,
+                                            'BAND': 1,
+                                            'DISTANCE': 10,
+                                            'ITERATIONS': 0,
+                                            'NO_MASK': True,
+                                            'OUTPUT': outsource}, context, feedback),
+                    ['gdal_fillnodata.py',
+                    f'{source} {outsource} -md 10 -b 1 -nomask -of GTiff'])
 
             # creation options
             self.assertEqual(


### PR DESCRIPTION
## Description

The `-nomask` option of the GDAL prrogram [`gdal_fillnodata`](https://gdal.org/programs/gdal_fillnodata.html) is no longer supported since GDAL 3.4.0 https://github.com/OSGeo/gdal/pull/4201.

This PR hides the "Do not use default validity mask for the input band" (`NO_MASK`) parameter of the GDAL "[Fill NoData](https://docs.qgis.org/testing/en/docs/user_manual/processing_algs/gdal/rasteranalysis.html#fill-nodata)" processing algorithm ~if the GDAL version used by QGIS is >= 3.4.0~.

Fixes https://github.com/qgis/QGIS/issues/56014.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
