### PR TITLE
Insure that src/auth builds with QT_NO_SSL defined

### DIFF
--- a/src/auth/identcert/core/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/core/qgsauthidentcertmethod.cpp
@@ -40,7 +40,9 @@ const QString QgsAuthIdentCertMethod::AUTH_METHOD_KEY = QStringLiteral( "Identit
 const QString QgsAuthIdentCertMethod::AUTH_METHOD_DESCRIPTION = QStringLiteral( "Identity certificate authentication" );
 const QString QgsAuthIdentCertMethod::AUTH_METHOD_DISPLAY_DESCRIPTION = tr( "Identity certificate authentication" );
 
+#ifndef QT_NO_SSL
 QMap<QString, QgsPkiConfigBundle *> QgsAuthIdentCertMethod::sPkiConfigBundleCache = QMap<QString, QgsPkiConfigBundle *>();
+#endif
 
 
 QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
@@ -57,9 +59,11 @@ QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
 
 QgsAuthIdentCertMethod::~QgsAuthIdentCertMethod()
 {
+#ifndef QT_NO_SSL
   const QMutexLocker locker( &mMutex );
   qDeleteAll( sPkiConfigBundleCache );
   sPkiConfigBundleCache.clear();
+#endif
 }
 
 QString QgsAuthIdentCertMethod::key() const
@@ -80,6 +84,7 @@ QString QgsAuthIdentCertMethod::displayDescription() const
 bool QgsAuthIdentCertMethod::updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
     const QString &dataprovider )
 {
+#ifndef QT_NO_SSL
   Q_UNUSED( dataprovider )
   const QMutexLocker locker( &mMutex );
 
@@ -110,11 +115,15 @@ bool QgsAuthIdentCertMethod::updateNetworkRequest( QNetworkRequest &request, con
   request.setSslConfiguration( sslConfig );
 
   return true;
+#else
+  return false;
+#endif
 }
 
 bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg,
     const QString &dataprovider )
 {
+#ifndef QT_NO_SSL
   Q_UNUSED( dataprovider )
   const QMutexLocker locker( &mMutex );
 
@@ -210,6 +219,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
   }
 
   return true;
+#else
+  return false;
+#endif
 }
 
 void QgsAuthIdentCertMethod::clearCachedConfig( const QString &authcfg )
@@ -232,6 +244,7 @@ void QgsAuthIdentCertMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
   // TODO: add updates as method version() increases due to config storage changes
 }
 
+#ifndef QT_NO_SSL
 QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &authcfg )
 {
   const QMutexLocker locker( &mMutex );
@@ -303,6 +316,7 @@ void QgsAuthIdentCertMethod::removePkiConfigBundle( const QString &authcfg )
     QgsDebugMsgLevel( QStringLiteral( "Removed PKI bundle for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
+#endif
 
 #ifdef HAVE_GUI
 QWidget *QgsAuthIdentCertMethod::editWidget( QWidget *parent ) const

--- a/src/auth/identcert/core/qgsauthidentcertmethod.h
+++ b/src/auth/identcert/core/qgsauthidentcertmethod.h
@@ -61,6 +61,7 @@ class QgsAuthIdentCertMethod : public QgsAuthMethod
 
   private:
 
+#ifndef QT_NO_SSL
     QgsPkiConfigBundle *getPkiConfigBundle( const QString &authcfg );
 
     void putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle );
@@ -68,6 +69,7 @@ class QgsAuthIdentCertMethod : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+#endif
 
 };
 

--- a/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
+++ b/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
@@ -39,7 +39,9 @@ const QString QgsAuthPkiPathsMethod::AUTH_METHOD_KEY = QStringLiteral( "PKI-Path
 const QString QgsAuthPkiPathsMethod::AUTH_METHOD_DESCRIPTION = QStringLiteral( "PKI paths authentication" );
 const QString QgsAuthPkiPathsMethod::AUTH_METHOD_DISPLAY_DESCRIPTION = tr( "PKI paths authentication" );
 
+#ifndef QT_NO_SSL
 QMap<QString, QgsPkiConfigBundle *> QgsAuthPkiPathsMethod::sPkiConfigBundleCache = QMap<QString, QgsPkiConfigBundle *>();
+#endif
 
 
 QgsAuthPkiPathsMethod::QgsAuthPkiPathsMethod()
@@ -56,9 +58,11 @@ QgsAuthPkiPathsMethod::QgsAuthPkiPathsMethod()
 
 QgsAuthPkiPathsMethod::~QgsAuthPkiPathsMethod()
 {
+#ifndef QT_NO_SSL
   const QMutexLocker locker( &mMutex );
   qDeleteAll( sPkiConfigBundleCache );
   sPkiConfigBundleCache.clear();
+#endif
 }
 
 QString QgsAuthPkiPathsMethod::key() const
@@ -80,6 +84,7 @@ QString QgsAuthPkiPathsMethod::displayDescription() const
 bool QgsAuthPkiPathsMethod::updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
     const QString &dataprovider )
 {
+#ifndef QT_NO_SSL
   Q_UNUSED( dataprovider )
   const QMutexLocker locker( &mMutex );
 
@@ -122,12 +127,16 @@ bool QgsAuthPkiPathsMethod::updateNetworkRequest( QNetworkRequest &request, cons
   request.setSslConfiguration( sslConfig );
 
   return true;
+#else
+  return false;
+#endif
 }
 
 
 bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg,
     const QString &dataprovider )
 {
+#ifndef QT_NO_SSL
   Q_UNUSED( dataprovider )
   const QMutexLocker locker( &mMutex );
 
@@ -243,12 +252,17 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
   }
 
   return true;
+#else
+  return false;
+#endif
 }
 
 void QgsAuthPkiPathsMethod::clearCachedConfig( const QString &authcfg )
 {
+#ifndef QT_NO_SSL
   const QMutexLocker locker( &mMutex );
   removePkiConfigBundle( authcfg );
+#endif
 }
 
 void QgsAuthPkiPathsMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
@@ -268,6 +282,7 @@ void QgsAuthPkiPathsMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
   // TODO: add updates as method version() increases due to config storage changes
 }
 
+#ifndef QT_NO_SSL
 QgsPkiConfigBundle *QgsAuthPkiPathsMethod::getPkiConfigBundle( const QString &authcfg )
 {
   const QMutexLocker locker( &mMutex );
@@ -337,6 +352,7 @@ void QgsAuthPkiPathsMethod::removePkiConfigBundle( const QString &authcfg )
     QgsDebugMsgLevel( QStringLiteral( "Removed PKI bundle for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
+#endif
 
 #ifdef HAVE_GUI
 QWidget *QgsAuthPkiPathsMethod::editWidget( QWidget *parent ) const

--- a/src/auth/pkipaths/core/qgsauthpkipathsmethod.h
+++ b/src/auth/pkipaths/core/qgsauthpkipathsmethod.h
@@ -61,6 +61,7 @@ class QgsAuthPkiPathsMethod : public QgsAuthMethod
 
   private:
 
+#ifndef QT_NO_SSL
     QgsPkiConfigBundle *getPkiConfigBundle( const QString &authcfg );
 
     void putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle );
@@ -68,6 +69,7 @@ class QgsAuthPkiPathsMethod : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+#endif
 
 };
 

--- a/src/auth/pkipkcs12/core/qgsauthpkcs12method.h
+++ b/src/auth/pkipkcs12/core/qgsauthpkcs12method.h
@@ -62,6 +62,7 @@ class QgsAuthPkcs12Method : public QgsAuthMethod
 
   private:
 
+#ifndef QT_NO_SSL
     QgsPkiConfigBundle *getPkiConfigBundle( const QString &authcfg );
 
     void putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle );
@@ -69,6 +70,7 @@ class QgsAuthPkcs12Method : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+#endif
 
 };
 


### PR DESCRIPTION
## Description

This PR fixes QGIS' failure to build against Qt version that has no OpenSSL support (i.e. QT_NO_SSL) due to three authentication methods referring to classes not defined (i.e. the QgsPki* classes here: https://github.com/qgis/QGIS/blob/master/src/core/auth/qgsauthconfig.cpp#L204-L208).

Edit: turns out there's actually plenty more that needs to be done to support a QT_NO_SSL build. This however is a step in the right direction.