### PR TITLE
qgspostgresprovider: Fix primary key retrieval with lowercase option

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4644,13 +4644,15 @@ Qgis::VectorExportResult QgsPostgresProvider::createEmptyLayer( const QString &u
   {
     pkList = parseUriKey( primaryKey );
     const auto constPkList = pkList;
+    const bool lowercaseFieldNames = options && options->value( QStringLiteral( "lowercaseFieldNames" ), false ).toBool();
     for ( const QString &col : constPkList )
     {
       // search for the passed field
       QString type;
       for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
       {
-        if ( fields[fldIdx].name() == col )
+        const QString fieldName = lowercaseFieldNames ? fields[fldIdx].name().toLower() : fields[fldIdx].name();
+        if ( fieldName == col )
         {
           // found, get the field type
           QgsField fld = fields[fldIdx];


### PR DESCRIPTION
The `lowercaseFieldNames` allows to transform the column names to lowercase. If this option is enabled, then the requested primary key (`primaryKey`) is in lowercase but the `fields` are not. Therefore, the requested primary key will never be found.

This issues is fixed by converting the field names to lowercase when looking for the primary key if the option is enabled.

Closes: https://github.com/qgis/QGIS/issues/55856

