### PR TITLE
Rename QgsShadowRenderingFrameGraph to QgsFrameGraph

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -20,6 +20,7 @@ set(QGIS_3D_SRCS
   qgscameracontroller.cpp
   qgscamerapose.cpp
   qgsfeature3dhandler_p.cpp
+  qgsframegraph.cpp
   qgsgltf3dutils.cpp
   qgsimagetexture.cpp
   qgslayoutitem3dmap.cpp
@@ -37,7 +38,6 @@ set(QGIS_3D_SRCS
   qgswindow3dengine.cpp
   qgsskyboxentity.cpp
   qgsskyboxsettings.cpp
-  qgsshadowrenderingframegraph.cpp
   qgspostprocessingentity.cpp
   qgsrenderpassquad.cpp
   qgsambientocclusionrenderentity.cpp
@@ -126,6 +126,7 @@ set(QGIS_3D_HDRS
   qgsabstractvectorlayer3drenderer.h
   qgscameracontroller.h
   qgscamerapose.h
+  qgsframegraph.h
   qgsgltf3dutils.h
   qgslayoutitem3dmap.h
   qgsmeshlayer3drenderer.h
@@ -139,7 +140,6 @@ set(QGIS_3D_HDRS
   qgswindow3dengine.h
   qgsskyboxentity.h
   qgsskyboxsettings.h
-  qgsshadowrenderingframegraph.h
   qgspostprocessingentity.h
   qgspreviewquad.h
   qgsshadowsettings.h

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -41,7 +41,6 @@ Qgs3DMapCanvas::Qgs3DMapCanvas()
   , m_inputAspect( new Qt3DInput::QInputAspect )
   , m_logicAspect( new Qt3DLogic::QLogicAspect )
   , m_renderSettings( new Qt3DRender::QRenderSettings )
-  , m_forwardRenderer( new Qt3DExtras::QForwardRenderer )
   , m_defaultCamera( new Qt3DRender::QCamera )
   , m_inputSettings( new Qt3DInput::QInputSettings )
   , m_root( new Qt3DCore::QEntity )
@@ -59,9 +58,6 @@ Qgs3DMapCanvas::Qgs3DMapCanvas()
   m_aspectEngine->registerAspect( m_logicAspect );
 
   m_defaultCamera->setParent( m_root );
-  m_forwardRenderer->setCamera( m_defaultCamera );
-  m_forwardRenderer->setSurface( this );
-  m_renderSettings->setActiveFrameGraph( m_forwardRenderer );
   m_inputSettings->setEventSource( this );
 
   const QgsSettings setting;
@@ -112,11 +108,6 @@ void Qgs3DMapCanvas::setActiveFrameGraph( Qt3DRender::QFrameGraphNode *activeFra
 Qt3DRender::QFrameGraphNode *Qgs3DMapCanvas::activeFrameGraph() const
 {
   return m_renderSettings->activeFrameGraph();
-}
-
-Qt3DExtras::QForwardRenderer *Qgs3DMapCanvas::defaultFrameGraph() const
-{
-  return m_forwardRenderer;
 }
 
 Qt3DRender::QCamera *Qgs3DMapCanvas::camera() const

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -118,11 +118,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     Qt3DRender::QFrameGraphNode *activeFrameGraph() const;
 
     /**
-     * Returns the node of the default framegraph
-     */
-    Qt3DExtras::QForwardRenderer *defaultFrameGraph() const;
-
-    /**
      * Returns the default camera of the 3D Window.
      */
     Qt3DRender::QCamera *camera() const;
@@ -227,7 +222,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 
     // Renderer configuration
     Qt3DRender::QRenderSettings *m_renderSettings;
-    Qt3DExtras::QForwardRenderer *m_forwardRenderer;
     Qt3DRender::QCamera *m_defaultCamera;
 
     // Input configuration

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -72,7 +72,7 @@
 #include "qgs3dsceneexporter.h"
 #include "qgs3dmapexportsettings.h"
 #include "qgsmessageoutput.h"
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 
 #include "qgsskyboxentity.h"
 #include "qgsskyboxsettings.h"
@@ -794,7 +794,7 @@ void Qgs3DMapScene::finalizeNewEntity( Qt3DCore::QEntity *newEntity )
   }
 
   // Finalize adding the 3D transparent objects by adding the layer components to the entities
-  QgsShadowRenderingFrameGraph *frameGraph = mEngine->frameGraph();
+  QgsFrameGraph *frameGraph = mEngine->frameGraph();
   Qt3DRender::QLayer *transparentLayer = frameGraph->transparentObjectLayer();
   const QList< Qt3DRender::QMaterial *> childMaterials = newEntity->findChildren<Qt3DRender::QMaterial *>();
   for ( Qt3DRender::QMaterial *material : childMaterials )
@@ -947,7 +947,7 @@ void Qgs3DMapScene::onSkyboxSettingsChanged()
 
 void Qgs3DMapScene::onShadowSettingsChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
+  QgsFrameGraph *frameGraph = mEngine->frameGraph();
 
   const QList< QgsLightSource * > lightSources = mMap.lightSources();
   QList< QgsDirectionalLightSettings * > directionalLightSources;
@@ -963,52 +963,47 @@ void Qgs3DMapScene::onShadowSettingsChanged()
   int selectedLight = shadowSettings.selectedDirectionalLight();
   if ( shadowSettings.renderShadows() && selectedLight >= 0 && selectedLight < directionalLightSources.count() )
   {
-    shadowRenderingFrameGraph->setShadowRenderingEnabled( true );
-    shadowRenderingFrameGraph->setShadowBias( shadowSettings.shadowBias() );
-    shadowRenderingFrameGraph->setShadowMapResolution( shadowSettings.shadowMapResolution() );
+    frameGraph->setShadowRenderingEnabled( true );
+    frameGraph->setShadowBias( shadowSettings.shadowBias() );
+    frameGraph->setShadowMapResolution( shadowSettings.shadowMapResolution() );
     QgsDirectionalLightSettings light = *directionalLightSources.at( selectedLight );
-    shadowRenderingFrameGraph->setupDirectionalLight( light, shadowSettings.maximumShadowRenderingDistance() );
+    frameGraph->setupDirectionalLight( light, shadowSettings.maximumShadowRenderingDistance() );
   }
   else
-    shadowRenderingFrameGraph->setShadowRenderingEnabled( false );
+    frameGraph->setShadowRenderingEnabled( false );
 }
 
 void Qgs3DMapScene::onAmbientOcclusionSettingsChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
+  QgsFrameGraph *frameGraph = mEngine->frameGraph();
   QgsAmbientOcclusionSettings ambientOcclusionSettings = mMap.ambientOcclusionSettings();
-  shadowRenderingFrameGraph->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
-  shadowRenderingFrameGraph->setAmbientOcclusionRadius( ambientOcclusionSettings.radius() );
-  shadowRenderingFrameGraph->setAmbientOcclusionIntensity( ambientOcclusionSettings.intensity() );
-  shadowRenderingFrameGraph->setAmbientOcclusionThreshold( ambientOcclusionSettings.threshold() );
+  frameGraph->setAmbientOcclusionEnabled( ambientOcclusionSettings.isEnabled() );
+  frameGraph->setAmbientOcclusionRadius( ambientOcclusionSettings.radius() );
+  frameGraph->setAmbientOcclusionIntensity( ambientOcclusionSettings.intensity() );
+  frameGraph->setAmbientOcclusionThreshold( ambientOcclusionSettings.threshold() );
 }
 
 void Qgs3DMapScene::onDebugShadowMapSettingsChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
-  shadowRenderingFrameGraph->setupShadowMapDebugging( mMap.debugShadowMapEnabled(), mMap.debugShadowMapCorner(), mMap.debugShadowMapSize() );
+  mEngine->frameGraph()->setupShadowMapDebugging( mMap.debugShadowMapEnabled(), mMap.debugShadowMapCorner(), mMap.debugShadowMapSize() );
 }
 
 void Qgs3DMapScene::onDebugDepthMapSettingsChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
-  shadowRenderingFrameGraph->setupDepthMapDebugging( mMap.debugDepthMapEnabled(), mMap.debugDepthMapCorner(), mMap.debugDepthMapSize() );
+  mEngine->frameGraph()->setupDepthMapDebugging( mMap.debugDepthMapEnabled(), mMap.debugDepthMapCorner(), mMap.debugDepthMapSize() );
 }
 
 void Qgs3DMapScene::onDebugOverlayEnabledChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
-  shadowRenderingFrameGraph->setDebugOverlayEnabled( mMap.isDebugOverlayEnabled() );
+  mEngine->frameGraph()->setDebugOverlayEnabled( mMap.isDebugOverlayEnabled() );
 }
 
 void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()
 {
-  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
-
   bool edlEnabled = mMap.eyeDomeLightingEnabled();
   double edlStrength = mMap.eyeDomeLightingStrength();
   double edlDistance = mMap.eyeDomeLightingDistance();
-  shadowRenderingFrameGraph->setupEyeDomeLighting( edlEnabled, edlStrength, edlDistance );
+  mEngine->frameGraph()->setupEyeDomeLighting( edlEnabled, edlStrength, edlDistance );
 }
 
 void Qgs3DMapScene::onCameraMovementSpeedChanged()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -54,7 +54,6 @@ class QgsChunkedEntity;
 class QgsSkyboxEntity;
 class QgsSkyboxSettings;
 class Qgs3DMapExportSettings;
-class QgsShadowRenderingFrameGraph;
 class QgsPostprocessingEntity;
 class QgsChunkNode;
 class QgsDoubleRange;

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -15,7 +15,7 @@
 
 #include "qgsabstract3dengine.h"
 
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 
 #include <Qt3DRender/QRenderCapture>
 #include <Qt3DRender/QRenderSettings>

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -39,7 +39,7 @@ namespace Qt3DRender
   class QFrameGraphNode;
 }
 
-class QgsShadowRenderingFrameGraph;
+class QgsFrameGraph;
 
 /**
  * \ingroup 3d
@@ -109,7 +109,7 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      *
      * \since QGIS 3.18
      */
-    QgsShadowRenderingFrameGraph *frameGraph() { return mFrameGraph; }
+    QgsFrameGraph *frameGraph() { return mFrameGraph; }
 
     /**
      * Sets whether it will be possible to render to an image
@@ -142,7 +142,7 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
      */
     void sizeChanged();
   protected:
-    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
+    QgsFrameGraph *mFrameGraph = nullptr;
 };
 
 

--- a/src/3d/qgsframegraph.cpp
+++ b/src/3d/qgsframegraph.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgsshadowrenderingframegraph.cpp
+  qgsframegraph.cpp
   --------------------------------------
   Date                 : August 2020
   Copyright            : (C) 2020 by Belgacem Nedjima
@@ -13,7 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 #include "qgsdirectionallightsettings.h"
 #include "qgspostprocessingentity.h"
 #include "qgspreviewquad.h"
@@ -47,7 +47,7 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include <Qt3DRender/QNoDepthMask>
 #include <Qt3DRender/QBlendEquationArguments>
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPreviewPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructTexturesPreviewPass()
 {
   mPreviewLayerFilter = new Qt3DRender::QLayerFilter;
   mPreviewLayerFilter->addLayer( mPreviewLayer );
@@ -63,7 +63,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPrev
   return mPreviewLayerFilter;
 }
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRenderPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructForwardRenderPass()
 {
   // This is where rendering of the 3D scene actually happens.
   // We define two forward passes: one for solid objects, followed by one for transparent objects.
@@ -201,7 +201,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   return mMainCameraSelector;
 }
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructShadowRenderPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructShadowRenderPass()
 {
   mLightCameraSelectorShadowPass = new Qt3DRender::QCameraSelector;
   mLightCameraSelectorShadowPass->setCamera( mLightCamera );
@@ -250,7 +250,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructShadowRender
   return mLightCameraSelectorShadowPass;
 }
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessingPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructPostprocessingPass()
 {
   mPostProcessingCameraSelector = new Qt3DRender::QCameraSelector;
   mPostProcessingCameraSelector->setCamera( mLightCamera );
@@ -305,7 +305,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructPostprocessi
   return mPostProcessingCameraSelector;
 }
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructAmbientOcclusionRenderPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructAmbientOcclusionRenderPass()
 {
   mAmbientOcclusionRenderCameraSelector = new Qt3DRender::QCameraSelector;
   mAmbientOcclusionRenderCameraSelector->setCamera( mMainCamera );
@@ -351,7 +351,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructAmbientOcclu
   return mAmbientOcclusionRenderCameraSelector;
 }
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructAmbientOcclusionBlurPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructAmbientOcclusionBlurPass()
 {
   mAmbientOcclusionBlurCameraSelector = new Qt3DRender::QCameraSelector;
   mAmbientOcclusionBlurCameraSelector->setCamera( mMainCamera );
@@ -398,7 +398,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructAmbientOcclu
 }
 
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructRubberBandsPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
 {
   mRubberBandsCameraSelector = new Qt3DRender::QCameraSelector;
   mRubberBandsCameraSelector->setCamera( mMainCamera );
@@ -422,7 +422,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructRubberBandsP
 
 
 
-Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructDepthRenderPass()
+Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructDepthRenderPass()
 {
   // depth buffer render to copy pass
 
@@ -485,7 +485,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructDepthRenderP
   return mDepthRenderCameraSelector;
 }
 
-Qt3DCore::QEntity *QgsShadowRenderingFrameGraph::constructDepthRenderQuad()
+Qt3DCore::QEntity *QgsFrameGraph::constructDepthRenderQuad()
 {
   Qt3DCore::QEntity *quad = new Qt3DCore::QEntity;
   quad->setObjectName( "depthRenderQuad" );
@@ -554,7 +554,7 @@ Qt3DCore::QEntity *QgsShadowRenderingFrameGraph::constructDepthRenderQuad()
   return quad;
 }
 
-QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
+QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root )
   : Qt3DCore::QEntity( root )
   , mSize( s )
 {
@@ -663,7 +663,7 @@ QgsShadowRenderingFrameGraph::QgsShadowRenderingFrameGraph( QSurface *surface, Q
   mDepthRenderQuad->setParent( mRootEntity );
 }
 
-QgsPreviewQuad *QgsShadowRenderingFrameGraph::addTexturePreviewOverlay( Qt3DRender::QTexture2D *texture, const QPointF &centerTexCoords, const QSizeF &sizeTexCoords, QVector<Qt3DRender::QParameter *> additionalShaderParameters )
+QgsPreviewQuad *QgsFrameGraph::addTexturePreviewOverlay( Qt3DRender::QTexture2D *texture, const QPointF &centerTexCoords, const QSizeF &sizeTexCoords, QVector<Qt3DRender::QParameter *> additionalShaderParameters )
 {
   QgsPreviewQuad *previewQuad = new QgsPreviewQuad( texture, centerTexCoords, sizeTexCoords, additionalShaderParameters );
   previewQuad->addComponent( mPreviewLayer );
@@ -732,7 +732,7 @@ void calculateViewExtent( Qt3DRender::QCamera *camera, float shadowRenderingDist
   }
 }
 
-void QgsShadowRenderingFrameGraph::setupDirectionalLight( const QgsDirectionalLightSettings &light, float maximumShadowRenderingDistance )
+void QgsFrameGraph::setupDirectionalLight( const QgsDirectionalLightSettings &light, float maximumShadowRenderingDistance )
 {
   float minX, maxX, minY, maxY, minZ, maxZ;
   QVector3D lookingAt = mMainCamera->viewCenter();
@@ -759,12 +759,12 @@ void QgsShadowRenderingFrameGraph::setupDirectionalLight( const QgsDirectionalLi
   mPostprocessingEntity->setupDirectionalLight( lightPosition, lightDirection );
 }
 
-void QgsShadowRenderingFrameGraph::setClearColor( const QColor &clearColor )
+void QgsFrameGraph::setClearColor( const QColor &clearColor )
 {
   mForwardClearBuffers->setClearColor( clearColor );
 }
 
-void QgsShadowRenderingFrameGraph::setShadowRenderingEnabled( bool enabled )
+void QgsFrameGraph::setShadowRenderingEnabled( bool enabled )
 {
   mShadowRenderingEnabled = enabled;
   mPostprocessingEntity->setShadowRenderingEnabled( mShadowRenderingEnabled );
@@ -774,45 +774,45 @@ void QgsShadowRenderingFrameGraph::setShadowRenderingEnabled( bool enabled )
     mShadowSceneEntitiesFilter->setEnabled( false );
 }
 
-void QgsShadowRenderingFrameGraph::setShadowBias( float shadowBias )
+void QgsFrameGraph::setShadowBias( float shadowBias )
 {
   mShadowBias = shadowBias;
   mPostprocessingEntity->setShadowBias( mShadowBias );
 }
 
-void QgsShadowRenderingFrameGraph::setShadowMapResolution( int resolution )
+void QgsFrameGraph::setShadowMapResolution( int resolution )
 {
   mShadowMapResolution = resolution;
   mShadowMapTexture->setWidth( mShadowMapResolution );
   mShadowMapTexture->setHeight( mShadowMapResolution );
 }
 
-void QgsShadowRenderingFrameGraph::setAmbientOcclusionEnabled( bool enabled )
+void QgsFrameGraph::setAmbientOcclusionEnabled( bool enabled )
 {
   mAmbientOcclusionEnabled = enabled;
   mAmbientOcclusionRenderEntity->setEnabled( enabled );
   mPostprocessingEntity->setAmbientOcclusionEnabled( enabled );
 }
 
-void QgsShadowRenderingFrameGraph::setAmbientOcclusionIntensity( float intensity )
+void QgsFrameGraph::setAmbientOcclusionIntensity( float intensity )
 {
   mAmbientOcclusionIntensity = intensity;
   mAmbientOcclusionRenderEntity->setIntensity( intensity );
 }
 
-void QgsShadowRenderingFrameGraph::setAmbientOcclusionRadius( float radius )
+void QgsFrameGraph::setAmbientOcclusionRadius( float radius )
 {
   mAmbientOcclusionRadius = radius;
   mAmbientOcclusionRenderEntity->setRadius( radius );
 }
 
-void QgsShadowRenderingFrameGraph::setAmbientOcclusionThreshold( float threshold )
+void QgsFrameGraph::setAmbientOcclusionThreshold( float threshold )
 {
   mAmbientOcclusionThreshold = threshold;
   mAmbientOcclusionRenderEntity->setThreshold( threshold );
 }
 
-void QgsShadowRenderingFrameGraph::setFrustumCullingEnabled( bool enabled )
+void QgsFrameGraph::setFrustumCullingEnabled( bool enabled )
 {
   if ( enabled == mFrustumCullingEnabled )
     return;
@@ -823,7 +823,7 @@ void QgsShadowRenderingFrameGraph::setFrustumCullingEnabled( bool enabled )
     mFrustumCulling->setParent( ( Qt3DCore::QNode * )nullptr );
 }
 
-void QgsShadowRenderingFrameGraph::setupEyeDomeLighting( bool enabled, double strength, int distance )
+void QgsFrameGraph::setupEyeDomeLighting( bool enabled, double strength, int distance )
 {
   mEyeDomeLightingEnabled = enabled;
   mEyeDomeLightingStrength = strength;
@@ -833,7 +833,7 @@ void QgsShadowRenderingFrameGraph::setupEyeDomeLighting( bool enabled, double st
   mPostprocessingEntity->setEyeDomeLightingDistance( distance );
 }
 
-void QgsShadowRenderingFrameGraph::setupShadowMapDebugging( bool enabled, Qt::Corner corner, double size )
+void QgsFrameGraph::setupShadowMapDebugging( bool enabled, Qt::Corner corner, double size )
 {
   mDebugShadowMapPreviewQuad->setEnabled( enabled );
   if ( enabled )
@@ -856,7 +856,7 @@ void QgsShadowRenderingFrameGraph::setupShadowMapDebugging( bool enabled, Qt::Co
   }
 }
 
-void QgsShadowRenderingFrameGraph::setupDepthMapDebugging( bool enabled, Qt::Corner corner, double size )
+void QgsFrameGraph::setupDepthMapDebugging( bool enabled, Qt::Corner corner, double size )
 {
   mDebugDepthMapPreviewQuad->setEnabled( enabled );
 
@@ -880,7 +880,7 @@ void QgsShadowRenderingFrameGraph::setupDepthMapDebugging( bool enabled, Qt::Cor
   }
 }
 
-void QgsShadowRenderingFrameGraph::setSize( QSize s )
+void QgsFrameGraph::setSize( QSize s )
 {
   mSize = s;
   mForwardColorTexture->setSize( mSize.width(), mSize.height() );
@@ -895,7 +895,7 @@ void QgsShadowRenderingFrameGraph::setSize( QSize s )
   mAmbientOcclusionBlurTexture->setSize( mSize.width(), mSize.height() );
 }
 
-void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
+void QgsFrameGraph::setRenderCaptureEnabled( bool enabled )
 {
   if ( enabled == mRenderCaptureEnabled )
     return;
@@ -903,7 +903,7 @@ void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
   mRenderCaptureTargetSelector->setEnabled( mRenderCaptureEnabled );
 }
 
-void QgsShadowRenderingFrameGraph::setDebugOverlayEnabled( bool enabled )
+void QgsFrameGraph::setDebugOverlayEnabled( bool enabled )
 {
   mDebugOverlay->setEnabled( enabled );
 }

--- a/src/3d/qgsframegraph.h
+++ b/src/3d/qgsframegraph.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgsshadowrenderingframegraph.h
+  qgsframegraph.h
   --------------------------------------
   Date                 : August 2020
   Copyright            : (C) 2020 by Belgacem Nedjima
@@ -13,8 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSSHADOWRENDERINGFRAMEGRAPH_H
-#define QGSSHADOWRENDERINGFRAMEGRAPH_H
+#ifndef QGSFRAMEGRAPH_H
+#define QGSFRAMEGRAPH_H
 
 #include <QWindow>
 #include <Qt3DRender/QCamera>
@@ -50,19 +50,21 @@ class QgsAmbientOcclusionBlurEntity;
 
 /**
  * \ingroup 3d
- * \brief Container class that holds different objects related to shadow rendering
+ * \brief Container class that holds different objects related to frame graph of 3D scenes
+ *
+ * A frame graph captures configuration of rendering passes when 3D scene gets rendered.
  *
  * \note Not available in Python bindings
  *
  * \since QGIS 3.16
  */
-class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
+class QgsFrameGraph : public Qt3DCore::QEntity
 {
     Q_OBJECT
 
   public:
     //! Constructor
-    QgsShadowRenderingFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
+      QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *root );
 
     //! Returns the root of the frame graph object
     Qt3DRender::QFrameGraphNode *frameGraphRoot() { return mRenderSurfaceSelector; }
@@ -353,7 +355,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
 
     bool mRenderCaptureEnabled = true;
 
-    Q_DISABLE_COPY( QgsShadowRenderingFrameGraph )
+    Q_DISABLE_COPY( QgsFrameGraph )
 };
 
-#endif // QGSSHADOWRENDERINGFRAMEGRAPH_H
+#endif // QGSFRAMEGRAPH_H

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsoffscreen3dengine.h"
 
+#include "qgsframegraph.h"
+
 #include <QCoreApplication>
 #include <QOffscreenSurface>
 #include <QSurfaceFormat>
@@ -99,7 +101,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   mOffscreenSurface->setFormat( format );
   mOffscreenSurface->create();
 
-  mFrameGraph = new QgsShadowRenderingFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
+  mFrameGraph = new QgsFrameGraph( mOffscreenSurface, mSize, mCamera, mRoot );
   mFrameGraph->setRenderCaptureEnabled( true );
   mFrameGraph->setShadowRenderingEnabled( false );
   // Set this frame graph to be in use.

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -48,7 +48,6 @@ namespace Qt3DLogic
   class QLogicAspect;
 }
 
-#include "qgsshadowrenderingframegraph.h"
 
 #define SIP_NO_FILE
 

--- a/src/3d/qgspostprocessingentity.cpp
+++ b/src/3d/qgspostprocessingentity.cpp
@@ -40,9 +40,9 @@ typedef Qt3DCore::QGeometry Qt3DQGeometry;
 #include <Qt3DRender/QDepthTest>
 #include <QUrl>
 
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 
-QgsPostprocessingEntity::QgsPostprocessingEntity( QgsShadowRenderingFrameGraph *frameGraph, QNode *parent )
+QgsPostprocessingEntity::QgsPostprocessingEntity( QgsFrameGraph *frameGraph, QNode *parent )
   : QgsRenderPassQuad( parent )
   , mFrameGraph( frameGraph )
 {

--- a/src/3d/qgspostprocessingentity.h
+++ b/src/3d/qgspostprocessingentity.h
@@ -18,7 +18,7 @@
 
 #include "qgsrenderpassquad.h"
 
-class QgsShadowRenderingFrameGraph;
+class QgsFrameGraph;
 
 #define SIP_NO_FILE
 
@@ -36,7 +36,7 @@ class QgsPostprocessingEntity : public QgsRenderPassQuad
 
   public:
     //! Constructor
-    QgsPostprocessingEntity( QgsShadowRenderingFrameGraph *frameGraph, QNode *parent = nullptr );
+    QgsPostprocessingEntity( QgsFrameGraph *frameGraph, QNode *parent = nullptr );
     //! Sets the parts of the scene where objects cast shadows
     void setupShadowRenderingExtent( float minX, float maxX, float minZ, float maxZ );
     //! Sets up a directional light that is used to render shadows
@@ -59,7 +59,7 @@ class QgsPostprocessingEntity : public QgsRenderPassQuad
     void setAmbientOcclusionEnabled( bool enabled );
 
   private:
-    QgsShadowRenderingFrameGraph *mFrameGraph = nullptr;
+    QgsFrameGraph *mFrameGraph = nullptr;
     Qt3DRender::QCamera *mMainCamera = nullptr;
 
     Qt3DRender::QParameter *mColorTextureParameter = nullptr;

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -20,7 +20,7 @@
 #include <Qt3DRender/QRenderSettings>
 
 #include "qgs3dmapcanvas.h"
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 
 
 QgsWindow3DEngine::QgsWindow3DEngine( Qgs3DMapCanvas *parent )
@@ -31,7 +31,7 @@ QgsWindow3DEngine::QgsWindow3DEngine( Qgs3DMapCanvas *parent )
   mRoot = new Qt3DCore::QEntity;
   mMapCanvas3D->setRootEntity( mRoot );
 
-  mFrameGraph = new QgsShadowRenderingFrameGraph( mMapCanvas3D, QSize( 1024, 768 ), mMapCanvas3D->camera(), mRoot );
+  mFrameGraph = new QgsFrameGraph( mMapCanvas3D, QSize( 1024, 768 ), mMapCanvas3D->camera(), mRoot );
   mFrameGraph->setRenderCaptureEnabled( false );
   mMapCanvas3D->setActiveFrameGraph( mFrameGraph->frameGraphRoot() );
 

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -24,7 +24,7 @@
 #include "qgs3dmeasuredialog.h"
 #include "qgsrubberband3d.h"
 #include "qgswindow3dengine.h"
-#include "qgsshadowrenderingframegraph.h"
+#include "qgsframegraph.h"
 
 
 Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -50,6 +50,7 @@
 #include "qgs3dsceneexporter.h"
 #include "qgsdirectionallightsettings.h"
 #include "qgsmetalroughmaterialsettings.h"
+#include "qgspointlightsettings.h"
 
 #include <QFileInfo>
 #include <QDir>

--- a/tests/src/3d/testqgsmesh3drendering.cpp
+++ b/tests/src/3d/testqgsmesh3drendering.cpp
@@ -28,7 +28,9 @@
 #include "qgsmeshlayer3drenderer.h"
 #include "qgsmaplayertemporalproperties.h"
 #include "qgsoffscreen3dengine.h"
+#include "qgspointlightsettings.h"
 #include "qgsproject.h"
+
 
 class TestQgsMesh3DRendering : public QgsTest
 {

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -27,6 +27,7 @@
 #include "qgspointcloudclassifiedrenderer.h"
 #include "qgspointcloudlayer3drenderer.h"
 #include "qgspointcloud3dsymbol.h"
+#include "qgspointlightsettings.h"
 #include "qgsstyle.h"
 #include "qgs3dutils.h"
 #include "qgs3dmapsettings.h"


### PR DESCRIPTION
The rationale is that it is not driving just shadow rendering, but this frame graph controls all the rendering passes and their configuration.

Also removes Qgs3DMapCanvas::defaultFrameGraph() which is never really used or needed.

No changes in actual code logic.