### PR TITLE
[Backport 3.36] QgsGeos::asGeos(): only error out on invalid subgeometry only if requested (typically from QgsGeometryCollection::isValid())

### DIFF
--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -871,7 +871,7 @@ bool QgsGeometryCollection::isValid( QString &error, Qgis::GeometryValidityFlags
     return error.isEmpty();
   }
 
-  QgsGeos geos( this );
+  QgsGeos geos( this, /* precision = */ 0, /* allowInvalidSubGeom = */ false );
   bool res = geos.isValid( &error, flags & Qgis::GeometryValidityFlag::AllowSelfTouchingHoles, nullptr );
   if ( flags == 0 )
   {

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -102,8 +102,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * GEOS geometry engine constructor
      * \param geometry The geometry
      * \param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
+     * \param allowInvalidSubGeom Whether invalid sub-geometries should be skipped without error (since QGIS 3.38)
      */
-    QgsGeos( const QgsAbstractGeometry *geometry, double precision = 0 );
+    QgsGeos( const QgsAbstractGeometry *geometry, double precision = 0, bool allowInvalidSubGeom = true );
 
     /**
      * Creates a new QgsGeometry object, feeding in a geometry in GEOS format.
@@ -654,8 +655,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Returns a geos geometry - caller takes ownership of the object (should be deleted with GEOSGeom_destroy_r)
      * \param geometry geometry to convert to GEOS representation
      * \param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
+     * \param allowInvalidSubGeom Whether invalid sub-geometries should be skipped without error (since QGIS 3.38)
      */
-    static geos::unique_ptr asGeos( const QgsAbstractGeometry *geometry, double precision = 0 );
+    static geos::unique_ptr asGeos( const QgsAbstractGeometry *geometry, double precision = 0, bool allowInvalidSubGeom = true );
     static QgsPoint coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, bool hasM );
 
     static GEOSContextHandle_t getGEOSHandler();
@@ -686,7 +688,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     };
 
     //geos util functions
-    void cacheGeos() const;
+    void cacheGeos( bool allowInvalidSubGeom ) const;
 
     /**
      * Returns a geometry representing the overlay operation with \a geom.


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/56667