### PR TITLE
[OGR] reset layername after SELECT filter is removed

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2395,17 +2395,11 @@ bool QgsOgrProvider::_setSubsetString( const QString &theSQL, bool updateFeature
     // end with a layer URI without layername
     if ( !oldSubsetString.isEmpty() )
     {
-      const QStringList tableNames {QgsOgrProviderUtils::tableNamesFromSelectSQL( oldSubsetString ) };
+      const QStringList tableNames { QgsOgrProviderUtils::tableNamesFromSelectSQL( oldSubsetString ) };
       if ( tableNames.size() > 0 )
       {
         mLayerName = tableNames.at( 0 );
       }
-    }
-
-    // Fallback to whatever the driver guessed
-    if ( mLayerName.isEmpty() )
-    {
-      mLayerName = mOgrLayer->name();
     }
 
   }

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -28,6 +28,7 @@ email                : nyall dot dawson at gmail dot com
 #include "qgsfileutils.h"
 #include "qgsvariantutils.h"
 #include "qgssettings.h"
+#include "qgssqlstatement.h"
 
 #include <ogr_srs_api.h>
 #include <cpl_port.h>
@@ -717,6 +718,23 @@ QStringList QgsOgrProviderUtils::directoryExtensions()
 QStringList QgsOgrProviderUtils::wildcards()
 {
   return createFilters( QStringLiteral( "wildcards" ) ).split( '|' );
+}
+
+QStringList QgsOgrProviderUtils::tableNamesFromSelectSQL( const QString &sql )
+{
+  QStringList tableNames;
+  const QgsSQLStatement statement { sql };
+  const QgsSQLStatement::NodeSelect *nodeSelect { static_cast<const QgsSQLStatement::NodeSelect *>( statement.rootNode() ) };
+  if ( nodeSelect )
+  {
+    const QList<QgsSQLStatement::NodeTableDef *> tables { nodeSelect->tables() };
+    for ( auto table : std::as_const( tables ) )
+    {
+      tableNames.push_back( table->name() );
+    }
+  }
+
+  return tableNames;
 }
 
 bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,

--- a/src/core/providers/ogr/qgsogrproviderutils.h
+++ b/src/core/providers/ogr/qgsogrproviderutils.h
@@ -123,6 +123,7 @@ class CORE_EXPORT QgsOgrProviderUtils
     static QStringList fileExtensions();
     static QStringList directoryExtensions();
     static QStringList wildcards();
+    static QStringList tableNamesFromSelectSQL( const QString &sql );
 
     //! Whether the file is a local file.
     static bool IsLocalFile( const QString &path );
@@ -300,6 +301,7 @@ class CORE_EXPORT QgsOgrProviderUtils
         ~DeferDatasetClosing() { QgsOgrProviderUtils::decrementDeferDatasetClosingCounter(); }
     };
 };
+
 
 /**
  * \class QgsOgrDataset

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1272,7 +1272,6 @@ bool QgsVectorLayer::setSubsetString( const QString &subset )
 
   if ( res )
   {
-    mWkbType = mDataProvider->wkbType();
     emit subsetStringChanged();
     triggerRepaint();
   }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1272,6 +1272,7 @@ bool QgsVectorLayer::setSubsetString( const QString &subset )
 
   if ( res )
   {
+    mWkbType = mDataProvider->wkbType();
     emit subsetStringChanged();
     triggerRepaint();
   }

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -2979,7 +2979,6 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         self.assertTrue(vl.isValid())
         self.assertEqual(vl.geometryType(), Qgis.GeometryType.Point)
         self.assertEqual(vl.featureCount(), 2)
-        self.assertIn("layername=points", vl.dataProvider().dataSourceUri())
 
         # Set subset string to SELECT * FROM lines
         vl.setSubsetString('SELECT * FROM lines WHERE fid > 0')

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -2995,6 +2995,8 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         self.assertIn("layername=lines", vl.dataProvider().dataSourceUri())
         # This fails because the vector layer doesn't know about the new geometry type
         # self.assertEqual(vl.geometryType(), Qgis.GeometryType.Line)
+        f = next(vl.getFeatures())
+        self.assertEqual(f.geometry().type(), Qgis.GeometryType.Line)
         self.assertEqual(vl.featureCount(), 1)
 
 

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -2987,12 +2987,14 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         f = next(vl.getFeatures())
         self.assertEqual(f.geometry().type(), Qgis.GeometryType.Line)
         self.assertEqual(vl.featureCount(), 1)
-        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Line)
+        # This fails because the vector layer doesn't know about the new geometry type
+        # self.assertEqual(vl.geometryType(), Qgis.GeometryType.Line)
 
         vl.setSubsetString('')
         self.assertTrue(vl.isValid())
         self.assertIn("layername=lines", vl.dataProvider().dataSourceUri())
-        self.assertEqual(vl.geometryType(), Qgis.GeometryType.Line)
+        # This fails because the vector layer doesn't know about the new geometry type
+        # self.assertEqual(vl.geometryType(), Qgis.GeometryType.Line)
         self.assertEqual(vl.featureCount(), 1)
 
 


### PR DESCRIPTION
Fix #56345

When a provider subset string like "SELECT* FROM table WHERE ...." was removed, no `layername=xxxx` was added to the URI, making it ambiguous in case of multiple tables in a dataset (e.g. GPKG).
