### PR TITLE
[processing] Don't try to interpret distance widget value as CRS

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1196,10 +1196,10 @@ void QgsProcessingDistanceWidgetWrapper::postInitialize( const QList<QgsAbstract
       {
         if ( wrapper->parameterDefinition()->name() == static_cast< const QgsProcessingParameterDistance * >( parameterDefinition() )->parentParameterName() )
         {
-          setUnitParameterValue( wrapper->parameterValue() );
+          setUnitParameterValue( wrapper->parameterValue(), wrapper );
           connect( wrapper, &QgsAbstractProcessingParameterWidgetWrapper::widgetValueHasChanged, this, [ = ]
           {
-            setUnitParameterValue( wrapper->parameterValue() );
+            setUnitParameterValue( wrapper->parameterValue(), wrapper );
           } );
           break;
         }
@@ -1213,7 +1213,7 @@ void QgsProcessingDistanceWidgetWrapper::postInitialize( const QList<QgsAbstract
   }
 }
 
-void QgsProcessingDistanceWidgetWrapper::setUnitParameterValue( const QVariant &value )
+void QgsProcessingDistanceWidgetWrapper::setUnitParameterValue( const QVariant &value, const QgsAbstractProcessingParameterWidgetWrapper *wrapper )
 {
   Qgis::DistanceUnit units = Qgis::DistanceUnit::Unknown;
 
@@ -1229,7 +1229,9 @@ void QgsProcessingDistanceWidgetWrapper::setUnitParameterValue( const QVariant &
     context = tmpContext.get();
   }
 
-  QgsCoordinateReferenceSystem crs = QgsProcessingParameters::parameterAsCrs( parameterDefinition(), value, *context );
+  const QgsCoordinateReferenceSystem crs = wrapper
+      ? QgsProcessingParameters::parameterAsCrs( wrapper->parameterDefinition(), wrapper->parameterValue(), *context )
+      : QgsProcessingUtils::variantToCrs( value, *context );
   if ( crs.isValid() )
   {
     units = crs.mapUnits();

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -387,7 +387,7 @@ class GUI_EXPORT QgsProcessingDistanceWidgetWrapper : public QgsProcessingNumeri
     void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
 
   public slots:
-    void setUnitParameterValue( const QVariant &value );
+    void setUnitParameterValue( const QVariant &value, const QgsAbstractProcessingParameterWidgetWrapper *unitParameterWrapper = nullptr );
     void setUnits( Qgis::DistanceUnit unit );
 
   protected:


### PR DESCRIPTION
There was a logic error in QgsProcessingDistanceWidgetWrapper::setUnitParameterValue which meant that when the linked crs parameter value was unset, we incorrectly took the default value from the DISTANCE parameter and tried to intrepret it as a CRS.

In practice, this meant we'd take a value like "100" and then try to turn that into a CRS. Since it doesn't match any possible CRS definition, the fallback code would try to interpret it as a map layer and ultimately try to load "100" as a OGR vector layer.

No real issue in doing that, but it results in a bunch of silly debug spam...!