### PR TITLE
[ui] When an attribute table is docked to the main window, disable the DEL keyboard shorcut (fixes #56262)

### DIFF
--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -242,6 +242,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QPointer< QgsVectorLayer > mLayer = nullptr;
     void updateMultiEditButtonState();
     void deleteFeature( QgsFeatureId fid );
+    void toggleShortcuts( bool enable );
 
     QList< QPointer< QgsVectorLayer> > mReferencingLayers;
 


### PR DESCRIPTION
## Description

This PR insures that the Delete keyboard key is not forcefully taken over by the attribute table when docked to the main window (i.e. as a non-floating dock). When docked, let the main window handle the delete key, which in turn fixes the use of the vertex tool when a docked attribute table is opened (with one or more feature selected).

It also fixes other UX interactions when delete is pressed, e.g. deletion of annotations.

Fixes #56262.