### PR TITLE
Make datetime stats range type consistent across Qt versions

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -38,13 +38,11 @@ PyQgsStyleStorageMssql
 
 # To be fixed
 PyQgsPythonProvider
-PyQgsAggregateCalculator
 PyQgsAnnotation
 PyQgsAuthenticationSystem
 PyQgsBlockingProcess
 PyQgsBookmarkModel
 PyQgsCodeEditor
-PyQgsDateTimeStatisticalSummary
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
 PyQgsElevationProfileCanvas

--- a/python/PyQt6/core/auto_generated/qgsinterval.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsinterval.sip.in
@@ -10,6 +10,9 @@
 
 
 
+%ModuleHeaderCode
+#include "qgsunittypes.h"
+%End
 
 
 class QgsInterval
@@ -64,6 +67,18 @@ Constructor for QgsInterval, using the specified ``years``, ``months``,
    Year units assumes a 365.25 day year length.
 
 .. versionadded:: 3.14
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str;
+    if ( ! sipCpp->isValid() )
+      str = QStringLiteral( "<QgsInterval: invalid>" );
+    else if ( sipCpp->originalUnit() != Qgis::TemporalUnit::Unknown )
+      str = QStringLiteral( "<QgsInterval: %1 %2>" ).arg( sipCpp->originalDuration() ).arg( QgsUnitTypes::toString( sipCpp->originalUnit() ) );
+    else
+      str = QStringLiteral( "<QgsInterval: %1 seconds>" ).arg( sipCpp->seconds() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
     double years() const;

--- a/python/core/auto_generated/qgsinterval.sip.in
+++ b/python/core/auto_generated/qgsinterval.sip.in
@@ -10,6 +10,9 @@
 
 
 
+%ModuleHeaderCode
+#include "qgsunittypes.h"
+%End
 
 
 class QgsInterval
@@ -64,6 +67,18 @@ Constructor for QgsInterval, using the specified ``years``, ``months``,
    Year units assumes a 365.25 day year length.
 
 .. versionadded:: 3.14
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str;
+    if ( ! sipCpp->isValid() )
+      str = QStringLiteral( "<QgsInterval: invalid>" );
+    else if ( sipCpp->originalUnit() != Qgis::TemporalUnit::Unknown )
+      str = QStringLiteral( "<QgsInterval: %1 %2>" ).arg( sipCpp->originalDuration() ).arg( QgsUnitTypes::toString( sipCpp->originalUnit() ) );
+    else
+      str = QStringLiteral( "<QgsInterval: %1 seconds>" ).arg( sipCpp->seconds() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
     double years() const;

--- a/src/core/qgsdatetimestatisticalsummary.cpp
+++ b/src/core/qgsdatetimestatisticalsummary.cpp
@@ -142,11 +142,24 @@ QVariant QgsDateTimeStatisticalSummary::statistic( Qgis::DateTimeStatistic stat 
     case Qgis::DateTimeStatistic::Max:
       return mIsTimes ? QVariant( mMax.time() ) : QVariant( mMax );
     case Qgis::DateTimeStatistic::Range:
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
       return mIsTimes ? QVariant::fromValue( mMax.time() - mMin.time() ) : QVariant::fromValue( mMax - mMin );
+#else
+      return mIsTimes ? QVariant::fromValue( mMax.time() - mMin.time() ) : QVariant::fromValue( QgsInterval( static_cast< double >( ( mMax - mMin ).count() ) / 1000.0 ) );
+#endif
     case Qgis::DateTimeStatistic::All:
       return 0;
   }
   return 0;
+}
+
+QgsInterval QgsDateTimeStatisticalSummary::range() const
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+  return mMax - mMin;
+#else
+  return QgsInterval( static_cast< double >( ( mMax - mMin ).count() ) / 1000.0 );
+#endif
 }
 
 QString QgsDateTimeStatisticalSummary::displayName( Qgis::DateTimeStatistic statistic )

--- a/src/core/qgsdatetimestatisticalsummary.h
+++ b/src/core/qgsdatetimestatisticalsummary.h
@@ -142,7 +142,7 @@ class CORE_EXPORT QgsDateTimeStatisticalSummary
     /**
      * Returns the range (interval between earliest and latest non-null datetime values).
      */
-    QgsInterval range() const { return mMax - mMin; }
+    QgsInterval range() const;
 
     /**
      * Returns the friendly display name for a statistic

--- a/src/core/qgsinterval.h
+++ b/src/core/qgsinterval.h
@@ -29,6 +29,11 @@
 #include "qgis_core.h"
 #include "qgis.h"
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+#include "qgsunittypes.h"
+% End
+#endif
 class QString;
 
 /**
@@ -89,6 +94,20 @@ class CORE_EXPORT QgsInterval
      * \since QGIS 3.14
      */
     QgsInterval( double years, double months, double weeks, double days, double hours, double minutes, double seconds );
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str;
+    if ( ! sipCpp->isValid() )
+      str = QStringLiteral( "<QgsInterval: invalid>" );
+    else if ( sipCpp->originalUnit() != Qgis::TemporalUnit::Unknown )
+      str = QStringLiteral( "<QgsInterval: %1 %2>" ).arg( sipCpp->originalDuration() ).arg( QgsUnitTypes::toString( sipCpp->originalUnit() ) );
+    else
+      str = QStringLiteral( "<QgsInterval: %1 seconds>" ).arg( sipCpp->seconds() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
     /**
      * Returns the interval duration in years (based on an average year length)

--- a/tests/src/python/test_qgsinterval.py
+++ b/tests/src/python/test_qgsinterval.py
@@ -40,6 +40,16 @@ class TestQgsInterval(unittest.TestCase):
         self.assertTrue(i.isValid())
         self.assertEqual(i.seconds(), 0.056)
 
+    def test_repr(self):
+        """
+        Test __repr__ implementation
+        """
+        self.assertEqual(repr(QgsInterval()), '<QgsInterval: invalid>')
+        self.assertEqual(repr(QgsInterval(5)), '<QgsInterval: 5 seconds>')
+        self.assertEqual(repr(QgsInterval(1, QgsUnitTypes.TemporalUnit.TemporalMonths)), '<QgsInterval: 1 months>')
+        self.assertEqual(
+            repr(QgsInterval(720, QgsUnitTypes.TemporalUnit.TemporalHours)), '<QgsInterval: 720 hours>')
+
     def testSettersGetters(self):
         # setters and getters
         i = QgsInterval()


### PR DESCRIPTION
On Qt >= 6.4, ensure that range stats calculated using datetime values
also return a QgsInterval object. With Qt >= 6.4 was introduced:

std::chrono::milliseconds operator-(const QDateTime &lhs, const QDateTime &rhs)

This inbuilt operator means we had to disable the

QgsInterval operator-( const QDateTime &datetime1, const QDateTime &datetime2 )

operator we used to have available in QGIS. But since BOTH QgsInterval
and std::chrono::milliseconds can be stored in a QVariant, the
compilation happily worked but the range calculations started returning
an unexcepted std::chrono::milliseconds value instead.