### PR TITLE
Use standard field model in query builder 

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsfieldproxymodel.py
+++ b/python/PyQt6/core/auto_additions/qgsfieldproxymodel.py
@@ -10,6 +10,7 @@ QgsFieldProxyModel.HideReadOnly = QgsFieldProxyModel.Filter.HideReadOnly
 QgsFieldProxyModel.DateTime = QgsFieldProxyModel.Filter.DateTime
 QgsFieldProxyModel.Binary = QgsFieldProxyModel.Filter.Binary
 QgsFieldProxyModel.Boolean = QgsFieldProxyModel.Filter.Boolean
+QgsFieldProxyModel.OriginProvider = QgsFieldProxyModel.Filter.OriginProvider
 QgsFieldProxyModel.AllTypes = QgsFieldProxyModel.Filter.AllTypes
 QgsFieldProxyModel.Filters = lambda flags=0: QgsFieldProxyModel.Filter(flags)
 QgsFieldProxyModel.Filters.baseClass = QgsFieldProxyModel

--- a/python/PyQt6/core/auto_generated/qgsfieldproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldproxymodel.sip.in
@@ -35,6 +35,7 @@ The :py:class:`QgsFieldProxyModel` class provides an easy to use model to displa
       DateTime,
       Binary,
       Boolean,
+      OriginProvider,
       AllTypes,
     };
     typedef QFlags<QgsFieldProxyModel::Filter> Filters;

--- a/python/core/auto_generated/qgsfieldproxymodel.sip.in
+++ b/python/core/auto_generated/qgsfieldproxymodel.sip.in
@@ -35,6 +35,7 @@ The :py:class:`QgsFieldProxyModel` class provides an easy to use model to displa
       DateTime,
       Binary,
       Boolean,
+      OriginProvider,
       AllTypes,
     };
     typedef QFlags<QgsFieldProxyModel::Filter> Filters;

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -15,7 +15,7 @@
 
 #include "qgsfieldproxymodel.h"
 #include "qgsfieldmodel.h"
-#include "qgsvectorlayer.h"
+#include "qgsvariantutils.h"
 
 QgsFieldProxyModel::QgsFieldProxyModel( QObject *parent )
   : QSortFilterProxyModel( parent )
@@ -84,6 +84,22 @@ bool QgsFieldProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
 
   if ( mFilters.testFlag( HideReadOnly ) && isReadOnly( index ) )
     return false;
+
+  if ( mFilters.testFlag( QgsFieldProxyModel::OriginProvider ) )
+  {
+    const QgsFields::FieldOrigin origin = static_cast< QgsFields::FieldOrigin >( sourceModel()->data( index, static_cast< int >( QgsFieldModel::CustomRole::FieldOrigin ) ).toInt() );
+    switch ( origin )
+    {
+      case QgsFields::OriginUnknown:
+      case QgsFields::OriginJoin:
+      case QgsFields::OriginEdit:
+      case QgsFields::OriginExpression:
+        return false;
+
+      case QgsFields::OriginProvider:
+        break;
+    }
+  }
 
   if ( mFilters.testFlag( AllTypes ) )
     return true;

--- a/src/core/qgsfieldproxymodel.h
+++ b/src/core/qgsfieldproxymodel.h
@@ -37,17 +37,18 @@ class CORE_EXPORT QgsFieldProxyModel : public QSortFilterProxyModel
     //! Field type filters
     enum Filter SIP_ENUM_BASETYPE( IntFlag )
     {
-      String = 1, //!< String fields
-      Int = 2, //!< Integer fields
-      LongLong = 4, //!< Longlong fields
-      Double = 8, //!< Double fields
+      String = 1 << 0, //!< String fields
+      Int = 1 << 1, //!< Integer fields
+      LongLong = 1 << 2, //!< Longlong fields
+      Double = 1 << 3, //!< Double fields
       Numeric = Int | LongLong | Double, //!< All numeric fields
-      Date = 16, //!< Date or datetime fields
-      Time = 32, //!< Time fields
-      HideReadOnly = 64,  //!< Hide read-only fields
-      DateTime = 128, //!< Datetime fields
-      Binary = 256, //!< Binary fields, since QGIS 3.34
-      Boolean = 512, //!< Boolean fields, since QGIS 3.34
+      Date = 1 << 4, //!< Date or datetime fields
+      Time = 1 << 5, //!< Time fields
+      HideReadOnly = 1 << 6,  //!< Hide read-only fields
+      DateTime = 1 << 7, //!< Datetime fields
+      Binary = 1 << 8, //!< Binary fields, since QGIS 3.34
+      Boolean = 1 << 9, //!< Boolean fields, since QGIS 3.34
+      OriginProvider = 1 << 10, //!< Fields with a provider origin, since QGIS 3.38
       AllTypes = Numeric | Date | String | Time | DateTime | Binary | Boolean, //!< All field types
     };
     Q_DECLARE_FLAGS( Filters, Filter )

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -28,6 +28,7 @@
 
 class QgsVectorLayer;
 class QgsCodeEditor;
+class QgsFieldProxyModel;
 
 /**
  * \ingroup gui
@@ -169,23 +170,17 @@ class GUI_EXPORT QgsQueryBuilder : public QgsSubsetStringEditorInterface, privat
 
   private:
 
-    /**
-     * Populate the field list for the selected table
-     */
-    void populateFields();
-
     void showHelp();
 
     /**
      * Setup models for listviews
      */
     void setupGuiViews();
-    void setupLstFieldsModel();
-    void fillValues( int idx, int limit );
+    void fillValues( const QString &field, int limit );
 
     // private members
     //! Model for fields ListView
-    QStandardItemModel *mModelFields = nullptr;
+    QgsFieldProxyModel *mModelFields = nullptr;
     //! Model for values ListView
     QStandardItemModel *mModelValues = nullptr;
     //! Filter proxy Model for values ListView

--- a/tests/src/gui/testqgsquerybuilder.cpp
+++ b/tests/src/gui/testqgsquerybuilder.cpp
@@ -101,13 +101,13 @@ void TestQgsQueryBuilder::testFillValues()
 
   QgsQueryBuilder queryBuilder( &vl );
 
-  queryBuilder.fillValues( 0, 10 );
+  queryBuilder.fillValues( "intarray", 10 );
   QCOMPARE( getModelItemDisplayStrings( queryBuilder.mModelValues ), QStringList() << "1" << "2, 3" << "4, 5, 6" << "NULL" );
 
-  queryBuilder.fillValues( 1, 10 );
+  queryBuilder.fillValues( "strarray", 10 );
   QCOMPARE( getModelItemDisplayStrings( queryBuilder.mModelValues ), QStringList() << "NULL" << "testA" << "testB, testC" );
 
-  queryBuilder.fillValues( 2, 10 );
+  queryBuilder.fillValues( "intf", 10 );
   QCOMPARE( getModelItemDisplayStrings( queryBuilder.mModelValues ), QStringList() << "0" << "42" << "NULL" );
 }
 

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -348,6 +348,14 @@ class TestQgsFieldModel(QgisTestCase):
         self.assertEqual(proxy_m.rowCount(), 1)
         self.assertEqual(proxy_m.data(proxy_m.index(0, 0)), 'id_a')
 
+        proxy_m.setFilters(QgsFieldProxyModel.Filter.AllTypes | QgsFieldProxyModel.Filter.OriginProvider)
+        proxy_m.sourceFieldModel().setLayer(layer)
+        self.assertEqual(proxy_m.rowCount(), 1)
+        self.assertEqual(proxy_m.data(proxy_m.index(0, 0)), 'id_a')
+        proxy_m.sourceFieldModel().setLayer(layer3)
+        self.assertEqual(proxy_m.rowCount(), 1)
+        self.assertEqual(proxy_m.data(proxy_m.index(0, 0)), 'id_a')
+
     def testFieldIsWidgetEditableRole(self):
         l, m = create_model()
         self.assertTrue(m.data(m.indexFromName('fldtxt'), QgsFieldModel.FieldRoles.FieldIsWidgetEditable))


### PR DESCRIPTION
Instead of a custom item model, use the standard fields model. Among other improvements, this gives icons for field types in the dialog and more informative tooltips.
