### PR TITLE
File downloader tweaks

### DIFF
--- a/tests/src/gui/testqgsfiledownloader.cpp
+++ b/tests/src/gui/testqgsfiledownloader.cpp
@@ -222,8 +222,6 @@ void TestQgsFileDownloader::testSslError_data()
                              << "SSL Errors: ;The certificate has expired";
   QTest::newRow( "self-signed" ) << "https://self-signed.badssl.com/"
                                  << "SSL Errors: ;The certificate is self-signed, and untrusted";
-  QTest::newRow( "untrusted-root" ) << "https://untrusted-root.badssl.com/"
-                                    << "No certificates could be verified;SSL Errors: ;The issuer certificate of a locally looked up certificate could not be found";
 }
 
 void TestQgsFileDownloader::testSslError()


### PR DESCRIPTION
- remove manual redirect handling, just use Qt's redirect handling instead
- remove an extraneous test which fails on some platforms (eg Fedora) because of different SSL error strings