### PR TITLE
Avoid doing invalid range requests if a node has no points

### DIFF
--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -525,6 +525,9 @@ std::unique_ptr<QgsPointCloudBlock> QgsPointCloud3DSymbolHandler::pointCloudBloc
   }
   else if ( pc->accessType() == QgsPointCloudIndex::AccessType::Remote )
   {
+    if ( pc->nodePointCount( n ) < 1 )
+      return block;
+
     bool loopAborted = false;
     QEventLoop loop;
     QgsPointCloudBlockRequest *req = pc->asyncNodeData( n, request );

--- a/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudblockrequest.cpp
@@ -35,6 +35,9 @@ QgsCopcPointCloudBlockRequest::QgsCopcPointCloudBlockRequest( const IndexedPoint
   : QgsPointCloudBlockRequest( node, uri, attributes, requestedAttributes, scale, offset, filterExpression, filterRect ),
     mBlockOffset( blockOffset ), mBlockSize( blockSize ), mPointCount( pointCount ), mLazInfo( lazInfo )
 {
+  // an empty block size will create an invalid range, causing a full request to the server
+  Q_ASSERT( mBlockSize > 0 );
+
   QNetworkRequest nr = QNetworkRequest( QUrl( mUri ) );
   QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsCopcPointCloudBlockRequest" ) );
   QgsSetRequestInitiatorId( nr, node.toString() );

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -591,7 +591,8 @@ QVector<IndexedPointCloudNode> QgsPointCloudLayerProfileGenerator::traverseTree(
   if ( !mSearchGeometryInLayerCrsGeometryEngine->intersects( nodeMapGeometry.constGet() ) )
     return nodes;
 
-  nodes.append( n );
+  if ( pc->nodePointCount( n ) > 0 )
+    nodes.append( n );
 
   double childrenErrorPixels = nodeErrorPixels / 2.0;
   if ( childrenErrorPixels < maxErrorPixels )

--- a/src/core/pointcloud/qgspointcloudstatscalculator.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculator.cpp
@@ -58,6 +58,9 @@ struct StatsProcessor
 
     QgsPointCloudStatistics operator()( IndexedPointCloudNode node )
     {
+      if ( mIndex->nodePointCount( node ) < 1 )
+        return QgsPointCloudStatistics();
+
       std::unique_ptr<QgsPointCloudBlock> block = nullptr;
       if ( mIndex->accessType() == QgsPointCloudIndex::Local )
       {

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -188,6 +188,8 @@ bool QgsRemoteCopcPointCloudIndex::isValid() const
 
 void QgsRemoteCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t byteSize ) const
 {
+  Q_ASSERT( byteSize > 0 );
+
   QNetworkRequest nr = QNetworkRequest( QUrl( mUri ) );
   QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsRemoteCopcPointCloudIndex" ) );
   nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );


### PR DESCRIPTION
## Description
If a remote copc file would have empty nodes, we would craft an invalid range request to the server (lower bound > upper bound) and the server would reply with the whole copc, which could be huge.

Fixes #55210

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
