### PR TITLE
Don't map non-list of QVariantMaps to QMap<QString,QVariant>

### DIFF
--- a/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -99,7 +99,7 @@ Returns 3D shape for points
 Sets 3D shape for points
 %End
 
-    QMap<QString, QVariant> shapeProperties() const;
+    QVariantMap shapeProperties() const;
 %Docstring
 Returns a key-value dictionary of point shape properties.
 
@@ -120,7 +120,7 @@ used when the property has not been explicitly set.
 .. versionadded:: 3.36
 %End
 
-    void setShapeProperties( const QMap<QString, QVariant> &properties );
+    void setShapeProperties( const QVariantMap &properties );
 %Docstring
 Sets a key-value dictionary of point shape properties
 %End

--- a/python/PyQt6/analysis/auto_generated/processing/qgsalgorithmbatchgeocode.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/qgsalgorithmbatchgeocode.sip.in
@@ -67,7 +67,7 @@ interface. Ownership of ``geocoder`` is not transferred, and the caller must ens
 exists for the lifetime of this algorithm.
 %End
 
-    virtual void initParameters( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() );
+    virtual void initParameters( const QVariantMap &configuration = QVariantMap() );
 
     virtual QStringList tags() const;
 
@@ -83,7 +83,7 @@ exists for the lifetime of this algorithm.
   protected:
     virtual QString outputName() const;
 
-    virtual bool prepareAlgorithm( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    virtual bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 
     virtual QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &, QgsProcessingFeedback *feedback );
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -140,13 +140,13 @@ Create a new Change
 
     typedef QMap<QString, QMap<QgsFeatureId, QList<QgsGeometryCheck::Change> > > Changes;
 
-    QgsGeometryCheck( const QgsGeometryCheckContext *context, const QMap<QString, QVariant> &configuration );
+    QgsGeometryCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
 %Docstring
 Create a new geometry check.
 %End
     virtual ~QgsGeometryCheck();
 
-    virtual void prepare( const QgsGeometryCheckContext *context, const QMap<QString, QVariant> &configuration );
+    virtual void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
 %Docstring
 Will be run in the main thread before :py:func:`~QgsGeometryCheck.collectErrors` is called (which may be run from a background thread).
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckfactory.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckfactory.sip.in
@@ -32,7 +32,7 @@ A factory for geometry checks.
 
     virtual ~QgsGeometryCheckFactory();
 
-    virtual QgsGeometryCheck *createGeometryCheck( const QgsGeometryCheckContext *context, const QMap<QString, QVariant> &configuration ) const = 0 /Factory/;
+    virtual QgsGeometryCheck *createGeometryCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration ) const = 0 /Factory/;
 %Docstring
 Creates a new geometry check with ``context`` and ``configuration``.
 %End
@@ -78,7 +78,7 @@ Template to create a factory for a geometry check.
 #include "qgsgeometrycheckfactory.h"
 %End
   public:
-    virtual QgsGeometryCheck *createGeometryCheck( const QgsGeometryCheckContext *context, const QMap<QString, QVariant> &configuration ) const;
+    virtual QgsGeometryCheck *createGeometryCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration ) const;
 
     virtual QString description() const;
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckregistry.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckregistry.sip.in
@@ -39,7 +39,7 @@ Constructor for QgsGeometryCheckRegistry. QgsGeometryCheckRegistry is not usuall
 
     ~QgsGeometryCheckRegistry();
 
-    QgsGeometryCheck *geometryCheck( const QString &checkId, QgsGeometryCheckContext *context, const QMap<QString, QVariant> &geometryCheckConfig ) /Factory/;
+    QgsGeometryCheck *geometryCheck( const QString &checkId, QgsGeometryCheckContext *context, const QVariantMap &geometryCheckConfig ) /Factory/;
 %Docstring
 Create a new geometryCheck of type ``checkId``
 Pass the ``context`` and ``geometryCheckConfiguration`` to the newly created check.

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
@@ -131,7 +131,7 @@ Subclasses need to implement the processGeometry method.
   public:
 
     QgsSingleGeometryCheck( const QgsGeometryCheckContext *context,
-                            const QMap<QString, QVariant> &configuration );
+                            const QVariantMap &configuration );
 %Docstring
 Creates a new single geometry check.
 %End

--- a/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
@@ -116,7 +116,7 @@ Duplicates a callout by creating a deep copy of the callout.
 Caller takes ownership of the returned object.
 %End
 
-    virtual QMap<QString, QVariant> properties( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap properties( const QgsReadWriteContext &context ) const;
 %Docstring
 Returns the properties describing the callout encoded in a
 string format.
@@ -129,7 +129,7 @@ in their returned value.
 .. seealso:: :py:func:`saveProperties`
 %End
 
-    virtual void readProperties( const QMap<QString, QVariant> &props, const QgsReadWriteContext &context );
+    virtual void readProperties( const QVariantMap &props, const QgsReadWriteContext &context );
 %Docstring
 Reads a string map of an callout's properties and restores the callout
 to the state described by the properties map.
@@ -490,7 +490,7 @@ A simple direct line callout style.
     ~QgsSimpleLineCallout();
 
 
-    static QgsCallout *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
+    static QgsCallout *create( const QVariantMap &properties = QVariantMap(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
 %Docstring
 Creates a new QgsSimpleLineCallout, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -501,9 +501,9 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual QgsSimpleLineCallout *clone() const;
 
-    virtual QMap<QString, QVariant> properties( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap properties( const QgsReadWriteContext &context ) const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props, const QgsReadWriteContext &context );
+    virtual void readProperties( const QVariantMap &props, const QgsReadWriteContext &context );
 
     virtual void startRender( QgsRenderContext &context );
 
@@ -753,7 +753,7 @@ Draws straight (right angled) lines as callouts.
     QgsManhattanLineCallout();
 
 
-    static QgsCallout *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
+    static QgsCallout *create( const QVariantMap &properties = QVariantMap(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
 %Docstring
 Creates a new QgsManhattanLineCallout, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -798,7 +798,7 @@ Draws curved lines as callouts.
     QgsCurvedLineCallout();
 
 
-    static QgsCallout *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
+    static QgsCallout *create( const QVariantMap &properties = QVariantMap(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
 %Docstring
 Creates a new QgsCurvedLineCallout, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -809,7 +809,7 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual QgsCurvedLineCallout *clone() const;
 
-    virtual QMap<QString, QVariant> properties( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap properties( const QgsReadWriteContext &context ) const;
 
 
     double curvature() const;
@@ -871,7 +871,7 @@ A cartoon talking bubble callout style.
     ~QgsBalloonCallout();
 
 
-    static QgsCallout *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
+    static QgsCallout *create( const QVariantMap &properties = QVariantMap(), const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
 %Docstring
 Creates a new QgsBalloonCallout, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -882,9 +882,9 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual QgsBalloonCallout *clone() const;
 
-    virtual QMap<QString, QVariant> properties( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap properties( const QgsReadWriteContext &context ) const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props, const QgsReadWriteContext &context );
+    virtual void readProperties( const QVariantMap &props, const QgsReadWriteContext &context );
 
     virtual void startRender( QgsRenderContext &context );
 

--- a/python/PyQt6/core/auto_generated/callouts/qgscalloutsregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscalloutsregistry.sip.in
@@ -67,7 +67,7 @@ Sets an ``icon`` representing the callout.
 .. seealso:: :py:func:`icon`
 %End
 
-    virtual QgsCallout *createCallout( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context ) = 0 /Factory/;
+    virtual QgsCallout *createCallout( const QVariantMap &properties, const QgsReadWriteContext &context ) = 0 /Factory/;
 %Docstring
 Create a callout of this type given the map of ``properties``.
 
@@ -101,7 +101,7 @@ Convenience metadata class that uses static functions to create callouts and the
 
 
 
-    virtual QgsCallout *createCallout( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context ) /Factory/;
+    virtual QgsCallout *createCallout( const QVariantMap &properties, const QgsReadWriteContext &context ) /Factory/;
 
     virtual QgsCalloutWidget *createCalloutWidget( QgsVectorLayer *vl ) /Factory/;
 
@@ -145,7 +145,7 @@ Registers a new callout type.
 Ownership of ``metadata`` is transferred to the registry.
 %End
 
-    QgsCallout *createCallout( const QString &type, const QMap<QString, QVariant> &properties = QMap<QString, QVariant>(), const QgsReadWriteContext &context = QgsReadWriteContext() ) const /Factory/;
+    QgsCallout *createCallout( const QString &type, const QVariantMap &properties = QVariantMap(), const QgsReadWriteContext &context = QgsReadWriteContext() ) const /Factory/;
 %Docstring
 Creates a new instance of a callout, given the callout ``type`` and ``properties``.
 

--- a/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -315,14 +315,14 @@ Returns the list of parameters
 .. versionadded:: 3.12
 %End
 
-    void setParameterValues( const QMap<QString, QVariant> &values );
+    void setParameterValues( const QVariantMap &values );
 %Docstring
 Defines the values of the additional parameters
 
 .. versionadded:: 3.12
 %End
 
-    QMap<QString, QVariant> parameterValues() const;
+    QVariantMap parameterValues() const;
 %Docstring
 Returns the values of the processing parameters.
 One could use :py:class:`QgsProcessingParameters`.parameterAsXxxx to retrieve the actual value of a parameter.

--- a/python/PyQt6/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
@@ -147,14 +147,14 @@ Sets the relation widget type
 .. versionadded:: 3.18
 %End
 
-    QMap<QString, QVariant> relationEditorConfiguration() const;
+    QVariantMap relationEditorConfiguration() const;
 %Docstring
 Returns the relation editor widget configuration
 
 .. versionadded:: 3.18
 %End
 
-    void setRelationEditorConfiguration( const QMap<QString, QVariant> &config );
+    void setRelationEditorConfiguration( const QVariantMap &config );
 %Docstring
 Sets the relation editor configuration
 

--- a/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -116,7 +116,7 @@ If ``ui`` is a URL, a local copy of the file will be made and will be used to cr
 ``context`` is provided to save error messages
 %End
 
-    bool setWidgetConfig( const QString &widgetName, const QMap<QString, QVariant> &config );
+    bool setWidgetConfig( const QString &widgetName, const QVariantMap &config );
 %Docstring
 Set the editor widget config for a widget which is not for a simple field.
 
@@ -139,7 +139,7 @@ Example
 .. seealso:: :py:func:`QgsVectorLayer.setEditorWidgetSetup`
 %End
 
-    QMap<QString, QVariant> widgetConfig( const QString &widgetName ) const;
+    QVariantMap widgetConfig( const QString &widgetName ) const;
 %Docstring
 Gets the configuration for the editor widget with the given name.
 

--- a/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
@@ -30,7 +30,7 @@ methods.
       GaussianBlur
     };
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsBlurEffect effect from a properties string map.
 
@@ -45,9 +45,9 @@ Constructor for QgsBlurEffect.
 %End
 
     virtual QString type() const;
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
     virtual QgsBlurEffect *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/effects/qgscoloreffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgscoloreffect.sip.in
@@ -23,7 +23,7 @@ source picture.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsColorEffect effect from a properties string map.
 
@@ -35,9 +35,9 @@ Creates a new QgsColorEffect effect from a properties string map.
     QgsColorEffect();
 
     virtual QString type() const;
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
     virtual QgsColorEffect *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/effects/qgseffectstack.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgseffectstack.sip.in
@@ -34,7 +34,7 @@ effect will be drawn using the original picture, not the blurred version.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsEffectStack effect. This method ignores
 the map parameter, and always returns an empty effect stack.
@@ -70,13 +70,13 @@ Creates a new QgsEffectStack effect from a single initial effect.
     virtual bool readProperties( const QDomElement &element );
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 %Docstring
 Unused for QgsEffectStack, will always return an empty string map
 %End
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
 %Docstring
 Unused for QgsEffectStack, props parameter will be ignored

--- a/python/PyQt6/core/auto_generated/effects/qgsgloweffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsgloweffect.sip.in
@@ -35,9 +35,9 @@ picture.
     QgsGlowEffect( const QgsGlowEffect &other );
     ~QgsGlowEffect();
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
 
     void setSpread( const double spread );
@@ -359,7 +359,7 @@ A paint effect which draws a glow outside of a picture.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsOuterGlowEffect effect from a properties string map.
 
@@ -395,7 +395,7 @@ A paint effect which draws a glow within a picture.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsInnerGlowEffect effect from a properties string map.
 

--- a/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
@@ -107,7 +107,7 @@ Duplicates an effect by creating a deep copy of the effect
 :return: clone of paint effect
 %End
 
-    virtual QMap<QString, QVariant> properties() const = 0;
+    virtual QVariantMap properties() const = 0;
 %Docstring
 Returns the properties describing the paint effect encoded in a
 string format.
@@ -119,7 +119,7 @@ string format.
 .. seealso:: :py:func:`saveProperties`
 %End
 
-    virtual void readProperties( const QMap<QString, QVariant> &props ) = 0;
+    virtual void readProperties( const QVariantMap &props ) = 0;
 %Docstring
 Reads a string map of an effect's properties and restores the effect
 to the state described by the properties map.
@@ -342,7 +342,7 @@ If no alterations are performed then the original picture will be rendered as a 
 Constructor for QgsDrawSourceEffect
 %End
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new :py:class:`QgsDrawSource` effect from a properties string map.
 
@@ -354,9 +354,9 @@ Creates a new :py:class:`QgsDrawSource` effect from a properties string map.
     virtual QString type() const;
     virtual QgsDrawSourceEffect *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
 
     void setOpacity( const double opacity );

--- a/python/PyQt6/core/auto_generated/effects/qgspainteffectregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgspainteffectregistry.sip.in
@@ -57,7 +57,7 @@ Returns the user visible string representing the paint effect class
 .. seealso:: :py:func:`name`
 %End
 
-    virtual QgsPaintEffect *createPaintEffect( const QMap<QString, QVariant> &map ) = 0 /Factory/;
+    virtual QgsPaintEffect *createPaintEffect( const QVariantMap &map ) = 0 /Factory/;
 %Docstring
 Create a paint effect of this class given an encoded map of properties.
 
@@ -119,7 +119,7 @@ Registers a new effect type.
 :return: ``True`` if add was successful.
 %End
 
-    QgsPaintEffect *createEffect( const QString &name, const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) const /Factory/;
+    QgsPaintEffect *createEffect( const QString &name, const QVariantMap &properties = QVariantMap() ) const /Factory/;
 %Docstring
 Creates a new paint effect given the effect name and properties map.
 

--- a/python/PyQt6/core/auto_generated/effects/qgsshadoweffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsshadoweffect.sip.in
@@ -25,9 +25,9 @@ Base class for paint effects which offset, blurred shadows
 
     QgsShadowEffect();
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
 
     void setBlurLevel( const double level );
@@ -309,7 +309,7 @@ A paint effect which draws an offset and optionally blurred drop shadow
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsDropShadowEffect effect from a properties string map.
 
@@ -346,7 +346,7 @@ within a picture.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsInnerShadowEffect effect from a properties string map.
 

--- a/python/PyQt6/core/auto_generated/effects/qgstransformeffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgstransformeffect.sip.in
@@ -23,7 +23,7 @@ scale and rotate) to a picture.
 %End
   public:
 
-    static QgsPaintEffect *create( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsPaintEffect *create( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new QgsTransformEffect effect from a properties string map.
 
@@ -38,9 +38,9 @@ Constructor for QgsTransformEffect.
 %End
 
     virtual QString type() const;
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
-    virtual void readProperties( const QMap<QString, QVariant> &props );
+    virtual void readProperties( const QVariantMap &props );
 
     virtual QgsTransformEffect *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -169,7 +169,7 @@ Abstract base class for storage of elevation profiles.
     {
       QString layerIdentifier;
       QgsGeometry geometry;
-      QMap<QString, QVariant> attributes;
+      QVariantMap attributes;
     };
 
     virtual ~QgsAbstractProfileResults();

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -65,7 +65,7 @@ Sets a global context variable. This variable will be contained within scopes re
 .. seealso:: :py:func:`removeGlobalVariable`
 %End
 
-    static void setGlobalVariables( const QMap<QString, QVariant> &variables );
+    static void setGlobalVariables( const QVariantMap &variables );
 %Docstring
 Sets all global context variables. Existing global variables will be removed and replaced
 with the variables specified.
@@ -118,7 +118,7 @@ Sets a project context variable. This variable will be contained within scopes r
 .. seealso:: :py:func:`projectScope`
 %End
 
-    static void setProjectVariables( QgsProject *project, const QMap<QString, QVariant> &variables );
+    static void setProjectVariables( QgsProject *project, const QVariantMap &variables );
 %Docstring
 Sets all project context variables. Existing project variables will be removed and replaced
 with the variables specified.
@@ -174,7 +174,7 @@ Sets a layer context variable. This variable will be contained within scopes ret
 .. seealso:: :py:func:`layerScope`
 %End
 
-    static void setLayerVariables( QgsMapLayer *layer, const QMap<QString, QVariant> &variables );
+    static void setLayerVariables( QgsMapLayer *layer, const QVariantMap &variables );
 %Docstring
 Sets all layer context variables. Existing layer variables will be removed and replaced
 with the variables specified.
@@ -245,7 +245,7 @@ Sets a layout context variable. This variable will be contained within scopes re
 .. versionadded:: 3.0
 %End
 
-    static void setLayoutVariables( QgsLayout *layout, const QMap<QString, QVariant> &variables );
+    static void setLayoutVariables( QgsLayout *layout, const QVariantMap &variables );
 %Docstring
 Sets all layout context variables. Existing layout variables will be removed and replaced
 with the variables specified.
@@ -293,7 +293,7 @@ This variable will be contained within scopes retrieved via
 .. versionadded:: 3.0
 %End
 
-    static void setLayoutItemVariables( QgsLayoutItem *item, const QMap<QString, QVariant> &variables );
+    static void setLayoutItemVariables( QgsLayoutItem *item, const QVariantMap &variables );
 %Docstring
 Sets all layout item context variables for an ``item``. Existing variables will be removed and replaced
 with the ``variables`` specified.
@@ -329,7 +329,7 @@ This variable will be contained within scopes retrieved via
 .. versionadded:: 3.10
 %End
 
-    static void setLayoutMultiFrameVariables( QgsLayoutMultiFrame *frame, const QMap<QString, QVariant> &variables );
+    static void setLayoutMultiFrameVariables( QgsLayoutMultiFrame *frame, const QVariantMap &variables );
 %Docstring
 Sets all layout multiframe context variables for an ``frame``. Existing variables will be removed and replaced
 with the ``variables`` specified.
@@ -348,7 +348,7 @@ collection. Generally this method should not be used as the created context does
 standard scopes such as the global and project scopes.
 %End
 
-    static QgsExpressionContextScope *processingAlgorithmScope( const QgsProcessingAlgorithm *algorithm, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) /Factory/;
+    static QgsExpressionContextScope *processingAlgorithmScope( const QgsProcessingAlgorithm *algorithm, const QVariantMap &parameters, QgsProcessingContext &context ) /Factory/;
 %Docstring
 Creates a new scope which contains variables and functions relating to a processing ``algorithm``,
 when used with the specified ``parameters`` and ``context``.
@@ -357,7 +357,7 @@ For instance, algorithm name and parameter functions.
 .. seealso:: :py:func:`processingModelAlgorithmScope`
 %End
 
-    static QgsExpressionContextScope *processingModelAlgorithmScope( const QgsProcessingModelAlgorithm *model, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) /Factory/;
+    static QgsExpressionContextScope *processingModelAlgorithmScope( const QgsProcessingModelAlgorithm *model, const QVariantMap &parameters, QgsProcessingContext &context ) /Factory/;
 %Docstring
 Creates a new scope which contains variables and functions relating to a processing ``model`` algorithm,
 when used with the specified ``parameters`` and ``context``.

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -35,7 +35,7 @@ Constructor for QgsCheckBoxFieldFormatter.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -38,7 +38,7 @@ Default constructor of field formatter for a date time field.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
     static QString defaultFormat( QVariant::Type type );

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgskeyvaluefieldformatter.sip.in
@@ -32,7 +32,7 @@ Default constructor of field formatter for a key value field.
 %End
     virtual QString id() const;
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgslistfieldformatter.sip.in
@@ -30,7 +30,7 @@ Default constructor of field formatter for a list field.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsrangefieldformatter.sip.in
@@ -28,7 +28,7 @@ Default constructor of field formatter for a range (double)field.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
 };

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsrelationreferencefieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsrelationreferencefieldformatter.sip.in
@@ -31,17 +31,17 @@ Default constructor of field formatter for a relation reference field.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config ) const;
+    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
 
 
 
-    virtual QVariantList availableValues( const QMap<QString, QVariant> &config, int countLimit, const QgsFieldFormatterContext &context ) const;
+    virtual QVariantList availableValues( const QVariantMap &config, int countLimit, const QgsFieldFormatterContext &context ) const;
 
 
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
@@ -42,13 +42,13 @@ Default constructor of field formatter for a value map field.
     virtual QString id() const;
 
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariantList availableValues( const QMap<QString, QVariant> &config, int countLimit, const QgsFieldFormatterContext &context ) const;
+    virtual QVariantList availableValues( const QVariantMap &config, int countLimit, const QgsFieldFormatterContext &context ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -50,13 +50,13 @@ Constructor for QgsValueRelationFieldFormatter.
 
     virtual QString id() const;
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
 
-    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config ) const;
+    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
 
 
     static QStringList valueToStringList( const QVariant &value );
@@ -66,7 +66,7 @@ Utility to convert a list or a string representation of an (hstore style: {1,2..
 .. versionadded:: 3.2
 %End
 
-    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QMap<QString, QVariant> &config, const QgsFeature &formFeature = QgsFeature(), const QgsFeature &parentFormFeature = QgsFeature() );
+    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature(), const QgsFeature &parentFormFeature = QgsFeature() );
 %Docstring
 Create a cache for a value relation field.
 This can be used to keep the value map in the local memory
@@ -160,7 +160,7 @@ optionally checks for ``parentFeature``
 .. versionadded:: 3.2
 %End
 
-    static QgsVectorLayer *resolveLayer( const QMap<QString, QVariant> &config, const QgsProject *project );
+    static QgsVectorLayer *resolveLayer( const QVariantMap &config, const QgsProject *project );
 %Docstring
 Returns the (possibly NULL) layer from the widget's ``config`` and ``project``
 
@@ -168,7 +168,7 @@ Returns the (possibly NULL) layer from the widget's ``config`` and ``project``
 %End
 
 
-    virtual QVariantList availableValues( const QMap<QString, QVariant> &config, int countLimit, const QgsFieldFormatterContext &context ) const;
+    virtual QVariantList availableValues( const QVariantMap &config, int countLimit, const QgsFieldFormatterContext &context ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/geocoding/qgsgeocoderresult.sip.in
+++ b/python/PyQt6/core/auto_generated/geocoding/qgsgeocoderresult.sip.in
@@ -127,7 +127,7 @@ The viewport CRS must match the CRS of geometry()d.
 .. seealso:: :py:func:`viewport`
 %End
 
-    QMap<QString, QVariant> additionalAttributes() const;
+    QVariantMap additionalAttributes() const;
 %Docstring
 Contains additional attributes generated during the geocode,
 which may be added to features being geocoded.
@@ -135,7 +135,7 @@ which may be added to features being geocoded.
 .. seealso:: :py:func:`setAdditionalAttributes`
 %End
 
-    void setAdditionalAttributes( const QMap<QString, QVariant> &attributes );
+    void setAdditionalAttributes( const QVariantMap &attributes );
 %Docstring
 Setss additional attributes generated during the geocode,
 which may be added to features being geocoded.

--- a/python/PyQt6/core/auto_generated/geocoding/qgsgooglemapsgeocoder.sip.in
+++ b/python/PyQt6/core/auto_generated/geocoding/qgsgooglemapsgeocoder.sip.in
@@ -60,7 +60,7 @@ e.g. "gb" for Great Britain.
 Returns the URL generated for geocoding the specified ``address``.
 %End
 
-    QgsGeocoderResult jsonToResult( const QMap<QString, QVariant> &json ) const;
+    QgsGeocoderResult jsonToResult( const QVariantMap &json ) const;
 %Docstring
 Converts a JSON result returned from the Google Maps service to a geocoder result object.
 %End

--- a/python/PyQt6/core/auto_generated/geocoding/qgsnominatimgeocoder.sip.in
+++ b/python/PyQt6/core/auto_generated/geocoding/qgsnominatimgeocoder.sip.in
@@ -54,7 +54,7 @@ The optional ``endpoint`` argument can be used to specify a non-default endpoint
 Returns the URL generated for geocoding the specified ``address``.
 %End
 
-    QgsGeocoderResult jsonToResult( const QMap<QString, QVariant> &json ) const;
+    QgsGeocoderResult jsonToResult( const QVariantMap &json ) const;
 %Docstring
 Converts a JSON result returned from the Nominatim service to a geocoder result object.
 %End

--- a/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
@@ -315,7 +315,7 @@ Set pal settings for a specific provider (takes ownership).
 %End
     virtual bool requiresAdvancedEffects() const;
 
-    virtual void toSld( QDomNode &parent, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomNode &parent, const QVariantMap &props ) const;
 
     virtual void multiplyOpacity( double opacityFactor );
 

--- a/python/PyQt6/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgsvectorlayerlabeling.sip.in
@@ -100,7 +100,7 @@ by ``opacity`` effectively changing the opacity of the whole labeling elements.
 Try to create instance of an implementation based on the XML data
 %End
 
-    virtual void toSld( QDomNode &parent, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomNode &parent, const QVariantMap &props ) const;
 %Docstring
 Writes the SE 1.1 TextSymbolizer element based on the current layer labeling settings
 %End
@@ -125,7 +125,7 @@ Returns the default layer settings to use for the specified vector ``layer``.
 
   protected:
 
-    virtual void writeTextSymbolizer( QDomNode &parent, QgsPalLayerSettings &settings, const QMap<QString, QVariant> &props ) const;
+    virtual void writeTextSymbolizer( QDomNode &parent, QgsPalLayerSettings &settings, const QVariantMap &props ) const;
 %Docstring
 Writes a TextSymbolizer element contents based on the provided labeling settings
 
@@ -181,7 +181,7 @@ Set pal settings (takes ownership).
 
     virtual bool requiresAdvancedEffects() const;
 
-    virtual void toSld( QDomNode &parent, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomNode &parent, const QVariantMap &props ) const;
 
     virtual void multiplyOpacity( double opacityFactor );
 

--- a/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
@@ -32,7 +32,7 @@ Current context for a report section.
 
     QgsVectorLayer *currentLayer;
 
-    QMap<QString, QVariant> fieldFilters;
+    QVariantMap fieldFilters;
 };
 
 class QgsAbstractReportSection : QgsAbstractLayoutIterator

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -64,7 +64,7 @@ Returns a translated, user visible name for plurals of the layout item class (e.
 Creates a layout item of this class for a specified ``layout``.
 %End
 
-    virtual void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    virtual void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Resolve paths in the item's ``properties`` (if there are any paths).
 When ``saving`` is ``True``, paths are converted from absolute to relative,
@@ -127,7 +127,7 @@ Returns a translated, user visible name for the layout multiframe class.
 Creates a layout multiframe of this class for a specified ``layout``.
 %End
 
-    virtual void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    virtual void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Resolve paths in the item's ``properties`` (if there are any paths).
 When ``saving`` is ``True``, paths are converted from absolute to relative,
@@ -269,7 +269,7 @@ Creates a new instance of a layout multiframe given the multiframe ``type``, and
 .. seealso:: :py:func:`createItem`
 %End
 
-    void resolvePaths( int type, QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving ) const;
+    void resolvePaths( int type, QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving ) const;
 %Docstring
 Resolve paths in properties of a particular symbol layer.
 This normally means converting relative paths to absolute paths when loading

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayerlabeling.sip.in
@@ -88,7 +88,7 @@ by ``opacity`` effectively changing the opacity of the whole labeling elements.
 Try to create instance of an implementation based on the XML data
 %End
 
-    virtual void toSld( QDomNode &parent, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomNode &parent, const QVariantMap &props ) const;
 %Docstring
 Writes the SE 1.1 TextSymbolizer element based on the current layer labeling settings
 %End

--- a/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgshttpheaders.sip.in
@@ -26,7 +26,7 @@ This class implements simple http header management.
   public:
 
 
-    QgsHttpHeaders( const QMap<QString, QVariant> &headers );
+    QgsHttpHeaders( const QVariantMap &headers );
 %Docstring
 Constructor from map
 
@@ -65,7 +65,7 @@ Constructor from a QDomElement ``element``
 
     virtual ~QgsHttpHeaders();
 
-    QMap<QString, QVariant> headers() const;
+    QVariantMap headers() const;
 %Docstring
 Returns the headers as a variant map
 
@@ -101,7 +101,7 @@ Updates an ``uri`` by adding all the HTTP headers
 :return: ``True`` if the update succeed
 %End
 
-    bool updateMap( QMap<QString, QVariant> &map ) const;
+    bool updateMap( QVariantMap &map ) const;
 %Docstring
 Updates a ``map`` by adding all the HTTP headers
 
@@ -136,7 +136,7 @@ Loads headers from the ``uri``
 :param uri:
 %End
 
-    void setFromMap( const QMap<QString, QVariant> &map );
+    void setFromMap( const QVariantMap &map );
 %Docstring
 Loads headers from the ``map``
 

--- a/python/PyQt6/core/auto_generated/numericformats/qgsbasicnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsbasicnumericformat.sip.in
@@ -41,9 +41,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     int numberDecimalPlaces() const;
@@ -160,7 +160,7 @@ then the QGIS locale separator is used instead.
 
   protected:
 
-    virtual void setConfiguration( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context );
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
 %Docstring
 Sets the format's ``configuration``.
 %End

--- a/python/PyQt6/core/auto_generated/numericformats/qgsbearingnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsbearingnumericformat.sip.in
@@ -44,9 +44,9 @@ Default constructor
 
     virtual QgsBearingNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     FormatDirectionOption directionFormat() const;
@@ -65,7 +65,7 @@ described in the returned strings.
 .. seealso:: :py:func:`directionFormat`
 %End
 
-    virtual void setConfiguration( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context );
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
 
 
 };

--- a/python/PyQt6/core/auto_generated/numericformats/qgscoordinatenumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgscoordinatenumericformat.sip.in
@@ -47,9 +47,9 @@ Default constructor
 
     virtual QgsGeographicCoordinateNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     AngleFormat angleFormat() const;
@@ -110,7 +110,7 @@ Sets whether directional suffixes (e.g. "N") should be included.
 .. seealso:: :py:func:`showDirectionalSuffix`
 %End
 
-    virtual void setConfiguration( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context );
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
 
 
 };

--- a/python/PyQt6/core/auto_generated/numericformats/qgscurrencynumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgscurrencynumericformat.sip.in
@@ -37,9 +37,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     QString prefix() const;

--- a/python/PyQt6/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsfallbacknumericformat.sip.in
@@ -34,9 +34,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/numericformats/qgsfractionnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsfractionnumericformat.sip.in
@@ -35,9 +35,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
     virtual double suggestSampleValue() const;
 
@@ -156,7 +156,7 @@ Converts numbers in an ``input`` string to unicode subscript equivalents.
 
   protected:
 
-    virtual void setConfiguration( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context );
+    virtual void setConfiguration( const QVariantMap &configuration, const QgsReadWriteContext &context );
 %Docstring
 Sets the format's ``configuration``.
 %End

--- a/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsnumericformat.sip.in
@@ -249,14 +249,14 @@ Clones the format, returning a new object.
 The caller takes ownership of the returned object.
 %End
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const = 0 /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const = 0 /Factory/;
 %Docstring
 Creates a new copy of the format, using the supplied ``configuration``.
 
 The caller takes ownership of the returned object.
 %End
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const = 0;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const = 0;
 %Docstring
 Returns the current configuration of the formatter. This value can be used in a call to :py:func:`~QgsNumericFormat.create`
 in order to recreate this formatter in its current state.

--- a/python/PyQt6/core/auto_generated/numericformats/qgsnumericformatregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsnumericformatregistry.sip.in
@@ -58,7 +58,7 @@ a default :py:class:`QgsFallbackNumericFormat` with a null id will be returned i
 The caller takes ownership of the returned object.
 %End
 
-    QgsNumericFormat *create( const QString &id, const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /TransferBack/;
+    QgsNumericFormat *create( const QString &id, const QVariantMap &configuration, const QgsReadWriteContext &context ) const /TransferBack/;
 %Docstring
 Creates a new numeric format by ``id``, using the supplied ``configuration``. If there is no such ``id`` registered,
 a default :py:class:`QgsFallbackNumericFormat` with a null id will be returned instead.

--- a/python/PyQt6/core/auto_generated/numericformats/qgspercentagenumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgspercentagenumericformat.sip.in
@@ -43,9 +43,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     InputValues inputValues() const;

--- a/python/PyQt6/core/auto_generated/numericformats/qgsscientificnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsscientificnumericformat.sip.in
@@ -35,9 +35,9 @@ Default constructor
 
     virtual QgsNumericFormat *clone() const /Factory/;
 
-    virtual QgsNumericFormat *create( const QMap<QString, QVariant> &configuration, const QgsReadWriteContext &context ) const /Factory/;
+    virtual QgsNumericFormat *create( const QVariantMap &configuration, const QgsReadWriteContext &context ) const /Factory/;
 
-    virtual QMap<QString, QVariant> configuration( const QgsReadWriteContext &context ) const;
+    virtual QVariantMap configuration( const QgsReadWriteContext &context ) const;
 
 
     virtual void setNumberDecimalPlaces( int places );

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudclassifiedrenderer.sip.in
@@ -147,7 +147,7 @@ Constructor for QgsPointCloudClassifiedRenderer.
 
     virtual void renderBlock( const QgsPointCloudBlock *block, QgsPointCloudRenderContext &context );
 
-    virtual bool willRenderPoint( const QMap<QString, QVariant> &pointAttributes );
+    virtual bool willRenderPoint( const QVariantMap &pointAttributes );
 
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const;
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -147,7 +147,7 @@ This method will not attempt to calculate the data bounds, rather it will return
 are included in the data source's metadata.
 %End
 
-    virtual QMap<QString, QVariant> originalMetadata() const;
+    virtual QVariantMap originalMetadata() const;
 %Docstring
 Returns a representation of the original metadata included in a point cloud dataset.
 
@@ -155,7 +155,7 @@ This is a free-form dictionary of values, the contents and structure of which wi
 dataset.
 %End
 
-    virtual QgsPointCloudRenderer *createRenderer( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) const /Factory/;
+    virtual QgsPointCloudRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
 Creates a new 2D point cloud renderer, using provider backend specific information.
 

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -31,7 +31,7 @@ Model based algorithm with processing.
 Constructor for QgsProcessingModelAlgorithm.
 %End
 
-    virtual void initAlgorithm( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() );  //#spellok
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );  //#spellok
 
 
     virtual QString name() const;
@@ -55,9 +55,9 @@ Constructor for QgsProcessingModelAlgorithm.
 
     virtual bool canExecute( QString *errorMessage /Out/ = 0 ) const;
 
-    virtual QString asPythonCommand( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) const;
+    virtual QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const;
 
-    virtual QgsExpressionContext createExpressionContext( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeatureSource *source = 0 ) const;
+    virtual QgsExpressionContext createExpressionContext( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeatureSource *source = 0 ) const;
 
 
     void setName( const QString &name );
@@ -435,7 +435,7 @@ Reads the model from a file, at the specified ``path``.
 
     QVariant toVariant() const;
 %Docstring
-Saves this model to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this model to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -445,7 +445,7 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
     bool loadVariant( const QVariant &variant );
 %Docstring
-Loads this model from a QMap<QString, QVariant>, wrapped in a QVariant ``variant``.
+Loads this model from a QVariantMap, wrapped in a QVariant ``variant``.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
@@ -453,7 +453,7 @@ You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 .. versionadded:: 3.4
 %End
 
-    QMap<QString, QVariant> &helpContent();
+    QVariantMap &helpContent();
 %Docstring
 Returns the model's help contents (a free-form map of values describing the algorithm's
 use and metadata).
@@ -462,7 +462,7 @@ use and metadata).
 %End
 
 
-    void setHelpContent( const QMap<QString, QVariant> &contents );
+    void setHelpContent( const QVariantMap &contents );
 %Docstring
 Sets the model's help ``contents`` (a free-form map of values describing the algorithm's
 use and metadata).
@@ -540,8 +540,8 @@ parameter ``source``, and ``description``.
         QString description;
     };
 
-    QMap< QString, QgsProcessingModelAlgorithm::VariableDefinition > variablesForChildAlgorithm( const QString &childId, QgsProcessingContext *context = 0, const QMap<QString, QVariant> &modelParameters = QMap<QString, QVariant>(),
-        const QMap<QString, QVariant> &results = QMap<QString, QVariant>() ) const;
+    QMap< QString, QgsProcessingModelAlgorithm::VariableDefinition > variablesForChildAlgorithm( const QString &childId, QgsProcessingContext *context = 0, const QVariantMap &modelParameters = QVariantMap(),
+        const QVariantMap &results = QVariantMap() ) const;
 %Docstring
 Returns a map of variable name to variable definition for expression context variables which are available
 for use by child algorithm during model execution.
@@ -557,15 +557,15 @@ algorithm ``results`` must be passed.
 .. seealso:: :py:func:`createExpressionContextScopeForChildAlgorithm`
 %End
 
-    QgsExpressionContextScope *createExpressionContextScopeForChildAlgorithm( const QString &childId, QgsProcessingContext &context, const QMap<QString, QVariant> &modelParameters = QMap<QString, QVariant>(),
-        const QMap<QString, QVariant> &results = QMap<QString, QVariant>() ) const /Factory/;
+    QgsExpressionContextScope *createExpressionContextScopeForChildAlgorithm( const QString &childId, QgsProcessingContext &context, const QVariantMap &modelParameters = QVariantMap(),
+        const QVariantMap &results = QVariantMap() ) const /Factory/;
 %Docstring
 Creates a new expression context scope for a child algorithm within the model.
 
 .. seealso:: :py:func:`variablesForChildAlgorithm`
 %End
 
-    QMap<QString, QVariant> variables() const;
+    QVariantMap variables() const;
 %Docstring
 Returns the map of custom expression context variables defined for this model.
 
@@ -577,7 +577,7 @@ These variables are added to the model's expression context scope, allowing for 
 .. versionadded:: 3.8
 %End
 
-    void setVariables( const QMap<QString, QVariant> &variables );
+    void setVariables( const QVariantMap &variables );
 %Docstring
 Sets the map of custom expression context ``variables`` for this model.
 
@@ -589,7 +589,7 @@ These variables are added to the model's expression context scope, allowing for 
 .. versionadded:: 3.8
 %End
 
-    QMap<QString, QVariant> designerParameterValues() const;
+    QVariantMap designerParameterValues() const;
 %Docstring
 Returns the parameter values to use as default values when running this model through the
 designer dialog.
@@ -602,7 +602,7 @@ run through the designer.
 .. versionadded:: 3.14
 %End
 
-    void setDesignerParameterValues( const QMap<QString, QVariant> &values );
+    void setDesignerParameterValues( const QVariantMap &values );
 %Docstring
 Sets the parameter ``values`` to use as default values when running this model through the
 designer dialog.
@@ -637,7 +637,7 @@ If ``capitalize`` is ``True`` then the string will be converted to a camel case 
     virtual QgsProcessingAlgorithm *createInstance() const /Factory/;
 
 
-    virtual QMap<QString, QVariant> processAlgorithm( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
+    virtual QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
 
 
 };

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -112,7 +112,7 @@ Returns ``True`` if the algorithm was successfully reattached.
 .. seealso:: :py:func:`setAlgorithmId`
 %End
 
-    QMap<QString, QVariant> configuration() const;
+    QVariantMap configuration() const;
 %Docstring
 Returns the child algorithm's configuration map.
 
@@ -124,7 +124,7 @@ to adjust their behavior at run time according to some user configuration.
 .. seealso:: :py:func:`setConfiguration`
 %End
 
-    void setConfiguration( const QMap<QString, QVariant> &configuration );
+    void setConfiguration( const QVariantMap &configuration );
 %Docstring
 Sets the child algorithm's ``configuration`` map.
 

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchilddependency.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchilddependency.sip.in
@@ -40,9 +40,9 @@ Saves this dependency to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this dependency from a QMap<QString, QVariant>.
+Loads this dependency from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
@@ -231,9 +231,9 @@ Saves this source to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this source from a QMap<QString, QVariant>.
+Loads this source from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelcomment.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelcomment.sip.in
@@ -38,9 +38,9 @@ Saves this comment to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this comment from a QMap<QString, QVariant>.
+Loads this comment from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
@@ -143,16 +143,16 @@ Copies are protected to avoid slicing
 %End
 
 
-    void saveCommonProperties( QMap<QString, QVariant> &map ) const;
+    void saveCommonProperties( QVariantMap &map ) const;
 %Docstring
-Saves the component properties to a QMap<QString, QVariant>.
+Saves the component properties to a QVariantMap.
 
 .. seealso:: :py:func:`restoreCommonProperties`
 %End
 
-    void restoreCommonProperties( const QMap<QString, QVariant> &map );
+    void restoreCommonProperties( const QVariantMap &map );
 %Docstring
-Restores the component properties from a QMap<QString, QVariant>.
+Restores the component properties from a QVariantMap.
 
 .. seealso:: :py:func:`saveCommonProperties`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelgroupbox.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelgroupbox.sip.in
@@ -38,9 +38,9 @@ Saves this group box to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map, bool ignoreUuid = false );
+    bool loadVariant( const QVariantMap &map, bool ignoreUuid = false );
 %Docstring
-Loads this group box from a QMap<QString, QVariant>.
+Loads this group box from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
@@ -120,9 +120,9 @@ Saves this output to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this output from a QMap<QString, QVariant>.
+Loads this output from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
@@ -56,9 +56,9 @@ Saves this parameter to a QVariant.
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this parameter from a QMap<QString, QVariant>.
+Loads this parameter from a QVariantMap.
 
 .. seealso:: :py:func:`toVariant`
 %End

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -48,7 +48,7 @@ a pre-initialized copy of the algorithm.
 
 
 
-    QgsProcessingAlgorithm *create( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) const throw( QgsProcessingException ) /TransferBack/;
+    QgsProcessingAlgorithm *create( const QVariantMap &configuration = QVariantMap() ) const throw( QgsProcessingException ) /TransferBack/;
 %Docstring
 Creates a copy of the algorithm, ready for execution.
 
@@ -198,7 +198,7 @@ external dependencies. If specified, the ``errorMessage`` argument will be fille
 with a localised error message describing why the algorithm cannot execute.
 %End
 
-    virtual bool checkParameterValues( const QMap<QString, QVariant> &parameters,
+    virtual bool checkParameterValues( const QVariantMap &parameters,
                                        QgsProcessingContext &context, QString *message /Out/ = 0 ) const;
 %Docstring
 Checks the supplied ``parameter`` values to verify that they satisfy the requirements
@@ -209,7 +209,7 @@ Overridden implementations should also check this base class implementation.
 :return: ``True`` if parameters are acceptable for the algorithm.
 %End
 
-    virtual QMap<QString, QVariant> preprocessParameters( const QMap<QString, QVariant> &parameters );
+    virtual QVariantMap preprocessParameters( const QVariantMap &parameters );
 %Docstring
 Pre-processes a set of ``parameters``, allowing the algorithm to clean their
 values.
@@ -292,7 +292,7 @@ Returns ``True`` if this algorithm generates HTML outputs.
     };
 
     virtual QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
-        const QMap<QString, QVariant> &parameters,
+        const QVariantMap &parameters,
         QgsProcessingContext &context,
         const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const;
 %Docstring
@@ -311,7 +311,7 @@ is passed in order to make a best guess determination of the output properties.
 .. versionadded:: 3.14
 %End
 
-    QMap<QString, QVariant> run( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok /Out/ = 0, const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>(),
+    QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok /Out/ = 0, const QVariantMap &configuration = QVariantMap(),
                      bool catchExceptions = true ) const throw( QgsProcessingException );
 %Docstring
 Executes the algorithm using the specified ``parameters``. This method internally
@@ -336,7 +336,7 @@ the algorithm run will not be automatically caught and will be raised instead.
    if you need to run algorithms from a background thread, or use the :py:class:`QgsProcessingAlgRunnerTask` class.
 %End
 
-    bool prepare( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    bool prepare( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 %Docstring
 Prepares the algorithm for execution. This must be run in the main thread, and allows the algorithm
 to pre-evaluate input parameters in a thread-safe manner. This must be called before
@@ -353,7 +353,7 @@ calling :py:func:`~QgsProcessingAlgorithm.runPrepared` (which is safe to do in a
    of the algorithm should be created with :py:func:`~QgsProcessingAlgorithm.clone` and :py:func:`~QgsProcessingAlgorithm.prepare`/:py:func:`~QgsProcessingAlgorithm.runPrepared` called on the copy.
 %End
 
-    QMap<QString, QVariant> runPrepared( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
+    QVariantMap runPrepared( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
 %Docstring
 Runs the algorithm, which has been prepared by an earlier call to :py:func:`~QgsProcessingAlgorithm.prepare`.
 This method is safe to call from any thread. Returns ``True`` if the algorithm was successfully executed.
@@ -371,7 +371,7 @@ to allow the algorithm to perform any required cleanup tasks and return its fina
    of the algorithm should be created with :py:func:`~QgsProcessingAlgorithm.clone` and :py:func:`~QgsProcessingAlgorithm.prepare`/:py:func:`~QgsProcessingAlgorithm.runPrepared` called on the copy.
 %End
 
-    QMap<QString, QVariant> postProcess( QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    QVariantMap postProcess( QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 %Docstring
 Should be called in the main thread following the completion of :py:func:`~QgsProcessingAlgorithm.runPrepared`. This method
 allows the algorithm to perform any required cleanup tasks. The returned variant map
@@ -392,7 +392,7 @@ The base class implementation returns ``None``, which indicates that an autogene
 parameters widget should be used.
 %End
 
-    virtual QgsExpressionContext createExpressionContext( const QMap<QString, QVariant> &parameters,
+    virtual QgsExpressionContext createExpressionContext( const QVariantMap &parameters,
         QgsProcessingContext &context, QgsProcessingFeatureSource *source = 0 ) const;
 %Docstring
 Creates an expression context relating to the algorithm. This can be called by algorithms
@@ -401,7 +401,7 @@ Optionally, a ``source`` can be specified which will be used to populate the con
 implements the :py:class:`QgsExpressionContextGenerator` interface.
 %End
 
-    virtual bool validateInputCrs( const QMap<QString, QVariant> &parameters,
+    virtual bool validateInputCrs( const QVariantMap &parameters,
                                    QgsProcessingContext &context ) const;
 %Docstring
 Checks whether the coordinate reference systems for the specified set of ``parameters``
@@ -410,7 +410,7 @@ checks to ensure that all input CRS are equal
 Returns ``True`` if ``parameters`` have passed the CRS check.
 %End
 
-    virtual QString asPythonCommand( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) const;
+    virtual QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const;
 %Docstring
 Returns a Python command string which can be executed to run the algorithm
 using the specified ``parameters``.
@@ -419,7 +419,7 @@ Algorithms which cannot be run from a Python command should return an empty
 string.
 %End
 
-    virtual QString asQgisProcessCommand( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, bool &ok /Out/ ) const;
+    virtual QString asQgisProcessCommand( const QVariantMap &parameters, QgsProcessingContext &context, bool &ok /Out/ ) const;
 %Docstring
 Returns a command string which will execute the algorithm using the specified ``parameters``
 via the command line qgis_process tool.
@@ -436,7 +436,7 @@ Note that some combinations of parameter types and values cannot be represented 
 .. versionadded:: 3.24
 %End
 
-    virtual QMap<QString, QVariant> asMap( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) const;
+    virtual QVariantMap asMap( const QVariantMap &parameters, QgsProcessingContext &context ) const;
 %Docstring
 Returns a JSON serializable variant map containing the specified ``parameters`` and ``context`` settings.
 
@@ -457,7 +457,7 @@ Creates a new instance of the algorithm class.
 This method should return a 'pristine' instance of the algorithm class.
 %End
 
-    virtual void initAlgorithm( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) = 0;
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) = 0;
 %Docstring
 Initializes the algorithm using the specified ``configuration``.
 
@@ -520,7 +520,7 @@ See the notes in :py:func:`~QgsProcessingAlgorithm.addParameter` for a descripti
 .. seealso:: :py:func:`initAlgorithm`
 %End
 
-    virtual bool prepareAlgorithm( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) /VirtualErrorHandler=processing_exception_handler/;
+    virtual bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) /VirtualErrorHandler=processing_exception_handler/;
 %Docstring
 Prepares the algorithm to run using the specified ``parameters``. Algorithms should implement
 their logic for evaluating parameter values here. The evaluated parameter results should
@@ -554,7 +554,7 @@ will be canceled.
 .. seealso:: :py:func:`postProcessAlgorithm`
 %End
 
-    virtual QMap<QString, QVariant> processAlgorithm( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) = 0 /VirtualErrorHandler=processing_exception_handler/;
+    virtual QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) = 0 /VirtualErrorHandler=processing_exception_handler/;
 %Docstring
 Runs the algorithm using the specified ``parameters``. Algorithms should implement
 their custom processing logic here.
@@ -586,7 +586,7 @@ to indicate that a fatal error occurred within the execution.
 .. seealso:: :py:func:`postProcessAlgorithm`
 %End
 
-    virtual QMap<QString, QVariant> postProcessAlgorithm( QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) /VirtualErrorHandler=processing_exception_handler/;
+    virtual QVariantMap postProcessAlgorithm( QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException ) /VirtualErrorHandler=processing_exception_handler/;
 %Docstring
 Allows the algorithm to perform any required cleanup tasks. The returned variant map
 includes the results evaluated by the algorithm. These may be output layer references, or calculated
@@ -616,71 +616,71 @@ or if an exception was raised by the :py:func:`~QgsProcessingAlgorithm.processAl
 .. seealso:: :py:func:`processAlgorithm`
 %End
 
-    QString parameterAsString( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QString parameterAsString( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static string value.
 %End
 
-    QString parameterAsExpression( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QString parameterAsExpression( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to an expression.
 %End
 
-    double parameterAsDouble( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    double parameterAsDouble( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static double value.
 %End
 
-    int parameterAsInt( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    int parameterAsInt( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static integer value.
 %End
 
-    QList<int> parameterAsInts( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QList<int> parameterAsInts( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of integer values.
 
 .. versionadded:: 3.4
 %End
 
-    int parameterAsEnum( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    int parameterAsEnum( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a enum value.
 %End
 
-    QList<int> parameterAsEnums( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QList<int> parameterAsEnums( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to list of enum values.
 %End
 
-    QString parameterAsEnumString( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QString parameterAsEnumString( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static enum string.
 
 .. versionadded:: 3.18
 %End
 
-    QStringList parameterAsEnumStrings( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    QStringList parameterAsEnumStrings( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to list of static enum strings.
 
 .. versionadded:: 3.18
 %End
 
-    bool parameterAsBool( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    bool parameterAsBool( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static boolean value.
 %End
 
-    bool parameterAsBoolean( const QMap<QString, QVariant> &parameters, const QString &name, const QgsProcessingContext &context ) const;
+    bool parameterAsBoolean( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a static boolean value.
 
 .. versionadded:: 3.8
 %End
 
-    QgsFeatureSink *parameterAsSink( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context, QString &destinationIdentifier /Out/,
-                                     const QgsFields &fields, Qgis::WkbType geometryType = Qgis::WkbType::NoGeometry, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QMap<QString, QVariant> &createOptions = QMap<QString, QVariant>(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) const throw( QgsProcessingException ) /Factory/;
+    QgsFeatureSink *parameterAsSink( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QString &destinationIdentifier /Out/,
+                                     const QgsFields &fields, Qgis::WkbType geometryType = Qgis::WkbType::NoGeometry, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(), QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QVariantMap &createOptions = QVariantMap(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) const throw( QgsProcessingException ) /Factory/;
 %Docstring
 Evaluates the parameter with matching ``name`` to a feature sink.
 
@@ -702,7 +702,7 @@ This function creates a new object and the caller takes responsibility for delet
 :raises QgsProcessingException: 
 %End
 
-    QgsProcessingFeatureSource *parameterAsSource( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const /Factory/;
+    QgsProcessingFeatureSource *parameterAsSource( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Factory/;
 %Docstring
 Evaluates the parameter with matching ``name`` to a feature source.
 
@@ -712,7 +712,7 @@ sources and stored temporarily in the ``context``.
 This function creates a new object and the caller takes responsibility for deleting the returned object.
 %End
 
-    QString parameterAsCompatibleSourceLayerPath( const QMap<QString, QVariant> &parameters, const QString &name,
+    QString parameterAsCompatibleSourceLayerPath( const QVariantMap &parameters, const QString &name,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0 ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a source vector layer file path of compatible format.
@@ -730,7 +730,7 @@ When an algorithm is capable of handling multi-layer input files (such as Geopac
 to use :py:func:`~QgsProcessingAlgorithm.parameterAsCompatibleSourceLayerPathAndLayerName` which may avoid conversion in more situations.
 %End
 
-    QString parameterAsCompatibleSourceLayerPathAndLayerName( const QMap<QString, QVariant> &parameters, const QString &name,
+    QString parameterAsCompatibleSourceLayerPathAndLayerName( const QVariantMap &parameters, const QString &name,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0, QString *layerName /Out/ = 0 ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a source vector layer file path and layer name of compatible format.
@@ -764,7 +764,7 @@ a conversion in this case and will return the target layer name in the ``layerNa
 .. versionadded:: 3.10
 %End
 
-    QgsMapLayer *parameterAsLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsMapLayer *parameterAsLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a map layer.
 
@@ -773,7 +773,7 @@ sources and stored temporarily in the ``context``. In either case, callers do no
 need to handle deletion of the returned layer.
 %End
 
-    QgsRasterLayer *parameterAsRasterLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsRasterLayer *parameterAsRasterLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a raster layer.
 
@@ -782,7 +782,7 @@ sources and stored temporarily in the ``context``. In either case, callers do no
 need to handle deletion of the returned layer.
 %End
 
-    QgsMeshLayer *parameterAsMeshLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsMeshLayer *parameterAsMeshLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a mesh layer.
 
@@ -793,17 +793,17 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.6
 %End
 
-    QString parameterAsOutputLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsOutputLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a output layer destination.
 %End
 
-    QString parameterAsFileOutput( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a file based output destination.
 %End
 
-    QgsVectorLayer *parameterAsVectorLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsVectorLayer *parameterAsVectorLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a vector layer.
 
@@ -812,12 +812,12 @@ sources and stored temporarily in the ``context``. In either case, callers do no
 need to handle deletion of the returned layer.
 %End
 
-    QgsCoordinateReferenceSystem parameterAsCrs( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsCoordinateReferenceSystem parameterAsCrs( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a coordinate reference system.
 %End
 
-    QgsRectangle parameterAsExtent( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context,
+    QgsRectangle parameterAsExtent( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context,
                                     const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a rectangular extent.
@@ -828,7 +828,7 @@ reprojected so that it is in the specified ``crs``. In this case the extent of t
 .. seealso:: :py:func:`parameterAsExtentGeometry`
 %End
 
-    QgsGeometry parameterAsExtentGeometry( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context,
+    QgsGeometry parameterAsExtentGeometry( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context,
                                            const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a rectangular extent, and returns a geometry covering this extent.
@@ -841,14 +841,14 @@ just the extent of the reprojected rectangle).
 .. seealso:: :py:func:`parameterAsExtent`
 %End
 
-    QgsCoordinateReferenceSystem parameterAsExtentCrs( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsCoordinateReferenceSystem parameterAsExtentCrs( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Returns the coordinate reference system associated with an extent parameter value.
 
 .. seealso:: :py:func:`parameterAsExtent`
 %End
 
-    QgsPointXY parameterAsPoint( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context,
+    QgsPointXY parameterAsPoint( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context,
                                  const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a point.
@@ -859,14 +859,14 @@ reprojected so that it is in the specified ``crs``.
 .. seealso:: :py:func:`parameterAsPointCrs`
 %End
 
-    QgsCoordinateReferenceSystem parameterAsPointCrs( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsCoordinateReferenceSystem parameterAsPointCrs( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Returns the coordinate reference system associated with an point parameter value.
 
 .. seealso:: :py:func:`parameterAsPoint`
 %End
 
-    QgsGeometry parameterAsGeometry( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context,
+    QgsGeometry parameterAsGeometry( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context,
                                      const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a geometry.
@@ -877,43 +877,43 @@ reprojected so that it is in the specified ``crs``.
 .. seealso:: :py:func:`parameterAsGeometryCrs`
 %End
 
-    QgsCoordinateReferenceSystem parameterAsGeometryCrs( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsCoordinateReferenceSystem parameterAsGeometryCrs( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Returns the coordinate reference system associated with a geometry parameter value.
 
 .. seealso:: :py:func:`parameterAsGeometry`
 %End
 
-    QString parameterAsFile( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsFile( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a file/folder name.
 %End
 
-    QVariantList parameterAsMatrix( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QVariantList parameterAsMatrix( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a matrix/table of values.
 Tables are collapsed to a 1 dimensional list.
 %End
 
-    QList< QgsMapLayer *> parameterAsLayerList( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
+    QList< QgsMapLayer *> parameterAsLayerList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of map layers.
 The ``flags`` are used to set options for loading layers (e.g. skip index generation).
 %End
 
-    QStringList parameterAsFileList( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QStringList parameterAsFileList( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of files (for :py:class:`QgsProcessingParameterMultipleLayers` in :py:class:`QgsProcessing`:TypeFile mode).
 
 .. versionadded:: 3.10
 %End
 
-    QList<double> parameterAsRange( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QList<double> parameterAsRange( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a range of values.
 %End
 
- QStringList parameterAsFields( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated/;
+ QStringList parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Deprecated/;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of fields.
 
@@ -921,14 +921,14 @@ Evaluates the parameter with matching ``name`` to a list of fields.
    use :py:func:`~QgsProcessingAlgorithm.parameterAsStrings` instead.
 %End
 
-    QStringList parameterAsStrings( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QStringList parameterAsStrings( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a list of strings (e.g. field names or point cloud attributes).
 
 .. versionadded:: 3.32
 %End
 
-    QgsPrintLayout *parameterAsLayout( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context );
+    QgsPrintLayout *parameterAsLayout( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``name`` to a print layout.
 
@@ -940,7 +940,7 @@ Evaluates the parameter with matching ``name`` to a print layout.
 .. versionadded:: 3.8
 %End
 
-    QgsLayoutItem *parameterAsLayoutItem( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context, QgsPrintLayout *layout );
+    QgsLayoutItem *parameterAsLayoutItem( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsPrintLayout *layout );
 %Docstring
 Evaluates the parameter with matching ``name`` to a print layout item, taken from the specified ``layout``.
 
@@ -952,42 +952,42 @@ Evaluates the parameter with matching ``name`` to a print layout item, taken fro
 .. versionadded:: 3.8
 %End
 
-    QColor parameterAsColor( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QColor parameterAsColor( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a color, or returns an invalid color if the parameter was not set.
 
 .. versionadded:: 3.10
 %End
 
-    QString parameterAsConnectionName( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsConnectionName( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a connection name string.
 
 .. versionadded:: 3.14
 %End
 
-    QString parameterAsSchema( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsSchema( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a database schema name string.
 
 .. versionadded:: 3.14
 %End
 
-    QString parameterAsDatabaseTableName( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QString parameterAsDatabaseTableName( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a database table name string.
 
 .. versionadded:: 3.14
 %End
 
-    QDateTime parameterAsDateTime( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QDateTime parameterAsDateTime( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a DateTime, or returns an invalid date time if the parameter was not set.
 
 .. versionadded:: 3.14
 %End
 
-    QgsPointCloudLayer *parameterAsPointCloudLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
+    QgsPointCloudLayer *parameterAsPointCloudLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a point cloud layer.
 The ``flags`` are used to set options for loading layer (e.g. skip index generation).
@@ -999,7 +999,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
-    QgsAnnotationLayer *parameterAsAnnotationLayer( const QMap<QString, QVariant> &parameters, const QString &name, QgsProcessingContext &context ) const;
+    QgsAnnotationLayer *parameterAsAnnotationLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to an annotation layer.
 
@@ -1016,7 +1016,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
-    static QString invalidSourceError( const QMap<QString, QVariant> &parameters, const QString &name );
+    static QString invalidSourceError( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a source parameter could
 not be loaded.
@@ -1033,7 +1033,7 @@ should correspond to the invalid source parameter name.
 .. versionadded:: 3.2
 %End
 
-    static QString invalidRasterError( const QMap<QString, QVariant> &parameters, const QString &name );
+    static QString invalidRasterError( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a raster layer input could
 not be loaded.
@@ -1050,7 +1050,7 @@ should correspond to the invalid raster parameter name.
 .. versionadded:: 3.2
 %End
 
-    static QString invalidSinkError( const QMap<QString, QVariant> &parameters, const QString &name );
+    static QString invalidSinkError( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a sink parameter could
 not be created.
@@ -1067,7 +1067,7 @@ should correspond to the invalid sink parameter name.
 .. versionadded:: 3.2
 %End
 
-    static QString invalidPointCloudError( const QMap<QString, QVariant> &parameters, const QString &name );
+    static QString invalidPointCloudError( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a point cloud layer input could
 not be loaded.
@@ -1084,7 +1084,7 @@ should correspond to the invalid point cloud parameter name.
 .. versionadded:: 3.32
 %End
 
-    static QString writeFeatureError( QgsFeatureSink *sink, const QMap<QString, QVariant> &parameters, const QString &name );
+    static QString writeFeatureError( QgsFeatureSink *sink, const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a feature cannot be
 written into a sink.
@@ -1176,7 +1176,7 @@ can break valid model execution - so use with extreme caution, and consider usin
 
   protected:
 
-    virtual void initAlgorithm( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() );
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );
 
 
     virtual QString inputParameterName() const /HoldGIL/;
@@ -1260,7 +1260,7 @@ This is called once by the base class when creating the output sink for the algo
 not called once per feature processed).
 %End
 
-    virtual void initParameters( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() );
+    virtual void initParameters( const QVariantMap &configuration = QVariantMap() );
 %Docstring
 Initializes any extra parameters added by the algorithm subclass. There is no need
 to declare the input source or output sink, as these are automatically created by
@@ -1274,7 +1274,7 @@ called from a subclasses' :py:func:`~QgsProcessingFeatureBasedAlgorithm.processF
 %End
 
 
-    virtual QMap<QString, QVariant> processAlgorithm( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
+    virtual QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) throw( QgsProcessingException );
 
 
     virtual QgsFeatureRequest request() const;
@@ -1295,7 +1295,7 @@ checks based on the geometry type of the layer.
 .. versionadded:: 3.4
 %End
 
-    void prepareSource( const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    void prepareSource( const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Read the source from ``parameters`` and ``context`` and set it
 
@@ -1303,7 +1303,7 @@ Read the source from ``parameters`` and ``context`` and set it
 %End
 
      virtual QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
-        const QMap<QString, QVariant> &parameters,
+        const QVariantMap &parameters,
         QgsProcessingContext &context,
         const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const;
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgrunnertask.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgrunnertask.sip.in
@@ -24,7 +24,7 @@ class QgsProcessingAlgRunnerTask : QgsTask
   public:
 
     QgsProcessingAlgRunnerTask( const QgsProcessingAlgorithm *algorithm,
-                                const QMap<QString, QVariant> &parameters,
+                                const QVariantMap &parameters,
                                 QgsProcessingContext &context,
                                 QgsProcessingFeedback *feedback = 0,
                                 QgsTask::Flags flags = QgsTask::CanCancel );
@@ -47,7 +47,7 @@ Returns ``True`` if the algorithm was canceled.
 
   signals:
 
-    void executed( bool successful, const QMap<QString, QVariant> &results );
+    void executed( bool successful, const QVariantMap &results );
 %Docstring
 Emitted when the algorithm has finished execution. If the algorithm completed
 execution without errors then ``successful`` will be ``True``. The ``results`` argument

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -645,7 +645,7 @@ setting will be ignored.
 .. versionadded:: 3.32
 %End
 
-    QMap<QString, QVariant> exportToMap() const /HoldGIL/;
+    QVariantMap exportToMap() const /HoldGIL/;
 %Docstring
 Exports the context's settings to a variant map.
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -155,7 +155,7 @@ Pushes a summary of the QGIS (and underlying library) version information to the
 .. versionadded:: 3.4.7
 %End
 
-    void pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QMap<QString, QVariant> &results );
+    void pushFormattedResults( const QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, const QVariantMap &results );
 %Docstring
 Pushes a summary of the execution ``results`` to the log
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameteraggregate.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameteraggregate.sip.in
@@ -38,9 +38,9 @@ Constructor for QgsProcessingParameterAggregate.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QStringList dependsOnOtherParameters() const;
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameteralignrasterlayers.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameteralignrasterlayers.sip.in
@@ -66,13 +66,13 @@ Returns the type name for the parameter class.
 %Docstring
 Converts a QVariant value (a QVariantList) to a list of input layers
 %End
-    static QgsAlignRasterData::RasterItem variantMapAsItem( const QMap<QString, QVariant> &layerVariantMap, QgsProcessingContext &context );
+    static QgsAlignRasterData::RasterItem variantMapAsItem( const QVariantMap &layerVariantMap, QgsProcessingContext &context );
 %Docstring
-Converts a QVariant value (a QMap<QString, QVariant>) to a single input layer
+Converts a QVariant value (a QVariantMap) to a single input layer
 %End
-    static QMap<QString, QVariant> itemAsVariantMap( const QgsAlignRasterData::RasterItem &item );
+    static QVariantMap itemAsVariantMap( const QgsAlignRasterData::RasterItem &item );
 %Docstring
-Converts a single input layer to QVariant representation (a QMap<QString, QVariant>)
+Converts a single input layer to QVariant representation (a QVariantMap)
 %End
 };
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameterdxflayers.sip.in
@@ -64,13 +64,13 @@ Returns the type name for the parameter class.
 %Docstring
 Converts a QVariant value (a QVariantList) to a list of input layers
 %End
-    static QgsDxfExport::DxfLayer variantMapAsLayer( const QMap<QString, QVariant> &layerVariantMap, QgsProcessingContext &context );
+    static QgsDxfExport::DxfLayer variantMapAsLayer( const QVariantMap &layerVariantMap, QgsProcessingContext &context );
 %Docstring
-Converts a QVariant value (a QMap<QString, QVariant>) to a single input layer
+Converts a QVariant value (a QVariantMap) to a single input layer
 %End
-    static QMap<QString, QVariant> layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
+    static QVariantMap layerAsVariantMap( const QgsDxfExport::DxfLayer &layer );
 %Docstring
-Converts a single input layer to QVariant representation (a QMap<QString, QVariant>)
+Converts a single input layer to QVariant representation (a QVariantMap)
 %End
 };
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameterfieldmap.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameterfieldmap.sip.in
@@ -38,9 +38,9 @@ Constructor for QgsProcessingParameterFieldMapping.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QStringList dependsOnOtherParameters() const;
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparametermeshdataset.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparametermeshdataset.sip.in
@@ -55,9 +55,9 @@ Constructor
 
     virtual QStringList dependsOnOtherParameters() const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QString typeName();
@@ -132,9 +132,9 @@ Constructor
 
     virtual QStringList dependsOnOtherParameters() const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QString typeName();

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -77,7 +77,7 @@ the default geometry check method (as dictated by :py:class:`QgsProcessingContex
 
     QVariant toVariant() const;
 %Docstring
-Saves this source definition to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this source definition to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -85,9 +85,9 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 .. versionadded:: 3.14
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this source definition from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this source definition from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
@@ -139,7 +139,7 @@ to automatically load the resulting sink/layer after completing processing.
 
     QString destinationName;
 
-    QMap<QString, QVariant> createOptions;
+    QVariantMap createOptions;
 
     bool useRemapping() const;
 %Docstring
@@ -176,7 +176,7 @@ Calling this method will set :py:func:`~QgsProcessingOutputLayerDefinition.useRe
 
     QVariant toVariant() const;
 %Docstring
-Saves this output layer definition to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -184,9 +184,9 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 .. versionadded:: 3.2
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this output layer definition from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this output layer definition from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
@@ -590,24 +590,24 @@ i.e. the intended end use of the generated Python code.
 .. versionadded:: 3.6
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 %Docstring
-Saves this parameter to a QMap<QString, QVariant>. Subclasses should ensure that they call the base class
+Saves this parameter to a QVariantMap. Subclasses should ensure that they call the base class
 method and then extend the result with additional properties.
 
 .. seealso:: :py:func:`fromVariantMap`
 %End
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 %Docstring
-Restores this parameter to a QMap<QString, QVariant>. Subclasses should ensure that they call the base class
+Restores this parameter to a QVariantMap. Subclasses should ensure that they call the base class
 method.
 
 .. seealso:: :py:func:`toVariantMap`
 %End
 
 
-    QMap<QString, QVariant> &metadata();
+    QVariantMap &metadata();
 %Docstring
 Returns the parameter's freeform metadata. This is mostly used by parameter widget wrappers
 in order to customize their appearance and behavior.
@@ -615,7 +615,7 @@ in order to customize their appearance and behavior.
 .. seealso:: :py:func:`setMetadata`
 %End
 
-    void setMetadata( const QMap<QString, QVariant> &metadata );
+    void setMetadata( const QVariantMap &metadata );
 %Docstring
 Sets the parameter's freeform ``metadata``. This is mostly used by parameter widget wrappers
 in order to customize their appearance and behavior.
@@ -803,7 +803,7 @@ class QgsProcessingParameters
 
 A collection of utilities for working with parameters when running a processing algorithm.
 
-Parameters are stored in a QMap<QString, QVariant> and referenced by a unique string key.
+Parameters are stored in a QVariantMap and referenced by a unique string key.
 The QVariants in parameters are not usually accessed
 directly, and instead the high level API provided through :py:class:`QgsProcessingParameters`
 :py:func:`~QgsProcessingParameterDefinition.parameterAsString`, :py:func:`~QgsProcessingParameterDefinition.parameterAsDouble` are used instead.
@@ -820,13 +820,13 @@ the evaluation to understand available map layers and expression contexts
 %End
   public:
 
-    static bool isDynamic( const QMap<QString, QVariant> &parameters, const QString &name );
+    static bool isDynamic( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns ``True`` if the parameter with matching ``name`` is a dynamic parameter, and must
 be evaluated once for every input feature processed.
 %End
 
-    static QString parameterAsString( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsString( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static string value.
 %End
@@ -838,7 +838,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static s
 .. versionadded:: 3.4
 %End
 
-    static QString parameterAsExpression( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsExpression( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to an expression.
 %End
@@ -850,7 +850,7 @@ Evaluates the parameter with matching ``definitionand`` ``value`` to an expressi
 .. versionadded:: 3.4
 %End
 
-    static double parameterAsDouble( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static double parameterAsDouble( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static double value.
 %End
@@ -862,7 +862,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static d
 .. versionadded:: 3.4
 %End
 
-    static int parameterAsInt( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static int parameterAsInt( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static integer value.
 %End
@@ -874,7 +874,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static i
 .. versionadded:: 3.4
 %End
 
-    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of integer values.
 
@@ -888,7 +888,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a list of 
 .. versionadded:: 3.4
 %End
 
-    static QDateTime parameterAsDateTime( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QDateTime parameterAsDateTime( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static datetime value.
 
@@ -910,7 +910,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static d
 .. versionadded:: 3.14
 %End
 
-    static QDate parameterAsDate( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QDate parameterAsDate( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static date value.
 
@@ -932,7 +932,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static d
 .. versionadded:: 3.14
 %End
 
-    static QTime parameterAsTime( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QTime parameterAsTime( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static time value.
 
@@ -954,7 +954,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static t
 .. versionadded:: 3.14
 %End
 
-    static int parameterAsEnum( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static int parameterAsEnum( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a enum value.
 %End
@@ -966,7 +966,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a enum val
 .. versionadded:: 3.4
 %End
 
-    static QList<int> parameterAsEnums( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QList<int> parameterAsEnums( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to list of enum values.
 %End
@@ -978,7 +978,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to list of en
 .. versionadded:: 3.4
 %End
 
-    static QString parameterAsEnumString( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsEnumString( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static enum string.
 
@@ -992,7 +992,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static e
 .. versionadded:: 3.18
 %End
 
-    static QStringList parameterAsEnumStrings( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QStringList parameterAsEnumStrings( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to list of static enum strings.
 
@@ -1006,12 +1006,12 @@ Evaluates the parameter with matching ``definition`` and ``value`` to list of st
 .. versionadded:: 3.18
 %End
 
-    static bool parameterAsBool( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static bool parameterAsBool( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static boolean value.
 %End
 
-    static bool parameterAsBoolean( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static bool parameterAsBoolean( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a static boolean value.
 
@@ -1032,9 +1032,9 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static b
 .. versionadded:: 3.8
 %End
 
-    static QgsFeatureSink *parameterAsSink( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters,
+    static QgsFeatureSink *parameterAsSink( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
                                             const QgsFields &fields, Qgis::WkbType geometryType, const QgsCoordinateReferenceSystem &crs,
-                                            QgsProcessingContext &context, QString &destinationIdentifier /Out/, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QMap<QString, QVariant> &createOptions = QMap<QString, QVariant>(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) /Factory/;
+                                            QgsProcessingContext &context, QString &destinationIdentifier /Out/, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QVariantMap &createOptions = QVariantMap(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) /Factory/;
 %Docstring
 Evaluates the parameter with matching ``definition`` to a feature sink.
 
@@ -1055,7 +1055,7 @@ This function creates a new object and the caller takes responsibility for delet
 
     static QgsFeatureSink *parameterAsSink( const QgsProcessingParameterDefinition *definition, const QVariant &value,
                                             const QgsFields &fields, Qgis::WkbType geometryType, const QgsCoordinateReferenceSystem &crs,
-                                            QgsProcessingContext &context, QString &destinationIdentifier /Out/, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QMap<QString, QVariant> &createOptions = QMap<QString, QVariant>(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) throw( QgsProcessingException ) /Factory/;
+                                            QgsProcessingContext &context, QString &destinationIdentifier /Out/, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags(), const QVariantMap &createOptions = QVariantMap(), const QStringList &datasourceOptions = QStringList(), const QStringList &layerOptions = QStringList() ) throw( QgsProcessingException ) /Factory/;
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to a feature sink.
 
@@ -1078,7 +1078,7 @@ This function creates a new object and the caller takes responsibility for delet
 .. versionadded:: 3.4
 %End
 
-    static QgsProcessingFeatureSource *parameterAsSource( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) /Factory/;
+    static QgsProcessingFeatureSource *parameterAsSource( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Factory/;
 %Docstring
 Evaluates the parameter with matching ``definition`` to a feature source.
 
@@ -1100,7 +1100,7 @@ This function creates a new object and the caller takes responsibility for delet
 .. versionadded:: 3.4
 %End
 
-    static QString parameterAsCompatibleSourceLayerPath( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters,
+    static QString parameterAsCompatibleSourceLayerPath( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0 );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a source vector layer file path of compatible format.
@@ -1118,7 +1118,7 @@ When an algorithm is capable of handling multi-layer input files (such as Geopac
 to use :py:func:`~QgsProcessingParameters.parameterAsCompatibleSourceLayerPathAndLayerName` which may avoid conversion in more situations.
 %End
 
-    static QString parameterAsCompatibleSourceLayerPathAndLayerName( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters,
+    static QString parameterAsCompatibleSourceLayerPathAndLayerName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0, QString *layerName /Out/ = 0 );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a source vector layer file path and layer name of compatible format.
@@ -1152,7 +1152,7 @@ a conversion in this case and will return the target layer name in the ``layerNa
 .. versionadded:: 3.10
 %End
 
-    static QgsMapLayer *parameterAsLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessingUtils::LayerHint layerHint = QgsProcessingUtils::LayerHint::UnknownType, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
+    static QgsMapLayer *parameterAsLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingUtils::LayerHint layerHint = QgsProcessingUtils::LayerHint::UnknownType, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a map layer.
 
@@ -1172,7 +1172,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.4
 %End
 
-    static QgsRasterLayer *parameterAsRasterLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsRasterLayer *parameterAsRasterLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a raster layer.
 
@@ -1192,7 +1192,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.4
 %End
 
-    static QString parameterAsOutputLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QString parameterAsOutputLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a output layer destination.
 %End
@@ -1204,7 +1204,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a output l
 .. versionadded:: 3.4
 %End
 
-    static QString parameterAsFileOutput( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QString parameterAsFileOutput( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a file based output destination.
 %End
@@ -1216,7 +1216,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a file bas
 .. versionadded:: 3.4
 %End
 
-    static QgsVectorLayer *parameterAsVectorLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsVectorLayer *parameterAsVectorLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a vector layer.
 
@@ -1236,7 +1236,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.4
 %End
 
-    static QgsMeshLayer *parameterAsMeshLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsMeshLayer *parameterAsMeshLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to a mesh layer.
 
@@ -1258,7 +1258,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.6
 %End
 
-    static QgsCoordinateReferenceSystem parameterAsCrs( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsCoordinateReferenceSystem parameterAsCrs( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a coordinate reference system.
 %End
@@ -1270,7 +1270,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a coordina
 .. versionadded:: 3.4
 %End
 
-    static QgsRectangle parameterAsExtent( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context,
+    static QgsRectangle parameterAsExtent( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context,
                                            const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a rectangular extent.
@@ -1298,7 +1298,7 @@ reprojected so that it is in the specified ``crs``. In this case the extent of t
 .. versionadded:: 3.4
 %End
 
-    static QgsGeometry parameterAsExtentGeometry( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context,
+    static QgsGeometry parameterAsExtentGeometry( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context,
         const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a rectangular extent, and returns a geometry covering this extent.
@@ -1313,7 +1313,7 @@ just the extent of the reprojected rectangle).
 .. seealso:: :py:func:`parameterAsExtentCrs`
 %End
 
-    static QgsCoordinateReferenceSystem parameterAsExtentCrs( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsCoordinateReferenceSystem parameterAsExtentCrs( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Returns the coordinate reference system associated with an extent parameter value.
 
@@ -1328,7 +1328,7 @@ Returns the coordinate reference system associated with an extent parameter valu
 %End
 
 
-    static QgsPointXY parameterAsPoint( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context,
+    static QgsPointXY parameterAsPoint( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context,
                                         const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a point.
@@ -1350,7 +1350,7 @@ If ``crs`` is set then the point will be automatically reprojected so that it is
 .. versionadded:: 3.4
 %End
 
-    static QgsCoordinateReferenceSystem parameterAsPointCrs( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsCoordinateReferenceSystem parameterAsPointCrs( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Returns the coordinate reference system associated with an point parameter value.
 
@@ -1366,7 +1366,7 @@ Returns the coordinate reference system associated with an point parameter value
 .. versionadded:: 3.8
 %End
 
-    static QgsGeometry parameterAsGeometry( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+    static QgsGeometry parameterAsGeometry( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a geometry.
 
@@ -1380,7 +1380,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a geometry
 .. versionadded:: 3.16
 %End
 
-    static QgsCoordinateReferenceSystem parameterAsGeometryCrs( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsCoordinateReferenceSystem parameterAsGeometryCrs( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Returns the coordinate reference system associated with a geometry parameter value.
 
@@ -1398,7 +1398,7 @@ Returns the coordinate reference system associated with an point parameter value
 .. versionadded:: 3.16
 %End
 
-    static QString parameterAsFile( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QString parameterAsFile( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a file/folder name.
 %End
@@ -1410,7 +1410,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a file/fol
 .. versionadded:: 3.4
 %End
 
-    static QVariantList parameterAsMatrix( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QVariantList parameterAsMatrix( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a matrix/table of values.
 Tables are collapsed to a 1 dimensional list.
@@ -1424,7 +1424,7 @@ Tables are collapsed to a 1 dimensional list.
 .. versionadded:: 3.4
 %End
 
-    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
+    static QList< QgsMapLayer *> parameterAsLayerList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of map layers.
 The ``flags`` are used to set options for loading layers (e.g. skip index generation).
@@ -1445,14 +1445,14 @@ Evaluates the parameter with matching ``definition`` to a list of files (for :py
 .. versionadded:: 3.10
 %End
 
-    static QStringList parameterAsFileList( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QStringList parameterAsFileList( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of files (for :py:class:`QgsProcessingParameterMultipleLayers` in :py:class:`QgsProcessing`:TypeFile mode).
 
 .. versionadded:: 3.10
 %End
 
-    static QList<double> parameterAsRange( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QList<double> parameterAsRange( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a range of values.
 %End
@@ -1464,7 +1464,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a range of
 .. versionadded:: 3.4
 %End
 
- static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context ) /Deprecated/;
+ static QStringList parameterAsFields( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context ) /Deprecated/;
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of fields.
 
@@ -1482,7 +1482,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a list of 
    use :py:func:`~QgsProcessingParameters.parameterAsStrings` instead.
 %End
 
-    static QStringList parameterAsStrings( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QStringList parameterAsStrings( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a list of strings (e.g. field names or point cloud attributes).
 
@@ -1496,7 +1496,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a list of 
 .. versionadded:: 3.32
 %End
 
-    static QgsPrintLayout *parameterAsLayout( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsPrintLayout *parameterAsLayout( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a print layout.
 
@@ -1520,7 +1520,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a print la
 .. versionadded:: 3.8
 %End
 
-    static QgsLayoutItem *parameterAsLayoutItem( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsPrintLayout *layout );
+    static QgsLayoutItem *parameterAsLayoutItem( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsPrintLayout *layout );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a print layout item, taken from the specified ``layout``.
 
@@ -1544,7 +1544,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a print la
 .. versionadded:: 3.8
 %End
 
-    static QColor parameterAsColor( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QColor parameterAsColor( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Returns the color associated with an point parameter value, or an invalid color if the parameter was not set.
 
@@ -1558,7 +1558,7 @@ Returns the color associated with an color parameter value, or an invalid color 
 .. versionadded:: 3.10
 %End
 
-    static QString parameterAsConnectionName( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsConnectionName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a connection name string.
 
@@ -1572,7 +1572,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a connecti
 .. versionadded:: 3.14
 %End
 
-    static QString parameterAsSchema( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsSchema( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a database schema name.
 
@@ -1586,7 +1586,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a database
 .. versionadded:: 3.14
 %End
 
-    static QString parameterAsDatabaseTableName( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, const QgsProcessingContext &context );
+    static QString parameterAsDatabaseTableName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a database table name.
 
@@ -1600,7 +1600,7 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a database
 .. versionadded:: 3.14
 %End
 
-    static QgsPointCloudLayer *parameterAsPointCloudLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
+    static QgsPointCloudLayer *parameterAsPointCloudLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessing::LayerOptionsFlags flags = QgsProcessing::LayerOptionsFlags() );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a point cloud layer.
 The ``flags`` are used to set options for loading layer (e.g. skip index generation).
@@ -1624,7 +1624,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
-    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QMap<QString, QVariant> &parameters, QgsProcessingContext &context );
+    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to an annotation layer.
 
@@ -1658,7 +1658,7 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
-    static QgsProcessingParameterDefinition *parameterFromVariantMap( const QMap<QString, QVariant> &map ) /Factory/;
+    static QgsProcessingParameterDefinition *parameterFromVariantMap( const QVariantMap &map ) /Factory/;
 %Docstring
 Creates a new :py:class:`QgsProcessingParameterDefinition` using the configuration from a
 supplied variant ``map``.
@@ -1878,9 +1878,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     QList<int>  geometryTypes() const;
@@ -2021,9 +2021,9 @@ Calling this method resets any existing :py:func:`~QgsProcessingParameterFile.ex
 .. versionadded:: 3.10
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterFile *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition, Qgis::ProcessingFileParameterBehavior behavior = Qgis::ProcessingFileParameterBehavior::File ) /Factory/;
@@ -2120,9 +2120,9 @@ Sets whether the table has a fixed number of rows.
 .. seealso:: :py:func:`hasFixedNumberRows`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterMatrix *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2204,9 +2204,9 @@ if the parameter is not optional.
 .. seealso:: :py:func:`minimumNumberInputs`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterMultipleLayers *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2309,9 +2309,9 @@ Sets the acceptable data ``type`` for the parameter.
 .. seealso:: :py:func:`dataType`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterNumber *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2403,9 +2403,9 @@ Sets the default distance ``unit`` for the parameter.
 .. versionadded:: 3.4.3
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
 };
@@ -2460,9 +2460,9 @@ Sets the default duration ``unit`` for the parameter.
 .. seealso:: :py:func:`defaultUnit`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
 };
@@ -2559,9 +2559,9 @@ Sets the acceptable data ``type`` for the range.
 .. seealso:: :py:func:`dataType`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterRange *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2714,9 +2714,9 @@ values for its enumeration choice list.
 .. versionadded:: 3.18
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterEnum *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2794,9 +2794,9 @@ Sets whether the parameter allows multiline strings.
 .. seealso:: :py:func:`multiLine`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterString *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -2916,9 +2916,9 @@ Sets the parameter's expression ``type``.
 .. versionadded:: 3.32
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterExpression *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3008,9 +3008,9 @@ Returns the type name for the parameter class.
     virtual QString createFileFilter() const;
 
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterVectorLayer *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3107,9 +3107,9 @@ Returns the type name for the parameter class.
     virtual QString createFileFilter() const;
 
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterMapLayer *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3226,9 +3226,9 @@ If ``True``, this will override any existing :py:func:`~QgsProcessingParameterFi
 .. versionadded:: 3.12
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterField *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3281,9 +3281,9 @@ Returns the type name for the parameter class.
     virtual QString createFileFilter() const;
 
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterFeatureSource *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3317,9 +3317,9 @@ output will not be created by default.
 %End
 
     virtual bool isDestination() const;
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
@@ -3509,9 +3509,9 @@ Sets whether the sink supports appending features to an existing table.
 .. versionadded:: 3.14
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QString generateTemporaryDestination( const QgsProcessingContext *context = 0 ) const;
 
@@ -3603,9 +3603,9 @@ Sets the layer ``type`` for the created vector layer.
 .. seealso:: :py:func:`dataType`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterVectorDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3747,9 +3747,9 @@ Sets the file ``filter`` string for file destinations compatible with this param
 .. seealso:: :py:func:`fileFilter`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterFileDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3856,9 +3856,9 @@ Sets the name of the parent layer parameter. Use an empty string if this is not 
 .. seealso:: :py:func:`parentLayerParameterName`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterBand *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -3968,9 +3968,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QStringList dependsOnOtherParameters() const;
 
@@ -4053,9 +4053,9 @@ Returns the type name for the parameter class.
 
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     bool opacityEnabled() const;
@@ -4124,9 +4124,9 @@ Returns the type name for the parameter class.
     virtual QStringList dependsOnOtherParameters() const;
 
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterCoordinateOperation *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -4245,9 +4245,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterMapTheme *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -4359,9 +4359,9 @@ Sets the acceptable data ``type`` for the parameter.
 .. seealso:: :py:func:`dataType`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterDateTime *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
@@ -4414,9 +4414,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     QString providerId() const;
@@ -4485,9 +4485,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QStringList dependsOnOtherParameters() const;
 
@@ -4563,9 +4563,9 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonOutputType::PythonQgsProcessingAlgorithmSubclass ) const;
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
     virtual QStringList dependsOnOtherParameters() const;
 
@@ -4851,9 +4851,9 @@ If ``True``, this will override any existing :py:func:`~QgsProcessingParameterPo
 .. seealso:: :py:func:`defaultToAllAttributes`
 %End
 
-    virtual QMap<QString, QVariant> toVariantMap() const;
+    virtual QVariantMap toVariantMap() const;
 
-    virtual bool fromVariantMap( const QMap<QString, QVariant> &map );
+    virtual bool fromVariantMap( const QVariantMap &map );
 
 
     static QgsProcessingParameterPointCloudAttribute *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparametertype.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparametertype.sip.in
@@ -75,7 +75,7 @@ Determines if this parameter is available in the modeler.
 The default implementation returns ``True``.
 %End
 
-    virtual QMap<QString, QVariant> metadata() const;
+    virtual QVariantMap metadata() const;
 %Docstring
 Metadata for this parameter type. Can be used for example to define custom widgets.
 The default implementation returns an empty map.

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparametervectortilewriterlayers.sip.in
@@ -60,13 +60,13 @@ Returns the type name for the parameter class.
 %Docstring
 Converts a QVariant value (a QVariantList) to a list of input layers
 %End
-    static QgsVectorTileWriter::Layer variantMapAsLayer( const QMap<QString, QVariant> &layerVariantMap, QgsProcessingContext &context );
+    static QgsVectorTileWriter::Layer variantMapAsLayer( const QVariantMap &layerVariantMap, QgsProcessingContext &context );
 %Docstring
-Converts a QVariant value (a QMap<QString, QVariant>) to a single input layer
+Converts a QVariant value (a QVariantMap) to a single input layer
 %End
-    static QMap<QString, QVariant> layerAsVariantMap( const QgsVectorTileWriter::Layer &layer );
+    static QVariantMap layerAsVariantMap( const QgsVectorTileWriter::Layer &layer );
 %Docstring
-Converts a single input layer to QVariant representation (a QMap<QString, QVariant>)
+Converts a single input layer to QVariant representation (a QVariantMap)
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingregistry.sip.in
@@ -120,7 +120,7 @@ is returned.
 %End
 
 
-    QgsProcessingAlgorithm *createAlgorithmById( const QString &id, const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) const /TransferBack/;
+    QgsProcessingAlgorithm *createAlgorithmById( const QString &id, const QVariantMap &configuration = QVariantMap() ) const /TransferBack/;
 %Docstring
 Creates a new instance of an algorithm by its ID. If no matching algorithm is found, ``None``
 is returned. Callers take responsibility for deleting the returned object.

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -363,7 +363,7 @@ Converts a string to a Python string literal. E.g. by replacing ' with \'.
 %End
 
 
-    static void createFeatureSinkPython( QgsFeatureSink **sink /Out,TransferBack/, QString &destination /In,Out/, QgsProcessingContext &context, const QgsFields &fields, Qgis::WkbType geometryType, const QgsCoordinateReferenceSystem &crs, const QMap<QString, QVariant> &createOptions = QMap<QString, QVariant>() ) throw( QgsProcessingException ) /PyName=createFeatureSink/;
+    static void createFeatureSinkPython( QgsFeatureSink **sink /Out,TransferBack/, QString &destination /In,Out/, QgsProcessingContext &context, const QgsFields &fields, Qgis::WkbType geometryType, const QgsCoordinateReferenceSystem &crs, const QVariantMap &createOptions = QVariantMap() ) throw( QgsProcessingException ) /PyName=createFeatureSink/;
 %Docstring
 Creates a feature sink ready for adding features. The ``destination`` specifies a destination
 URI for the resultant layer. It may be updated in place to reflect the actual destination
@@ -432,7 +432,7 @@ but not changing the ``basename``.
 .. seealso:: :py:func:`tempFolder`
 %End
 
-    static QString formatHelpMapAsHtml( const QMap<QString, QVariant> &map, const QgsProcessingAlgorithm *algorithm );
+    static QString formatHelpMapAsHtml( const QVariantMap &map, const QgsProcessingAlgorithm *algorithm );
 %Docstring
 Returns a HTML formatted version of the help text encoded in a variant ``map`` for
 a specified ``algorithm``.
@@ -612,7 +612,7 @@ This method returns a fallback value of "mbtiles".
 .. versionadded:: 3.32
 %End
 
-    static QMap<QString, QVariant> removePointerValuesFromMap( const QMap<QString, QVariant> &map );
+    static QVariantMap removePointerValuesFromMap( const QVariantMap &map );
 %Docstring
 Removes any raw pointer values from an input ``map``, replacing them with
 appropriate string values where possible.
@@ -620,7 +620,7 @@ appropriate string values where possible.
 .. versionadded:: 3.26
 %End
 
-    static QMap<QString, QVariant> preprocessQgisProcessParameters( const QMap<QString, QVariant> &parameters, bool &ok, QString &error );
+    static QVariantMap preprocessQgisProcessParameters( const QVariantMap &parameters, bool &ok, QString &error );
 %Docstring
 Pre-processes a set of ``parameter`` values for the qgis_process command.
 

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -1029,14 +1029,14 @@ Returns the current avoid intersections mode.
 .. versionadded:: 3.14
 %End
 
-    QMap<QString, QVariant> customVariables() const;
+    QVariantMap customVariables() const;
 %Docstring
 A map of custom project variables.
 To get all available variables including generated ones
 use :py:func:`QgsExpressionContextUtils.projectScope()` instead.
 %End
 
-    void setCustomVariables( const QMap<QString, QVariant> &customVariables );
+    void setCustomVariables( const QVariantMap &customVariables );
 %Docstring
 A map of custom project variables.
 Be careful not to set generated variables.

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -25,7 +25,7 @@ Utility functions for working with ArcGIS REST services.
 %End
   public:
 
-    static QMap<QString, QVariant> retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
 %Docstring
 Retrieves JSON user info for the specified user name.
 
@@ -44,7 +44,7 @@ If ``user`` is blank then the user associated with the current logon details wil
 .. versionadded:: 3.24
 %End
 
- static QMap<QString, QVariant> retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0 ) /Deprecated/;
+ static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback = 0 ) /Deprecated/;
 %Docstring
 Retrieves JSON user info for the specified user name. Only to avoid API break.
 

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -84,7 +84,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static QgsAbstractGeometry *convertGeometry( const QMap<QString, QVariant> &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 ) /Factory/;
+    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 ) /Factory/;
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a :py:class:`QgsAbstractGeometry`.
 
@@ -99,19 +99,19 @@ Caller takes ownership of the returned object.
          - crs: will be set to the parsed geometry CRS
 %End
 
-    static QgsCoordinateReferenceSystem convertSpatialReference( const QMap<QString, QVariant> &spatialReferenceMap );
+    static QgsCoordinateReferenceSystem convertSpatialReference( const QVariantMap &spatialReferenceMap );
 %Docstring
 Converts a spatial reference JSON definition to a :py:class:`QgsCoordinateReferenceSystem` value.
 %End
 
-    static QgsSymbol *convertSymbol( const QMap<QString, QVariant> &definition ) /Factory/;
+    static QgsSymbol *convertSymbol( const QVariantMap &definition ) /Factory/;
 %Docstring
 Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
 
 Caller takes ownership of the returned symbol.
 %End
 
-    static QgsFeatureRenderer *convertRenderer( const QMap<QString, QVariant> &rendererData ) /Factory/;
+    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) /Factory/;
 %Docstring
 Converts renderer JSON ``data`` to an equivalent :py:class:`QgsFeatureRenderer`.
 
@@ -150,7 +150,7 @@ Converts an ESRI fill ``style`` to a Qt brush style.
 Converts a date time ``value`` to a QDateTime.
 %End
 
-    static QMap<QString, QVariant> geometryToJson( const QgsGeometry &geometry, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+    static QVariantMap geometryToJson( const QgsGeometry &geometry, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 %Docstring
 Converts a ``geometry`` to an ArcGIS REST JSON representation.
 
@@ -159,7 +159,7 @@ Returns an empty map if the geometry cannot be converted.
 .. versionadded:: 3.28
 %End
 
-    static QMap<QString, QVariant> crsToJson( const QgsCoordinateReferenceSystem &crs );
+    static QVariantMap crsToJson( const QgsCoordinateReferenceSystem &crs );
 %Docstring
 Converts a ``crs`` to an ArcGIS REST JSON representation.
 
@@ -186,7 +186,7 @@ Returns a null rectangle if the value cannot be converted.
     typedef QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> FeatureToJsonFlags;
 
 
-    static QMap<QString, QVariant> featureToJson( const QgsFeature &feature,
+    static QVariantMap featureToJson( const QgsFeature &feature,
                                       const QgsArcGisRestContext &context,
                                       const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
                                       QgsArcGisRestUtils::FeatureToJsonFlags flags = QgsArcGisRestUtils::FeatureToJsonFlags( static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry ) | static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes ) ) );
@@ -203,7 +203,7 @@ Converts a variant to a REST attribute value.
 .. versionadded:: 3.28
 %End
 
-    static QMap<QString, QVariant> fieldDefinitionToJson( const QgsField &field );
+    static QVariantMap fieldDefinitionToJson( const QgsField &field );
 %Docstring
 Converts a ``field``'s definition to an ArcGIS REST JSON representation.
 

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -277,7 +277,7 @@ Returns the table comment.
 Sets the table ``comment``.
 %End
 
-        QMap<QString, QVariant> info() const;
+        QVariantMap info() const;
 %Docstring
 Returns additional information about the table.
 
@@ -285,7 +285,7 @@ Provider classes may use this property
 to store custom bits of information.
 %End
 
-        void setInfo( const QMap<QString, QVariant> &info );
+        void setInfo( const QVariantMap &info );
 %Docstring
 Sets additional information about the table to ``info``.
 
@@ -385,7 +385,7 @@ Creates a new connection with ``name`` by reading its configuration from the set
 If a connection with this name cannot be found, an empty connection will be returned.
 %End
 
-    QgsAbstractDatabaseProviderConnection( const QString &uri, const QMap<QString, QVariant> &configuration );
+    QgsAbstractDatabaseProviderConnection( const QString &uri, const QVariantMap &configuration );
 %Docstring
 Creates a new connection from the given ``uri`` and ``configuration``.
 

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractproviderconnection.sip.in
@@ -52,7 +52,7 @@ Creates a new connection with ``name`` by reading its configuration from the set
 If a connection with this name cannot be found, an empty connection will be returned.
 %End
 
-    QgsAbstractProviderConnection( const QString &uri, const QMap<QString, QVariant> &configuration );
+    QgsAbstractProviderConnection( const QString &uri, const QVariantMap &configuration );
 %Docstring
 Creates a new connection from the given ``uri`` and ``configuration``.
 The connection is not automatically stored in the settings.
@@ -89,12 +89,12 @@ Returns the connection data source URI string representation
 Sets the connection data source URI to ``uri``
 %End
 
-    QMap<QString, QVariant> configuration() const;
+    QVariantMap configuration() const;
 %Docstring
 Returns the connection configuration parameters
 %End
 
-    void setConfiguration( const QMap<QString, QVariant> &configuration );
+    void setConfiguration( const QVariantMap &configuration );
 %Docstring
 Sets the connection ``configuration``
 %End

--- a/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -411,7 +411,7 @@ Class factory to return a pointer to a newly created :py:class:`QgsDataProvider`
 .. versionadded:: 3.10
 %End
 
-    static void setBoolParameter( QMap<QString, QVariant> &uri, const QString &parameter, const QVariant &value );
+    static void setBoolParameter( QVariantMap &uri, const QString &parameter, const QVariant &value );
 %Docstring
 Sets the ``value`` into the ``uri`` ``parameter`` as a bool.
 eg. "yes" value will be saved as ``True``, 0 will be saved as ``False``
@@ -419,7 +419,7 @@ eg. "yes" value will be saved as ``True``, 0 will be saved as ``False``
 .. versionadded:: 3.14
 %End
 
-    static bool boolParameter( const QMap<QString, QVariant> &uri, const QString &parameter, bool defaultValue = false );
+    static bool boolParameter( const QVariantMap &uri, const QString &parameter, bool defaultValue = false );
 %Docstring
 Returns the ``parameter`` value in the ``uri`` as a bool.
 eg. "yes" value will be returned as ``True``, 0 will be returned as ``False``
@@ -494,7 +494,7 @@ Returns pyramid resampling methods available for provider
 .. versionadded:: 3.10
 %End
 
-    virtual QMap<QString, QVariant> decodeUri( const QString &uri ) const;
+    virtual QVariantMap decodeUri( const QString &uri ) const;
 %Docstring
 Breaks a provider data source URI into its component paths (e.g. file path, layer name).
 
@@ -518,7 +518,7 @@ Breaks a provider data source URI into its component paths (e.g. file path, laye
 .. versionadded:: 3.10
 %End
 
-    virtual QString encodeUri( const QMap<QString, QVariant> &parts ) const;
+    virtual QString encodeUri( const QVariantMap &parts ) const;
 %Docstring
 Reassembles a provider data source URI from its component paths (e.g. file path, layer name).
 
@@ -739,7 +739,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 %End
 
 
-    virtual QgsAbstractProviderConnection *createConnection( const QString &uri, const QMap<QString, QVariant> &configuration ) throw( QgsProviderConnectionException ) /Factory/;
+    virtual QgsAbstractProviderConnection *createConnection( const QString &uri, const QVariantMap &configuration ) throw( QgsProviderConnectionException ) /Factory/;
 %Docstring
 Creates a new connection from ``uri`` and ``configuration``,
 the newly created connection is not automatically stored in the settings, call

--- a/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -134,7 +134,7 @@ Returns list of raster pyramid resampling methods
 .. versionadded:: 3.10
 %End
 
-    QMap<QString, QVariant> decodeUri( const QString &providerKey, const QString &uri );
+    QVariantMap decodeUri( const QString &providerKey, const QString &uri );
 %Docstring
 Breaks a provider data source URI into its component paths (e.g. file path, layer name).
 
@@ -150,7 +150,7 @@ Breaks a provider data source URI into its component paths (e.g. file path, laye
 .. versionadded:: 3.4
 %End
 
-    QString encodeUri( const QString &providerKey, const QMap<QString, QVariant> &parts );
+    QString encodeUri( const QString &providerKey, const QVariantMap &parts );
 %Docstring
 Reassembles a provider data source URI from its component paths (e.g. file path, layer name).
 

--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -1048,7 +1048,7 @@ in a widget or sending it to a web browser.
 \copydoc :py:func:`~QgsApplication.nullRepresentation`
 %End
 
-    static QMap<QString, QVariant> customVariables();
+    static QVariantMap customVariables();
 %Docstring
 Custom expression variables for this application.
 This does not include generated variables (like system name, user name etc.)
@@ -1058,7 +1058,7 @@ This does not include generated variables (like system name, user name etc.)
 .. versionadded:: 3.0
 %End
 
-    static void setCustomVariables( const QMap<QString, QVariant> &customVariables );
+    static void setCustomVariables( const QVariantMap &customVariables );
 %Docstring
 Custom expression variables for this application.
 Do not include generated variables (like system name, user name etc.)

--- a/python/PyQt6/core/auto_generated/qgscolorramp.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorramp.sip.in
@@ -74,7 +74,7 @@ Inverts the ordering of the color ramp.
 Creates a clone of the color ramp.
 %End
 
-    virtual QMap<QString, QVariant> properties() const = 0;
+    virtual QVariantMap properties() const = 0;
 %Docstring
 Returns a string map containing all the color ramp's properties.
 %End

--- a/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
@@ -122,7 +122,7 @@ Constructor for QgsGradientColorRamp
 :param stops: optional list of additional color stops
 %End
 
-    static QgsColorRamp *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new :py:class:`QgsColorRamp` from a map of properties
 %End
@@ -146,7 +146,7 @@ Returns the string identifier for QgsGradientColorRamp.
 
     virtual QgsGradientColorRamp *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     QColor color1() const;
@@ -352,7 +352,7 @@ Constructor for QgsLimitedRandomColorRamp
 :param valMax: maximum color value
 %End
 
-    static QgsColorRamp *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Returns a new QgsLimitedRandomColorRamp color ramp created using the properties encoded in a string
 map.
@@ -378,7 +378,7 @@ Returns the string identifier for QgsLimitedRandomColorRamp.
 
     virtual QgsLimitedRandomColorRamp *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual int count() const;
 
@@ -542,7 +542,7 @@ Returns the string identifier for QgsRandomColorRamp.
     virtual QgsRandomColorRamp *clone() const /Factory/;
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
   protected:
@@ -578,7 +578,7 @@ Constructor for :py:class:`QgsPresetColorRamp`.
 :param colors: list of named colors in ramp
 %End
 
-    static QgsColorRamp *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Returns a new QgsPresetSchemeColorRamp color ramp created using the properties encoded in a string
 map.
@@ -622,7 +622,7 @@ Returns the string identifier for QgsPresetSchemeColorRamp.
 
     virtual QgsPresetSchemeColorRamp *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual int count() const;
 
@@ -660,7 +660,7 @@ Constructor for QgsColorBrewerColorRamp
 :param inverted: invert ramp ordering
 %End
 
-    static QgsColorRamp *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Returns a new QgsColorBrewerColorRamp color ramp created using the properties encoded in a string
 map.
@@ -687,7 +687,7 @@ Returns the string identifier for QgsColorBrewerColorRamp.
 
     virtual QgsColorBrewerColorRamp *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual int count() const;
 
@@ -788,7 +788,7 @@ Constructor for QgsCptCityColorRamp
 :param doLoadFile: load cpt-city ramp from file
 %End
 
-    static QgsColorRamp *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates the symbol layer
 %End
@@ -811,7 +811,7 @@ Returns the string identifier for QgsCptCityColorRamp.
     void copy( const QgsCptCityColorRamp *other );
     QgsGradientColorRamp *cloneGradientRamp() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     QString schemeName() const;

--- a/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
+++ b/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
@@ -21,7 +21,7 @@ Holder for the widget type and its configuration for a field.
 %End
   public:
 
-    QgsEditorWidgetSetup( const QString &type, const QMap<QString, QVariant> &config );
+    QgsEditorWidgetSetup( const QString &type, const QVariantMap &config );
 %Docstring
 Constructor
 %End
@@ -37,7 +37,7 @@ Constructor for QgsEditorWidgetSetup
 :return: the widget type to use
 %End
 
-    QMap<QString, QVariant> config() const;
+    QVariantMap config() const;
 %Docstring
 
 :return: the widget configuration to used

--- a/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsexpressioncontext.sip.in
@@ -557,7 +557,7 @@ variable set.
 .. seealso:: :py:func:`variableNames`
 %End
 
-    QMap<QString, QVariant> variablesToMap() const;
+    QVariantMap variablesToMap() const;
 %Docstring
 Returns a map of variable name to value representing all the expression variables
 contained by the context.

--- a/python/PyQt6/core/auto_generated/qgsfeature.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeature.sip.in
@@ -243,7 +243,7 @@ Returns the feature's attributes as a map of field name to value.
     }
     else
     {
-      QMap<QString, QVariant> *v = new QMap<QString, QVariant>( sipCpp->attributeMap() );
+      QVariantMap *v = new QVariantMap( sipCpp->attributeMap() );
       const sipTypeDef *qvariantmap_type = sipFindType( "QMap<QString,QVariant>" );
       sipRes = sipConvertFromNewType( v, qvariantmap_type, Py_None );
     }

--- a/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
@@ -86,7 +86,7 @@ This id will later be used to identify this field formatter in the registry with
 This id matches the id of a :py:class:`QgsEditorWidgetFactory`.
 %End
 
-    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 %Docstring
 Create a pretty String representation of the value.
 
@@ -95,7 +95,7 @@ Create a pretty String representation of the value.
 .. versionadded:: 3.0
 %End
 
-    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config, const QVariant &cache, const QVariant &value ) const;
+    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 %Docstring
 If the default sort order should be overwritten for this widget, you can transform the value in here.
 
@@ -104,7 +104,7 @@ If the default sort order should be overwritten for this widget, you can transfo
 .. versionadded:: 3.0
 %End
 
-    virtual Qt::AlignmentFlag alignmentFlag( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config ) const;
+    virtual Qt::AlignmentFlag alignmentFlag( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
 %Docstring
 Returns the alignment for a particular field. By default this will consider the field type but can be overwritten if mapped
 values are represented.
@@ -112,7 +112,7 @@ values are represented.
 .. versionadded:: 3.0
 %End
 
-    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QMap<QString, QVariant> &config ) const;
+    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
 %Docstring
 Create a cache for a given field.
 
@@ -121,14 +121,14 @@ to other methods on :py:class:`QgsFieldKit` and :py:class:`QgsEditorWidgetWrappe
 
 For example, the attribute table will create a cache once for each field and then use this
 cache for representation. The :py:class:`QgsValueRelationFieldFormatter` and :py:class:`QgsValueRelationEditorWidget`
-implement this functionality to create a lookuptable once (a QMap<QString, QVariant> / dict) and are
+implement this functionality to create a lookuptable once (a QVariantMap / dict) and are
 make use of a cache if present.
 
 .. versionadded:: 3.0
 %End
 
 
-    virtual QVariantList availableValues( const QMap<QString, QVariant> &config, int countLimit, const QgsFieldFormatterContext &context ) const;
+    virtual QVariantList availableValues( const QVariantMap &config, int countLimit, const QgsFieldFormatterContext &context ) const;
 %Docstring
 Returns a list of the values that would be possible to select with this widget type
 On a RelationReference that would be the parents ids or on ValueMap all the configured keys

--- a/python/PyQt6/core/auto_generated/qgsgeometryoptions.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsgeometryoptions.sip.in
@@ -91,14 +91,14 @@ A list of activated geometry checks.
 .. versionadded:: 3.4
 %End
 
-    QMap<QString, QVariant> checkConfiguration( const QString &checkId ) const;
+    QVariantMap checkConfiguration( const QString &checkId ) const;
 %Docstring
 Access the configuration for the check ``checkId``.
 
 .. versionadded:: 3.4
 %End
 
-    void setCheckConfiguration( const QString &checkId, const QMap<QString, QVariant> &checkConfiguration );
+    void setCheckConfiguration( const QString &checkId, const QVariantMap &checkConfiguration );
 %Docstring
 Set the configuration for the check ``checkId``.
 

--- a/python/PyQt6/core/auto_generated/qgshstoreutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgshstoreutils.sip.in
@@ -15,18 +15,18 @@
 namespace QgsHstoreUtils
 {
 
-  QMap<QString, QVariant> parse( const QString &string );
+  QVariantMap parse( const QString &string );
 %Docstring
-Returns a QMap<QString, QVariant> object containing the key and values from a hstore-formatted string.
+Returns a QVariantMap object containing the key and values from a hstore-formatted string.
 
 :param string: The hstored-formatted string
 
 .. versionadded:: 3.4
 %End
 
-  QString build( const QMap<QString, QVariant> &map );
+  QString build( const QVariantMap &map );
 %Docstring
-Build a hstore-formatted string from a QMap<QString, QVariant>.
+Build a hstore-formatted string from a QVariantMap.
 
 :param map: The map to format as a string
 

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -225,7 +225,7 @@ take precedence over attributes included via :py:func:`~QgsJsonExporter.attribut
 %End
 
     QString exportFeature( const QgsFeature &feature,
-                           const QMap<QString, QVariant> &extraProperties = QMap<QString, QVariant>(),
+                           const QVariantMap &extraProperties = QVariantMap(),
                            const QVariant &id = QVariant(),
                            int indent = -1 ) const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmapsettings.sip.in
@@ -323,7 +323,7 @@ Sets the custom rendering flags. Layers might honour these to alter their render
    use \see :py:func:`~QgsMapSettings.setCustomRenderingFlag` instead.
 %End
 
-    QMap<QString, QVariant> customRenderingFlags() const;
+    QVariantMap customRenderingFlags() const;
 %Docstring
 Returns any custom rendering flags. Layers might honour these to alter their rendering.
 

--- a/python/PyQt6/core/auto_generated/qgsproperty.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsproperty.sip.in
@@ -187,7 +187,7 @@ can be grouped using a :py:class:`QgsPropertyCollection` for easier bulk storage
 %End
   public:
 
-    static QMap<QString, QVariant> propertyMapToVariantMap( const QMap<QString, QgsProperty> &propertyMap );
+    static QVariantMap propertyMapToVariantMap( const QMap<QString, QgsProperty> &propertyMap );
 %Docstring
 Convert a map of QgsProperty to a map of QVariant
 This is useful to save a map of properties
@@ -195,7 +195,7 @@ This is useful to save a map of properties
 .. versionadded:: 3.20
 %End
 
-    static QMap<QString, QgsProperty> variantMapToPropertyMap( const QMap<QString, QVariant> &variantMap );
+    static QMap<QString, QgsProperty> variantMapToPropertyMap( const QVariantMap &variantMap );
 %Docstring
 Convert a map of QVariant to a map of QgsProperty
 This is useful to restore a map of properties.
@@ -518,7 +518,7 @@ Calculates the current value of the property and interprets it as an boolean.
 
     QVariant toVariant() const;
 %Docstring
-Saves this property to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this property to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -526,7 +526,7 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
     bool loadVariant( const QVariant &property );
 %Docstring
-Loads this property from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this property from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`

--- a/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertycollection.sip.in
@@ -327,7 +327,7 @@ Reads property collection state from an XML element.
 
     virtual QVariant toVariant( const QgsPropertiesDefinition &definitions ) const = 0;
 %Docstring
-Saves this property collection to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this property collection to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -335,7 +335,7 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
     virtual bool loadVariant( const QVariant &configuration, const QgsPropertiesDefinition &definitions ) = 0;
 %Docstring
-Loads this property collection from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this property collection from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to save it to an XML document.
 
 .. seealso:: :py:func:`toVariant`

--- a/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
@@ -122,7 +122,7 @@ Writes the current state of the transform into an XML element
 
     QVariant toVariant() const;
 %Docstring
-Saves this curve transformer to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this curve transformer to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
@@ -130,7 +130,7 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
     bool loadVariant( const QVariant &transformer );
 %Docstring
-Load this curve transformer from a QMap<QString, QVariant>, wrapped in a QVariant.
+Load this curve transformer from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
@@ -204,7 +204,7 @@ Returns a clone of the transformer.
 
     virtual bool loadVariant( const QVariant &transformer );
 %Docstring
-Loads this transformer from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this transformer from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to read it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
@@ -212,7 +212,7 @@ You can use :py:class:`QgsXmlUtils`.readVariant to read it from an XML document.
 
     virtual QVariant toVariant() const;
 %Docstring
-Saves this transformer to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this transformer to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`

--- a/python/PyQt6/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -122,15 +122,15 @@ Sets the ``fields`` for the destination sink.
 
     QVariant toVariant() const;
 %Docstring
-Saves this remapping definition to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves this remapping definition to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
 %End
 
-    bool loadVariant( const QMap<QString, QVariant> &map );
+    bool loadVariant( const QVariantMap &map );
 %Docstring
-Loads this remapping definition from a QMap<QString, QVariant>, wrapped in a QVariant.
+Loads this remapping definition from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`

--- a/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrendercontext.sip.in
@@ -899,7 +899,7 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
-    QMap<QString, QVariant> customRenderingFlags() const;
+    QVariantMap customRenderingFlags() const;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 

--- a/python/PyQt6/core/auto_generated/qgstablecell.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstablecell.sip.in
@@ -166,14 +166,14 @@ Sets the vertical ``alignment`` for text in the cell.
 .. versionadded:: 3.16
 %End
 
-    QMap<QString, QVariant> properties( const QgsReadWriteContext &context ) const;
+    QVariantMap properties( const QgsReadWriteContext &context ) const;
 %Docstring
 Returns the properties of the cell.
 
 .. seealso:: :py:func:`setProperties`
 %End
 
-    void setProperties( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context );
+    void setProperties( const QVariantMap &properties, const QgsReadWriteContext &context );
 %Docstring
 Sets the ``properties`` for the cell.
 

--- a/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
@@ -25,7 +25,7 @@ Contains utilities for working with EXIF tags in images.
 
   public:
 
-    static QMap<QString, QVariant> readTags( const QString &imagePath );
+    static QVariantMap readTags( const QString &imagePath );
 %Docstring
 Returns a map object containing all exif tags stored in the image at ``imagePath``.
 

--- a/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
@@ -59,7 +59,7 @@ Factory method to create a new renderer
     virtual QList<int> usesBands() const;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
     int band() const;

--- a/python/PyQt6/core/auto_generated/raster/qgsmultibandcolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsmultibandcolorrenderer.sip.in
@@ -126,7 +126,7 @@ Ownership of the enhancement is transferred.
     virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) /Factory/;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
   private:

--- a/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -141,7 +141,7 @@ Returns the raster band used for rendering the raster.
 
     virtual QList<int> usesBands() const;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -403,7 +403,7 @@ Draws a preview of the rasterlayer into a QImage
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
-    bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QVariantMap &props = QVariantMap() ) const;
 %Docstring
 Writes the symbology of the layer into the document provided in SLD 1.0.0 format
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterrenderer.sip.in
@@ -171,7 +171,7 @@ Returns const reference to origin of min/max values
 Sets origin of min/max values
 %End
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 %Docstring
 Used from subclasses to create SLD Rule elements following SLD v1.0 specs
 

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -65,7 +65,7 @@ Takes ownership
     virtual QList<int> usesBands() const;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
     const QgsColorRampLegendNodeSettings *legendSettings() const;

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -85,7 +85,7 @@ Creates a color ramp shader
 
     virtual QList<int> usesBands() const;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentryimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentryimpl.sip.in
@@ -710,7 +710,7 @@ typedef QgsSettingsEntryBaseTemplate<QVariantMap> QgsSettingsEntryBaseTemplateQV
 
     QgsSettingsEntryVariantMap( const QString &name,
                                 QgsSettingsTreeNode *parent,
-                                const QMap<QString, QVariant> &defaultValue = QMap<QString, QVariant>(),
+                                const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
                                 Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
@@ -726,7 +726,7 @@ Constructor for QgsSettingsEntryVariantMap.
   private:
     QgsSettingsEntryVariantMap( const QString &key,
                                 const QString &section,
-                                const QMap<QString, QVariant> &defaultValue = QMap<QString, QVariant>(),
+                                const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
                                 Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
@@ -742,7 +742,7 @@ Constructor for QgsSettingsEntryVariantMap.
 
     QgsSettingsEntryVariantMap( const QString &key,
                                 const QString &pluginName,
-                                const QMap<QString, QVariant> &defaultValue = QMap<QString, QVariant>(),
+                                const QVariantMap &defaultValue = QVariantMap(),
                                 const QString &description = QString(),
                                 Qgis::SettingsOptions options = Qgis::SettingsOptions() ) throw( QgsSettingsException ) /Transfer/;
 %Docstring
@@ -761,7 +761,7 @@ This constructor is intended to be used from plugins.
 
     virtual Qgis::SettingsType settingsType() const;
 
-    virtual QMap<QString, QVariant> convertFromVariant( const QVariant &value ) const;
+    virtual QVariantMap convertFromVariant( const QVariant &value ) const;
 
 };
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
@@ -29,7 +29,7 @@ Simple constructor
 %End
     ~QgsArrowSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Create a new QgsArrowSymbolLayer
 
@@ -203,7 +203,7 @@ Gets the current arrow type
 Sets the arrow type
 %End
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QString layerType() const;
 

--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -127,7 +127,7 @@ Sets whether the category is currently enabled and should be rendered.
 Returns a string representing the categories settings, used for debugging purposes only.
 %End
 
-    void toSld( QDomDocument &doc, QDomElement &element, QMap<QString, QVariant> props ) const;
+    void toSld( QDomDocument &doc, QDomElement &element, QVariantMap props ) const;
 %Docstring
 Converts the category to a matching SLD rule, within the specified DOM document and ``element``.
 %End
@@ -184,7 +184,7 @@ can be added later by calling :py:func:`~QgsCategorizedSymbolRenderer.addCategor
 
     virtual QgsCategorizedSymbolRenderer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
     virtual QgsFeatureRenderer::Capabilities capabilities();
     virtual QString filter( const QgsFields &fields = QgsFields() );

--- a/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -57,7 +57,7 @@ Returns ``True`` if a ``shape`` has a fill.
     QgsEllipseSymbolLayer();
     ~QgsEllipseSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates the symbol layer
 %End
@@ -73,12 +73,12 @@ Creates the symbol layer
 
     virtual QgsEllipseSymbolLayer *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
-    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
 
     virtual bool writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift = QPointF( 0.0, 0.0 ) ) const;

--- a/python/PyQt6/core/auto_generated/symbology/qgsfillsymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsfillsymbol.sip.in
@@ -20,7 +20,7 @@ A fill symbol type, for rendering Polygon and MultiPolygon geometries.
 %End
   public:
 
-    static QgsFillSymbol *createSimple( const QMap<QString, QVariant> &properties ) /Factory/;
+    static QgsFillSymbol *createSimple( const QVariantMap &properties ) /Factory/;
 %Docstring
 Create a fill symbol with one symbol layer: SimpleFill with specified properties.
 This is a convenience method for easier creation of fill symbols.

--- a/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -30,7 +30,7 @@ class QgsSimpleFillSymbolLayer : QgsFillSymbolLayer
     ~QgsSimpleFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsSimpleFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsSimpleFillSymbolLayer.properties`).
 
@@ -51,13 +51,13 @@ Caller takes ownership of the returned symbol layer.
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     virtual QgsSimpleFillSymbolLayer *clone() const /Factory/;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
 
     virtual QString ogrFeatureStyle( double mmScaleFactor, double mapUnitScaleFactor ) const;
@@ -217,7 +217,7 @@ Constructor for QgsGradientFillSymbolLayer.
     ~QgsGradientFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsGradientFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsGradientFillSymbolLayer.properties`).
 
@@ -233,7 +233,7 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsGradientFillSymbolLayer *clone() const /Factory/;
 
@@ -488,7 +488,7 @@ Constructor for QgsShapeburstFillSymbolLayer.
 
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsShapeburstFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsShapeburstFillSymbolLayer.properties`).
 
@@ -504,7 +504,7 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsShapeburstFillSymbolLayer *clone() const /Factory/;
 
@@ -894,7 +894,7 @@ fill is positioned relative to the feature.
 
     virtual Qt::PenStyle dxfPenStyle() const;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
   protected:
@@ -937,7 +937,7 @@ specified ``imageFilePath``.
 
     ~QgsRasterFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsRasterFillSymbolLayer from a ``properties`` map. The caller takes
 ownership of the returned object.
@@ -951,7 +951,7 @@ ownership of the returned object.
 .. versionadded:: 3.30
 %End
 
-    static void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.
 Used internally when reading/writing symbols.
@@ -967,7 +967,7 @@ Used internally when reading/writing symbols.
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsRasterFillSymbolLayer *clone() const /Factory/;
 
@@ -1323,7 +1323,7 @@ Constructor for QgsSVGFillSymbolLayer, using the specified SVG picture data.
 
     ~QgsSVGFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsSVGFillSymbolLayer from a ``properties`` map. The caller takes
 ownership of the returned object.
@@ -1335,7 +1335,7 @@ Creates a new QgsSVGFillSymbolLayer from a SLD ``element``. The caller takes
 ownership of the returned object.
 %End
 
-    static void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.
 Used internally when reading/writing symbols.
@@ -1352,11 +1352,11 @@ Used internally when reading/writing symbols.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsSVGFillSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual bool usesMapUnits() const;
 
@@ -1625,7 +1625,7 @@ A symbol fill consisting of repeated parallel lines.
     QgsLinePatternFillSymbolLayer();
     ~QgsLinePatternFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsLinePatternFillSymbolLayer from a ``properties`` map. The caller takes
 ownership of the returned object.
@@ -1645,11 +1645,11 @@ ownership of the returned object.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsLinePatternFillSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual QImage toTiledPatternImage( ) const;
 
@@ -1922,7 +1922,7 @@ A fill symbol layer which fills polygon shapes with repeating marker symbols.
     QgsPointPatternFillSymbolLayer();
     ~QgsPointPatternFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsPointPatternFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsPointPatternFillSymbolLayer.properties`).
 
@@ -1942,11 +1942,11 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsPointPatternFillSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual QImage toTiledPatternImage( ) const;
 
@@ -2588,7 +2588,7 @@ a truly random sequence will be used on every rendering, causing points to appea
 
     ~QgsRandomMarkerFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsRandomMarkerFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsRandomMarkerFillSymbolLayer.properties`).
 
@@ -2603,7 +2603,7 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsRandomMarkerFillSymbolLayer *clone() const /Factory/;
 
@@ -2775,7 +2775,7 @@ class QgsCentroidFillSymbolLayer : QgsFillSymbolLayer
     ~QgsCentroidFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsCentroidFillSymbolLayer using the specified ``properties`` map containing symbol properties (see :py:func:`~QgsCentroidFillSymbolLayer.properties`).
 
@@ -2792,11 +2792,11 @@ Caller takes ownership of the returned symbol layer.
 
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsCentroidFillSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual void setColor( const QColor &color );
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
@@ -18,7 +18,7 @@ class QgsGeometryGeneratorSymbolLayer : QgsSymbolLayer
   public:
     ~QgsGeometryGeneratorSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties ) /Factory/;
 %Docstring
 Creates the symbol layer
 %End
@@ -64,7 +64,7 @@ that is created by this generator.
     virtual QgsSymbolLayer *clone() const /Factory/;
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );

--- a/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -36,7 +36,7 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
 
     virtual QgsGraduatedSymbolRenderer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
     virtual QgsFeatureRenderer::Capabilities capabilities();
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;

--- a/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -312,7 +312,7 @@ The interpolation is done between two values defined at the extremities
 Constructor
 %End
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties ) /Factory/;
 %Docstring
 Creates the symbol layer
 %End
@@ -327,7 +327,7 @@ Creates the symbol layer
 
     virtual QgsInterpolatedLineSymbolLayer *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );
 

--- a/python/PyQt6/core/auto_generated/symbology/qgslinesymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinesymbol.sip.in
@@ -20,7 +20,7 @@ A line symbol type, for rendering LineString and MultiLineString geometries.
 %End
   public:
 
-    static QgsLineSymbol *createSimple( const QMap<QString, QVariant> &properties ) /Factory/;
+    static QgsLineSymbol *createSimple( const QVariantMap &properties ) /Factory/;
 %Docstring
 Create a line symbol with one symbol layer: SimpleLine with specified properties.
 This is a convenience method for easier creation of line symbols.

--- a/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -34,7 +34,7 @@ and ``penStyle``.
     ~QgsSimpleLineSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsSimpleLineSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -56,11 +56,11 @@ Creates a new QgsSimpleLineSymbolLayer from an SLD XML DOM ``element``.
 
     virtual void renderPolygonStroke( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsSimpleLineSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual QString ogrFeatureStyle( double mmScaleFactor, double mapUnitScaleFactor ) const;
 
@@ -905,7 +905,7 @@ calculating individual symbol angles.
 
     virtual QgsMapUnitScale mapUnitScale() const ${SIP_FINAL};
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 
@@ -955,7 +955,7 @@ style and colors instead of the symbol's normal style.
 Copies all common properties of this layer to another templated symbol layer.
 %End
 
-    static void setCommonProperties( QgsTemplatedLineSymbolLayerBase *destLayer, const QMap<QString, QVariant> &properties );
+    static void setCommonProperties( QgsTemplatedLineSymbolLayerBase *destLayer, const QVariantMap &properties );
 %Docstring
 Sets all common symbol properties in the ``destLayer``, using the settings
 serialized in the ``properties`` map.
@@ -987,7 +987,7 @@ should be rotated to match the line segment alignment.
     ~QgsMarkerLineSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsMarkerLineSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -1008,7 +1008,7 @@ Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM ``element``.
 
     virtual QgsMarkerLineSymbolLayer *clone() const /Factory/;
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual void setColor( const QColor &color );
 
@@ -1101,7 +1101,7 @@ should be rotated to match the line segment alignment.
 
     ~QgsHashedLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsHashedLineSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -1114,7 +1114,7 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsHashedLineSymbolLayer *clone() const /Factory/;
 
@@ -1311,14 +1311,14 @@ Constructor for QgsRasterLineSymbolLayer, with the specified raster image path.
 %End
     virtual ~QgsRasterLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsRasterLineSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
 :py:func:`QgsRasterLineSymbolLayer.properties()` ).
 %End
 
-    static void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.
 Used internally when reading/writing symbols.
@@ -1364,7 +1364,7 @@ Set the line opacity.
 
     virtual void renderPolyline( const QPolygonF &points, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsRasterLineSymbolLayer *clone() const /Factory/;
 
@@ -1412,7 +1412,7 @@ Constructor for QgsLineburstSymbolLayer, with the specified start and end gradie
 %End
     ~QgsLineburstSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsLineburstSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -1427,7 +1427,7 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual void renderPolyline( const QPolygonF &points, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsLineburstSymbolLayer *clone() const /Factory/;
 
@@ -1523,7 +1523,7 @@ symbol will be used.
 %End
     ~QgsFilledLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsFilledLineSymbolLayer, using the settings
 serialized in the ``properties`` map (corresponding to the output from
@@ -1538,7 +1538,7 @@ serialized in the ``properties`` map (corresponding to the output from
 
     virtual void renderPolyline( const QPolygonF &points, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsFilledLineSymbolLayer *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbol.sip.in
@@ -21,7 +21,7 @@ A marker symbol type, for rendering Point and MultiPoint geometries.
 %End
   public:
 
-    static QgsMarkerSymbol *createSimple( const QMap<QString, QVariant> &properties ) /Factory/;
+    static QgsMarkerSymbol *createSimple( const QVariantMap &properties ) /Factory/;
 %Docstring
 Create a marker symbol with one symbol layer: SimpleMarker with specified properties.
 This is a convenience method for easier creation of marker symbols.

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -195,7 +195,7 @@ Constructor for QgsSimpleMarkerSymbolLayer.
     ~QgsSimpleMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsSimpleMarkerSymbolLayer.
 
@@ -220,11 +220,11 @@ Creates a new QgsSimpleMarkerSymbolLayer from an SLD XML element.
 
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsSimpleMarkerSymbolLayer *clone() const /Factory/;
 
-    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual QString ogrFeatureStyle( double mmScaleFactor, double mapUnitScaleFactor ) const;
 
@@ -495,7 +495,7 @@ Constructor for QgsFilledMarkerSymbolLayer.
 
     ~QgsFilledMarkerSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsFilledMarkerSymbolLayer.
 
@@ -510,7 +510,7 @@ Creates a new QgsFilledMarkerSymbolLayer.
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsFilledMarkerSymbolLayer *clone() const /Factory/;
 
@@ -559,13 +559,13 @@ Constructs SVG marker symbol layer with picture from given absolute path to a SV
     ~QgsSvgMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates the symbol
 %End
     static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
 
-    static void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.
 Used internally when reading/writing symbols.
@@ -586,7 +586,7 @@ Used internally when reading/writing symbols.
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual bool usesMapUnits() const;
 
@@ -594,7 +594,7 @@ Used internally when reading/writing symbols.
     virtual QgsSvgMarkerSymbolLayer *clone() const /Factory/;
 
 
-    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
 
     QString path() const;
@@ -771,14 +771,14 @@ Constructs raster marker symbol layer with picture from given absolute path to a
     ~QgsRasterMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a raster marker symbol layer from a string map of properties.
 
-:param properties: QMap<QString, QVariant> properties object
+:param properties: QVariantMap properties object
 %End
 
-    static void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Turns relative paths in properties map to absolute when reading and vice versa when writing.
 Used internally when reading/writing symbols.
@@ -792,7 +792,7 @@ Used internally when reading/writing symbols.
 
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsRasterMarkerSymbolLayer *clone() const /Factory/;
 
@@ -906,7 +906,7 @@ if the value set is lower or equal to 0 the aspect ratio will be preserved in re
 
   protected:
 
-    void setCommonProperties( const QMap<QString, QVariant> &properties );
+    void setCommonProperties( const QVariantMap &properties );
 %Docstring
 Sets common class properties from a ``properties`` map.
 
@@ -948,7 +948,7 @@ Constructs a font marker symbol layer.
     ~QgsFontMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates a new QgsFontMarkerSymbolLayer from a property map (see :py:func:`~QgsFontMarkerSymbolLayer.properties`)
 %End
@@ -958,7 +958,7 @@ Creates a new QgsFontMarkerSymbolLayer from a property map (see :py:func:`~QgsFo
 Creates a new QgsFontMarkerSymbolLayer from an SLD XML ``element``.
 %End
 
-    static void resolveFonts( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context );
+    static void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
 %Docstring
 Resolves fonts from a ``properties`` map, raising warnings in the specified ``context`` if the
 required fonts are not available on the system.
@@ -979,13 +979,13 @@ required fonts are not available on the system.
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     virtual QgsFontMarkerSymbolLayer *clone() const /Factory/;
 
 
-    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual bool usesMapUnits() const;
 
@@ -1170,7 +1170,7 @@ Constructor for animated marker symbol layer using the specified source image ``
     ~QgsAnimatedMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Creates an animated marker symbol layer from a string map of ``properties``.
 %End
@@ -1178,7 +1178,7 @@ Creates an animated marker symbol layer from a string map of ``properties``.
 
     virtual QString layerType() const;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual QgsAnimatedMarkerSymbolLayer *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
@@ -29,7 +29,7 @@ Simple constructor
 
     ~QgsMaskMarkerSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) /Factory/;
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
 %Docstring
 Create a new QgsMaskMarkerSymbolLayer
 
@@ -49,7 +49,7 @@ Create a new QgsMaskMarkerSymbolLayer
     virtual bool hasDataDefinedProperties() const;
 
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
 
     virtual QString layerType() const;

--- a/python/PyQt6/core/auto_generated/symbology/qgspointdistancerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgspointdistancerenderer.sip.in
@@ -64,7 +64,7 @@ Constructor for QgsPointDistanceRenderer.
 :param labelAttributeName: optional attribute for labeling points
 %End
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
     virtual bool renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) throw( QgsCsException );
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -277,7 +277,7 @@ Subclasses which override this method should call :py:func:`~QgsFeatureRenderer.
 implementation in order to store all common base class properties in the returned DOM element.
 %End
 
-    virtual QDomElement writeSld( QDomDocument &doc, const QString &styleName, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual QDomElement writeSld( QDomDocument &doc, const QString &styleName, const QVariantMap &props = QVariantMap() ) const;
 %Docstring
 create the SLD UserStyle element following the SLD v1.1 specs with the given name
 
@@ -299,7 +299,7 @@ the UserStyle element of a SLD style document
 :return: the renderer
 %End
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 %Docstring
 used from subclasses to create SLD Rule elements following SLD v1.1 specs
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrendererrange.sip.in
@@ -148,7 +148,7 @@ Sets whether the range should be rendered.
 Dumps a string representation of the range.
 %End
 
-    void toSld( QDomDocument &doc, QDomElement &element, QMap<QString, QVariant> props, bool firstRange = false ) const;
+    void toSld( QDomDocument &doc, QDomElement &element, QVariantMap props, bool firstRange = false ) const;
 %Docstring
 Creates a DOM element representing the range in SLD format.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -287,7 +287,7 @@ Sets if this rule is active
 clone this rule, return new instance
 %End
 
-        void toSld( QDomDocument &doc, QDomElement &element, QMap<QString, QVariant> props ) const;
+        void toSld( QDomDocument &doc, QDomElement &element, QVariantMap props ) const;
 %Docstring
 Saves the symbol layer as SLD
 %End
@@ -513,7 +513,7 @@ Returns symbol for current feature. Should not be used individually: there could
     virtual QgsRuleBasedRenderer *clone() const /Factory/;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
     static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) /Factory/;

--- a/python/PyQt6/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
@@ -59,7 +59,7 @@ of the symbol is transferred to the renderer.
     virtual QgsSingleSymbolRenderer *clone() const /Factory/;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props = QVariantMap() ) const;
 
 
     static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) /Factory/;

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
@@ -414,7 +414,7 @@ Returns a deep copy of this symbol.
 Ownership is transferred to the caller.
 %End
 
-    void toSld( QDomDocument &doc, QDomElement &element, QMap<QString, QVariant> props ) const;
+    void toSld( QDomDocument &doc, QDomElement &element, QVariantMap props ) const;
 %Docstring
 Converts the symbol to a SLD representation.
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -408,14 +408,14 @@ The default implementation does nothing.
 Shall be reimplemented by subclasses to create a deep copy of the instance.
 %End
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 %Docstring
 Saves the symbol layer as SLD
 %End
 
     virtual QString ogrFeatureStyle( double mmScaleFactor, double mapUnitScaleFactor ) const;
 
-    virtual QMap<QString, QVariant> properties() const = 0;
+    virtual QVariantMap properties() const = 0;
 %Docstring
 Should be reimplemented by subclasses to return a string map that
 contains the configuration information for the symbol layer. This
@@ -709,7 +709,7 @@ Constructor for QgsSymbolLayer.
 
 
 
-    void restoreOldDataDefinedProperties( const QMap<QString, QVariant> &stringMap );
+    void restoreOldDataDefinedProperties( const QVariantMap &stringMap );
 %Docstring
 Restores older data defined properties from string map.
 
@@ -1056,10 +1056,10 @@ the vertical anchor point is aligned with the marker's desired location.
 .. seealso:: :py:func:`horizontalAnchorPoint`
 %End
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
 
-    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void writeSldMarker( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 %Docstring
 Writes the symbol layer definition as a SLD XML element.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerregistry.sip.in
@@ -41,7 +41,7 @@ Constructor for QgsSymbolLayerAbstractMetadata.
     QString visibleName() const;
     Qgis::SymbolType type() const;
 
-    virtual QgsSymbolLayer *createSymbolLayer( const QMap<QString, QVariant> &map ) = 0 /Factory/;
+    virtual QgsSymbolLayer *createSymbolLayer( const QVariantMap &map ) = 0 /Factory/;
 %Docstring
 Create a symbol layer of this type given the map of properties.
 %End
@@ -54,7 +54,7 @@ Create widget for symbol layer of this type. Can return ``None`` if there's no G
 Create a symbol layer of this type given the map of properties.
 %End
 
-    virtual void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    virtual void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
 Resolve paths in symbol layer's properties (if there are any paths).
 When saving is ``True``, paths are converted from absolute to relative,
@@ -65,7 +65,7 @@ instances the paths are always absolute
 .. versionadded:: 3.0
 %End
 
-    virtual void resolveFonts( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context );
+    virtual void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
 %Docstring
 Resolve fonts from the  symbol layer's ``properties``.
 
@@ -92,12 +92,12 @@ Convenience metadata class that uses static functions to create symbol layer and
 
 
 
-    virtual QgsSymbolLayer *createSymbolLayer( const QMap<QString, QVariant> &map ) /Factory/;
+    virtual QgsSymbolLayer *createSymbolLayer( const QVariantMap &map ) /Factory/;
     virtual QgsSymbolLayerWidget *createSymbolLayerWidget( QgsVectorLayer *vl ) /Factory/;
     virtual QgsSymbolLayer *createSymbolLayerFromSld( QDomElement &elem ) /Factory/;
-    virtual void resolvePaths( QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving );
+    virtual void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 
-    virtual void resolveFonts( const QMap<QString, QVariant> &properties, const QgsReadWriteContext &context );
+    virtual void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
 
   protected:
 
@@ -142,7 +142,7 @@ Removes a symbol layer type
 .. versionadded:: 3.22.2
 %End
 
-    QgsSymbolLayer *createSymbolLayer( const QString &name, const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() ) const /Factory/;
+    QgsSymbolLayer *createSymbolLayer( const QString &name, const QVariantMap &properties = QVariantMap() ) const /Factory/;
 %Docstring
 create a new instance of symbol layer given symbol layer name and properties
 %End
@@ -152,7 +152,7 @@ create a new instance of symbol layer given symbol layer name and properties
 create a new instance of symbol layer given symbol layer name and SLD
 %End
 
-    void resolvePaths( const QString &name, QMap<QString, QVariant> &properties, const QgsPathResolver &pathResolver, bool saving ) const;
+    void resolvePaths( const QString &name, QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving ) const;
 %Docstring
 Resolve paths in properties of a particular symbol layer.
 This normally means converting relative paths to absolute paths when loading
@@ -161,7 +161,7 @@ and converting absolute paths to relative paths when saving.
 .. versionadded:: 3.0
 %End
 
-    void resolveFonts( const QString &name, QMap<QString, QVariant> &properties, const QgsReadWriteContext &context ) const;
+    void resolveFonts( const QString &name, QVariantMap &properties, const QgsReadWriteContext &context ) const;
 %Docstring
 Resolve fonts from the ``properties`` of a particular symbol layer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -558,11 +558,11 @@ Creates a OGC Expression element based on the provided function expression
     static QDomElement createVendorOptionElement( QDomDocument &doc, const QString &name, const QString &value );
     static QgsStringMap getVendorOptionList( QDomElement &element );
 
-    static QMap<QString, QVariant> parseProperties( const QDomElement &element );
+    static QVariantMap parseProperties( const QDomElement &element );
 %Docstring
 Parses the properties from XML and returns a map
 %End
-    static void saveProperties( QMap<QString, QVariant> props, QDomDocument &doc, QDomElement &element );
+    static void saveProperties( QVariantMap props, QDomDocument &doc, QDomElement &element );
 %Docstring
 Saves the map of properties to XML
 %End
@@ -625,7 +625,7 @@ Encodes a color ramp's settings to an XML element
 
     static QVariant colorRampToVariant( const QString &name, QgsColorRamp *ramp );
 %Docstring
-Saves a color ramp to a QMap<QString, QVariant>, wrapped in a QVariant.
+Saves a color ramp to a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadColorRamp`
@@ -633,7 +633,7 @@ You can use :py:class:`QgsXmlUtils`.writeVariant to save it to an XML document.
 
     static QgsColorRamp *loadColorRamp( const QVariant &value ) /Factory/;
 %Docstring
-Load a color ramp from a QMap<QString, QVariant>, wrapped in a QVariant.
+Load a color ramp from a QVariantMap, wrapped in a QVariant.
 You can use :py:class:`QgsXmlUtils`.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`colorRampToVariant`
@@ -911,7 +911,7 @@ The values are chosen so that they are 1, 2 or 5 times a power of 10.
 .. versionadded:: 2.10
 %End
 
-    static double rescaleUom( double size, Qgis::RenderUnit unit, const QMap<QString, QVariant> &props );
+    static double rescaleUom( double size, Qgis::RenderUnit unit, const QVariantMap &props );
 %Docstring
 Rescales the given size based on the uomScale found in the props, if any is found, otherwise
 returns the value un-modified
@@ -919,7 +919,7 @@ returns the value un-modified
 .. versionadded:: 3.0
 %End
 
-    static QPointF rescaleUom( QPointF point, Qgis::RenderUnit unit, const QMap<QString, QVariant> &props ) /PyName=rescalePointUom/;
+    static QPointF rescaleUom( QPointF point, Qgis::RenderUnit unit, const QVariantMap &props ) /PyName=rescalePointUom/;
 %Docstring
 Rescales the given point based on the uomScale found in the props, if any is found, otherwise
 returns a copy of the original point
@@ -927,7 +927,7 @@ returns a copy of the original point
 .. versionadded:: 3.0
 %End
 
-    static QVector<qreal> rescaleUom( const QVector<qreal> &array, Qgis::RenderUnit unit, const QMap<QString, QVariant> &props ) /PyName=rescaleArrayUom/;
+    static QVector<qreal> rescaleUom( const QVector<qreal> &array, Qgis::RenderUnit unit, const QVariantMap &props ) /PyName=rescaleArrayUom/;
 %Docstring
 Rescales the given array based on the uomScale found in the props, if any is found, otherwise
 returns a copy of the original point
@@ -935,14 +935,14 @@ returns a copy of the original point
 .. versionadded:: 3.0
 %End
 
-    static void applyScaleDependency( QDomDocument &doc, QDomElement &ruleElem, QMap<QString, QVariant> &props );
+    static void applyScaleDependency( QDomDocument &doc, QDomElement &ruleElem, QVariantMap &props );
 %Docstring
 Checks if the properties contain scaleMinDenom and scaleMaxDenom, if available, they are added into the SE Rule element
 
 .. versionadded:: 3.0
 %End
 
-    static void mergeScaleDependencies( double mScaleMinDenom, double mScaleMaxDenom, QMap<QString, QVariant> &props );
+    static void mergeScaleDependencies( double mScaleMinDenom, double mScaleMaxDenom, QVariantMap &props );
 %Docstring
 Merges the local scale limits, if any, with the ones already in the map, if any
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
@@ -42,7 +42,7 @@ A symbol layer class for displaying displacement arrows based on point layer att
     QgsVectorFieldSymbolLayer();
     ~QgsVectorFieldSymbolLayer();
 
-    static QgsSymbolLayer *create( const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() );
+    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates the symbol layer
 %End
@@ -69,12 +69,12 @@ Creates the symbol layer
 
     virtual QgsVectorFieldSymbolLayer *clone() const /Factory/;
 
-    virtual QMap<QString, QVariant> properties() const;
+    virtual QVariantMap properties() const;
 
     virtual bool usesMapUnits() const;
 
 
-    virtual void toSld( QDomDocument &doc, QDomElement &element, const QMap<QString, QVariant> &props ) const;
+    virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetile.sip.in
@@ -105,14 +105,14 @@ in order to transform them to the dataset's coordinate reference system.
 .. seealso:: :py:func:`transform`
 %End
 
-    QMap<QString, QVariant> resources() const;
+    QVariantMap resources() const;
 %Docstring
 Returns the resources attached to the tile.
 
 .. seealso:: :py:func:`setResources`
 %End
 
-    void setResources( const QMap<QString, QVariant> &resources );
+    void setResources( const QVariantMap &resources );
 %Docstring
 Sets the ``resources`` ``attached`` to the tile.
 
@@ -151,14 +151,14 @@ get resolved against this URL.
 .. seealso:: :py:func:`baseUrl`
 %End
 
-    QMap<QString, QVariant> metadata() const;
+    QVariantMap metadata() const;
 %Docstring
 Returns additional metadata attached to the tile.
 
 .. seealso:: :py:func:`setMetadata`
 %End
 
-    void setMetadata( const QMap<QString, QVariant> &metadata );
+    void setMetadata( const QVariantMap &metadata );
 %Docstring
 Sets additional ``metadata`` attached to the tile.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -545,7 +545,7 @@ Clear recorded errors
 Gets recorded errors
 %End
 
-    virtual QgsFeatureRenderer *createRenderer( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) const /Factory/;
+    virtual QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
 Creates a new vector layer feature renderer, using provider backend specific information.
 
@@ -562,7 +562,7 @@ providers will return ``None``.
 .. versionadded:: 3.2
 %End
 
-    virtual QgsAbstractVectorLayerLabeling *createLabeling( const QMap<QString, QVariant> &configuration = QMap<QString, QVariant>() ) const /Factory/;
+    virtual QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
 Creates labeling settings, using provider backend specific information.
 
@@ -610,7 +610,7 @@ Discover the available relations with the given layers.
 .. versionadded:: 3.0
 %End
 
-    virtual QMap<QString, QVariant> metadata() const;
+    virtual QVariantMap metadata() const;
 %Docstring
 Gets metadata, dependent on the provider type, that will be display in the metadata tab of the layer properties.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -984,7 +984,7 @@ Returns the current auxiliary layer.
      virtual bool writeStyle( QDomNode &node, QDomDocument &doc, QString &errorMessage,
                      const QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories ) const ${SIP_FINAL};
 
-    bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QMap<QString, QVariant> &props = QMap<QString, QVariant>() ) const;
+    bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QVariantMap &props = QVariantMap() ) const;
 %Docstring
 Writes the symbology of the layer into the document provided in SLD 1.1 format
 

--- a/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -96,7 +96,7 @@ Returns the sprite image to use during conversion, or an invalid image if this i
 .. seealso:: :py:func:`setSprites`
 %End
 
-    QMap<QString, QVariant> spriteDefinitions() const;
+    QVariantMap spriteDefinitions() const;
 %Docstring
 Returns the sprite definitions to use during conversion.
 
@@ -105,7 +105,7 @@ Returns the sprite definitions to use during conversion.
 .. seealso:: :py:func:`setSprites`
 %End
 
-    void setSprites( const QImage &image, const QMap<QString, QVariant> &definitions );
+    void setSprites( const QImage &image, const QVariantMap &definitions );
 %Docstring
 Sets the sprite ``image`` and ``definitions`` JSON to use during conversion.
 
@@ -184,7 +184,7 @@ Constructor for QgsMapBoxGlStyleAbstractSource.
 Returns the source type.
 %End
 
-    virtual bool setFromJson( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext *context ) = 0;
+    virtual bool setFromJson( const QVariantMap &json, QgsMapBoxGlStyleConversionContext *context ) = 0;
 %Docstring
 Sets the source's state from a ``json`` map.
 %End
@@ -221,7 +221,7 @@ Constructor for QgsMapBoxGlStyleRasterSource.
 
     virtual Qgis::MapBoxGlStyleSourceType type() const;
 
-    virtual bool setFromJson( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext *context );
+    virtual bool setFromJson( const QVariantMap &json, QgsMapBoxGlStyleConversionContext *context );
 
 
     QString attribution() const;
@@ -348,7 +348,7 @@ Constructor for QgsMapBoxGlStyleConverter.
       Point,
     };
 
-    Result convert( const QMap<QString, QVariant> &style, QgsMapBoxGlStyleConversionContext *context = 0 );
+    Result convert( const QVariantMap &style, QgsMapBoxGlStyleConversionContext *context = 0 );
 %Docstring
 Converts a JSON ``style`` map, and returns the resultant status of the conversion.
 
@@ -427,7 +427,7 @@ The caller takes ownership of the returned layers.
 
   protected:
 
-    void parseSources( const QMap<QString, QVariant> &sources, QgsMapBoxGlStyleConversionContext *context = 0 );
+    void parseSources( const QVariantMap &sources, QgsMapBoxGlStyleConversionContext *context = 0 );
 %Docstring
 Parse list of ``sources`` from JSON.
 
@@ -438,7 +438,7 @@ Parse list of ``sources`` from JSON.
 .. versionadded:: 3.28
 %End
 
-    void parseRasterSource( const QMap<QString, QVariant> &source, const QString &name, QgsMapBoxGlStyleConversionContext *context = 0 );
+    void parseRasterSource( const QVariantMap &source, const QString &name, QgsMapBoxGlStyleConversionContext *context = 0 );
 %Docstring
 Parse a raster ``source`` from JSON.
 
@@ -458,7 +458,7 @@ Parse list of ``layers`` from JSON.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static bool parseFillLayer( const QMap<QString, QVariant> &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context, bool isBackgroundStyle = false );
+    static bool parseFillLayer( const QVariantMap &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context, bool isBackgroundStyle = false );
 %Docstring
 Parses a fill layer.
 
@@ -474,7 +474,7 @@ Parses a fill layer.
          - style: generated QGIS vector tile style
 %End
 
-    static bool parseLineLayer( const QMap<QString, QVariant> &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context );
+    static bool parseLineLayer( const QVariantMap &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context );
 %Docstring
 Parses a line layer.
 
@@ -489,7 +489,7 @@ Parses a line layer.
          - style: generated QGIS vector tile style
 %End
 
-    static bool parseCircleLayer( const QMap<QString, QVariant> &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context );
+    static bool parseCircleLayer( const QVariantMap &jsonLayer, QgsVectorTileBasicRendererStyle &style /Out/, QgsMapBoxGlStyleConversionContext &context );
 %Docstring
 Parses a circle layer.
 
@@ -504,7 +504,7 @@ Parses a circle layer.
          - style: generated QGIS vector tile style
 %End
 
-    static void parseSymbolLayer( const QMap<QString, QVariant> &jsonLayer,
+    static void parseSymbolLayer( const QVariantMap &jsonLayer,
                                   QgsVectorTileBasicRendererStyle &rendererStyle /Out/,
                                   bool &hasRenderer /Out/,
                                   QgsVectorTileBasicLabelingStyle &labelingStyle /Out/,
@@ -523,7 +523,7 @@ Parses a symbol layer as renderer or labeling.
 :param context: conversion context
 %End
 
-    static bool parseSymbolLayerAsRenderer( const QMap<QString, QVariant> &jsonLayer,
+    static bool parseSymbolLayerAsRenderer( const QVariantMap &jsonLayer,
                                             QgsVectorTileBasicRendererStyle &rendererStyle /Out/, QgsMapBoxGlStyleConversionContext &context );
 %Docstring
 Parses a symbol layer as a renderer
@@ -540,7 +540,7 @@ Parses a symbol layer as a renderer
          - rendererStyle: generated QGIS vector tile style
 %End
 
-    static QgsProperty parseInterpolateColorByZoom( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor /Out/ = 0 );
+    static QgsProperty parseInterpolateColorByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor /Out/ = 0 );
 %Docstring
 Parses a color value which is interpolated by zoom range.
 
@@ -551,7 +551,7 @@ Parses a color value which is interpolated by zoom range.
          - defaultColor: storage for a reasonable "default" color representing the overall property.
 %End
 
-    static QgsProperty parseInterpolateByZoom( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, double *defaultNumber /Out/ = 0 );
+    static QgsProperty parseInterpolateByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, double *defaultNumber /Out/ = 0 );
 %Docstring
 Parses a numeric value which is interpolated by zoom range.
 
@@ -563,7 +563,7 @@ Parses a numeric value which is interpolated by zoom range.
          - defaultNumber: storage for a reasonable "default" number representing the overall property.
 %End
 
-    static QgsProperty parseInterpolateOpacityByZoom( const QMap<QString, QVariant> &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr = 0 );
+    static QgsProperty parseInterpolateOpacityByZoom( const QVariantMap &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr = 0 );
 %Docstring
 Interpolates opacity with either :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or :py:func:`~QgsMapBoxGlStyleConverter.scale_exp` (depending on base value).
 For ``json`` with intermediate stops it uses :py:func:`~QgsMapBoxGlStyleConverter.parseOpacityStops` function.
@@ -584,7 +584,7 @@ to interpolate alpha component of color.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QgsProperty parseInterpolatePointByZoom( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, QPointF *defaultPoint /Out/ = 0 );
+    static QgsProperty parseInterpolatePointByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, QPointF *defaultPoint /Out/ = 0 );
 %Docstring
 Interpolates a point/offset with either :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or :py:func:`~QgsMapBoxGlStyleConverter.scale_exp` (depending on base value).
 For ``json`` with intermediate stops it uses :py:func:`~QgsMapBoxGlStyleConverter.parsePointStops` function.
@@ -594,8 +594,8 @@ For ``json`` with intermediate stops it uses :py:func:`~QgsMapBoxGlStyleConverte
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QgsProperty parseInterpolateStringByZoom( const QMap<QString, QVariant> &json, QgsMapBoxGlStyleConversionContext &context,
-        const QMap<QString, QVariant> &conversionMap,
+    static QgsProperty parseInterpolateStringByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context,
+        const QVariantMap &conversionMap,
         QString *defaultString /Out/ = 0 );
 %Docstring
 Interpolates a string by zoom.
@@ -636,7 +636,7 @@ Parses a list of interpolation stops
 %End
 
     static QString parseStringStops( const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context,
-                                     const QMap<QString, QVariant> &conversionMap,
+                                     const QVariantMap &conversionMap,
                                      QString *defaultString /Out/ = 0 );
 %Docstring
 Parses a list of interpolation stops containing string values.

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortilematrixset.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortilematrixset.sip.in
@@ -27,7 +27,7 @@ Encapsulates properties of a vector tile matrix set, including tile origins and 
 Returns a vector tile structure corresponding to the standard web mercator/GoogleCRS84Quad setup.
 %End
 
-    bool fromEsriJson( const QMap<QString, QVariant> &json, const QMap<QString, QVariant> &rootTileMap = QMap<QString, QVariant>() );
+    bool fromEsriJson( const QVariantMap &json, const QVariantMap &rootTileMap = QVariantMap() );
 %Docstring
 Initializes the tile structure settings from an ESRI REST VectorTileService ``json`` map.
 

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -31,7 +31,7 @@ the "url" key is normally the path. Currently supported types:
 
 Currently the writer only support MVT encoding of data.
 
-Metadata support: it is possible to pass a QMap<QString, QVariant> with metadata. This
+Metadata support: it is possible to pass a QVariantMap with metadata. This
 is backend dependent. Currently only "mbtiles" source type supports writing
 of metadata. The key-value pairs will be written to the "metadata" table
 in the MBTiles file. Some useful metadata keys listed here, but see MBTiles spec
@@ -146,7 +146,7 @@ Sets the maximum zoom level of tiles. Allowed values are in interval [0,24]
 Sets vector layers and their configuration for output of vector tiles
 %End
 
-    void setMetadata( const QMap<QString, QVariant> &metadata );
+    void setMetadata( const QVariantMap &metadata );
 %Docstring
 Sets that will be written to the output dataset. See class description for more on metadata support
 %End

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvtpktiles.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvtpktiles.sip.in
@@ -40,19 +40,19 @@ Tries to open the file, returns true on success
 Returns whether the VTPK file is currently opened
 %End
 
-    QMap<QString, QVariant> metadata() const;
+    QVariantMap metadata() const;
 %Docstring
 Returns the VTPK metadata.
 
 This method returns the contents of the "root.json" file.
 %End
 
-    QMap<QString, QVariant> styleDefinition() const;
+    QVariantMap styleDefinition() const;
 %Docstring
 Returns the VTPK style definition.
 %End
 
-    QMap<QString, QVariant> spriteDefinition() const;
+    QVariantMap spriteDefinition() const;
 %Docstring
 Returns the VTPK sprites definitions.
 %End
@@ -67,7 +67,7 @@ Returns the VTPK sprite image, if it exists.
 Reads layer metadata from the VTPK file.
 %End
 
-    QMap<QString, QVariant> rootTileMap() const;
+    QVariantMap rootTileMap() const;
 %Docstring
 Returns the root tilemap content, if it exists.
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorconfigwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorconfigwidget.sip.in
@@ -35,14 +35,14 @@ Create a new configuration widget
 :param parent: A parent widget
 %End
 
-    virtual QMap<QString, QVariant> config() = 0;
+    virtual QVariantMap config() = 0;
 %Docstring
 Create a configuration from the current GUI state
 
 :return: A widget configuration
 %End
 
-    virtual void setConfig( const QMap<QString, QVariant> &config ) = 0;
+    virtual void setConfig( const QVariantMap &config ) = 0;
 %Docstring
 Update the configuration widget to represent the given configuration.
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetregistry.sip.in
@@ -60,7 +60,7 @@ Find the best editor widget and its configuration for a given field.
     QgsEditorWidgetWrapper *create( const QString &widgetId,
                                     QgsVectorLayer *vl,
                                     int fieldIdx,
-                                    const QMap<QString, QVariant> &config,
+                                    const QVariantMap &config,
                                     QWidget *editor,
                                     QWidget *parent /TransferThis/ ) /Factory/;
 
@@ -98,7 +98,7 @@ The editor may be ``None`` if you want the widget wrapper to create a default wi
     QgsSearchWidgetWrapper *createSearchWidget( const QString &widgetId,
         QgsVectorLayer *vl,
         int fieldIdx,
-        const QMap<QString, QVariant> &config,
+        const QVariantMap &config,
         QWidget *parent /TransferThis/ ) /Factory/;
 
 

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
@@ -80,7 +80,7 @@ Access the widget managed by this wrapper
 %End
 
 
-    void setConfig( const QMap<QString, QVariant> &config );
+    void setConfig( const QVariantMap &config );
 %Docstring
 Will set the config of this wrapper to the specified config.
 
@@ -104,7 +104,7 @@ Use this inside your overridden classes to access the configuration.
 :return: the value assigned to this configuration option
 %End
 
-    QMap<QString, QVariant> config() const;
+    QVariantMap config() const;
 %Docstring
 Returns the whole config
 %End

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -143,7 +143,7 @@ Returns the buttons which are shown
 %End
 
 
-    void setWidgetConfig( const QMap<QString, QVariant> &config );
+    void setWidgetConfig( const QVariantMap &config );
 %Docstring
 Will set the config of this widget wrapper to the specified config.
 
@@ -152,7 +152,7 @@ Will set the config of this widget wrapper to the specified config.
 .. versionadded:: 3.18
 %End
 
-    QMap<QString, QVariant> widgetConfig() const;
+    QVariantMap widgetConfig() const;
 %Docstring
 Returns the whole widget config
 

--- a/python/PyQt6/gui/auto_generated/history/qgshistoryentry.sip.in
+++ b/python/PyQt6/gui/auto_generated/history/qgshistoryentry.sip.in
@@ -26,12 +26,12 @@ Encapsulates a history entry.
 Constructor for an invalid entry.
 %End
 
-    explicit QgsHistoryEntry( const QString &providerId, const QDateTime &timestamp, const QMap<QString, QVariant> &entry );
+    explicit QgsHistoryEntry( const QString &providerId, const QDateTime &timestamp, const QVariantMap &entry );
 %Docstring
 Constructor for QgsHistoryEntry ``entry``, with the specified ``providerId`` and ``timestamp``.
 %End
 
-    explicit QgsHistoryEntry( const QMap<QString, QVariant> &entry );
+    explicit QgsHistoryEntry( const QVariantMap &entry );
 %Docstring
 Constructor for QgsHistoryEntry ``entry``.
 
@@ -51,7 +51,7 @@ Returns ``True`` if the entry is valid.
 
     QString providerId;
 
-    QMap<QString, QVariant> entry;
+    QVariantMap entry;
 
     SIP_PYOBJECT __repr__();
 %MethodCode

--- a/python/PyQt6/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
@@ -86,7 +86,7 @@ Constructor for HistoryEntryOptions.
         Qgis::HistoryProviderBackends storageBackends;
     };
 
-    long long addEntry( const QString &providerId, const QMap<QString, QVariant> &entry, bool &ok /Out/, QgsHistoryProviderRegistry::HistoryEntryOptions options = QgsHistoryProviderRegistry::HistoryEntryOptions() );
+    long long addEntry( const QString &providerId, const QVariantMap &entry, bool &ok /Out/, QgsHistoryProviderRegistry::HistoryEntryOptions options = QgsHistoryProviderRegistry::HistoryEntryOptions() );
 %Docstring
 Adds an ``entry`` to the history logs.
 
@@ -137,7 +137,7 @@ Returns the entry with matching ID, from the specified ``backend``.
 :return: matching entry if found
 %End
 
-    bool updateEntry( long long id, const QMap<QString, QVariant> &entry, Qgis::HistoryProviderBackend backend = Qgis::HistoryProviderBackend::LocalProfile );
+    bool updateEntry( long long id, const QVariantMap &entry, Qgis::HistoryProviderBackend backend = Qgis::HistoryProviderBackend::LocalProfile );
 %Docstring
 Updates the existing entry with matching ``id``.
 
@@ -174,7 +174,7 @@ Emitted when an ``entry`` is added.
 .. versionadded:: 3.32
 %End
 
-    void entryUpdated( long long id, const QMap<QString, QVariant> &entry, Qgis::HistoryProviderBackend backend );
+    void entryUpdated( long long id, const QVariantMap &entry, Qgis::HistoryProviderBackend backend );
 %Docstring
 Emitted when an ``entry`` is updated.
 

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -231,7 +231,7 @@ Returns a reference to the item group with matching ``id``.
 Creates a new instance of a layout item given the item metadata ``metadataId``, target ``layout``.
 %End
 
-    void newItemAddedToLayout( int metadataId, QgsLayoutItem *item, const QMap<QString, QVariant> &properties = QMap<QString, QVariant>() );
+    void newItemAddedToLayout( int metadataId, QgsLayoutItem *item, const QVariantMap &properties = QVariantMap() );
 %Docstring
 Called when a newly created item of the associated metadata ``metadataId`` has been added to a layout.
 

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutviewtooladditem.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutviewtooladditem.sip.in
@@ -54,7 +54,7 @@ from :py:class:`QgsLayoutItemGuiRegistry`.
     virtual void deactivate();
 
 
-    QMap<QString, QVariant> customProperties() const;
+    QVariantMap customProperties() const;
 %Docstring
 Returns any custom properties set for the tool.
 
@@ -63,7 +63,7 @@ Returns any custom properties set for the tool.
 .. versionadded:: 3.18
 %End
 
-    void setCustomProperties( const QMap<QString, QVariant> &properties );
+    void setCustomProperties( const QVariantMap &properties );
 %Docstring
 Sets custom ``properties`` for the tool.
 

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -396,12 +396,12 @@ Ownership of ``child`` is transferred to the item.
     virtual bool canDeleteComponent();
 
 
-    void setResults( const QMap<QString, QVariant> &results );
+    void setResults( const QVariantMap &results );
 %Docstring
 Sets the results obtained for this child algorithm for the last model execution through the dialog.
 %End
 
-    void setInputs( const QMap<QString, QVariant> &inputs );
+    void setInputs( const QVariantMap &inputs );
 %Docstring
 Sets the inputs used for this child algorithm for the last model execution through the dialog.
 %End

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -115,12 +115,12 @@ Checks if there are unsaved changes in the model, and if so, prompts the user to
 Returns ``False`` if the cancel option was selected
 %End
 
-    void setLastRunChildAlgorithmResults( const QMap<QString, QVariant> &results );
+    void setLastRunChildAlgorithmResults( const QVariantMap &results );
 %Docstring
 Sets the results of child algorithms for the last run of the model through the designer window.
 %End
 
-    void setLastRunChildAlgorithmInputs( const QMap<QString, QVariant> &inputs );
+    void setLastRunChildAlgorithmInputs( const QVariantMap &inputs );
 %Docstring
 Sets the inputs for child algorithms for the last run of the model through the designer window.
 %End

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -124,12 +124,12 @@ not correctly emit signals to allow the scene's model to update.
 Clears any selected items and sets ``item`` as the current selection.
 %End
 
-    void setChildAlgorithmResults( const QMap<QString, QVariant> &results );
+    void setChildAlgorithmResults( const QVariantMap &results );
 %Docstring
 Sets the results for child algorithms for the last model execution.
 %End
 
-    void setChildAlgorithmInputs( const QMap<QString, QVariant> &inputs );
+    void setChildAlgorithmInputs( const QVariantMap &inputs );
 %Docstring
 Sets the inputs for child algorithms for the last model execution.
 %End

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmconfigurationwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmconfigurationwidget.sip.in
@@ -33,12 +33,12 @@ Creates a new QgsProcessingAlgorithmConfigurationWidget
 %End
     ~QgsProcessingAlgorithmConfigurationWidget();
 
-    virtual QMap<QString, QVariant> configuration() const = 0;
+    virtual QVariantMap configuration() const = 0;
 %Docstring
 Read the current configuration from this widget.
 %End
 
-    virtual void setConfiguration( const QMap<QString, QVariant> &configuration ) = 0;
+    virtual void setConfiguration( const QVariantMap &configuration ) = 0;
 %Docstring
 Set the configuration which this widget should represent.
 %End

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -91,7 +91,7 @@ Returns ``True`` if an algorithm was executed in the dialog.
 .. seealso:: :py:func:`setExecuted`
 %End
 
-    QMap<QString, QVariant> results() const;
+    QVariantMap results() const;
 %Docstring
 Returns the results returned by the algorithm executed.
 
@@ -134,7 +134,7 @@ Sets the logging ``level`` to use when running algorithms from the dialog.
 .. versionadded:: 3.20
 %End
 
-    virtual void setParameters( const QMap<QString, QVariant> &values );
+    virtual void setParameters( const QVariantMap &values );
 %Docstring
 Sets the parameter ``values`` to show in the dialog.
 
@@ -280,7 +280,7 @@ Sets whether the algorithm was executed through the dialog.
 Sets whether the algorithm was executed through the dialog (no matter the result).
 %End
 
-    void setResults( const QMap<QString, QVariant> &results );
+    void setResults( const QVariantMap &results );
 %Docstring
 Sets the algorithm results.
 
@@ -363,7 +363,7 @@ This allows the dialog to override default Processing settings for an individual
 
   signals:
 
-    void algorithmFinished( bool successful, const QMap<QString, QVariant> &result );
+    void algorithmFinished( bool successful, const QVariantMap &result );
 %Docstring
 Emitted whenever an algorithm has finished executing in the dialog.
 
@@ -372,7 +372,7 @@ Emitted whenever an algorithm has finished executing in the dialog.
 
   protected slots:
 
-    virtual void finished( bool successful, const QMap<QString, QVariant> &result, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    virtual void finished( bool successful, const QVariantMap &result, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 %Docstring
 Called when the algorithm has finished executing.
 %End
@@ -382,7 +382,7 @@ Called when the algorithm has finished executing.
 Called when the dialog's algorithm should be run. Must be overridden by subclasses.
 %End
 
-    virtual void algExecuted( bool successful, const QMap<QString, QVariant> &results );
+    virtual void algExecuted( bool successful, const QVariantMap &results );
 %Docstring
 Called when an algorithm task has completed.
 

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingbatchalgorithmdialogbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingbatchalgorithmdialogbase.sip.in
@@ -49,7 +49,7 @@ Will be called when the "Run as Single" button is clicked.
 
   protected slots:
 
-    virtual void algExecuted( bool successful, const QMap<QString, QVariant> &results );
+    virtual void algExecuted( bool successful, const QVariantMap &results );
 
 
   protected:
@@ -70,12 +70,12 @@ Creates a new Processing context.
 (Each step in the batch processing will use a new Processing context)
 %End
 
-    virtual void handleAlgorithmResults( QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, QgsProcessingFeedback *feedback, const QMap<QString, QVariant> &parameters ) = 0;
+    virtual void handleAlgorithmResults( QgsProcessingAlgorithm *algorithm, QgsProcessingContext &context, QgsProcessingFeedback *feedback, const QVariantMap &parameters ) = 0;
 %Docstring
 Called when the dialog should handle the results of an algorithm, e.g. by loading layers into the current project.
 %End
 
-    virtual void loadHtmlResults( const QMap<QString, QVariant> &results, int index ) = 0;
+    virtual void loadHtmlResults( const QVariantMap &results, int index ) = 0;
 %Docstring
 Populates the HTML results dialog as a result of a successful algorithm execution.
 %End

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -56,7 +56,7 @@ An interface for objects which can create sets of parameter values for processin
     typedef QFlags<QgsProcessingParametersGenerator::Flag> Flags;
 
 
-    virtual QMap<QString, QVariant> createProcessingParameters( QgsProcessingParametersGenerator::Flags flags = QgsProcessingParametersGenerator::Flags() ) = 0;
+    virtual QVariantMap createProcessingParameters( QgsProcessingParametersGenerator::Flags flags = QgsProcessingParametersGenerator::Flags() ) = 0;
 %Docstring
 This method needs to be reimplemented in all classes which implement this interface
 and return a algorithm parameters.
@@ -340,7 +340,7 @@ Returns the current value of the parameter.
 .. seealso:: :py:func:`setParameterValue`
 %End
 
-    virtual QMap<QString, QVariant> customProperties() const;
+    virtual QVariantMap customProperties() const;
 %Docstring
 Returns any custom properties set by the wrapper.
 %End

--- a/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -36,7 +36,7 @@ Base class to build new relation widgets.
   public:
 
 
-    QgsAbstractRelationEditorWidget( const QMap<QString, QVariant> &config, QWidget *parent /TransferThis/ = 0 );
+    QgsAbstractRelationEditorWidget( const QVariantMap &config, QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor
 %End
@@ -167,12 +167,12 @@ Sets force suppress form popup status with ``forceSuppressFormPopup``
 configured for this widget
 %End
 
-    virtual QMap<QString, QVariant> config() const = 0;
+    virtual QVariantMap config() const = 0;
 %Docstring
 Returns the widget configuration
 %End
 
-    virtual void setConfig( const QMap<QString, QVariant> &config ) = 0;
+    virtual void setConfig( const QVariantMap &config ) = 0;
 %Docstring
 Defines the widget configuration
 %End
@@ -353,14 +353,14 @@ Create a new configuration widget
 :param parent: A parent widget
 %End
 
-    virtual QMap<QString, QVariant> config() = 0;
+    virtual QVariantMap config() = 0;
 %Docstring
 Create a configuration from the current GUI state
 
 :return: A widget configuration
 %End
 
-    virtual void setConfig( const QMap<QString, QVariant> &config ) = 0;
+    virtual void setConfig( const QVariantMap &config ) = 0;
 %Docstring
 Update the configuration widget to represent the given configuration.
 
@@ -430,7 +430,7 @@ Returns the machine readable identifier name of this widget type
 Returns the human readable identifier name of this widget type
 %End
 
-    virtual QgsAbstractRelationEditorWidget *create( const QMap<QString, QVariant> &config, QWidget *parent = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractRelationEditorWidget *create( const QVariantMap &config, QWidget *parent = 0 ) const = 0 /Factory/;
 %Docstring
 Override this in your implementation.
 Create a new relation widget. Call :py:func:`QgsEditorWidgetRegistry.create()`

--- a/python/PyQt6/gui/auto_generated/qgskeyvaluewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgskeyvaluewidget.sip.in
@@ -13,7 +13,7 @@
 class QgsKeyValueWidget: QgsTableWidgetBase
 {
 %Docstring(signature="appended")
-Widget allowing to edit a QMap<QString, QVariant>, using a table.
+Widget allowing to edit a QVariantMap, using a table.
 
 .. versionadded:: 3.0
 %End
@@ -28,16 +28,16 @@ Widget allowing to edit a QMap<QString, QVariant>, using a table.
 Constructor.
 %End
 
-    void setMap( const QMap<QString, QVariant> &map );
+    void setMap( const QVariantMap &map );
 %Docstring
 Set the initial value of the widget.
 %End
 
-    QMap<QString, QVariant> map() const;
+    QVariantMap map() const;
 %Docstring
 Gets the edit value.
 
-:return: the QMap<QString, QVariant>
+:return: the QVariantMap
 %End
 
 };

--- a/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -49,7 +49,7 @@ The default relation widget in QGIS.
     typedef QFlags<QgsRelationEditorWidget::Button> Buttons;
 
 
-    QgsRelationEditorWidget( const QMap<QString, QVariant> &config, QWidget *parent /TransferThis/ = 0 );
+    QgsRelationEditorWidget( const QVariantMap &config, QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor
 
@@ -124,13 +124,13 @@ Deletes the currently selected features
 Zooms to the selected features
 %End
 
-    virtual QMap<QString, QVariant> config() const;
+    virtual QVariantMap config() const;
 
 %Docstring
 Returns the current configuration
 %End
 
-    virtual void setConfig( const QMap<QString, QVariant> &config );
+    virtual void setConfig( const QVariantMap &config );
 
 %Docstring
 Defines the current configuration
@@ -175,7 +175,7 @@ Create a new configuration widget
 :param parent: A parent widget
 %End
 
-    virtual QMap<QString, QVariant> config();
+    virtual QVariantMap config();
 
 %Docstring
 Create a configuration from the current GUI state
@@ -183,7 +183,7 @@ Create a configuration from the current GUI state
 :return: A widget configuration
 %End
 
-    virtual void setConfig( const QMap<QString, QVariant> &config );
+    virtual void setConfig( const QVariantMap &config );
 
 %Docstring
 Update the configuration widget to represent the given configuration.

--- a/python/PyQt6/gui/auto_generated/qgsrelationwidgetregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrelationwidgetregistry.sip.in
@@ -50,7 +50,7 @@ Returns a list of names of registered relation widgets
 Gets access to all registered factories
 %End
 
-    QgsAbstractRelationEditorWidget *create( const QString &widgetType, const QMap<QString, QVariant> &config, QWidget *parent = 0 ) const /TransferBack/;
+    QgsAbstractRelationEditorWidget *create( const QString &widgetType, const QVariantMap &config, QWidget *parent = 0 ) const /TransferBack/;
 %Docstring
 Create a relation widget of a given type for a given field.
 

--- a/python/PyQt6/gui/auto_generated/qgsvariableeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsvariableeditorwidget.sip.in
@@ -95,7 +95,7 @@ of columns in the tree widget.
 .. seealso:: :py:func:`setSettingGroup`
 %End
 
-    QMap<QString, QVariant> variablesInActiveScope() const;
+    QVariantMap variablesInActiveScope() const;
 %Docstring
 Returns a map variables set within the editable scope. Read only variables are not
 returned. This method can be used to retrieve the variables edited an added by

--- a/python/PyQt6/server/auto_generated/qgsserverogcapihandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapihandler.sip.in
@@ -152,7 +152,7 @@ extract validated parameters from the request.
 :raises QgsServerApiBadRequestError: if the method encounters any error
 %End
 
-    virtual QMap<QString, QVariant> values( const QgsServerApiContext &context ) const throw( QgsServerApiBadRequestException );
+    virtual QVariantMap values( const QgsServerApiContext &context ) const throw( QgsServerApiBadRequestException );
 %Docstring
 Analyzes the incoming request ``context`` and returns the validated
 parameter map, throws :py:class:`QgsServerApiBadRequestError` in case of errors.
@@ -183,7 +183,7 @@ returns an empty string if there are not matches.
 
 
 
-    void write( QVariant &data, const QgsServerApiContext &context, const QMap<QString, QVariant> &htmlMetadata = QMap<QString, QVariant>() ) const throw( QgsServerApiBadRequestException );
+    void write( QVariant &data, const QgsServerApiContext &context, const QVariantMap &htmlMetadata = QVariantMap() ) const throw( QgsServerApiBadRequestException );
 %Docstring
 Writes ``data`` to the ``context`` response stream, content-type is calculated from the ``context`` request,
 optional ``htmlMetadata`` for the HTML templates can be specified and will be added as "metadata" to

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1010,7 +1010,7 @@ sub replace_macros {
     if ( $is_qt6 )
     {
         # sip for Qt6 chokes on QList/QVector<QVariantMap>, but is happy if you expand out the map explicitly
-        $line =~ s/(\s|QList<\s*|QVector<\s*)QVariantMap/$1QMap<QString, QVariant>/g;
+        $line =~ s/(QList<\s*|QVector<\s*)QVariantMap/$1QMap<QString, QVariant>/g;
     }
     return $line;
 }


### PR DESCRIPTION
The original workaround was only supposed to apply to QList/ QVector of QVariantMaps. By replacing them all in sip we break mapping of signals defined in c++ which are emitted by Python code.

Fixes exceptions after running processing algorithms in Qt6 builds.
