### PR TITLE
Some test suite fixes for qt6

### DIFF
--- a/python/plugins/grassprovider/tests/AlgorithmsTestBase.py
+++ b/python/plugins/grassprovider/tests/AlgorithmsTestBase.py
@@ -64,7 +64,7 @@ class AlgorithmsTest:
         """
         This is the main test function. All others will be executed based on the definitions in testdata/algorithm_tests.yaml
         """
-        with open(os.path.join(processingTestDataPath(), self.test_definition_file())) as stream:
+        with open(os.path.join(processingTestDataPath(), self.definition_file())) as stream:
             algorithm_tests = yaml.load(stream, Loader=yaml.SafeLoader)
 
         if 'tests' in algorithm_tests and algorithm_tests['tests'] is not None:

--- a/python/plugins/grassprovider/tests/grass_algorithms_imagery_test.py
+++ b/python/plugins/grassprovider/tests/grass_algorithms_imagery_test.py
@@ -50,7 +50,7 @@ class TestGrassAlgorithmsImageryTest(QgisTestCase, AlgorithmsTestBase.Algorithms
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'grass_algorithms_imagery_tests.yaml'
 
 

--- a/python/plugins/grassprovider/tests/grass_algorithms_raster_test_pt1.py
+++ b/python/plugins/grassprovider/tests/grass_algorithms_raster_test_pt1.py
@@ -51,7 +51,7 @@ class TestGrassAlgorithmsRasterTest(QgisTestCase, AlgorithmsTestBase.AlgorithmsT
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'grass_algorithms_raster_tests1.yaml'
 
 

--- a/python/plugins/grassprovider/tests/grass_algorithms_raster_test_pt2.py
+++ b/python/plugins/grassprovider/tests/grass_algorithms_raster_test_pt2.py
@@ -62,7 +62,7 @@ class TestGrassAlgorithmsRasterTest(QgisTestCase, AlgorithmsTestBase.AlgorithmsT
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'grass_algorithms_raster_tests2.yaml'
 
     def testNeighbors(self):

--- a/python/plugins/grassprovider/tests/grass_algorithms_vector_test.py
+++ b/python/plugins/grassprovider/tests/grass_algorithms_vector_test.py
@@ -67,7 +67,7 @@ class TestGrassAlgorithmsVectorTest(QgisTestCase, AlgorithmsTestBase.AlgorithmsT
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'grass_algorithms_vector_tests.yaml'
 
     def testMemoryLayerInput(self):

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -69,7 +69,7 @@ class AlgorithmsTest:
         """
         This is the main test function. All others will be executed based on the definitions in testdata/algorithm_tests.yaml
         """
-        with open(os.path.join(processingTestDataPath(), self.test_definition_file())) as stream:
+        with open(os.path.join(processingTestDataPath(), self.definition_file())) as stream:
             algorithm_tests = yaml.load(stream, Loader=yaml.SafeLoader)
 
         if 'tests' in algorithm_tests and algorithm_tests['tests'] is not None:

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -98,7 +98,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'gdal_algorithm_raster_tests.yaml'
 
     @staticmethod

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -59,7 +59,7 @@ class TestGdalVectorAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'gdal_algorithm_vector_tests.yaml'
 
     def testOgr2Ogr(self):

--- a/python/plugins/processing/tests/QgisAlgorithmsTest1.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest1.py
@@ -77,7 +77,7 @@ class TestQgisAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'qgis_algorithm_tests1.yaml'
 
     def testProcessingException(self):

--- a/python/plugins/processing/tests/QgisAlgorithmsTest2.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest2.py
@@ -52,7 +52,7 @@ class TestQgisAlgorithms2(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'qgis_algorithm_tests2.yaml'
 
 

--- a/python/plugins/processing/tests/QgisAlgorithmsTest3.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest3.py
@@ -52,7 +52,7 @@ class TestQgisAlgorithms3(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'qgis_algorithm_tests3.yaml'
 
 

--- a/python/plugins/processing/tests/QgisAlgorithmsTest4.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest4.py
@@ -61,7 +61,7 @@ class TestQgisAlgorithms4(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             shutil.rmtree(path)
         ProcessingConfig.setSettingValue(ModelerUtils.MODELS_FOLDER, cls._original_models_folder)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'qgis_algorithm_tests4.yaml'
 
 

--- a/python/plugins/processing/tests/QgisAlgorithmsTest5.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest5.py
@@ -46,7 +46,7 @@ class TestQgisAlgorithms5(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
         for path in cls.cleanup_paths:
             shutil.rmtree(path)
 
-    def test_definition_file(self):
+    def definition_file(self):
         return 'qgis_algorithm_tests5.yaml'
 
 

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -448,7 +448,7 @@ class QgisTestCase(unittest.TestCase):
 
             return True
 
-        def sort_by_pk_or_fid(f):
+        def get_pk_or_fid(f):
             if 'pk' in kwargs and kwargs['pk'] is not None:
                 key = kwargs['pk']
                 if isinstance(key, list) or isinstance(key, tuple):
@@ -457,6 +457,14 @@ class QgisTestCase(unittest.TestCase):
                     return f[kwargs['pk']]
             else:
                 return f.id()
+
+        def sort_by_pk_or_fid(f):
+            pk = get_pk_or_fid(f)
+            # we want NULL values sorted first, and don't want to try to
+            # directly compare NULL against non-NULL values
+            if isinstance(pk, list):
+                pk = [(v == NULL, v) for v in pk]
+            return (pk == NULL, pk)
 
         expected_features = sorted(layer_expected.getFeatures(request), key=sort_by_pk_or_fid)
         result_features = sorted(layer_result.getFeatures(request), key=sort_by_pk_or_fid)


### PR DESCRIPTION
- Gracefully handle NULL/not-NULL comparisons in QgisTestCase.checkLayersEqual. This just worked on Qt5 because NULL was a QVariant and the comparison was handed off to QVariant comparison, but on Qt6 NULL is None and Python raises an exception if we don't take care to avoid None/not None < comparisons
- Rename test_definition_file to definition_file. Avoids deprecation warnings when running test suite