### PR TITLE
[pyqt5toqt6] Raise warning on QFontMetrics.width() 

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -96,7 +96,6 @@ PyQgsServerWMSGetMap
 PyQgsServerSettings
 PyQgsServerAccessControlWFSTransactional
 PyQgsServerWFS
-ProcessingGuiTest
 ProcessingProjectProviderTest
 ProcessingQgisAlgorithmsTestPt1
 ProcessingQgisAlgorithmsTestPt2

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -272,7 +272,7 @@ class DistanceInputPanel(NumberInputPanel):
                   QgsUnitTypes.DistanceUnit.DistanceYards):
             self.units_combo.addItem(QgsUnitTypes.toString(u), u)
 
-        label_margin = self.fontMetrics().width('X')
+        label_margin = self.fontMetrics().horizontalAdvance('X')
         self.layout().insertSpacing(1, int(label_margin / 2))
         self.layout().insertWidget(2, self.label)
         self.layout().insertWidget(3, self.units_combo)

--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -292,6 +292,14 @@ def fix_file(filename: str, qgis3_compat: bool) -> int:
                         src='')
 
                 custom_updates[Offset(node.lineno, node.col_offset)] = _replace_qvariant_type
+        elif isinstance(_node.value, ast.Call):
+            if (isinstance(_node.value.func, ast.Attribute) and
+                _node.value.func.attr == 'fontMetrics' and
+                    _node.attr == 'width'):
+                sys.stderr.write(
+                    f'{filename}:{_node.lineno}:{_node.col_offset} WARNING: QFontMetrics.width() '
+                    'has been removed in Qt6. Use QFontMetrics.horizontalAdvance() if plugin can '
+                    'safely require Qt >= 5.11, or QFontMetrics.boundingRect().width() otherwise.\n')
 
     def visit_import(_node: ast.ImportFrom, _parent):
         import_offsets[Offset(node.lineno, node.col_offset)] = (


### PR DESCRIPTION
This is removed in Qt6. Use QFontMetrics.horizontalAdvance() if plugin can safely require Qt >= 5.11, or QFontMetrics.boundingRect().width() otherwise