### PR TITLE
[3.34 backport] qgsshadowrenderingframegraph: Fix blendequation for transparent entities

### DIFF
--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -186,10 +186,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
     transparentObjectsRenderStateSet->addRenderState( blendEquation );
 
     Qt3DRender::QBlendEquationArguments *blenEquationArgs = new Qt3DRender::QBlendEquationArguments;
-    blenEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::One );
-    blenEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
-    blenEquationArgs->setSourceAlpha( Qt3DRender::QBlendEquationArguments::Blending::One );
-    blenEquationArgs->setDestinationAlpha( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
+    blenEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::SourceAlpha );
+    blenEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSourceAlpha );
     transparentObjectsRenderStateSet->addRenderState( blenEquationArgs );
   }
 


### PR DESCRIPTION
## Description

See discussion from
https://github.com/qgis/QGIS/pull/55943#issuecomment-1972177646

