### PR TITLE
Regenerate primary keys for Split Lines by Length outputs (Backport)

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
@@ -149,6 +149,11 @@ QgsProcessingFeatureSource::Flag QgsSplitLinesByLengthAlgorithm::sourceFlags() c
   return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
 }
 
+QgsFeatureSink::SinkFlags QgsSplitLinesByLengthAlgorithm::sinkFlags() const
+{
+  return QgsFeatureSink::RegeneratePrimaryKey;
+}
+
 
 ///@endcond
 

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
@@ -52,6 +52,7 @@ class QgsSplitLinesByLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsProcessingFeatureSource::Flag sourceFlags() const override;
+    QgsFeatureSink::SinkFlags sinkFlags() const override;
 
   private:
 


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/56490