### PR TITLE
Consistently return invalid QVariant for QgsVectorDataProvider::defaultValue

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1411,8 +1411,8 @@ QVariant QgsOgrProvider::defaultValue( int fieldId ) const
     }
   }
 
-  ( void )mAttributeFields.at( fieldId ).convertCompatible( resultVar );
-  return resultVar;
+  const bool compatible = mAttributeFields.at( fieldId ).convertCompatible( resultVar );
+  return compatible && !QgsVariantUtils::isNull( resultVar ) ? resultVar : QVariant();
 }
 
 QString QgsOgrProvider::defaultValueClause( int fieldIndex ) const

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -21,6 +21,7 @@
 #include "qgsmssqlproviderconnection.h"
 #include "qgsfeedback.h"
 #include "qgsdbquerylog.h"
+#include "qgsvariantutils.h"
 
 #include <QtGlobal>
 #include <QFileInfo>
@@ -709,7 +710,8 @@ QVariant QgsMssqlProvider::defaultValue( int fieldId ) const
     return QVariant();
   }
 
-  return query.value( 0 );
+  const QVariant res = query.value( 0 );
+  return QgsVariantUtils::isNull( res ) ? QVariant() : res;
 }
 
 QString QgsMssqlProvider::storageType() const

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -1110,8 +1110,8 @@ QVariant QgsSpatiaLiteProvider::defaultValue( int fieldId ) const
     }
   }
 
-  ( void )mAttributeFields.at( fieldId ).convertCompatible( resultVar );
-  return resultVar;
+  const bool compatible = mAttributeFields.at( fieldId ).convertCompatible( resultVar );
+  return compatible && !QgsVariantUtils::isNull( resultVar ) ? resultVar : QVariant();
 }
 
 QString QgsSpatiaLiteProvider::defaultValueClause( int fieldIndex ) const

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -1155,8 +1155,7 @@ class PyQgsOGRProvider(QgisTestCase):
 
         # Test default values
         dp = vl.dataProvider()
-        # FIXME: should it be None?
-        self.assertTrue(dp.defaultValue(0).isNull())
+        self.assertEqual(dp.defaultValue(0), NULL)
         self.assertIsNone(dp.defaultValue(1))
         # FIXME: This fails because there is no backend-side evaluation in this provider
         # self.assertTrue(dp.defaultValue(2).startswith(now.strftime('%Y-%m-%d')))

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1561,9 +1561,8 @@ class TestQgsSpatialiteProvider(QgisTestCase, ProviderTestCase):
 
         # Test default values
         dp = vl.dataProvider()
-        # FIXME: should it be None?
-        self.assertTrue(dp.defaultValue(0).isNull())
-        self.assertIsNone(dp.defaultValue(1))
+        self.assertEqual(dp.defaultValue(0), NULL)
+        self.assertEqual(dp.defaultValue(1), NULL)
         # FIXME: This fails because there is no backend-side evaluation in this provider
         # self.assertTrue(dp.defaultValue(2).startswith(now.strftime('%Y-%m-%d')))
         self.assertTrue(dp.defaultValue(


### PR DESCRIPTION
Previously we mixed invalid QVariant values with null QVariants, resulting in a mix of results between Qt 5 and Qt 6 and across different data providers
