### PR TITLE
[Backport release-3_34] Fix QgsProcessingFeatureSourceDefinition::geometryCheck description

### DIFF
--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -154,10 +154,9 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
 
     /**
      * Geometry check method to apply to this source. This setting is only
-     * utilized if the QgsProcessingFeatureSourceDefinition::Flag::FlagCreateIndividualOutputPerInputFeature is
+     * utilized if the QgsProcessingFeatureSourceDefinition::Flag::FlagOverrideDefaultGeometryCheck is
      * set in QgsProcessingFeatureSourceDefinition::flags.
      *
-     * \see overrideDefaultGeometryCheck
      * \since QGIS 3.14
      */
     QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/56631 to the `release-3_34` branch.