### PR TITLE
Build docker images for 3.36

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ ^refs/tags ]]; then
             echo "matrix={\"branch\":[\"${GITHUB_REF##*/}\"]}" >> $GITHUB_OUTPUT
           else
-            echo "matrix={\"branch\":[\"master\", \"release-3_34\", \"release-3_28\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"branch\":[\"master\", \"release-3_34\", \"release-3_36\"]}" >> $GITHUB_OUTPUT
           fi
 
   build-docker:


### PR DESCRIPTION
Let's try to build docker image and appropriate 3.36 PyQGIS docs, despite I suspect the docs will continue to fail as reported weeks ago in #56313