### PR TITLE
Revert 9df62b9 : safeguards in algs are enough

### DIFF
--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -777,11 +777,6 @@ class BatchPanel(QgsPanelWidget, WIDGET):
             widget = self.tblParameters.cellWidget(row + 1, col)
             text = widget.getValue()
             if not warnOnInvalid or out.checkValueIsAcceptable(text):
-                ok, error = out.isSupportedOutputValue(text, createContext())
-                if not ok:
-                    self.parent.messageBar().pushMessage("", error, level=Qgis.MessageLevel.Warning, duration=5)
-                    return {}, False
-
                 if isinstance(out, (QgsProcessingParameterRasterDestination,
                                     QgsProcessingParameterVectorDestination,
                                     QgsProcessingParameterFeatureSink)):


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/56132

As described in issue, 9df62b9 cause a regression and prevent user from filling output filename with an expression as expression context is missing (@INPUT is not recognized)

`ok, error = out.isSupportedOutputValue(text, createContext())` tries to evaluate the value of first row. It's often empty as user wants to file it with an expression.
It returns false and cause an early return without variable names mandatory for the expression context.

@pblottiere Could you take a look at this ?

I would like to backport this to 3.34.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
