### PR TITLE
Try to avoid crash when starting qt3d views

### DIFF
--- a/src/core/pointcloud/qgspointcloudstatscalculator.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculator.cpp
@@ -216,9 +216,7 @@ bool QgsPointCloudStatsCalculator::calculateStats( QgsFeedback *feedback, const 
 
   feedback->setProgress( 0 );
 
-  QThreadPool::globalInstance()->releaseThread();
   QVector<QgsPointCloudStatistics> list = QtConcurrent::blockingMapped( nodes, StatsProcessor( mIndex.get(), mRequest, feedback, 100.0 / ( double )nodes.size() ) );
-  QThreadPool::globalInstance()->reserveThread();
 
   for ( QgsPointCloudStatistics &s : list )
   {


### PR DESCRIPTION
This reverts #52913 which should not be needed anymore, because since #54845 the task manager has its own thread pool.

More about my findings here: https://github.com/qgis/QGIS/issues/53941#issuecomment-1939856859

I am not sure this will completely fix #53941 as #52913 was introduced in 3.32, however some people claim they got segfaults also in earlier versions. Nevertheless, at least for me, this changes from getting constant crashes when opening 3D views with COPC files (without statistics) to not crashing at all...


