### PR TITLE
Service Area Units

### DIFF
--- a/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
@@ -43,7 +43,7 @@ QString QgsServiceAreaFromLayerAlgorithm::shortHelpString() const
                       "edges of a network line layer that can be reached within a distance "
                       "or a time, starting from features of a point layer. The distance and "
                       "the time (both referred to as \"travel cost\") must be specified "
-                      "respectively in the network layer units or in hours." );
+                      "respectively in meters or in hours." );
 }
 
 QgsServiceAreaFromLayerAlgorithm *QgsServiceAreaFromLayerAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
@@ -42,8 +42,7 @@ QString QgsServiceAreaFromPointAlgorithm::shortHelpString() const
   return QObject::tr( "This algorithm creates a new vector with all the edges or parts of edges "
                       "of a network line layer that can be reached within a distance or a time, "
                       "starting from a point feature. The distance and the time (both referred to "
-                      "as \"travel cost\") must be specified respectively in the network layer "
-                      "units or in hours." );
+                      "as \"travel cost\") must be specified respectively in meters or in hours." );
 }
 
 QgsServiceAreaFromPointAlgorithm *QgsServiceAreaFromPointAlgorithm::createInstance() const


### PR DESCRIPTION
## Description

The network service area processing plugin uses only meters and hours to specify time or distance for the area calculation. 

This is incorrect in the algorithm description, which says that the units of the input feature layer will be used for distance. 

I've tested this myself and found setting the QGIS project length units to feet and using input datasets with a CRS using feet still requires length specified in meters to correctly calculate results. 

https://github.com/qgis/QGIS/issues/37926


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
