### PR TITLE
use qint64 instead of qint32 for point cloud node data bounds

### DIFF
--- a/src/core/pointcloud/qgspointcloudindex.cpp
+++ b/src/core/pointcloud/qgspointcloudindex.cpp
@@ -119,7 +119,7 @@ uint qHash( const QgsPointCloudCacheKey &key )
 
 QgsPointCloudDataBounds::QgsPointCloudDataBounds() = default;
 
-QgsPointCloudDataBounds::QgsPointCloudDataBounds( qint32 xmin, qint32 ymin, qint32 zmin, qint32 xmax, qint32 ymax, qint32 zmax )
+QgsPointCloudDataBounds::QgsPointCloudDataBounds( qint64 xmin, qint64 ymin, qint64 zmin, qint64 xmax, qint64 ymax, qint64 zmax )
   : mXMin( xmin )
   , mYMin( ymin )
   , mZMin( zmin )
@@ -130,32 +130,32 @@ QgsPointCloudDataBounds::QgsPointCloudDataBounds( qint32 xmin, qint32 ymin, qint
 
 }
 
-qint32 QgsPointCloudDataBounds::xMin() const
+qint64 QgsPointCloudDataBounds::xMin() const
 {
   return mXMin;
 }
 
-qint32 QgsPointCloudDataBounds::yMin() const
+qint64 QgsPointCloudDataBounds::yMin() const
 {
   return mYMin;
 }
 
-qint32 QgsPointCloudDataBounds::xMax() const
+qint64 QgsPointCloudDataBounds::xMax() const
 {
   return mXMax;
 }
 
-qint32 QgsPointCloudDataBounds::yMax() const
+qint64 QgsPointCloudDataBounds::yMax() const
 {
   return mYMax;
 }
 
-qint32 QgsPointCloudDataBounds::zMin() const
+qint64 QgsPointCloudDataBounds::zMin() const
 {
   return mZMin;
 }
 
-qint32 QgsPointCloudDataBounds::zMax() const
+qint64 QgsPointCloudDataBounds::zMax() const
 {
   return mZMax;
 }
@@ -225,10 +225,9 @@ QgsPointCloudAttributeCollection QgsPointCloudIndex::attributes() const
 
 QgsPointCloudDataBounds QgsPointCloudIndex::nodeBounds( const IndexedPointCloudNode &n ) const
 {
-  qint32 xMin = -999999999, yMin = -999999999, zMin = -999999999;
-  qint32 xMax = 999999999, yMax = 999999999, zMax = 999999999;
+  qint64 xMin, yMin, zMin, xMax, yMax, zMax;
 
-  const int d = mRootBounds.xMax() - mRootBounds.xMin();
+  const qint64 d = mRootBounds.xMax() - mRootBounds.xMin();
   const double dLevel = ( double )d / pow( 2, n.d() );
 
   xMin = round( mRootBounds.xMin() + dLevel * n.x() );

--- a/src/core/pointcloud/qgspointcloudindex.h
+++ b/src/core/pointcloud/qgspointcloudindex.h
@@ -162,25 +162,25 @@ class CORE_EXPORT QgsPointCloudDataBounds
     //! Constructs invalid bounds
     QgsPointCloudDataBounds();
     //! Constructs bounds
-    QgsPointCloudDataBounds( qint32 xmin, qint32 ymin, qint32 zmin, qint32 xmax, qint32 ymax, qint32 zmax );
+    QgsPointCloudDataBounds( qint64 xmin, qint64 ymin, qint64 zmin, qint64 xmax, qint64 ymax, qint64 zmax );
 
     //! Returns x min
-    qint32 xMin() const;
+    qint64 xMin() const;
 
     //! Returns y min
-    qint32 yMin() const;
+    qint64 yMin() const;
 
     //! Returns z min
-    qint32 zMin() const;
+    qint64 zMin() const;
 
     //! Returns x max
-    qint32 xMax() const;
+    qint64 xMax() const;
 
     //! Returns y max
-    qint32 yMax() const;
+    qint64 yMax() const;
 
     //! Returns z max
-    qint32 zMax() const;
+    qint64 zMax() const;
 
     //! Returns 2D rectangle in map coordinates
     QgsRectangle mapExtent( const QgsVector3D &offset, const QgsVector3D &scale ) const;
@@ -189,12 +189,12 @@ class CORE_EXPORT QgsPointCloudDataBounds
     QgsDoubleRange zRange( const QgsVector3D &offset, const QgsVector3D &scale ) const;
 
   private:
-    qint32 mXMin = 0;
-    qint32 mYMin = 0;
-    qint32 mZMin = 0;
-    qint32 mXMax = 0;
-    qint32 mYMax = 0;
-    qint32 mZMax = 0;
+    qint64 mXMin = 0;
+    qint64 mYMin = 0;
+    qint64 mZMin = 0;
+    qint64 mXMax = 0;
+    qint64 mYMax = 0;
+    qint64 mZMax = 0;
 };
 
 /**


### PR DESCRIPTION
## Description
Point clouds with ridiculously small scale values, like the one in #53670, where overflowing integer variables of the root node's data bounds and the node bounds' calculation.
Switching to qint64 resolves this.

Fixes #53670 (the indexing issue has already been fixed, this addresses the rendering issues)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
