### PR TITLE
[network logger] Insure the actual request URL is properly reflected in the logger

### DIFF
--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -499,7 +499,7 @@ created in any thread.
 .. versionadded:: 3.6
 %End
 
-    void requestCreated( QgsNetworkRequestParameters request );
+    void requestCreated( const QgsNetworkRequestParameters &request );
 %Docstring
 Emitted when a network request has been created.
 
@@ -513,7 +513,7 @@ created in any thread.
 
 .. seealso:: :py:func:`requestTimedOut`
 
-.. versionadded:: 3.36
+.. versionadded:: 3.38
 %End
 
     void finished( QgsNetworkReplyContent reply );

--- a/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -490,11 +490,30 @@ This signal is propagated to the main thread QgsNetworkAccessManager instance, s
 only to connect to the main thread's signal in order to receive notifications about requests
 created in any thread.
 
+.. seealso:: :py:func:`requestCreated`
+
 .. seealso:: :py:func:`finished`
 
 .. seealso:: :py:func:`requestTimedOut`
 
 .. versionadded:: 3.6
+%End
+
+    void requestCreated( QgsNetworkRequestParameters request );
+%Docstring
+Emitted when a network request has been created.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. seealso:: :py:func:`requestAboutToBeCreated`
+
+.. seealso:: :py:func:`finished`
+
+.. seealso:: :py:func:`requestTimedOut`
+
+.. versionadded:: 3.36
 %End
 
     void finished( QgsNetworkReplyContent reply );

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -499,7 +499,7 @@ created in any thread.
 .. versionadded:: 3.6
 %End
 
-    void requestCreated( QgsNetworkRequestParameters request );
+    void requestCreated( const QgsNetworkRequestParameters &request );
 %Docstring
 Emitted when a network request has been created.
 
@@ -513,7 +513,7 @@ created in any thread.
 
 .. seealso:: :py:func:`requestTimedOut`
 
-.. versionadded:: 3.36
+.. versionadded:: 3.38
 %End
 
     void finished( QgsNetworkReplyContent reply );

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -490,11 +490,30 @@ This signal is propagated to the main thread QgsNetworkAccessManager instance, s
 only to connect to the main thread's signal in order to receive notifications about requests
 created in any thread.
 
+.. seealso:: :py:func:`requestCreated`
+
 .. seealso:: :py:func:`finished`
 
 .. seealso:: :py:func:`requestTimedOut`
 
 .. versionadded:: 3.6
+%End
+
+    void requestCreated( QgsNetworkRequestParameters request );
+%Docstring
+Emitted when a network request has been created.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. seealso:: :py:func:`requestAboutToBeCreated`
+
+.. seealso:: :py:func:`finished`
+
+.. seealso:: :py:func:`requestTimedOut`
+
+.. versionadded:: 3.36
 %End
 
     void finished( QgsNetworkReplyContent reply );

--- a/src/app/devtools/networklogger/qgsnetworklogger.cpp
+++ b/src/app/devtools/networklogger/qgsnetworklogger.cpp
@@ -46,6 +46,7 @@ void QgsNetworkLogger::enableLogging( bool enabled )
   if ( enabled )
   {
     connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ), this, &QgsNetworkLogger::requestAboutToBeCreated, Qt::UniqueConnection );
+    connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated, Qt::UniqueConnection );
     connect( mNam, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ), this, &QgsNetworkLogger::requestFinished, Qt::UniqueConnection );
     connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsNetworkLogger::requestTimedOut, Qt::UniqueConnection );
     connect( mNam, &QgsNetworkAccessManager::downloadProgress, this, &QgsNetworkLogger::downloadProgress, Qt::UniqueConnection );
@@ -54,6 +55,7 @@ void QgsNetworkLogger::enableLogging( bool enabled )
   else
   {
     disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ), this, &QgsNetworkLogger::requestAboutToBeCreated );
+    disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated );
     disconnect( mNam, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ), this, &QgsNetworkLogger::requestFinished );
     disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsNetworkLogger::requestTimedOut );
     disconnect( mNam, &QgsNetworkAccessManager::downloadProgress, this, &QgsNetworkLogger::downloadProgress );
@@ -80,6 +82,21 @@ void QgsNetworkLogger::requestAboutToBeCreated( QgsNetworkRequestParameters para
   mRequestGroups.insert( parameters.requestId(), group.get() );
   mRootNode->addChild( std::move( group ) );
   endInsertRows();
+}
+
+void QgsNetworkLogger::requestCreated( QgsNetworkRequestParameters parameters )
+{
+  QgsNetworkLoggerRequestGroup *requestGroup = mRequestGroups.value( parameters.requestId() );
+  if ( !requestGroup )
+    return;
+
+  const QUrl url = parameters.request().url();
+  if ( requestGroup->url() != url )
+  {
+    requestGroup->setUrl( url );
+    const QModelIndex requestIndex = node2index( requestGroup );
+    emit dataChanged( requestIndex, requestIndex );
+  }
 }
 
 void QgsNetworkLogger::requestFinished( QgsNetworkReplyContent content )

--- a/src/app/devtools/networklogger/qgsnetworklogger.cpp
+++ b/src/app/devtools/networklogger/qgsnetworklogger.cpp
@@ -46,7 +46,7 @@ void QgsNetworkLogger::enableLogging( bool enabled )
   if ( enabled )
   {
     connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ), this, &QgsNetworkLogger::requestAboutToBeCreated, Qt::UniqueConnection );
-    connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated, Qt::UniqueConnection );
+    connect( mNam, qOverload< const QgsNetworkRequestParameters &>( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated, Qt::UniqueConnection );
     connect( mNam, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ), this, &QgsNetworkLogger::requestFinished, Qt::UniqueConnection );
     connect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsNetworkLogger::requestTimedOut, Qt::UniqueConnection );
     connect( mNam, &QgsNetworkAccessManager::downloadProgress, this, &QgsNetworkLogger::downloadProgress, Qt::UniqueConnection );
@@ -55,7 +55,7 @@ void QgsNetworkLogger::enableLogging( bool enabled )
   else
   {
     disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ), this, &QgsNetworkLogger::requestAboutToBeCreated );
-    disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated );
+    disconnect( mNam, qOverload< const QgsNetworkRequestParameters &>( &QgsNetworkAccessManager::requestCreated ), this, &QgsNetworkLogger::requestCreated );
     disconnect( mNam, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ), this, &QgsNetworkLogger::requestFinished );
     disconnect( mNam, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsNetworkLogger::requestTimedOut );
     disconnect( mNam, &QgsNetworkAccessManager::downloadProgress, this, &QgsNetworkLogger::downloadProgress );
@@ -84,7 +84,7 @@ void QgsNetworkLogger::requestAboutToBeCreated( QgsNetworkRequestParameters para
   endInsertRows();
 }
 
-void QgsNetworkLogger::requestCreated( QgsNetworkRequestParameters parameters )
+void QgsNetworkLogger::requestCreated( const QgsNetworkRequestParameters &parameters )
 {
   QgsNetworkLoggerRequestGroup *requestGroup = mRequestGroups.value( parameters.requestId() );
   if ( !requestGroup )

--- a/src/app/devtools/networklogger/qgsnetworklogger.h
+++ b/src/app/devtools/networklogger/qgsnetworklogger.h
@@ -101,7 +101,7 @@ class QgsNetworkLogger : public QAbstractItemModel
 
   private slots:
     void requestAboutToBeCreated( QgsNetworkRequestParameters parameters );
-    void requestCreated( QgsNetworkRequestParameters parameters );
+    void requestCreated( const QgsNetworkRequestParameters &parameters );
     void requestFinished( QgsNetworkReplyContent content );
     void requestTimedOut( QgsNetworkRequestParameters parameters );
     void downloadProgress( int requestId, qint64 bytesReceived, qint64 bytesTotal );

--- a/src/app/devtools/networklogger/qgsnetworklogger.h
+++ b/src/app/devtools/networklogger/qgsnetworklogger.h
@@ -101,6 +101,7 @@ class QgsNetworkLogger : public QAbstractItemModel
 
   private slots:
     void requestAboutToBeCreated( QgsNetworkRequestParameters parameters );
+    void requestCreated( QgsNetworkRequestParameters parameters );
     void requestFinished( QgsNetworkReplyContent content );
     void requestTimedOut( QgsNetworkRequestParameters parameters );
     void downloadProgress( int requestId, qint64 bytesReceived, qint64 bytesTotal );

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
@@ -230,6 +230,11 @@ QVariant QgsNetworkLoggerRequestGroup::toVariant() const
   return res;
 }
 
+void QgsNetworkLoggerRequestGroup::setUrl( const QUrl &url )
+{
+  mUrl = url;
+}
+
 void QgsNetworkLoggerRequestGroup::setReply( const QgsNetworkReplyContent &reply )
 {
   switch ( reply.error() )

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -112,6 +112,11 @@ class QgsNetworkLoggerRequestGroup final : public QgsDevToolsModelGroup
     QUrl url() const { return mUrl; }
 
     /**
+     * Sets the request's URL.
+     */
+    void setUrl( const QUrl &url );
+
+    /**
      * Returns TRUE if the request was served directly from local cache.
      */
     bool replyFromCache() const { return mReplyFromCache; }

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -634,8 +634,8 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     connect( this, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ),
              sMainNAM, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ) );
 
-    connect( this, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ),
-             sMainNAM, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ) );
+    connect( this, qOverload< const QgsNetworkRequestParameters & >( &QgsNetworkAccessManager::requestCreated ),
+             sMainNAM, qOverload< const QgsNetworkRequestParameters & >( &QgsNetworkAccessManager::requestCreated ) );
 
     connect( this, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ),
              sMainNAM, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ) );

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -358,6 +358,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
   reply->setProperty( "requestId", requestId );
 
+  emit requestCreated( QgsNetworkRequestParameters( op, reply->request(), requestId, content ) );
   Q_NOWARN_DEPRECATED_PUSH
   emit requestCreated( reply );
   Q_NOWARN_DEPRECATED_POP
@@ -632,6 +633,9 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
 
     connect( this, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ),
              sMainNAM, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestAboutToBeCreated ) );
+
+    connect( this, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ),
+             sMainNAM, qOverload< QgsNetworkRequestParameters >( &QgsNetworkAccessManager::requestCreated ) );
 
     connect( this, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ),
              sMainNAM, qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ) );

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -688,11 +688,26 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * only to connect to the main thread's signal in order to receive notifications about requests
      * created in any thread.
      *
+     * \see requestCreated( QgsNetworkRequestParameters )
      * \see finished( QgsNetworkReplyContent )
      * \see requestTimedOut( QgsNetworkRequestParameters )
      * \since QGIS 3.6
      */
     void requestAboutToBeCreated( QgsNetworkRequestParameters request );
+
+    /**
+     * Emitted when a network request has been created.
+     *
+     * This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+     * only to connect to the main thread's signal in order to receive notifications about requests
+     * created in any thread.
+     *
+     * \see requestAboutToBeCreated( QgsNetworkRequestParameters )
+     * \see finished( QgsNetworkReplyContent )
+     * \see requestTimedOut( QgsNetworkRequestParameters )
+     * \since QGIS 3.36
+     */
+    void requestCreated( QgsNetworkRequestParameters request );
 
     /**
      * Emitted whenever a pending network reply is finished.

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -688,7 +688,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * only to connect to the main thread's signal in order to receive notifications about requests
      * created in any thread.
      *
-     * \see requestCreated( QgsNetworkRequestParameters )
+     * \see requestCreated( const QgsNetworkRequestParameters & )
      * \see finished( QgsNetworkReplyContent )
      * \see requestTimedOut( QgsNetworkRequestParameters )
      * \since QGIS 3.6
@@ -705,9 +705,9 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * \see requestAboutToBeCreated( QgsNetworkRequestParameters )
      * \see finished( QgsNetworkReplyContent )
      * \see requestTimedOut( QgsNetworkRequestParameters )
-     * \since QGIS 3.36
+     * \since QGIS 3.38
      */
-    void requestCreated( QgsNetworkRequestParameters request );
+    void requestCreated( const QgsNetworkRequestParameters &request );
 
     /**
      * Emitted whenever a pending network reply is finished.


### PR DESCRIPTION
## Description

This PR fixes the network logger following the enabling of Strict Transport Security, which can result in http:// URLs automatically upgraded to https:// ones.