### PR TITLE
Don't force full calculation of layer extent when cloning layers

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -143,9 +143,9 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   if ( layer->dataProvider() && layer->dataProvider()->elevationProperties() )
   {
     if ( layer->dataProvider()->elevationProperties()->containsElevationData() )
-      layer->setExtent3D( extent3D() );
+      layer->mExtent3D = mExtent3D;
     else
-      layer->setExtent( extent() );
+      layer->mExtent2D = mExtent2D;
   }
 
   layer->setMaximumScale( maximumScale() );

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -297,6 +297,12 @@ QgsVectorLayer *QgsVectorLayer::clone() const
     layer->dataProvider()->handlePostCloneOperations( mDataProvider );
   }
   QgsMapLayer::clone( layer );
+  layer->mXmlExtent2D = mXmlExtent2D;
+  layer->mLazyExtent2D = mLazyExtent2D;
+  layer->mValidExtent2D = mValidExtent2D;
+  layer->mXmlExtent3D = mXmlExtent3D;
+  layer->mLazyExtent3D = mLazyExtent3D;
+  layer->mValidExtent3D = mValidExtent3D;
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();
   const auto constJoins = joins;


### PR DESCRIPTION
This can be extremely expensive to calculate for some sources, so just clone whatever information we currently have available instead of force calculating the full exact extent.
