### PR TITLE
Avoid storing some null strings/other types in variants when reading from XML

### DIFF
--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -316,12 +316,13 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
   }
   else if ( type == QLatin1String( "QString" ) )
   {
-    return element.attribute( QStringLiteral( "value" ) );
+    const QString res = element.attribute( QStringLiteral( "value" ) );
+    return res.isEmpty() ? QVariant() : res;
   }
   else if ( type == QLatin1String( "QChar" ) )
   {
     const QString res = element.attribute( QStringLiteral( "value" ) );
-    return res.isEmpty() ? QChar() : res.at( 0 );
+    return res.isEmpty() ? QVariant() : res.at( 0 );
   }
   else if ( type == QLatin1String( "bool" ) )
   {
@@ -329,19 +330,19 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
   }
   else if ( type == QLatin1String( "color" ) )
   {
-    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QColor() : QgsColorUtils::colorFromString( element.attribute( QStringLiteral( "value" ) ) );
+    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QVariant() : QgsColorUtils::colorFromString( element.attribute( QStringLiteral( "value" ) ) );
   }
   else if ( type == QLatin1String( "datetime" ) )
   {
-    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QDateTime() : QDateTime::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
+    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QVariant() : QDateTime::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
   }
   else if ( type == QLatin1String( "date" ) )
   {
-    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QDate() : QDate::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
+    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QVariant() : QDate::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
   }
   else if ( type == QLatin1String( "time" ) )
   {
-    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QTime() : QTime::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
+    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QVariant() : QTime::fromString( element.attribute( QStringLiteral( "value" ) ), Qt::ISODate );
   }
   else if ( type == QLatin1String( "Map" ) )
   {
@@ -394,11 +395,12 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
   {
     QgsCoordinateReferenceSystem crs;
     crs.readXml( element );
-    return crs;
+    return crs.isValid() ? crs : QVariant();
   }
   else if ( type == QLatin1String( "QgsGeometry" ) )
   {
-    return QgsGeometry::fromWkt( element.attribute( "value" ) );
+    const QgsGeometry g = QgsGeometry::fromWkt( element.attribute( "value" ) );
+    return !g.isNull() ? g : QVariant();
   }
   else if ( type == QLatin1String( "QgsProcessingOutputLayerDefinition" ) )
   {

--- a/tests/src/python/test_qgslayerdefinition.py
+++ b/tests/src/python/test_qgslayerdefinition.py
@@ -253,8 +253,8 @@ class TestQgsLayerDefinition(QgisTestCase):
         field = vl.fields().at(0)
         config = field.editorWidgetSetup().config()
 
-        self.assertEqual(config['Description'], '')
-        self.assertEqual(config['FilterExpression'], '')
+        self.assertFalse(config['Description'])
+        self.assertFalse(config['FilterExpression'])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -81,7 +81,7 @@ class TestQgsXmlUtils(QgisTestCase):
 
         prop2 = QgsXmlUtils.readVariant(elem)
 
-        self.assertEqual(my_properties, prop2)
+        self.assertEqual(prop2, {'a': 'a', 'b': 'b', 'c': 'something_else', 'empty': None})
 
     def test_double(self):
         """
@@ -178,7 +178,7 @@ class TestQgsXmlUtils(QgisTestCase):
         elem = QgsXmlUtils.writeVariant(crs, doc)
 
         crs2 = QgsXmlUtils.readVariant(elem)
-        self.assertFalse(crs2.isValid())
+        self.assertIsNone(crs2)
 
     def test_geom(self):
         """
@@ -206,7 +206,7 @@ class TestQgsXmlUtils(QgisTestCase):
         self.assertEqual(c, QColor(100, 200, 210, 50))
         elem = QgsXmlUtils.writeVariant(QColor(), doc)
         c = QgsXmlUtils.readVariant(elem)
-        self.assertFalse(c.isValid())
+        self.assertIsNone(c)
 
     def test_datetime(self):
         """


### PR DESCRIPTION
This triggers a bunch of the "storing null xxx in QVariant - stop it!" warnings, and likely fixes some issues on qt6 builds