### PR TITLE
Fix unresponsive 'Add Record' action and snapping activated when adding records to a non-spatial table.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -15966,13 +15966,13 @@ void QgisApp::manageDigitizingConfig( QgsVectorLayer *vlayer )
   }
   if ( !vlayer->isSpatial() )
   {
-      QgsSnappingConfig config = QgsSnappingConfig();
-      config.setEnabled( false );
-      mMapCanvas->snappingUtils()->setConfig( config );
+    QgsSnappingConfig config = QgsSnappingConfig();
+    config.setEnabled( false );
+    mMapCanvas->snappingUtils()->setConfig( config );
   }
   else
   {
-      mMapCanvas->snappingUtils()->setConfig( QgsProject::instance()->snappingConfig() );
+    mMapCanvas->snappingUtils()->setConfig( QgsProject::instance()->snappingConfig() );
   }
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1908,6 +1908,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Activates or deactivates actions depending on the selected layers in the layer panel.
     void activateDeactivateMultipleLayersRelatedActions();
 
+    void manageDigitizingConfig( QgsVectorLayer *vlayer );
+
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
     void extentChanged();

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -558,6 +558,14 @@ void QgsSnappingUtils::setEnableSnappingForInvisibleFeature( bool enable )
 
 void QgsSnappingUtils::setConfig( const QgsSnappingConfig &config )
 {
+  if ( mCurrentLayer && !mCurrentLayer->isSpatial() )
+  {
+    QgsSnappingConfig config = QgsSnappingConfig();
+    config.setEnabled( false );
+    mSnappingConfig = config;
+    emit configChanged( mSnappingConfig );
+    return;
+  }
   if ( mSnappingConfig == config )
     return;
 


### PR DESCRIPTION
Fix 'Add Record' action remains toggled/not enabled and snapping activated when adding records to a non-spatial table.
Fix open hand cursor persists when switching between non-spatial and spatial layers in edit mode.

Fixes #55092
Fixes #56152

## Description

This PR fixes two reported bugs and also fixes some undesirable/confusing UX/ UI behaviour in relation to the digitizing cursor when switching between non-spatial & spatial vector layers (all in edit mode) in the TOC.

- The cursor used when the Add Feature tool was active when adding records to a non-spatial layer was identical to the Pan cursor, but not responsive- potentially leading to confusion/ frustration. This PR replaces it with a generic Qt::ArrowCursor.

- When switching from a non-spatial table layer to a spatial vector layer with both in edit mode and the Add Feature tool active, the canvas/ map tool cursor remains set to the open hand cursor, making accurate digitizing more difficult. This PR also attempts to fix that behavior.

The two screencasts below show the current behavior.

Unresponsive Add Record action:

![unresponsive_action](https://github.com/qgis/QGIS/assets/47767794/a2b86eba-327f-44d1-af30-b9c8c5d0da7f)

Incorrect digitizing cursor:

![wrong_map_tool_cursor](https://github.com/qgis/QGIS/assets/47767794/d6f2b7b7-e006-423e-bb0e-d35ba9b9bc9c)

The two screencast below show the improved behavior implemented by this PR.

Responsive Add Record action:

![responsive_action](https://github.com/qgis/QGIS/assets/47767794/61a0fb65-24ce-40cf-8b54-8d208b5ea34b)

Set correct digitizing cursor:

![set_correct_cursor](https://github.com/qgis/QGIS/assets/47767794/5e272a2d-af9d-4084-bb6c-d3fc9d357a40)

Screencasts below show fixes to snapping behavior when snapping is active/activated with add feature tool set via Add Record action.

![fix_snap_on_add_record](https://github.com/qgis/QGIS/assets/47767794/0b9c9e9f-d9f8-4a18-afdf-a331f61490c9)

![fix_activate_snapping_with_add_record_tool](https://github.com/qgis/QGIS/assets/47767794/3beeb820-d4ed-487f-9de9-caf424b82a40)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
