### PR TITLE
QVariant.Type, Qt.ItemFlag and Qt.CheckState need to be int compatible

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -42,14 +42,12 @@ PyQgsAggregateCalculator
 PyQgsAnnotation
 PyQgsAuthenticationSystem
 PyQgsBlockingProcess
-PyQgsBookmarkModel
 PyQgsCodeEditor
 PyQgsDateTimeStatisticalSummary
 PyQgsDelimitedTextProvider
 PyQgsEditWidgets
 PyQgsElevationProfileCanvas
 PyQgsProject
-PyQgsFieldModel
 PyQgsFloatingWidget
 PyQgsJsonUtils
 PyQgsLayerMetadata

--- a/python/PyQt/PyQt/QtCore.py.in
+++ b/python/PyQt/PyQt/QtCore.py.in
@@ -132,6 +132,20 @@ if (QT_VERSION >= 0x060000):
     QVariant.SizePolicy = QMetaType.Type.QSizePolicy
     QVariant.UserType = QMetaType.Type.User
 
+    from enum import Enum
+
+
+    def _force_int(v): return int(v.value) if isinstance(v, Enum) else v
+
+    QMetaType.Type.__int__ = _force_int
+    QMetaType.Type.__eq__ = lambda t1, t2: _force_int(t1) == _force_int(t2)
+
+    # These types aren't IntEnums or IntFlags, so patch that back in
+    Qt.ItemFlag.__int__ = _force_int
+    Qt.ItemFlag.__eq__ = lambda t1, t2: _force_int(t1) == _force_int(t2)
+    Qt.CheckState.__int__ = _force_int
+    Qt.CheckState.__eq__ = lambda t1, t2: _force_int(t1) == _force_int(t2)
+
     # patch back in Qt flags removed in PyQt
 
     QAbstractItemModel.CheckIndexOptions = lambda flags=0: QAbstractItemModel.CheckIndexOption(flags)


### PR DESCRIPTION
For reasons(?) these aren't IntEnums/IntFlags on PyQt6, but we need them to be int compatible for compatibility with PyQt5 code
