### PR TITLE
Don't force calculate layer extents when saving layers (backport)

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -624,7 +624,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  if ( !extent().isNull() )
+  if ( !mExtent.isNull() )
   {
     layerElement.appendChild( QgsXmlUtils::writeRectangle( mExtent, document ) );
     layerElement.appendChild( QgsXmlUtils::writeRectangle( wgs84Extent( true ), document, QStringLiteral( "wgs84extent" ) ) );


### PR DESCRIPTION
If we don't already have an extent available, don't force a full recalculation of it when saving the layer to XML. This can be extremely expensive to calculate for some vector layer sources, so if we force calculate it when saving then QGIS projects can take minutes++ to save!

Fixes a (private) project with multiple vector layers from Geodatabases which takes upwards of 5 minutes to save.

Manual backport of https://github.com/qgis/QGIS/pull/56433