### PR TITLE
Add data provider flags for FastExtent2D/FastExtent3D, simplify extent calculation for some providers

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -1830,7 +1830,9 @@ Qgis.AutoRefreshMode.__doc__ = "Map layer automatic refresh modes.\n\n.. version
 Qgis.AutoRefreshMode.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.DataProviderFlag.IsBasemapSource.__doc__ = "Associated source should be considered a 'basemap' layer. See Qgis.MapLayerProperty.IsBasemapLayer."
-Qgis.DataProviderFlag.__doc__ = "Generic data provider flags.\n\n.. versionadded:: 3.26\n\n" + '* ``IsBasemapSource``: ' + Qgis.DataProviderFlag.IsBasemapSource.__doc__
+Qgis.DataProviderFlag.FastExtent2D.__doc__ = "Provider's 2D extent retrieval via QgsDataProvider.extent() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38."
+Qgis.DataProviderFlag.FastExtent3D.__doc__ = "Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38."
+Qgis.DataProviderFlag.__doc__ = "Generic data provider flags.\n\n.. versionadded:: 3.26\n\n" + '* ``IsBasemapSource``: ' + Qgis.DataProviderFlag.IsBasemapSource.__doc__ + '\n' + '* ``FastExtent2D``: ' + Qgis.DataProviderFlag.FastExtent2D.__doc__ + '\n' + '* ``FastExtent3D``: ' + Qgis.DataProviderFlag.FastExtent3D.__doc__
 # --
 Qgis.DataProviderFlags = lambda flags=0: Qgis.DataProviderFlag(flags)
 Qgis.DataProviderFlag.baseClass = Qgis

--- a/python/PyQt6/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -175,16 +175,26 @@ This may be ``None``, depending on the data provider.
 
     virtual QgsRectangle extent() const = 0;
 %Docstring
-Returns the extent of the layer
+Returns the extent of the layer.
 
-:return: :py:class:`QgsRectangle` containing the extent of the layer
+.. warning::
+
+   This may be expensive to calculate for some data providers, as it may involve
+   additional network requests or in some cases, iterating through all the features in a layer.
+   If the provider returns the :py:class:`Qgis`.DataProviderFlag.FastExtent2D flag from the :py:func:`~QgsDataProvider.flags` method
+   then the call to :py:func:`~QgsDataProvider.extent` is guaranteed to ALWAYS be fast and not involve any additional work.
 %End
 
     virtual QgsBox3D extent3D() const;
 %Docstring
-Returns the 3D extent of the layer
+Returns the 3D extent of the layer.
 
-:return: :py:class:`QgsBox3D` containing the 3D extent of the layer
+.. warning::
+
+   This may be expensive to calculate for some data providers, as it may involve
+   additional network requests or in some cases, iterating through all the features in a layer.
+   If the provider returns the :py:class:`Qgis`.DataProviderFlag.FastExtent3D flag from the :py:func:`~QgsDataProvider.flags` method
+   then the call to :py:func:`~QgsDataProvider.extent3D` is guaranteed to ALWAYS be fast and not involve any additional work.
 
 .. versionadded:: 3.36
 %End

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1068,6 +1068,8 @@ The development version
     enum class DataProviderFlag /BaseType=IntFlag/
     {
       IsBasemapSource,
+      FastExtent2D,
+      FastExtent3D,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1795,7 +1795,9 @@ Qgis.AutoRefreshMode.__doc__ = "Map layer automatic refresh modes.\n\n.. version
 Qgis.AutoRefreshMode.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.DataProviderFlag.IsBasemapSource.__doc__ = "Associated source should be considered a 'basemap' layer. See Qgis.MapLayerProperty.IsBasemapLayer."
-Qgis.DataProviderFlag.__doc__ = "Generic data provider flags.\n\n.. versionadded:: 3.26\n\n" + '* ``IsBasemapSource``: ' + Qgis.DataProviderFlag.IsBasemapSource.__doc__
+Qgis.DataProviderFlag.FastExtent2D.__doc__ = "Provider's 2D extent retrieval via QgsDataProvider.extent() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38."
+Qgis.DataProviderFlag.FastExtent3D.__doc__ = "Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38."
+Qgis.DataProviderFlag.__doc__ = "Generic data provider flags.\n\n.. versionadded:: 3.26\n\n" + '* ``IsBasemapSource``: ' + Qgis.DataProviderFlag.IsBasemapSource.__doc__ + '\n' + '* ``FastExtent2D``: ' + Qgis.DataProviderFlag.FastExtent2D.__doc__ + '\n' + '* ``FastExtent3D``: ' + Qgis.DataProviderFlag.FastExtent3D.__doc__
 # --
 Qgis.DataProviderFlag.baseClass = Qgis
 Qgis.DataProviderFlags.baseClass = Qgis

--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -175,16 +175,26 @@ This may be ``None``, depending on the data provider.
 
     virtual QgsRectangle extent() const = 0;
 %Docstring
-Returns the extent of the layer
+Returns the extent of the layer.
 
-:return: :py:class:`QgsRectangle` containing the extent of the layer
+.. warning::
+
+   This may be expensive to calculate for some data providers, as it may involve
+   additional network requests or in some cases, iterating through all the features in a layer.
+   If the provider returns the :py:class:`Qgis`.DataProviderFlag.FastExtent2D flag from the :py:func:`~QgsDataProvider.flags` method
+   then the call to :py:func:`~QgsDataProvider.extent` is guaranteed to ALWAYS be fast and not involve any additional work.
 %End
 
     virtual QgsBox3D extent3D() const;
 %Docstring
-Returns the 3D extent of the layer
+Returns the 3D extent of the layer.
 
-:return: :py:class:`QgsBox3D` containing the 3D extent of the layer
+.. warning::
+
+   This may be expensive to calculate for some data providers, as it may involve
+   additional network requests or in some cases, iterating through all the features in a layer.
+   If the provider returns the :py:class:`Qgis`.DataProviderFlag.FastExtent3D flag from the :py:func:`~QgsDataProvider.flags` method
+   then the call to :py:func:`~QgsDataProvider.extent3D` is guaranteed to ALWAYS be fast and not involve any additional work.
 
 .. versionadded:: 3.36
 %End

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1068,6 +1068,8 @@ The development version
     enum class DataProviderFlag
     {
       IsBasemapSource,
+      FastExtent2D,
+      FastExtent3D,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 

--- a/src/core/providers/copc/qgscopcprovider.cpp
+++ b/src/core/providers/copc/qgscopcprovider.cpp
@@ -64,6 +64,11 @@ QgsCoordinateReferenceSystem QgsCopcProvider::crs() const
   return mIndex->crs();
 }
 
+Qgis::DataProviderFlags QgsCopcProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsRectangle QgsCopcProvider::extent() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/providers/copc/qgscopcprovider.h
+++ b/src/core/providers/copc/qgscopcprovider.h
@@ -40,7 +40,7 @@ class QgsCopcProvider: public QgsPointCloudDataProvider
     ~QgsCopcProvider();
 
     QgsCoordinateReferenceSystem crs() const override;
-
+    Qgis::DataProviderFlags flags() const override;
     QgsRectangle extent() const override;
     QgsPointCloudAttributeCollection attributes() const override;
     bool isValid() const override;

--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -51,6 +51,11 @@ QgsEptProvider::QgsEptProvider(
   loadIndex( );
 }
 
+Qgis::DataProviderFlags QgsEptProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsEptProvider::~QgsEptProvider() = default;
 
 QgsCoordinateReferenceSystem QgsEptProvider::crs() const

--- a/src/core/providers/ept/qgseptprovider.h
+++ b/src/core/providers/ept/qgseptprovider.h
@@ -39,8 +39,8 @@ class QgsEptProvider: public QgsPointCloudDataProvider
 
     ~QgsEptProvider();
 
+    Qgis::DataProviderFlags flags() const override;
     QgsCoordinateReferenceSystem crs() const override;
-
     QgsRectangle extent() const override;
     QgsPointCloudAttributeCollection attributes() const override;
     bool isValid() const override;

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -1780,6 +1780,11 @@ QString QgsGdalProvider::description() const
   return PROVIDER_DESCRIPTION;
 }
 
+Qgis::DataProviderFlags QgsGdalProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsRasterDataProvider::ProviderCapabilities QgsGdalProvider::providerCapabilities() const
 {
   return ProviderCapability::ProviderHintBenefitsFromResampling |

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -130,6 +130,7 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     static QString expandAuthConfig( const QString &dsName );
 
     QString description() const override;
+    Qgis::DataProviderFlags flags() const override;
     QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const override;
     QgsCoordinateReferenceSystem crs() const override;
     QgsRectangle extent() const override;

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -252,14 +252,23 @@ class CORE_EXPORT QgsDataProvider : public QObject
     virtual const QgsDataProviderElevationProperties *elevationProperties() const SIP_SKIP;
 
     /**
-     * Returns the extent of the layer
-     * \returns QgsRectangle containing the extent of the layer
+     * Returns the extent of the layer.
+     *
+     * \warning This may be expensive to calculate for some data providers, as it may involve
+     * additional network requests or in some cases, iterating through all the features in a layer.
+     * If the provider returns the Qgis::DataProviderFlag::FastExtent2D flag from the flags() method
+     * then the call to extent() is guaranteed to ALWAYS be fast and not involve any additional work.
      */
     virtual QgsRectangle extent() const = 0;
 
     /**
-     * Returns the 3D extent of the layer
-     * \returns QgsBox3D containing the 3D extent of the layer
+     * Returns the 3D extent of the layer.
+     *
+     * \warning This may be expensive to calculate for some data providers, as it may involve
+     * additional network requests or in some cases, iterating through all the features in a layer.
+     * If the provider returns the Qgis::DataProviderFlag::FastExtent3D flag from the flags() method
+     * then the call to extent3D() is guaranteed to ALWAYS be fast and not involve any additional work.
+     *
      * \since QGIS 3.36
      */
     virtual QgsBox3D extent3D() const

--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
@@ -58,6 +58,11 @@ QgsVirtualPointCloudProvider::QgsVirtualPointCloudProvider(
   parseFile();
 }
 
+Qgis::DataProviderFlags QgsVirtualPointCloudProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsVirtualPointCloudProvider::~QgsVirtualPointCloudProvider() = default;
 
 QgsPointCloudDataProvider::Capabilities QgsVirtualPointCloudProvider::capabilities() const

--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.h
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.h
@@ -39,6 +39,7 @@ class CORE_EXPORT QgsVirtualPointCloudProvider: public QgsPointCloudDataProvider
 
     ~QgsVirtualPointCloudProvider();
 
+    Qgis::DataProviderFlags flags() const override;
     QgsPointCloudDataProvider::Capabilities capabilities() const override;
     QgsCoordinateReferenceSystem crs() const override;
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1827,6 +1827,8 @@ class CORE_EXPORT Qgis
     enum class DataProviderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
       IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
+      FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38.
+      FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate. Since QGIS 3.38.
     };
     //! Data provider flags
     Q_DECLARE_FLAGS( DataProviderFlags, DataProviderFlag )

--- a/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.cpp
@@ -914,6 +914,11 @@ QgsCesiumTilesDataProvider::QgsCesiumTilesDataProvider( const QgsCesiumTilesData
   mShared = other.mShared;
 }
 
+Qgis::DataProviderFlags QgsCesiumTilesDataProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 Qgis::TiledSceneProviderCapabilities QgsCesiumTilesDataProvider::capabilities() const
 {
   return Qgis::TiledSceneProviderCapability::ReadLayerMetadata;

--- a/src/core/tiledscene/qgscesiumtilesdataprovider.h
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.h
@@ -46,6 +46,7 @@ class CORE_EXPORT QgsCesiumTilesDataProvider final: public QgsTiledSceneDataProv
     QgsCesiumTilesDataProvider &operator=( const QgsCesiumTilesDataProvider &other ) = delete;
 
     ~QgsCesiumTilesDataProvider() final;
+    Qgis::DataProviderFlags flags() const override;
     Qgis::TiledSceneProviderCapabilities capabilities() const final;
     QgsCesiumTilesDataProvider *clone() const final;
     QgsCoordinateReferenceSystem crs() const final;

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1032,22 +1032,34 @@ QgsRectangle QgsVectorLayer::extent() const
   if ( !isSpatial() )
     return rect;
 
-  if ( !mValidExtent2D && mLazyExtent2D && mReadExtentFromXml && !mXmlExtent2D.isNull() )
+  if ( mDataProvider && mDataProvider->isValid() && mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D )
   {
-    updateExtent( mXmlExtent2D );
-    mValidExtent2D = true;
-    mLazyExtent2D = false;
-  }
-
-  if ( !mValidExtent2D && mLazyExtent2D && mDataProvider && mDataProvider->isValid() )
-  {
-    // store the extent
+    // Provider has a trivial 2D extent calculation => always get extent from provider.
+    // Things are nice and simple this way, e.g. we can always trust that this extent is
+    // accurate and up to date.
     updateExtent( mDataProvider->extent() );
     mValidExtent2D = true;
     mLazyExtent2D = false;
+  }
+  else
+  {
+    if ( !mValidExtent2D && mLazyExtent2D && mReadExtentFromXml && !mXmlExtent2D.isNull() )
+    {
+      updateExtent( mXmlExtent2D );
+      mValidExtent2D = true;
+      mLazyExtent2D = false;
+    }
 
-    // show the extent
-    QgsDebugMsgLevel( QStringLiteral( "2D Extent of layer: %1" ).arg( mExtent2D.toString() ), 3 );
+    if ( !mValidExtent2D && mLazyExtent2D && mDataProvider && mDataProvider->isValid() )
+    {
+      // store the extent
+      updateExtent( mDataProvider->extent() );
+      mValidExtent2D = true;
+      mLazyExtent2D = false;
+
+      // show the extent
+      QgsDebugMsgLevel( QStringLiteral( "2D Extent of layer: %1" ).arg( mExtent2D.toString() ), 3 );
+    }
   }
 
   if ( mValidExtent2D )
@@ -1133,22 +1145,34 @@ QgsBox3D QgsVectorLayer:: extent3D() const
   if ( !isSpatial() )
     return extent;
 
-  if ( !mValidExtent3D && mLazyExtent3D && mReadExtentFromXml && !mXmlExtent3D.isNull() )
+  if ( mDataProvider && mDataProvider->isValid() && mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent3D )
   {
-    updateExtent( mXmlExtent3D );
-    mValidExtent3D = true;
-    mLazyExtent3D = false;
-  }
-
-  if ( !mValidExtent3D && mLazyExtent3D && mDataProvider && mDataProvider->isValid() )
-  {
-    // store the extent
+    // Provider has a trivial 3D extent calculation => always get extent from provider.
+    // Things are nice and simple this way, e.g. we can always trust that this extent is
+    // accurate and up to date.
     updateExtent( mDataProvider->extent3D() );
     mValidExtent3D = true;
     mLazyExtent3D = false;
+  }
+  else
+  {
+    if ( !mValidExtent3D && mLazyExtent3D && mReadExtentFromXml && !mXmlExtent3D.isNull() )
+    {
+      updateExtent( mXmlExtent3D );
+      mValidExtent3D = true;
+      mLazyExtent3D = false;
+    }
 
-    // show the extent
-    QgsDebugMsgLevel( QStringLiteral( "3D Extent of layer: %1" ).arg( mExtent3D.toString() ), 3 );
+    if ( !mValidExtent3D && mLazyExtent3D && mDataProvider && mDataProvider->isValid() )
+    {
+      // store the extent
+      updateExtent( mDataProvider->extent3D() );
+      mValidExtent3D = true;
+      mLazyExtent3D = false;
+
+      // show the extent
+      QgsDebugMsgLevel( QStringLiteral( "3D Extent of layer: %1" ).arg( mExtent3D.toString() ), 3 );
+    }
   }
 
   if ( mValidExtent3D )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1032,7 +1032,7 @@ QgsRectangle QgsVectorLayer::extent() const
   if ( !isSpatial() )
     return rect;
 
-  if ( mDataProvider && mDataProvider->isValid() && (mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D) )
+  if ( mDataProvider && mDataProvider->isValid() && ( mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D ) )
   {
     // Provider has a trivial 2D extent calculation => always get extent from provider.
     // Things are nice and simple this way, e.g. we can always trust that this extent is
@@ -1145,7 +1145,7 @@ QgsBox3D QgsVectorLayer:: extent3D() const
   if ( !isSpatial() )
     return extent;
 
-  if ( mDataProvider && mDataProvider->isValid() && (mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent3D) )
+  if ( mDataProvider && mDataProvider->isValid() && ( mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent3D ) )
   {
     // Provider has a trivial 3D extent calculation => always get extent from provider.
     // Things are nice and simple this way, e.g. we can always trust that this extent is

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1032,7 +1032,7 @@ QgsRectangle QgsVectorLayer::extent() const
   if ( !isSpatial() )
     return rect;
 
-  if ( mDataProvider && mDataProvider->isValid() && mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D )
+  if ( mDataProvider && mDataProvider->isValid() && (mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D) )
   {
     // Provider has a trivial 2D extent calculation => always get extent from provider.
     // Things are nice and simple this way, e.g. we can always trust that this extent is
@@ -1145,7 +1145,7 @@ QgsBox3D QgsVectorLayer:: extent3D() const
   if ( !isSpatial() )
     return extent;
 
-  if ( mDataProvider && mDataProvider->isValid() && mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent3D )
+  if ( mDataProvider && mDataProvider->isValid() && (mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent3D) )
   {
     // Provider has a trivial 3D extent calculation => always get extent from provider.
     // Things are nice and simple this way, e.g. we can always trust that this extent is

--- a/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
+++ b/src/core/vectortile/qgsarcgisvectortileservicedataprovider.cpp
@@ -72,6 +72,11 @@ QgsArcGisVectorTileServiceDataProvider::QgsArcGisVectorTileServiceDataProvider( 
   mLayerMetadata = other.mLayerMetadata;
 }
 
+Qgis::DataProviderFlags QgsArcGisVectorTileServiceDataProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 Qgis::VectorTileProviderFlags QgsArcGisVectorTileServiceDataProvider::providerFlags() const
 {
   return QgsXyzVectorTileDataProviderBase::providerFlags() | Qgis::VectorTileProviderFlag::AlwaysUseTileMatrixSetFromProvider;

--- a/src/core/vectortile/qgsarcgisvectortileservicedataprovider.h
+++ b/src/core/vectortile/qgsarcgisvectortileservicedataprovider.h
@@ -41,6 +41,7 @@ class CORE_EXPORT QgsArcGisVectorTileServiceDataProvider : public QgsXyzVectorTi
      */
     QgsArcGisVectorTileServiceDataProvider &operator=( const QgsArcGisVectorTileServiceDataProvider &other ) = delete;
 
+    Qgis::DataProviderFlags flags() const override;
     Qgis::VectorTileProviderFlags providerFlags() const override;
     Qgis::VectorTileProviderCapabilities providerCapabilities() const override;
     QString name() const override;

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.cpp
@@ -93,6 +93,11 @@ QgsMbTilesVectorTileDataProvider::QgsMbTilesVectorTileDataProvider( const QgsMbT
   mMatrixSet = other.mMatrixSet;
 }
 
+Qgis::DataProviderFlags QgsMbTilesVectorTileDataProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QString QgsMbTilesVectorTileDataProvider::name() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
+++ b/src/core/vectortile/qgsmbtilesvectortiledataprovider.h
@@ -44,6 +44,7 @@ class CORE_EXPORT QgsMbTilesVectorTileDataProvider : public QgsVectorTileDataPro
      */
     QgsMbTilesVectorTileDataProvider &operator=( const QgsMbTilesVectorTileDataProvider &other ) = delete;
 
+    Qgis::DataProviderFlags flags() const override;
     QString name() const override;
     QString description() const override;
     QgsVectorTileDataProvider *clone() const override;

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.cpp
@@ -83,6 +83,11 @@ QgsVtpkVectorTileDataProvider::QgsVtpkVectorTileDataProvider( const QgsVtpkVecto
   mSpriteImage = other.mSpriteImage;
 }
 
+Qgis::DataProviderFlags QgsVtpkVectorTileDataProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 Qgis::VectorTileProviderFlags QgsVtpkVectorTileDataProvider::providerFlags() const
 {
   return Qgis::VectorTileProviderFlag::AlwaysUseTileMatrixSetFromProvider;

--- a/src/core/vectortile/qgsvtpkvectortiledataprovider.h
+++ b/src/core/vectortile/qgsvtpkvectortiledataprovider.h
@@ -45,6 +45,7 @@ class CORE_EXPORT QgsVtpkVectorTileDataProvider : public QgsVectorTileDataProvid
      */
     QgsVtpkVectorTileDataProvider &operator=( const QgsVtpkVectorTileDataProvider &other ) = delete;
 
+    Qgis::DataProviderFlags flags() const override;
     Qgis::VectorTileProviderFlags providerFlags() const override;
     Qgis::VectorTileProviderCapabilities providerCapabilities() const override;
     QString name() const override;

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.cpp
@@ -332,6 +332,11 @@ QgsXyzVectorTileDataProvider::QgsXyzVectorTileDataProvider( const QgsXyzVectorTi
   mMatrixSet = other.mMatrixSet;
 }
 
+Qgis::DataProviderFlags QgsXyzVectorTileDataProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QString QgsXyzVectorTileDataProvider::name() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/vectortile/qgsxyzvectortiledataprovider.h
+++ b/src/core/vectortile/qgsxyzvectortiledataprovider.h
@@ -79,6 +79,7 @@ class CORE_EXPORT QgsXyzVectorTileDataProvider : public QgsXyzVectorTileDataProv
      */
     QgsXyzVectorTileDataProvider &operator=( const QgsXyzVectorTileDataProvider &other ) = delete;
 
+    Qgis::DataProviderFlags flags() const override;
     QString name() const override;
     QString description() const override;
     QgsVectorTileDataProvider *clone() const override;

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -346,6 +346,11 @@ QgsAmsProvider::QgsAmsProvider( const QgsAmsProvider &other, const QgsDataProvid
   mTimestamp = QDateTime::currentDateTime();
 }
 
+Qgis::DataProviderFlags QgsAmsProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsRasterDataProvider::ProviderCapabilities QgsAmsProvider::providerCapabilities() const
 {
   return ProviderCapability::ReadLayerMetadata | ProviderCapability::ReloadData;

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -75,6 +75,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QgsAmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
 
     explicit QgsAmsProvider( const QgsAmsProvider &other, const QgsDataProvider::ProviderOptions &providerOptions );
+    Qgis::DataProviderFlags flags() const override;
     QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const override;
     /* Inherited from QgsDataProvider */
     bool isValid() const override { return mValid; }

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -58,6 +58,11 @@ QgsPdalProvider::QgsPdalProvider(
   loadIndex( );
 }
 
+Qgis::DataProviderFlags QgsPdalProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsPdalProvider::~QgsPdalProvider() = default;
 
 QgsCoordinateReferenceSystem QgsPdalProvider::crs() const

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -33,6 +33,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
                      QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
 
     ~QgsPdalProvider();
+    Qgis::DataProviderFlags flags() const override;
     QgsCoordinateReferenceSystem crs() const override;
     QgsRectangle extent() const override;
     QgsPointCloudAttributeCollection attributes() const override;

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -198,6 +198,10 @@ QgsPostgresRasterProvider::QgsPostgresRasterProvider( const QgsPostgresRasterPro
 {
 }
 
+Qgis::DataProviderFlags QgsPostgresRasterProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
 
 bool QgsPostgresRasterProvider::hasSufficientPermsAndCapabilities()
 {

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -42,6 +42,7 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
   public:
 
     // QgsDataProvider interface
+    Qgis::DataProviderFlags flags() const override;
     virtual QgsCoordinateReferenceSystem crs() const override;
     virtual QgsRectangle extent() const override;
     virtual bool isValid() const override;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -656,6 +656,11 @@ QgsSpatiaLiteProvider::~QgsSpatiaLiteProvider()
   invalidateConnections( mSqlitePath );
 }
 
+Qgis::DataProviderFlags QgsSpatiaLiteProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D | Qgis::DataProviderFlag::FastExtent3D;
+}
+
 QgsAbstractFeatureSource *QgsSpatiaLiteProvider::featureSource() const
 {
   return new QgsSpatiaLiteFeatureSource( this );

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -85,6 +85,7 @@ class QgsSpatiaLiteProvider final: public QgsVectorDataProvider
 
     ~ QgsSpatiaLiteProvider() override;
 
+    Qgis::DataProviderFlags flags() const override;
     QgsAbstractFeatureSource *featureSource() const override;
     QString storageType() const override;
     QgsCoordinateReferenceSystem crs() const override;

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
@@ -215,6 +215,11 @@ QgsRasterBlock *QgsVirtualRasterProvider::block( int bandNo, const QgsRectangle 
   return tblock.release();
 }
 
+Qgis::DataProviderFlags QgsVirtualRasterProvider::flags() const
+{
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsRectangle QgsVirtualRasterProvider::extent() const
 {
   return mExtent;

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.h
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.h
@@ -40,6 +40,7 @@ class QgsVirtualRasterProvider : public QgsRasterDataProvider
     { Q_UNUSED( bandNo ) Q_UNUSED( viewExtent ); Q_UNUSED( width ); Q_UNUSED( height ); Q_UNUSED( data ); Q_UNUSED( feedback ); return true; }
 
     // QgsDataProvider interface
+    Qgis::DataProviderFlags flags() const override;
     virtual bool isValid() const override;
     virtual QgsCoordinateReferenceSystem crs() const override;
     virtual QgsRectangle extent() const override;


### PR DESCRIPTION
This PR adds data provider flags for FastExtent2D/FastExtent3D. These flags reflect that retrieval of the provider's 2D or 3D extent retrieval via QgsDataProvider::extent()/extent3D() are **ALWAYS** guaranteed to be trivial/fast to calculate and involve absolutely no extra work.

Then, if the provider reflects these flags, we ALWAYS just retrieve the provider's extent directly when asked for a vector layer's 2d/3d extent. This not only considerably simplifies things for these providers (we can ignore lazy loaded extents and stored xml extents), but also ensures that the extent of these layers ALWAYS stays in sync with the actual data provider's known extents.

I've added the flags for all providers which meet this criteria (i.e. those where calls to extent() are just returning an already calculated member variable).

While I'm reluctant to add additional logic to the vector layer extent calculations, I think this is a valuable improvement for providers which meet this criteria. In particular, it can be used to solve an issue where a data provider has internal knowledge regarding changes to the data provider's actual extent, and there's no easy way for the provider to inform the layer of these changes (while there's been a fullExtentCalculated() signal in QgsDataProvider for many years, using signals for this is a risky approach that may cause deadlocks or other issues when eg a data provider knows that the extent has changed but is not ready for the map layer level slots connecting to this signal to be called immediately)