### PR TITLE
Fix handling of font family from HTML on Qt 6 builds

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -64,7 +64,6 @@ PyQgsTextRenderer
 PyQgsOGRProvider
 PyQgsSpatialiteProvider
 PyQgsSymbolLayerReadSld
-PyQgsTextDocument
 PyQgsVectorLayerCache
 PyQgsVectorLayerEditBuffer
 PyQgsVectorLayerEditUtils

--- a/src/core/textrenderer/qgstextcharacterformat.cpp
+++ b/src/core/textrenderer/qgstextcharacterformat.cpp
@@ -48,12 +48,22 @@ QgsTextCharacterFormat::QgsTextCharacterFormat( const QTextCharFormat &format )
   , mStyleName( format.font().styleName() )
   , mItalic( format.hasProperty( QTextFormat::FontItalic ) ? ( format.fontItalic() ? BooleanValue::SetTrue : BooleanValue::SetFalse ) : BooleanValue::NotSet )
   , mFontPointSize( format.hasProperty( QTextFormat::FontPointSize ) ? format.fontPointSize() : - 1 )
-  , mFontFamily( format.hasProperty( QTextFormat::FontFamily ) ? format.fontFamily() : QString() )
   , mStrikethrough( format.hasProperty( QTextFormat::FontStrikeOut ) ? ( format.fontStrikeOut() ? BooleanValue::SetTrue : BooleanValue::SetFalse ) : BooleanValue::NotSet )
   , mUnderline( format.hasProperty( QTextFormat::FontUnderline ) ? ( format.fontUnderline() ? BooleanValue::SetTrue : BooleanValue::SetFalse ) : BooleanValue::NotSet )
   , mOverline( format.hasProperty( QTextFormat::FontOverline ) ? ( format.fontOverline() ? BooleanValue::SetTrue : BooleanValue::SetFalse ) : BooleanValue::NotSet )
 {
   mVerticalAlign = convertTextCharFormatVAlign( format, mHasVerticalAlignSet );
+
+  if ( format.hasProperty( QTextFormat::FontFamily ) )
+  {
+    mFontFamily = format.fontFamily();
+  }
+  if ( mFontFamily.isEmpty() && format.hasProperty( QTextFormat::FontFamilies ) )
+  {
+    const QStringList families = format.fontFamilies().toStringList();
+    if ( !families.isEmpty() )
+      mFontFamily = families.at( 0 );
+  }
 }
 
 QColor QgsTextCharacterFormat::textColor() const

--- a/tests/src/python/test_qgstextdocument.py
+++ b/tests/src/python/test_qgstextdocument.py
@@ -11,9 +11,10 @@ __author__ = 'Nyall Dawson'
 __date__ = '12/05/2020'
 __copyright__ = 'Copyright 2020, The QGIS Project'
 
-
+from qgis.PyQt.QtCore import QT_VERSION_STR
 from qgis.core import (
     Qgis,
+    QgsFontUtils,
     QgsStringUtils,
     QgsTextBlock,
     QgsTextCharacterFormat,
@@ -72,7 +73,10 @@ class TestQgsTextDocument(QgisTestCase):
         self.assertEqual(doc[1][0].text(), 'def')
         self.assertEqual(doc[1][0].characterFormat().underline(), QgsTextCharacterFormat.BooleanValue.SetTrue)
         self.assertEqual(doc[1][0].characterFormat().italic(), QgsTextCharacterFormat.BooleanValue.SetTrue)
-        self.assertEqual(doc[1][0].characterFormat().fontWeight(), 75)
+        if int(QT_VERSION_STR.split('.')[0]) >= 6:
+            self.assertEqual(doc[1][0].characterFormat().fontWeight(), 700)
+        else:
+            self.assertEqual(doc[1][0].characterFormat().fontWeight(), 75)
         self.assertEqual(doc[1][0].characterFormat().family(), 'Serif')
         self.assertEqual(doc[1][0].characterFormat().textColor().name(), '#ff0000')
         self.assertEqual(doc[1][0].characterFormat().fontPointSize(), 15)


### PR DESCRIPTION
At some stage we'll likely need to update QgsTextCharacterFormat to use a list of families to match the Qt 6 changes, but for now just get the first listed font.
