### PR TITLE
[ui][wms] Fix WMS source select interpretation combobox not setting proper index on empty interpretation string

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1371,6 +1371,10 @@ void QgsWmsInterpretationComboBox::setInterpretation( const QString &interpretat
     else
       setCurrentIndex( index );
   }
+  else
+  {
+    setCurrentIndex( 0 );
+  }
 }
 
 QString QgsWmsInterpretationComboBox::interpretation() const


### PR DESCRIPTION
## Description

Fix issue reported here ( https://github.com/qgis/QGIS/pull/56418#issuecomment-1954156134 ) whereas the interpretation combobox isn't set to the right index on empty interpretation string value from URI.