### PR TITLE
Server: onProjectReady method for filter plugin

### DIFF
--- a/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverfilter.sip.in
@@ -95,6 +95,16 @@ parameters, just before entering the main switch for core services.
 .. versionadded:: 3.24
 %End
 
+    virtual bool onProjectReady();
+%Docstring
+Method called when the :py:class:`QgsProject` instance is ready to be used to perform the request,
+just before entering the main switch for core services.
+
+:return: true if the call must propagate to the subsequent filters, false otherwise
+
+.. versionadded:: 3.36
+%End
+
     virtual bool onResponseComplete();
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` processing has done and

--- a/python/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/server/auto_generated/qgsserverfilter.sip.in
@@ -95,6 +95,16 @@ parameters, just before entering the main switch for core services.
 .. versionadded:: 3.24
 %End
 
+    virtual bool onProjectReady();
+%Docstring
+Method called when the :py:class:`QgsProject` instance is ready to be used to perform the request,
+just before entering the main switch for core services.
+
+:return: true if the call must propagate to the subsequent filters, false otherwise
+
+.. versionadded:: 3.36
+%End
+
     virtual bool onResponseComplete();
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` processing has done and

--- a/src/server/qgsfilterresponsedecorator.cpp
+++ b/src/server/qgsfilterresponsedecorator.cpp
@@ -41,6 +41,21 @@ void QgsFilterResponseDecorator::start()
 #endif
 }
 
+void QgsFilterResponseDecorator::ready()
+{
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+  QgsServerFiltersMap::const_iterator filtersIterator;
+  for ( filtersIterator = mFilters.constBegin(); filtersIterator != mFilters.constEnd(); ++filtersIterator )
+  {
+    if ( ! filtersIterator.value()->onProjectReady() )
+    {
+      // stop propagation
+      return;
+    }
+  }
+#endif
+}
+
 void QgsFilterResponseDecorator::finish()
 {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
@@ -76,5 +91,3 @@ void QgsFilterResponseDecorator::flush()
 #endif
   mResponse.flush();
 }
-
-

--- a/src/server/qgsfilterresponsedecorator.h
+++ b/src/server/qgsfilterresponsedecorator.h
@@ -47,6 +47,12 @@ class QgsFilterResponseDecorator: public QgsServerResponse
      */
     void start() SIP_THROW( QgsServerException ) SIP_VIRTUALERRORHANDLER( server_exception_handler );
 
+    /**
+     * Call filters projectReady() method
+     * \since QGIS 3.36
+     */
+    void ready() SIP_THROW( QgsServerException ) SIP_VIRTUALERRORHANDLER( server_exception_handler );
+
     // QgsServerResponse overrides
 
     void setHeader( const QString &key, const QString &value ) override {  mResponse.setHeader( key, value ); }
@@ -85,8 +91,3 @@ class QgsFilterResponseDecorator: public QgsServerResponse
 };
 
 #endif
-
-
-
-
-

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -444,7 +444,7 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
       sServerInterface->setConfigFilePath( project->fileName() );
     }
 
-    // Call  requestReady() method (if enabled)
+    // Call requestReady() method (if enabled)
     // This may also throw exceptions if there are errors in python plugins code
     try
     {
@@ -489,6 +489,10 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         {
           sServerInterface->setConfigFilePath( QString() );
         }
+
+        // Call projectReady() method (if enabled)
+        // This may also throw exceptions if there are errors in python plugins code
+        responseDecorator.ready();
 
         // Note that at this point we still might not have set a valid project.
         // There are APIs that work without a project (e.g. the landing page catalog API that
@@ -617,4 +621,3 @@ void QgsServer::initPython()
   }
 }
 #endif
-

--- a/src/server/qgsserverfilter.cpp
+++ b/src/server/qgsserverfilter.cpp
@@ -56,6 +56,11 @@ bool QgsServerFilter::onRequestReady()
   return true;
 }
 
+bool QgsServerFilter::onProjectReady()
+{
+  return true;
+}
+
 bool QgsServerFilter::onResponseComplete()
 {
   Q_NOWARN_DEPRECATED_PUSH
@@ -71,5 +76,3 @@ bool QgsServerFilter::onSendResponse()
   Q_NOWARN_DEPRECATED_POP
   return true;
 }
-
-

--- a/src/server/qgsserverfilter.h
+++ b/src/server/qgsserverfilter.h
@@ -106,6 +106,16 @@ class SERVER_EXPORT QgsServerFilter
     virtual bool onRequestReady();
 
     /**
+     * Method called when the QgsProject instance is ready to be used to perform the request,
+     * just before entering the main switch for core services.
+     *
+     * \return true if the call must propagate to the subsequent filters, false otherwise
+     *
+     * \since QGIS 3.36
+     */
+    virtual bool onProjectReady();
+
+    /**
      * Method called when the QgsRequestHandler processing has done and
      * the response is ready, just after the main switch for core services
      * and before final sending response to FCGI stdout.

--- a/tests/src/python/test_qgsserver_plugins.py
+++ b/tests/src/python/test_qgsserver_plugins.py
@@ -304,6 +304,10 @@ class TestQgsServerPlugins(QgsServerTestBase):
                 request = self.serverInterface().requestHandler()
                 return self.propagate
 
+            def onProjectReady(self):
+                request = self.serverInterface().requestHandler()
+                return self.propagate
+
             def onSendResponse(self):
                 request = self.serverInterface().requestHandler()
                 request.clearBody()
@@ -324,10 +328,16 @@ class TestQgsServerPlugins(QgsServerTestBase):
             def __init__(self, iface):
                 super().__init__(iface)
                 self.request_ready = False
+                self.project_ready = False
 
             def onRequestReady(self):
                 request = self.serverInterface().requestHandler()
                 self.request_ready = True
+                return True
+
+            def onProjectReady(self):
+                request = self.serverInterface().requestHandler()
+                self.project_ready = True
                 return True
 
             def onSendResponse(self):
@@ -359,12 +369,14 @@ class TestQgsServerPlugins(QgsServerTestBase):
         filter1.propagate = False
         _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
         self.assertFalse(filter2.request_ready)
+        self.assertFalse(filter2.project_ready)
         self.assertEqual(body, b'ABC')
 
         # Test with propagation
         filter1.propagate = True
         _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
         self.assertTrue(filter2.request_ready)
+        self.assertTrue(filter2.project_ready)
         self.assertEqual(body, b'ABDCE')
 
         serverIface.setFilters({})

--- a/tests/src/python/test_qgsserver_plugins.py
+++ b/tests/src/python/test_qgsserver_plugins.py
@@ -350,6 +350,37 @@ class TestQgsServerPlugins(QgsServerTestBase):
                 request.appendBody(b'E')
                 return True
 
+        # Methods to manage propagate filter
+        class Filter3(QgsServerFilter):
+            def __init__(self, iface, propagate_filter):
+                super().__init__(iface)
+                self.propagate_filter = propagate_filter
+                self.step_to_stop_propagate = None
+
+            def onRequestReady(self):
+                request = self.serverInterface().requestHandler()
+                if self.step_to_stop_propagate == 'onRequestReady':
+                    self.propagate_filter.propagate = False
+                return True
+
+            def onProjectReady(self):
+                request = self.serverInterface().requestHandler()
+                if self.step_to_stop_propagate == 'onProjectReady':
+                    self.propagate_filter.propagate = False
+                return True
+
+            def onSendResponse(self):
+                request = self.serverInterface().requestHandler()
+                if self.step_to_stop_propagate == 'onSendResponse':
+                    self.propagate_filter.propagate = False
+                return True
+
+            def onResponseComplete(self):
+                request = self.serverInterface().requestHandler()
+                if self.step_to_stop_propagate == 'onResponseComplete':
+                    self.propagate_filter.propagate = False
+                return True
+
         serverIface = self.server.serverInterface()
         serverIface.setFilters({})
 
@@ -378,6 +409,50 @@ class TestQgsServerPlugins(QgsServerTestBase):
         self.assertTrue(filter2.request_ready)
         self.assertTrue(filter2.project_ready)
         self.assertEqual(body, b'ABDCE')
+
+        # Manage propagation
+        filter3 = Filter3(serverIface, filter1)
+        serverIface.registerFilter(filter3, 100)
+
+        # Stop at onResponseComplete
+        filter1.propagate = True
+        filter2.request_ready = False
+        filter2.project_ready = False
+        filter3.step_to_stop_propagate = 'onResponseComplete'
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
+        self.assertTrue(filter2.request_ready)
+        self.assertTrue(filter2.project_ready)
+        self.assertEqual(body, b'ABDC')
+
+        # Stop at onSendResponse
+        filter1.propagate = True
+        filter2.request_ready = False
+        filter2.project_ready = False
+        filter3.step_to_stop_propagate = 'onSendResponse'
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
+        self.assertTrue(filter2.request_ready)
+        self.assertTrue(filter2.project_ready)
+        self.assertEqual(body, b'ABC')
+
+        # Stop at onProjectReady
+        filter1.propagate = True
+        filter2.request_ready = False
+        filter2.project_ready = False
+        filter3.step_to_stop_propagate = 'onProjectReady'
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
+        self.assertTrue(filter2.request_ready)
+        self.assertFalse(filter2.project_ready)
+        self.assertEqual(body, b'ABC')
+
+        # Stop at onRequestReady
+        filter1.propagate = True
+        filter2.request_ready = False
+        filter2.project_ready = False
+        filter3.step_to_stop_propagate = 'onRequestReady'
+        _, body = self._execute_request_project(f'?service={service0.name()}', project=project)
+        self.assertFalse(filter2.request_ready)
+        self.assertFalse(filter2.project_ready)
+        self.assertEqual(body, b'ABC')
 
         serverIface.setFilters({})
         reg.unregisterService(service0.name(), service0.version())


### PR DESCRIPTION
The `onProjectReady` method is called after the `QgsProject` instance is ready for the request and before entering the main switch for core services.

The `onRequestReady` method is called after the `QgsRequestHandler` is ready and populated with parameters but before the `QgsProject` instance is ready.

The `onProjectReady` method coud be used to perform operation at the project level like adding variables, checking vector layer categories, etc.

Funded by 3Liz