### PR TITLE
[themes] Fix missing checkbox partially checked state styling

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -788,6 +788,10 @@ QCheckBox::indicator
     height:0.8em;
 }
 
+QCheckBox::indicator:intermediary {
+    image: url(@theme_path/icons/qcheckbox-intermediary.svg);
+}
+
 QCheckBox::indicator:unchecked {
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
 }

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -789,13 +789,20 @@ QCheckBox::indicator {
     height:0.8em;
 }
 
+QCheckBox::indicator:intermediary {
+    background-color: @toggleoff;
+    image: url(@theme_path/icons/qcheckbox-intermediary.svg);
+}
+
 QCheckBox::indicator:unchecked {
     background-color: @toggleoff;
+    image: none;
 }
 
 QCheckBox::indicator:unchecked:disabled {
     border-color: @itemdarkbackground;
     background-color: rgba(0, 0, 0, 0);
+    image: none;
 }
 
 QCheckBox::indicator:checked {


### PR DESCRIPTION
## Description

Title says it all; our themes were missing styling covering partially checked state for QCheckBox widgets. This PR fixes that.