### PR TITLE
[attribute form] Implement an optional null state representation to the checkbox editor widget to allow for UI reflection of failing constraint

### DIFF
--- a/src/gui/editorwidgets/qgscheckboxconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgscheckboxconfigdlg.cpp
@@ -47,6 +47,7 @@ QVariantMap QgsCheckBoxConfigDlg::config()
   cfg.insert( QStringLiteral( "CheckedState" ), leCheckedState->text() );
   cfg.insert( QStringLiteral( "UncheckedState" ), leUncheckedState->text() );
   cfg.insert( QStringLiteral( "TextDisplayMethod" ), mDisplayAsTextComboBox->currentData().toInt() );
+  cfg.insert( QStringLiteral( "AllowNullState" ), mAllowNullState->isChecked() );
 
   return cfg;
 }
@@ -59,4 +60,5 @@ void QgsCheckBoxConfigDlg::setConfig( const QVariantMap &config )
     leUncheckedState->setText( config.value( QStringLiteral( "UncheckedState" ) ).toString() );
   }
   mDisplayAsTextComboBox->setCurrentIndex( mDisplayAsTextComboBox->findData( config.value( QStringLiteral( "TextDisplayMethod" ), QString::number( static_cast< int >( QgsCheckBoxFieldFormatter::ShowTrueFalse ) ) ).toInt() ) );
+  mAllowNullState->setChecked( config.value( QStringLiteral( "AllowNullState" ) ).toBool() );
 }

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -70,6 +70,8 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
 
     QCheckBox *mCheckBox = nullptr;
     QGroupBox *mGroupBox = nullptr;
+
+    bool mIndeterminateStateEnabled = false;
 };
 
 #endif // QGSCHECKBOXWIDGETWRAPPER_H

--- a/src/ui/editorwidgets/qgscheckboxconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgscheckboxconfigdlgbase.ui
@@ -45,6 +45,13 @@
       <item row="1" column="0" colspan="2">
        <widget class="QComboBox" name="mDisplayAsTextComboBox"/>
       </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mAllowNullState">
+        <property name="text">
+         <string>Allow NULL representation</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This PR adds a new [x] allow null representation option for the attribute form's checkbox editor widget. When toggled on, the checkbox will reflect a feature attribute's null value by using the Qt::PartiallyChecked checkbox state. 

This allows for the attribute form's non-null constraint to be properly reflected in the checkbox editor widget by returning a null value() when the widget was passed on a feature attribute's null value.

![image](https://github.com/qgis/QGIS/assets/1728657/18c3e672-d3eb-40f7-9551-cacc4a3ad345)

![image](https://github.com/qgis/QGIS/assets/1728657/dd13c4bd-cce5-4613-af77-a0bbcb23af20)

@nyalldawson , as discussed on Google Chat, this is an alternative to the (now closed) PR https://github.com/qgis/QGIS/pull/56002 .

This fixes #55390.

_As a nice side bonus, this change allows for the use of a blocking null constraint a given checkbox editor widget to insure that people filling the attribute form makes a **deliberate** false/true value decision (instead of not touching it which, without this new option, would automatically set the value to false._