### PR TITLE
Don't force calculate layer extents when saving layers

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -648,10 +648,10 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  if ( dataProvider() && dataProvider()->elevationProperties() && dataProvider()->elevationProperties()->containsElevationData() )
-    layerElement.appendChild( QgsXmlUtils::writeBox3D( extent3D(), document ) );
-  else
-    layerElement.appendChild( QgsXmlUtils::writeRectangle( extent(), document ) );
+  if ( !mExtent3D.isNull() && dataProvider() && dataProvider()->elevationProperties() && dataProvider()->elevationProperties()->containsElevationData() )
+    layerElement.appendChild( QgsXmlUtils::writeBox3D( mExtent3D, document ) );
+  else if ( !mExtent2D.isNull() )
+    layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent2D, document ) );
 
   layerElement.appendChild( QgsXmlUtils::writeRectangle( wgs84Extent( true ), document, QStringLiteral( "wgs84extent" ) ) );
 


### PR DESCRIPTION
If we don't already have an extent available, don't force a full recalculation of it when saving the layer to XML. This can be extremely expensive to calculate for some vector layer sources, so if we force calculate it when saving then QGIS projects can take minutes++ to save!

Fixes a (private) project with multiple vector layers from Geodatabases which takes upwards of 5 minutes to save.
