### PR TITLE
Fix crash when applying vector properties dialog

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -84,7 +84,11 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   connect( pbnSelectEditForm, &QToolButton::clicked, this, &QgsAttributesFormProperties::pbnSelectEditForm_clicked );
   connect( mTbInitCode, &QPushButton::clicked, this, &QgsAttributesFormProperties::mTbInitCode_clicked );
 
-  connect( mLayer, &QgsVectorLayer::updatedFields, this, &QgsAttributesFormProperties::updatedFields );
+  connect( mLayer, &QgsVectorLayer::updatedFields, this, [this]
+  {
+    if ( !mBlockUpdates )
+      updatedFields();
+  } );
 }
 
 void QgsAttributesFormProperties::init()
@@ -948,6 +952,7 @@ void QgsAttributesFormProperties::store()
 
 void QgsAttributesFormProperties::apply()
 {
+  mBlockUpdates++;
   storeAttributeWidgetEdit();
   storeAttributeContainerEdit();
   storeAttributeTypeDialog();
@@ -1058,6 +1063,7 @@ void QgsAttributesFormProperties::apply()
   }
 
   mLayer->setEditFormConfig( editFormConfig );
+  mBlockUpdates--;
 }
 
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -422,6 +422,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QString mInitFunction;
     QString mInitFilePath;
     QString mInitCode;
+    int mBlockUpdates = 0;
 
 };
 


### PR DESCRIPTION
Applyling the field configuration was setting the field properties for the layer, which was triggering a connection to rebuild the dialog properties while we were still mid-way through applying the changes.

Master only.

Regression from https://github.com/qgis/QGIS/pull/55938