### PR TITLE
Boolean type in expressions - fix #55923

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -471,6 +471,18 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         ENSURE_NO_EVAL_ERROR
         return compare( fL - fR ) ? TVL_True : TVL_False;
       }
+
+      else if ( vL.type() == QVariant::Bool || vR.type() == QVariant::Bool )
+      {
+        // if one of value is boolean, then the other must also be boolean,
+        // in order to avoid confusion between different expression evaluations
+        // amongst providers and QVariant, that can consider or not the string
+        // 'false' as boolean or text
+        if ( vL.type() == QVariant::Bool && vR.type() == QVariant::Bool )
+          return vL.toBool() == vR.toBool() ? TVL_True : TVL_False;
+        return TVL_False;
+      }
+
       // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here
       else if ( vL.userType() == QMetaType::type( "QgsInterval" ) && vR.userType() == QMetaType::type( "QgsInterval" ) )
       {

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -25,7 +25,6 @@
 #include "qgspointdisplacementrenderer.h"
 #include "qgsinvertedpolygonrenderer.h"
 #include "qgspainteffect.h"
-#include "qgspainteffectregistry.h"
 #include "qgssymbollayer.h"
 #include "qgsfeature.h"
 #include "qgsvectorlayer.h"
@@ -592,13 +591,12 @@ QString QgsCategorizedSymbolRenderer::filter( const QgsFields &fields )
     noneActive = noneActive && !cat.renderState();
     allActive = allActive && cat.renderState();
 
-    QVariant::Type valType = isExpression ? cat.value().type() : fields.at( attrNum ).type();
     const bool isList = cat.value().type() == QVariant::List;
-    QString value = QgsExpression::quotedValue( cat.value(), valType );
+    QString value = QgsExpression::quotedValue( cat.value(), cat.value().type() );
 
     if ( !cat.renderState() )
     {
-      if ( cat.value() != "" )
+      if ( value != "" )
       {
         if ( isList )
         {
@@ -622,7 +620,7 @@ QString QgsCategorizedSymbolRenderer::filter( const QgsFields &fields )
     }
     else
     {
-      if ( cat.value() != "" )
+      if ( value != "" )
       {
         if ( isList )
         {
@@ -1521,4 +1519,3 @@ QgsCategoryList QgsCategorizedSymbolRenderer::createCategories( const QList<QVar
 
   return cats;
 }
-

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -556,7 +556,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, QgsV
     bool forceRepresentedValue = false;
     if ( QgsVariantUtils::isNull( value ) )
       strValue = QStringLiteral( "NULL" );
-    else if ( value.type() == QVariant::Int || value.type() == QVariant::Double || value.type() == QVariant::LongLong )
+    else if ( value.type() == QVariant::Int || value.type() == QVariant::Double || value.type() == QVariant::LongLong || value.type() == QVariant::Bool )
       strValue = value.toString();
     else if ( value.type() == QVariant::StringList )
     {

--- a/tests/src/python/test_qgsexpressionbuilderwidget.py
+++ b/tests/src/python/test_qgsexpressionbuilderwidget.py
@@ -229,7 +229,7 @@ class TestQgsExpressionBuilderWidget(QgisTestCase):
         self.assertTrue(valuesModel)
 
         layer = QgsVectorLayer(
-            "None?field=myarray:string[]&field=mystr:string&field=myint:integer&field=myintarray:int[]&field=mydoublearray:double[]",
+            "None?field=myarray:string[]&field=mystr:string&field=myint:integer&field=myintarray:int[]&field=mydoublearray:double[]&field=mybool:boolean(0,0)",
             "arraylayer", "memory")
 
         self.assertTrue(layer.isValid())
@@ -237,11 +237,11 @@ class TestQgsExpressionBuilderWidget(QgisTestCase):
         # add some features, one has invalid geometry
         pr = layer.dataProvider()
         f1 = QgsFeature(1)
-        f1.setAttributes([["one 'item'", 'B'], "another 'item'", 0, [1, 2], [1.1, 2.1]])
+        f1.setAttributes([["one 'item'", 'B'], "another 'item'", 0, [1, 2], [1.1, 2.1], True])
         f2 = QgsFeature(2)
-        f2.setAttributes([['C'], "", 1, [3, 4], [-0.1, 2.0]])
+        f2.setAttributes([['C'], "", 1, [3, 4], [-0.1, 2.0], False])
         f3 = QgsFeature(3)
-        f3.setAttributes([[], "test", 2, [], []])
+        f3.setAttributes([[], "test", 2, [], [], False])
         f4 = QgsFeature(4)
         self.assertTrue(pr.addFeatures([f1, f2, f3, f4]))
 
@@ -330,6 +330,26 @@ class TestQgsExpressionBuilderWidget(QgisTestCase):
                                  ("1.1, 2.1 [array(1.1, 2.1)]", "array(1.1, 2.1)"),
                                  ("NULL [NULL]", "NULL"),
                                  ])
+
+        # test boolean
+        items = w.expressionTree().findExpressions("mybool")
+        self.assertEqual(len(items), 1)
+        currentIndex = w.expressionTree().model().mapFromSource(items[0].index())
+        self.assertTrue(currentIndex.isValid())
+        w.expressionTree().setCurrentIndex(currentIndex)
+        self.assertTrue(w.expressionTree().currentItem())
+
+        w.loadAllValues()
+
+        datas = [(valuesModel.data(valuesModel.index(i, 0), Qt.ItemDataRole.DisplayRole), valuesModel.data(valuesModel.index(i, 0), Qt.ItemDataRole.UserRole + 1)) for i in range(4)]
+        datas.remove((None, None))
+        datas.sort()
+        datas.append((None, None))
+
+        self.assertEqual(datas, [("NULL [NULL]", "NULL"),
+                                 ("false", "false"),
+                                 ("true", "true"),
+                                 (None, None)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Originally I wanted to fix #55923 but as often, I found other bugs and decided to dig into QGIS expressions...

This PR fixes the use of boolean type fields in QGIS expressions:
- in categorized symbology the use of a boolean field to classify was resulting in wrong feature counts and wrong filtering
- stop treating the quoted strings `'false'` and `'true'` as booleans in pure QGIS expression evaluation, to avoid discrepancies with keywords `false` and `true` with expressions interpreted by QGIS SQL expression compiler
- the actual bug of #55923 which is to insert `true` or `false` keyword with the value list selection from the expression builder, instead of strings