### PR TITLE
[wms] Fix handling of mbtiles in paths containing non-latin characters

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -729,7 +729,9 @@ void QgsDataSourceUri::setEncodedUri( const QByteArray &uri )
 
 void QgsDataSourceUri::setEncodedUri( const QString &uri )
 {
-  setEncodedUri( uri.toLatin1() );
+  QUrl url;
+  url.setQuery( uri );
+  setEncodedUri( url.query( QUrl::EncodeUnicode ).toLatin1() );
 }
 
 QString QgsDataSourceUri::quotedTablename() const

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -36,6 +36,7 @@ class TestQgsDataSourceUri: public QObject
     void checkAuthParams();
     void checkParameterKeys();
     void checkRemovePassword();
+    void checkUnicodeUri();
 };
 
 void TestQgsDataSourceUri::checkparser_data()
@@ -605,6 +606,14 @@ void TestQgsDataSourceUri::checkRemovePassword()
   const QString uri2 = QgsDataSourceUri::removePassword( QStringLiteral( "postgresql://user@127.0.0.1:5432?dbname=test" ) );
   QCOMPARE( uri2, QStringLiteral( "postgresql://user@127.0.0.1:5432?dbname=test" ) );
 }
+
+void TestQgsDataSourceUri::checkUnicodeUri()
+{
+  QgsDataSourceUri uri;
+  uri.setEncodedUri( QStringLiteral( "url=file:///directory/テスト.mbtiles&type=mbtiles" ) );
+  QCOMPARE( uri.param( QStringLiteral( "url" ) ), QStringLiteral( "file:///directory/テスト.mbtiles" ) );
+}
+
 
 QGSTEST_MAIN( TestQgsDataSourceUri )
 #include "testqgsdatasourceuri.moc"


### PR DESCRIPTION
## Description

This PR fixes the loading of mbtiles dataset through our WMS provider when the file path contains non-latin characters. Should make quite a few people around the world happy :wink

Proof of life:
![image](https://github.com/qgis/QGIS/assets/1728657/0c7ea048-7430-450b-af06-3ff5a162e043)

Fixes #56023.
