### PR TITLE
Use pixel based scrolling instead of row based scrolling for identify results

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -364,6 +364,8 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 
   mOpenFormAction->setDisabled( true );
 
+  lstResults->setVerticalScrollMode( QListView::ScrollMode::ScrollPerPixel );
+
   QgsSettings mySettings;
   mDock = new QgsDockWidget( tr( "Identify Results" ), QgisApp::instance() );
   mDock->setObjectName( QStringLiteral( "IdentifyResultsDock" ) );


### PR DESCRIPTION
This behaves much nicer when row heights grow large, eg when there's multiline content in a field or when json fields are present
