### PR TITLE
Plugin manager startup checks -> QGIS informs every 3 days

### DIFF
--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -940,7 +940,7 @@
                         </size>
                        </property>
                        <property name="text">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;If this function is enabled, QGIS will inform you whenever a plugin update is available.&lt;/span&gt; Otherwise, fetching repositories will be performed during opening of the Plugin Manager window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;If this function is enabled, QGIS will inform you every 3 days when a plugin update is available.&lt;/span&gt; Otherwise, fetching repositories will be performed during opening of the Plugin Manager window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/50206 this interval is hardcoded at 3 days:

> Additionally, the option to control the number of days between plugin startup checks has been removed and is hardcoded at 3 days.