### PR TITLE
Remove expression evaluation in layout legend widget

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -499,9 +499,11 @@ Evaluates  and returns the text label of the current node
 
     QgsExpressionContextScope *createSymbolScope() const /Factory/;
 %Docstring
-Create an expressionContextScope containing symbol related variables
+Create an expression context scope containing symbol related variables.
 
-.. versionadded:: 3.10
+The caller takes ownership of the returned object.
+
+.. versionadded:: 3.36
 %End
 
     SIP_PYOBJECT __repr__();

--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -497,6 +497,13 @@ Evaluates  and returns the text label of the current node
 .. versionadded:: 3.10
 %End
 
+    QgsExpressionContextScope *createSymbolScope() const /Factory/;
+%Docstring
+Create an expressionContextScope containing symbol related variables
+
+.. versionadded:: 3.10
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsSymbolLegendNode: %1 \"%2\"" ).arg(

--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -499,9 +499,11 @@ Evaluates  and returns the text label of the current node
 
     QgsExpressionContextScope *createSymbolScope() const /Factory/;
 %Docstring
-Create an expressionContextScope containing symbol related variables
+Create an expression context scope containing symbol related variables.
 
-.. versionadded:: 3.10
+The caller takes ownership of the returned object.
+
+.. versionadded:: 3.36
 %End
 
     SIP_PYOBJECT __repr__();

--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -497,6 +497,13 @@ Evaluates  and returns the text label of the current node
 .. versionadded:: 3.10
 %End
 
+    QgsExpressionContextScope *createSymbolScope() const /Factory/;
+%Docstring
+Create an expressionContextScope containing symbol related variables
+
+.. versionadded:: 3.10
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsSymbolLegendNode: %1 \"%2\"" ).arg(

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -908,7 +908,10 @@ void QgsSymbolLegendNode::updateLabel()
 
   const bool showFeatureCount = mLayerNode->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toBool();
   QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mLayerNode->layer() );
-  mLabel = symbolLabel();
+  if ( !mLayerNode->labelExpression().isEmpty() )
+    mLabel = "[%" + mLayerNode->labelExpression() + "%]";
+  else
+    mLabel = symbolLabel();
 
   if ( showFeatureCount && vl )
   {
@@ -940,13 +943,11 @@ QString QgsSymbolLegendNode::evaluateLabel( const QgsExpressionContext &context,
 
     if ( label.isEmpty() )
     {
+      const QString symLabel = symbolLabel();
       if ( ! mLayerNode->labelExpression().isEmpty() )
         mLabel = QgsExpression::replaceExpressionText( "[%" + mLayerNode->labelExpression() + "%]", &contextCopy );
-      else if ( mLabel.contains( "[%" ) )
-      {
-        const QString symLabel = symbolLabel();
+      else if ( symLabel.contains( "[%" ) )
         mLabel = QgsExpression::replaceExpressionText( symLabel, &contextCopy );
-      }
       return mLabel;
     }
     else

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -550,6 +550,12 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
      */
     QString evaluateLabel( const QgsExpressionContext &context = QgsExpressionContext(), const QString &label = QString() );
 
+    /**
+     * Create an expressionContextScope containing symbol related variables
+     * \since QGIS 3.10
+     */
+    QgsExpressionContextScope *createSymbolScope() const SIP_FACTORY;
+
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
@@ -578,12 +584,6 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
 
     // ident the symbol icon to make it look like a tree structure
     static const int INDENT_SIZE = 20;
-
-    /**
-     * Create an expressionContextScope containing symbol related variables
-     * \since QGIS 3.10
-     */
-    QgsExpressionContextScope *createSymbolScope() const SIP_FACTORY;
 
 };
 

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -551,8 +551,11 @@ class CORE_EXPORT QgsSymbolLegendNode : public QgsLayerTreeModelLegendNode
     QString evaluateLabel( const QgsExpressionContext &context = QgsExpressionContext(), const QString &label = QString() );
 
     /**
-     * Create an expressionContextScope containing symbol related variables
-     * \since QGIS 3.10
+     * Create an expression context scope containing symbol related variables.
+     *
+     * The caller takes ownership of the returned object.
+     *
+     * \since QGIS 3.36
      */
     QgsExpressionContextScope *createSymbolScope() const SIP_FACTORY;
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -1383,36 +1383,6 @@ QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const
         return name;
       }
     }
-
-    const bool evaluate = ( vlayer && !nodeLayer->labelExpression().isEmpty() ) || name.contains( "[%" );
-    if ( evaluate )
-    {
-      QgsExpressionContext expressionContext;
-      if ( vlayer )
-      {
-        connect( vlayer, &QgsVectorLayer::symbolFeatureCountMapChanged, this, &QgsLegendModel::forceRefresh, Qt::UniqueConnection );
-        // counting is done here to ensure that a valid vector layer needs to be evaluated, count is used to validate previous count or update the count if invalidated
-        vlayer->countSymbolFeatures();
-      }
-
-      if ( mLayoutLegend )
-        expressionContext = mLayoutLegend->createExpressionContext();
-
-      const QList<QgsLayerTreeModelLegendNode *> legendnodes = layerLegendNodes( nodeLayer, false );
-      if ( ! legendnodes.isEmpty() )
-      {
-        if ( legendnodes.count() > 1 ) // evaluate all existing legend nodes but leave the name for the legend evaluator
-        {
-          for ( QgsLayerTreeModelLegendNode *treenode : legendnodes )
-          {
-            if ( QgsSymbolLegendNode *symnode = qobject_cast<QgsSymbolLegendNode *>( treenode ) )
-              symnode->evaluateLabel( expressionContext );
-          }
-        }
-        else if ( QgsSymbolLegendNode *symnode = qobject_cast<QgsSymbolLegendNode *>( legendnodes.first() ) )
-          symnode->evaluateLabel( expressionContext );
-      }
-    }
     node->setCustomProperty( QStringLiteral( "cached_name" ), name );
     return name;
   }

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -928,7 +928,10 @@ QgsLegendRenderer::LegendComponent QgsLegendRenderer::drawSymbolItem( QgsLayerTr
   ctx.maxSiblingSymbolWidth = maxSiblingSymbolWidth;
 
   if ( const QgsSymbolLegendNode *symbolNode = dynamic_cast< const QgsSymbolLegendNode * >( symbolItem ) )
+  {
+    context.expressionContext().appendScope( symbolNode->createSymbolScope() );
     ctx.patchShape = symbolNode->patchShape();
+  }
 
   ctx.patchSize = symbolItem->userPatchSize();
 

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -927,15 +927,20 @@ QgsLegendRenderer::LegendComponent QgsLegendRenderer::drawSymbolItem( QgsLayerTr
 
   ctx.maxSiblingSymbolWidth = maxSiblingSymbolWidth;
 
+  QgsExpressionContextScope *symbolScope = nullptr;
   if ( const QgsSymbolLegendNode *symbolNode = dynamic_cast< const QgsSymbolLegendNode * >( symbolItem ) )
   {
-    context.expressionContext().appendScope( symbolNode->createSymbolScope() );
+    symbolScope = symbolNode->createSymbolScope();
+    context.expressionContext().appendScope( symbolScope );
     ctx.patchShape = symbolNode->patchShape();
   }
 
   ctx.patchSize = symbolItem->userPatchSize();
 
   QgsLayerTreeModelLegendNode::ItemMetrics im = symbolItem->draw( mSettings, &ctx );
+
+  if ( symbolScope )
+    delete context.expressionContext().popScope();
 
   if ( layerScope )
     delete context.expressionContext().popScope();

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1166,28 +1166,16 @@ void QgsLayoutLegendWidget::mLayerExpressionButton_clicked()
   QgsExpressionContext legendContext = mLegend->createExpressionContext();
   legendContext.appendScope( vl->createExpressionContextScope() );
 
-  QgsExpressionContextScope *symbolLegendScope = new QgsExpressionContextScope( tr( "Symbol scope" ) );
-
-  QgsFeatureRenderer *r = vl->renderer();
-
   QStringList highlighted;
-  if ( r )
+  const QList<QgsLayerTreeModelLegendNode *> legendnodes = mLegend->model()->layerLegendNodes( layerNode, false );
+  if ( !legendnodes.isEmpty() )
   {
-    const QgsLegendSymbolList legendSymbols = r->legendSymbolItems();
-
-    if ( !legendSymbols.empty() )
+    if ( QgsSymbolLegendNode *symnode = qobject_cast<QgsSymbolLegendNode *>( legendnodes.first() ) )
     {
-      QgsSymbolLegendNode legendNode( layerNode, legendSymbols.first() );
-
-      symbolLegendScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "symbol_label" ), legendNode.symbolLabel().remove( QStringLiteral( "[%" ) ).remove( QStringLiteral( "%]" ) ), true ) );
-      symbolLegendScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "symbol_id" ), legendSymbols.first().ruleKey(), true ) );
-      highlighted << QStringLiteral( "symbol_label" ) << QStringLiteral( "symbol_id" );
-      symbolLegendScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "symbol_count" ), QVariant::fromValue( vl->featureCount( legendSymbols.first().ruleKey() ) ), true ) );
-      highlighted << QStringLiteral( "symbol_count" );
+      legendContext.appendScope( symnode->createSymbolScope() );
+      highlighted << QStringLiteral( "symbol_label" ) << QStringLiteral( "symbol_id" ) << QStringLiteral( "symbol_count" );
     }
   }
-
-  legendContext.appendScope( symbolLegendScope );
 
   legendContext.setHighlightedVariables( highlighted );
 
@@ -1199,7 +1187,10 @@ void QgsLayoutLegendWidget::mLayerExpressionButton_clicked()
 
   QgsExpressionBuilderDialog expressiondialog( nullptr, currentExpression, nullptr, QStringLiteral( "generic" ), legendContext );
   if ( expressiondialog.exec() )
+  {
     layerNode->setLabelExpression( expressiondialog.expressionText() );
+    mItemTreeView->layerTreeModel()->refreshLayerLegend( layerNode );
+  }
 
   mLegend->beginCommand( tr( "Update Legend" ) );
   mLegend->refresh();

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1167,13 +1167,16 @@ void QgsLayoutLegendWidget::mLayerExpressionButton_clicked()
   legendContext.appendScope( vl->createExpressionContextScope() );
 
   QStringList highlighted;
-  const QList<QgsLayerTreeModelLegendNode *> legendnodes = mLegend->model()->layerLegendNodes( layerNode, false );
-  if ( !legendnodes.isEmpty() )
+  if ( QgsLegendModel *model = mLegend->model() )
   {
-    if ( QgsSymbolLegendNode *symnode = qobject_cast<QgsSymbolLegendNode *>( legendnodes.first() ) )
+    const QList<QgsLayerTreeModelLegendNode *> legendNodes = model->layerLegendNodes( layerNode, false );
+    if ( !legendNodes.isEmpty() )
     {
-      legendContext.appendScope( symnode->createSymbolScope() );
-      highlighted << QStringLiteral( "symbol_label" ) << QStringLiteral( "symbol_id" ) << QStringLiteral( "symbol_count" );
+      if ( QgsSymbolLegendNode *symbolNode = qobject_cast<QgsSymbolLegendNode *>( legendNodes.first() ) )
+      {
+        legendContext.appendScope( symbolNode->createSymbolScope() );
+        highlighted << QStringLiteral( "symbol_label" ) << QStringLiteral( "symbol_id" ) << QStringLiteral( "symbol_count" );
+      }
     }
   }
 
@@ -2092,5 +2095,3 @@ bool QgsLayoutLegendMapFilteringModel::filterAcceptsRow( int source_row, const Q
 
 
 ///@endcond
-
-


### PR DESCRIPTION
Re-opening of https://github.com/qgis/QGIS/pull/53631 for bugfix session.

## Description

This PR comes from trying to fix #53442.

I jumped into parts of code that are very strange.

The evaluation of expressions for the `QgsLayoutLegendItem` in the composer, vs the evaluation of expressions in the `QTreeView` in the composer legend widget are somewhat correlated but not completely...

![image](https://github.com/qgis/QGIS/assets/34267385/a43003b8-3e4b-4400-a231-51430689129f)

I will explain my observations, and why I suggest the changes in this PR.

## User observations

- The layout item always evaluates the legend label, expression or not being present (in `QgsLayerTreeModelLegendNode::draw`)

- The legend tree view does not always evaluate the legend labels
  ![image](https://github.com/qgis/QGIS/assets/34267385/76d45747-a67a-4dff-8327-c6b6dc7246ec)  
  ![image](https://github.com/qgis/QGIS/assets/34267385/87803c53-873e-4562-a5e2-d4712f12d430)  
  ![image](https://github.com/qgis/QGIS/assets/34267385/7c289170-b590-4ef2-ac44-dff724ac7602)

- The legend tree view does not evaluate expressions when refreshing the layout (![image](https://github.com/qgis/QGIS/assets/34267385/2b3e499c-d9bf-4fdf-9dbe-e96f15f1a80b)) or when moving to the next atlas page (except if the filtering for items - in linked map or atlas - is enabled)

## Technical observations

Technically, what is very strange, is that the label evaluation occurs in the `getData` method of the legend model.

That means that the model is changed inside a method that should not change the model (and the model is not aware of this change).

Also, the legend layout item evaluates the label of the model, whereas the legend tree view evaluates the `UserLabel` (edit role) to change and update the model label...

The way it is implemented is also strange (evaluating children symbols nodes but not layer nodes, only if the layer node has an expression... !).

After a lot of time digging into the code, trying to update the labels at the right place/moment, I ended with this conclusion:

the expression evaluation is very situational (symbol expressions that can be added for every child, atlas page number, layer feature-count enabled, user-defined variables, filters, etc.) and should not be part of the model. It is a representation, by definition, the real data being the raw expression. Furthermore, the expressions are today evaluated at different places with possibly different contexts (for the legend layout item and for the legend tree view).

## Suggested changes

I think that the model should contain the label, with the textual expression (not evaluated), and that it is the responsibility of the view to evaluate the expression, like it is done with the legend layout item.

As a result, in this PR I removed the label evaluation taking place in the `getData` method of the model.

The proposition is to always see the expressions in the legend tree view, and leave the layout legend item be the only one evaluating the label.

It is technically easier because evaluating the label in every situation is difficult to handle (with expressions being able to be in the layer style label, in the legend node widget, with the entity count, atlas page, etc.), so having the "total" expression, not evaluated, in the model label makes sense, and it is evaluated at the very end, for the rendering.

From a user point of view it can be argued that it is also more convenient to see his expression in the legend tree widget, and the evaluation on his composer page. 