### PR TITLE
DB Manager: tweaks for running Qt6

### DIFF
--- a/python/plugins/db_manager/db_plugins/data_model.py
+++ b/python/plugins/db_manager/db_plugins/data_model.py
@@ -19,7 +19,7 @@ email                : brush.tyler@gmail.com
 """
 
 from qgis.PyQt.QtCore import (Qt,
-                              QTime,
+                              QElapsedTimer,
                               QRegularExpression,
                               QAbstractTableModel,
                               pyqtSignal,
@@ -185,7 +185,8 @@ class SqlResultModel(BaseTableModel):
     def __init__(self, db, sql, parent=None):
         self.db = db.connector
 
-        t1 = QTime().currentTime()
+        t = QElapsedTimer()
+        t.start()
         c = self.db._execute(None, sql)
 
         self._affectedRows = 0
@@ -208,11 +209,9 @@ class SqlResultModel(BaseTableModel):
         # commit before closing the cursor to make sure that the changes are stored
         self.db._commit()
         c.close()
-        t2 = QTime().currentTime()
-        self._secs = t1.msecsTo(t2) / 1000.0
+        self._secs = t.elapsed() / 1000.0
         del c
-        del t1
-        del t2
+        del t
 
     def secs(self):
         return self._secs

--- a/python/plugins/db_manager/db_plugins/data_model.py
+++ b/python/plugins/db_manager/db_plugins/data_model.py
@@ -185,8 +185,7 @@ class SqlResultModel(BaseTableModel):
     def __init__(self, db, sql, parent=None):
         self.db = db.connector
 
-        t = QTime()
-        t.start()
+        t1 = QTime().currentTime()
         c = self.db._execute(None, sql)
 
         self._affectedRows = 0
@@ -209,9 +208,11 @@ class SqlResultModel(BaseTableModel):
         # commit before closing the cursor to make sure that the changes are stored
         self.db._commit()
         c.close()
-        self._secs = t.elapsed() / 1000.0
+        t2 = QTime().currentTime()
+        self._secs = t1.msecsTo(t2) / 1000.0
         del c
-        del t
+        del t1
+        del t2
 
     def secs(self):
         return self._secs

--- a/python/plugins/db_manager/db_plugins/oracle/data_model.py
+++ b/python/plugins/db_manager/db_plugins/oracle/data_model.py
@@ -21,7 +21,7 @@ The content of this file is based on
  ***************************************************************************/
 """
 
-from qgis.PyQt.QtCore import QTime
+from qgis.PyQt.QtCore import QElapsedTimer
 from qgis.core import QgsMessageLog
 from ..data_model import (TableDataModel,
                           SqlResultModel,
@@ -151,7 +151,8 @@ class ORSqlResultModel(SqlResultModel):
     def __init__(self, db, sql, parent=None):
         self.db = db.connector
 
-        t1 = QTime().currentTime()
+        t = QElapsedTimer()
+        t.start()
         c = self.db._execute(None, str(sql))
 
         self._affectedRows = 0
@@ -169,10 +170,8 @@ class ORSqlResultModel(SqlResultModel):
             data = []
             header = []
 
-        t2 = QTime().currentTime()
-        self._secs = t1.msecsTo(t2) / 1000.0
-        del t1
-        del t2
+        self._secs = t.elapsed() / 1000.0
+        del t
 
         BaseTableModel.__init__(self, header, data, parent)
 

--- a/python/plugins/db_manager/db_plugins/oracle/data_model.py
+++ b/python/plugins/db_manager/db_plugins/oracle/data_model.py
@@ -151,8 +151,7 @@ class ORSqlResultModel(SqlResultModel):
     def __init__(self, db, sql, parent=None):
         self.db = db.connector
 
-        t = QTime()
-        t.start()
+        t1 = QTime().currentTime()
         c = self.db._execute(None, str(sql))
 
         self._affectedRows = 0
@@ -170,8 +169,10 @@ class ORSqlResultModel(SqlResultModel):
             data = []
             header = []
 
-        self._secs = t.elapsed() / 1000.0
-        del t
+        t2 = QTime().currentTime()
+        self._secs = t1.msecsTo(t2) / 1000.0
+        del t1
+        del t2
 
         BaseTableModel.__init__(self, header, data, parent)
 

--- a/python/plugins/db_manager/db_plugins/vlayers/data_model.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/data_model.py
@@ -26,7 +26,7 @@ from .connector import VLayerRegistry, getQueryGeometryName
 from .plugin import LVectorTable
 from ..plugin import DbError, BaseError
 
-from qgis.PyQt.QtCore import QTime, QTemporaryFile
+from qgis.PyQt.QtCore import QElapsedTimer, QTemporaryFile
 from qgis.core import (QgsVectorLayer,
                        QgsWkbTypes,
                        QgsVirtualLayerDefinition,
@@ -119,7 +119,8 @@ class LSqlResultModelAsync(SqlResultModelAsync):
 class LSqlResultModel(BaseTableModel):
 
     def __init__(self, db, sql, parent=None, layer=None, path=None):
-        t1 = QTime().currentTime()
+        t = QElapsedTimer()
+        t.start()
 
         if not layer:
             tf = QTemporaryFile()
@@ -131,8 +132,7 @@ class LSqlResultModel(BaseTableModel):
             df.setFilePath(path)
             df.setQuery(sql)
             layer = QgsVectorLayer(df.toString(), "vv", "virtual")
-            t2 = QTime().currentTime()
-            self._secs = t1.msecsTo(t2) / 1000.0
+            self._secs = t.elapsed() / 1000.0
 
         data = []
         header = []

--- a/python/plugins/db_manager/db_plugins/vlayers/data_model.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/data_model.py
@@ -119,8 +119,7 @@ class LSqlResultModelAsync(SqlResultModelAsync):
 class LSqlResultModel(BaseTableModel):
 
     def __init__(self, db, sql, parent=None, layer=None, path=None):
-        t = QTime()
-        t.start()
+        t1 = QTime().currentTime()
 
         if not layer:
             tf = QTemporaryFile()
@@ -132,7 +131,8 @@ class LSqlResultModel(BaseTableModel):
             df.setFilePath(path)
             df.setQuery(sql)
             layer = QgsVectorLayer(df.toString(), "vv", "virtual")
-            self._secs = t.elapsed() / 1000.0
+            t2 = QTime().currentTime()
+            self._secs = t1.msecsTo(t2) / 1000.0
 
         data = []
         header = []

--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -129,8 +129,8 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
 
         self.presetStore.clicked.connect(self.storePreset)
         self.presetDelete.clicked.connect(self.deletePreset)
-        self.presetCombo.activated[str].connect(self.loadPreset)
-        self.presetCombo.activated[str].connect(self.presetName.setText)
+        self.presetCombo.textActivated.connect(self.loadPreset)
+        self.presetCombo.textActivated.connect(self.presetName.setText)
 
         self.editSql.textChanged.connect(self.updatePresetButtonsState)
         self.presetName.textChanged.connect(self.updatePresetButtonsState)

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -174,8 +174,8 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         self.presetSaveAsFile.clicked.connect(self.saveAsFilePreset)
         self.presetLoadFile.clicked.connect(self.loadFilePreset)
         self.presetDelete.clicked.connect(self.deletePreset)
-        self.presetCombo.activated[str].connect(self.loadPreset)
-        self.presetCombo.activated[str].connect(self.presetName.setText)
+        self.presetCombo.textActivated.connect(self.loadPreset)
+        self.presetCombo.textActivated.connect(self.presetName.setText)
 
         self.updatePresetsCombobox()
 


### PR DESCRIPTION
Small tweaks to running in Qt 6(removed obsolete method calls QTime().start() and QTime().elapsed(), and changed an overloaded slot (QComboBox::activated()) to a non-overloaded one (textActivated()).

