### PR TITLE
[network] Enable strict transport security to fix http->https WMS (et al) data sources

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -216,6 +216,8 @@ QgsNetworkAccessManager::QgsNetworkAccessManager( QObject *parent )
 {
   setProxyFactory( new QgsNetworkProxyFactory() );
   setCookieJar( new QgsNetworkCookieJar( this ) );
+  enableStrictTransportSecurityStore( true );
+  setStrictTransportSecurityEnabled( true );
 }
 
 void QgsNetworkAccessManager::setSslErrorHandler( std::unique_ptr<QgsSslErrorHandler> handler )


### PR DESCRIPTION
## Description

This PR enables strict transport security within QgsNetworkAccessManager in order to gain a bit of extra security and to make WMS servers *relying* on this http->https upgrade to work.

This WMS server (https://cartes.geogratis.gc.ca/wms/hydro_network_fr?SERVICE=WMS&REQUEST=GetCapabilities) is a good example of what it fixes.

In the capabilities XML reply, the GetMap URL is provided using _http://_ , which isn't working. However, when fetch the GetCapabilities using the _https://_ URL, the server relies on strict transport security header to inform clients that it should automatically upgrade those http URLs into https.

Without the fix, this WMS does not work and times out after 60, long, seconds.
