### PR TITLE
Fix a deadlock in remote COPC handling (3D views)

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -194,7 +194,6 @@ qint64 QgsCopcPointCloudIndex::pointCount() const
 
 bool QgsCopcPointCloudIndex::loadHierarchy()
 {
-  QMutexLocker locker( &mHierarchyMutex );
   fetchHierarchyPage( mCopcInfoVlr.root_hier_offset, mCopcInfoVlr.root_hier_size );
   return true;
 }
@@ -315,6 +314,8 @@ void QgsCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t byteS
     int32_t byteSize;
     int32_t pointCount;
   };
+
+  QMutexLocker locker( &mHierarchyMutex );
 
   for ( uint64_t i = 0; i < byteSize; i += sizeof( CopcEntry ) )
   {

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -175,6 +175,7 @@ bool QgsRemoteCopcPointCloudIndex::fetchNodeHierarchy( const IndexedPointCloudNo
     if ( nodesCount < 0 )
     {
       auto hierarchyNodePos = mHierarchyNodePos.constFind( n );
+      locker.unlock();
       fetchHierarchyPage( hierarchyNodePos->first, hierarchyNodePos->second );
     }
   }
@@ -226,6 +227,8 @@ void QgsRemoteCopcPointCloudIndex::fetchHierarchyPage( uint64_t offset, uint64_t
     int32_t byteSize;
     int32_t pointCount;
   };
+
+  QMutexLocker locker( &mHierarchyMutex );
 
   for ( uint64_t i = 0; i < byteSize; i += sizeof( CopcEntry ) )
   {


### PR DESCRIPTION
This gets often triggered from 3D views when the hierachy gets fetched, because a QEventLoop gets started in the main thread while waiting for network request to be finished. The event loop was running with hierarchy mutex locked, which was causing deadlocks when other events ended up trying to access the hierarchy. This fix unlocks the mutex while the hierarchy network request is ongoing (the same approach as remote EPT implementation uses, which seems to work fine).

Looking at the copc/ept hierarchy handling, it is not great - both formats are conceptually the same, yet the hierarchy implementations are different, and there are also non-trivial differences between local/remote datasets. All of this could get some code cleanups (also unifying local/remote access), but at this time let's just try to fix the worst bit, and hope something else does not break...
