### PR TITLE
Fix setting vector filter through layer properties dialog

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -759,19 +759,6 @@ void QgsVectorLayerProperties::apply()
   if ( mMaskingWidget && mMaskingWidget->hasBeenPopulated() )
     mMaskingWidget->apply();
 
-  //
-  // Set up sql subset query if applicable
-  //
-  mSubsetGroupBox->setEnabled( true );
-
-  if ( txtSubsetSQL->text() != mLayer->subsetString() )
-  {
-    // set the subset sql for the layer
-    mLayer->setSubsetString( txtSubsetSQL->text() );
-    mMetadataFilled = false;
-  }
-  mOriginalSubsetSQL = mLayer->subsetString();
-
   // set up the scale based layer visibility stuff....
   mLayer->setScaleBasedVisibility( mScaleVisibilityGroupBox->isChecked() );
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
@@ -961,6 +948,7 @@ void QgsVectorLayerProperties::apply()
   // happens BEFORE we change the source, otherwise we might end up with a renderer which is not
   // compatible with the new geometry type of the layer. (And likewise for other properties like
   // fields!)
+  bool dialogNeedsResync = false;
   if ( mSourceWidget )
   {
     const QString newSource = mSourceWidget->sourceUri();
@@ -972,9 +960,25 @@ void QgsVectorLayerProperties::apply()
       // resync dialog to layer's new state -- this allows any changed layer properties
       // (such as a forced creation of a new renderer compatible with the new layer, new field configuration, etc)
       // to show in the dialog correctly
-      syncToLayer();
+      dialogNeedsResync = true;
     }
   }
+  // now apply the subset string AFTER setting the layer's source. It's messy, but the subset string
+  // can form part of the layer's source, but it WON'T be present in the URI returned by the source widget!
+  // If we don't apply the subset string AFTER changing the source, then the subset string will be lost.
+  mSubsetGroupBox->setEnabled( true );
+  if ( txtSubsetSQL->text() != mLayer->subsetString() )
+  {
+    // set the subset sql for the layer
+    mLayer->setSubsetString( txtSubsetSQL->text() );
+    mMetadataFilled = false;
+    // need to resync the dialog, the subset string may have changed the layer's geometry type!
+    dialogNeedsResync = true;
+  }
+  mOriginalSubsetSQL = mLayer->subsetString();
+
+  if ( dialogNeedsResync )
+    syncToLayer();
 
   mLayer->triggerRepaint();
   // notify the project we've made a change


### PR DESCRIPTION
Applies when layer's data provider has a source widget implementation. In this case we MUST set the subset string AFTER applying source widget changes, or the filter is lost.

Fixes #56536
