### PR TITLE
Allow non-explicit supportsQt6 plugins to be installed if (developper-intended) QGIS_DISABLE_SUPPORTS_QT6_CHECK env var is set

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -583,7 +583,7 @@ class Plugins(QObject):
 
         qt_version = int(QT_VERSION_STR.split('.')[0])
         supports_qt6 = pluginMetadata("supportsQt6").strip().upper() in ("TRUE", "YES")
-        if qt_version == 6 and not supports_qt6:
+        if qt_version == 6 and not supports_qt6 and "QGIS_DISABLE_SUPPORTS_QT6_CHECK" not in os.environ:
             error = "incompatible"
             errorDetails = QCoreApplication.translate("QgsPluginInstaller", "Plugin does not support Qt6 versions of QGIS")
         elif version:

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -725,7 +725,10 @@ bool QgsPluginRegistry::isPythonPluginCompatible( const QString &packageName ) c
   const QString supportsQt6 = mPythonUtils->getPluginMetadata( packageName, QStringLiteral( "supportsQt6" ) ).trimmed();
   if ( supportsQt6.compare( QLatin1String( "YES" ), Qt::CaseInsensitive ) != 0 && supportsQt6.compare( QLatin1String( "TRUE" ), Qt::CaseInsensitive ) != 0 )
   {
-    return false;
+    if ( !getenv( "QGIS_DISABLE_SUPPORTS_QT6_CHECK" ) )
+    {
+      return false;
+    }
   }
 #endif
   const QString minVersion = mPythonUtils->getPluginMetadata( packageName, QStringLiteral( "qgisMinimumVersion" ) );


### PR DESCRIPTION
Not sure if this is good-enough or if we want a proper setting for that

While enabling that, I've tried to install a random sample of plugins, and none manage to install. They all fail at import stage. Not sure how reasonable it will be to declare that QGIS 3 is QT6 compat if none of the existing plugin ecosystem is ready for it without modifications. It would probably be cleaner to call it QGIS 4, as a clear signal that some changes are needed... IMHO... 