### PR TITLE
[pyqt5toqt6] Replace invalid QVariant() constructor with NULL

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -79,6 +79,7 @@ PyQgsLayerDefinition
 PyQgsSettings
 PyQgsSettingsEntry
 PyQgsSelectiveMasking
+PyQgsServerApi
 PyQgsServerWMSGetFeatureInfo
 PyQgsServerWMSGetMap
 PyQgsServerAccessControlWFSTransactional

--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -60,7 +60,6 @@ PyQgsMapBoxGlStyleConverter
 PyQgsMetadataBase
 PyQgsMemoryProvider
 PyQgsNetworkAccessManager
-PyQgsOGRProviderGpkg
 PyQgsPalLabelingPlacement
 PyQgsPlot
 PyQgsProjectMetadata

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -269,8 +269,8 @@ class TestPyQgsHanaProvider(QgisTestCase, ProviderTestCase):
                                  bool(vl.fieldConstraints(field_idx) & QgsFieldConstraints.Constraint.ConstraintUnique))
             if fields.count() > 0:
                 if vl.featureCount() == 0:
-                    self.assertEqual(QVariant(), vl.maximumValue(0))
-                    self.assertEqual(QVariant(), vl.minimumValue(0))
+                    self.assertEqual(NULL, vl.maximumValue(0))
+                    self.assertEqual(NULL, vl.minimumValue(0))
                 else:
                     vl.maximumValue(0)
                     vl.minimumValue(0)

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -2814,9 +2814,9 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         vl.commitChanges()
 
         got = [feat["int_field"] for feat in vl.getFeatures()]
-        self.assertEqual(set(got), set([1, QVariant()]))
+        self.assertEqual(set(got), set([1, NULL]))
         got = [feat["int64_field"] for feat in vl.getFeatures()]
-        self.assertEqual(set(got), set([1, QVariant()]))
+        self.assertEqual(set(got), set([1, NULL]))
 
         # Does not trigger the optim: not all features updated
         vl.startEditing()
@@ -2828,7 +2828,7 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         vl.commitChanges()
 
         got = [feat["real_field"] for feat in vl.getFeatures()]
-        self.assertEqual(set(got), set([1.5, QVariant()]))
+        self.assertEqual(set(got), set([1.5, NULL]))
 
         # Triggers the optim
         for field_name, value in [("str_field", "my_value"),
@@ -2847,7 +2847,7 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
             if value:
                 self.assertEqual(set(got), set([value]))
             else:
-                self.assertEqual(set(got), set([QVariant()]))
+                self.assertEqual(set(got), set([NULL]))
 
     def testChangeAttributeValuesErrors(self):
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2636,7 +2636,7 @@ class TestPyQgsPostgresProvider(QgisTestCase, ProviderTestCase):
         f.setAttribute('test_string', 'QGIS Rocks')
 
         dp = vl.dataProvider()
-        self.assertNotEqual(dp.defaultValue(0), QVariant())
+        self.assertNotEqual(dp.defaultValue(0), NULL)
 
     @unittest.skipIf(os.environ.get('QGIS_CONTINUOUS_INTEGRATION_RUN', 'true'), 'Test flaky')
     def testDefaultValuesAndClauses(self):

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -271,13 +271,13 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
 
         # test when value is null
         field = "myfield"
-        value = QVariant()
+        value = NULL
         res = '"myfield" IS NULL'
         self.assertEqual(e.createFieldEqualityExpression(field, value), res)
 
         # test when value is null and field name has a quote
         field = "my'field"
-        value = QVariant()
+        value = NULL
         res = '"my\'field" IS NULL'
         self.assertEqual(e.createFieldEqualityExpression(field, value), res)
 

--- a/tests/src/python/test_qgsfieldmappingwidget.py
+++ b/tests/src/python/test_qgsfieldmappingwidget.py
@@ -16,7 +16,7 @@ from qgis.PyQt.QtCore import (
     QModelIndex,
     QVariant, Qt)
 from qgis.PyQt.QtGui import QColor
-from qgis.core import QgsField, QgsFieldConstraints, QgsFields, QgsProperty
+from qgis.core import QgsField, QgsFieldConstraints, QgsFields, QgsProperty, NULL
 from qgis.gui import QgsFieldMappingModel, QgsFieldMappingWidget
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -92,7 +92,7 @@ class TestPyQgsFieldMappingModel(QgisTestCase):
         self.assertEqual(model.data(model.index(1, 6), Qt.ItemDataRole.DisplayRole), 'my alias')
         self.assertFalse(model.data(model.index(1, 7), Qt.ItemDataRole.DisplayRole))
 
-        self.assertEqual(model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), QVariant())
+        self.assertEqual(model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), NULL)
         self.assertEqual(model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), 'destination_field3')
         self.assertFalse(model.data(model.index(2, 6), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(2, 7), Qt.ItemDataRole.DisplayRole))
@@ -157,7 +157,7 @@ class TestPyQgsFieldMappingModel(QgisTestCase):
         """Test that changing source fields also empty expressions are updated"""
 
         model = QgsFieldMappingModel(self.source_fields, self.destination_fields)
-        self.assertEqual(model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), QVariant())
+        self.assertEqual(model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), NULL)
         self.assertEqual(model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), 'destination_field3')
 
         f = QgsField('source_field3', QVariant.String)

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -37,8 +37,7 @@ from qgis.core import (
     QgsSettings,
     QgsVectorLayer,
     QgsVectorLayerUtils,
-    QgsWkbTypes,
-)
+    QgsWkbTypes, NULL)
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -424,16 +423,16 @@ class TestQgsProcessingInPlace(QgisTestCase):
         f1.setAttributes([])
         new_features = QgsVectorLayerUtils.makeFeaturesCompatible([f1], layer)
         self.assertEqual(len(new_features[0].attributes()), 2)
-        self.assertEqual(new_features[0].attributes()[0], QVariant())
-        self.assertEqual(new_features[0].attributes()[1], QVariant())
+        self.assertEqual(new_features[0].attributes()[0], NULL)
+        self.assertEqual(new_features[0].attributes()[1], NULL)
 
         # Test pad with 0 without fields
         f1 = QgsFeature()
         f1.setGeometry(QgsGeometry.fromWkt('Point(9 45)'))
         new_features = QgsVectorLayerUtils.makeFeaturesCompatible([f1], layer)
         self.assertEqual(len(new_features[0].attributes()), 2)
-        self.assertEqual(new_features[0].attributes()[0], QVariant())
-        self.assertEqual(new_features[0].attributes()[1], QVariant())
+        self.assertEqual(new_features[0].attributes()[0], NULL)
+        self.assertEqual(new_features[0].attributes()[1], NULL)
 
         # Test drop extra attrs
         f1 = QgsFeature(layer.fields())

--- a/tests/src/python/test_qgsqueryresultmodel.py
+++ b/tests/src/python/test_qgsqueryresultmodel.py
@@ -23,8 +23,7 @@ from qgis.PyQt.QtTest import QAbstractItemModelTester
 from qgis.PyQt.QtWidgets import QDialog, QLabel, QListView, QVBoxLayout
 from qgis.core import (
     QgsProviderRegistry,
-    QgsQueryResultModel,
-)
+    QgsQueryResultModel, NULL)
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -92,8 +91,8 @@ class TestPyQgsQgsQueryResultModel(QgisTestCase):
         for i in range(1000):
             self.assertEqual(model.data(model.index(i, 0), Qt.ItemDataRole.DisplayRole), i + 1)
 
-        self.assertEqual(model.data(model.index(1000, 0), Qt.ItemDataRole.DisplayRole), QVariant())
-        self.assertEqual(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole), QVariant())
+        self.assertEqual(model.data(model.index(1000, 0), Qt.ItemDataRole.DisplayRole), NULL)
+        self.assertEqual(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole), NULL)
 
     def test_model_stop(self):
         """Test that when a model is deleted fetching query rows is also interrupted"""

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -14,7 +14,7 @@ import tempfile
 from pathlib import Path
 
 from qgis.PyQt.QtCore import QSettings, QVariant
-from qgis.core import Qgis, QgsMapLayerProxyModel, QgsSettings, QgsTolerance
+from qgis.core import Qgis, QgsMapLayerProxyModel, QgsSettings, QgsTolerance, NULL
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -444,14 +444,14 @@ class TestQgsSettings(QgisTestCase):
     def test_overwriteDefaultValues(self):
         """Test that unchanged values are not stored"""
         self.globalsettings.setValue('a_value_with_default', 'a value')
-        self.globalsettings.setValue('an_invalid_value', QVariant())
+        self.globalsettings.setValue('an_invalid_value', NULL)
 
         self.assertEqual(self.settings.value('a_value_with_default'), 'a value')
-        self.assertEqual(self.settings.value('an_invalid_value'), QVariant())
+        self.assertEqual(self.settings.value('an_invalid_value'), NULL)
 
         # Now, set them with the same current value
         self.settings.setValue('a_value_with_default', 'a value')
-        self.settings.setValue('an_invalid_value', QVariant())
+        self.settings.setValue('an_invalid_value', NULL)
 
         # Check
         pure_settings = QSettings(self.settings.fileName(), QSettings.Format.IniFormat)
@@ -471,10 +471,10 @@ class TestQgsSettings(QgisTestCase):
 
         # Re-set to original values
         self.settings.setValue('a_value_with_default', 'a value')
-        self.settings.setValue('an_invalid_value', QVariant())
+        self.settings.setValue('an_invalid_value', NULL)
 
         self.assertEqual(self.settings.value('a_value_with_default'), 'a value')
-        self.assertEqual(self.settings.value('an_invalid_value'), QVariant())
+        self.assertEqual(self.settings.value('an_invalid_value'), NULL)
 
         # Check if they are gone
         pure_settings = QSettings(self.settings.fileName(), QSettings.Format.IniFormat)

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -689,15 +689,15 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         f1.setAttributes([])
         QgsVectorLayerUtils.matchAttributesToFields(f1, fields)
         self.assertEqual(len(f1.attributes()), 2)
-        self.assertEqual(f1.attributes()[0], QVariant())
-        self.assertEqual(f1.attributes()[1], QVariant())
+        self.assertEqual(f1.attributes()[0], NULL)
+        self.assertEqual(f1.attributes()[1], NULL)
 
         # Test pad with 0 without fields
         f1 = QgsFeature()
         QgsVectorLayerUtils.matchAttributesToFields(f1, fields)
         self.assertEqual(len(f1.attributes()), 2)
-        self.assertEqual(f1.attributes()[0], QVariant())
-        self.assertEqual(f1.attributes()[1], QVariant())
+        self.assertEqual(f1.attributes()[0], NULL)
+        self.assertEqual(f1.attributes()[1], NULL)
 
         # Test drop extra attrs
         f1 = QgsFeature(fields)
@@ -727,7 +727,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         self.assertEqual(len(f1.attributes()), 3)
         self.assertEqual(f1.attributes()[0], 'foo')
         self.assertEqual(f1.attributes()[1], 1)
-        self.assertEqual(f1.attributes()[2], QVariant())
+        self.assertEqual(f1.attributes()[2], NULL)
 
         fields.append(QgsField('extra', QVariant.Int))
         f1.setAttributes([1, 'foo', 'blah'])
@@ -736,7 +736,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         self.assertEqual(f1.attributes()[0], 1)
         self.assertEqual(f1.attributes()[1], 'foo')
         self.assertEqual(f1.attributes()[2], 'blah')
-        self.assertEqual(f1.attributes()[3], QVariant())
+        self.assertEqual(f1.attributes()[3], NULL)
 
         # case insensitive
         fields2.append(QgsField('extra3', QVariant.String))
@@ -747,7 +747,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         self.assertEqual(len(f1.attributes()), 5)
         self.assertEqual(f1.attributes()[0], 'foo')
         self.assertEqual(f1.attributes()[1], 1)
-        self.assertEqual(f1.attributes()[2], QVariant())
+        self.assertEqual(f1.attributes()[2], NULL)
         self.assertEqual(f1.attributes()[3], 'blah')
         self.assertEqual(f1.attributes()[4], 'blergh')
 
@@ -778,7 +778,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         features_data.append(
             QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 44)'), {0: 'test_1', 1: None}))
         features_data.append(
-            QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: 'test_2', 1: QVariant()}))
+            QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: 'test_2', 1: NULL}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'),
                                                                 {0: 'test_3', 1: NULL}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {0: 'test_4'}))
@@ -793,7 +793,7 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         features_data = []
         context = vl.createExpressionContext()
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 44)'), {0: None}))
-        features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: QVariant()}))
+        features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 45)'), {0: NULL}))
         features_data.append(
             QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {0: NULL}))
         features_data.append(QgsVectorLayerUtils.QgsFeatureData(QgsGeometry.fromWkt('Point (7 46)'), {}))


### PR DESCRIPTION
This approach works for both Qt5 and Qt6 builds