### PR TITLE
Don't lose ellipse marker units when cloning

### DIFF
--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -386,7 +386,6 @@ QgsEllipseSymbolLayer *QgsEllipseSymbolLayer::clone() const
   m->setSizeMapUnitScale( mSizeMapUnitScale );
   m->setOffsetUnit( mOffsetUnit );
   m->setOffsetMapUnitScale( mOffsetMapUnitScale );
-  m->setOutputUnit( outputUnit() );
   m->setShape( mShape );
   m->setSymbolWidth( mSymbolWidth );
   m->setSymbolHeight( mSymbolHeight );


### PR DESCRIPTION
outputUnit/setOutputUnit is a funny beast, it shouldn't be copied when cloning symbols. Doing so force overwrites the previously set size/offset units
