### PR TITLE
Insure that saving map [canvas] as image/PDF take high DPI scaling factor into account

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -64,6 +64,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   mExtent = ms.visibleExtent();
   mDpi = ms.outputDpi();
   mSize = ms.outputSize();
+  mDevicePixelRatio = ms.devicePixelRatio();
 
   mResolutionSpinBox->setValue( static_cast< int >( std::round( mDpi ) ) );
 
@@ -341,6 +342,7 @@ void QgsMapSaveDialog::applyMapSettings( QgsMapSettings &mapSettings )
       mapSettings.setFlag( Qgis::MapSettingsFlag::HighQualityImageTransforms, settings.value( QStringLiteral( "qgis/enable_anti_aliasing" ), true ).toBool() );
       break;
   }
+
   mapSettings.setFlag( Qgis::MapSettingsFlag::ForceVectorOutput, true ); // force vector output (no caching of marker images etc.)
   mapSettings.setFlag( Qgis::MapSettingsFlag::DrawEditingInfo, false );
   mapSettings.setFlag( Qgis::MapSettingsFlag::DrawSelection, true );
@@ -349,6 +351,7 @@ void QgsMapSaveDialog::applyMapSettings( QgsMapSettings &mapSettings )
   mapSettings.setExtent( extent() );
   mapSettings.setOutputSize( size() );
   mapSettings.setOutputDpi( dpi() );
+  mapSettings.setDevicePixelRatio( mDevicePixelRatio );
   mapSettings.setBackgroundColor( mMapCanvas->canvasColor() );
   mapSettings.setRotation( mMapCanvas->rotation() );
   mapSettings.setEllipsoid( QgsProject::instance()->ellipsoid() );
@@ -397,13 +400,14 @@ void QgsMapSaveDialog::copyToClipboard()
   QPainter *p = nullptr;
   QImage *img = nullptr;
 
-  img = new QImage( ms.outputSize(), QImage::Format_ARGB32 );
+  img = new QImage( ms.outputSize() * ms.devicePixelRatio(), QImage::Format_ARGB32 );
   if ( img->isNull() )
   {
     QgisApp::instance()->messageBar()->pushWarning( tr( "Save as image" ), tr( "Could not allocate required memory for image" ) );
     return;
   }
 
+  img->setDevicePixelRatio( ms.devicePixelRatio() );
   img->setDotsPerMeterX( 1000 * ms.outputDpi() / 25.4 );
   img->setDotsPerMeterY( 1000 * ms.outputDpi() / 25.4 );
 

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -109,6 +109,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     QgsRectangle mExtent;
     int mDpi;
     QSize mSize;
+    double mDevicePixelRatio;
 
     QString mInfoDetails;
 

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -109,7 +109,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     QgsRectangle mExtent;
     int mDpi;
     QSize mSize;
-    double mDevicePixelRatio;
+    float mDevicePixelRatio;
 
     QString mInfoDetails;
 

--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -126,6 +126,12 @@ QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString 
   , mGeoPDF( geoPDF && mFileFormat == QLatin1String( "PDF" ) && QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
   , mGeoPdfExportDetails( geoPdfExportDetails )
 {
+  if ( mFileFormat == QLatin1String( "PDF" ) && !qgsDoubleNear( mMapSettings.devicePixelRatio(), 1.0 ) )
+  {
+    mMapSettings.setOutputSize( mMapSettings.outputSize() * mMapSettings.devicePixelRatio() );
+    mMapSettings.setOutputDpi( mMapSettings.outputDpi() * mMapSettings.devicePixelRatio() );
+    mMapSettings.setDevicePixelRatio( 1.0 );
+  }
   prepare();
 }
 
@@ -480,7 +486,7 @@ void QgsMapRendererTask::prepare()
   if ( !mDestPainter )
   {
     // save rendered map to an image file
-    mImage = QImage( mMapSettings.outputSize(), QImage::Format_ARGB32 );
+    mImage = QImage( mMapSettings.outputSize() * mMapSettings.devicePixelRatio(), QImage::Format_ARGB32 );
     if ( mImage.isNull() )
     {
       mErrored = true;
@@ -488,6 +494,7 @@ void QgsMapRendererTask::prepare()
       return;
     }
 
+    mImage.setDevicePixelRatio( mMapSettings.devicePixelRatio() );
     mImage.setDotsPerMeterX( 1000 * mMapSettings.outputDpi() / 25.4 );
     mImage.setDotsPerMeterY( 1000 * mMapSettings.outputDpi() / 25.4 );
 


### PR DESCRIPTION
## Description

This PR insures that saving the map canvas as an image or PDF will end up with the same output size (in pixel) as the QGIS map canvas was occupying on high DPI screens when Qt's auto scaling factor is on. 

Until this PR, the resulting image would end up being sized down by quite a lot. For e.g., say you had a high DPI screen leading to a scale factor of 2.0, you'd end up with an image file half the size.