### PR TITLE
Add layer tree filter for "Show Broken Layers Only"

### DIFF
--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -46,6 +46,24 @@ Returns if private layers are shown.
 Determines if private layers are shown.
 %End
 
+    bool hideValidLayers() const;
+%Docstring
+Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
+    void setHideValidLayers( bool hideValid );
+%Docstring
+Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
   protected:
 
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
@@ -324,6 +342,22 @@ Returns width of contextual menu mark, at right of layer node items.
 
 
 
+    bool showPrivateLayers() const;
+%Docstring
+Returns the show private layers status
+
+.. versionadded:: 3.18
+%End
+
+    bool hideValidLayers() const;
+%Docstring
+Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
   public slots:
     void refreshLayerSymbology( const QString &layerId );
 %Docstring
@@ -363,11 +397,13 @@ Set the show private layers to ``showPrivate``
 .. versionadded:: 3.18
 %End
 
-    bool showPrivateLayers( );
+    void setHideValidLayers( bool hideValid );
 %Docstring
-Returns the show private layers status
+Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
 
-.. versionadded:: 3.18
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
 %End
 
   signals:

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -46,6 +46,24 @@ Returns if private layers are shown.
 Determines if private layers are shown.
 %End
 
+    bool hideValidLayers() const;
+%Docstring
+Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
+    void setHideValidLayers( bool hideValid );
+%Docstring
+Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
   protected:
 
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
@@ -324,6 +342,22 @@ Returns width of contextual menu mark, at right of layer node items.
 
 
 
+    bool showPrivateLayers() const;
+%Docstring
+Returns the show private layers status
+
+.. versionadded:: 3.18
+%End
+
+    bool hideValidLayers() const;
+%Docstring
+Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
+%End
+
   public slots:
     void refreshLayerSymbology( const QString &layerId );
 %Docstring
@@ -363,11 +397,13 @@ Set the show private layers to ``showPrivate``
 .. versionadded:: 3.18
 %End
 
-    bool showPrivateLayers( );
+    void setHideValidLayers( bool hideValid );
 %Docstring
-Returns the show private layers status
+Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
 
-.. versionadded:: 3.18
+.. seealso:: :py:func:`setHideValidLayers`
+
+.. versionadded:: 3.38
 %End
 
   signals:

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4976,6 +4976,11 @@ void QgisApp::initLayerTreeView()
   connect( mFilterLegendToggleShowPrivateLayersAction, &QAction::toggled, this, [ = ]( bool showPrivateLayers ) { layerTreeView()->setShowPrivateLayers( showPrivateLayers ); } );
   filterLegendMenu->addAction( mFilterLegendToggleShowPrivateLayersAction );
 
+  mFilterLegendToggleHideValidLayersAction = new QAction( tr( "Show Broken Layers Only" ), this );
+  mFilterLegendToggleHideValidLayersAction->setCheckable( true );
+  connect( mFilterLegendToggleHideValidLayersAction, &QAction::toggled, this, [ = ]( bool hideValidLayers ) { layerTreeView()->setHideValidLayers( hideValidLayers ); } );
+  filterLegendMenu->addAction( mFilterLegendToggleHideValidLayersAction );
+
   mLegendExpressionFilterButton = new QgsLegendFilterButton( this );
   mLegendExpressionFilterButton->setToolTip( tr( "Filter legend by expression" ) );
   connect( mLegendExpressionFilterButton, &QAbstractButton::toggled, this, &QgisApp::toggleFilterLegendByExpression );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2643,6 +2643,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QToolButton *mFilterLegendToolButton = nullptr;
     QAction *mFilterLegendByMapContentAction = nullptr;
     QAction *mFilterLegendToggleShowPrivateLayersAction = nullptr;
+    QAction *mFilterLegendToggleHideValidLayersAction = nullptr;
     QAction *mActionStyleDock = nullptr;
 
     QgsLegendFilterButton *mLegendExpressionFilterButton = nullptr;

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -111,6 +111,7 @@ void QgsLayerTreeView::setModel( QAbstractItemModel *model )
 #endif
 
   mProxyModel->setShowPrivateLayers( mShowPrivateLayers );
+  mProxyModel->setHideValidLayers( mHideValidLayers );
   QTreeView::setModel( mProxyModel );
 
   connect( treeModel->rootGroup(), &QgsLayerTreeNode::expandedChanged, this, &QgsLayerTreeView::onExpandedChanged );
@@ -601,9 +602,20 @@ void QgsLayerTreeView::setShowPrivateLayers( bool showPrivate )
   mProxyModel->setShowPrivateLayers( showPrivate );
 }
 
-bool QgsLayerTreeView::showPrivateLayers()
+void QgsLayerTreeView::setHideValidLayers( bool hideValid )
+{
+  mHideValidLayers = hideValid;
+  mProxyModel->setHideValidLayers( mHideValidLayers );
+}
+
+bool QgsLayerTreeView::showPrivateLayers() const
 {
   return mShowPrivateLayers;
+}
+
+bool QgsLayerTreeView::hideValidLayers() const
+{
+  return mHideValidLayers;
 }
 
 void QgsLayerTreeView::mouseDoubleClickEvent( QMouseEvent *event )
@@ -852,6 +864,9 @@ bool QgsLayerTreeProxyModel::nodeShown( QgsLayerTreeNode *node ) const
     {
       return false;
     }
+    if ( mHideValidLayers && layer->isValid() )
+      return false;
+
     return true;
   }
 }
@@ -863,6 +878,23 @@ bool QgsLayerTreeProxyModel::showPrivateLayers() const
 
 void QgsLayerTreeProxyModel::setShowPrivateLayers( bool showPrivate )
 {
+  if ( showPrivate == mShowPrivateLayers )
+    return;
+
   mShowPrivateLayers = showPrivate;
+  invalidateFilter();
+}
+
+bool QgsLayerTreeProxyModel::hideValidLayers() const
+{
+  return mHideValidLayers;
+}
+
+void QgsLayerTreeProxyModel::setHideValidLayers( bool hideValid )
+{
+  if ( hideValid == mHideValidLayers )
+    return;
+
+  mHideValidLayers = hideValid;
   invalidateFilter();
 }

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -69,6 +69,22 @@ class GUI_EXPORT QgsLayerTreeProxyModel : public QSortFilterProxyModel
      */
     void setShowPrivateLayers( bool showPrivate );
 
+    /**
+     * Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+     *
+     * \see setHideValidLayers()
+     * \since QGIS 3.38
+     */
+    bool hideValidLayers() const;
+
+    /**
+     * Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
+     *
+     * \see setHideValidLayers()
+     * \since QGIS 3.38
+     */
+    void setHideValidLayers( bool hideValid );
+
   protected:
 
     bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
@@ -80,6 +96,7 @@ class GUI_EXPORT QgsLayerTreeProxyModel : public QSortFilterProxyModel
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
     QString mFilterText;
     bool mShowPrivateLayers = false;
+    bool mHideValidLayers = false;
 
 };
 
@@ -332,6 +349,20 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
 
 ///@endcond
 
+    /**
+     * Returns the show private layers status
+     * \since QGIS 3.18
+     */
+    bool showPrivateLayers() const;
+
+    /**
+     * Returns if valid layers should be hidden (i.e. only invalid layers are shown).
+     *
+     * \see setHideValidLayers()
+     * \since QGIS 3.38
+     */
+    bool hideValidLayers() const;
+
   public slots:
     //! Force refresh of layer symbology. Normally not needed as the changes of layer's renderer are monitored by the model
     void refreshLayerSymbology( const QString &layerId );
@@ -366,10 +397,12 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     void setShowPrivateLayers( bool showPrivate );
 
     /**
-     * Returns the show private layers status
-     * \since QGIS 3.18
+     * Sets whether valid layers should be hidden (i.e. only invalid layers are shown).
+     *
+     * \see setHideValidLayers()
+     * \since QGIS 3.38
      */
-    bool showPrivateLayers( );
+    void setHideValidLayers( bool hideValid );
 
   signals:
     //! Emitted when a current layer is changed
@@ -443,6 +476,7 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     QgsMessageBar *mMessageBar = nullptr;
 
     bool mShowPrivateLayers = false;
+    bool mHideValidLayers = false;
 
     QTimer *mBlockDoubleClickTimer = nullptr;
     // For model  debugging

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -626,6 +626,34 @@ class TestQgsLayerTreeView(QgisTestCase):
 
         self.assertEqual(proxy_items, ['layer2'])
 
+        # test valid layer filtering
+        broken_layer = QgsVectorLayer("xxxx", "broken", "ogr")
+        self.assertFalse(broken_layer.isValid())
+        self.project.addMapLayers([broken_layer])
+
+        proxy_model.setFilterText(None)
+
+        proxy_items = []
+        for r in range(proxy_model.rowCount()):
+            proxy_items.append(proxy_model.data(proxy_model.index(r, 0)))
+        self.assertEqual(proxy_items, ['broken', 'layer1', 'layer2'])
+
+        proxy_model.setHideValidLayers(True)
+
+        proxy_items = []
+        for r in range(proxy_model.rowCount()):
+            proxy_items.append(proxy_model.data(proxy_model.index(r, 0)))
+        self.assertEqual(proxy_items, ['broken'])
+
+        proxy_model.setHideValidLayers(False)
+
+        proxy_items = []
+        for r in range(proxy_model.rowCount()):
+            proxy_items.append(proxy_model.data(proxy_model.index(r, 0)))
+        self.assertEqual(proxy_items, ['broken', 'layer1', 'layer2'])
+
+        self.project.removeMapLayer(broken_layer)
+
     def testProxyModelCurrentIndex(self):
         """Test a crash spotted out while developing the proxy model"""
 


### PR DESCRIPTION
When checked, only layers with broken sources will be shown in the tree. This allows users to easily find broken layers in large complex projects, where they may otherwise escape notice!
