### PR TITLE
[labeling] fix BR in HTML labels

### DIFF
--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
@@ -47,6 +47,21 @@ Constructor for QgsTextCharacterFormat, based on the specified QTextCharFormat `
       SetFalse,
     };
 
+    void overrideWith( const QgsTextCharacterFormat &other );
+%Docstring
+Override all the default/unset properties of the current character format
+with the settings from another format.
+
+This will replace any default/unset existing settings with the
+settings from ``other``.
+
+Any settings which are default/unset in ``other`` will be left unchanged.
+
+:param other: The format to override with.
+
+.. versionadded:: 3.36
+%End
+
     QColor textColor() const;
 %Docstring
 Returns the character's text color, or an invalid color if no color override

--- a/python/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextcharacterformat.sip.in
@@ -47,6 +47,21 @@ Constructor for QgsTextCharacterFormat, based on the specified QTextCharFormat `
       SetFalse,
     };
 
+    void overrideWith( const QgsTextCharacterFormat &other );
+%Docstring
+Override all the default/unset properties of the current character format
+with the settings from another format.
+
+This will replace any default/unset existing settings with the
+settings from ``other``.
+
+Any settings which are default/unset in ``other`` will be left unchanged.
+
+:param other: The format to override with.
+
+.. versionadded:: 3.36
+%End
+
     QColor textColor() const;
 %Docstring
 Returns the character's text color, or an invalid color if no color override

--- a/src/core/textrenderer/qgstextcharacterformat.cpp
+++ b/src/core/textrenderer/qgstextcharacterformat.cpp
@@ -56,6 +56,33 @@ QgsTextCharacterFormat::QgsTextCharacterFormat( const QTextCharFormat &format )
   mVerticalAlign = convertTextCharFormatVAlign( format, mHasVerticalAlignSet );
 }
 
+void QgsTextCharacterFormat::overrideWith( const QgsTextCharacterFormat &other )
+{
+  if ( !mTextColor.isValid() && other.mTextColor.isValid() )
+    mTextColor = other.mTextColor;
+  if ( mFontPointSize == -1 && other.mFontPointSize != -1 )
+    mFontPointSize = other.mFontPointSize;
+  if ( mFontFamily.isEmpty() && !other.mFontFamily.isEmpty() )
+    mFontFamily = other.mFontFamily;
+  if ( mStrikethrough == BooleanValue::NotSet && other.mStrikethrough != BooleanValue::NotSet )
+    mStrikethrough = other.mStrikethrough;
+  if ( mUnderline == BooleanValue::NotSet && other.mUnderline != BooleanValue::NotSet )
+    mUnderline = other.mUnderline;
+  if ( mOverline == BooleanValue::NotSet && other.mOverline != BooleanValue::NotSet )
+    mOverline = other.mOverline;
+  if ( mItalic == BooleanValue::NotSet && other.mItalic != BooleanValue::NotSet )
+    mItalic = other.mItalic;
+  if ( mFontWeight == -1 && other.mFontWeight != -1 )
+    mFontWeight = other.mFontWeight;
+  if ( mStyleName.isEmpty() && ! other.mStyleName.isEmpty() )
+    mStyleName = other.mStyleName;
+  if ( mHasVerticalAlignSet && other.hasVerticalAlignmentSet() )
+  {
+    mVerticalAlign = other.mVerticalAlign;
+    mHasVerticalAlignSet = true;
+  }
+}
+
 QColor QgsTextCharacterFormat::textColor() const
 {
   return mTextColor;

--- a/src/core/textrenderer/qgstextcharacterformat.h
+++ b/src/core/textrenderer/qgstextcharacterformat.h
@@ -61,6 +61,21 @@ class CORE_EXPORT QgsTextCharacterFormat
     };
 
     /**
+     * Override all the default/unset properties of the current character format
+     * with the settings from another format.
+     *
+     * This will replace any default/unset existing settings with the
+     * settings from \a other.
+     *
+     * Any settings which are default/unset in \a other will be left unchanged.
+     *
+     * \param other The format to override with.
+     *
+     * \since QGIS 3.36
+     */
+    void overrideWith( const QgsTextCharacterFormat &other );
+
+    /**
      * Returns the character's text color, or an invalid color if no color override
      * is set and the default format color should be used.
      *

--- a/src/core/textrenderer/qgstextdocument.cpp
+++ b/src/core/textrenderer/qgstextdocument.cpp
@@ -75,7 +75,7 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
         if ( fragment.isValid() )
         {
           // Search for line breaks in the fragment
-          if ( fragment.text().contains( 0x2028 ) )
+          if ( fragment.text().contains( QStringLiteral( "\u2028" ) ) )
           {
 
             // Flush last block
@@ -86,7 +86,7 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
             }
 
             // Split fragment text into lines
-            const QStringList splitLines = fragment.text().split( 0x2028, Qt::SplitBehaviorFlags::SkipEmptyParts );
+            const QStringList splitLines = fragment.text().split( QStringLiteral( "\u2028" ), Qt::SplitBehaviorFlags::SkipEmptyParts );
 
             for ( const QString &splitLine : std::as_const( splitLines ) )
             {

--- a/src/core/textrenderer/qgstextdocument.cpp
+++ b/src/core/textrenderer/qgstextdocument.cpp
@@ -48,18 +48,23 @@ QgsTextDocument QgsTextDocument::fromPlainText( const QStringList &lines )
 
 QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
 {
+
   QgsTextDocument document;
 
   document.reserve( lines.size() );
-  for ( const QString &line : lines )
+
+  for ( const QString &line : std::as_const( lines ) )
   {
     // QTextDocument is a very heavy way of parsing HTML + css (it's heavily geared toward an editable text document,
     // and includes a LOT of calculations we don't need, when all we're after is a HTML + CSS style parser).
     // TODO - try to find an alternative library we can use here
+
     QTextDocument sourceDoc;
+
     sourceDoc.setHtml( line );
 
     QTextBlock sourceBlock = sourceDoc.firstBlock();
+
     while ( true )
     {
       auto it = sourceBlock.begin();
@@ -69,10 +74,57 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
         const QTextFragment fragment = it.fragment();
         if ( fragment.isValid() )
         {
-          block.append( QgsTextFragment( fragment ) );
+          // Search for line breaks in the fragment
+          if ( fragment.text().contains( 0x2028 ) )
+          {
+
+            // Flush last block
+            if ( !block.empty() )
+            {
+              document.append( block );
+              block.clear();
+            }
+
+            // Split fragment text into lines
+            const QStringList splitLines = fragment.text().split( 0x2028, Qt::SplitBehaviorFlags::SkipEmptyParts );
+
+            for ( const QString &splitLine : std::as_const( splitLines ) )
+            {
+              QgsTextBlock splitLineBlock;
+
+              QgsTextFragment splitFragment( fragment );
+              splitFragment.setText( splitLine );
+
+              const QgsTextCharacterFormat *previousFormat = nullptr;
+
+              // If the splitLine is not the first, inherit style from previous fragment
+              if ( splitLine != splitLines.first() && document.size() > 0 )
+              {
+                previousFormat = &document.at( document.size() - 1 ).at( 0 ).characterFormat();
+              }
+
+              if ( previousFormat )
+              {
+                // Apply overrides from previous fragment
+                QgsTextCharacterFormat newFormat { splitFragment.characterFormat() };
+                newFormat.overrideWith( *previousFormat );
+                splitFragment.setCharacterFormat( newFormat );
+              }
+
+              splitLineBlock.append( splitFragment );
+              document.append( splitLineBlock );
+
+            }
+          }
+          else
+          {
+            block.append( QgsTextFragment( fragment ) );
+          }
+
         }
         it++;
       }
+
       if ( !block.empty() )
         document.append( block );
 
@@ -80,7 +132,9 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
       if ( !sourceBlock.isValid() )
         break;
     }
+
   }
+
   return document;
 }
 

--- a/src/core/textrenderer/qgstextdocument.cpp
+++ b/src/core/textrenderer/qgstextdocument.cpp
@@ -120,7 +120,6 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
           {
             block.append( QgsTextFragment( fragment ) );
           }
-
         }
         it++;
       }
@@ -132,7 +131,6 @@ QgsTextDocument QgsTextDocument::fromHtml( const QStringList &lines )
       if ( !sourceBlock.isValid() )
         break;
     }
-
   }
 
   return document;

--- a/tests/src/python/test_qgstextdocument.py
+++ b/tests/src/python/test_qgstextdocument.py
@@ -92,6 +92,18 @@ class TestQgsTextDocument(QgisTestCase):
         self.assertEqual(len(doc[4]), 1)
         self.assertEqual(doc[4][0].text(), 'e')
 
+        doc = QgsTextDocument.fromHtml(['<span style="color:red">a<br><span style="color:blue">b<br></span>c</span>d'])
+        self.assertEqual(len(doc), 3)
+        self.assertEqual(doc[0][0].characterFormat().textColor().name(), '#ff0000')
+        self.assertEqual(doc[0][0].text(), 'a')
+        self.assertEqual(doc[1][0].characterFormat().textColor().name(), '#0000ff')
+        self.assertEqual(doc[1][0].text(), 'b')
+        self.assertEqual(len(doc[2]), 2)
+        self.assertEqual(doc[2][0].characterFormat().textColor().name(), '#ff0000')
+        self.assertEqual(doc[2][0].text(), 'c')
+        self.assertEqual(doc[2][1].characterFormat().textColor().name(), '#000000')
+        self.assertEqual(doc[2][1].text(), 'd')
+
     def testFromHtmlVerticalAlignment(self):
         doc = QgsTextDocument.fromHtml(['abc<div style="color: red"><sub>def<b>extra</b></sub> ghi</div><sup>sup</sup><span style="vertical-align: sub">css</span>'])
         self.assertEqual(len(doc), 3)


### PR DESCRIPTION
Fix `<br>` ignored in HTML formatted labels.

Fix #55532

