### PR TITLE
Fix the option dialog's minimum width being overly large

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -207,10 +207,18 @@
                      </widget>
                     </item>
                     <item row="0" column="1">
-                     <widget class="QComboBox" name="cboTranslation"/>
+                     <widget class="QComboBox" name="cboTranslation">
+                      <property name="sizeAdjustPolicy">
+                       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                      </property>
+                     </widget>
                     </item>
                     <item row="2" column="1">
-                     <widget class="QComboBox" name="cboGlobalLocale"/>
+                     <widget class="QComboBox" name="cboGlobalLocale">
+                      <property name="sizeAdjustPolicy">
+                       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                      </property>
+                     </widget>
                     </item>
                     <item row="3" column="1">
                      <widget class="QCheckBox" name="cbShowGroupSeparator">
@@ -408,7 +416,11 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QFontComboBox" name="mFontFamilyComboBox"/>
+                     <widget class="QFontComboBox" name="mFontFamilyComboBox">
+                      <property name="sizeAdjustPolicy">
+                       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                      </property>
+                     </widget>
                     </item>
                     <item>
                      <widget class="QLabel" name="label_20">
@@ -850,23 +862,16 @@
                       </property>
                      </widget>
                     </item>
-                    <item row="0" column="2">
-                     <spacer name="horizontalSpacer_12">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
                     <item row="0" column="1">
                      <widget class="QRadioButton" name="mFileFormatQgzButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
                       <property name="text">
-                       <string>QGZ Bundled project format, compressed into a single zip file, embeds auxiliary data</string>
+                       <string>QGZ Bundled project format</string>
                       </property>
                       <attribute name="buttonGroup">
                        <string notr="true">mDefaultProjectFileFormatButtonGroup</string>
@@ -874,16 +879,42 @@
                      </widget>
                     </item>
                     <item row="1" column="1">
+                     <widget class="QLabel" name="mFileFormatQgzDescription">
+                      <property name="text">
+                       <string>Compressed into a single zip file, embeds auxiliary data</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
                      <widget class="QRadioButton" name="mFileFormatQgsButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
                       <property name="toolTip">
                        <string>The auxiliary data will be kept in a separate .qgd data file which must be distributed along with the .qgs project file.</string>
                       </property>
                       <property name="text">
-                       <string>QGS XML project format, saved in a clear text, does not embed auxiliary data</string>
+                       <string>QGS XML project format</string>
                       </property>
                       <attribute name="buttonGroup">
                        <string notr="true">mDefaultProjectFileFormatButtonGroup</string>
                       </attribute>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QLabel" name="mFileFormatQgsDescription">
+                      <property name="text">
+                       <string>Saved in a clear text, does not embed auxiliary data</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>true</bool>
+                      </property>
                      </widget>
                     </item>
                    </layout>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2588,6 +2588,9 @@
                       <string>Open layer styling dock</string>
                      </property>
                     </item>
+                    <property name="sizeAdjustPolicy">
+                     <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                    </property>
                    </widget>
                   </item>
                   <item row="1" column="0">
@@ -2598,7 +2601,11 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QComboBox" name="mLayerTreeInsertionMethod"/>
+                   <widget class="QComboBox" name="mLayerTreeInsertionMethod">
+                    <property name="sizeAdjustPolicy">
+                     <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                    </property>                     
+                   </widget>
                   </item>
                   <item row="2" column="0" colspan="2">
                    <widget class="QCheckBox" name="mShowFeatureCountByDefaultCheckBox">
@@ -5190,6 +5197,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <widget class="QLabel" name="label_64">
                 <property name="text">
                  <string>The following OpenCL devices were found on this system (changing the default device requires QGIS to be restarted).</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/src/ui/qgsrasterrenderingoptionsbase.ui
+++ b/src/ui/qgsrasterrenderingoptionsbase.ui
@@ -60,20 +60,10 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QgsSpinBox" name="spnRed"/>
-         </item>
          <item row="2" column="0">
           <widget class="QLabel" name="lbldefaultZoomedOutResampling">
            <property name="text">
             <string>Zoomed out resampling</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="5">
-          <widget class="QLabel" name="label_24">
-           <property name="text">
-            <string>Blue band</string>
            </property>
           </widget>
          </item>
@@ -84,12 +74,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="6">
-          <widget class="QgsSpinBox" name="spnBlue"/>
-         </item>
-         <item row="0" column="4">
-          <widget class="QgsSpinBox" name="spnGreen"/>
-         </item>
          <item row="3" column="0">
           <widget class="QLabel" name="lbldefaultOversampling">
            <property name="text">
@@ -97,22 +81,42 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="3">
-          <widget class="QLabel" name="label_23">
-           <property name="text">
-            <string>Green band</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1" colspan="6">
           <widget class="QComboBox" name="mZoomedInResamplingComboBox"/>
          </item>
          <item row="0" column="1">
-          <widget class="QLabel" name="label_22">
-           <property name="text">
-            <string>Red band</string>
-           </property>
-          </widget>
+          <layout class="QGridLayout" name="bandsGridLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_22">
+             <property name="text">
+              <string>Red band</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_23">
+             <property name="text">
+              <string>Green band</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_24">
+             <property name="text">
+              <string>Blue band</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QgsSpinBox" name="spnRed"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="QgsSpinBox" name="spnGreen"/>
+           </item>
+           <item row="2" column="1">
+            <widget class="QgsSpinBox" name="spnBlue"/>
+           </item>
+          </layout>
          </item>
          <item row="2" column="1" colspan="6">
           <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
@@ -156,10 +160,18 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1,0">
       <item row="1" column="3" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementLimitsSingleBand"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementLimitsSingleBand">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="2" column="1" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandSingleByte"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandSingleByte">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="5" column="3">
        <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutUpperDoubleSpinBox">
@@ -176,7 +188,11 @@
        </widget>
       </item>
       <item row="1" column="1" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmSingleBand"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmSingleBand">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="0" column="1">
        <widget class="QLabel" name="label_50">
@@ -189,7 +205,11 @@
        </widget>
       </item>
       <item row="2" column="3" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandSingleByte"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandSingleByte">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_25">
@@ -199,7 +219,11 @@
        </widget>
       </item>
       <item row="3" column="3" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandMultiByte"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandMultiByte">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="0" column="3" colspan="2">
        <widget class="QLabel" name="label_51">
@@ -261,7 +285,11 @@
        </widget>
       </item>
       <item row="3" column="1" colspan="2">
-       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandMultiByte"/>
+       <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandMultiByte">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
       <item row="6" column="1">
        <widget class="QgsDoubleSpinBox" name="spnThreeBandStdDev">

--- a/src/ui/qgsvectorrenderingoptionsbase.ui
+++ b/src/ui/qgsvectorrenderingoptionsbase.ui
@@ -64,9 +64,12 @@
         <property name="value">
          <double>1.000000000000000</double>
         </property>
+        <property name="suffix">
+         <string> px</string>
+        </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="mSimplifyAlgorithmLabel">
         <property name="toolTip">
          <string>This algorithm is only applied to simplify on local side</string>
@@ -79,7 +82,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1" colspan="2">
+      <item row="5" column="1">
        <widget class="QgsScaleComboBox" name="mSimplifyMaximumScaleComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -89,50 +92,57 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="mSimplifyMaxScaleLabel">
         <property name="text">
-         <string>Maximum scale at which the layer should be simplified (1:1 always simplifies)</string>
+         <string>Maximum scale at which the layer should be simplified</string>
         </property>
         <property name="margin">
          <number>2</number>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
+      <item row="6" column="0" colspan="2">
+       <widget class="QLabel" name="mSimplifyMaxScaleExtraLabel">
+        <property name="text">
+         <string>(1:1 always simplifies)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="mSimplifyDrawingAtProvider">
         <property name="text">
          <string>Simplify on provider side if possible</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="3">
+      <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_59">
         <property name="text">
          <string>&lt;b&gt;Note:&lt;/b&gt; Feature simplification may speed up rendering but can result in rendering inconsistencies</string>
         </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="3" column="1">
        <widget class="QComboBox" name="mSimplifyAlgorithmComboBox"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_65">
+       <widget class="QLabel" name="mSimplificationThresholdLabel">
         <property name="text">
-         <string>Simplification threshold (higher values result in more simplification)</string>
+         <string>Simplification threshold</string>
         </property>
         <property name="margin">
          <number>2</number>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="mSimplifyDrawingPx">
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="mSimplificationThresholdExtraLabel">
         <property name="text">
-         <string>pixels</string>
-        </property>
-        <property name="margin">
-         <number>2</number>
+         <string>(higher values result in more simplification)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Description

This PR improves the QGIS option dialog by insuring that each panel's minimum width size isn't unreasonably width.

E.g., general panel before (left) vs. PR (right):

![image](https://github.com/qgis/QGIS/assets/1728657/b205fb5b-e715-4004-9c5a-edb8a6ffba08)


