### PR TITLE
[plugin manager] Show plugin update date in local time

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1045,9 +1045,12 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     QString dateUpdatedStr;
     if ( ! metadata->value( QStringLiteral( "update_date_stable" ) ).isEmpty() )
     {
-      const QDateTime dateUpdated = QDateTime::fromString( metadata->value( QStringLiteral( "update_date_stable" ) ).trimmed(), Qt::ISODate );
-      if ( dateUpdated.isValid() )
-        dateUpdatedStr += tr( "updated at %1" ).arg( QLocale().toString( dateUpdated, dateTimeFormat ) );
+      const QDateTime dateUpdatedUtc = QDateTime::fromString( metadata->value( QStringLiteral( "update_date_stable" ) ).trimmed(), Qt::ISODate );
+      if ( dateUpdatedUtc.isValid() )
+      {
+        const QDateTime dateUpdatedLocal = dateUpdatedUtc.toLocalTime();
+        dateUpdatedStr += tr( "updated at %1 %2" ).arg( QLocale().toString( dateUpdatedLocal, dateTimeFormat ), dateUpdatedLocal.timeZoneAbbreviation() );
+      }
     }
 
     html += QStringLiteral( "<tr><td class='key'>%1 </td><td title='%2'><a href='%2'>%3</a> %4</td></tr>"


### PR DESCRIPTION
The plugin list delivers now the `update_date` in UTC (https://github.com/qgis/QGIS-Django/pull/360), so we could show it in local time.

https://plugins.qgis.org/plugins/plugins.xml?qgis=3.36 (view source)

![image](https://github.com/qgis/QGIS/assets/20856381/5bb71c6f-5410-4ea8-adfa-b1df228d8f32)



<h2>Before:</h2>
<img src="https://github.com/qgis/QGIS/assets/20856381/7d1eeb59-0bb1-4a11-a71e-361519cf56f0" width=450" />

<h2>This PR:</h2>
<img src="https://github.com/qgis/QGIS/assets/20856381/c7982329-2a79-43a5-b1eb-35d3545f7e06" width="450" />


