### PR TITLE
[Feature][WMS] Add crs information in WMS GetFeatureInfo output when it differs from WGS84

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -975,6 +975,14 @@ Returns an empty string on failure.
 .. versionadded:: 3.30
 %End
 
+    QString toOgcUrn() const;
+%Docstring
+Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
+Returns an empty string on failure.
+
+.. versionadded:: 3.30
+%End
+
 
     void updateDefinition();
 %Docstring

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -980,7 +980,7 @@ Returns an empty string on failure.
 Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
 Returns an empty string on failure.
 
-.. versionadded:: 3.30
+.. versionadded:: 3.38
 %End
 
 

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -363,6 +363,7 @@ Returns a null geometry if the geometry could not be parsed.
 
 
 
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -975,6 +975,14 @@ Returns an empty string on failure.
 .. versionadded:: 3.30
 %End
 
+    QString toOgcUrn() const;
+%Docstring
+Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
+Returns an empty string on failure.
+
+.. versionadded:: 3.30
+%End
+
 
     void updateDefinition();
 %Docstring

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -980,7 +980,7 @@ Returns an empty string on failure.
 Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
 Returns an empty string on failure.
 
-.. versionadded:: 3.30
+.. versionadded:: 3.38
 %End
 
 

--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -363,6 +363,7 @@ Returns a null geometry if the geometry could not be parsed.
 
 
 
+
 };
 
 /************************************************************************

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1600,6 +1600,30 @@ QString QgsCoordinateReferenceSystem::toOgcUri() const
   return QString();
 }
 
+QString QgsCoordinateReferenceSystem::toOgcUrn() const
+{
+  const auto parts { authid().split( ':' ) };
+  if ( parts.length() == 2 )
+  {
+    if ( parts[0] == QLatin1String( "EPSG" ) )
+      return  QStringLiteral( "urn:ogc:def:crs:EPSG:0:%1" ).arg( parts[1] );
+    else if ( parts[0] == QLatin1String( "OGC" ) )
+    {
+      return  QStringLiteral( "urn:ogc:def:crs:OGC:1.3:%1" ).arg( parts[1] );
+    }
+    else
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Error converting published CRS to URN %1: (not OGC or EPSG)" ).arg( authid() ), QStringLiteral( "CRS" ), Qgis::MessageLevel::Critical );
+    }
+  }
+  else
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Error converting published CRS to URN: %1" ).arg( authid() ), QStringLiteral( "CRS" ), Qgis::MessageLevel::Critical );
+  }
+  return QString();
+}
+
+
 void QgsCoordinateReferenceSystem::updateDefinition()
 {
   if ( !d->mIsValid )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -899,7 +899,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
      * Returns an empty string on failure.
      *
-     * \since QGIS 3.30
+     * \since QGIS 3.38
      */
     QString toOgcUrn() const;
 

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -895,6 +895,14 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     QString toOgcUri() const;
 
+    /**
+     * Returns the crs as OGC URN (format: urn:ogc:def:crs:OGC:1.3:CRS84)
+     * Returns an empty string on failure.
+     *
+     * \since QGIS 3.30
+     */
+    QString toOgcUrn() const;
+
     // Mutators -----------------------------------
 
     /**

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -245,6 +245,9 @@ json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features
     { "type", "FeatureCollection" },
     { "features", json::array() }
   };
+
+  QgsJsonUtils::addCrsInfo( data, mDestinationCrs );
+
   for ( const QgsFeature &feature : std::as_const( features ) )
   {
     data["features"].push_back( exportFeatureToJsonObject( feature ) );
@@ -911,4 +914,15 @@ json QgsJsonUtils::exportAttributesToJsonObject( const QgsFeature &feature, QgsV
     attrs[fields.at( i ).name().toStdString()] = jsonFromVariant( val );
   }
   return attrs;
+}
+
+void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs )
+{
+  // When user request EPSG:4326 we return a compliant CRS84 lon/lat GeoJSON
+  // so no need to add CRS information
+  if ( crs.authid() == "OGC:CRS84" || crs.authid() == "EPSG:4326" )
+    return;
+
+  value["crs"]["type"] = "name";
+  value["crs"]["properties"]["name"] = crs.toOgcUrn().toStdString();
 }

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -428,7 +428,7 @@ class CORE_EXPORT QgsJsonUtils
      * if it differs from OGC:CRS84 or EPSG:4326.
      * According to new specification RFC 7946, coordinate reference system for all GeoJSON coordinates
      * is assumed to be OGC:CRS84 but when user specifically request a different CRS, this method
-     * allow to add this information in the JSON output
+     * adds this information in the JSON output
      */
     static void addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs ) SIP_SKIP;
 

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -423,6 +423,15 @@ class CORE_EXPORT QgsJsonUtils
      */
     static QVariant jsonToVariant( const json &value ) SIP_SKIP;
 
+    /**
+     * Add \a crs information entry in \a json object regarding old GeoJSON specification format
+     * if it differs from OGC:CRS84 or EPSG:4326.
+     * According to new specification RFC 7946, coordinate reference system for all GeoJSON coordinates
+     * is assumed to be OGC:CRS84 but when user specifically request a different CRS, this method
+     * allow to add this information in the JSON output
+     */
+    static void addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs ) SIP_SKIP;
+
 };
 
 #endif // QGSJSONUTILS_H

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1184,7 +1184,7 @@ namespace QgsWfs
 
         json value;
         QgsJsonUtils::addCrsInfo( value, destinationCrs );
-        for ( auto it : value.items() )
+        for ( const auto &it : value.items() )
         {
           fcString += " \"" + QString::fromStdString( it.key() ) + "\": " + QString::fromStdString( it.value().dump() ) + ",\n";
         }

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1174,6 +1174,21 @@ namespace QgsWfs
 
         fcString = QStringLiteral( "{\"type\": \"FeatureCollection\",\n" );
         fcString += " \"bbox\": [ " + qgsDoubleToString( rect->xMinimum(), prec ) + ", " + qgsDoubleToString( rect->yMinimum(), prec ) + ", " + qgsDoubleToString( rect->xMaximum(), prec ) + ", " + qgsDoubleToString( rect->yMaximum(), prec ) + "],\n";
+
+        const QString srsName {request.serverParameters().value( QStringLiteral( "SRSNAME" ) )};
+        const QgsCoordinateReferenceSystem destinationCrs { srsName.isEmpty( ) ? QStringLiteral( "EPSG:4326" ) : srsName };
+        if ( ! destinationCrs.isValid() )
+        {
+          throw QgsRequestNotWellFormedException( QStringLiteral( "srsName error: '%1' is not valid." ).arg( srsName ) );
+        }
+
+        json value;
+        QgsJsonUtils::addCrsInfo( value, destinationCrs );
+        for ( auto it : value.items() )
+        {
+          fcString += " \"" + QString::fromStdString( it.key() ) + "\": " + QString::fromStdString( it.value().dump() ) + ",\n";
+        }
+
         fcString += QLatin1String( " \"features\": [\n" );
         response.write( fcString.toUtf8() );
       }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1316,7 +1316,7 @@ namespace QgsWms
     else if ( infoFormat == QgsWmsParameters::Format::HTML )
       ba = convertFeatureInfoToHtml( result );
     else if ( infoFormat == QgsWmsParameters::Format::JSON )
-      ba = convertFeatureInfoToJson( layers, result );
+      ba = convertFeatureInfoToJson( layers, result, mapSettings.destinationCrs() );
     else
       ba = result.toByteArray();
 
@@ -2813,7 +2813,7 @@ namespace QgsWms
     return featureInfoString.toUtf8();
   }
 
-  QByteArray QgsRenderer::convertFeatureInfoToJson( const QList<QgsMapLayer *> &layers, const QDomDocument &doc ) const
+  QByteArray QgsRenderer::convertFeatureInfoToJson( const QList<QgsMapLayer *> &layers, const QDomDocument &doc, const QgsCoordinateReferenceSystem &destCRS ) const
   {
     json json
     {
@@ -2914,6 +2914,8 @@ namespace QgsWms
         exporter.setAttributes( attributes );
         exporter.setIncludeGeometry( withGeometry );
         exporter.setTransformGeometries( false );
+
+        QgsJsonUtils::addCrsInfo( json, destCRS );
 
         for ( const auto &feature : std::as_const( features ) )
         {

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -323,7 +323,7 @@ namespace QgsWms
       QByteArray convertFeatureInfoToText( const QDomDocument &doc ) const;
 
       //! Converts a feature info xml document to json
-      QByteArray convertFeatureInfoToJson( const QList<QgsMapLayer *> &layers, const QDomDocument &doc ) const;
+      QByteArray convertFeatureInfoToJson( const QList<QgsMapLayer *> &layers, const QDomDocument &doc, const QgsCoordinateReferenceSystem &destCRS ) const;
 
       QDomElement createFeatureGML(
         const QgsFeature *feat,

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -787,6 +787,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual(jdata['features'][0]['geometry']['coordinates'], [807305, 5592878])
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:3857")
 
         query_string = "?" + "&".join(["%s=%s" % i for i in list({
             "SERVICE": "WFS",
@@ -803,6 +804,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual([int(i) for i in jdata['features'][0]['geometry']['coordinates']], [7, 44])
+        self.assertFalse('crs' in jdata)
 
         query_string = "?" + "&".join(["%s=%s" % i for i in list({
             "SERVICE": "WFS",
@@ -834,6 +836,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual([int(i) for i in jdata['features'][0]['geometry']['coordinates']], [361806, 4964192])
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:32632")
 
         query_string = "?" + "&".join(["%s=%s" % i for i in list({
             "SERVICE": "WFS",
@@ -851,6 +854,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         jdata['features'][0]['geometry']
         jdata['features'][0]['geometry']['coordinates']
         self.assertEqual([int(i) for i in jdata['features'][0]['geometry']['coordinates']], [812191, 5589555])
+        self.assertEqual(jdata['crs']['properties']['name'], "urn:ogc:def:crs:EPSG:0:3857")
 
     def test_insert_srsName(self):
         """Test srsName is respected when insering"""

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -615,6 +615,30 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'wms_getfeatureinfo_raster_json',
                                  normalizeJson=True)
 
+        # simple test with geometry with underlying layer in 4326 and CRS is EPSG:4326
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=application%2Fjson&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG:4326&' +
+                                 'bbox=44.9014173,8.2034387,44.9015094,8.2036094&' +
+                                 'query_layers=testlayer2&X=203&Y=116&' +
+                                 'with_geometry=true',
+                                 'wms_getfeatureinfo_geometry_CRS84_json',
+                                 'test_project.qgs',
+                                 normalizeJson=True)
+
+        # simple test with geometry with underlying layer in 4326 and CRS is CRS84
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=application%2Fjson&transparent=true&' +
+                                 'width=600&height=400&srs=OGC:CRS84&' +
+                                 'bbox=8.2034387,44.9014173,8.2036094,44.9015094&' +
+                                 'query_layers=testlayer2&X=203&Y=116&' +
+                                 'with_geometry=true',
+                                 'wms_getfeatureinfo_geometry_CRS84_json',
+                                 'test_project.qgs',
+                                 normalizeJson=True)
+
     def testGetFeatureInfoGroupedLayers(self):
         """Test that we can get feature info from the top and group layers"""
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
@@ -2,6 +2,13 @@
 Content-Type: application/json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": null,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
@@ -2,6 +2,13 @@
 Content-Type: application/json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": null,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
@@ -2,6 +2,13 @@
 Content-Type: application/geo+json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": null,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_CRS84_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_CRS84_json.txt
@@ -1,0 +1,24 @@
+*****
+Content-Type: application/json; charset=utf-8
+
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          8.2035,
+          44.9015
+        ],
+        "type": "Point"
+      },
+      "id": "testlayer2.0",
+      "properties": {
+        "id": 1,
+        "name": "one",
+        "utf8nameè": "one èé"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
@@ -2,6 +2,13 @@
 Content-Type: application/json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
@@ -2,6 +2,13 @@
 Content-Type: application/json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": null,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
@@ -2,6 +2,13 @@
 Content-Type: application/json; charset=utf-8
 
 {
+  "crs":
+    {
+      "properties": {
+        "name": "urn:ogc:def:crs:EPSG:0:3857"
+      },
+      "type": "name"
+    },
   "features": [
     {
       "geometry": null,


### PR DESCRIPTION
GeoJSON states that CRS should always be OGC:CRS84, but when user requests explicitly a given CRS different from WGS84 on WMS GetFeatureInfo, it's better to expose the output CRS using the old GeoJSON specification [format](http://wiki.geojson.org/GeoJSON_draft_version_6#Specification).

Related to a QWC issue, see [comment](https://github.com/qgis/qwc2/pull/278#issuecomment-1830670920)

**Funded by Eurométropole de Strasbourg**

cc @benoitblanc 
