### PR TITLE
[expression] Add @map_z_range_{lower,upper} pair of variables reflecting the map's z range values

### DIFF
--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -528,6 +528,13 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )
 
+  const QgsDoubleRange zRange = mapSettings.zRange();
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_z_range_lower" ), !zRange.isInfinite() ? zRange.lower() : QVariant(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_z_range_upper" ), !zRange.isInfinite() ? zRange.upper() : QVariant(), true ) );
+
+  // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
+  // (rationale is described in QgsLayoutItemMap::createExpressionContext() )
+
   if ( mapSettings.frameRate() >= 0 )
     scope->setVariable( QStringLiteral( "frame_rate" ), mapSettings.frameRate(), true );
   if ( mapSettings.currentFrame() >= 0 )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -582,6 +582,23 @@ void TestQgsMapSettings::testExpressionContext()
 
   QCOMPARE( r.toString(), QStringLiteral( "EPSG:7030" ) );
 
+  e = QgsExpression( QStringLiteral( "@map_z_range_lower" ) );
+  r = e.evaluate( &c );
+  QVERIFY( !r.isValid() );
+  e = QgsExpression( QStringLiteral( "@map_z_range_upper" ) );
+  r = e.evaluate( &c );
+  QVERIFY( !r.isValid() );
+
+  ms.setZRange( QgsDoubleRange( 0.5, 100.5 ) );
+  c = QgsExpressionContext();
+  c << QgsExpressionContextUtils::mapSettingsScope( ms );
+  e = QgsExpression( QStringLiteral( "@map_z_range_lower" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toDouble(), 0.5 );
+  e = QgsExpression( QStringLiteral( "@map_z_range_upper" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toDouble(), 100.5 );
+
   e = QgsExpression( QStringLiteral( "@map_start_time" ) );
   r = e.evaluate( &c );
   QVERIFY( !r.isValid() );


### PR DESCRIPTION
## Description

@nyalldawson , your work massively improving Z range filtering support is inspiring :wink: this PR adds a pair of @map_z_range_{lower,upper} variables to reflect the map canvas' z range value, which allows us to do stuff like:

[Screencast from 2024-03-04 11-59-13.webm](https://github.com/qgis/QGIS/assets/1728657/1fb318a9-855b-4f89-b186-0c712de70f41)

It is _not_ a substitute to proper Z range filtering of vector layers (lacks a dedicated UI, optimizations, etc.) but it does allow us to do some interesting experiments using rule-based rendering using pre-existing z(geom) z_min(geom) and z_max(geom) functions.