### PR TITLE
Regenerate primary keys for Split Lines by Length outputs

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
@@ -149,6 +149,11 @@ Qgis::ProcessingFeatureSourceFlags QgsSplitLinesByLengthAlgorithm::sourceFlags()
   return Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks;
 }
 
+QgsFeatureSink::SinkFlags QgsSplitLinesByLengthAlgorithm::sinkFlags() const
+{
+  return QgsFeatureSink::RegeneratePrimaryKey;
+}
+
 
 ///@endcond
 

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
@@ -52,6 +52,7 @@ class QgsSplitLinesByLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     Qgis::ProcessingFeatureSourceFlags sourceFlags() const override;
+    QgsFeatureSink::SinkFlags sinkFlags() const override;
 
   private:
 


### PR DESCRIPTION
Fixes #56486
