### PR TITLE
correctly migrate old settings

### DIFF
--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -242,11 +242,14 @@ bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringLi
   if ( settings->contains( oldCompleteKey ) )
   {
     QVariant oldValue = settings->value( oldCompleteKey, mDefaultValue );
-    setVariantValue( oldValue, dynamicKeyPartList );
+    // do not copy if it is equal to the default value
+    if ( oldValue != defaultValueAsVariant() )
+      setVariantValue( oldValue, dynamicKeyPartList );
     if ( removeSettingAtKey )
       settings->remove( oldCompleteKey );
     return true;
   }
+
   return false;
 }
 

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -235,9 +235,6 @@ QVariant QgsSettingsEntryBase::formerValueAsVariant( const QStringList &dynamicK
 
 bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringList &dynamicKeyPartList, bool removeSettingAtKey ) const
 {
-  if ( exists( dynamicKeyPartList ) )
-    return false;
-
   auto settings = QgsSettings::get();
 
   const QString oldCompleteKey = completeKeyPrivate( key, dynamicKeyPartList );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -276,9 +276,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       settings.endGroup();
       Q_NOWARN_DEPRECATED_POP
 
-      QgsOwsConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/username" ), {service, connection}, true );
-      QgsOwsConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/password" ), {service, connection}, true );
-      QgsOwsConnection::settingsAuthCfg->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ), {service, connection}, true );
+      QgsOwsConnection::settingsUsername->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/username" ).arg( service, connection ), {service.toLower(), connection}, true );
+      QgsOwsConnection::settingsPassword->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/password" ).arg( service, connection ), {service.toLower(), connection}, true );
+      QgsOwsConnection::settingsAuthCfg->copyValueFromKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ).arg( service, connection ), {service.toLower(), connection}, true );
     }
     if ( settings.contains( QStringLiteral( "selected" ) ) )
       QgsOwsConnection::sTreeOwsConnections->setSelectedItem( settings.value( QStringLiteral( "selected" ) ).toString(), {service.toLower()} );
@@ -493,9 +493,9 @@ void QgsSettingsRegistryCore::backwardCompatibility()
           Q_NOWARN_DEPRECATED_POP
         }
 
-        QgsOwsConnection::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/username" ), {service, connection} );
-        QgsOwsConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/password" ), {service, connection} );
-        QgsOwsConnection::settingsAuthCfg->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ), {service, connection} );
+        QgsOwsConnection::settingsUsername->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/username" ).arg( service, connection ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsPassword->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/password" ).arg( service, connection ), {service.toLower(), connection} );
+        QgsOwsConnection::settingsAuthCfg->copyValueToKey( QStringLiteral( "qgis/connections/%1/%2/authcfg" ).arg( service, connection ), {service.toLower(), connection} );
       }
     }
   }


### PR DESCRIPTION
by not checking if the setting already exist

fixes #53321

in the migration of connection, if the new connection didn't exist yet, then the former code was not reaching the part where the old key was deleted. Thus at closing QGIS, the old connection is still there and when reopening, the connection would be migrated again (while deleted in former session).