### PR TITLE
Add setters for QgsWeakRelation layer sources

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsweakrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsweakrelation.sip.in
@@ -92,12 +92,20 @@ Returns the relationship's name.
 %Docstring
 Returns the source URI for the referencing (or "child" / "right") layer.
 
+.. seealso:: :py:func:`referencingLayerProvider`
+
+.. seealso:: :py:func:`setReferencingLayer`
+
 .. versionadded:: 3.28
 %End
 
     QString referencingLayerProvider() const;
 %Docstring
 Returns the provider ID for the referencing (or "child" / "right") layer.
+
+.. seealso:: :py:func:`referencingLayerSource`
+
+.. seealso:: :py:func:`setReferencingLayer`
 
 .. versionadded:: 3.28
 %End
@@ -114,10 +122,25 @@ Returns the layer name of the referencing (or "child" / "right") layer.
 .. versionadded:: 3.28
 %End
 
+    void setReferencingLayer( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the referencing (or "child" / "right") layer, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`referencingLayerSource`
+
+.. seealso:: :py:func:`referencingLayerProvider`
+
+.. versionadded:: 3.36
+%End
+
 
     QString referencedLayerSource() const;
 %Docstring
 Returns the source URI for the referenced (or "parent" / "left") layer.
+
+.. seealso:: :py:func:`referencedLayerProvider`
+
+.. seealso:: :py:func:`setReferencedLayer`
 
 .. versionadded:: 3.28
 %End
@@ -125,6 +148,10 @@ Returns the source URI for the referenced (or "parent" / "left") layer.
     QString referencedLayerProvider() const;
 %Docstring
 Returns the provider ID for the referenced (or "parent" / "left") layer.
+
+.. seealso:: :py:func:`referencedLayerSource`
+
+.. seealso:: :py:func:`setReferencedLayer`
 
 .. versionadded:: 3.28
 %End
@@ -141,11 +168,26 @@ Returns the layer name of the referenced (or "parent" / "left") layer.
 .. versionadded:: 3.28
 %End
 
+    void setReferencedLayer( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the referenced (or "parent" / "left") layer, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`referencedLayerSource`
+
+.. seealso:: :py:func:`referencedLayerProvider`
+
+.. versionadded:: 3.36
+%End
+
 
 
     QString mappingTableSource() const;
 %Docstring
 Returns the source URI for the mapping table, which forms the middle table in many-to-many relationships.
+
+.. seealso:: :py:func:`mappingTableProvider`
+
+.. seealso:: :py:func:`setMappingTable`
 
 .. versionadded:: 3.28
 %End
@@ -153,6 +195,10 @@ Returns the source URI for the mapping table, which forms the middle table in ma
     QString mappingTableProvider() const;
 %Docstring
 Returns the provider ID for the mapping table, which forms the middle table in many-to-many relationships.
+
+.. seealso:: :py:func:`mappingTableSource`
+
+.. seealso:: :py:func:`setMappingTable`
 
 .. versionadded:: 3.28
 %End
@@ -167,6 +213,17 @@ Returns the layer name of the mapping table, which forms the middle table in man
    :py:class:`QgsVectorLayer`.
 
 .. versionadded:: 3.28
+%End
+
+    void setMappingTable( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the mapping table, which forms the middle table in many-to-many relationships, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`mappingTableSource`
+
+.. seealso:: :py:func:`mappingTableProvider`
+
+.. versionadded:: 3.36
 %End
 
     QStringList referencingLayerFields() const;

--- a/python/core/auto_generated/qgsweakrelation.sip.in
+++ b/python/core/auto_generated/qgsweakrelation.sip.in
@@ -92,12 +92,20 @@ Returns the relationship's name.
 %Docstring
 Returns the source URI for the referencing (or "child" / "right") layer.
 
+.. seealso:: :py:func:`referencingLayerProvider`
+
+.. seealso:: :py:func:`setReferencingLayer`
+
 .. versionadded:: 3.28
 %End
 
     QString referencingLayerProvider() const;
 %Docstring
 Returns the provider ID for the referencing (or "child" / "right") layer.
+
+.. seealso:: :py:func:`referencingLayerSource`
+
+.. seealso:: :py:func:`setReferencingLayer`
 
 .. versionadded:: 3.28
 %End
@@ -114,10 +122,25 @@ Returns the layer name of the referencing (or "child" / "right") layer.
 .. versionadded:: 3.28
 %End
 
+    void setReferencingLayer( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the referencing (or "child" / "right") layer, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`referencingLayerSource`
+
+.. seealso:: :py:func:`referencingLayerProvider`
+
+.. versionadded:: 3.36
+%End
+
 
     QString referencedLayerSource() const;
 %Docstring
 Returns the source URI for the referenced (or "parent" / "left") layer.
+
+.. seealso:: :py:func:`referencedLayerProvider`
+
+.. seealso:: :py:func:`setReferencedLayer`
 
 .. versionadded:: 3.28
 %End
@@ -125,6 +148,10 @@ Returns the source URI for the referenced (or "parent" / "left") layer.
     QString referencedLayerProvider() const;
 %Docstring
 Returns the provider ID for the referenced (or "parent" / "left") layer.
+
+.. seealso:: :py:func:`referencedLayerSource`
+
+.. seealso:: :py:func:`setReferencedLayer`
 
 .. versionadded:: 3.28
 %End
@@ -141,11 +168,26 @@ Returns the layer name of the referenced (or "parent" / "left") layer.
 .. versionadded:: 3.28
 %End
 
+    void setReferencedLayer( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the referenced (or "parent" / "left") layer, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`referencedLayerSource`
+
+.. seealso:: :py:func:`referencedLayerProvider`
+
+.. versionadded:: 3.36
+%End
+
 
 
     QString mappingTableSource() const;
 %Docstring
 Returns the source URI for the mapping table, which forms the middle table in many-to-many relationships.
+
+.. seealso:: :py:func:`mappingTableProvider`
+
+.. seealso:: :py:func:`setMappingTable`
 
 .. versionadded:: 3.28
 %End
@@ -153,6 +195,10 @@ Returns the source URI for the mapping table, which forms the middle table in ma
     QString mappingTableProvider() const;
 %Docstring
 Returns the provider ID for the mapping table, which forms the middle table in many-to-many relationships.
+
+.. seealso:: :py:func:`mappingTableSource`
+
+.. seealso:: :py:func:`setMappingTable`
 
 .. versionadded:: 3.28
 %End
@@ -167,6 +213,17 @@ Returns the layer name of the mapping table, which forms the middle table in man
    :py:class:`QgsVectorLayer`.
 
 .. versionadded:: 3.28
+%End
+
+    void setMappingTable( const QString &sourceUri, const QString &provider );
+%Docstring
+Sets the source for the mapping table, which forms the middle table in many-to-many relationships, by ``sourceUri`` and ``provider`` ID.
+
+.. seealso:: :py:func:`mappingTableSource`
+
+.. seealso:: :py:func:`mappingTableProvider`
+
+.. versionadded:: 3.36
 %End
 
     QStringList referencingLayerFields() const;

--- a/src/core/qgsweakrelation.cpp
+++ b/src/core/qgsweakrelation.cpp
@@ -142,6 +142,12 @@ QString QgsWeakRelation::referencingLayerProvider() const
   return mReferencingLayer.provider;
 }
 
+void QgsWeakRelation::setReferencingLayer( const QString &sourceUri, const QString &provider )
+{
+  mReferencingLayer.source = sourceUri;
+  mReferencingLayer.provider = provider;
+}
+
 QString QgsWeakRelation::referencingLayerName() const
 {
   if ( QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( mReferencingLayer.provider ) )
@@ -175,6 +181,12 @@ QString QgsWeakRelation::referencedLayerName() const
   return QString();
 }
 
+void QgsWeakRelation::setReferencedLayer( const QString &sourceUri, const QString &provider )
+{
+  mReferencedLayer.source = sourceUri;
+  mReferencedLayer.provider = provider;
+}
+
 QgsVectorLayerRef QgsWeakRelation::mappingTable() const
 {
   return mMappingTable;
@@ -202,6 +214,12 @@ QString QgsWeakRelation::mappingTableName() const
     return metadata->decodeUri( mMappingTable.source ).value( QStringLiteral( "layerName" ) ).toString();
   }
   return QString();
+}
+
+void QgsWeakRelation::setMappingTable( const QString &sourceUri, const QString &provider )
+{
+  mMappingTable.source = sourceUri;
+  mMappingTable.provider = provider;
 }
 
 Qgis::RelationshipStrength QgsWeakRelation::strength() const

--- a/src/core/qgsweakrelation.h
+++ b/src/core/qgsweakrelation.h
@@ -113,6 +113,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the source URI for the referencing (or "child" / "right") layer.
      *
+     * \see referencingLayerProvider()
+     * \see setReferencingLayer()
      * \since QGIS 3.28
      */
     QString referencingLayerSource() const;
@@ -120,6 +122,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the provider ID for the referencing (or "child" / "right") layer.
      *
+     * \see referencingLayerSource()
+     * \see setReferencingLayer()
      * \since QGIS 3.28
      */
     QString referencingLayerProvider() const;
@@ -135,6 +139,15 @@ class CORE_EXPORT QgsWeakRelation
     QString referencingLayerName() const;
 
     /**
+     * Sets the source for the referencing (or "child" / "right") layer, by \a sourceUri and \a provider ID.
+     *
+     * \see referencingLayerSource()
+     * \see referencingLayerProvider()
+     * \since QGIS 3.36
+     */
+    void setReferencingLayer( const QString &sourceUri, const QString &provider );
+
+    /**
      * Returns a weak reference to the referenced (or "parent" / "left") layer.
      *
      * \note Not available in Python bindings.
@@ -144,6 +157,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the source URI for the referenced (or "parent" / "left") layer.
      *
+     * \see referencedLayerProvider()
+     * \see setReferencedLayer()
      * \since QGIS 3.28
      */
     QString referencedLayerSource() const;
@@ -151,6 +166,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the provider ID for the referenced (or "parent" / "left") layer.
      *
+     * \see referencedLayerSource()
+     * \see setReferencedLayer()
      * \since QGIS 3.28
      */
     QString referencedLayerProvider() const;
@@ -164,6 +181,15 @@ class CORE_EXPORT QgsWeakRelation
      * \since QGIS 3.28
      */
     QString referencedLayerName() const;
+
+    /**
+     * Sets the source for the referenced (or "parent" / "left") layer, by \a sourceUri and \a provider ID.
+     *
+     * \see referencedLayerSource()
+     * \see referencedLayerProvider()
+     * \since QGIS 3.36
+     */
+    void setReferencedLayer( const QString &sourceUri, const QString &provider );
 
     /**
      * Returns a weak reference to the mapping table, which forms the middle table in many-to-many relationships.
@@ -186,6 +212,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the source URI for the mapping table, which forms the middle table in many-to-many relationships.
      *
+     * \see mappingTableProvider()
+     * \see setMappingTable()
      * \since QGIS 3.28
      */
     QString mappingTableSource() const;
@@ -193,6 +221,8 @@ class CORE_EXPORT QgsWeakRelation
     /**
      * Returns the provider ID for the mapping table, which forms the middle table in many-to-many relationships.
      *
+     * \see mappingTableSource()
+     * \see setMappingTable()
      * \since QGIS 3.28
      */
     QString mappingTableProvider() const;
@@ -206,6 +236,15 @@ class CORE_EXPORT QgsWeakRelation
      * \since QGIS 3.28
      */
     QString mappingTableName() const;
+
+    /**
+     * Sets the source for the mapping table, which forms the middle table in many-to-many relationships, by \a sourceUri and \a provider ID.
+     *
+     * \see mappingTableSource()
+     * \see mappingTableProvider()
+     * \since QGIS 3.36
+     */
+    void setMappingTable( const QString &sourceUri, const QString &provider );
 
     /**
      * Returns the list of fields from the referencingLayer() involved in the relationship.

--- a/tests/src/core/testqgsweakrelation.cpp
+++ b/tests/src/core/testqgsweakrelation.cpp
@@ -31,6 +31,8 @@ class TestQgsWeakRelation: public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
 
+    void testSetters();
+
     void testResolved(); // Test if relation can be resolved
     void testResolvedManyToMany();
     void testReadWrite(); // Test if relation can be read and write
@@ -63,6 +65,28 @@ void TestQgsWeakRelation::init()
 void TestQgsWeakRelation::cleanup()
 {
   QLocale::setDefault( QLocale::English );
+}
+
+void TestQgsWeakRelation::testSetters()
+{
+  QgsWeakRelation weakRel;
+  QCOMPARE( weakRel.referencedLayerSource(), QString() );
+  QCOMPARE( weakRel.referencedLayerProvider(), QString() );
+  weakRel.setReferencedLayer( QStringLiteral( "referenced_source" ), QStringLiteral( "referenced_provider" ) );
+  QCOMPARE( weakRel.referencedLayerSource(), QStringLiteral( "referenced_source" ) );
+  QCOMPARE( weakRel.referencedLayerProvider(), QStringLiteral( "referenced_provider" ) );
+
+  QCOMPARE( weakRel.referencingLayerSource(), QString() );
+  QCOMPARE( weakRel.referencingLayerProvider(), QString() );
+  weakRel.setReferencingLayer( QStringLiteral( "referencing_source" ), QStringLiteral( "referencing_provider" ) );
+  QCOMPARE( weakRel.referencingLayerSource(), QStringLiteral( "referencing_source" ) );
+  QCOMPARE( weakRel.referencingLayerProvider(), QStringLiteral( "referencing_provider" ) );
+
+  QCOMPARE( weakRel.mappingTableSource(), QString() );
+  QCOMPARE( weakRel.mappingTableProvider(), QString() );
+  weakRel.setMappingTable( QStringLiteral( "mapping_source" ), QStringLiteral( "mapping_provider" ) );
+  QCOMPARE( weakRel.mappingTableSource(), QStringLiteral( "mapping_source" ) );
+  QCOMPARE( weakRel.mappingTableProvider(), QStringLiteral( "mapping_provider" ) );
 }
 
 void TestQgsWeakRelation::testResolved()


### PR DESCRIPTION
This is a particularly annoying limitation in PyQGIS API -- there's some existing c++ setters for this class, but they use QgsVectorLayerRef which is not available for use in Python.  Accordingly there's no way for a Python script to construct a relationship definition from scratch, which in turn prevents calling the methods like QgsAbstractDatabaseProviderConnection::addRelationship to create a relationship in a datasource....