### PR TITLE
[gps] Don't emit stateChanged for incomplete nmea messages

### DIFF
--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -68,7 +68,11 @@ void QgsNmeaConnection::parseData()
     //append new data to the remaining results from last parseData() call
     mStringBuffer.append( mSource->read( numBytes ) );
     processStringBuffer();
-    emit stateChanged( mLastGPSInformation );
+
+    if ( mStatus == GPSDataReceived )
+    {
+      emit stateChanged( mLastGPSInformation );
+    }
   }
 }
 


### PR DESCRIPTION
If we only have receieved the first part of a message, don't emit stateChanged until we've received the rest.

Possibly refs #56460
