### PR TITLE
Fix bookmarks manager model signals emitted twice

### DIFF
--- a/src/core/qgsbookmarkmodel.cpp
+++ b/src/core/qgsbookmarkmodel.cpp
@@ -222,11 +222,9 @@ bool QgsBookmarkManagerModel::setData( const QModelIndex &index, const QVariant 
   return false;
 }
 
-bool QgsBookmarkManagerModel::insertRows( int, int count, const QModelIndex &parent )
+bool QgsBookmarkManagerModel::insertRows( int, int count, const QModelIndex & )
 {
   // append
-  const int oldCount = mManager->bookmarks().count();
-  beginInsertRows( parent, oldCount, oldCount + count );
   bool result = true;
   for ( int i = 0; i < count; ++i )
   {
@@ -236,14 +234,11 @@ bool QgsBookmarkManagerModel::insertRows( int, int count, const QModelIndex &par
     mBlocked = false;
     result &= res;
   }
-  endInsertRows();
   return result;
 }
 
-bool QgsBookmarkManagerModel::removeRows( int row, int count, const QModelIndex &parent )
+bool QgsBookmarkManagerModel::removeRows( int row, int count, const QModelIndex & )
 {
-  beginRemoveRows( parent, row, row + count );
-
   const QList< QgsBookmark > appBookmarks = mManager->bookmarks();
   const QList< QgsBookmark > projectBookmarks = mProjectManager->bookmarks();
   for ( int r = row + count - 1; r >= row; --r )
@@ -253,7 +248,6 @@ bool QgsBookmarkManagerModel::removeRows( int row, int count, const QModelIndex 
     else
       mManager->removeBookmark( appBookmarks.at( r ).id() );
   }
-  endRemoveRows();
   return true;
 }
 


### PR DESCRIPTION
rows inserted/added was fired twice (once by the manager and once by the model), confusing the proxy model.

Also count was wrong by 1 in beginInsertRows( parent, oldCount, oldCount + count ) and beginRemoveRows, but now these two calls have been removed completely.

Fix #56493
