### PR TITLE
Fix a crash in point cloud renderer when cleaning up preview painter

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -388,6 +388,9 @@ int QgsPointCloudLayerRenderer::renderNodesSync( const QVector<IndexedPointCloud
 
 int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled )
 {
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return 0;
+
   QPainter *finalPainter = context.renderContext().painter();
   if ( mRenderer->renderAsTriangles() && context.renderContext().previewRenderPainter() )
   {
@@ -397,9 +400,6 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
   }
 
   int nodesDrawn = 0;
-
-  if ( context.feedback() && context.feedback()->isCanceled() )
-    return 0;
 
   // Async loading of nodes
   QVector<QgsPointCloudBlockRequest *> blockRequests;


### PR DESCRIPTION
This fixes a crash in 2D rendering:

1. load a remote COPC layer
2. enable render as a surface
3. zoom in and out quickly
4. crash upon job cleanup when deleting preview painter

The crash was happening because in renderNodesAsync() we may have set the preview painter as the main painter, and then exit early upon cancellation, without setting the original painter back.

Fixed by making sure the early exit happens before any changes to the painter.
