### PR TITLE
[geometry snapper] Fix wrong point-to-segment distance within maths

### DIFF
--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -99,7 +99,7 @@ bool QgsSnapIndex::SegmentSnapItem::getProjection( const QgsPoint &p, QgsPoint &
   return true;
 }
 
-bool QgsSnapIndex::SegmentSnapItem::withinDistance( const QgsPoint &p, const double tolerance )
+bool QgsSnapIndex::SegmentSnapItem::withinSqrDistance( const QgsPoint &p, const double tolerance )
 {
   double minDistX, minDistY;
   const double distance = QgsGeometryUtilsBase::sqrDistToLine( p.x(), p.y(), idxFrom->point().x(), idxFrom->point().y(), idxTo->point().x(), idxTo->point().y(), minDistX, minDistY, 4 * std::numeric_limits<double>::epsilon() );
@@ -250,6 +250,7 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
   QgsSnapIndex::SegmentSnapItem *snapSegment = nullptr;
   QgsSnapIndex::PointSnapItem *snapPoint = nullptr;
 
+  const double sqrTolerance = tolerance * tolerance;
   const auto constItems = items;
   for ( QgsSnapIndex::SnapItem *item : constItems )
   {
@@ -264,7 +265,7 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
     }
     else if ( item->type == SnapSegment && !endPointOnly )
     {
-      if ( !static_cast<SegmentSnapItem *>( item )->withinDistance( pos, tolerance ) )
+      if ( !static_cast<SegmentSnapItem *>( item )->withinSqrDistance( pos, sqrTolerance ) )
         continue;
 
       QgsPoint pProj;
@@ -279,8 +280,8 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
       }
     }
   }
-  snapPoint = minDistPoint < tolerance * tolerance ? snapPoint : nullptr;
-  snapSegment = minDistSegment < tolerance * tolerance ? snapSegment : nullptr;
+  snapPoint = minDistPoint < sqrTolerance ? snapPoint : nullptr;
+  snapSegment = minDistSegment < sqrTolerance ? snapSegment : nullptr;
   if ( pSnapPoint ) *pSnapPoint = snapPoint;
   if ( pSnapSegment ) *pSnapSegment = snapSegment;
   return minDistPoint < minDistSegment ? static_cast<QgsSnapIndex::SnapItem *>( snapPoint ) : static_cast<QgsSnapIndex::SnapItem *>( snapSegment );

--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -99,11 +99,10 @@ bool QgsSnapIndex::SegmentSnapItem::getProjection( const QgsPoint &p, QgsPoint &
   return true;
 }
 
-bool QgsSnapIndex::SegmentSnapItem::withinSqrDistance( const QgsPoint &p, const double tolerance )
+bool QgsSnapIndex::SegmentSnapItem::withinSquaredDistance( const QgsPoint &p, const double squaredDistance )
 {
   double minDistX, minDistY;
-  const double distance = QgsGeometryUtilsBase::sqrDistToLine( p.x(), p.y(), idxFrom->point().x(), idxFrom->point().y(), idxTo->point().x(), idxTo->point().y(), minDistX, minDistY, 4 * std::numeric_limits<double>::epsilon() );
-  return distance <= tolerance;
+  return QgsGeometryUtilsBase::sqrDistToLine( p.x(), p.y(), idxFrom->point().x(), idxFrom->point().y(), idxTo->point().x(), idxTo->point().y(), minDistX, minDistY, 4 * std::numeric_limits<double>::epsilon() ) <= squaredDistance;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -250,7 +249,7 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
   QgsSnapIndex::SegmentSnapItem *snapSegment = nullptr;
   QgsSnapIndex::PointSnapItem *snapPoint = nullptr;
 
-  const double sqrTolerance = tolerance * tolerance;
+  const double squaredTolerance = tolerance * tolerance;
   const auto constItems = items;
   for ( QgsSnapIndex::SnapItem *item : constItems )
   {
@@ -265,7 +264,7 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
     }
     else if ( item->type == SnapSegment && !endPointOnly )
     {
-      if ( !static_cast<SegmentSnapItem *>( item )->withinSqrDistance( pos, sqrTolerance ) )
+      if ( !static_cast<SegmentSnapItem *>( item )->withinSquaredDistance( pos, squaredTolerance ) )
         continue;
 
       QgsPoint pProj;
@@ -280,8 +279,8 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
       }
     }
   }
-  snapPoint = minDistPoint < sqrTolerance ? snapPoint : nullptr;
-  snapSegment = minDistSegment < sqrTolerance ? snapSegment : nullptr;
+  snapPoint = minDistPoint < squaredTolerance ? snapPoint : nullptr;
+  snapSegment = minDistSegment < squaredTolerance ? snapSegment : nullptr;
   if ( pSnapPoint ) *pSnapPoint = snapPoint;
   if ( pSnapSegment ) *pSnapSegment = snapSegment;
   return minDistPoint < minDistSegment ? static_cast<QgsSnapIndex::SnapItem *>( snapPoint ) : static_cast<QgsSnapIndex::SnapItem *>( snapSegment );

--- a/src/analysis/vector/qgsgeometrysnapper.h
+++ b/src/analysis/vector/qgsgeometrysnapper.h
@@ -209,7 +209,7 @@ class QgsSnapIndex
         QgsPoint getSnapPoint( const QgsPoint &p ) const override;
         bool getIntersection( const QgsPoint &p1, const QgsPoint &p2, QgsPoint &inter ) const;
         bool getProjection( const QgsPoint &p, QgsPoint &pProj ) const;
-        bool withinDistance( const QgsPoint &p, const double distance );
+        bool withinSqrDistance( const QgsPoint &p, const double distance );
         const CoordIdx *idxFrom = nullptr;
         const CoordIdx *idxTo = nullptr;
     };

--- a/src/analysis/vector/qgsgeometrysnapper.h
+++ b/src/analysis/vector/qgsgeometrysnapper.h
@@ -209,7 +209,7 @@ class QgsSnapIndex
         QgsPoint getSnapPoint( const QgsPoint &p ) const override;
         bool getIntersection( const QgsPoint &p1, const QgsPoint &p2, QgsPoint &inter ) const;
         bool getProjection( const QgsPoint &p, QgsPoint &pProj ) const;
-        bool withinSqrDistance( const QgsPoint &p, const double distance );
+        bool withinSquaredDistance( const QgsPoint &p, const double squaredDistance );
         const CoordIdx *idxFrom = nullptr;
         const CoordIdx *idxTo = nullptr;
     };

--- a/tests/src/analysis/testqgsgeometrysnapper.cpp
+++ b/tests/src/analysis/testqgsgeometrysnapper.cpp
@@ -378,6 +378,10 @@ void TestQgsGeometrySnapper::snapPointToLine()
   pointGeom = QgsGeometry::fromWkt( QStringLiteral( "Point(0.5 0.5)" ) );
   result = snapper.snapGeometry( pointGeom, 1 );
   QCOMPARE( result.asWkt(), QStringLiteral( "Point (0 0)" ) );
+
+  pointGeom = QgsGeometry::fromWkt( QStringLiteral( "Point(3 3)" ) );
+  result = snapper.snapGeometry( pointGeom, 4 );
+  QCOMPARE( result.asWkt(), QStringLiteral( "Point (3 0)" ) );
 }
 
 void TestQgsGeometrySnapper::snapPointToLinePreferNearest()


### PR DESCRIPTION
## Description

This PR fixes a pretty serious issue with our QgsGeometrySnapper class whereas snapping of point geometry to line  segments would often fail due to a bogus distance to line calculation. 

We were checking whether a given tolerance/distance was within a _squared distance_ value, leading to failures :scream:

Fixes #56424 , #50121 , and likely other issues. A test has been added.