### PR TITLE
Avoid sip property code for old api compatibility 

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -53,16 +53,13 @@ PyQgsProject
 PyQgsFieldModel
 PyQgsFloatingWidget
 PyQgsJsonUtils
-PyQgsLayerMetadata
 PyQgsLayoutHtml
 PyQgsLineSymbolLayers
 PyQgsMapBoxGlStyleConverter
-PyQgsMetadataBase
 PyQgsMemoryProvider
 PyQgsNetworkAccessManager
 PyQgsPalLabelingPlacement
 PyQgsPlot
-PyQgsProjectMetadata
 PyQgsRasterAttributeTable
 PyQgsRasterLayerRenderer
 PyQgsShapefileProvider

--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -160,6 +160,12 @@ GEOPROJ4 = geoProj4()
 GEO_EPSG_CRS_AUTHID = geoEpsgCrsAuthId()
 GEO_NONE = geoNone()
 
+# TODO QGIS 4.0 - remove, require use of explicit getter/setter
+
+QgsAbstractMetadataBaseValidator.ValidationResult.identifier = property(QgsAbstractMetadataBaseValidator.ValidationResult._identifier)
+QgsAbstractMetadataBaseValidator.ValidationResult.identifier = QgsAbstractMetadataBaseValidator.ValidationResult.identifier.setter(QgsAbstractMetadataBaseValidator.ValidationResult.setIdentifier)
+
+
 # TODO QGIS 4.0 - remove, replaced by Qgis.LinePlacementFlags
 class LinePlacementFlags:
   OnLine = 1

--- a/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -45,9 +45,7 @@ Constructor for ValidationResult.
         QString section;
 
 
-%Property( name = identifier, get = _identifier, set = _setIdentifier )
-
-        QVariant _identifier() const;
+        QVariant identifier() const /PyName=_identifier/;
 %Docstring
 Returns the optional identifier for the failed metadata item.
 For instance, in list type metadata elements this
@@ -55,7 +53,7 @@ will be set to the list index of the failed metadata
 item.
 %End
 
-        void _setIdentifier( QVariant identifier );
+        void setIdentifier( const QVariant &identifier );
 %Docstring
 Sets the optional ``identifier`` for the failed metadata item.
 For instance, in list type metadata elements this

--- a/python/PyQt6/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
@@ -55,10 +55,10 @@ Load/Reload model data synchronously.
 Load/Reload model data asynchronously using threads.
 %End
 
-    enum Roles /BaseType=IntEnum/
+
+    enum class CustomRole /BaseType=IntEnum/
     {
-      //! Layer metadata role
-      Metadata
+      Metadata,
     };
 
     enum Sections /BaseType=IntEnum/

--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -166,6 +166,11 @@ GEO_EPSG_CRS_AUTHID = geoEpsgCrsAuthId()
 GEO_NONE = geoNone()
 
 
+# TODO QGIS 4.0 - remove, require use of explicit getter/setter
+
+QgsAbstractMetadataBaseValidator.ValidationResult.identifier = property(QgsAbstractMetadataBaseValidator.ValidationResult._identifier)
+QgsAbstractMetadataBaseValidator.ValidationResult.identifier = QgsAbstractMetadataBaseValidator.ValidationResult.identifier.setter(QgsAbstractMetadataBaseValidator.ValidationResult.setIdentifier)
+
 
 # TODO QGIS 4.0 - remove, replaced by Qgis.LinePlacementFlags
 class LinePlacementFlags:

--- a/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -45,9 +45,7 @@ Constructor for ValidationResult.
         QString section;
 
 
-%Property( name = identifier, get = _identifier, set = _setIdentifier )
-
-        QVariant _identifier() const;
+        QVariant identifier() const /PyName=_identifier/;
 %Docstring
 Returns the optional identifier for the failed metadata item.
 For instance, in list type metadata elements this
@@ -55,7 +53,7 @@ will be set to the list index of the failed metadata
 item.
 %End
 
-        void _setIdentifier( QVariant identifier );
+        void setIdentifier( const QVariant &identifier );
 %Docstring
 Sets the optional ``identifier`` for the failed metadata item.
 For instance, in list type metadata elements this

--- a/python/gui/auto_additions/qgslayermetadataresultsmodel.py
+++ b/python/gui/auto_additions/qgslayermetadataresultsmodel.py
@@ -7,8 +7,3 @@ QgsLayerMetadataResultsModel.Metadata.__doc__ = "Layer metadata role"
 QgsLayerMetadataResultsModel.CustomRole.__doc__ = "The Roles enum represents the user roles for the model.\n\n.. note::\n\n   Prior to QGIS 3.36 this was available as QgsLayerMetadataResultsModel.Roles\n\n.. versionadded:: 3.36\n\n" + '* ``Metadata``: ' + QgsLayerMetadataResultsModel.CustomRole.Metadata.__doc__
 # --
 QgsLayerMetadataResultsModel.CustomRole.baseClass = QgsLayerMetadataResultsModel
-QgsLayerMetadataResultsModel.Identifier = QgsLayerMetadataResultsModel.Sections.Identifier
-QgsLayerMetadataResultsModel.Title = QgsLayerMetadataResultsModel.Sections.Title
-QgsLayerMetadataResultsModel.Abstract = QgsLayerMetadataResultsModel.Sections.Abstract
-QgsLayerMetadataResultsModel.DataProviderName = QgsLayerMetadataResultsModel.Sections.DataProviderName
-QgsLayerMetadataResultsModel.GeometryType = QgsLayerMetadataResultsModel.Sections.GeometryType

--- a/python/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
+++ b/python/gui/auto_generated/qgslayermetadataresultsmodel.sip.in
@@ -55,10 +55,10 @@ Load/Reload model data synchronously.
 Load/Reload model data asynchronously using threads.
 %End
 
-    enum Roles
+
+    enum class CustomRole
     {
-      //! Layer metadata role
-      Metadata
+      Metadata,
     };
 
     enum Sections

--- a/src/core/metadata/qgslayermetadatavalidator.h
+++ b/src/core/metadata/qgslayermetadatavalidator.h
@@ -60,11 +60,7 @@ class CORE_EXPORT QgsAbstractMetadataBaseValidator
         //! Metadata section which failed the validation
         QString section;
 
-        // TODO QGIS 4.0 - fix this
-
-#ifdef SIP_RUN
-        SIP_PROPERTY( name = identifier, get = _identifier, set = _setIdentifier )
-#endif
+        // TODO QGIS 4.0 - remove compatibility code
 
         /**
          * Returns the optional identifier for the failed metadata item.
@@ -72,7 +68,7 @@ class CORE_EXPORT QgsAbstractMetadataBaseValidator
          * will be set to the list index of the failed metadata
          * item.
          */
-        QVariant _identifier() const { return mIdentifier; }
+        QVariant identifier() const SIP_PYNAME( _identifier ) { return mIdentifier; }
 
         /**
          * Sets the optional \a identifier for the failed metadata item.
@@ -80,7 +76,7 @@ class CORE_EXPORT QgsAbstractMetadataBaseValidator
          * will be set to the list index of the failed metadata
          * item.
          */
-        void _setIdentifier( QVariant identifier ) { mIdentifier = identifier; }
+        void setIdentifier( const QVariant &identifier ) { mIdentifier = identifier; }
 
         //! The reason behind the validation failure.
         QString note;

--- a/src/gui/qgslayermetadataresultsmodel.cpp
+++ b/src/gui/qgslayermetadataresultsmodel.cpp
@@ -101,7 +101,7 @@ QVariant QgsLayerMetadataResultsModel::data( const QModelIndex &index, int role 
         }
         break;
       }
-      case Roles::Metadata:
+      case static_cast< int >( CustomRole::Metadata ):
       {
         return QVariant::fromValue( mResult.metadata().at( index.row() ) );
       }

--- a/src/gui/qgslayermetadataresultsmodel.h
+++ b/src/gui/qgslayermetadataresultsmodel.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include <QThread>
 #include "qgis_gui.h"
+#include "qgis_sip.h"
 #include "qgsabstractlayermetadataprovider.h"
 
 class QgsFeedback;

--- a/src/gui/qgslayermetadataresultsmodel.h
+++ b/src/gui/qgslayermetadataresultsmodel.h
@@ -96,14 +96,20 @@ class GUI_EXPORT QgsLayerMetadataResultsModel : public QAbstractTableModel
     //! Load/Reload model data asynchronously using threads.
     void reloadAsync( );
 
+    // *INDENT-OFF*
+
     /**
      * The Roles enum represents the user roles for the model.
+     *
+     * \note Prior to QGIS 3.36 this was available as QgsLayerMetadataResultsModel::Roles
+     * \since QGIS 3.36
      */
-    enum Roles
+    enum class CustomRole SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayerMetadataResultsModel, Roles ) : int
     {
-      //! Layer metadata role
-      Metadata = Qt::ItemDataRole::UserRole
+      Metadata = Qt::ItemDataRole::UserRole, //!< Layer metadata role
     };
+    Q_ENUM( CustomRole )
+    // *INDENT-ON*
 
     /**
      * The Sections enum represents the data columns.

--- a/src/gui/qgslayermetadatasearchwidget.cpp
+++ b/src/gui/qgslayermetadatasearchwidget.cpp
@@ -205,7 +205,7 @@ void QgsLayerMetadataSearchWidget::addButtonClicked()
   {
     for ( const auto &selectedIndex : std::as_const( selectedIndexes ) )
     {
-      const QgsLayerMetadataProviderResult metadataResult { mSourceModel->data( mProxyModel->mapToSource( selectedIndex ), QgsLayerMetadataResultsModel::Roles::Metadata ).value<QgsLayerMetadataProviderResult>() };
+      const QgsLayerMetadataProviderResult metadataResult { mSourceModel->data( mProxyModel->mapToSource( selectedIndex ), static_cast< int >( QgsLayerMetadataResultsModel::CustomRole::Metadata ) ).value<QgsLayerMetadataProviderResult>() };
       switch ( metadataResult.layerType() )
       {
         case Qgis::LayerType::Raster:

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -855,9 +855,9 @@ bool QgsMetadataWidget::checkMetadata()
     for ( const QgsAbstractMetadataBaseValidator::ValidationResult &result : std::as_const( validationResults ) )
     {
       errors += QLatin1String( "<b>" ) % result.section;
-      if ( ! QgsVariantUtils::isNull( result._identifier() ) )
+      if ( ! QgsVariantUtils::isNull( result.identifier() ) )
       {
-        errors += QLatin1Char( ' ' ) % QVariant( result._identifier().toInt() + 1 ).toString();
+        errors += QLatin1Char( ' ' ) % QVariant( result.identifier().toInt() + 1 ).toString();
       }
       errors += QLatin1String( "</b>: " ) % result.note % QLatin1String( "<br />" );
     }


### PR DESCRIPTION
This causes crashes on Qt6. Use Python monkey patching instead.