### PR TITLE
[processing] Fix "Generate XYZ tiles" algs: set antialiasing when requested and use the QUALITY parameter only for JPG

### DIFF
--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -198,6 +198,7 @@ void QgsXyzTilesBaseAlgorithm::startJobs()
     settings.setDestinationCrs( mMercatorCrs );
     settings.setLayers( mLayers );
     settings.setOutputDpi( mDpi );
+    settings.setFlag( MapSettingsFlag.Antialiasing, mAntialias );
     if ( mTileFormat == QLatin1String( "PNG" ) || mBackgroundColor.alpha() == 255 )
     {
       settings.setBackgroundColor( mBackgroundColor );

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -154,7 +154,7 @@ bool QgsXyzTilesBaseAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
   mBackgroundColor = parameterAsColor( parameters, QStringLiteral( "BACKGROUND_COLOR" ), context );
   mAntialias = parameterAsBool( parameters, QStringLiteral( "ANTIALIAS" ), context );
   mTileFormat = parameterAsEnum( parameters, QStringLiteral( "TILE_FORMAT" ), context ) ? QStringLiteral( "JPG" ) : QStringLiteral( "PNG" );
-  mJpgQuality = parameterAsInt( parameters, QStringLiteral( "QUALITY" ), context );
+  mJpgQuality = mTileFormat == QLatin1String( "JPG" ) ? parameterAsInt( parameters, QStringLiteral( "QUALITY" ), context ) : -1;
   mMetaTileSize = parameterAsInt( parameters, QStringLiteral( "METATILESIZE" ), context );
   mThreadsNumber = context.maximumThreads();
   mTransformContext = context.transformContext();


### PR DESCRIPTION
## Description

This PR fixes an oversight which prevents the "Generate XYZ tiles" processing algorithms to properly use and set the `ANTIALIAS` parameter and a probably longstanding oversights which makes the `QUALITY` parameter incorrectly used for PNG format.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
