### PR TITLE
Abort blocking range requests when not supported by the server

### DIFF
--- a/src/core/network/qgsblockingnetworkrequest.h
+++ b/src/core/network/qgsblockingnetworkrequest.h
@@ -291,6 +291,8 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
     QString errorMessageFailedAuth();
 
     void sendRequestToNetworkAccessManager( const QNetworkRequest &request );
+
+    void abortIfNotPartialContentReturned();
 };
 
 ///@cond PRIVATE

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -297,12 +297,6 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
 {
   QgsLazInfo lazInfo;
 
-  if ( !supportsRangeQueries( url ) )
-  {
-    lazInfo.mError = QStringLiteral( "The server of submitted URL doesn't support range queries" );
-    return lazInfo;
-  }
-
   // Fetch header data
   {
     QNetworkRequest nr( url );
@@ -315,11 +309,20 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
     if ( errCode != QgsBlockingNetworkRequest::NoError )
     {
       QgsDebugError( QStringLiteral( "Request failed: " ) + url.toString() );
-      lazInfo.mError = QStringLiteral( "Range query 0-374 to \"%1\" failed: \"%2\"" ).arg( url.toString() ).arg( req.errorMessage() );
+
+      if ( req.reply().attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt() == 200 )
+      {
+        lazInfo.mError = req.errorMessage();
+      }
+      else
+      {
+        lazInfo.mError = QStringLiteral( "Range query 0-374 to \"%1\" failed: \"%2\"" ).arg( url.toString() ).arg( req.errorMessage() );
+      }
       return lazInfo;
     }
 
     const QgsNetworkReplyContent reply = req.reply();
+
     QByteArray lazHeaderData = reply.content();
 
     lazInfo.parseRawHeader( lazHeaderData.data(), lazHeaderData.size() );
@@ -350,20 +353,4 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
   }
 
   return lazInfo;
-}
-
-bool QgsLazInfo::supportsRangeQueries( QUrl &url )
-{
-  QNetworkRequest nr( url );
-  QgsSetRequestInitiatorClass( nr, QStringLiteral( "QgsLazInfo" ) );
-  nr.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
-  nr.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
-  nr.setRawHeader( "Range", "bytes=0-0" );
-  QgsBlockingNetworkRequest req;
-  // ignore the reply's status, we only care if accept-ranges is in the headers
-  req.head( nr );
-  QgsNetworkReplyContent reply = req.reply();
-
-  const QString acceptRangesHeader = reply.rawHeader( QStringLiteral( "Accept-Ranges" ).toLocal8Bit() );
-  return acceptRangesHeader.compare( QStringLiteral( "bytes" ), Qt::CaseSensitivity::CaseInsensitive ) == 0;
 }

--- a/src/core/pointcloud/qgslazinfo.h
+++ b/src/core/pointcloud/qgslazinfo.h
@@ -135,9 +135,6 @@ class CORE_EXPORT QgsLazInfo
     //! Static function to create a QgsLazInfo class from a file over network
     static QgsLazInfo fromUrl( QUrl &url );
 
-    //! Static function to check whether the server of URL \a url supports range queries
-    static bool supportsRangeQueries( QUrl &url );
-
   private:
     void parseHeader( lazperf::header14 &header );
     void parseCrs();


### PR DESCRIPTION
## Description
We used to rely on the server's `Accept-Ranges` header to see if we can perform range requests for remote point clouds, but apparently many servers do not include that in their replies.

Now we request a range without checking and abort as soon as we receive a `200` instead of a `206` code.

Fixes: #53612

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
