### PR TITLE
Fix ellipse symbol size units not stored

### DIFF
--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -382,13 +382,16 @@ void QgsEllipseSymbolLayer::stopRender( QgsSymbolRenderContext & )
 QgsEllipseSymbolLayer *QgsEllipseSymbolLayer::clone() const
 {
   QgsEllipseSymbolLayer *m = new QgsEllipseSymbolLayer();
+  m->setSizeUnit( mSizeUnit );
+  m->setSizeMapUnitScale( mSizeMapUnitScale );
+  m->setOffsetUnit( mOffsetUnit );
+  m->setOffsetMapUnitScale( mOffsetMapUnitScale );
+  m->setOutputUnit( outputUnit() );
   m->setShape( mShape );
   m->setSymbolWidth( mSymbolWidth );
   m->setSymbolHeight( mSymbolHeight );
   m->setStrokeStyle( mStrokeStyle );
   m->setOffset( mOffset );
-  m->setOffsetUnit( mOffsetUnit );
-  m->setOffsetMapUnitScale( mOffsetMapUnitScale );
   m->setStrokeStyle( mStrokeStyle );
   m->setPenJoinStyle( mPenJoinStyle );
   m->setPenCapStyle( mPenCapStyle );

--- a/src/ui/layout/qgslayoutlegendwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendwidgetbase.ui
@@ -63,9 +63,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-2299</y>
-        <width>517</width>
-        <height>3237</height>
+        <y>0</y>
+        <width>362</width>
+        <height>1883</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -872,7 +872,7 @@
           <item row="4" column="1">
            <widget class="QgsDoubleSpinBox" name="mMaxSymbolSizeSpinBox">
             <property name="suffix">
-             <string>mm</string>
+             <string> mm</string>
             </property>
            </widget>
           </item>
@@ -893,7 +893,7 @@
           <item row="3" column="1">
            <widget class="QgsDoubleSpinBox" name="mMinSymbolSizeSpinBox">
             <property name="suffix">
-             <string>mm</string>
+             <string> mm</string>
             </property>
            </widget>
           </item>
@@ -1488,7 +1488,6 @@
   <tabstop>mGroupSpaceSpinBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Fix #56236

Also, add a space before 'mm' for consistecy with all other input boxes.
