### PR TITLE
Add extent based filtering for SensorThings layers

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -63,6 +63,25 @@ Returns a filter string which restricts results to those matching the specified
 ``entityType`` and ``wkbType``.
 %End
 
+    static QString filterForExtent( const QString &geometryField, const QgsRectangle &extent );
+%Docstring
+Returns a filter string which restricts results to those within the specified
+``extent``.
+
+The ``extent`` should always be specified in EPSG:4326.
+
+.. versionadded:: 3.38
+%End
+
+    static QString combineFilters( const QStringList &filters );
+%Docstring
+Combines a set of SensorThings API filter operators.
+
+See https://docs.ogc.org/is/18-088/18-088.html#requirement-request-data-filter
+
+.. versionadded:: 3.38
+%End
+
     static QList< Qgis::GeometryType > availableGeometryTypes( const QString &uri, Qgis::SensorThingsEntity type, QgsFeedback *feedback = 0, const QString &authCfg = QString() );
 %Docstring
 Returns a list of available geometry types for the server at the specified ``uri``

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -63,6 +63,25 @@ Returns a filter string which restricts results to those matching the specified
 ``entityType`` and ``wkbType``.
 %End
 
+    static QString filterForExtent( const QString &geometryField, const QgsRectangle &extent );
+%Docstring
+Returns a filter string which restricts results to those within the specified
+``extent``.
+
+The ``extent`` should always be specified in EPSG:4326.
+
+.. versionadded:: 3.38
+%End
+
+    static QString combineFilters( const QStringList &filters );
+%Docstring
+Combines a set of SensorThings API filter operators.
+
+See https://docs.ogc.org/is/18-088/18-088.html#requirement-request-data-filter
+
+.. versionadded:: 3.38
+%End
+
     static QList< Qgis::GeometryType > availableGeometryTypes( const QString &uri, Qgis::SensorThingsEntity type, QgsFeedback *feedback = 0, const QString &authCfg = QString() );
 %Docstring
 Returns a list of available geometry types for the server at the specified ``uri``

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
@@ -183,6 +183,13 @@ QString QgsSensorThingsProvider::htmlMetadata() const
   return metadata;
 }
 
+Qgis::DataProviderFlags QgsSensorThingsProvider::flags() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  return Qgis::DataProviderFlag::FastExtent2D;
+}
+
 QgsVectorDataProvider::Capabilities QgsSensorThingsProvider::capabilities() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -196,6 +203,8 @@ QgsVectorDataProvider::Capabilities QgsSensorThingsProvider::capabilities() cons
 
 void QgsSensorThingsProvider::setDataSourceUri( const QString &uri )
 {
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
   mSharedData = std::make_shared< QgsSensorThingsSharedData >( uri );
   QgsDataProvider::setDataSourceUri( uri );
 }
@@ -210,12 +219,7 @@ QgsCoordinateReferenceSystem QgsSensorThingsProvider::crs() const
 QgsRectangle QgsSensorThingsProvider::extent() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-#if 0
   return mSharedData->extent();
-#endif
-
-  return QgsRectangle();
 }
 
 QString QgsSensorThingsProvider::name() const

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.h
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.h
@@ -30,7 +30,7 @@
  *
  * \since QGIS 3.36
  */
-class QgsSensorThingsProvider : public QgsVectorDataProvider
+class QgsSensorThingsProvider final : public QgsVectorDataProvider
 {
     Q_OBJECT
 
@@ -41,29 +41,30 @@ class QgsSensorThingsProvider : public QgsVectorDataProvider
 
     QgsSensorThingsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() );
 
-    QgsAbstractFeatureSource *featureSource() const override;
-    QString storageType() const override;
-    QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const override;
-    Qgis::WkbType wkbType() const override;
-    long long featureCount() const override;
-    QgsFields fields() const override;
-    QgsLayerMetadata layerMetadata() const override;
-    QString htmlMetadata() const override;
+    QgsAbstractFeatureSource *featureSource() const final;
+    QString storageType() const final;
+    QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const final;
+    Qgis::WkbType wkbType() const final;
+    long long featureCount() const final;
+    QgsFields fields() const final;
+    QgsLayerMetadata layerMetadata() const final;
+    QString htmlMetadata() const final;
 
-    QgsVectorDataProvider::Capabilities capabilities() const override;
+    Qgis::DataProviderFlags flags() const final;
+    QgsVectorDataProvider::Capabilities capabilities() const final;
 
-    QgsCoordinateReferenceSystem crs() const override;
-    void setDataSourceUri( const QString &uri ) override;
-    QgsRectangle extent() const override;
-    bool isValid() const override { return mValid; }
+    QgsCoordinateReferenceSystem crs() const final;
+    void setDataSourceUri( const QString &uri ) final;
+    QgsRectangle extent() const final;
+    bool isValid() const final { return mValid; }
 
-    QString name() const override;
-    QString description() const override;
-    bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
+    QString name() const final;
+    QString description() const final;
+    bool renderInPreview( const QgsDataProvider::PreviewContext &context ) final;
 
     static QString providerKey();
 
-    void handlePostCloneOperations( QgsVectorDataProvider *source ) override;
+    void handlePostCloneOperations( QgsVectorDataProvider *source ) final;
 
   private:
     bool mValid = false;
@@ -71,28 +72,28 @@ class QgsSensorThingsProvider : public QgsVectorDataProvider
 
     QgsLayerMetadata mLayerMetadata;
 
-    void reloadProviderData() override;
+    void reloadProviderData() final;
 };
 
-class QgsSensorThingsProviderMetadata: public QgsProviderMetadata
+class QgsSensorThingsProviderMetadata final: public QgsProviderMetadata
 {
     Q_OBJECT
 
   public:
     QgsSensorThingsProviderMetadata();
-    QIcon icon() const override;
-    QList<QgsDataItemProvider *> dataItemProviders() const override;
-    QVariantMap decodeUri( const QString &uri ) const override;
-    QString encodeUri( const QVariantMap &parts ) const override;
-    QgsSensorThingsProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
-    QList< Qgis::LayerType > supportedLayerTypes() const override;
+    QIcon icon() const final;
+    QList<QgsDataItemProvider *> dataItemProviders() const final;
+    QVariantMap decodeUri( const QString &uri ) const final;
+    QString encodeUri( const QVariantMap &parts ) const final;
+    QgsSensorThingsProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) final;
+    QList< Qgis::LayerType > supportedLayerTypes() const final;
 
     // handling of stored connections
 
-    QMap<QString, QgsAbstractProviderConnection *> connections( bool cached ) override;
-    QgsAbstractProviderConnection *createConnection( const QString &name ) override;
-    void deleteConnection( const QString &name ) override;
-    void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) override;
+    QMap<QString, QgsAbstractProviderConnection *> connections( bool cached ) final;
+    QgsAbstractProviderConnection *createConnection( const QString &name ) final;
+    void deleteConnection( const QString &name ) final;
+    void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) final;
 
 };
 

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.h
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.h
@@ -50,6 +50,7 @@ class QgsSensorThingsSharedData
     QString error() const { return mError; }
 
     QgsCoordinateReferenceSystem crs() const { return mSourceCRS; }
+    QgsRectangle extent() const;
     long long featureCount( QgsFeedback *feedback = nullptr ) const;
 
     bool hasCachedAllFeatures() const;
@@ -82,6 +83,10 @@ class QgsSensorThingsSharedData
     Qgis::WkbType mGeometryType = Qgis::WkbType::Unknown;
     QString mGeometryField;
     QgsFields mFields;
+
+    //! Extent calculated from features actually fetched so far
+    QgsRectangle mFetchedFeatureExtent;
+
     QgsCoordinateReferenceSystem mSourceCRS;
 
     mutable long long mFeatureCount = static_cast< long long >( Qgis::FeatureCountState::Uncounted );

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.h
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.h
@@ -84,6 +84,8 @@ class QgsSensorThingsSharedData
     QString mGeometryField;
     QgsFields mFields;
 
+    QgsRectangle mFilterExtent;
+
     //! Extent calculated from features actually fetched so far
     QgsRectangle mFetchedFeatureExtent;
 

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -21,6 +21,7 @@
 
 class QgsFields;
 class QgsFeedback;
+class QgsRectangle;
 
 /**
  * \ingroup core
@@ -77,6 +78,25 @@ class CORE_EXPORT QgsSensorThingsUtils
      * \a entityType and \a wkbType.
      */
     static QString filterForWkbType( Qgis::SensorThingsEntity entityType, Qgis::WkbType wkbType );
+
+    /**
+     * Returns a filter string which restricts results to those within the specified
+     * \a extent.
+     *
+     * The \a extent should always be specified in EPSG:4326.
+     *
+     * \since QGIS 3.38
+     */
+    static QString filterForExtent( const QString &geometryField, const QgsRectangle &extent );
+
+    /**
+     * Combines a set of SensorThings API filter operators.
+     *
+     * See https://docs.ogc.org/is/18-088/18-088.html#requirement-request-data-filter
+     *
+     * \since QGIS 3.38
+     */
+    static QString combineFilters( const QStringList &filters );
 
     /**
      * Returns a list of available geometry types for the server at the specified \a uri

--- a/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
+++ b/src/gui/providers/sensorthings/qgssensorthingssourceselect.cpp
@@ -212,6 +212,12 @@ void QgsSensorThingsSourceSelect::addButtonClicked()
   emit addLayer( Qgis::LayerType::Vector, layerUri, baseName, QgsSensorThingsProvider::SENSORTHINGS_PROVIDER_KEY );
 }
 
+void QgsSensorThingsSourceSelect::setMapCanvas( QgsMapCanvas *mapCanvas )
+{
+  QgsAbstractDataSourceWidget::setMapCanvas( mapCanvas );
+  mSourceWidget->setMapCanvas( mapCanvas );
+}
+
 void QgsSensorThingsSourceSelect::populateConnectionList()
 {
   cmbConnections->blockSignals( true );

--- a/src/gui/providers/sensorthings/qgssensorthingssourceselect.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourceselect.h
@@ -33,9 +33,8 @@ class QgsSensorThingsSourceSelect : public QgsAbstractDataSourceWidget, private 
 
   public:
     QgsSensorThingsSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
-
-    //! Determines the layers the user selected
     void addButtonClicked() override;
+    void setMapCanvas( QgsMapCanvas *mapCanvas ) override;
 
   private slots:
 

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -23,7 +23,7 @@
 #include <QVariantMap>
 #include <QPointer>
 
-class QgsFileWidget;
+class QgsExtentWidget;
 class QgsSensorThingsConnectionPropertiesTask;
 
 ///@cond PRIVATE
@@ -40,6 +40,7 @@ class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui
     void setSourceUri( const QString &uri ) override;
     QString sourceUri() const override;
     QString groupTitle() const override;
+    void setMapCanvas( QgsMapCanvas *mapCanvas ) override;
 
     /**
      * Updates a connection uri with the layer specific URI settings defined in the widget.
@@ -59,6 +60,7 @@ class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui
     void rebuildGeometryTypes( Qgis::SensorThingsEntity type );
     void setCurrentGeometryTypeFromString( const QString &geometryType );
 
+    QgsExtentWidget *mExtentWidget = nullptr;
     QVariantMap mSourceParts;
     bool mIsValid = false;
     QPointer< QgsSensorThingsConnectionPropertiesTask > mPropertiesTask;

--- a/src/ui/qgssensorthingssourcewidgetbase.ui
+++ b/src/ui/qgssensorthingssourcewidgetbase.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>537</width>
-    <height>91</height>
+    <height>134</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>QgsSensorThingsSourceWidgetBase</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -40,23 +40,20 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mComboGeometryType"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Extent limit</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Page size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="mComboGeometryType"/>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mComboEntityType"/>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QgsSpinBox" name="mSpinPageSize">
-     <property name="maximum">
-      <number>9999999</number>
      </property>
     </widget>
    </item>
@@ -87,6 +84,23 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mComboEntityType"/>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsSpinBox" name="mSpinPageSize">
+     <property name="maximum">
+      <number>9999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QWidget" name="mExtentLimitFrame" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -96,6 +110,13 @@
    <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mComboEntityType</tabstop>
+  <tabstop>mComboGeometryType</tabstop>
+  <tabstop>mRetrieveTypesButton</tabstop>
+  <tabstop>mSpinPageSize</tabstop>
+  <tabstop>mExtentLimitFrame</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -265,6 +265,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             self.assertTrue(vl.isValid())
             self.assertEqual(vl.storageType(), "OGC SensorThings API")
             self.assertEqual(vl.wkbType(), Qgis.WkbType.PointZ)
+            # pessimistic "worst case" extent should be used
+            self.assertEqual(vl.extent(), QgsRectangle(-180, -90, 180, 90))
             self.assertEqual(vl.featureCount(), 4962)
             self.assertIn("Entity Type</td><td>Location</td>", vl.htmlMetadata())
             self.assertIn(f'href="http://{endpoint}/Locations"', vl.htmlMetadata())
@@ -404,6 +406,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             self.assertTrue(vl.isValid())
             self.assertEqual(vl.storageType(), "OGC SensorThings API")
             self.assertEqual(vl.wkbType(), Qgis.WkbType.NoGeometry)
+            self.assertTrue(vl.extent().isNull())
             self.assertEqual(vl.featureCount(), 3)
             self.assertFalse(vl.crs().isValid())
             self.assertIn("Entity Type</td><td>Thing</td>", vl.htmlMetadata())
@@ -494,8 +497,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
       "location": {
         "type": "Point",
         "coordinates": [
-          11.623373,
-          52.132017
+          11.6,
+          52.1
         ]
       },
       "properties": {
@@ -513,8 +516,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
       "location": {
         "type": "Point",
         "coordinates": [
-          12.623373,
-          53.132017
+          12.6,
+          53.1
         ]
       },
       "properties": {
@@ -550,8 +553,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                   "location": {
                     "type": "Point",
                     "coordinates": [
-                      13.623373,
-                      55.132017
+                      13.6,
+                      55.1
                     ]
                   },
                   "properties": {
@@ -575,6 +578,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             self.assertTrue(vl.isValid())
             self.assertEqual(vl.storageType(), "OGC SensorThings API")
             self.assertEqual(vl.wkbType(), Qgis.WkbType.PointZ)
+            # pessimistic "worst case" extent should initially be used
+            self.assertEqual(vl.extent(), QgsRectangle(-180, -90, 180, 90))
             self.assertEqual(vl.featureCount(), 3)
             self.assertEqual(vl.crs().authid(), "EPSG:4326")
             self.assertIn("Entity Type</td><td>Location</td>", vl.htmlMetadata())
@@ -624,6 +629,9 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                 [f.geometry().asWkt(1) for f in features],
                 ["Point (11.6 52.1)", "Point (12.6 53.1)", "Point (13.6 55.1)"],
             )
+
+            # all features fetched, accurate extent should be returned
+            self.assertEqual(vl.extent(), QgsRectangle(11.6, 52.1, 13.6, 55.1))
 
     def test_filter_rect(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -170,6 +170,19 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             Qgis.SensorThingsEntity.FeatureOfInterest,
         )
 
+    def test_filter_for_extent(self):
+        self.assertFalse(QgsSensorThingsUtils.filterForExtent('', QgsRectangle()))
+        self.assertFalse(QgsSensorThingsUtils.filterForExtent('test', QgsRectangle()))
+        self.assertFalse(QgsSensorThingsUtils.filterForExtent('', QgsRectangle(1,2 ,3 ,4 )))
+        self.assertEqual(QgsSensorThingsUtils.filterForExtent('test', QgsRectangle(1,2 ,3 ,4 )), "geo.intersects(test, geography'POLYGON((1 2, 3 2, 3 4, 1 4, 1 2))')")
+
+    def test_combine_filters(self):
+        self.assertFalse(QgsSensorThingsUtils.combineFilters([]))
+        self.assertFalse(QgsSensorThingsUtils.combineFilters(['']))
+        self.assertEqual(QgsSensorThingsUtils.combineFilters(['', 'a eq 1']), 'a eq 1')
+        self.assertEqual(QgsSensorThingsUtils.combineFilters(['a eq 1', 'b eq 2']), '(a eq 1) and (b eq 2)')
+        self.assertEqual(QgsSensorThingsUtils.combineFilters(['a eq 1', '', 'b eq 2', 'c eq 3']), '(a eq 1) and (b eq 2) and (c eq 3)')
+
     def test_invalid_layer(self):
         vl = QgsVectorLayer(
             "url='http://fake.com/fake_qgis_http_endpoint'", "test", "sensorthings"
@@ -753,7 +766,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                     )
 
                 with open(
-                    sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))') and location/type eq 'Point'"),
+                    sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))')) and (location/type eq 'Point')"),
                     "wt",
                     encoding="utf8",
                 ) as f:
@@ -806,7 +819,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                     )
 
             with open(
-                sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=geo.intersects(location, geography'POLYGON((10 0, 20 0, 20 80, 10 80, 10 0))') and location/type eq 'Point'"),
+                sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((10 0, 20 0, 20 80, 10 80, 10 0))')) and (location/type eq 'Point')"),
                 "wt",
                 encoding="utf8",
             ) as f:
@@ -926,6 +939,253 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                 [f["selfLink"][-13:] for f in features],
                 ["/Locations(1)", "/Locations(3)", "/Locations(2)"],
             )
+
+    def test_extent_limit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_path = temp_dir.replace("\\", "/")
+            endpoint = base_path + "/fake_qgis_http_endpoint"
+            with open(sanitize(endpoint, ""), "wt", encoding="utf8") as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "name": "Locations",
+      "url": "endpoint/Locations"
+    }
+  ],
+  "serverSettings": {
+  }
+}""".replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+            with open(
+                sanitize(endpoint, "/Locations?$top=0&$count=true&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write("""{"@iot.count":2,"value":[]}""")
+
+            with open(
+                sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write(
+                    """
+{
+  "value": [
+    {
+      "@iot.selfLink": "endpoint/Locations(1)",
+      "@iot.id": 1,
+      "name": "Location 1",
+      "description": "Desc 1",
+      "encodingType": "application/geo+json",
+      "location": {
+        "type": "Point",
+        "coordinates": [
+          1.623373,
+          52.132017
+        ]
+      },
+      "properties": {
+        "owner": "owner 1"
+      },
+      "Things@iot.navigationLink": "endpoint/Locations(1)/Things",
+      "HistoricalLocations@iot.navigationLink": "endpoint/Locations(1)/HistoricalLocations"
+    },
+    {
+                  "@iot.selfLink": "endpoint/Locations(3)",
+                  "@iot.id": 3,
+                  "name": "Location 3",
+                  "description": "Desc 3",
+                  "encodingType": "application/geo+json",
+                  "location": {
+                    "type": "Point",
+                    "coordinates": [
+                      3.623373,
+                      55.132017
+                    ]
+                  },
+                  "properties": {
+                    "owner": "owner 3"
+                  },
+                  "Things@iot.navigationLink": "endpoint/Locations(3)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(3)/HistoricalLocations"
+                }
+  ]
+}
+                """.replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+                with open(
+                    sanitize(endpoint,
+                             "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))')) and (location/type eq 'Point')"),
+                    "wt",
+                    encoding="utf8",
+                ) as f:
+                    f.write(
+                        """
+            {
+              "value": [
+                          {
+                  "@iot.selfLink": "endpoint/Locations(1)",
+                  "@iot.id": 1,
+                  "name": "Location 1",
+                  "description": "Desc 1",
+                  "encodingType": "application/geo+json",
+                  "location": {
+                    "type": "Point",
+                    "coordinates": [
+                      1.623373,
+                      52.132017
+                    ]
+                  },
+                  "properties": {
+                    "owner": "owner 1"
+                  },
+                  "Things@iot.navigationLink": "endpoint/Locations(1)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(1)/HistoricalLocations"
+                },
+                {
+                  "@iot.selfLink": "endpoint/Locations(3)",
+                  "@iot.id": 3,
+                  "name": "Location 3",
+                  "description": "Desc 3",
+                  "encodingType": "application/geo+json",
+                  "location": {
+                    "type": "Point",
+                    "coordinates": [
+                      3.623373,
+                      55.132017
+                    ]
+                  },
+                  "properties": {
+                    "owner": "owner 3"
+                  },
+                  "Things@iot.navigationLink": "endpoint/Locations(3)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(3)/HistoricalLocations"
+                }
+              ]
+            }""".replace(
+                            "endpoint", "http://" + endpoint
+                        )
+                    )
+
+            with open(
+                sanitize(endpoint,
+                         "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((1 0, 3 0, 3 50, 1 50, 1 0))')) and (location/type eq 'Point')"),
+                "wt",
+                encoding="utf8",
+            ) as f:
+                f.write(
+                    """
+            {
+              "value": [
+                             {
+                  "@iot.selfLink": "endpoint/Locations(1)",
+                  "@iot.id": 1,
+                  "name": "Location 1",
+                  "description": "Desc 1",
+                  "encodingType": "application/geo+json",
+                  "location": {
+                    "type": "Point",
+                    "coordinates": [
+                      1.623373,
+                      52.132017
+                    ]
+                  },
+                  "properties": {
+                    "owner": "owner 1"
+                  },
+                  "Things@iot.navigationLink": "endpoint/Locations(1)/Things",
+                  "HistoricalLocations@iot.navigationLink": "endpoint/Locations(1)/HistoricalLocations"
+                }
+              ]
+            }""".replace(
+                        "endpoint", "http://" + endpoint
+                    )
+                )
+
+            vl = QgsVectorLayer(
+                f"url='http://{endpoint}' bbox='1,0,10,80' type=PointZ pageSize=2 entity='Location'",
+                "test",
+                "sensorthings",
+            )
+            self.assertTrue(vl.isValid())
+            self.assertEqual(vl.storageType(), "OGC SensorThings API")
+            self.assertEqual(vl.wkbType(), Qgis.WkbType.PointZ)
+            self.assertEqual(vl.featureCount(), 2)
+            # should use the hardcoded extent limit as the initial guess, not global extents
+            self.assertEqual(vl.extent(), QgsRectangle(1, 0, 10, 80))
+            self.assertEqual(vl.crs().authid(), "EPSG:4326")
+            self.assertIn("Entity Type</td><td>Location</td>",
+                          vl.htmlMetadata())
+            self.assertIn(f'href="http://{endpoint}/Locations"',
+                          vl.htmlMetadata())
+
+            request = QgsFeatureRequest()
+            request.setFilterRect(
+                QgsRectangle(1, 0, 3, 50)
+            )
+
+            features = list(vl.getFeatures(request))
+            self.assertEqual([f["id"] for f in features], ["1"])
+            self.assertEqual(
+                [f["selfLink"][-13:] for f in features],
+                ["/Locations(1)"],
+            )
+            self.assertEqual(
+                [f["name"] for f in features],
+                ["Location 1"],
+            )
+            self.assertEqual(
+                [f["description"] for f in features],
+                ["Desc 1"]
+            )
+            self.assertEqual(
+                [f["properties"] for f in features],
+                [{"owner": "owner 1"}],
+            )
+
+            self.assertEqual(
+                [f.geometry().asWkt(1) for f in features],
+                ["Point (1.6 52.1)"],
+            )
+
+            request = QgsFeatureRequest()
+            features = list(vl.getFeatures(request))
+            self.assertEqual([f["id"] for f in features], ["1", "3"])
+            self.assertEqual(
+                [f["selfLink"][-13:] for f in features],
+                ["/Locations(1)", "/Locations(3)"],
+            )
+            self.assertEqual(
+                [f["name"] for f in features],
+                ["Location 1", "Location 3"],
+            )
+            self.assertEqual(
+                [f["description"] for f in features],
+                ["Desc 1", "Desc 3"]
+            )
+            self.assertEqual(
+                [f["properties"] for f in features],
+                [{"owner": "owner 1"},
+                 {"owner": "owner 3"}],
+            )
+
+            self.assertEqual(
+                [f.geometry().asWkt(1) for f in features],
+                ["Point (1.6 52.1)",
+                 "Point (3.6 55.1)"],
+            )
+
+            # should have accurate layer extent now
+            self.assertEqual(vl.extent(), QgsRectangle(1.62337299999999995, 52.13201699999999761, 3.62337299999999995, 55.13201699999999761))
 
     def test_historical_location(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -2093,6 +2353,19 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             },
         )
 
+        uri = "url='https://sometest.com/api' bbox='1,2,3,4' type=MultiPolygonZ authcfg='abc' entity='Location'"
+        parts = QgsProviderRegistry.instance().decodeUri("sensorthings", uri)
+        self.assertEqual(
+            parts,
+            {
+                "url": "https://sometest.com/api",
+                "entity": "Location",
+                "geometryType": "polygon",
+                "authcfg": "abc",
+                "bounds": QgsRectangle(1, 2, 3, 4)
+            },
+        )
+
     def testEncodeUri(self):
         """
         Test encoding a SensorThings uri
@@ -2144,6 +2417,19 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
         self.assertEqual(
             uri,
             "authcfg=aaaaa type=MultiPolygonZ entity='Location' url='http://blah.com'",
+        )
+
+        parts = {
+            "url": "http://blah.com",
+            "authcfg": "aaaaa",
+            "entity": "location",
+            "geometryType": "polygon",
+            "bounds": QgsRectangle(1,2 ,3 ,4 )
+        }
+        uri = QgsProviderRegistry.instance().encodeUri("sensorthings", parts)
+        self.assertEqual(
+            uri,
+            "authcfg=aaaaa type=MultiPolygonZ bbox='1,2,3,4' entity='Location' url='http://blah.com'",
         )
 
 

--- a/tests/src/python/test_provider_sensorthings.py
+++ b/tests/src/python/test_provider_sensorthings.py
@@ -80,19 +80,23 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
 
     def test_filter_for_wkb_type(self):
         self.assertEqual(
-            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.Point), "location/type eq 'Point'"
+            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.Point),
+            "location/type eq 'Point'"
         )
         self.assertEqual(
-            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.PointZ), "location/type eq 'Point'"
+            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.PointZ),
+            "location/type eq 'Point'"
         )
         self.assertEqual(
-            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.FeatureOfInterest, Qgis.WkbType.Polygon), "feature/type eq 'Polygon'"
+            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.FeatureOfInterest, Qgis.WkbType.Polygon),
+            "feature/type eq 'Polygon'"
         )
         # TODO -- there is NO documentation on what the type must be for line filtering,
         # and I can't find any public servers with line geometries to test with!
         # Find some way to confirm if this is 'Line' or 'LineString' or ...
         self.assertEqual(
-            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.LineString), "location/type eq 'LineString'"
+            QgsSensorThingsUtils.filterForWkbType(Qgis.SensorThingsEntity.Location, Qgis.WkbType.LineString),
+            "location/type eq 'LineString'"
         )
 
     def test_utils_string_to_entity(self):
@@ -173,15 +177,17 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
     def test_filter_for_extent(self):
         self.assertFalse(QgsSensorThingsUtils.filterForExtent('', QgsRectangle()))
         self.assertFalse(QgsSensorThingsUtils.filterForExtent('test', QgsRectangle()))
-        self.assertFalse(QgsSensorThingsUtils.filterForExtent('', QgsRectangle(1,2 ,3 ,4 )))
-        self.assertEqual(QgsSensorThingsUtils.filterForExtent('test', QgsRectangle(1,2 ,3 ,4 )), "geo.intersects(test, geography'POLYGON((1 2, 3 2, 3 4, 1 4, 1 2))')")
+        self.assertFalse(QgsSensorThingsUtils.filterForExtent('', QgsRectangle(1, 2, 3, 4)))
+        self.assertEqual(QgsSensorThingsUtils.filterForExtent('test', QgsRectangle(1, 2, 3, 4)),
+                         "geo.intersects(test, geography'POLYGON((1 2, 3 2, 3 4, 1 4, 1 2))')")
 
     def test_combine_filters(self):
         self.assertFalse(QgsSensorThingsUtils.combineFilters([]))
         self.assertFalse(QgsSensorThingsUtils.combineFilters(['']))
         self.assertEqual(QgsSensorThingsUtils.combineFilters(['', 'a eq 1']), 'a eq 1')
         self.assertEqual(QgsSensorThingsUtils.combineFilters(['a eq 1', 'b eq 2']), '(a eq 1) and (b eq 2)')
-        self.assertEqual(QgsSensorThingsUtils.combineFilters(['a eq 1', '', 'b eq 2', 'c eq 3']), '(a eq 1) and (b eq 2) and (c eq 3)')
+        self.assertEqual(QgsSensorThingsUtils.combineFilters(['a eq 1', '', 'b eq 2', 'c eq 3']),
+                         '(a eq 1) and (b eq 2) and (c eq 3)')
 
     def test_invalid_layer(self):
         vl = QgsVectorLayer(
@@ -766,7 +772,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                     )
 
                 with open(
-                    sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))')) and (location/type eq 'Point')"),
+                    sanitize(endpoint,
+                             "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))')) and (location/type eq 'Point')"),
                     "wt",
                     encoding="utf8",
                 ) as f:
@@ -819,7 +826,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                     )
 
             with open(
-                sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((10 0, 20 0, 20 80, 10 80, 10 0))')) and (location/type eq 'Point')"),
+                sanitize(endpoint,
+                         "/Locations?$top=2&$count=false&$filter=(geo.intersects(location, geography'POLYGON((10 0, 20 0, 20 80, 10 80, 10 0))')) and (location/type eq 'Point')"),
                 "wt",
                 encoding="utf8",
             ) as f:
@@ -962,14 +970,16 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
                 )
 
             with open(
-                sanitize(endpoint, "/Locations?$top=0&$count=true&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
+                sanitize(endpoint,
+                         "/Locations?$top=0&$count=true&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
                 "wt",
                 encoding="utf8",
             ) as f:
                 f.write("""{"@iot.count":2,"value":[]}""")
 
             with open(
-                sanitize(endpoint, "/Locations?$top=2&$count=false&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
+                sanitize(endpoint,
+                         "/Locations?$top=2&$count=false&$filter=(location/type eq 'Point') and (geo.intersects(location, geography'POLYGON((1 0, 10 0, 10 80, 1 80, 1 0))'))"),
                 "wt",
                 encoding="utf8",
             ) as f:
@@ -1185,7 +1195,8 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             )
 
             # should have accurate layer extent now
-            self.assertEqual(vl.extent(), QgsRectangle(1.62337299999999995, 52.13201699999999761, 3.62337299999999995, 55.13201699999999761))
+            self.assertEqual(vl.extent(), QgsRectangle(1.62337299999999995, 52.13201699999999761, 3.62337299999999995,
+                                                       55.13201699999999761))
 
     def test_historical_location(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -2290,7 +2301,15 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             )
             self.assertEqual(
                 [f["properties"] for f in features],
-                [{'localId': 'SAM.09.LAA.822.7.1', 'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample', 'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'}, {'localId': 'SAM.09.LOB.823.7.1', 'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample', 'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'}, {'localId': 'SAM.09.LOB.824.1.1', 'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample', 'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'}],
+                [{'localId': 'SAM.09.LAA.822.7.1',
+                  'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample',
+                  'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'},
+                 {'localId': 'SAM.09.LOB.823.7.1',
+                  'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample',
+                  'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'},
+                 {'localId': 'SAM.09.LOB.824.1.1',
+                  'metadata': 'http://luft.umweltbundesamt.at/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=aqd:AQD_Sample',
+                  'namespace': 'AT.0008.20.AQ', 'owner': 'http://luft.umweltbundesamt.at'}],
             )
 
             self.assertEqual(
@@ -2424,7 +2443,7 @@ class TestPyQgsSensorThingsProvider(QgisTestCase):  # , ProviderTestCase):
             "authcfg": "aaaaa",
             "entity": "location",
             "geometryType": "polygon",
-            "bounds": QgsRectangle(1,2 ,3 ,4 )
+            "bounds": QgsRectangle(1, 2, 3, 4)
         }
         uri = QgsProviderRegistry.instance().encodeUri("sensorthings", parts)
         self.assertEqual(


### PR DESCRIPTION
Allows users to set an extent limit for the layer, so that features are only ever loaded within this extent

The extent can be set from the data source manager before adding the layer initially, or modified from the layer properties, source
tab.