### PR TITLE
[vector layer] Fix QgsVectorLayerFeatureIterator::isValid() value when initiated against editing-enabled vector layer

### DIFF
--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -622,7 +622,7 @@ void QgsVectorLayerFeatureIterator::setInterruptionChecker( QgsFeedback *interru
 
 bool QgsVectorLayerFeatureIterator::isValid() const
 {
-  return mProviderIterator.isValid();
+  return mChangedFeaturesIterator.isValid() || mProviderIterator.isValid();
 }
 
 bool QgsVectorLayerFeatureIterator::fetchNextAddedFeature( QgsFeature &f )

--- a/tests/src/python/test_qgsfeatureiterator.py
+++ b/tests/src/python/test_qgsfeatureiterator.py
@@ -115,6 +115,29 @@ class TestQgsFeatureIterator(QgisTestCase):
         feat['Staff'] = 2
         vl.addFeature(feat)
 
+    def test_VectorLayerEditing(self):
+        ogr_layer = QgsVectorLayer(os.path.join(TEST_DATA_DIR, 'points.shp'), 'Points', 'ogr')
+        self.assertTrue(ogr_layer.isValid())
+
+        request = QgsFeatureRequest()
+        iterator = ogr_layer.getFeatures(request)
+        self.assertTrue(iterator.isValid())
+
+        self.assertTrue(ogr_layer.startEditing())
+        iterator = ogr_layer.getFeatures(request)
+        self.assertTrue(iterator.isValid())
+
+        memory_layer = QgsVectorLayer("Point?field=x:string&field=y:integer&field=z:integer", "layer", "memory")
+        self.assertTrue(memory_layer.isValid())
+
+        request = QgsFeatureRequest()
+        iterator = memory_layer.getFeatures(request)
+        self.assertTrue(iterator.isValid())
+
+        self.assertTrue(memory_layer.startEditing())
+        iterator = memory_layer.getFeatures(request)
+        self.assertTrue(iterator.isValid())
+
     def test_ExpressionFieldNested(self):
         myShpFile = os.path.join(TEST_DATA_DIR, 'points.shp')
         layer = QgsVectorLayer(myShpFile, 'Points', 'ogr')


### PR DESCRIPTION
## Description

This PR fixes an issue with QgsVectorLayerFeatureIterator objects created through QgsVectorLayer::getFeatures( QgsFeatureRequest ) wrongly returning false when calling the class' isValid() function.

This led to at least one known issue whereas the active layer feature locator would skip searching through feature display name when the active layer's editing mode was toggled on due to this isValid() check (https://github.com/qgis/QGIS/blob/master/src/app/locator/qgsactivelayerfeatureslocatorfilter.cpp#L186).