### PR TITLE
[wms] Insure that mbtiles layers are invalidated when dataset is missing

### DIFF
--- a/src/core/qgsmbtiles.cpp
+++ b/src/core/qgsmbtiles.cpp
@@ -31,6 +31,9 @@ bool QgsMbTiles::open()
   if ( mDatabase )
     return true;  // already opened
 
+  if ( mFilename.isEmpty() )
+    return false;
+
   const sqlite3_database_unique_ptr database;
   const int result = mDatabase.open_v2( mFilename, SQLITE_OPEN_READONLY, nullptr );
   if ( result != SQLITE_OK )


### PR DESCRIPTION
## Description

This fixes an issue whereas passing a WMS mbtiles source with a blank url fails to flag the layer as invalid.

The reason this is happening is because sqlite won't error when opening an empty-string database. In turn, that wrongly informs the WMS provider that everything is fine (ouch). 

The fix is to simply check for an empty filename when calling QgsMbTiles::open() and return false (failure to open) when that's the case.

As for when a WMS mbtiles layer gets a blank url, it will easily happen if the .mbtile file is in a localized path where the file has been moved or deleted. In that cause, prior to the PR, QGIS would create a valid WMS layer rendering *nothingness* :)

