### PR TITLE
Remove unused cmake var

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2508,11 +2508,6 @@ if (FORCE_STATIC_LIBS)
   endif()
 endif()
 
-if (MSVC)
-  #needed for linking to gdal which needs odbc
-  set(TARGET_LINK_LIBRARIES qgis_core odbc32 odbccp32)
-endif()
-
 if (${QT_VERSION_BASE}SerialPort_FOUND)
   target_link_libraries(qgis_core
     ${QT_VERSION_BASE}::SerialPort


### PR DESCRIPTION
[Dates back to 2007](https://github.com/qgis/QGIS/commit/daa35e58bd3fad4b2d2b004e9bca5532f66d3480), is unused nowadays (and I am not sure if it ever had an effect)