### PR TITLE
On qt6 builds, even non-class enums should be IntEnum types

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -45,7 +45,6 @@ PyQgsAuthenticationSystem
 PyQgsBlockingProcess
 PyQgsBookmarkModel
 PyQgsCodeEditor
-PyQgsColorRampLegendNode
 PyQgsDateTimeStatisticalSummary
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
@@ -55,12 +54,7 @@ PyQgsFieldModel
 PyQgsFloatingWidget
 PyQgsJsonUtils
 PyQgsLayerMetadata
-PyQgsLayerMetadataResultsModel
-PyQgsLayoutView
 PyQgsLayoutHtml
-PyQgsLayoutMarker
-PyQgsLayoutPolygon
-PyQgsLayoutPolyline
 PyQgsLineSymbolLayers
 PyQgsMapBoxGlStyleConverter
 PyQgsMetadataBase
@@ -69,7 +63,6 @@ PyQgsNetworkAccessManager
 PyQgsOGRProviderGpkg
 PyQgsPalLabelingPlacement
 PyQgsPlot
-PyQgsPointCloudAttributeModel
 PyQgsProjectMetadata
 PyQgsRasterAttributeTable
 PyQgsRasterLayerRenderer
@@ -77,10 +70,8 @@ PyQgsShapefileProvider
 PyQgsTextRenderer
 PyQgsOGRProvider
 PyQgsSpatialiteProvider
-PyQgsSymbolLayerCreateSld
 PyQgsSymbolLayerReadSld
 PyQgsStringUtils
-PyQgsStyleModel
 PyQgsTextDocument
 PyQgsVectorLayerCache
 PyQgsVectorLayerEditBuffer
@@ -89,10 +80,8 @@ PyQgsLayerDefinition
 PyQgsSettings
 PyQgsSettingsEntry
 PyQgsSelectiveMasking
-PyQgsServerApi
 PyQgsServerWMSGetFeatureInfo
 PyQgsServerWMSGetMap
-PyQgsServerSettings
 PyQgsServerAccessControlWFSTransactional
 PyQgsServerWFS
 ProcessingQgisAlgorithmsTestPt2

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -68,7 +68,7 @@ Returns number of pending jobs for all chunked entities
 .. versionadded:: 3.12
 %End
 
-    enum SceneState
+    enum SceneState /BaseType=IntEnum/
     {
       Ready,
       Updating,

--- a/python/PyQt6/3d/auto_generated/qgs3dtypes.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dtypes.sip.in
@@ -26,7 +26,7 @@ Defines enumerations and other auxiliary types for QGIS 3D
 %End
   public:
 
-    enum CullingMode
+    enum CullingMode /BaseType=IntEnum/
     {
       NoCulling,
       Front,
@@ -36,7 +36,7 @@ Defines enumerations and other auxiliary types for QGIS 3D
 
     static const char *PROP_NAME_3D_RENDERER_FLAG;
 
-    enum Flag3DRenderer
+    enum Flag3DRenderer /BaseType=IntEnum/
     {
       Main3DRenderer,
       Selected3DRenderer,

--- a/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -80,7 +80,7 @@ takes ownership of symbol, symbol may be ``None``
         ~Rule();
 
 
-        enum RegisterResult
+        enum RegisterResult /BaseType=IntEnum/
         {
           Filtered,
           Inactive,

--- a/python/PyQt6/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -28,7 +28,7 @@ class QgsPointCloud3DSymbol : QgsAbstract3DSymbol /Abstract/
 %End
   public:
 
-    enum RenderingStyle
+    enum RenderingStyle /BaseType=IntEnum/
     {
       // Do not render anything
       NoRendering,

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -49,21 +49,21 @@ can be an attribute or the z-coordinates in case of 3D types.
 %End
   public:
 
-    enum SourceType
+    enum SourceType /BaseType=IntEnum/
     {
       SourcePoints,
       SourceStructureLines,
       SourceBreakLines,
     };
 
-    enum ValueSource
+    enum ValueSource /BaseType=IntEnum/
     {
       ValueAttribute,
       ValueZ,
       ValueM,
     };
 
-    enum Result
+    enum Result /BaseType=IntEnum/
     {
       Success,
       Canceled,

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
@@ -23,7 +23,7 @@ Interpolation in a triangular irregular network
 %End
   public:
 
-    enum TinInterpolation
+    enum TinInterpolation /BaseType=IntEnum/
     {
       Linear,
       CloughTocher,

--- a/python/PyQt6/analysis/auto_generated/network/qgsvectorlayerdirector.sip.in
+++ b/python/PyQt6/analysis/auto_generated/network/qgsvectorlayerdirector.sip.in
@@ -23,7 +23,7 @@ Determine making the graph from vector line layer
 %End
   public:
 
-    enum Direction
+    enum Direction /BaseType=IntEnum/
     {
       DirectionForward,
       DirectionBackward,

--- a/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgskde.sip.in
@@ -24,7 +24,7 @@ Performs Kernel Density Estimation ("heatmap") calculations on a vector layer.
 %End
   public:
 
-    enum KernelShape
+    enum KernelShape /BaseType=IntEnum/
     {
       KernelQuartic,
       KernelTriangular,
@@ -33,13 +33,13 @@ Performs Kernel Density Estimation ("heatmap") calculations on a vector layer.
       KernelEpanechnikov,
     };
 
-    enum OutputValues
+    enum OutputValues /BaseType=IntEnum/
     {
       OutputRaw,
       OutputScaled,
     };
 
-    enum Result
+    enum Result /BaseType=IntEnum/
     {
       Success,
       DriverError,

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -21,7 +21,7 @@ Represents a node in a raster calculator.
 #include "qgsrastercalcnode.h"
 %End
   public:
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       tOperator,
       tNumber,
@@ -30,7 +30,7 @@ Represents a node in a raster calculator.
       tFunction
     };
 
-    enum Operator
+    enum Operator /BaseType=IntEnum/
     {
       opPLUS,
       opMINUS,

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -54,7 +54,7 @@ Performs raster layer calculations.
 %End
   public:
 
-    enum Result
+    enum Result /BaseType=IntEnum/
     {
       Success,
       CreateOutputError,

--- a/python/PyQt6/analysis/auto_generated/raster/qgsrastermatrix.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrastermatrix.sip.in
@@ -20,7 +20,7 @@ Represents a matrix in a raster calculator operation.
 %End
   public:
 
-    enum TwoArgOperator
+    enum TwoArgOperator /BaseType=IntEnum/
     {
       opPLUS,
       opMINUS,
@@ -39,7 +39,7 @@ Represents a matrix in a raster calculator operation.
       opMAX
     };
 
-    enum OneArgOperator
+    enum OneArgOperator /BaseType=IntEnum/
     {
       opSQRT,
       opSIN,

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -89,7 +89,7 @@ is aware of the available geometry checks.
 
     };
 
-    enum ChangeWhat
+    enum ChangeWhat /BaseType=IntEnum/
     {
       ChangeFeature,
       ChangePart,
@@ -97,21 +97,21 @@ is aware of the available geometry checks.
       ChangeNode
     };
 
-    enum ChangeType
+    enum ChangeType /BaseType=IntEnum/
     {
       ChangeAdded,
       ChangeRemoved,
       ChangeChanged
     };
 
-    enum CheckType
+    enum CheckType /BaseType=IntEnum/
     {
       FeatureNodeCheck,
       FeatureCheck,
       LayerCheck
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       AvailableInValidation
     };

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerror.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerror.sip.in
@@ -28,7 +28,7 @@ This represents an error reported by a geometry check.
 %End
   public:
 
-    enum Status
+    enum Status /BaseType=IntEnum/
     {
       StatusPending,
       StatusFixFailed,
@@ -36,7 +36,7 @@ This represents an error reported by a geometry check.
       StatusObsolete
     };
 
-    enum ValueType
+    enum ValueType /BaseType=IntEnum/
     {
       ValueLength,
       ValueArea,

--- a/python/PyQt6/analysis/auto_generated/vector/qgsgeometrysnapper.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/qgsgeometrysnapper.sip.in
@@ -26,7 +26,7 @@ match the reference layer features within a specified snap tolerance.
 %End
   public:
 
-    enum SnapMode
+    enum SnapMode /BaseType=IntEnum/
     {
       PreferNodes,
       PreferClosest,

--- a/python/PyQt6/core/auto_additions/qgsabstractdatabaseproviderconnection.py
+++ b/python/PyQt6/core/auto_additions/qgsabstractdatabaseproviderconnection.py
@@ -72,7 +72,10 @@ QgsAbstractDatabaseProviderConnection.GeometryColumnCapability.baseClass = QgsAb
 QgsAbstractDatabaseProviderConnection.GeometryColumnCapabilities = lambda flags=0: QgsAbstractDatabaseProviderConnection.GeometryColumnCapability(flags)
 QgsAbstractDatabaseProviderConnection.GeometryColumnCapabilities.baseClass = QgsAbstractDatabaseProviderConnection
 GeometryColumnCapabilities = QgsAbstractDatabaseProviderConnection  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsAbstractDatabaseProviderConnection.Capability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsabstractgeometry.py
+++ b/python/PyQt6/core/auto_additions/qgsabstractgeometry.py
@@ -7,7 +7,10 @@ QgsAbstractGeometry.YX = QgsAbstractGeometry.AxisOrder.YX
 QgsAbstractGeometry.FlagExportTrianglesAsPolygons = QgsAbstractGeometry.WkbFlag.FlagExportTrianglesAsPolygons
 QgsAbstractGeometry.FlagExportNanAsDoubleMin = QgsAbstractGeometry.WkbFlag.FlagExportNanAsDoubleMin
 QgsAbstractGeometry.WkbFlags = lambda flags=0: QgsAbstractGeometry.WkbFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsAbstractGeometry.WkbFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsattributeeditorrelation.py
+++ b/python/PyQt6/core/auto_additions/qgsattributeeditorrelation.py
@@ -11,7 +11,10 @@ QgsAttributeEditorRelation.Button.baseClass = QgsAttributeEditorRelation
 QgsAttributeEditorRelation.Buttons = lambda flags=0: QgsAttributeEditorRelation.Button(flags)
 QgsAttributeEditorRelation.Buttons.baseClass = QgsAttributeEditorRelation
 Buttons = QgsAttributeEditorRelation  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsAttributeEditorRelation.Button.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsauthmethod.py
+++ b/python/PyQt6/core/auto_additions/qgsauthmethod.py
@@ -6,7 +6,10 @@ QgsAuthMethod.GenericDataSourceUri = QgsAuthMethod.Expansion.GenericDataSourceUr
 QgsAuthMethod.NetworkProxy = QgsAuthMethod.Expansion.NetworkProxy
 QgsAuthMethod.All = QgsAuthMethod.Expansion.All
 QgsAuthMethod.Expansions = lambda flags=0: QgsAuthMethod.Expansion(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsAuthMethod.Expansion.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsclassificationmethod.py
+++ b/python/PyQt6/core/auto_additions/qgsclassificationmethod.py
@@ -7,7 +7,10 @@ QgsClassificationMethod.MethodProperties = lambda flags=0: QgsClassificationMeth
 QgsClassificationMethod.LowerBound = QgsClassificationMethod.ClassPosition.LowerBound
 QgsClassificationMethod.Inner = QgsClassificationMethod.ClassPosition.Inner
 QgsClassificationMethod.UpperBound = QgsClassificationMethod.ClassPosition.UpperBound
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsClassificationMethod.MethodProperty.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgscolorscheme.py
+++ b/python/PyQt6/core/auto_additions/qgscolorscheme.py
@@ -3,7 +3,10 @@ QgsColorScheme.ShowInColorDialog = QgsColorScheme.SchemeFlag.ShowInColorDialog
 QgsColorScheme.ShowInColorButtonMenu = QgsColorScheme.SchemeFlag.ShowInColorButtonMenu
 QgsColorScheme.ShowInAllContexts = QgsColorScheme.SchemeFlag.ShowInAllContexts
 QgsColorScheme.SchemeFlags = lambda flags=0: QgsColorScheme.SchemeFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsColorScheme.SchemeFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgscoordinateformatter.py
+++ b/python/PyQt6/core/auto_additions/qgscoordinateformatter.py
@@ -6,7 +6,10 @@ QgsCoordinateFormatter.FormatDecimalDegrees = QgsCoordinateFormatter.Format.Form
 QgsCoordinateFormatter.FlagDegreesUseStringSuffix = QgsCoordinateFormatter.FormatFlag.FlagDegreesUseStringSuffix
 QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds = QgsCoordinateFormatter.FormatFlag.FlagDegreesPadMinutesSeconds
 QgsCoordinateFormatter.FormatFlags = lambda flags=0: QgsCoordinateFormatter.FormatFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsCoordinateFormatter.FormatFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsdataprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsdataprovider.py
@@ -10,7 +10,10 @@ QgsDataProvider.ForceReadOnly = QgsDataProvider.ReadFlag.ForceReadOnly
 QgsDataProvider.SkipCredentialsRequest = QgsDataProvider.ReadFlag.SkipCredentialsRequest
 QgsDataProvider.ParallelThreadLoading = QgsDataProvider.ReadFlag.ParallelThreadLoading
 QgsDataProvider.ReadFlags = lambda flags=0: QgsDataProvider.ReadFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsDataProvider.ReadFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsdxfexport.py
+++ b/python/PyQt6/core/auto_additions/qgsdxfexport.py
@@ -35,7 +35,10 @@ QgsDxfExport.PolygonMesh = QgsDxfExport.DxfPolylineFlag.PolygonMesh
 QgsDxfExport.PolyfaceMesh = QgsDxfExport.DxfPolylineFlag.PolyfaceMesh
 QgsDxfExport.ContinuousPattern = QgsDxfExport.DxfPolylineFlag.ContinuousPattern
 QgsDxfExport.DxfPolylineFlags = lambda flags=0: QgsDxfExport.DxfPolylineFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsDxfExport.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsfeaturesink.py
+++ b/python/PyQt6/core/auto_additions/qgsfeaturesink.py
@@ -4,7 +4,10 @@ QgsFeatureSink.SinkFlags = lambda flags=0: QgsFeatureSink.SinkFlag(flags)
 QgsFeatureSink.FastInsert = QgsFeatureSink.Flag.FastInsert
 QgsFeatureSink.RollBackOnErrors = QgsFeatureSink.Flag.RollBackOnErrors
 QgsFeatureSink.Flags = lambda flags=0: QgsFeatureSink.Flag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsFeatureSink.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsfieldconstraints.py
+++ b/python/PyQt6/core/auto_additions/qgsfieldconstraints.py
@@ -9,7 +9,10 @@ QgsFieldConstraints.ConstraintOriginLayer = QgsFieldConstraints.ConstraintOrigin
 QgsFieldConstraints.ConstraintStrengthNotSet = QgsFieldConstraints.ConstraintStrength.ConstraintStrengthNotSet
 QgsFieldConstraints.ConstraintStrengthHard = QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard
 QgsFieldConstraints.ConstraintStrengthSoft = QgsFieldConstraints.ConstraintStrength.ConstraintStrengthSoft
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsFieldConstraints.Constraint.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsfieldproxymodel.py
+++ b/python/PyQt6/core/auto_additions/qgsfieldproxymodel.py
@@ -14,7 +14,10 @@ QgsFieldProxyModel.AllTypes = QgsFieldProxyModel.Filter.AllTypes
 QgsFieldProxyModel.Filters = lambda flags=0: QgsFieldProxyModel.Filter(flags)
 QgsFieldProxyModel.Filters.baseClass = QgsFieldProxyModel
 Filters = QgsFieldProxyModel  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsFieldProxyModel.Filter.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslayertreemodel.py
+++ b/python/PyQt6/core/auto_additions/qgslayertreemodel.py
@@ -11,7 +11,10 @@ QgsLayerTreeModel.AllowLegendChangeState = QgsLayerTreeModel.Flag.AllowLegendCha
 QgsLayerTreeModel.ActionHierarchical = QgsLayerTreeModel.Flag.ActionHierarchical
 QgsLayerTreeModel.UseThreadedHitTest = QgsLayerTreeModel.Flag.UseThreadedHitTest
 QgsLayerTreeModel.Flags = lambda flags=0: QgsLayerTreeModel.Flag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLayerTreeModel.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslayoutitem.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitem.py
@@ -116,7 +116,10 @@ QgsLayoutItem.CanGroupWithAnyOtherItem = QgsLayoutItem.ExportLayerBehavior.CanGr
 QgsLayoutItem.CanGroupWithItemsOfSameType = QgsLayoutItem.ExportLayerBehavior.CanGroupWithItemsOfSameType
 QgsLayoutItem.MustPlaceInOwnLayer = QgsLayoutItem.ExportLayerBehavior.MustPlaceInOwnLayer
 QgsLayoutItem.ItemContainsSubLayers = QgsLayoutItem.ExportLayerBehavior.ItemContainsSubLayers
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLayoutItem.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslayoutitemmap.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitemmap.py
@@ -5,7 +5,10 @@ QgsLayoutItemMap.Auto = QgsLayoutItemMap.AtlasScalingMode.Auto
 QgsLayoutItemMap.ShowPartialLabels = QgsLayoutItemMap.MapItemFlag.ShowPartialLabels
 QgsLayoutItemMap.ShowUnplacedLabels = QgsLayoutItemMap.MapItemFlag.ShowUnplacedLabels
 QgsLayoutItemMap.MapItemFlags = lambda flags=0: QgsLayoutItemMap.MapItemFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLayoutItemMap.MapItemFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslayoutitemmapgrid.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitemmapgrid.py
@@ -50,7 +50,10 @@ QgsLayoutItemMapGrid.FrameBottom = QgsLayoutItemMapGrid.FrameSideFlag.FrameBotto
 QgsLayoutItemMapGrid.FrameSideFlags = lambda flags=0: QgsLayoutItemMapGrid.FrameSideFlag(flags)
 QgsLayoutItemMapGrid.Longitude = QgsLayoutItemMapGrid.AnnotationCoordinate.Longitude
 QgsLayoutItemMapGrid.Latitude = QgsLayoutItemMapGrid.AnnotationCoordinate.Latitude
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLayoutItemMapGrid.FrameSideFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslayoutmanager.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutmanager.py
@@ -13,7 +13,10 @@ QgsLayoutManagerProxyModel.FilterReports = QgsLayoutManagerProxyModel.Filter.Fil
 QgsLayoutManagerProxyModel.Filters = lambda flags=0: QgsLayoutManagerProxyModel.Filter(flags)
 QgsLayoutManagerProxyModel.Filters.baseClass = QgsLayoutManagerProxyModel
 Filters = QgsLayoutManagerProxyModel  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLayoutManagerProxyModel.Filter.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgslocatorfilter.py
+++ b/python/PyQt6/core/auto_additions/qgslocatorfilter.py
@@ -9,7 +9,10 @@ QgsLocatorFilter.FlagFast = QgsLocatorFilter.Flag.FlagFast
 QgsLocatorFilter.Flags = lambda flags=0: QgsLocatorFilter.Flag(flags)
 QgsLocatorFilter.Flags.baseClass = QgsLocatorFilter
 Flags = QgsLocatorFilter  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsLocatorFilter.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsmaplayer.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayer.py
@@ -37,7 +37,10 @@ QgsMapLayer.FlagTrustLayerMetadata = QgsMapLayer.ReadFlag.FlagTrustLayerMetadata
 QgsMapLayer.FlagReadExtentFromXml = QgsMapLayer.ReadFlag.FlagReadExtentFromXml
 QgsMapLayer.FlagForceReadOnly = QgsMapLayer.ReadFlag.FlagForceReadOnly
 QgsMapLayer.ReadFlags = lambda flags=0: QgsMapLayer.ReadFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsMapLayer.LayerFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgspointcloudattributemodel.py
+++ b/python/PyQt6/core/auto_additions/qgspointcloudattributemodel.py
@@ -38,7 +38,10 @@ QgsPointCloudAttributeProxyModel.AllTypes = QgsPointCloudAttributeProxyModel.Fil
 QgsPointCloudAttributeProxyModel.Filters = lambda flags=0: QgsPointCloudAttributeProxyModel.Filter(flags)
 QgsPointCloudAttributeProxyModel.Filters.baseClass = QgsPointCloudAttributeProxyModel
 Filters = QgsPointCloudAttributeProxyModel  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsPointCloudAttributeProxyModel.Filter.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsprocessingcontext.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingcontext.py
@@ -6,7 +6,10 @@ QgsProcessingContext.ProcessArgumentFlag.IncludeProjectPath.__doc__ = "Include t
 QgsProcessingContext.ProcessArgumentFlag.__doc__ = "Flags controlling the results given by :py:func:`~QgsProcessingContext.asQgisProcessArguments`.\n\n.. versionadded:: 3.24\n\n" + '* ``IncludeProjectPath``: ' + QgsProcessingContext.ProcessArgumentFlag.IncludeProjectPath.__doc__
 # --
 QgsProcessingContext.ProcessArgumentFlags = lambda flags=0: QgsProcessingContext.ProcessArgumentFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsProcessingContext.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsprovidermetadata.py
+++ b/python/PyQt6/core/auto_additions/qgsprovidermetadata.py
@@ -7,7 +7,10 @@ QgsMeshDriverMetadata.MeshDriverCapability.baseClass = QgsMeshDriverMetadata
 QgsMeshDriverMetadata.MeshDriverCapabilities = lambda flags=0: QgsMeshDriverMetadata.MeshDriverCapability(flags)
 QgsMeshDriverMetadata.MeshDriverCapabilities.baseClass = QgsMeshDriverMetadata
 MeshDriverCapabilities = QgsMeshDriverMetadata  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsMeshDriverMetadata.MeshDriverCapability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsrasterdataprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsrasterdataprovider.py
@@ -21,7 +21,10 @@ QgsRasterDataProvider.ResamplingMethod.Mode.__doc__ = "Mode (selects the value w
 QgsRasterDataProvider.ResamplingMethod.Gauss.__doc__ = "Gauss blurring"
 QgsRasterDataProvider.ResamplingMethod.__doc__ = "Resampling method for provider-level resampling.\n\n.. versionadded:: 3.16\n\n" + '* ``Nearest``: ' + QgsRasterDataProvider.ResamplingMethod.Nearest.__doc__ + '\n' + '* ``Bilinear``: ' + QgsRasterDataProvider.ResamplingMethod.Bilinear.__doc__ + '\n' + '* ``Cubic``: ' + QgsRasterDataProvider.ResamplingMethod.Cubic.__doc__ + '\n' + '* ``CubicSpline``: ' + QgsRasterDataProvider.ResamplingMethod.CubicSpline.__doc__ + '\n' + '* ``Lanczos``: ' + QgsRasterDataProvider.ResamplingMethod.Lanczos.__doc__ + '\n' + '* ``Average``: ' + QgsRasterDataProvider.ResamplingMethod.Average.__doc__ + '\n' + '* ``Mode``: ' + QgsRasterDataProvider.ResamplingMethod.Mode.__doc__ + '\n' + '* ``Gauss``: ' + QgsRasterDataProvider.ResamplingMethod.Gauss.__doc__
 # --
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsRasterDataProvider.ProviderCapability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsrenderer.py
+++ b/python/PyQt6/core/auto_additions/qgsrenderer.py
@@ -4,7 +4,10 @@ QgsFeatureRenderer.MoreSymbolsPerFeature = QgsFeatureRenderer.Capability.MoreSym
 QgsFeatureRenderer.Filter = QgsFeatureRenderer.Capability.Filter
 QgsFeatureRenderer.ScaleDependent = QgsFeatureRenderer.Capability.ScaleDependent
 QgsFeatureRenderer.Capabilities = lambda flags=0: QgsFeatureRenderer.Capability(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsFeatureRenderer.Capability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsrendererregistry.py
+++ b/python/PyQt6/core/auto_additions/qgsrendererregistry.py
@@ -4,7 +4,10 @@ QgsRendererAbstractMetadata.LineLayer = QgsRendererAbstractMetadata.LayerType.Li
 QgsRendererAbstractMetadata.PolygonLayer = QgsRendererAbstractMetadata.LayerType.PolygonLayer
 QgsRendererAbstractMetadata.All = QgsRendererAbstractMetadata.LayerType.All
 QgsRendererAbstractMetadata.LayerTypes = lambda flags=0: QgsRendererAbstractMetadata.LayerType(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsRendererAbstractMetadata.LayerType.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsspatialindex.py
+++ b/python/PyQt6/core/auto_additions/qgsspatialindex.py
@@ -1,7 +1,10 @@
 # The following has been generated automatically from src/core/qgsspatialindex.h
 QgsSpatialIndex.FlagStoreFeatureGeometries = QgsSpatialIndex.Flag.FlagStoreFeatureGeometries
 QgsSpatialIndex.Flags = lambda flags=0: QgsSpatialIndex.Flag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsSpatialIndex.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgstaskmanager.py
+++ b/python/PyQt6/core/auto_additions/qgstaskmanager.py
@@ -13,7 +13,10 @@ QgsTask.AllFlags = QgsTask.Flag.AllFlags
 QgsTask.Flags = lambda flags=0: QgsTask.Flag(flags)
 QgsTask.SubTaskIndependent = QgsTask.SubTaskDependency.SubTaskIndependent
 QgsTask.ParentDependsOnSubTask = QgsTask.SubTaskDependency.ParentDependsOnSubTask
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsTask.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsvectordataprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsvectordataprovider.py
@@ -25,7 +25,10 @@ QgsVectorDataProvider.CreateLabeling = QgsVectorDataProvider.Capability.CreateLa
 QgsVectorDataProvider.ReloadData = QgsVectorDataProvider.Capability.ReloadData
 QgsVectorDataProvider.FeatureSymbology = QgsVectorDataProvider.Capability.FeatureSymbology
 QgsVectorDataProvider.Capabilities = lambda flags=0: QgsVectorDataProvider.Capability(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsVectorDataProvider.Capability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsvectorfilewriter.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorfilewriter.py
@@ -29,7 +29,10 @@ QgsVectorFileWriter.CreateOrOverwriteFile = QgsVectorFileWriter.ActionOnExisting
 QgsVectorFileWriter.CreateOrOverwriteLayer = QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
 QgsVectorFileWriter.AppendToLayerNoNewFields = QgsVectorFileWriter.ActionOnExistingFile.AppendToLayerNoNewFields
 QgsVectorFileWriter.AppendToLayerAddFields = QgsVectorFileWriter.ActionOnExistingFile.AppendToLayerAddFields
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsVectorFileWriter.EditionCapability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_additions/qgsvectorsimplifymethod.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorsimplifymethod.py
@@ -12,7 +12,10 @@ QgsVectorSimplifyMethod.SnapToGrid = QgsVectorSimplifyMethod.SimplifyAlgorithm.S
 QgsVectorSimplifyMethod.Visvalingam = QgsVectorSimplifyMethod.SimplifyAlgorithm.Visvalingam
 QgsVectorSimplifyMethod.SnappedToGridGlobal = QgsVectorSimplifyMethod.SimplifyAlgorithm.SnappedToGridGlobal
 QgsVectorSimplifyMethod.SimplifyAlgorithm.baseClass = QgsVectorSimplifyMethod
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsVectorSimplifyMethod.SimplifyHint.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/core/auto_generated/auth/qgsauthcertutils.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthcertutils.sip.in
@@ -23,7 +23,7 @@ Utilities for working with certificates and keys
 #include "qgsauthcertutils.h"
 %End
   public:
-    enum CaCertSource
+    enum CaCertSource /BaseType=IntEnum/
     {
       SystemRoot,
       FromFile,
@@ -31,7 +31,7 @@ Utilities for working with certificates and keys
       Connection
     };
 
-    enum CertTrustPolicy
+    enum CertTrustPolicy /BaseType=IntEnum/
     {
       DefaultTrust,
       Trusted,
@@ -39,7 +39,7 @@ Utilities for working with certificates and keys
       NoPolicy
     };
 
-    enum CertUsageType
+    enum CertUsageType /BaseType=IntEnum/
     {
       UndeterminedUsage,
       AnyOrUnspecifiedUsage,
@@ -54,7 +54,7 @@ Utilities for working with certificates and keys
       CRLSigningUsage
     };
 
-    enum ConstraintGroup
+    enum ConstraintGroup /BaseType=IntEnum/
     {
       KeyUsage,
       ExtendedKeyUsage

--- a/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -28,7 +28,7 @@ and to utilize configurations through various authentication method plugins
 %End
   public:
 
-    enum MessageLevel
+    enum MessageLevel /BaseType=IntEnum/
     {
       INFO,
       WARNING,

--- a/python/PyQt6/core/auto_generated/auth/qgsauthmethod.sip.in
+++ b/python/PyQt6/core/auto_generated/auth/qgsauthmethod.sip.in
@@ -21,7 +21,7 @@ Abstract base class for authentication method plugins
 %End
   public:
 
-    enum Expansion
+    enum Expansion /BaseType=IntEnum/
     {
       // TODO: Figure out all different authentication expansions current layer providers use
       NetworkRequest,

--- a/python/PyQt6/core/auto_generated/browser/qgsbrowserproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsbrowserproxymodel.sip.in
@@ -21,7 +21,7 @@ A QSortFilterProxyModel subclass for filtering and sorting browser model items.
 %End
   public:
 
-    enum FilterSyntax
+    enum FilterSyntax /BaseType=IntEnum/
     {
       Normal,
       Wildcards,

--- a/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
@@ -70,13 +70,13 @@ relevant symbology elements to render them.
       BlendMode,
     };
 
-    enum DrawOrder
+    enum DrawOrder /BaseType=IntEnum/
     {
       OrderBelowAllLabels,
       OrderBelowIndividualLabels,
     };
 
-    enum AnchorPoint
+    enum AnchorPoint /BaseType=IntEnum/
     {
       PoleOfInaccessibility,
       PointOnExterior,
@@ -84,7 +84,7 @@ relevant symbology elements to render them.
       Centroid,
     };
 
-    enum LabelAnchorPoint
+    enum LabelAnchorPoint /BaseType=IntEnum/
     {
       LabelPointOnExterior,
       LabelCentroid,
@@ -788,7 +788,7 @@ Draws curved lines as callouts.
 %End
   public:
 
-    enum Orientation
+    enum Orientation /BaseType=IntEnum/
     {
       Automatic,
       Clockwise,

--- a/python/PyQt6/core/auto_generated/classification/qgsclassificationlogarithmic.sip.in
+++ b/python/PyQt6/core/auto_generated/classification/qgsclassificationlogarithmic.sip.in
@@ -22,7 +22,7 @@ Implementation of a logarithmic scale method
 %End
   public:
 
-    enum NegativeValueHandling
+    enum NegativeValueHandling /BaseType=IntEnum/
     {
       NoHandling,
       Discard,

--- a/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
+++ b/python/PyQt6/core/auto_generated/classification/qgsclassificationmethod.sip.in
@@ -95,7 +95,7 @@ class QgsClassificationMethod /Abstract/
 %End
   public:
 
-    enum MethodProperty
+    enum MethodProperty /BaseType=IntEnum/
     {
       NoFlag,
       ValuesNotRequired,
@@ -106,7 +106,7 @@ class QgsClassificationMethod /Abstract/
 
 
 
-    enum ClassPosition
+    enum ClassPosition /BaseType=IntEnum/
     {
       LowerBound,
       Inner,

--- a/python/PyQt6/core/auto_generated/diagram/qgstextdiagram.sip.in
+++ b/python/PyQt6/core/auto_generated/diagram/qgstextdiagram.sip.in
@@ -19,14 +19,14 @@ A text based diagram.
 #include "qgstextdiagram.h"
 %End
   public:
-    enum Shape
+    enum Shape /BaseType=IntEnum/
     {
       Circle,
       Rectangle,
       Triangle
     };
 
-    enum Orientation
+    enum Orientation /BaseType=IntEnum/
     {
       Horizontal,
       Vertical

--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -53,7 +53,7 @@ unique value.
 
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagNoMText,
     };
@@ -88,7 +88,7 @@ unique value.
       Undefined
     };
 
-    enum DxfPolylineFlag
+    enum DxfPolylineFlag /BaseType=IntEnum/
     {
       Closed,
       Curve,

--- a/python/PyQt6/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
@@ -22,7 +22,7 @@ This element will load a relation editor onto the form.
 
   public:
 
-    enum Button
+    enum Button /BaseType=IntEnum/
     {
       Link,
       Unlink,

--- a/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsblureffect.sip.in
@@ -24,7 +24,7 @@ methods.
 %End
   public:
 
-    enum BlurMethod
+    enum BlurMethod /BaseType=IntEnum/
     {
       StackBlur,
       GaussianBlur

--- a/python/PyQt6/core/auto_generated/effects/qgsgloweffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsgloweffect.sip.in
@@ -25,7 +25,7 @@ picture.
 %End
   public:
 
-    enum GlowColorType
+    enum GlowColorType /BaseType=IntEnum/
     {
       SingleColor,
       ColorRamp

--- a/python/PyQt6/core/auto_generated/effects/qgsimageoperation.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgsimageoperation.sip.in
@@ -32,7 +32,7 @@ on which is faster for the particular operation.
 %End
   public:
 
-    enum GrayscaleMode
+    enum GrayscaleMode /BaseType=IntEnum/
     {
       GrayscaleLightness,
       GrayscaleLuminosity,
@@ -40,7 +40,7 @@ on which is faster for the particular operation.
       GrayscaleOff
     };
 
-    enum FlipType
+    enum FlipType /BaseType=IntEnum/
     {
       FlipHorizontal,
       FlipVertical

--- a/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/PyQt6/core/auto_generated/effects/qgspainteffect.sip.in
@@ -78,7 +78,7 @@ and render the result to the render context's paint device.
 %End
   public:
 
-    enum DrawMode
+    enum DrawMode /BaseType=IntEnum/
     {
       Modifier,
       Render,

--- a/python/PyQt6/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpression.sip.in
@@ -81,7 +81,7 @@ Implicit sharing was added in 2.14
 
     struct ParserError
     {
-      enum ParserErrorType
+      enum ParserErrorType /BaseType=IntEnum/
       {
         Unknown,
         FunctionUnknown,
@@ -494,7 +494,7 @@ value.
 .. versionadded:: 2.7
 %End
 
-    enum SpatialOperator
+    enum SpatialOperator /BaseType=IntEnum/
     {
       soBbox,
       soIntersects,

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -55,7 +55,7 @@ Abstract base class for all nodes that can appear in an expression.
 %End
   public:
 
-    enum NodeType
+    enum NodeType /BaseType=IntEnum/
     {
       ntUnaryOperator,
       ntBinaryOperator,

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -20,7 +20,7 @@ A unary node is either negative as in boolean (not) or as in numbers (minus).
 %End
   public:
 
-    enum UnaryOperator
+    enum UnaryOperator /BaseType=IntEnum/
     {
       uoNot,
       uoMinus,
@@ -88,7 +88,7 @@ A binary expression operator, which operates on two values.
 %End
   public:
 
-    enum BinaryOperator
+    enum BinaryOperator /BaseType=IntEnum/
     {
       // logical
       boOr,

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -21,7 +21,7 @@ Field formatter for a checkbox field.
 %End
   public:
 
-    enum TextDisplayMethod
+    enum TextDisplayMethod /BaseType=IntEnum/
     {
       ShowTrueFalse,
       ShowStoredValues,

--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -73,7 +73,7 @@ Abstract base class for all geometries
 
   public:
 
-    enum SegmentationToleranceType
+    enum SegmentationToleranceType /BaseType=IntEnum/
     {
 
       MaximumAngle,
@@ -81,7 +81,7 @@ Abstract base class for all geometries
       MaximumDifference
     };
 
-    enum AxisOrder
+    enum AxisOrder /BaseType=IntEnum/
     {
 
       XY,
@@ -243,7 +243,7 @@ Sets the geometry from a WKT string.
 %End
 
 
-    enum WkbFlag
+    enum WkbFlag /BaseType=IntEnum/
     {
       FlagExportTrianglesAsPolygons,
       FlagExportNanAsDoubleMin,

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -58,7 +58,7 @@ Example
 %End
   public:
 
-    enum EngineOperationResult
+    enum EngineOperationResult /BaseType=IntEnum/
     {
       Success,
       NothingHappened,

--- a/python/PyQt6/core/auto_generated/geometry/qgsquadrilateral.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsquadrilateral.sip.in
@@ -56,7 +56,7 @@ Construct a QgsQuadrilateral from four :py:class:`QgsPointXY`.
 %End
 
 
-    enum ConstructionOption
+    enum ConstructionOption /BaseType=IntEnum/
     {
       Distance,
       Projected,
@@ -138,7 +138,7 @@ A QgsQuadrilateral must be simple (not self-intersecting) and
 cannot have collinear points.
 %End
 
-    enum Point
+    enum Point /BaseType=IntEnum/
     {
       Point1,
       Point2,

--- a/python/PyQt6/core/auto_generated/geometry/qgsregularpolygon.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsregularpolygon.sip.in
@@ -27,7 +27,7 @@ The regular polygon is defined by a center point with a number of sides/vertices
 %End
   public:
 
-    enum ConstructionOption
+    enum ConstructionOption /BaseType=IntEnum/
     {
       InscribedCircle,
       CircumscribedCircle

--- a/python/PyQt6/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -38,7 +38,7 @@ Abstract base class for connection to a GPS device
 %End
   public:
 
-    enum Status
+    enum Status /BaseType=IntEnum/
     {
       NotConnected,
       Connected,

--- a/python/PyQt6/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgslabelingenginesettings.sip.in
@@ -22,7 +22,7 @@ Stores global configuration for labeling engine
   public:
 
 
-    enum Search
+    enum Search /BaseType=IntEnum/
     {
       Chain,
       Popmusic_Tabu,

--- a/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
@@ -44,7 +44,7 @@ takes ownership of settings, settings may be ``None``
         ~Rule();
 
 
-        enum RegisterResult
+        enum RegisterResult /BaseType=IntEnum/
         {
           Filtered,
           Inactive,

--- a/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgscolorramplegendnodesettings.sip.in
@@ -23,7 +23,7 @@ Settings for a color ramp legend node.
 %End
   public:
 
-    enum Direction
+    enum Direction /BaseType=IntEnum/
     {
       MinimumToMaximum,
       MaximumToMinimum,

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreelayer.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreelayer.sip.in
@@ -186,7 +186,7 @@ symbol width or height from :py:class:`QgsLegendSettings`.
 .. versionadded:: 3.14
 %End
 
-    enum LegendNodesSplitBehavior
+    enum LegendNodesSplitBehavior /BaseType=IntEnum/
     {
       UseDefaultLegendSetting,
       AllowSplittingLegendNodesOverMultipleColumns,

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -75,7 +75,7 @@ The root node is not transferred by the model.
 
 
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       // display flags
       ShowLegend,

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -55,7 +55,7 @@ and customized look.
       NodeType,
     };
 
-    enum NodeTypes
+    enum NodeTypes /BaseType=IntEnum/
     {
       SimpleLegend,
       SymbolLegend,

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -82,7 +82,7 @@ Custom properties that have already been used within QGIS:
 %End
   public:
 
-    enum NodeType
+    enum NodeType /BaseType=IntEnum/
     {
       NodeGroup,
       NodeLayer

--- a/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgsabstractreportsection.sip.in
@@ -357,7 +357,7 @@ should be canceled.
 
   protected:
 
-    enum SubSection
+    enum SubSection /BaseType=IntEnum/
     {
       Header,
       Body,

--- a/python/PyQt6/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayout.sip.in
@@ -27,7 +27,7 @@ user settings such as the layout context DPI.
 %End
   public:
 
-    enum ZValues
+    enum ZValues /BaseType=IntEnum/
     {
       ZPage,
       ZItem,
@@ -39,7 +39,7 @@ user settings such as the layout context DPI.
       ZSnapIndicator,
     };
 
-    enum UndoCommand
+    enum UndoCommand /BaseType=IntEnum/
     {
       UndoLayoutDpi,
       UndoNone,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutaligner.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutaligner.sip.in
@@ -24,7 +24,7 @@ sets of layout items, e.g. aligning a group of items to top or left sides.
 %End
   public:
 
-    enum Alignment
+    enum Alignment /BaseType=IntEnum/
     {
       AlignLeft,
       AlignHCenter,
@@ -34,7 +34,7 @@ sets of layout items, e.g. aligning a group of items to top or left sides.
       AlignBottom,
     };
 
-    enum Distribution
+    enum Distribution /BaseType=IntEnum/
     {
       DistributeLeft,
       DistributeHCenter,
@@ -46,7 +46,7 @@ sets of layout items, e.g. aligning a group of items to top or left sides.
       DistributeBottom,
     };
 
-    enum Resize
+    enum Resize /BaseType=IntEnum/
     {
       ResizeNarrowest,
       ResizeWidest,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -110,7 +110,7 @@ Returns the rendered image, or a null QImage if the image does not fit into avai
 %End
 
 
-    enum ExportResult
+    enum ExportResult /BaseType=IntEnum/
     {
       Success,
       Canceled,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutgridsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutgridsettings.sip.in
@@ -21,7 +21,7 @@ Contains settings relating to the appearance, spacing and offset for layout grid
 %End
   public:
 
-    enum Style
+    enum Style /BaseType=IntEnum/
     {
       StyleLines,
       StyleDots,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -158,7 +158,7 @@ Base class for graphical items within a :py:class:`QgsLayout`.
 %End
   public:
 
-    enum ReferencePoint
+    enum ReferencePoint /BaseType=IntEnum/
     {
       UpperLeft,
       UpperMiddle,
@@ -171,7 +171,7 @@ Base class for graphical items within a :py:class:`QgsLayout`.
       LowerRight,
     };
 
-    enum UndoCommand
+    enum UndoCommand /BaseType=IntEnum/
     {
       UndoNone,
       UndoIncrementalMove,
@@ -276,7 +276,7 @@ Base class for graphical items within a :py:class:`QgsLayout`.
       UndoCustomCommand,
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagOverridesPaint,
       FlagProvidesClipPath,
@@ -426,7 +426,7 @@ Sets the item's parent ``group``.
 .. seealso:: :py:func:`parentGroup`
 %End
 
-    enum ExportLayerBehavior
+    enum ExportLayerBehavior /BaseType=IntEnum/
     {
       CanGroupWithAnyOtherItem,
       CanGroupWithItemsOfSameType,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -23,7 +23,7 @@ A layout table subclass that displays attributes from a vector layer.
 %End
   public:
 
-    enum ContentSource
+    enum ContentSource /BaseType=IntEnum/
     {
       LayerAttributes,
       AtlasFeature,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemhtml.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemhtml.sip.in
@@ -22,7 +22,7 @@ A layout multiframe subclass for HTML content.
 %End
   public:
 
-    enum ContentMode
+    enum ContentMode /BaseType=IntEnum/
     {
       Url,
       ManualHtml

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -22,7 +22,7 @@ A layout item subclass for text labels.
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       ModeFont,
       ModeHtml,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -298,7 +298,7 @@ Layout graphical items for displaying a map.
 %End
   public:
 
-    enum AtlasScalingMode
+    enum AtlasScalingMode /BaseType=IntEnum/
     {
       Fixed,
 
@@ -307,7 +307,7 @@ Layout graphical items for displaying a map.
       Auto
     };
 
-    enum MapItemFlag
+    enum MapItemFlag /BaseType=IntEnum/
     {
       ShowPartialLabels,
       ShowUnplacedLabels,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -137,7 +137,7 @@ An individual grid which is drawn above the map content in a
 %End
   public:
 
-    enum GridUnit
+    enum GridUnit /BaseType=IntEnum/
     {
       MapUnit,
       MM,
@@ -145,7 +145,7 @@ An individual grid which is drawn above the map content in a
       DynamicPageSizeBased,
     };
 
-    enum GridStyle
+    enum GridStyle /BaseType=IntEnum/
     {
       Solid,
       Cross,
@@ -153,7 +153,7 @@ An individual grid which is drawn above the map content in a
       FrameAnnotationsOnly
     };
 
-    enum DisplayMode
+    enum DisplayMode /BaseType=IntEnum/
     {
       ShowAll,
       LatitudeOnly,
@@ -161,13 +161,13 @@ An individual grid which is drawn above the map content in a
       HideAll
     };
 
-    enum AnnotationPosition
+    enum AnnotationPosition /BaseType=IntEnum/
     {
       InsideMapFrame,
       OutsideMapFrame,
     };
 
-    enum AnnotationDirection
+    enum AnnotationDirection /BaseType=IntEnum/
     {
       Horizontal,
       Vertical,
@@ -178,7 +178,7 @@ An individual grid which is drawn above the map content in a
       UnderTick,
     };
 
-    enum AnnotationFormat
+    enum AnnotationFormat /BaseType=IntEnum/
     {
       Decimal,
       DegreeMinute,
@@ -191,7 +191,7 @@ An individual grid which is drawn above the map content in a
       CustomFormat
     };
 
-    enum BorderSide
+    enum BorderSide /BaseType=IntEnum/
     {
       Left,
       Right,
@@ -199,7 +199,7 @@ An individual grid which is drawn above the map content in a
       Top,
     };
 
-    enum FrameStyle
+    enum FrameStyle /BaseType=IntEnum/
     {
       NoFrame,
       Zebra,
@@ -211,13 +211,13 @@ An individual grid which is drawn above the map content in a
       ZebraNautical,
     };
 
-    enum TickLengthMode
+    enum TickLengthMode /BaseType=IntEnum/
     {
       OrthogonalTicks,
       NormalizedTicks,
     };
 
-    enum FrameSideFlag
+    enum FrameSideFlag /BaseType=IntEnum/
     {
       FrameLeft,
       FrameRight,
@@ -227,7 +227,7 @@ An individual grid which is drawn above the map content in a
     typedef QFlags<QgsLayoutItemMapGrid::FrameSideFlag> FrameSideFlags;
 
 
-    enum AnnotationCoordinate
+    enum AnnotationCoordinate /BaseType=IntEnum/
     {
       Longitude,
       Latitude

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapitem.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmapitem.sip.in
@@ -22,7 +22,7 @@ An item which is drawn inside a :py:class:`QgsLayoutItemMap`, e.g., a grid or ma
 %End
   public:
 
-    enum StackingPosition
+    enum StackingPosition /BaseType=IntEnum/
     {
       StackBelowMap,
       StackBelowMapLayer,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitempage.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitempage.sip.in
@@ -24,13 +24,13 @@ Item representing the paper in a layout.
 %End
   public:
 
-    enum Orientation
+    enum Orientation /BaseType=IntEnum/
     {
       Portrait,
       Landscape
     };
 
-    enum UndoCommand
+    enum UndoCommand /BaseType=IntEnum/
     {
       UndoPageSymbol,
     };

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -22,7 +22,7 @@ A layout item subclass that displays SVG files or raster format images (jpg, png
 %End
   public:
 
-    enum ResizeMode
+    enum ResizeMode /BaseType=IntEnum/
     {
       Zoom,
       Stretch,
@@ -31,14 +31,14 @@ A layout item subclass that displays SVG files or raster format images (jpg, png
       FrameToImageSize
     };
 
-    enum Format
+    enum Format /BaseType=IntEnum/
     {
       FormatSVG,
       FormatRaster,
       FormatUnknown,
     };
 
-    enum NorthMode
+    enum NorthMode /BaseType=IntEnum/
     {
       GridNorth,
       TrueNorth,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -23,7 +23,7 @@ Layout item for node based polyline shapes.
 %End
   public:
 
-    enum MarkerMode
+    enum MarkerMode /BaseType=IntEnum/
     {
       NoMarker,
       ArrowHead,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -161,7 +161,7 @@ of layout items.
 %End
   public:
 
-    enum ItemType
+    enum ItemType /BaseType=IntEnum/
     {
       LayoutItem,
       LayoutGroup,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemshape.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemshape.sip.in
@@ -21,7 +21,7 @@ Layout item for basic filled shapes (e.g. rectangles, ellipses).
 %End
   public:
 
-    enum Shape
+    enum Shape /BaseType=IntEnum/
     {
       Ellipse,
       Rectangle,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutmanager.sip.in
@@ -236,7 +236,7 @@ QSortFilterProxyModel subclass for QgsLayoutManagerModel
 %End
   public:
 
-    enum Filter
+    enum Filter /BaseType=IntEnum/
     {
       FilterPrintLayouts,
       FilterReports,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutmodel.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutmodel.sip.in
@@ -35,7 +35,7 @@ as required.
 %End
   public:
 
-    enum Columns
+    enum Columns /BaseType=IntEnum/
     {
       Visibility,
       LockStatus,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutmultiframe.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutmultiframe.sip.in
@@ -61,7 +61,7 @@ several frames (:py:class:`QgsLayoutFrame` items).
 %End
   public:
 
-    enum ResizeMode
+    enum ResizeMode /BaseType=IntEnum/
     {
       UseExistingFrames,
       ExtendToNextPage,
@@ -69,7 +69,7 @@ several frames (:py:class:`QgsLayoutFrame` items).
       RepeatUntilFinished
     };
 
-    enum UndoCommand
+    enum UndoCommand /BaseType=IntEnum/
     {
       UndoHtmlBreakDistance,
       UndoHtmlSource,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutnortharrowhandler.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutnortharrowhandler.sip.in
@@ -22,7 +22,7 @@ An object which handles north-arrow type behavior for layout items.
 %End
   public:
 
-    enum NorthMode
+    enum NorthMode /BaseType=IntEnum/
     {
       GridNorth,
       TrueNorth,

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutobject.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutobject.sip.in
@@ -211,7 +211,7 @@ A base class for objects which belong to a layout.
     };
 
 
-    enum PropertyValueType
+    enum PropertyValueType /BaseType=IntEnum/
     {
       EvaluatedValue,
       OriginalValue

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -21,7 +21,7 @@ Stores information relating to the current rendering settings for a layout.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagDebug,
       FlagOutlineOnly,

--- a/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayouttable.sip.in
@@ -79,7 +79,7 @@ the table to span over multiple frames
 %End
   public:
 
-    enum HeaderHAlignment
+    enum HeaderHAlignment /BaseType=IntEnum/
     {
       FollowColumn,
       HeaderLeft,
@@ -87,27 +87,27 @@ the table to span over multiple frames
       HeaderRight
     };
 
-    enum HeaderMode
+    enum HeaderMode /BaseType=IntEnum/
     {
       FirstFrame,
       AllFrames,
       NoHeaders
     };
 
-    enum EmptyTableMode
+    enum EmptyTableMode /BaseType=IntEnum/
     {
       HeadersOnly,
       HideTable,
       ShowMessage
     };
 
-    enum WrapBehavior
+    enum WrapBehavior /BaseType=IntEnum/
     {
       TruncateText,
       WrapText
     };
 
-    enum CellStyleGroup
+    enum CellStyleGroup /BaseType=IntEnum/
     {
       OddColumns,
       EvenColumns,

--- a/python/PyQt6/core/auto_generated/layout/qgsmasterlayoutinterface.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgsmasterlayoutinterface.sip.in
@@ -41,7 +41,7 @@ Interface for master layout type objects, such as print layouts and reports.
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       PrintLayout,
       Report,

--- a/python/PyQt6/core/auto_generated/layout/qgsreportsectionfieldgroup.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgsreportsectionfieldgroup.sip.in
@@ -28,7 +28,7 @@ A report section consisting of a features
 %End
   public:
 
-    enum SectionVisibility
+    enum SectionVisibility /BaseType=IntEnum/
     {
       IncludeWhenFeaturesFound,
       AlwaysInclude

--- a/python/PyQt6/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/PyQt6/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -106,7 +106,7 @@ Abstract base class for filters which collect locator results.
 %End
   public:
 
-    enum Priority
+    enum Priority /BaseType=IntEnum/
     {
       Highest,
       High,
@@ -115,7 +115,7 @@ Abstract base class for filters which collect locator results.
       Lowest
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagFast,
     };

--- a/python/PyQt6/core/auto_generated/maprenderer/qgsmaprenderertask.sip.in
+++ b/python/PyQt6/core/auto_generated/maprenderer/qgsmaprenderertask.sip.in
@@ -25,7 +25,7 @@ task. This can be used to draw maps without blocking the QGIS interface.
 %End
   public:
 
-    enum ErrorType
+    enum ErrorType /BaseType=IntEnum/
     {
       ImageAllocationFail,
       ImageSaveFail,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmesh3daveraging.sip.in
@@ -55,7 +55,7 @@ Abstract class to interpolate 3d stacked mesh data to 2d data
     }
 %End
   public:
-    enum Method
+    enum Method /BaseType=IntEnum/
     {
       //! Method to average values from selected vertical layers
       MultiLevelsAveragingMethod,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -32,7 +32,7 @@ Resulting dataset is always scalar
 %End
   public:
 
-    enum Result
+    enum Result /BaseType=IntEnum/
     {
       Success,
       Canceled,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -22,7 +22,7 @@ typedef QPair<int, int> QgsMeshEdge;
 struct QgsMesh
 {
 
-  enum ElementType
+  enum ElementType /BaseType=IntEnum/
   {
     Vertex,
     Edge,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovidertemporalcapabilities.sip.in
@@ -23,7 +23,7 @@ Class for handling properties relating to a mesh data provider's temporal capabi
 %End
   public:
 
-    enum MatchingTemporalDatasetMethod
+    enum MatchingTemporalDatasetMethod /BaseType=IntEnum/
     {
       FindClosestDatasetBeforeStartRangeTime,
       FindClosestDatasetFromStartRangeTime

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -144,7 +144,7 @@ value by value (slower) with :py:func:`~QgsMeshDatasetValue.active` or :py:func:
 #include "qgsmeshdataset.h"
 %End
   public:
-    enum DataType
+    enum DataType /BaseType=IntEnum/
     {
       ActiveFlagInteger,
       ScalarDouble,
@@ -390,7 +390,7 @@ such as whether the data is vector or scalar, name
 %End
   public:
 
-    enum DataType
+    enum DataType /BaseType=IntEnum/
     {
       DataOnFaces,
       DataOnVertices,
@@ -627,7 +627,7 @@ Abstract class that represents a dataset group
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       None,
       Persistent,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -97,7 +97,7 @@ Represents a mesh renderer settings for scalar datasets
 %End
   public:
 
-    enum DataResamplingMethod
+    enum DataResamplingMethod /BaseType=IntEnum/
     {
 
       NoResampling,
@@ -209,7 +209,7 @@ Represents a mesh renderer settings for vector datasets displayed with arrows
 %End
   public:
 
-    enum ArrowScalingMethod
+    enum ArrowScalingMethod /BaseType=IntEnum/
     {
 
       MinMax,
@@ -330,7 +330,7 @@ Represents a streamline renderer settings for vector datasets displayed by strea
 #include "qgsmeshrenderersettings.h"
 %End
   public:
-    enum SeedingStartPointsMethod
+    enum SeedingStartPointsMethod /BaseType=IntEnum/
     {
 
       MeshGridded,
@@ -437,7 +437,7 @@ Represents a renderer settings for vector datasets
 %End
   public:
 
-    enum Symbology
+    enum Symbology /BaseType=IntEnum/
     {
       //! Displaying vector dataset with arrows
       Arrows,

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
@@ -24,7 +24,7 @@ Represents a mesh time settings for mesh datasets
 %End
   public:
 
-    enum TimeUnit
+    enum TimeUnit /BaseType=IntEnum/
     {
       //! second unit
       seconds,

--- a/python/PyQt6/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
@@ -32,7 +32,7 @@ between threads without issue.
 %End
   public:
 
-    enum ErrorCode
+    enum ErrorCode /BaseType=IntEnum/
     {
       NoError,
       NetworkError,

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -25,7 +25,7 @@ Encapsulates parameters and properties of a network request.
 %End
   public:
 
-    enum RequestAttributes
+    enum RequestAttributes /BaseType=IntEnum/
     {
       AttributeInitiatorClass,
       AttributeInitiatorRequestId,

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkcontentfetcherregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkcontentfetcherregistry.sip.in
@@ -24,7 +24,7 @@ FetchedContent holds useful information about a network content being fetched
 #include "qgsnetworkcontentfetcherregistry.h"
 %End
   public:
-    enum ContentStatus
+    enum ContentStatus /BaseType=IntEnum/
     {
       NotStarted,
       Downloading,

--- a/python/PyQt6/core/auto_generated/numericformats/qgsbasicnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsbasicnumericformat.sip.in
@@ -20,7 +20,7 @@ A numeric formatter which returns a simple text representation of a value.
 %End
   public:
 
-    enum RoundingType
+    enum RoundingType /BaseType=IntEnum/
     {
       DecimalPlaces,
       SignificantFigures,

--- a/python/PyQt6/core/auto_generated/numericformats/qgsbearingnumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgsbearingnumericformat.sip.in
@@ -20,7 +20,7 @@ A numeric formatter which returns a text representation of a direction/bearing.
 %End
   public:
 
-    enum FormatDirectionOption
+    enum FormatDirectionOption /BaseType=IntEnum/
     {
       UseRange0To180WithEWDirectionalSuffix,
       UseRangeNegative180ToPositive180,

--- a/python/PyQt6/core/auto_generated/numericformats/qgspercentagenumericformat.sip.in
+++ b/python/PyQt6/core/auto_generated/numericformats/qgspercentagenumericformat.sip.in
@@ -20,7 +20,7 @@ A numeric formatter which returns a text representation of a percentage value.
 %End
   public:
 
-    enum InputValues
+    enum InputValues /BaseType=IntEnum/
     {
       ValuesArePercentage,
       ValuesAreFractions,

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattribute.sip.in
@@ -25,7 +25,7 @@ pair of name and size in bytes
 #include "qgspointcloudattribute.h"
 %End
   public:
-    enum DataType
+    enum DataType /BaseType=IntEnum/
     {
       Char,
       UChar,

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattributemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudattributemodel.sip.in
@@ -129,7 +129,7 @@ A proxy model for filtering available attributes from a point cloud attribute mo
 %End
   public:
 
-    enum Filter
+    enum Filter /BaseType=IntEnum/
     {
       Char,
       Short,

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -29,7 +29,7 @@ Responsible for reading native point cloud data and returning the indexed data.
 %End
   public:
 
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       NoCapabilities,
       ReadLayerMetadata,
@@ -41,7 +41,7 @@ Responsible for reading native point cloud data and returning the indexed data.
     typedef QFlags<QgsPointCloudDataProvider::Capability> Capabilities;
 
 
-    enum PointCloudIndexGenerationState
+    enum PointCloudIndexGenerationState /BaseType=IntEnum/
     {
       NotIndexed,
       Indexing,

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -29,7 +29,7 @@ expression context.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       // For future API flexibility only and to avoid sip issues, remove when real entries are added to flags.
       Unused,

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -182,7 +182,7 @@ both flavors.
 
   public:
 
-    enum CrsType
+    enum CrsType /BaseType=IntEnum/
     {
       InternalCrsId,
       PostgisCrsId,

--- a/python/PyQt6/core/auto_generated/project/qgsprojectbadlayerhandler.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectbadlayerhandler.sip.in
@@ -36,14 +36,14 @@ log.
 
   protected:
 
-    enum DataType
+    enum DataType /BaseType=IntEnum/
     {
       IS_VECTOR,
       IS_RASTER,
       IS_BOGUS
     };
 
-    enum ProviderType
+    enum ProviderType /BaseType=IntEnum/
     {
       IS_FILE,
       IS_DATABASE,

--- a/python/PyQt6/core/auto_generated/project/qgsprojectservervalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectservervalidator.sip.in
@@ -28,7 +28,7 @@ Validates the server specific parts of the configuration of a QGIS project.
 Constructor for QgsProjectServerValidator.
 %End
 
-    enum ValidationError
+    enum ValidationError /BaseType=IntEnum/
     {
       DuplicatedNames,
       LayerShortName,

--- a/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -328,7 +328,7 @@ This information is calculated from the geometry columns types.
       QString geometryColumnName;
     };
 
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       CreateVectorTable,
       DropRasterTable,
@@ -364,7 +364,7 @@ This information is calculated from the geometry columns types.
     typedef QFlags<QgsAbstractDatabaseProviderConnection::Capability> Capabilities;
 
 
-    enum GeometryColumnCapability
+    enum GeometryColumnCapability /BaseType=IntEnum/
     {
       Z,
       M,

--- a/python/PyQt6/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -44,7 +44,7 @@ Abstract base class for spatial data provider implementations.
 %End
   public:
 
-    enum ProviderProperty
+    enum ProviderProperty /BaseType=IntEnum/
     {
       EvaluateDefaultValues,
       CustomData
@@ -57,7 +57,7 @@ Abstract base class for spatial data provider implementations.
 
     };
 
-    enum ReadFlag
+    enum ReadFlag /BaseType=IntEnum/
     {
       FlagTrustDataSource,
       SkipFeatureCount,

--- a/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -30,7 +30,7 @@ Holds metadata about mesh driver
 
   public:
 
-    enum MeshDriverCapability
+    enum MeshDriverCapability /BaseType=IntEnum/
     {
       CanWriteFaceDatasets,
       CanWriteVertexDatasets,
@@ -143,7 +143,7 @@ library object.
 %End
   public:
 
-    enum ProviderMetadataCapability
+    enum ProviderMetadataCapability /BaseType=IntEnum/
     {
       PriorityForUri,
       LayerTypesForUri,
@@ -153,7 +153,7 @@ library object.
     typedef QFlags<QgsProviderMetadata::ProviderMetadataCapability> ProviderMetadataCapabilities;
 
 
-    enum ProviderCapability
+    enum ProviderCapability /BaseType=IntEnum/
     {
       FileBasedUris,
       SaveLayerMetadata,

--- a/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -35,7 +35,7 @@ ogr and postgres.
   public:
 
 
-    enum WidgetMode
+    enum WidgetMode /BaseType=IntEnum/
     {
 
       None,

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -65,7 +65,7 @@ The development version
 %End
 
 
-    enum MessageLevel
+    enum MessageLevel /BaseType=IntEnum/
     {
       Info,
       Warning,

--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -75,7 +75,7 @@ to change due to centralization.
 %End
   public:
 
-    enum StyleSheetType
+    enum StyleSheetType /BaseType=IntEnum/
     {
       Qt,
       WebBrowser,
@@ -355,7 +355,7 @@ Since QGIS 3.20, the optional ``fillColor`` and ``strokeColor`` arguments can be
 control the color of parameter based SVG icons.
 %End
 
-    enum Cursor
+    enum Cursor /BaseType=IntEnum/
     {
       ZoomIn,
       ZoomOut,
@@ -558,7 +558,7 @@ deletes provider registry and map layer registry
 Gets application icon
 %End
 
-    enum endian_t
+    enum endian_t /BaseType=IntEnum/
     {
       XDR,
       NDR

--- a/python/PyQt6/core/auto_generated/qgsattributetableconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsattributetableconfig.sip.in
@@ -24,7 +24,7 @@ The configuration is specific for one vector layer.
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Field,
       Action
@@ -47,7 +47,7 @@ Constructor for ColumnConfig
       int width;
     };
 
-    enum ActionWidgetStyle
+    enum ActionWidgetStyle /BaseType=IntEnum/
     {
       ButtonList,
       DropDown

--- a/python/PyQt6/core/auto_generated/qgsbookmarkmodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsbookmarkmodel.sip.in
@@ -39,7 +39,7 @@ model data is a merge of the bookmarks stored in both managers.
       Rotation,
     };
 
-    enum Columns
+    enum Columns /BaseType=IntEnum/
     {
       ColumnName,
       ColumnGroup,

--- a/python/PyQt6/core/auto_generated/qgsclipper.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsclipper.sip.in
@@ -41,7 +41,7 @@ magnitude of the screen coordinates (+/- 32768, i.e. 16 bit integer).
     static const double MIN_Y;
 
 
-    enum Boundary
+    enum Boundary /BaseType=IntEnum/
     {
       XMax,
       XMin,

--- a/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
@@ -43,7 +43,7 @@ can be generated using an optional base color.
 %End
   public:
 
-    enum SchemeFlag
+    enum SchemeFlag /BaseType=IntEnum/
     {
       ShowInColorDialog,
       ShowInColorButtonMenu,

--- a/python/PyQt6/core/auto_generated/qgscoordinateformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscoordinateformatter.sip.in
@@ -30,7 +30,7 @@ based formats.
 %End
   public:
 
-    enum Format
+    enum Format /BaseType=IntEnum/
     {
       FormatPair,
       FormatDegreesMinutesSeconds,
@@ -38,7 +38,7 @@ based formats.
       FormatDecimalDegrees,
     };
 
-    enum FormatFlag
+    enum FormatFlag /BaseType=IntEnum/
     {
       FlagDegreesUseStringSuffix,
       FlagDegreesPadMinutesSeconds,

--- a/python/PyQt6/core/auto_generated/qgsdartmeasurement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdartmeasurement.sip.in
@@ -16,7 +16,7 @@ class QgsDartMeasurement
 #include "qgsdartmeasurement.h"
 %End
   public:
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Text,
       ImagePng,

--- a/python/PyQt6/core/auto_generated/qgsdatadefinedsizelegend.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdatadefinedsizelegend.sip.in
@@ -39,13 +39,13 @@ Constructor for QgsDataDefinedSizeLegend.
 Copy constructor
 %End
 
-    enum LegendType
+    enum LegendType /BaseType=IntEnum/
     {
       LegendSeparated,
       LegendCollapsed,
     };
 
-    enum VerticalAlignment
+    enum VerticalAlignment /BaseType=IntEnum/
     {
       AlignCenter,
       AlignBottom,

--- a/python/PyQt6/core/auto_generated/qgsdatasourceuri.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdatasourceuri.sip.in
@@ -27,7 +27,7 @@ user name, password, schema, password, and SQL where clause.
 
   public:
 
-    enum SslMode
+    enum SslMode /BaseType=IntEnum/
     {
       SslPrefer,
       SslDisable,

--- a/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsdiagramrenderer.sip.in
@@ -26,7 +26,7 @@ Stores the settings for rendering of all diagrams for a layer.
 %End
   public:
 
-    enum Placement
+    enum Placement /BaseType=IntEnum/
     {
       AroundPoint,
       OverPoint,
@@ -36,7 +36,7 @@ Stores the settings for rendering of all diagrams for a layer.
       Free
     };
 
-    enum LinePlacementFlag
+    enum LinePlacementFlag /BaseType=IntEnum/
     {
       OnLine,
       AboveLine,
@@ -353,13 +353,13 @@ QgsDiagramLayerSettings stores settings which control how ALL diagrams within a 
 %End
   public:
 
-    enum LabelPlacementMethod
+    enum LabelPlacementMethod /BaseType=IntEnum/
     {
       Height,
       XHeight
     };
 
-    enum DiagramOrientation
+    enum DiagramOrientation /BaseType=IntEnum/
     {
       Up,
       Down,
@@ -367,7 +367,7 @@ QgsDiagramLayerSettings stores settings which control how ALL diagrams within a 
       Right
     };
 
-    enum Direction
+    enum Direction /BaseType=IntEnum/
     {
       Clockwise,
       Counterclockwise,

--- a/python/PyQt6/core/auto_generated/qgserror.sip.in
+++ b/python/PyQt6/core/auto_generated/qgserror.sip.in
@@ -20,7 +20,7 @@ class QgsErrorMessage
 #include "qgserror.h"
 %End
   public:
-    enum Format
+    enum Format /BaseType=IntEnum/
     {
       Text,
       Html

--- a/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeatureiterator.sip.in
@@ -19,7 +19,7 @@ Internal feature iterator to be implemented within data providers
 %End
   public:
 
-    enum CompileStatus
+    enum CompileStatus /BaseType=IntEnum/
     {
       NoCompilation,
       PartiallyCompiled,

--- a/python/PyQt6/core/auto_generated/qgsfeaturesink.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturesink.sip.in
@@ -22,7 +22,7 @@ An interface for objects which accept features via addFeature(s) methods.
 %End
   public:
 
-    enum SinkFlag
+    enum SinkFlag /BaseType=IntEnum/
     {
 
       RegeneratePrimaryKey,
@@ -30,7 +30,7 @@ An interface for objects which accept features via addFeature(s) methods.
     typedef QFlags<QgsFeatureSink::SinkFlag> SinkFlags;
 
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
 
       FastInsert,

--- a/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldconstraints.sip.in
@@ -26,7 +26,7 @@ Stores information about constraints which may be present on a field.
 
   public:
 
-    enum Constraint
+    enum Constraint /BaseType=IntEnum/
     {
       ConstraintNotNull,
       ConstraintUnique,
@@ -35,14 +35,14 @@ Stores information about constraints which may be present on a field.
     typedef QFlags<QgsFieldConstraints::Constraint> Constraints;
 
 
-    enum ConstraintOrigin
+    enum ConstraintOrigin /BaseType=IntEnum/
     {
       ConstraintOriginNotSet,
       ConstraintOriginProvider,
       ConstraintOriginLayer,
     };
 
-    enum ConstraintStrength
+    enum ConstraintStrength /BaseType=IntEnum/
     {
       ConstraintStrengthNotSet,
       ConstraintStrengthHard,

--- a/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
@@ -71,7 +71,7 @@ Default constructor
 
     virtual ~QgsFieldFormatter();
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       CanProvideAvailableValues
     };

--- a/python/PyQt6/core/auto_generated/qgsfieldproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldproxymodel.sip.in
@@ -24,7 +24,7 @@ The :py:class:`QgsFieldProxyModel` class provides an easy to use model to displa
 %End
   public:
 
-    enum Filter
+    enum Filter /BaseType=IntEnum/
     {
       String,
       Int,

--- a/python/PyQt6/core/auto_generated/qgsfields.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfields.sip.in
@@ -30,7 +30,7 @@ In addition to storing a list of :py:class:`QgsField` instances, it also:
 %End
   public:
 
-    enum FieldOrigin
+    enum FieldOrigin /BaseType=IntEnum/
     {
       OriginUnknown,
       OriginProvider,

--- a/python/PyQt6/core/auto_generated/qgslegendstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslegendstyle.sip.in
@@ -21,7 +21,7 @@ Contains detailed styling information relating to how a layout legend should be 
 %End
   public:
 
-    enum Style
+    enum Style /BaseType=IntEnum/
     {
       Undefined,
       Hidden,
@@ -33,7 +33,7 @@ Contains detailed styling information relating to how a layout legend should be 
     };
 
 
-    enum Side
+    enum Side /BaseType=IntEnum/
     {
       Top,
       Bottom,

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -68,13 +68,13 @@ This is the base class for all map layer types (vector, raster).
 %End
   public:
 
-    enum PropertyType
+    enum PropertyType /BaseType=IntEnum/
     {
       Style,
       Metadata,
     };
 
-    enum LayerFlag
+    enum LayerFlag /BaseType=IntEnum/
     {
       Identifiable,
       Removable,
@@ -84,7 +84,7 @@ This is the base class for all map layer types (vector, raster).
     typedef QFlags<QgsMapLayer::LayerFlag> LayerFlags;
 
 
-    enum StyleCategory
+    enum StyleCategory /BaseType=IntEnum/
     {
       LayerConfiguration,
       Symbology,
@@ -635,7 +635,7 @@ or layer with temporary data (as temporary mesh layer dataset)
 .. versionadded:: 3.10.1
 %End
 
-    enum ReadFlag
+    enum ReadFlag /BaseType=IntEnum/
     {
       FlagDontResolveLayers,
       FlagTrustLayerMetadata,

--- a/python/PyQt6/core/auto_generated/qgsmaplayerdependency.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerdependency.sip.in
@@ -28,13 +28,13 @@ The two combinations of type/origin that are currently supported are:
 #include "qgsmaplayerdependency.h"
 %End
   public:
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       PresenceDependency,
       DataDependency
     };
 
-    enum Origin
+    enum Origin /BaseType=IntEnum/
     {
       FromProvider,
       FromUser

--- a/python/PyQt6/core/auto_generated/qgsmaplayerelevationproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerelevationproperties.sip.in
@@ -67,7 +67,7 @@ how an individual :py:class:`QgsMapLayer` behaves with relation to z values or e
       ExtrusionHeight,
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagDontInvalidateCachedRendersWhenRangeChanges
     };

--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -98,7 +98,7 @@ Manages QGIS Server properties for Wms dimensions
 
   public:
 
-    enum PredefinedWmsDimensionName
+    enum PredefinedWmsDimensionName /BaseType=IntEnum/
     {
       TIME,
       DATE,
@@ -108,7 +108,7 @@ Manages QGIS Server properties for Wms dimensions
     struct WmsDimensionInfo
     {
 
-      enum DefaultDisplay
+      enum DefaultDisplay /BaseType=IntEnum/
       {
         AllValues,
         MinValue,

--- a/python/PyQt6/core/auto_generated/qgsmaptopixelgeometrysimplifier.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaptopixelgeometrysimplifier.sip.in
@@ -23,7 +23,7 @@ This class enables simplify the geometries to be rendered in a MapCanvas target 
 #include "qgsmaptopixelgeometrysimplifier.h"
 %End
   public:
-    enum SimplifyAlgorithm
+    enum SimplifyAlgorithm /BaseType=IntEnum/
     {
       Distance,
       SnapToGrid,
@@ -36,7 +36,7 @@ This class enables simplify the geometries to be rendered in a MapCanvas target 
 Constructor
 %End
 
-    enum SimplifyFlag
+    enum SimplifyFlag /BaseType=IntEnum/
     {
       NoFlags,
       SimplifyGeometry,

--- a/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
@@ -32,7 +32,7 @@ signal :py:func:`~destroyed` to notify the deletion
 %End
   public:
 
-    enum MessageType { MessageText, MessageHtml };
+    enum MessageType /BaseType=IntEnum/ { MessageText, MessageHtml };
 
     virtual ~QgsMessageOutput();
 

--- a/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
@@ -17,7 +17,7 @@ class QgsOfflineEditing : QObject
 #include "qgsofflineediting.h"
 %End
   public:
-    enum ProgressMode
+    enum ProgressMode /BaseType=IntEnum/
     {
       CopyFeatures,
       ProcessFeatures,
@@ -28,7 +28,7 @@ class QgsOfflineEditing : QObject
       UpdateGeometries
     };
 
-    enum ContainerType
+    enum ContainerType /BaseType=IntEnum/
     {
       SpatiaLite,
       GPKG

--- a/python/PyQt6/core/auto_generated/qgsogcutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsogcutils.sip.in
@@ -38,7 +38,7 @@ Constructs a Context from ``layer`` and ``transformContext``
       QgsCoordinateTransformContext transformContext;
     };
 
-    enum GMLVersion
+    enum GMLVersion /BaseType=IntEnum/
     {
       GML_2_1_2,
       GML_3_1_0,
@@ -156,7 +156,7 @@ according to the OGC filter specs (=,!=,<,>,<=,>=,AND,OR,NOT)
          otherwise null QDomElement
 %End
 
-    enum FilterVersion
+    enum FilterVersion /BaseType=IntEnum/
     {
       FILTER_OGC_1_0,
       FILTER_OGC_1_1,

--- a/python/PyQt6/core/auto_generated/qgspointlocator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspointlocator.sip.in
@@ -87,7 +87,7 @@ Configure render context  - if not ``None``, it will use to index only visible f
 .. versionadded:: 3.2
 %End
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Invalid,
       Vertex,

--- a/python/PyQt6/core/auto_generated/qgsproperty.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsproperty.sip.in
@@ -27,7 +27,7 @@ commonly used property types, such as colors and blend modes.
 %End
   public:
 
-    enum StandardPropertyTemplate
+    enum StandardPropertyTemplate /BaseType=IntEnum/
     {
       Boolean,
       Integer,
@@ -59,7 +59,7 @@ commonly used property types, such as colors and blend modes.
       Custom,
     };
 
-    enum DataType
+    enum DataType /BaseType=IntEnum/
     {
 
       DataTypeString,

--- a/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspropertytransformer.sip.in
@@ -163,7 +163,7 @@ Possible uses include transformers which map a value into a scaled size or color
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       GenericNumericTransformer,
       SizeScaleTransformer,
@@ -461,7 +461,7 @@ scaling methods.
 %End
   public:
 
-    enum ScaleType
+    enum ScaleType /BaseType=IntEnum/
     {
       Linear,
       Area,

--- a/python/PyQt6/core/auto_generated/qgsreadwritelocker.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsreadwritelocker.sip.in
@@ -32,7 +32,7 @@ If locked, the lock will be unlocked when the :py:class:`QgsReadWriteLocker` is 
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       Read,
       Write,

--- a/python/PyQt6/core/auto_generated/qgssimplifymethod.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssimplifymethod.sip.in
@@ -21,7 +21,7 @@ This class contains information about how to simplify geometries fetched from a 
 #include "qgssimplifymethod.h"
 %End
   public:
-    enum MethodType
+    enum MethodType /BaseType=IntEnum/
     {
       NoSimplification,
       OptimizeForRendering,

--- a/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
@@ -27,14 +27,14 @@ This is a container for configuration of the snapping of the project
 
   public:
 
-    enum SnappingType
+    enum SnappingType /BaseType=IntEnum/
     {
       Vertex,
       VertexAndSegment,
       Segment,
     };
 
-    enum ScaleDependencyMode
+    enum ScaleDependencyMode /BaseType=IntEnum/
     {
       Disabled,
       Global,

--- a/python/PyQt6/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssnappingutils.sip.in
@@ -95,7 +95,7 @@ The current layer used if mode is SnapCurrentLayer
 %End
 
 
-    enum IndexingStrategy
+    enum IndexingStrategy /BaseType=IntEnum/
     {
       IndexAlwaysFull,
       IndexNeverFull,

--- a/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsspatialindex.sip.in
@@ -39,7 +39,7 @@ A spatial index for :py:class:`QgsFeature` objects.
   public:
 
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagStoreFeatureGeometries,
     };

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -108,13 +108,13 @@ Returns a quoted version of a string (in single quotes)
 .. seealso:: :py:func:`quotedIdentifier`
 %End
 
-    enum UnaryOperator
+    enum UnaryOperator /BaseType=IntEnum/
     {
       uoNot,
       uoMinus,
     };
 
-    enum BinaryOperator
+    enum BinaryOperator /BaseType=IntEnum/
     {
       // logical
       boOr,
@@ -147,7 +147,7 @@ Returns a quoted version of a string (in single quotes)
       boConcat,
     };
 
-    enum JoinType
+    enum JoinType /BaseType=IntEnum/
     {
       jtDefault,
       jtLeft,
@@ -164,7 +164,7 @@ Returns a quoted version of a string (in single quotes)
 
 
 
-    enum NodeType
+    enum NodeType /BaseType=IntEnum/
     {
       ntUnaryOperator,
       ntBinaryOperator,

--- a/python/PyQt6/core/auto_generated/qgsstoredexpressionmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsstoredexpressionmanager.sip.in
@@ -28,7 +28,7 @@ Stored expression containing name, content (expression text) and a category tag.
 %End
   public:
 
-    enum Category
+    enum Category /BaseType=IntEnum/
     {
       FilterExpression,
       DefaultValueExpression,

--- a/python/PyQt6/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstaskmanager.sip.in
@@ -35,7 +35,7 @@ clean up and terminate at the earliest possible convenience.
 %End
   public:
 
-    enum TaskStatus
+    enum TaskStatus /BaseType=IntEnum/
     {
       Queued,
       OnHold,
@@ -44,7 +44,7 @@ clean up and terminate at the earliest possible convenience.
       Terminated,
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       CanCancel,
       CancelWithoutPrompt,
@@ -144,7 +144,7 @@ task in not currently being held then calling this has no effect.
 .. seealso:: :py:func:`hold`
 %End
 
-    enum SubTaskDependency
+    enum SubTaskDependency /BaseType=IntEnum/
     {
       SubTaskIndependent,
       ParentDependsOnSubTask,

--- a/python/PyQt6/core/auto_generated/qgstemporalproperty.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstemporalproperty.sip.in
@@ -25,7 +25,7 @@ Base class for temporal property.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagDontInvalidateCachedRendersWhenRangeChanges
     };

--- a/python/PyQt6/core/auto_generated/qgstracer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstracer.sip.in
@@ -133,7 +133,7 @@ indicating some input data topology problems
 .. versionadded:: 2.16
 %End
 
-    enum PathError
+    enum PathError /BaseType=IntEnum/
     {
       ErrNone,
       ErrTooManyFeatures,

--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -25,7 +25,7 @@ There are two possibilities how to use this class:
 #include "qgsvectorfilewriter.h"
 %End
   public:
-    enum OptionType
+    enum OptionType /BaseType=IntEnum/
     {
       Set,
       String,
@@ -124,7 +124,7 @@ Constructor for MetaData
       QString compulsoryEncoding;
     };
 
-    enum WriterError
+    enum WriterError /BaseType=IntEnum/
     {
       NoError,
       ErrDriverNotFound,
@@ -139,13 +139,13 @@ Constructor for MetaData
       Canceled,
     };
 
-    enum FieldNameSource
+    enum FieldNameSource /BaseType=IntEnum/
     {
       Original,
       PreferAlias,
     };
 
-    enum VectorFormatOption
+    enum VectorFormatOption /BaseType=IntEnum/
     {
       SortRecommended,
       SkipNonSpatialFormats,
@@ -198,7 +198,7 @@ Creates a clone of the FieldValueConverter.
 %End
     };
 
-    enum EditionCapability
+    enum EditionCapability /BaseType=IntEnum/
     {
       //! Flag to indicate that a new layer can be added to the dataset
       CanAddNewLayer,
@@ -216,7 +216,7 @@ Creates a clone of the FieldValueConverter.
     typedef QFlags<QgsVectorFileWriter::EditionCapability> EditionCapabilities;
 
 
-    enum ActionOnExistingFile
+    enum ActionOnExistingFile /BaseType=IntEnum/
     {
       //! Create or overwrite file
       CreateOrOverwriteFile,

--- a/python/PyQt6/core/auto_generated/qgsvectorsimplifymethod.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorsimplifymethod.sip.in
@@ -29,7 +29,7 @@ This class contains information how to simplify geometries fetched from a vector
 construct a default object
 %End
 
-    enum SimplifyHint
+    enum SimplifyHint /BaseType=IntEnum/
     {
       NoSimplification,
       GeometrySimplification,
@@ -48,7 +48,7 @@ Sets the simplification hints of the vector layer managed
 Gets the simplification hints of the vector layer managed
 %End
 
-    enum SimplifyAlgorithm
+    enum SimplifyAlgorithm /BaseType=IntEnum/
     {
       Distance,
       SnapToGrid,

--- a/python/PyQt6/core/auto_generated/qgsweakrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsweakrelation.sip.in
@@ -33,7 +33,7 @@ and cannot be translated to :py:class:`QgsRelations` or respected in QGIS relati
 %End
   public:
 
-    enum WeakRelationType
+    enum WeakRelationType /BaseType=IntEnum/
     {
       Referencing,
       Referenced

--- a/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -22,14 +22,14 @@ A ramp shader will color a raster pixel based on a list of values ranges in a ra
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Interpolated,
       Discrete,
       Exact
     };
 
-    enum ClassificationMode
+    enum ClassificationMode /BaseType=IntEnum/
     {
       Continuous,
       EqualInterval,

--- a/python/PyQt6/core/auto_generated/raster/qgscontrastenhancement.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscontrastenhancement.sip.in
@@ -24,7 +24,7 @@ ContrastEnhancementAlgorithm.
 %End
   public:
 
-    enum ContrastEnhancementAlgorithm
+    enum ContrastEnhancementAlgorithm /BaseType=IntEnum/
     {
       NoEnhancement,
       StretchToMinimumMaximum,

--- a/python/PyQt6/core/auto_generated/raster/qgshuesaturationfilter.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgshuesaturationfilter.sip.in
@@ -21,7 +21,7 @@ Color and saturation filter pipe for rasters.
 %End
   public:
 
-    enum GrayscaleMode
+    enum GrayscaleMode /BaseType=IntEnum/
     {
       GrayscaleOff,
       GrayscaleLightness,

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -70,7 +70,7 @@ Base class for raster data providers.
 %End
   public:
 
-    enum ProviderCapability
+    enum ProviderCapability /BaseType=IntEnum/
     {
       NoProviderCapabilities,
       ReadLayerMetadata,
@@ -602,7 +602,7 @@ and it's possible that there is renderable content outside of these extents.
 .. versionadded:: 3.10.0
 %End
 
-    enum TransformType
+    enum TransformType /BaseType=IntEnum/
     {
       TransformImageToLayer,
       TransformLayerToImage,

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -22,7 +22,7 @@ data providers can be used by calling :py:func:`~setOutputFormat` and :py:func:`
 %End
   public:
 
-    enum RasterFormatOption
+    enum RasterFormatOption /BaseType=IntEnum/
     {
       SortRecommended,
     };

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterinterface.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterinterface.sip.in
@@ -170,7 +170,7 @@ Base class for processing filters like renderers, reprojector, resampler etc.
       sipType = 0;
 %End
   public:
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       NoCapabilities,
       Size,

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterminmaxorigin.sip.in
@@ -31,7 +31,7 @@ itself the min/max values.
     static const double DEFAULT_STDDEV_FACTOR;
 
     //! \brief This enumerator describes the limits used to compute min/max values
-    enum Limits
+    enum Limits /BaseType=IntEnum/
     {
       None /PyName=None_/,
       MinMax,
@@ -39,7 +39,7 @@ itself the min/max values.
       CumulativeCut
     };
 
-    enum Extent
+    enum Extent /BaseType=IntEnum/
     {
       //! Whole raster is used to compute statistics.
       WholeRaster,
@@ -49,7 +49,7 @@ itself the min/max values.
       UpdatedCanvas
     };
 
-    enum StatAccuracy
+    enum StatAccuracy /BaseType=IntEnum/
     {
       //! Exact statistics.
       Exact,

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterprojector.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterprojector.sip.in
@@ -29,7 +29,7 @@ which are used to calculate affine transformation matrices.
 
   public:
 
-    enum Precision
+    enum Precision /BaseType=IntEnum/
     {
       Approximate,
       Exact,

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterrange.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterrange.sip.in
@@ -24,7 +24,7 @@ including min and max value.
 %End
   public:
 
-    enum BoundsType
+    enum BoundsType /BaseType=IntEnum/
     {
       IncludeMinAndMax,
       IncludeMax,

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -21,7 +21,7 @@ Raster renderer pipe for single band gray.
 #include "qgssinglebandgrayrenderer.h"
 %End
   public:
-    enum Gradient
+    enum Gradient /BaseType=IntEnum/
     {
       BlackToWhite,
       WhiteToBlack

--- a/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsscalebarsettings.sip.in
@@ -23,26 +23,26 @@ for scalebar drawing with :py:class:`QgsScaleBarRenderer`.
 %End
   public:
 
-    enum Alignment
+    enum Alignment /BaseType=IntEnum/
     {
       AlignLeft,
       AlignMiddle,
       AlignRight,
     };
 
-    enum SegmentSizeMode
+    enum SegmentSizeMode /BaseType=IntEnum/
     {
       SegmentSizeFixed,
       SegmentSizeFitWidth
     };
 
-    enum LabelVerticalPlacement
+    enum LabelVerticalPlacement /BaseType=IntEnum/
     {
       LabelAboveSegment,
       LabelBelowSegment,
     };
 
-    enum LabelHorizontalPlacement
+    enum LabelHorizontalPlacement /BaseType=IntEnum/
     {
       LabelCenteredEdge,
       LabelCenteredSegment,

--- a/python/PyQt6/core/auto_generated/scalebar/qgsticksscalebarrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/scalebar/qgsticksscalebarrenderer.sip.in
@@ -21,7 +21,7 @@ A scale bar that draws segments using short ticks.
 %End
   public:
 
-    enum TickPosition
+    enum TickPosition /BaseType=IntEnum/
     {
       TicksUp,
       TicksDown,

--- a/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettings.sip.in
@@ -51,7 +51,7 @@ static bool setGlobalSettingsPath( QString path );
 %End
   public:
 
-    enum Section
+    enum Section /BaseType=IntEnum/
     {
       NoSection,
       Core,

--- a/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
@@ -171,7 +171,7 @@ Returns whether the arrow is repeated along the line or not
 Sets whether the arrow is repeated along the line
 %End
 
-    enum HeadType
+    enum HeadType /BaseType=IntEnum/
     {
       HeadSingle,
       HeadReversed,
@@ -187,7 +187,7 @@ Gets the current head type
 Sets the head type
 %End
 
-    enum ArrowType
+    enum ArrowType /BaseType=IntEnum/
     {
       ArrowPlain,
       ArrowLeftHalf,

--- a/python/PyQt6/core/auto_generated/symbology/qgscptcityarchive.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscptcityarchive.sip.in
@@ -60,7 +60,7 @@ Base class for all items in the model
 #include "qgscptcityarchive.h"
 %End
   public:
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       ColorRamp,
       Collection,
@@ -266,7 +266,7 @@ class QgsCptCityBrowserModel : QAbstractItemModel
 %End
   public:
 
-    enum ViewType
+    enum ViewType /BaseType=IntEnum/
     {
       Authors,
       Selections,

--- a/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -20,7 +20,7 @@ A symbol layer for rendering objects with major and minor axis (e.g. ellipse, re
 %End
   public:
 
-    enum Shape
+    enum Shape /BaseType=IntEnum/
     {
       Circle,
       Rectangle,

--- a/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -145,7 +145,7 @@ This will take ownership of the method
 .. versionadded:: 3.10
 %End
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       EqualInterval,
       Quantile,

--- a/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -24,7 +24,7 @@ Class defining color to render mesh datasets. The color can vary depending on th
 %End
   public:
 
-    enum ColoringMethod
+    enum ColoringMethod /BaseType=IntEnum/
     {
       //! Render with a single color
       SingleColor,

--- a/python/PyQt6/core/auto_generated/symbology/qgsmergedfeaturerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmergedfeaturerenderer.sip.in
@@ -127,7 +127,7 @@ Constructor for QgsMergedFeatureRenderer.
 :param embeddedRenderer: optional embeddedRenderer. Ownership will be transferred.
 %End
 
-    enum GeometryOperation
+    enum GeometryOperation /BaseType=IntEnum/
     {
       Merge,
       InvertOnly,

--- a/python/PyQt6/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
@@ -20,7 +20,7 @@ A renderer that automatically displaces points with the same geographic location
 %End
   public:
 
-    enum Placement
+    enum Placement /BaseType=IntEnum/
     {
       Ring,
       ConcentricRings,

--- a/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -227,7 +227,7 @@ If layer is not -1, the renderer should draw only a particular layer from symbol
 Returns debug information about this renderer
 %End
 
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       SymbolLevels,
       MoreSymbolsPerFeature,

--- a/python/PyQt6/core/auto_generated/symbology/qgsrendererregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrendererregistry.sip.in
@@ -26,7 +26,7 @@ Stores metadata about one renderer class.
 %End
   public:
 
-    enum LayerType
+    enum LayerType /BaseType=IntEnum/
     {
       PointLayer,
       LineLayer,

--- a/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -25,7 +25,7 @@ the rules and draws features with symbols from rules that match.
 %End
   public:
 
-    enum FeatureFlags
+    enum FeatureFlags /BaseType=IntEnum/
     {
       FeatIsSelected,
       FeatDrawMarkers
@@ -92,7 +92,7 @@ A rule matches if both filter and scale range match.
 #include "qgsrulebasedrenderer.h"
 %End
       public:
-        enum RenderResult
+        enum RenderResult /BaseType=IntEnum/
         {
           Filtered,
           Inactive,

--- a/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
@@ -22,7 +22,7 @@ typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
 typedef QMultiMap<QString, QString> QgsSmartConditionMap;
 
 
-enum SymbolTable
+enum SymbolTable /BaseType=IntEnum/
 {
   SymbolId,
   SymbolName,
@@ -30,19 +30,19 @@ enum SymbolTable
   SymbolFavoriteId,
 };
 
-enum TagTable
+enum TagTable /BaseType=IntEnum/
 {
   TagId,
   TagName,
 };
 
-enum TagmapTable
+enum TagmapTable /BaseType=IntEnum/
 {
   TagmapTagId,
   TagmapSymbolId,
 };
 
-enum ColorrampTable
+enum ColorrampTable /BaseType=IntEnum/
 {
   ColorrampId,
   ColorrampName,
@@ -50,7 +50,7 @@ enum ColorrampTable
   ColorrampFavoriteId,
 };
 
-enum TextFormatTable
+enum TextFormatTable /BaseType=IntEnum/
 {
   TextFormatId,
   TextFormatName,
@@ -58,7 +58,7 @@ enum TextFormatTable
   TextFormatFavoriteId,
 };
 
-enum LabelSettingsTable
+enum LabelSettingsTable /BaseType=IntEnum/
 {
   LabelSettingsId,
   LabelSettingsName,
@@ -66,7 +66,7 @@ enum LabelSettingsTable
   LabelSettingsFavoriteId,
 };
 
-enum SmartgroupTable
+enum SmartgroupTable /BaseType=IntEnum/
 {
   SmartgroupId,
   SmartgroupName,
@@ -87,7 +87,7 @@ Constructor for QgsStyle, with the specified ``parent`` object.
 %End
     ~QgsStyle();
 
-    enum StyleEntity
+    enum StyleEntity /BaseType=IntEnum/
     {
       SymbolEntity,
       TagEntity,

--- a/python/PyQt6/core/auto_generated/symbology/qgsstylemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstylemodel.sip.in
@@ -31,7 +31,7 @@ instead.
 %End
   public:
 
-    enum Column
+    enum Column /BaseType=IntEnum/
     {
       Name,
       Tags,

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -780,14 +780,14 @@ Abstract base class for marker symbol layers.
 %End
   public:
 
-    enum HorizontalAnchorPoint
+    enum HorizontalAnchorPoint /BaseType=IntEnum/
     {
       Left,
       HCenter,
       Right,
     };
 
-    enum VerticalAnchorPoint
+    enum VerticalAnchorPoint /BaseType=IntEnum/
     {
       Top,
       VCenter,
@@ -1158,7 +1158,7 @@ class QgsLineSymbolLayer : QgsSymbolLayer
 %End
   public:
 
-    enum RenderRingFilter
+    enum RenderRingFilter /BaseType=IntEnum/
     {
       AllRings,
       ExteriorRingOnly,

--- a/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
@@ -20,20 +20,20 @@ A symbol layer class for displaying displacement arrows based on point layer att
 #include "qgsvectorfieldsymbollayer.h"
 %End
   public:
-    enum VectorFieldType
+    enum VectorFieldType /BaseType=IntEnum/
     {
       Cartesian,
       Polar,
       Height
     };
 
-    enum AngleOrientation
+    enum AngleOrientation /BaseType=IntEnum/
     {
       ClockwiseFromNorth,
       CounterclockwiseFromEast
     };
 
-    enum AngleUnits
+    enum AngleUnits /BaseType=IntEnum/
     {
       Degrees,
       Radians

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextbackgroundsettings.sip.in
@@ -27,7 +27,7 @@ Container for settings relating to a text background object.
 %End
   public:
 
-    enum ShapeType
+    enum ShapeType /BaseType=IntEnum/
     {
       ShapeRectangle,
       ShapeSquare,
@@ -37,14 +37,14 @@ Container for settings relating to a text background object.
       ShapeMarkerSymbol,
     };
 
-    enum SizeType
+    enum SizeType /BaseType=IntEnum/
     {
       SizeBuffer,
       SizeFixed,
       SizePercent
     };
 
-    enum RotationType
+    enum RotationType /BaseType=IntEnum/
     {
       RotationSync,
       RotationOffset,

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextmasksettings.sip.in
@@ -29,7 +29,7 @@ A selective masking only makes sense in contexts where the text is rendered over
 %End
   public:
 
-    enum MaskType
+    enum MaskType /BaseType=IntEnum/
     {
       MaskBuffer
     };

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextshadowsettings.sip.in
@@ -27,7 +27,7 @@ Container for settings relating to a text shadow.
 %End
   public:
 
-    enum ShadowPlacement
+    enum ShadowPlacement /BaseType=IntEnum/
     {
       ShadowLowest,
       ShadowText,

--- a/python/PyQt6/core/auto_generated/validity/qgsabstractvaliditycheck.sip.in
+++ b/python/PyQt6/core/auto_generated/validity/qgsabstractvaliditycheck.sip.in
@@ -25,7 +25,7 @@ result will be communicated to users, but not prevent them from proceeding.
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Warning,
       Critical,

--- a/python/PyQt6/core/auto_generated/validity/qgsvaliditycheckcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/validity/qgsvaliditycheckcontext.sip.in
@@ -32,7 +32,7 @@ context, containing a reference to the :py:class:`QgsLayout` to be checked.
 %End
   public:
 
-    enum ContextType
+    enum ContextType /BaseType=IntEnum/
     {
       TypeLayoutContext,
       TypeUserContext,

--- a/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectordataprovider.sip.in
@@ -28,7 +28,7 @@ of feature and attribute information from a spatial datasource.
   public:
 
 
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       NoCapabilities,
       AddFeatures,

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -342,7 +342,7 @@ feature depending on the join's "upsert on edit" capabilities.
 .. versionadded:: 3.12
 %End
 
-    enum CascadedFeatureFlag
+    enum CascadedFeatureFlag /BaseType=IntEnum/
     {
       IgnoreAuxiliaryLayers,
     };

--- a/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -334,7 +334,7 @@ Constructor for QgsMapBoxGlStyleConverter.
 
     ~QgsMapBoxGlStyleConverter();
 
-    enum Result
+    enum Result /BaseType=IntEnum/
     {
       Success,
       NoLayerList,

--- a/python/PyQt6/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
@@ -10,7 +10,10 @@ QgsAdvancedDigitizingDockWidget.ReturnPressed = QgsAdvancedDigitizingDockWidget.
 QgsAdvancedDigitizingDockWidget.CadConstraint.NoLock = QgsAdvancedDigitizingDockWidget.CadConstraint.LockMode.NoLock
 QgsAdvancedDigitizingDockWidget.CadConstraint.SoftLock = QgsAdvancedDigitizingDockWidget.CadConstraint.LockMode.SoftLock
 QgsAdvancedDigitizingDockWidget.CadConstraint.HardLock = QgsAdvancedDigitizingDockWidget.CadConstraint.LockMode.HardLock
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsAdvancedDigitizingDockWidget.CadCapacity.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgscoordinatereferencesystemmodel.py
+++ b/python/PyQt6/gui/auto_additions/qgscoordinatereferencesystemmodel.py
@@ -42,7 +42,10 @@ QgsCoordinateReferenceSystemProxyModel.FilterCompound = QgsCoordinateReferenceSy
 QgsCoordinateReferenceSystemProxyModel.Filters = lambda flags=0: QgsCoordinateReferenceSystemProxyModel.Filter(flags)
 QgsCoordinateReferenceSystemProxyModel.Filters.baseClass = QgsCoordinateReferenceSystemProxyModel
 Filters = QgsCoordinateReferenceSystemProxyModel  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsCoordinateReferenceSystemProxyModel.Filter.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsgui.py
+++ b/python/PyQt6/gui/auto_additions/qgsgui.py
@@ -5,7 +5,10 @@ QgsGui.ProjectCrsBehavior.baseClass = QgsGui
 QgsGui.HigMenuTextIsTitleCase = QgsGui.HigFlag.HigMenuTextIsTitleCase
 QgsGui.HigDialogTitleIsTitleCase = QgsGui.HigFlag.HigDialogTitleIsTitleCase
 QgsGui.HigFlags = lambda flags=0: QgsGui.HigFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsGui.HigFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsmaptool.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptool.py
@@ -4,7 +4,10 @@ QgsMapTool.EditTool = QgsMapTool.Flag.EditTool
 QgsMapTool.AllowZoomRect = QgsMapTool.Flag.AllowZoomRect
 QgsMapTool.ShowContextMenu = QgsMapTool.Flag.ShowContextMenu
 QgsMapTool.Flags = lambda flags=0: QgsMapTool.Flag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsMapTool.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsmaptoolcapture.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptoolcapture.py
@@ -7,7 +7,10 @@ QgsMapToolCapture.NoCapabilities = QgsMapToolCapture.Capability.NoCapabilities
 QgsMapToolCapture.SupportsCurves = QgsMapToolCapture.Capability.SupportsCurves
 QgsMapToolCapture.ValidateGeometries = QgsMapToolCapture.Capability.ValidateGeometries
 QgsMapToolCapture.Capabilities = lambda flags=0: QgsMapToolCapture.Capability(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsMapToolCapture.Capability.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsmaptoolidentify.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptoolidentify.py
@@ -14,7 +14,10 @@ QgsMapToolIdentify.AllLayers = QgsMapToolIdentify.Type.AllLayers
 QgsMapToolIdentify.LayerType = lambda flags=0: QgsMapToolIdentify.Type(flags)
 QgsMapToolIdentify.LayerType.baseClass = QgsMapToolIdentify
 LayerType = QgsMapToolIdentify  # dirty hack since SIP seems to introduce the flags in module
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsMapToolIdentify.Type.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsmodelcomponentgraphicitem.py
+++ b/python/PyQt6/gui/auto_additions/qgsmodelcomponentgraphicitem.py
@@ -4,7 +4,10 @@ QgsModelComponentGraphicItem.Selected = QgsModelComponentGraphicItem.State.Selec
 QgsModelComponentGraphicItem.Hover = QgsModelComponentGraphicItem.State.Hover
 QgsModelComponentGraphicItem.Unused = QgsModelComponentGraphicItem.Flag.Unused
 QgsModelComponentGraphicItem.Flags = lambda flags=0: QgsModelComponentGraphicItem.Flag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsModelComponentGraphicItem.Flag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgsnewhttpconnection.py
+++ b/python/PyQt6/gui/auto_additions/qgsnewhttpconnection.py
@@ -13,7 +13,10 @@ QgsNewHttpConnection.WFS_VERSION_1_0 = QgsNewHttpConnection.WfsVersionIndex.WFS_
 QgsNewHttpConnection.WFS_VERSION_1_1 = QgsNewHttpConnection.WfsVersionIndex.WFS_VERSION_1_1
 QgsNewHttpConnection.WFS_VERSION_2_0 = QgsNewHttpConnection.WfsVersionIndex.WFS_VERSION_2_0
 QgsNewHttpConnection.WFS_VERSION_API_FEATURES_1_0 = QgsNewHttpConnection.WfsVersionIndex.WFS_VERSION_API_FEATURES_1_0
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsNewHttpConnection.ConnectionType.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_additions/qgssearchwidgetwrapper.py
+++ b/python/PyQt6/gui/auto_additions/qgssearchwidgetwrapper.py
@@ -15,7 +15,10 @@ QgsSearchWidgetWrapper.IsNotNull = QgsSearchWidgetWrapper.FilterFlag.IsNotNull
 QgsSearchWidgetWrapper.StartsWith = QgsSearchWidgetWrapper.FilterFlag.StartsWith
 QgsSearchWidgetWrapper.EndsWith = QgsSearchWidgetWrapper.FilterFlag.EndsWith
 QgsSearchWidgetWrapper.FilterFlags = lambda flags=0: QgsSearchWidgetWrapper.FilterFlag(flags)
-def _force_int(v): return v if isinstance(v, int) else int(v.value)
+from enum import Enum
+
+
+def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
 
 
 QgsSearchWidgetWrapper.FilterFlag.__bool__ = lambda flag: bool(_force_int(flag))

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -18,7 +18,7 @@ class QgsAttributeTableFilterModel: QSortFilterProxyModel, QgsFeatureModel
 %End
   public:
 
-    enum FilterMode
+    enum FilterMode /BaseType=IntEnum/
     {
       ShowAll,
       ShowSelected,
@@ -28,7 +28,7 @@ class QgsAttributeTableFilterModel: QSortFilterProxyModel, QgsFeatureModel
       ShowInvalid,
     };
 
-    enum ColumnType
+    enum ColumnType /BaseType=IntEnum/
     {
       ColumnTypeField,
       ColumnTypeActionButton

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -27,7 +27,7 @@ and the attributes for the currently selected feature are shown in a form.
 %End
   public:
 
-    enum ViewMode
+    enum ViewMode /BaseType=IntEnum/
     {
 
       AttributeTable,
@@ -36,7 +36,7 @@ and the attributes for the currently selected feature are shown in a form.
     };
 
 
-    enum FeatureListBrowsingAction
+    enum FeatureListBrowsingAction /BaseType=IntEnum/
     {
       NoAction,
       PanToFeature,

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -31,7 +31,7 @@ Constructor for FeatureInfo.
         bool isEdited;
     };
 
-    enum Role
+    enum Role /BaseType=IntEnum/
     {
       FeatureInfoRole,
       FeatureRole

--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistviewdelegate.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistviewdelegate.sip.in
@@ -17,7 +17,7 @@ class QgsFeatureListViewDelegate : QItemDelegate
   public:
     static const int ICON_SIZE;
 
-    enum Element
+    enum Element /BaseType=IntEnum/
     {
       EditElement,
       SelectionElement

--- a/python/PyQt6/gui/auto_generated/auth/qgsauthimportcertdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/auth/qgsauthimportcertdialog.sip.in
@@ -20,13 +20,13 @@ Widget for importing a certificate into the authentication database
 #include "qgsauthimportcertdialog.h"
 %End
   public:
-    enum CertFilter
+    enum CertFilter /BaseType=IntEnum/
     {
       NoFilter,
       CaFilter,
     };
 
-    enum CertInput
+    enum CertInput /BaseType=IntEnum/
     {
       AllInputs,
       FileInput,

--- a/python/PyQt6/gui/auto_generated/auth/qgsauthimportidentitydialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/auth/qgsauthimportidentitydialog.sip.in
@@ -20,18 +20,18 @@ Widget for importing an identity certificate/key bundle into the authentication 
 #include "qgsauthimportidentitydialog.h"
 %End
   public:
-    enum IdentityType
+    enum IdentityType /BaseType=IntEnum/
     {
       CertIdentity,
     };
 
-    enum BundleTypes
+    enum BundleTypes /BaseType=IntEnum/
     {
       PkiPaths,
       PkiPkcs12,
     };
 
-    enum Validity
+    enum Validity /BaseType=IntEnum/
     {
       Valid,
       Invalid,

--- a/python/PyQt6/gui/auto_generated/auth/qgsauthsettingswidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/auth/qgsauthsettingswidget.sip.in
@@ -26,7 +26,7 @@ to an authentication configuration.
 %End
   public:
 
-    enum WarningType
+    enum WarningType /BaseType=IntEnum/
     {
       ProjectFile,
       UserSettings

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -32,7 +32,7 @@ for their corresponding values and emit valuesChanged signal.
 %End
   public:
 
-    enum ConstraintResult
+    enum ConstraintResult /BaseType=IntEnum/
     {
       ConstraintResultPass,
       ConstraintResultFailHard,

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgssearchwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgssearchwidgetwrapper.sip.in
@@ -69,7 +69,7 @@ Shows a search widget on a filter form.
 %End
   public:
 
-    enum FilterFlag
+    enum FilterFlag /BaseType=IntEnum/
     {
       EqualTo,
       NotEqualTo,

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
@@ -37,7 +37,7 @@ This value can then be handled by a special value text.
 %End
   public:
 
-    enum ClearValueMode
+    enum ClearValueMode /BaseType=IntEnum/
     {
       MinimumValue,
       MaximumValue,

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsmultiedittoolbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsmultiedittoolbutton.sip.in
@@ -23,7 +23,7 @@ edit mode.
 %End
   public:
 
-    enum State
+    enum State /BaseType=IntEnum/
     {
       Default,
       MixedValues,

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -31,7 +31,7 @@ class QgsRelationReferenceWidget : QWidget
 %End
   public:
 
-    enum CanvasExtent
+    enum CanvasExtent /BaseType=IntEnum/
     {
       Fixed,
       Pan,

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
@@ -37,7 +37,7 @@ This value can then be handled by a special value text.
 %End
   public:
 
-    enum ClearValueMode
+    enum ClearValueMode /BaseType=IntEnum/
     {
       MinimumValue,
       MaximumValue,

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -44,7 +44,7 @@ open layout designer dialogs.
 %End
   public:
 
-    enum StandardTool
+    enum StandardTool /BaseType=IntEnum/
     {
       ToolMoveItemContent,
       ToolMoveItemNodes,

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -29,7 +29,7 @@ the components related to the GUI behavior of a layout item.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagNoCreationTools,
     };

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutview.sip.in
@@ -30,13 +30,13 @@ A graphical widget to display and interact with :py:class:`QgsLayouts`.
 %End
   public:
 
-    enum ClipboardOperation
+    enum ClipboardOperation /BaseType=IntEnum/
     {
       ClipboardCut,
       ClipboardCopy,
     };
 
-    enum PasteMode
+    enum PasteMode /BaseType=IntEnum/
     {
       PasteModeCursor,
       PasteModeCenter,

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutviewtool.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutviewtool.sip.in
@@ -34,7 +34,7 @@ to :py:class:`QgsLayoutView` widgets.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagSnaps,
     };

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelarrowitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelarrowitem.sip.in
@@ -28,7 +28,7 @@ A link arrow item for use in the model designer.
 %End
   public:
 
-    enum Marker
+    enum Marker /BaseType=IntEnum/
     {
       Circle,
       ArrowHead,

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -27,14 +27,14 @@ Base class for graphic items representing model components in the model designer
 %End
   public:
 
-    enum State
+    enum State /BaseType=IntEnum/
     {
       Normal,
       Selected,
       Hover,
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       // For future API flexibility only and to avoid sip issues, remove when real entries are added to flags.
       Unused,

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -27,7 +27,7 @@ QGraphicsScene subclass representing the model designer.
 %End
   public:
 
-    enum ZValues
+    enum ZValues /BaseType=IntEnum/
     {
       GroupBox,
       ArrowLink,
@@ -38,7 +38,7 @@ QGraphicsScene subclass representing the model designer.
 
     };
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagHideControls,
       FlagHideComments,

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -81,7 +81,7 @@ Ends a macro command, containing a group of interactions in the view.
 %End
 
 
-    enum ClipboardOperation
+    enum ClipboardOperation /BaseType=IntEnum/
     {
       ClipboardCut,
       ClipboardCopy,
@@ -105,7 +105,7 @@ Cuts or copies the a list of ``items``, respecting the specified ``operation``.
 .. seealso:: :py:func:`pasteItems`
 %End
 
-    enum PasteMode
+    enum PasteMode /BaseType=IntEnum/
     {
       PasteModeCursor,
       PasteModeCenter,

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -29,7 +29,7 @@ Base class for processing algorithm dialogs.
 %End
   public:
 
-    enum LogFormat
+    enum LogFormat /BaseType=IntEnum/
     {
       FormatPlainText,
       FormatHtml,

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessinggui.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessinggui.sip.in
@@ -24,7 +24,7 @@ Contains general functions and values related to Processing GUI components.
 %End
   public:
 
-    enum WidgetType
+    enum WidgetType /BaseType=IntEnum/
     {
       Standard,
       Batch,

--- a/python/PyQt6/gui/auto_generated/proj/qgscoordinatereferencesystemmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgscoordinatereferencesystemmodel.sip.in
@@ -88,7 +88,7 @@ A sort/filter proxy model for coordinate reference systems.
 %End
   public:
 
-    enum Filter
+    enum Filter /BaseType=IntEnum/
     {
       FilterHorizontal,
       FilterVertical,

--- a/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectionwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/proj/qgsprojectionselectionwidget.sip.in
@@ -24,7 +24,7 @@ A widget for selecting a projection.
 %End
   public:
 
-    enum CrsOption
+    enum CrsOption /BaseType=IntEnum/
     {
       Invalid,
       LayerCrs,

--- a/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -26,7 +26,7 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
 %End
   public:
 
-    enum CadCapacity
+    enum CadCapacity /BaseType=IntEnum/
     {
       AbsoluteAngle,
       RelativeAngle,
@@ -36,7 +36,7 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
     typedef QFlags<QgsAdvancedDigitizingDockWidget::CadCapacity> CadCapacities;
 
 
-    enum WidgetSetMode
+    enum WidgetSetMode /BaseType=IntEnum/
     {
       ReturnPressed,
     };
@@ -58,7 +58,7 @@ It contains all values (locked, value, relative) and pointers to corresponding w
 %End
       public:
 
-        enum LockMode
+        enum LockMode /BaseType=IntEnum/
         {
           NoLock,
           SoftLock,

--- a/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -27,7 +27,7 @@ showing an embedded form due to relations)
 
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       SingleEditMode,
       AddFeatureMode,
@@ -38,14 +38,14 @@ showing an embedded form due to relations)
       IdentifyMode
     };
 
-    enum RelationMode
+    enum RelationMode /BaseType=IntEnum/
     {
       Undefined,
       Multiple,
       Single
     };
 
-    enum FormMode
+    enum FormMode /BaseType=IntEnum/
     {
       Embed,
       StandaloneDialog,

--- a/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeform.sip.in
@@ -20,7 +20,7 @@ class QgsAttributeForm : QWidget
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       SingleEditMode,
       AddFeatureMode,
@@ -30,7 +30,7 @@ class QgsAttributeForm : QWidget
       IdentifyMode
     };
 
-    enum FilterType
+    enum FilterType /BaseType=IntEnum/
     {
       ReplaceFilter,
       FilterAnd,

--- a/python/PyQt6/gui/auto_generated/qgsattributeformwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeformwidget.sip.in
@@ -24,7 +24,7 @@ Consists of the widget which is visible in edit mode as well as the widget visib
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       DefaultMode,
       MultiEditMode,

--- a/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
@@ -29,7 +29,7 @@ and pasting colors, picking colors from the screen, and selecting colors from co
 %End
   public:
 
-    enum Behavior
+    enum Behavior /BaseType=IntEnum/
     {
       ShowDialog,
       SignalOnly

--- a/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorwidgets.sip.in
@@ -26,7 +26,7 @@ set to a color with an ambiguous hue (e.g., black or white shades).
 %End
   public:
 
-    enum ColorComponent
+    enum ColorComponent /BaseType=IntEnum/
     {
       Multiple,
       Red,
@@ -388,7 +388,7 @@ its length by a single color component (e.g., varying saturation from 0 to 100%)
 %End
   public:
 
-    enum Orientation
+    enum Orientation /BaseType=IntEnum/
     {
       Horizontal,
       Vertical
@@ -543,7 +543,7 @@ of colors.
 %End
   public:
 
-    enum ColorTextFormat
+    enum ColorTextFormat /BaseType=IntEnum/
     {
       HexRgb,
       HexRgbA,

--- a/python/PyQt6/gui/auto_generated/qgscompoundcolorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscompoundcolorwidget.sip.in
@@ -24,7 +24,7 @@ hue wheel, color swatches, and a color sampler.
 %End
   public:
 
-    enum Layout
+    enum Layout /BaseType=IntEnum/
     {
       LayoutDefault,
       LayoutVertical,

--- a/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -25,7 +25,7 @@ See :py:class:`QgsExpressionBuilderDialog` for example of usage.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       LoadNothing,
       LoadRecent,

--- a/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -23,7 +23,7 @@ An expression item that can be used in the :py:class:`QgsExpressionBuilderWidget
 #include "qgsexpressiontreeview.h"
 %End
   public:
-    enum ItemType
+    enum ItemType /BaseType=IntEnum/
     {
       Header,
       Field,

--- a/python/PyQt6/gui/auto_generated/qgsextentgroupbox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsextentgroupbox.sip.in
@@ -32,7 +32,7 @@ When using the group box, make sure to call :py:func:`~setOriginalExtent`, :py:f
   public:
 
 
-    enum ExtentState
+    enum ExtentState /BaseType=IntEnum/
     {
       OriginalExtent,
       CurrentExtent,

--- a/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsextentwidget.sip.in
@@ -32,7 +32,7 @@ When using the widget, make sure to call :py:func:`~setOriginalExtent`, :py:func
 %End
   public:
 
-    enum ExtentState
+    enum ExtentState /BaseType=IntEnum/
     {
       OriginalExtent,
       CurrentExtent,
@@ -41,7 +41,7 @@ When using the widget, make sure to call :py:func:`~setOriginalExtent`, :py:func
       DrawOnCanvas,
     };
 
-    enum WidgetStyle
+    enum WidgetStyle /BaseType=IntEnum/
     {
       CondensedStyle,
       ExpandedStyle,

--- a/python/PyQt6/gui/auto_generated/qgsexternalresourcewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexternalresourcewidget.sip.in
@@ -38,7 +38,7 @@ It can also be used to display a picture or a web page.
       sipType = NULL;
 %End
   public:
-    enum DocumentViewerContent
+    enum DocumentViewerContent /BaseType=IntEnum/
     {
       NoContent,
       Image,

--- a/python/PyQt6/gui/auto_generated/qgsfilecontentsourcelineedit.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfilecontentsourcelineedit.sip.in
@@ -112,7 +112,7 @@ A line edit widget with toolbutton for setting a raster image path.
 %End
   public:
 
-    enum Format
+    enum Format /BaseType=IntEnum/
     {
       Svg,
       Image,

--- a/python/PyQt6/gui/auto_generated/qgsfilewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfilewidget.sip.in
@@ -28,7 +28,7 @@ The :py:class:`QgsFileWidget` class creates a widget for selecting a file or a f
 %End
   public:
 
-    enum StorageMode
+    enum StorageMode /BaseType=IntEnum/
     {
       GetFile,
       GetDirectory,
@@ -36,7 +36,7 @@ The :py:class:`QgsFileWidget` class creates a widget for selecting a file or a f
       SaveFile,
     };
 
-    enum RelativeStorage
+    enum RelativeStorage /BaseType=IntEnum/
     {
       Absolute,
       RelativeProject,

--- a/python/PyQt6/gui/auto_generated/qgsfilterlineedit.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfilterlineedit.sip.in
@@ -32,7 +32,7 @@ signal should be used instead of :py:func:`~textChanged`.
 %End
   public:
 
-    enum ClearMode
+    enum ClearMode /BaseType=IntEnum/
     {
       ClearToNull,
       ClearToDefault,

--- a/python/PyQt6/gui/auto_generated/qgsfloatingwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfloatingwidget.sip.in
@@ -24,7 +24,7 @@ within their parent widget.
 %End
   public:
 
-    enum AnchorPoint
+    enum AnchorPoint /BaseType=IntEnum/
     {
       TopLeft,
       TopMiddle,

--- a/python/PyQt6/gui/auto_generated/qgsfontbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfontbutton.sip.in
@@ -32,7 +32,7 @@ used only in a QFont object.
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       ModeTextRenderer,
       ModeQFont,

--- a/python/PyQt6/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -32,7 +32,7 @@ A rubberband class for :py:class:`QgsAbstractGeometry` (considering curved geome
       sipType = nullptr;
 %End
   public:
-    enum IconType
+    enum IconType /BaseType=IntEnum/
     {
 
       ICON_NONE,

--- a/python/PyQt6/gui/auto_generated/qgsgui.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsgui.sip.in
@@ -24,7 +24,7 @@ related to GUI classes.
 %End
   public:
 
-    enum ProjectCrsBehavior
+    enum ProjectCrsBehavior /BaseType=IntEnum/
     {
       UseCrsOfFirstLayerAdded,
       UsePresetCrs,
@@ -206,7 +206,7 @@ Returns the global input controller manager.
 .. versionadded:: 3.32
 %End
 
-    enum HigFlag
+    enum HigFlag /BaseType=IntEnum/
     {
       HigMenuTextIsTitleCase,
       HigDialogTitleIsTitleCase

--- a/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsidentifymenu.sip.in
@@ -23,7 +23,7 @@ If used in a :py:class:`QgsMapToolIdentify`, it is accessible via :py:func:`QgsM
 #include "qgsidentifymenu.h"
 %End
   public:
-    enum MenuLevel
+    enum MenuLevel /BaseType=IntEnum/
     {
       LayerLevel,
       FeatureLevel

--- a/python/PyQt6/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
@@ -55,13 +55,13 @@ Load/Reload model data synchronously.
 Load/Reload model data asynchronously using threads.
 %End
 
-    enum Roles
+    enum Roles /BaseType=IntEnum/
     {
       //! Layer metadata role
       Metadata
     };
 
-    enum Sections
+    enum Sections /BaseType=IntEnum/
     {
       //! Metadata identifier
       Identifier,

--- a/python/PyQt6/gui/auto_generated/qgsmanageconnectionsdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmanageconnectionsdialog.sip.in
@@ -16,13 +16,13 @@ class QgsManageConnectionsDialog : QDialog
 #include "qgsmanageconnectionsdialog.h"
 %End
   public:
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       Export,
       Import
     };
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       WMS,
       PostGIS,

--- a/python/PyQt6/gui/auto_generated/qgsmapcanvasannotationitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmapcanvasannotationitem.sip.in
@@ -37,7 +37,7 @@ An interactive map canvas item which displays a :py:class:`QgsAnnotation`.
 %End
   public:
 
-    enum MouseMoveAction
+    enum MouseMoveAction /BaseType=IntEnum/
     {
       NoAction,
       MoveMapPosition,

--- a/python/PyQt6/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptool.sip.in
@@ -67,7 +67,7 @@ implemented as map tools.
 %End
   public:
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       Transient,
       EditTool,

--- a/python/PyQt6/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -26,7 +26,7 @@ as well as a more specific handler (pointCaptured, lineCaptured or polygonCaptur
 %End
   public:
 
-    enum CaptureMode
+    enum CaptureMode /BaseType=IntEnum/
     {
       CaptureNone,
       CapturePoint,
@@ -34,7 +34,7 @@ as well as a more specific handler (pointCaptured, lineCaptured or polygonCaptur
       CapturePolygon
     };
 
-    enum Capability
+    enum Capability /BaseType=IntEnum/
     {
       NoCapabilities,
       SupportsCurves,

--- a/python/PyQt6/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptooledit.sip.in
@@ -77,7 +77,7 @@ returned object
 Returns the current vector layer of the map canvas or 0
 %End
 
-    enum TopologicalResult
+    enum TopologicalResult /BaseType=IntEnum/
     {
       Success,
       InvalidCanvas,

--- a/python/PyQt6/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -27,7 +27,7 @@ after selecting a point, performs the identification:
 %End
   public:
 
-    enum IdentifyMode
+    enum IdentifyMode /BaseType=IntEnum/
     {
       DefaultQgsSetting,
       ActiveLayer,
@@ -36,7 +36,7 @@ after selecting a point, performs the identification:
       LayerSelection
     };
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       VectorLayer,
       RasterLayer,

--- a/python/PyQt6/gui/auto_generated/qgsmediawidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmediawidget.sip.in
@@ -23,7 +23,7 @@ The :py:class:`QgsMediaWidget` class creates a widget for playing back audio and
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       Audio,
       Video,

--- a/python/PyQt6/gui/auto_generated/qgsmetadatawidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmetadatawidget.sip.in
@@ -24,7 +24,7 @@ A wizard to edit metadata on a map layer.
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       LayerMetadata,
       ProjectMetadata,

--- a/python/PyQt6/gui/auto_generated/qgsnewgeopackagelayerdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewgeopackagelayerdialog.sip.in
@@ -20,7 +20,7 @@ Dialog to set up parameters to create a new GeoPackage layer, and on :py:func:`~
 %End
   public:
 
-    enum OverwriteBehavior
+    enum OverwriteBehavior /BaseType=IntEnum/
     {
       Prompt,
       Overwrite,

--- a/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -22,7 +22,7 @@ information for an HTTP Server for WMS, etc.
 %End
   public:
 
-    enum ConnectionType
+    enum ConnectionType /BaseType=IntEnum/
     {
       ConnectionWfs,
       ConnectionWms,
@@ -32,7 +32,7 @@ information for an HTTP Server for WMS, etc.
     typedef QFlags<QgsNewHttpConnection::ConnectionType> ConnectionTypes;
 
 
-    enum Flag
+    enum Flag /BaseType=IntEnum/
     {
       FlagShowTestConnection,
       FlagHideAuthenticationGroup,
@@ -78,7 +78,7 @@ Returns the current connection url.
 
   protected:
 
-    enum WfsVersionIndex
+    enum WfsVersionIndex /BaseType=IntEnum/
     {
       WFS_VERSION_MAX,
       WFS_VERSION_1_0,

--- a/python/PyQt6/gui/auto_generated/qgsprevieweffect.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsprevieweffect.sip.in
@@ -21,7 +21,7 @@ color blindness modes.
 #include "qgsprevieweffect.h"
 %End
   public:
-    enum PreviewMode
+    enum PreviewMode /BaseType=IntEnum/
     {
       PreviewGrayscale,
       PreviewMono,

--- a/python/PyQt6/gui/auto_generated/qgsrasterformatsaveoptionswidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrasterformatsaveoptionswidget.sip.in
@@ -21,7 +21,7 @@ A widget to select format-specific raster saving options
 %End
   public:
 
-    enum Type
+    enum Type /BaseType=IntEnum/
     {
       Default,
       Full,

--- a/python/PyQt6/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
@@ -15,18 +15,18 @@ class QgsRasterLayerSaveAsDialog: QDialog
 #include "qgsrasterlayersaveasdialog.h"
 %End
   public:
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       RawDataMode,
       RenderedImageMode
     };
-    enum CrsState
+    enum CrsState /BaseType=IntEnum/
     {
       OriginalCrs,
       CurrentCrs,
       UserCrs
     };
-    enum ResolutionState
+    enum ResolutionState /BaseType=IntEnum/
     {
       OriginalResolution,
       UserResolution

--- a/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -34,7 +34,7 @@ The default relation widget in QGIS.
 %End
   public:
 
-    enum Button
+    enum Button /BaseType=IntEnum/
     {
       NoButton,
       Link,

--- a/python/PyQt6/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrubberband.sip.in
@@ -42,7 +42,7 @@ for tracking the mouse while drawing polylines or polygons.
   public:
 
 
-    enum IconType
+    enum IconType /BaseType=IntEnum/
     {
 
       ICON_NONE,

--- a/python/PyQt6/gui/auto_generated/qgssourceselectprovider.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgssourceselectprovider.sip.in
@@ -25,7 +25,7 @@ This is the interface for those who want to add entries to the :py:class:`QgsDat
 
   public:
 
-    enum Ordering
+    enum Ordering /BaseType=IntEnum/
     {
       OrderLocalProvider,
       OrderDatabaseProvider,

--- a/python/PyQt6/gui/auto_generated/qgsstatusbar.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsstatusbar.sip.in
@@ -33,7 +33,7 @@ these widgets (and messages) should instead be added into the embedded :py:class
 %End
   public:
 
-    enum Anchor
+    enum Anchor /BaseType=IntEnum/
     {
       AnchorLeft,
       AnchorRight,

--- a/python/PyQt6/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgssublayersdialog.sip.in
@@ -21,7 +21,7 @@ class QgsSublayersDialog : QDialog
 %End
   public:
 
-    enum PromptMode
+    enum PromptMode /BaseType=IntEnum/
     {
 
       PromptAlways,
@@ -33,7 +33,7 @@ class QgsSublayersDialog : QDialog
       PromptLoadAll
     };
 
-    enum ProviderType
+    enum ProviderType /BaseType=IntEnum/
     {
       Ogr,
       Gdal,

--- a/python/PyQt6/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgstextformatwidget.sip.in
@@ -115,7 +115,7 @@ Emitted when an auxiliary field is created in the widget.
 
   protected:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       Text,
       Labeling,

--- a/python/PyQt6/gui/auto_generated/qgsvertexmarker.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsvertexmarker.sip.in
@@ -31,7 +31,7 @@ A class for marking vertices of features using e.g. circles or 'x'.
 %End
   public:
 
-    enum IconType
+    enum IconType /BaseType=IntEnum/
     {
       ICON_NONE,
       ICON_CROSS,

--- a/python/PyQt6/gui/auto_generated/qgswindowmanagerinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgswindowmanagerinterface.sip.in
@@ -30,7 +30,7 @@ the :py:class:`QgsGui` instance, via :py:func:`QgsGui.windowManager()`.
 %End
   public:
 
-    enum StandardDialog
+    enum StandardDialog /BaseType=IntEnum/
     {
       DialogStyleManager,
     };

--- a/python/PyQt6/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
@@ -19,7 +19,7 @@ class QgsStyleExportImportDialog : QDialog
 %End
   public:
 
-    enum Mode
+    enum Mode /BaseType=IntEnum/
     {
       Export,
       Import,

--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -43,7 +43,7 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
 
   public:
 
-    enum Rel
+    enum Rel /BaseType=IntEnum/
     {
       // The following registered link relation types are used
       alternate,
@@ -62,7 +62,7 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
       data
     };
 
-    enum ContentType
+    enum ContentType /BaseType=IntEnum/
     {
       GEOJSON,
       OPENAPI3,

--- a/python/PyQt6/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverparameters.sip.in
@@ -211,7 +211,7 @@ Parameter common to all services (WMS, WFS, ...)
     static const QMetaObject staticMetaObject;
 
   public:
-    enum Name
+    enum Name /BaseType=IntEnum/
     {
       UNKNOWN,
       SERVICE,

--- a/python/PyQt6/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverrequest.sip.in
@@ -24,7 +24,7 @@ class QgsServerRequest
     typedef QMap<QString, QString> Parameters;
     typedef QMap<QString, QString> Headers;
 
-    enum Method
+    enum Method /BaseType=IntEnum/
     {
       HeadMethod,
       PutMethod,
@@ -34,7 +34,7 @@ class QgsServerRequest
       PatchMethod
     };
 
-    enum RequestHeader
+    enum RequestHeader /BaseType=IntEnum/
     {
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
       HOST,

--- a/python/PyQt6/server/auto_generated/qgsserversettings.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserversettings.sip.in
@@ -23,14 +23,14 @@ Provides some enum describing the environment currently supported for configurat
 #include "qgsserversettings.h"
 %End
   public:
-    enum Source
+    enum Source /BaseType=IntEnum/
     {
       DEFAULT_VALUE,
       ENVIRONMENT_VARIABLE,
       INI_FILE
     };
 
-    enum EnvVar
+    enum EnvVar /BaseType=IntEnum/
     {
       QGIS_OPTIONS_PATH,
       QGIS_SERVER_PARALLEL_RENDERING,

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1618,6 +1618,10 @@ while ($LINE_IDX < $LINE_COUNT){
           exit_with_error("Unhandled enum type $enum_type for $enum_cpp_name");
         } elsif (defined $isclass) {
           push @ENUM_CLASS_NON_INT_TYPES, "$ACTUAL_CLASS.$enum_qualname";
+        } elsif ($is_qt6 eq 1) {
+          # non class enum in qt6 -- we always want these to be IntEnums
+          # for compatibility with qt5 code
+          $enum_decl .= " /BaseType=IntEnum/"
         }
 
         write_output("ENU1", "$enum_decl");
@@ -1832,7 +1836,7 @@ while ($LINE_IDX < $LINE_COUNT){
           if ( $is_qt6 ) {
             dbg_info("monkey patching operators for non class enum");
             if ($HAS_PUSHED_FORCE_INT eq 0) {
-              push @OUTPUT_PYTHON, "def _force_int(v): return v if isinstance(v, int) else int(v.value)\n\n\n";
+              push @OUTPUT_PYTHON, "from enum import Enum\n\n\ndef _force_int(v): return int(v.value) if isinstance(v, Enum) else v\n\n\n";
               $HAS_PUSHED_FORCE_INT = 1;
             }
             push @OUTPUT_PYTHON, "$py_flag.__bool__ = lambda flag: bool(_force_int(flag))\n";

--- a/tests/code_layout/sipify/sipifyheader.expected_pyqt6.sip
+++ b/tests/code_layout/sipify/sipifyheader.expected_pyqt6.sip
@@ -97,7 +97,7 @@ typedef QtClass<QVariant> QtClassQVariantBase;
     typedef QFlags<QgsSipifyHeader::MyEnum> Flags;
 
 
-    enum OneLiner { Success, NoSuccess };
+    enum OneLiner /BaseType=IntEnum/ { Success, NoSuccess };
 
   private:
     void makePrivate( int a );


### PR DESCRIPTION
This fixes compatiblity with existing code, where enums may be compared against integers directly