### PR TITLE
[editor widgets] Implement value relation's grouping functionality

### DIFF
--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -24,7 +24,7 @@ features on another layer.
   public:
     struct ValueRelationItem
     {
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString() );
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() );
 %Docstring
 Constructor for ValueRelationItem
 %End
@@ -37,6 +37,7 @@ Constructor for ValueRelationItem
       QVariant key;
       QString value;
       QString description;
+      QString group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -24,7 +24,7 @@ features on another layer.
   public:
     struct ValueRelationItem
     {
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() );
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QVariant group = QVariant() );
 %Docstring
 Constructor for ValueRelationItem
 %End
@@ -37,7 +37,7 @@ Constructor for ValueRelationItem
       QVariant key;
       QString value;
       QString description;
-      QString group;
+      QVariant group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -24,7 +24,7 @@ features on another layer.
   public:
     struct ValueRelationItem
     {
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString() );
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() );
 %Docstring
 Constructor for ValueRelationItem
 %End
@@ -37,6 +37,7 @@ Constructor for ValueRelationItem
       QVariant key;
       QString value;
       QString description;
+      QString group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -24,7 +24,7 @@ features on another layer.
   public:
     struct ValueRelationItem
     {
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() );
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QVariant group = QVariant() );
 %Docstring
 Constructor for ValueRelationItem
 %End
@@ -37,7 +37,7 @@ Constructor for ValueRelationItem
       QVariant key;
       QString value;
       QString description;
-      QString group;
+      QVariant group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -33,12 +33,12 @@ using namespace nlohmann;
 
 bool orderByKeyLessThan( const QgsValueRelationFieldFormatter::ValueRelationItem &p1, const QgsValueRelationFieldFormatter::ValueRelationItem &p2 )
 {
-  return qgsVariantLessThan( p1.key, p2.key );
+  return p1.group == p2.group ? qgsVariantLessThan( p1.key, p2.key ) : qgsVariantLessThan( p1.group, p2.group );
 }
 
 bool orderByValueLessThan( const QgsValueRelationFieldFormatter::ValueRelationItem &p1, const QgsValueRelationFieldFormatter::ValueRelationItem &p2 )
 {
-  return qgsVariantLessThan( p1.value, p2.value );
+  return p1.group == p2.group ? qgsVariantLessThan( p1.value, p2.value ) : qgsVariantLessThan( p1.group, p2.group );
 }
 
 QgsValueRelationFieldFormatter::QgsValueRelationFieldFormatter()
@@ -135,13 +135,19 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
     return cache;
 
   QgsFields fields = layer->fields();
-  int ki = fields.indexOf( config.value( QStringLiteral( "Key" ) ).toString() );
-  int vi = fields.indexOf( config.value( QStringLiteral( "Value" ) ).toString() );
+  const int keyIdx = fields.indexOf( config.value( QStringLiteral( "Key" ) ).toString() );
+  const int valueIdx = fields.indexOf( config.value( QStringLiteral( "Value" ) ).toString() );
 
   QgsFeatureRequest request;
 
   request.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
-  QgsAttributeIds subsetOfAttributes { ki, vi };
+  QgsAttributeIds subsetOfAttributes { keyIdx, valueIdx };
+
+  const int groupIdx = fields.indexOf( config.value( QStringLiteral( "Group" ) ).toString() );
+  if ( groupIdx > -1 )
+  {
+    subsetOfAttributes << groupIdx;
+  }
 
   const QString descriptionExpressionString = config.value( "Description" ).toString();
   QgsExpression descriptionExpression( descriptionExpressionString );
@@ -180,7 +186,8 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
       context.setFeature( f );
       description = descriptionExpression.evaluate( &context ).toString();
     }
-    cache.append( ValueRelationItem( f.attribute( ki ), f.attribute( vi ).toString(), description ) );
+    const QString group = groupIdx > -1 ? f.attribute( groupIdx ).toString() : QString();
+    cache.append( ValueRelationItem( f.attribute( keyIdx ), f.attribute( valueIdx ).toString(), description, group ) );
   }
 
   if ( config.value( QStringLiteral( "OrderByValue" ) ).toBool() )

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -143,7 +143,7 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
   request.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
   QgsAttributeIds subsetOfAttributes { keyIdx, valueIdx };
 
-  const int groupIdx = fields.indexOf( config.value( QStringLiteral( "Group" ) ).toString() );
+  const int groupIdx = fields.lookupField( config.value( QStringLiteral( "Group" ) ).toString() );
   if ( groupIdx > -1 )
   {
     subsetOfAttributes << groupIdx;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -186,7 +186,7 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
       context.setFeature( f );
       description = descriptionExpression.evaluate( &context ).toString();
     }
-    const QString group = groupIdx > -1 ? f.attribute( groupIdx ).toString() : QString();
+    const QVariant group = groupIdx > -1 ? f.attribute( groupIdx ) : QVariant();
     cache.append( ValueRelationItem( f.attribute( keyIdx ), f.attribute( valueIdx ).toString(), description, group ) );
   }
 

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
       QVariant key;
       QString value;
       QString description;
+      //! Value used to regroup items during sorting (since QGIS 3.38)
       QVariant group;
     };
 

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -39,10 +39,11 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     struct ValueRelationItem
     {
       //! Constructor for ValueRelationItem
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString() )
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() )
         : key( key )
         , value( value )
         , description( description )
+        , group( group )
       {}
 
       //! Constructor for ValueRelationItem
@@ -51,6 +52,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
       QVariant key;
       QString value;
       QString description;
+      QString group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     struct ValueRelationItem
     {
       //! Constructor for ValueRelationItem
-      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QString group = QString() )
+      ValueRelationItem( const QVariant &key, const QString &value, const QString &description = QString(), const QVariant group = QVariant() )
         : key( key )
         , value( value )
         , description( description )
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
       QVariant key;
       QString value;
       QString description;
-      QString group;
+      QVariant group;
     };
 
     typedef QVector < QgsValueRelationFieldFormatter::ValueRelationItem > ValueRelationCache;

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -27,9 +27,12 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   mLayerName->setFilters( Qgis::LayerFilter::VectorLayer );
   mKeyColumn->setLayer( mLayerName->currentLayer() );
   mValueColumn->setLayer( mLayerName->currentLayer() );
+  mGroupColumn->setLayer( mLayerName->currentLayer() );
+  mGroupColumn->setAllowEmptyFieldName( true );
   mDescriptionExpression->setLayer( mLayerName->currentLayer() );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mKeyColumn, &QgsFieldComboBox::setLayer );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mValueColumn, &QgsFieldComboBox::setLayer );
+  connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mGroupColumn, &QgsFieldComboBox::setLayer );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mDescriptionExpression, &QgsFieldExpressionWidget::setLayer );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, this, &QgsValueRelationConfigDlg::layerChanged );
   connect( mEditExpression, &QAbstractButton::clicked, this, &QgsValueRelationConfigDlg::editExpression );
@@ -41,6 +44,7 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, this, &QgsEditorConfigWidget::changed );
   connect( mKeyColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mValueColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
+  connect( mGroupColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mDescriptionExpression, static_cast<void ( QgsFieldExpressionWidget::* )( const QString & )>( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mAllowMulti, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mAllowNull, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
@@ -78,6 +82,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
               QString() );
   cfg.insert( QStringLiteral( "Key" ), mKeyColumn->currentField() );
   cfg.insert( QStringLiteral( "Value" ), mValueColumn->currentField() );
+  cfg.insert( QStringLiteral( "Group" ), mGroupColumn->currentField() );
   cfg.insert( QStringLiteral( "Description" ), mDescriptionExpression->expression() );
   cfg.insert( QStringLiteral( "AllowMulti" ), mAllowMulti->isChecked() );
   cfg.insert( QStringLiteral( "NofColumns" ), mNofColumns->value() );
@@ -97,6 +102,7 @@ void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
   mLayerName->setLayer( lyr );
   mKeyColumn->setField( config.value( QStringLiteral( "Key" ) ).toString() );
   mValueColumn->setField( config.value( QStringLiteral( "Value" ) ).toString() );
+  mGroupColumn->setField( config.value( QStringLiteral( "Group" ) ).toString() );
   mDescriptionExpression->setField( config.value( QStringLiteral( "Description" ) ).toString() );
   mAllowMulti->setChecked( config.value( QStringLiteral( "AllowMulti" ) ).toBool() );
   mNofColumns->setValue( config.value( QStringLiteral( "NofColumns" ), 1 ).toInt() );

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -44,7 +44,11 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, this, &QgsEditorConfigWidget::changed );
   connect( mKeyColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mValueColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
-  connect( mGroupColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
+  connect( mGroupColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]( int index )
+  {
+    mDisplayGroupName->setEnabled( index != 0 );
+    emit changed();
+  } );
   connect( mDescriptionExpression, static_cast<void ( QgsFieldExpressionWidget::* )( const QString & )>( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mAllowMulti, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mAllowNull, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
@@ -55,8 +59,7 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   {
     label_nofColumns->setEnabled( checked );
     mNofColumns->setEnabled( checked );
-  }
-         );
+  } );
 
   connect( mUseCompleter, &QCheckBox::stateChanged, this,  [ = ]( int state )
   {
@@ -83,6 +86,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
   cfg.insert( QStringLiteral( "Key" ), mKeyColumn->currentField() );
   cfg.insert( QStringLiteral( "Value" ), mValueColumn->currentField() );
   cfg.insert( QStringLiteral( "Group" ), mGroupColumn->currentField() );
+  cfg.insert( QStringLiteral( "DisplayGroupName" ), mDisplayGroupName->isChecked() );
   cfg.insert( QStringLiteral( "Description" ), mDescriptionExpression->expression() );
   cfg.insert( QStringLiteral( "AllowMulti" ), mAllowMulti->isChecked() );
   cfg.insert( QStringLiteral( "NofColumns" ), mNofColumns->value() );
@@ -103,6 +107,7 @@ void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
   mKeyColumn->setField( config.value( QStringLiteral( "Key" ) ).toString() );
   mValueColumn->setField( config.value( QStringLiteral( "Value" ) ).toString() );
   mGroupColumn->setField( config.value( QStringLiteral( "Group" ) ).toString() );
+  mDisplayGroupName->setChecked( config.value( QStringLiteral( "DisplayGroupName" ) ).toBool() );
   mDescriptionExpression->setField( config.value( QStringLiteral( "Description" ) ).toString() );
   mAllowMulti->setChecked( config.value( QStringLiteral( "AllowMulti" ) ).toBool() );
   mNofColumns->setValue( config.value( QStringLiteral( "NofColumns" ), 1 ).toInt() );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -112,7 +112,7 @@ void QgsFilteredTableWidget::filterStringChanged( const QString &filterString )
     }
     const int groupsCount = mDisplayGroupName ? groups.count() : groups.count() - 1;
 
-    const int rCount = std::max( 1, ( int ) std::ceil( ( float ) mCache.count() + groupsCount / ( float ) mColumnCount ) );
+    const int rCount = std::max( 1, ( int ) std::ceil( ( float )( mCache.count() + groupsCount ) / ( float ) mColumnCount ) );
     mTableWidget->setRowCount( rCount );
 
     int row = 0;

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -101,8 +101,8 @@ void QgsFilteredTableWidget::filterStringChanged( const QString &filterString )
   mTableWidget->clearContents();
   if ( !mCache.isEmpty() )
   {
-    QStringList groups;
-    groups << QString();
+    QVariantList groups;
+    groups << QVariant();
     for ( const QPair<QgsValueRelationFieldFormatter::ValueRelationItem, Qt::CheckState> &pair : std::as_const( mCache ) )
     {
       if ( !groups.contains( pair.first.group ) )
@@ -111,19 +111,26 @@ void QgsFilteredTableWidget::filterStringChanged( const QString &filterString )
       }
     }
     const int groupsCount = mDisplayGroupName ? groups.count() : groups.count() - 1;
+
     const int rCount = std::max( 1, ( int ) std::ceil( ( float ) mCache.count() + groupsCount / ( float ) mColumnCount ) );
     mTableWidget->setRowCount( rCount );
+
     int row = 0;
     int column = 0;
-    QString currentGroup;
+    QVariant currentGroup;
     for ( const QPair<QgsValueRelationFieldFormatter::ValueRelationItem, Qt::CheckState> &pair : std::as_const( mCache ) )
     {
+      if ( column == mColumnCount )
+      {
+        row++;
+        column = 0;
+      }
       if ( currentGroup != pair.first.group )
       {
         currentGroup = pair.first.group;
         if ( mDisplayGroupName || !( row == 0 && column == 0 ) )
         {
-          QTableWidgetItem *item = new QTableWidgetItem( mDisplayGroupName ? pair.first.group : QString() );
+          QTableWidgetItem *item = new QTableWidgetItem( mDisplayGroupName ? pair.first.group.toString() : QString() );
           item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
           mTableWidget->setItem( row, column, item );
           column++;
@@ -143,11 +150,6 @@ void QgsFilteredTableWidget::filterStringChanged( const QString &filterString )
         item->setFlags( mEnabledTable ? item->flags() | Qt::ItemIsEnabled : item->flags() & ~Qt::ItemIsEnabled );
         mTableWidget->setItem( row, column, item );
         column++;
-        if ( column == mColumnCount )
-        {
-          row++;
-          column = 0;
-        }
       }
     }
     mTableWidget->setRowCount( row + 1 );
@@ -573,7 +575,7 @@ void QgsValueRelationWidgetWrapper::populate()
 
     if ( !mCache.isEmpty() )
     {
-      QString currentGroup;
+      QVariant currentGroup;
       QStandardItemModel *model = qobject_cast<QStandardItemModel *>( mComboBox->model() );
       const bool displayGroupName = config( QStringLiteral( "DisplayGroupName" ) ).toBool();
       for ( const QgsValueRelationFieldFormatter::ValueRelationItem &element : std::as_const( mCache ) )
@@ -586,7 +588,7 @@ void QgsValueRelationWidgetWrapper::populate()
           }
           if ( displayGroupName )
           {
-            mComboBox->addItem( element.group );
+            mComboBox->addItem( element.group.toString() );
             QStandardItem *item = model->item( mComboBox->count() - 1 );
             item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
           }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -48,7 +48,7 @@ class QgsFilteredTableWidget : public QWidget
      * \param parent
      * \param showSearch Whether the search QgsFilterLineEdit should be visible or not
      */
-    QgsFilteredTableWidget( QWidget *parent, bool showSearch );
+    QgsFilteredTableWidget( QWidget *parent, bool showSearch, bool displayGroupName );
 
     bool eventFilter( QObject *watched, QEvent *event ) override;
 
@@ -104,6 +104,8 @@ class QgsFilteredTableWidget : public QWidget
     QTableWidget *mTableWidget = nullptr;
     bool mEnabledTable = true;
     QVector<QPair<QgsValueRelationFieldFormatter::ValueRelationItem, Qt::CheckState>> mCache;
+    bool mDisplayGroupName = false;
+
     friend class TestQgsValueRelationWidgetWrapper;
 };
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -47,6 +47,7 @@ class QgsFilteredTableWidget : public QWidget
      * \brief QgsFilteredTableWidget constructor
      * \param parent
      * \param showSearch Whether the search QgsFilterLineEdit should be visible or not
+     * \param displayGroupName Set to TRUE to display the grouping value as name in section header
      */
     QgsFilteredTableWidget( QWidget *parent, bool showSearch, bool displayGroupName );
 

--- a/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
@@ -6,33 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>427</width>
-    <height>489</height>
+    <width>318</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
-   <item row="1" column="1">
-    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
-   </item>
-   <item row="15" column="0" colspan="2">
-    <widget class="QTextEdit" name="mFilterExpression"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Value column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mValueColumn</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QgsFieldComboBox" name="mValueColumn"/>
-   </item>
    <item row="14" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -51,7 +32,7 @@
         <enum>Qt::RightToLeft</enum>
        </property>
        <property name="icon">
-        <iconset resource="../../../images/images.qrc">
+        <iconset>
          <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
        </property>
       </widget>
@@ -71,35 +52,22 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_nofColumns">
      <property name="text">
-      <string>Key column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mKeyColumn</cstring>
+      <string>Number of columns</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mDescriptionExpression" native="true"/>
+   <item row="17" column="0" colspan="2">
+    <widget class="QTextEdit" name="mFilterExpression"/>
    </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QCheckBox" name="mAllowMulti">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>Allow multiple selections</string>
+      <string>Select layer, key column and value column</string>
      </property>
     </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="mAllowNull">
-     <property name="text">
-      <string>Allow NULL value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QgsSpinBox" name="mNofColumns"/>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_5">
@@ -111,50 +79,109 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QgsFieldComboBox" name="mKeyColumn"/>
+   <item row="3" column="1">
+    <widget class="QgsFieldComboBox" name="mValueColumn"/>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_nofColumns">
-     <property name="text">
-      <string>Number of columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Description column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Select layer, key column and value column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QCheckBox" name="mOrderByValue">
      <property name="text">
       <string>Order by value</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <widget class="QCheckBox" name="mCompleterMatchFromStart">
+   <item row="1" column="1">
+    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QCheckBox" name="mAllowMulti">
      <property name="text">
-      <string>Only match from the beginning of the string </string>
+      <string>Allow multiple selections</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="mAllowNull">
+     <property name="text">
+      <string>Allow NULL value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
     <widget class="QCheckBox" name="mUseCompleter">
      <property name="text">
       <string>Use completer</string>
      </property>
     </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QCheckBox" name="mCompleterMatchFromStart">
+     <property name="text">
+      <string>Only match from the beginning of the string</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Key column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mKeyColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QgsSpinBox" name="mNofColumns">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFieldComboBox" name="mKeyColumn"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Value column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mValueColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Group column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mGroupColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QgsFieldComboBox" name="mGroupColumn"/>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="mDisplayGroupName">
+     <property name="text">
+      <string>Display group name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Description</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mDescriptionExpression" native="true"/>
    </item>
   </layout>
  </widget>
@@ -185,15 +212,17 @@
   <tabstop>mLayerName</tabstop>
   <tabstop>mKeyColumn</tabstop>
   <tabstop>mValueColumn</tabstop>
-  <tabstop>mAllowNull</tabstop>
+  <tabstop>mGroupColumn</tabstop>
+  <tabstop>mDescriptionExpression</tabstop>
   <tabstop>mOrderByValue</tabstop>
+  <tabstop>mAllowNull</tabstop>
   <tabstop>mAllowMulti</tabstop>
+  <tabstop>mUseCompleter</tabstop>
+  <tabstop>mCompleterMatchFromStart</tabstop>
   <tabstop>mNofColumns</tabstop>
   <tabstop>mEditExpression</tabstop>
   <tabstop>mFilterExpression</tabstop>
  </tabstops>
- <resources>
-  <include location="../../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/tests/src/core/testqgsvaluerelationfieldformatter.cpp
+++ b/tests/src/core/testqgsvaluerelationfieldformatter.cpp
@@ -38,6 +38,7 @@ class TestQgsValueRelationFieldFormatter: public QObject
     void cleanup(); // will be called after every testfunction.
     void testDependencies();
     void testSortValueNull();
+    void testGroup();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -162,6 +163,21 @@ void TestQgsValueRelationFieldFormatter::testSortValueNull()
 
   value = formatter.sortValue( mLayer2.get(), 1, config, QVariant(), QVariant( 10 ) );
   QCOMPARE( value, QVariant( QString( "iron" ) ) );
+}
+
+void TestQgsValueRelationFieldFormatter::testGroup()
+{
+  const QgsValueRelationFieldFormatter formatter;
+  QVariantMap config;
+  config.insert( QStringLiteral( "Layer" ), mLayer2->id() );
+  config.insert( QStringLiteral( "Key" ), QStringLiteral( "pk" ) );
+  config.insert( QStringLiteral( "Value" ), QStringLiteral( "raccord" ) );
+  config.insert( QStringLiteral( "Group" ), QStringLiteral( "material" ) );
+
+  QgsValueRelationFieldFormatter::ValueRelationCache cache = formatter.createCache( config );
+  QVERIFY( !cache.isEmpty() );
+  QCOMPARE( cache.at( 0 ).group, QVariant( QStringLiteral( "iron" ) ) );
+  QCOMPARE( cache.at( cache.size() - 1 ).group, QVariant( QStringLiteral( "steel" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsValueRelationFieldFormatter )


### PR DESCRIPTION
## Description

This PR implements grouping functionality for the value relation editor widget, allowing users to regroup items into buckets of values. Users are also given an option to show the group value as group header name in the combobox and table widgets.

Here's how it looks through a combobox:
![image](https://github.com/qgis/QGIS/assets/1728657/61a52ef4-47af-4bbc-9ebd-94f74b6312fe)

And here's how it looks through a table widget:
![image](https://github.com/qgis/QGIS/assets/1728657/ca72cd36-d32c-4925-82a9-1f767b2ed6e5)
